### PR TITLE
Fix bad expected NAT on egressip unit test flake

### DIFF
--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -5106,6 +5106,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				fakeOvn.patchEgressIPObj(node2Name, egressIPName, updatedEgressIP.String(), "::/64")
+				expectedNAT.ExternalIP = updatedEgressIP.String()
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(func() []string {


### PR DESCRIPTION
ed8842c065860b93c82101fb5980585b055304b2 removed a part of the fix introduced in c089c2ead7302c7fb5d69e641c4d267bd31312d8:
```
- fakeOvn.patchEgressIPObj(node2Name, updatedEgressIP.String())
- expectedNAT.ExternalIP = updatedEgressIP.String()
+ fakeOvn.patchEgressIPObj(node2Name, egressIPName, updatedEgressIP.String(), "::/64")
```
This commit adds it back.

Saw it here: https://github.com/ovn-org/ovn-kubernetes/actions/runs/6626475165/job/17999485415?pr=3972

/cc @martinkennelly @jcaamano @tssurya 
