### PR TITLE
Fix remove remote pod when no IPs annotated

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -146,8 +146,8 @@ func IsMigratedSourcePodStale(client *factory.WatchFactory, pod *corev1.Pod) (bo
 // ZoneContainsPodSubnet will return true if the logical switch tonains
 // the pod subnet and also the switch name owning it, this means that
 // this zone owns the that subnet.
-func ZoneContainsPodSubnet(lsManager *logicalswitchmanager.LogicalSwitchManager, podAnnotation *util.PodAnnotation) (string, bool) {
-	return lsManager.GetSubnetName(podAnnotation.IPs)
+func ZoneContainsPodSubnet(lsManager *logicalswitchmanager.LogicalSwitchManager, ips []*net.IPNet) (string, bool) {
+	return lsManager.GetSubnetName(ips)
 }
 
 // nodeContainsPodSubnet will return true if the node subnet annotation
@@ -267,7 +267,7 @@ func allocateSyncMigratablePodIPs(watchFactory *factory.WatchFactory, lsManager 
 	if err != nil {
 		return nil, "", nil, nil
 	}
-	switchName, zoneContainsPodSubnet := ZoneContainsPodSubnet(lsManager, annotation)
+	switchName, zoneContainsPodSubnet := ZoneContainsPodSubnet(lsManager, annotation.IPs)
 	// If this zone do not own the subnet or the node that is passed
 	// do not match the switch, they should not be deallocated
 	if !zoneContainsPodSubnet || (nodeName != "" && switchName != nodeName) {
@@ -295,7 +295,7 @@ func AllocateSyncMigratablePodIPsOnZone(watchFactory *factory.WatchFactory, lsMa
 // convenience, the host subnets might not provided in which case they might be
 // parsed and returned if used.
 func ZoneContainsPodSubnetOrUntracked(watchFactory *factory.WatchFactory, lsManager *logicalswitchmanager.LogicalSwitchManager, hostSubnets []*net.IPNet, annotation *util.PodAnnotation) ([]*net.IPNet, bool, error) {
-	_, local := ZoneContainsPodSubnet(lsManager, annotation)
+	_, local := ZoneContainsPodSubnet(lsManager, annotation.IPs)
 	if local {
 		return nil, true, nil
 	}

--- a/go-controller/pkg/kubevirt/router.go
+++ b/go-controller/pkg/kubevirt/router.go
@@ -78,7 +78,7 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 		return fmt.Errorf("failed reading local pod annotation: %v", err)
 	}
 
-	nodeOwningSubnet, _ := ZoneContainsPodSubnet(lsManager, podAnnotation)
+	nodeOwningSubnet, _ := ZoneContainsPodSubnet(lsManager, podAnnotation.IPs)
 	vmRunningAtNodeOwningSubnet := nodeOwningSubnet == pod.Spec.NodeName
 	if vmRunningAtNodeOwningSubnet {
 		// Point to point routing is no longer needed if vm

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -430,7 +430,7 @@ func (bnc *BaseNetworkController) ensurePodAnnotation(pod *kapi.Pod, nadName str
 		}
 		// The live migrated pods will have the pod annotation but the switch manager running
 		// at the node will not contain the switch as expected
-		_, zoneContainsPodSubnet := kubevirt.ZoneContainsPodSubnet(bnc.lsManager, podAnnotation)
+		_, zoneContainsPodSubnet := kubevirt.ZoneContainsPodSubnet(bnc.lsManager, podAnnotation.IPs)
 		return podAnnotation, zoneContainsPodSubnet, nil
 	}
 	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadName)


### PR DESCRIPTION
This was recently changed incorrectly. A pod can be deleted with no IPs annotated so don't assume that is an error.

Incidentally fix the case for a live migratable pod as well which would have failed in the same way before.

Fixes: #3919
