### PR TITLE
Adds port security for external OVS bridge for OVN MAC address

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -373,7 +373,7 @@ jobs:
       fail-fast: false
       matrix:
         # Valid options are:
-        # target: ["shard-conformance", "control-plane", "multi-homing", "multi-node-zones", "node-ip-migration", "compact-mode"]
+        # target: ["shard-conformance", "control-plane", "multi-homing", "multi-node-zones", "node-ip-mac-migration", "compact-mode"]
         #         shard-conformance: hybrid-overlay = multicast-enable = emptylb-enable = false
         #         control-plane: hybrid-overlay = multicast-enable = emptylb-enable = true
         # ha: ["HA", "noHA"]
@@ -395,8 +395,8 @@ jobs:
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "node-ip-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "node-ip-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
+          - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "compact-mode",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "multi-node-zones",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-multi-node-zones", "num-workers": "3", "num-nodes-per-zone": "2"}
@@ -483,8 +483,8 @@ jobs:
       run: |
         if [ "${{ matrix.target }}" == "multi-homing" ]; then
           make -C test control-plane WHAT="Multi Homing"
-        elif [ "${{ matrix.target }}" == "node-ip-migration" ]; then
-          make -C test control-plane WHAT="Node IP address migration"
+        elif [ "${{ matrix.target }}" == "node-ip-mac-migration" ]; then
+          make -C test control-plane WHAT="Node IP and MAC address migration"
         elif [ "${{ matrix.target }}" == "compact-mode" ]; then
           SINGLE_NODE_CLUSTER="true" make -C test shard-network
         elif [ "${{ matrix.target }}" == "multi-node-zones" ]; then

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -204,8 +204,9 @@ func initController(namespaces []corev1.Namespace, pods []corev1.Pod, egressIPs 
 	if err := watchFactory.Start(); err != nil {
 		return nil, nil, err
 	}
+	linkManager := linkmanager.NewController(node1Name, v4, v6)
 	c, err := NewController(watchFactory.EgressIPInformer(), watchFactory.NodeInformer(), watchFactory.NamespaceInformer(),
-		watchFactory.PodCoreInformer(), rm, v4, v6, node1Name)
+		watchFactory.PodCoreInformer(), rm, v4, v6, node1Name, linkManager)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -262,7 +263,7 @@ func runController(testNS ns.NetNS, c *Controller) (cleanupFn, error) {
 	// normally executed during Run but we call it manually here because run spawns a go routine that we cannot control its netns during test
 	wg.Add(1)
 	go testNS.Do(func(netNS ns.NetNS) error {
-		c.linkManager.Run(stopCh, 10*time.Millisecond)
+		c.linkManager.Run(stopCh, 10*time.Millisecond, nil)
 		wg.Done()
 		return nil
 	})

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -699,6 +699,11 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		nc.routeManager.Run(nc.stopChan, 4*time.Minute)
 	}()
 
+	// Bootstrap flows in OVS if just normal flow is present
+	if err := bootstrapOVSFlows(); err != nil {
+		return fmt.Errorf("failed to bootstrap OVS flows: %w", err)
+	}
+
 	if node, err = nc.Kube.GetNode(nc.name); err != nil {
 		return fmt.Errorf("error retrieving node %s: %v", nc.name, err)
 	}

--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -42,6 +42,9 @@ var _ = Describe("Egress Service Operations", func() {
 		app.Flags = config.Flags
 		fExec = ovntest.NewLooseCompareFakeExec()
 		fakeOvnNode = NewFakeOVNNode(fExec)
+		fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovs-vsctl --timeout=15 --no-heading --data=bare --format=csv --columns name list interface",
+		})
 
 		config.OVNKubernetesFeature.EnableEgressService = true
 		_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -9,13 +9,16 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	"github.com/pkg/errors"
 	"github.com/safchain/ethtool"
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -25,7 +28,7 @@ import (
 // are kept in sync
 type Gateway interface {
 	informer.ServiceAndEndpointsEventHandler
-	Init(factory.NodeWatchFactory, <-chan struct{}, *sync.WaitGroup) error
+	Init(<-chan struct{}, *sync.WaitGroup) error
 	Start()
 	GetGatewayBridgeIface() string
 	SetDefaultGatewayBridgeMAC(addr net.HardwareAddr)
@@ -45,6 +48,8 @@ type gateway struct {
 	nodeIPManager   *addressManager
 	initFunc        func() error
 	readyFunc       func() (bool, error)
+
+	servicesRetryFramework *retry.RetryFramework
 
 	watchFactory *factory.WatchFactory // used for retry
 	stopChan     <-chan struct{}
@@ -206,7 +211,7 @@ func (g *gateway) DeleteEndpointSlice(epSlice *discovery.EndpointSlice) error {
 
 }
 
-func (g *gateway) Init(wf factory.NodeWatchFactory, stopChan <-chan struct{}, wg *sync.WaitGroup) error {
+func (g *gateway) Init(stopChan <-chan struct{}, wg *sync.WaitGroup) error {
 	g.stopChan = stopChan
 	g.wg = wg
 
@@ -214,8 +219,8 @@ func (g *gateway) Init(wf factory.NodeWatchFactory, stopChan <-chan struct{}, wg
 	if err = g.initFunc(); err != nil {
 		return err
 	}
-	servicesRetryFramework := g.newRetryFrameworkNode(factory.ServiceForGatewayType)
-	if _, err = servicesRetryFramework.WatchResource(); err != nil {
+	g.servicesRetryFramework = g.newRetryFrameworkNode(factory.ServiceForGatewayType)
+	if _, err = g.servicesRetryFramework.WatchResource(); err != nil {
 		return fmt.Errorf("gateway init failed to start watching services: %v", err)
 	}
 
@@ -372,7 +377,7 @@ func (g *gateway) SetDefaultGatewayBridgeMAC(macAddr net.HardwareAddr) {
 	klog.Infof("Default gateway bridge MAC address updated to %s", macAddr)
 }
 
-// Reconcile handles triggering updates to different components of a gateway, like OFM
+// Reconcile handles triggering updates to different components of a gateway, like OFM, Services
 func (g *gateway) Reconcile() error {
 	klog.Info("Reconciling gateway with updates")
 	node, err := g.watchFactory.GetNode(g.nodeIPManager.nodeName)
@@ -386,7 +391,34 @@ func (g *gateway) Reconcile() error {
 	if err := g.openflowManager.updateBridgeFlowCache(subnets, g.nodeIPManager.ListAddresses()); err != nil {
 		return err
 	}
+	// Services create OpenFlow flows as well, need to update them all
+	if g.servicesRetryFramework != nil {
+		if errs := g.addAllServices(); errs != nil {
+			err := kerrors.NewAggregate(errs)
+			return err
+		}
+	}
 	return nil
+}
+
+func (g *gateway) addAllServices() []error {
+	errs := []error{}
+	svcs, err := g.watchFactory.GetServices()
+	if err != nil {
+		errs = append(errs, err)
+	} else {
+		for _, svc := range svcs {
+			svc := *svc
+			klog.V(5).Infof("Adding service %s/%s to retryServices", svc.Namespace, svc.Name)
+			err = g.servicesRetryFramework.AddRetryObjWithAddNoBackoff(&svc)
+			if err != nil {
+				err = fmt.Errorf("failed to add service %s/%s to retry framework: %w", svc.Namespace, svc.Name, err)
+				errs = append(errs, err)
+			}
+		}
+	}
+	g.servicesRetryFramework.RequestRetryObjs()
+	return errs
 }
 
 type bridgeConfiguration struct {

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -358,7 +358,7 @@ func gatewayReady(patchPort string) (bool, error) {
 }
 
 func (g *gateway) GetGatewayBridgeIface() string {
-	return g.openflowManager.defaultBridge.bridgeName
+	return g.openflowManager.getDefaultBridgeName()
 }
 
 // getMaxFrameLength returns the maximum frame size (ignoring VLAN header) that a gateway can handle
@@ -368,9 +368,7 @@ func getMaxFrameLength() int {
 
 // SetDefaultGatewayBridgeMAC updates the mac address for the OFM used to render flows with
 func (g *gateway) SetDefaultGatewayBridgeMAC(macAddr net.HardwareAddr) {
-	g.openflowManager.defaultBridge.Lock()
-	defer g.openflowManager.defaultBridge.Unlock()
-	g.openflowManager.defaultBridge.macAddress = macAddr
+	g.openflowManager.setDefaultBridgeMAC(macAddr)
 	klog.Infof("Default gateway bridge MAC address updated to %s", macAddr)
 }
 

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
@@ -533,4 +534,39 @@ func CleanupClusterNode(name string) error {
 	DelMgtPortIptRules()
 
 	return nil
+}
+
+func (nc *DefaultNodeNetworkController) updateGatewayMAC(link netlink.Link) error {
+	if nc.gateway.GetGatewayBridgeIface() != link.Attrs().Name {
+		return nil
+	}
+
+	node, err := nc.watchFactory.GetNode(nc.name)
+	if err != nil {
+		return err
+	}
+	l3gwConf, err := util.ParseNodeL3GatewayAnnotation(node)
+	if err != nil {
+		return err
+	}
+
+	if l3gwConf == nil || l3gwConf.MACAddress.String() == link.Attrs().HardwareAddr.String() {
+		return nil
+	}
+	// MAC must have changed, update node
+	nc.gateway.SetDefaultGatewayBridgeMAC(link.Attrs().HardwareAddr)
+	if err := nc.gateway.Reconcile(); err != nil {
+		return fmt.Errorf("failed to reconcile gateway for MAC address update: %w", err)
+	}
+	nodeAnnotator := kube.NewNodeAnnotator(nc.Kube, node.Name)
+	l3gwConf.MACAddress = link.Attrs().HardwareAddr
+	if err := util.SetL3GatewayConfig(nodeAnnotator, l3gwConf); err != nil {
+		return fmt.Errorf("failed to update L3 gateway config annotation for node: %s, error: %w", node.Name, err)
+	}
+	if err := nodeAnnotator.Run(); err != nil {
+		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
+	}
+
+	return nil
+
 }

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -403,7 +403,7 @@ func (nc *DefaultNodeNetworkController) initGateway(subnets []*net.IPNet, nodeAn
 	}
 
 	initGwFunc := func() error {
-		return gw.Init(nc.watchFactory, nc.stopChan, nc.wg)
+		return gw.Init(nc.stopChan, nc.wg)
 	}
 
 	readyGwFunc := func() (bool, error) {
@@ -502,7 +502,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost(kubeNodeIP net.IP) er
 		return fmt.Errorf("failed to add MAC bindings for service routing")
 	}
 
-	err = gw.Init(nc.watchFactory, nc.stopChan, nc.wg)
+	err = gw.Init(nc.stopChan, nc.wg)
 	nc.gateway = gw
 	return err
 }

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -271,7 +271,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs, nodeAnnotator, k,
 				&fakeMgmtPortConfig, wf, rm)
 			Expect(err).NotTo(HaveOccurred())
-			err = sharedGw.Init(wf, stop, wg)
+			err = sharedGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -644,7 +644,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
 				gatewayIntf, "", ifAddrs, nodeAnnotator, k, &fakeMgmtPortConfig, wf, rm)
 			Expect(err).NotTo(HaveOccurred())
-			err = sharedGw.Init(wf, stop, wg)
+			err = sharedGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = nodeAnnotator.Run()
@@ -847,6 +847,26 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			nodeSubnet string = "10.1.1.0/24"
 		)
 
+		ovsOFOutput := `
+OFPT_FEATURES_REPLY (xid=0x2): dpid:00000242ac120002
+n_tables:254, n_buffers:0
+capabilities: FLOW_STATS TABLE_STATS PORT_STATS QUEUE_STATS ARP_MATCH_IP
+actions: output enqueue set_vlan_vid set_vlan_pcp strip_vlan mod_dl_src mod_dl_dst mod_nw_src mod_nw_dst mod_nw_tos mod_tp_src mod_tp_dst
+ 1(eth0): addr:02:42:ac:12:00:02
+     config:     0
+     state:      0
+     current:    10GB-FD COPPER
+     speed: 10000 Mbps now, 0 Mbps max
+ 2(patch-breth0_ov): addr:8e:8d:f4:cd:4f:76
+     config:     0
+     state:      0
+     speed: 0 Mbps now, 0 Mbps max
+ LOCAL(breth0): addr:02:42:ac:12:00:02
+     config:     0
+     state:      0
+     speed: 0 Mbps now, 0 Mbps max
+OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
+
 		fexec := ovntest.NewLooseCompareFakeExec()
 
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -947,31 +967,9 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: "net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd: "ovs-ofctl show breth0",
-			Output: `
-OFPT_FEATURES_REPLY (xid=0x2): dpid:00000242ac120002
-n_tables:254, n_buffers:0
-capabilities: FLOW_STATS TABLE_STATS PORT_STATS QUEUE_STATS ARP_MATCH_IP
-actions: output enqueue set_vlan_vid set_vlan_pcp strip_vlan mod_dl_src mod_dl_dst mod_nw_src mod_nw_dst mod_nw_tos mod_tp_src mod_tp_dst
- 1(eth0): addr:02:42:ac:12:00:02
-     config:     0
-     state:      0
-     current:    10GB-FD COPPER
-     speed: 10000 Mbps now, 0 Mbps max
- 2(patch-breth0_ov): addr:8e:8d:f4:cd:4f:76
-     config:     0
-     state:      0
-     speed: 0 Mbps now, 0 Mbps max
- LOCAL(breth0): addr:02:42:ac:12:00:02
-     config:     0
-     state:      0
-     speed: 0 Mbps now, 0 Mbps max
-OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
+			Cmd:    "ovs-ofctl show breth0",
+			Output: ovsOFOutput,
 		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-ofctl -O OpenFlow13 --bundle replace-flows breth0 -",
-		})
-		// nodePortWatcher()
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface patch-breth0_" + nodeName + "-to-br-int ofport",
 			Output: "5",
@@ -979,6 +977,17 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface eth0 ofport",
 			Output: "7",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-ofctl show breth0",
+			Output: ovsOFOutput,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-ofctl -O OpenFlow13 --bundle replace-flows breth0 -",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-ofctl show breth0",
+			Output: ovsOFOutput,
 		})
 		// syncServices()
 
@@ -1079,7 +1088,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs,
 				nodeAnnotator, &fakeMgmtPortConfig, k, wf, rm)
 			Expect(err).NotTo(HaveOccurred())
-			err = localGw.Init(wf, stop, wg)
+			err = localGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = nodeAnnotator.Run()
@@ -1134,7 +1143,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
-
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
 
 		expectedTables := map[string]util.FakeTable{

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -848,6 +848,7 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		)
 
 		fexec := ovntest.NewLooseCompareFakeExec()
+
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd: "ovs-vsctl --timeout=15 port-to-br eth0",
 			Err: fmt.Errorf(""),

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -276,9 +276,11 @@ var _ = Describe("Node Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "1.1.1.1"
 				externalIPPort := int32(8032)
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
+				for i := 0; i < 2; i++ {
+					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+						Cmd: "ovs-ofctl show ",
+					})
+				}
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
@@ -631,12 +633,11 @@ var _ = Describe("Node Operations", func() {
 		It("inits iptables rules with LoadBalancer", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "1.1.1.1"
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
+				for i := 0; i < 6; i++ {
+					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+						Cmd: "ovs-ofctl show ",
+					})
+				}
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{
@@ -1312,12 +1313,11 @@ var _ = Describe("Node Operations", func() {
 				clusterIPv4 := "10.129.0.2"
 				clusterIPv6 := "fd00:10:96::10"
 				fNPW.gatewayIPv6 = v6localnetGatewayIP
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
+				for i := 0; i < 6; i++ {
+					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+						Cmd: "ovs-ofctl show ",
+					})
+				}
 
 				service := *newService("service1", "namespace1", clusterIPv4,
 					[]v1.ServicePort{
@@ -1407,10 +1407,11 @@ var _ = Describe("Node Operations", func() {
 		It("deletes iptables rules with ExternalIP", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "1.1.1.1"
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
-
+				for i := 0; i < 2; i++ {
+					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+						Cmd: "ovs-ofctl show ",
+					})
+				}
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{
@@ -1576,9 +1577,11 @@ var _ = Describe("Node Operations", func() {
 		It("manages iptables rules with ExternalIP", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "10.10.10.1"
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ovs-ofctl show ",
-				})
+				for i := 0; i < 3; i++ {
+					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+						Cmd: "ovs-ofctl show ",
+					})
+				}
 				externalIPPort := int32(8034)
 				service := *newService("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{

--- a/go-controller/pkg/node/linkmanager/link_network_manager_test.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager_test.go
@@ -118,7 +118,7 @@ var _ = ginkgo.Describe("Link network manager", func() {
 		nlMock.On("AddrList", nlLink1Mock, getIPFamilyInt(v4Enabled, v6Enabled)).Return(getLinkAddrs(existingLinkAddr, linkName1), nil)
 		nlMock.On("AddrList", nlLink2Mock, getIPFamilyInt(v4Enabled, v6Enabled)).Return(getLinkAddrs(existingLinkAddr, linkName2), nil)
 		nlMock.On("AddrAdd", nlLink1Mock, &expectedAddr).Return(nil)
-		c = NewController("test", v4Enabled, v6Enabled)
+		c = NewController("test", v4Enabled, v6Enabled, nil)
 		c.store = existingStore
 		err := c.AddAddress(addrToAdd)
 		expectedResMatcher := gomega.Succeed()
@@ -169,7 +169,7 @@ var _ = ginkgo.Describe("Link network manager", func() {
 		nlMock.On("AddrList", nlLink1Mock, getIPFamilyInt(v4Enabled, v6Enabled)).Return(getLinkAddrs(existingLinkAddr, linkName1), nil)
 		nlMock.On("AddrList", nlLink2Mock, getIPFamilyInt(v4Enabled, v6Enabled)).Return(getLinkAddrs(existingLinkAddr, linkName2), nil)
 		nlMock.On("AddrDel", nlLink1Mock, &expectedAddr).Return(nil)
-		c = NewController("test", v4Enabled, v6Enabled)
+		c = NewController("test", v4Enabled, v6Enabled, nil)
 		c.store = existingStore
 		err := c.DelAddress(addrToDel)
 		expectedResMatcher := gomega.Succeed()

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -29,6 +29,38 @@ type openflowManager struct {
 	flowChan chan struct{}
 }
 
+func (c *openflowManager) getDefaultBridgePorts() (string, string, string, string) {
+	c.defaultBridge.Lock()
+	defer c.defaultBridge.Unlock()
+	return c.defaultBridge.patchPort, c.defaultBridge.ofPortPatch,
+		c.defaultBridge.uplinkName, c.defaultBridge.ofPortPhys
+}
+
+func (c *openflowManager) getExGwBridgePorts() (string, string, string, string) {
+	c.externalGatewayBridge.Lock()
+	defer c.externalGatewayBridge.Unlock()
+	return c.externalGatewayBridge.patchPort, c.externalGatewayBridge.ofPortPatch,
+		c.externalGatewayBridge.uplinkName, c.externalGatewayBridge.ofPortPhys
+}
+
+func (c *openflowManager) getDefaultBridgeName() string {
+	c.defaultBridge.Lock()
+	defer c.defaultBridge.Unlock()
+	return c.defaultBridge.bridgeName
+}
+
+func (c *openflowManager) getDefaultBridgeMAC() net.HardwareAddr {
+	c.defaultBridge.Lock()
+	defer c.defaultBridge.Unlock()
+	return c.defaultBridge.macAddress
+}
+
+func (c *openflowManager) setDefaultBridgeMAC(macAddr net.HardwareAddr) {
+	c.defaultBridge.Lock()
+	defer c.defaultBridge.Unlock()
+	c.defaultBridge.macAddress = macAddr
+}
+
 func (c *openflowManager) updateFlowCacheEntry(key string, flows []string) {
 	c.flowMutex.Lock()
 	defer c.flowMutex.Unlock()
@@ -75,6 +107,9 @@ func (c *openflowManager) syncFlows() {
 	}
 
 	if c.externalGatewayBridge != nil {
+		c.externalGatewayBridge.Lock()
+		defer c.externalGatewayBridge.Unlock()
+
 		c.exGWFlowMutex.Lock()
 		defer c.exGWFlowMutex.Unlock()
 
@@ -90,8 +125,35 @@ func (c *openflowManager) syncFlows() {
 	}
 }
 
-// checkDefaultOpenFlow checks for the existence of default OpenFlow rules and
-// exits if the output is not as expected
+// since we share the host's k8s node IP, add OpenFlow flows
+// -- to steer the NodePort traffic arriving on the host to the OVN logical topology and
+// -- to also connection track the outbound north-south traffic through l3 gateway so that
+//
+//	the return traffic can be steered back to OVN logical topology
+//
+// -- to handle host -> service access, via masquerading from the host to OVN GR
+// -- to handle external -> service(ExternalTrafficPolicy: Local) -> host access without SNAT
+func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, subnets []*net.IPNet, extraIPs []net.IP) (*openflowManager, error) {
+	// add health check function to check default OpenFlow flows are on the shared gateway bridge
+	ofm := &openflowManager{
+		defaultBridge:         gwBridge,
+		externalGatewayBridge: exGWBridge,
+		flowCache:             make(map[string][]string),
+		flowMutex:             sync.Mutex{},
+		exGWFlowCache:         make(map[string][]string),
+		exGWFlowMutex:         sync.Mutex{},
+		flowChan:              make(chan struct{}, 1),
+	}
+
+	if err := ofm.updateBridgeFlowCache(subnets, extraIPs); err != nil {
+		return nil, err
+	}
+
+	// defer flowSync until syncService() to prevent the existing service OpenFlows being deleted
+	return ofm, nil
+}
+
+// Run starts OpenFlow Manager which will constantly sync flows for managed OVS bridges
 func (c *openflowManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) {
 	doneWg.Add(1)
 	go func() {
@@ -102,15 +164,14 @@ func (c *openflowManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) 
 		for {
 			select {
 			case <-timer.C:
-				if err := checkPorts(c.defaultBridge.patchPort, c.defaultBridge.ofPortPatch,
-					c.defaultBridge.uplinkName, c.defaultBridge.ofPortPhys); err != nil {
+
+				if err := checkPorts(c.getDefaultBridgePorts()); err != nil {
 					klog.Errorf("Checkports failed %v", err)
 					continue
 				}
+
 				if c.externalGatewayBridge != nil {
-					if err := checkPorts(
-						c.externalGatewayBridge.patchPort, c.externalGatewayBridge.ofPortPatch,
-						c.externalGatewayBridge.uplinkName, c.externalGatewayBridge.ofPortPhys); err != nil {
+					if err := checkPorts(c.getExGwBridgePorts()); err != nil {
 						klog.Errorf("Checkports failed %v", err)
 						continue
 					}
@@ -124,6 +185,43 @@ func (c *openflowManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) 
 			}
 		}
 	}()
+}
+
+// updateBridgeFlowCache generates the "static" per-bridge flows
+// note: this is shared between shared and local gateway modes
+func (c *openflowManager) updateBridgeFlowCache(subnets []*net.IPNet, extraIPs []net.IP) error {
+	// protect defaultBridge config from being updated by gw.nodeIPManager
+	c.defaultBridge.Lock()
+	defer c.defaultBridge.Unlock()
+
+	// CAUTION: when adding new flows where the in_port is ofPortPatch and the out_port is ofPortPhys, ensure
+	// that dl_src is included in match criteria!
+
+	dftFlows, err := flowsForDefaultBridge(c.defaultBridge, extraIPs)
+	if err != nil {
+		return err
+	}
+	dftCommonFlows, err := commonFlows(subnets, c.defaultBridge)
+	if err != nil {
+		return err
+	}
+	dftFlows = append(dftFlows, dftCommonFlows...)
+
+	c.updateFlowCacheEntry("NORMAL", []string{fmt.Sprintf("table=0,priority=0,actions=%s\n", util.NormalAction)})
+	c.updateFlowCacheEntry("DEFAULT", dftFlows)
+
+	// we consume ex gw bridge flows only if that is enabled
+	if c.externalGatewayBridge != nil {
+		c.externalGatewayBridge.Lock()
+		defer c.externalGatewayBridge.Unlock()
+		c.updateExBridgeFlowCacheEntry("NORMAL", []string{fmt.Sprintf("table=0,priority=0,actions=%s\n", util.NormalAction)})
+		exGWBridgeDftFlows, err := commonFlows(subnets, c.externalGatewayBridge)
+		if err != nil {
+			return err
+		}
+		c.updateExBridgeFlowCacheEntry("DEFAULT", exGWBridgeDftFlows)
+	}
+	return nil
 }
 
 func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -1,7 +1,13 @@
 package node
 
 import (
+	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"net"
 	"os"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -145,5 +151,93 @@ func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
 			physIntf, ofPortPhys, curOfportPhys)
 		os.Exit(1)
 	}
+	return nil
+}
+
+// bootstrapOVSFlows handles ensuring basic, required flows are in place. This is done before OpenFlow manager has
+// been created/started, and only done when there is just a NORMAL flow programmed and OVN/OVS is already setup
+func bootstrapOVSFlows() error {
+	// see if patch port exists already
+	var portsOutput string
+	var stderr string
+	var err error
+	if portsOutput, stderr, err = util.RunOVSVsctl("--no-heading", "--data=bare", "--format=csv", "--columns",
+		"name", "list", "interface"); err != nil {
+		// bridge exists, but could not list ports
+		return fmt.Errorf("failed to list ports on existing bridge br-int: %s, %w", stderr, err)
+	}
+
+	var bridge string
+	var patchPort string
+	// patch-br-int-to-<bridge name>_<node>
+	r := regexp.MustCompile("^patch-(.*)_.*?-to-br-int$")
+	for _, line := range strings.Split(portsOutput, "\n") {
+		matches := r.FindStringSubmatch(line)
+		if len(matches) == 2 {
+			patchPort = matches[0]
+			bridge = matches[1]
+			break
+		}
+	}
+
+	if len(bridge) == 0 {
+		// bridge exists but no patch port was found
+		return nil
+	}
+
+	// get the current flows and if there is more than just default flow, we dont need to bootstrap as we already
+	// have flows
+	flows, err := util.GetOFFlows(bridge)
+	if err != nil {
+		return err
+	}
+	if len(flows) > 1 {
+		// more than 1 flow, assume the OVS has retained previous flows from previous running OVNK instance
+		return nil
+	}
+
+	// only have 1 flow, need to install required flows
+	klog.Infof("Default NORMAL flow installed on OVS bridge: %s, will bootstrap with required port security flows", bridge)
+
+	// Get ofport of patchPort
+	ofportPatch, stderr, err := util.GetOVSOfPort("get", "Interface", patchPort, "ofport")
+	if err != nil {
+		return fmt.Errorf("failed while waiting on patch port %q to be created by ovn-controller and "+
+			"while getting ofport. stderr: %q, error: %v", patchPort, stderr, err)
+	}
+
+	var bridgeMACAddress net.HardwareAddr
+	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		hostRep, err := util.GetDPUHostInterface(bridge)
+		if err != nil {
+			return err
+		}
+		bridgeMACAddress, err = util.GetSriovnetOps().GetRepresentorPeerMacAddress(hostRep)
+		if err != nil {
+			return err
+		}
+	} else {
+		bridgeMACAddress, err = util.GetOVSPortMACAddress(bridge)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get MAC address for ovs port %s", bridge)
+		}
+	}
+
+	var dftFlows []string
+	// table 0, check packets coming from OVN have the correct mac address. Low priority flows that are a catch all
+	// for non-IP packets that would normally be forwarded with NORMAL action (table 0, priority 0 flow).
+	dftFlows = append(dftFlows,
+		fmt.Sprintf("cookie=%s, priority=10, table=0, in_port=%s, dl_src=%s, actions=output:NORMAL",
+			defaultOpenFlowCookie, ofportPatch, bridgeMACAddress))
+	dftFlows = append(dftFlows,
+		fmt.Sprintf("cookie=%s, priority=9, table=0, in_port=%s, actions=drop",
+			defaultOpenFlowCookie, ofportPatch))
+	dftFlows = append(dftFlows, "priority=0, table=0, actions=output:NORMAL")
+
+	_, stderr, err = util.ReplaceOFFlows(bridge, dftFlows)
+	if err != nil {
+		return fmt.Errorf("failed to add flows, error: %v, stderr, %s, flows: %s", err, stderr, dftFlows)
+	}
+
 	return nil
 }

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -658,7 +658,25 @@ func ReplaceOFFlows(bridgeName string, flows []string) (string, string, error) {
 	return strings.Trim(stdout.String(), "\" \n"), stderr.String(), err
 }
 
-// Get OpenFlow Port names or numbers for a given bridge
+// GetOFFlows gets all the flows from a bridge
+func GetOFFlows(bridgeName string) ([]string, error) {
+	stdout, stderr, err := RunOVSOfctl("dump-flows", bridgeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get flows on bridge %q:, stderr: %q, error: %v",
+			bridgeName, stderr, err)
+	}
+
+	var flows []string
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.Contains(line, "cookie=") {
+			flows = append(flows, strings.TrimSpace(line))
+		}
+	}
+
+	return flows, nil
+}
+
+// GetOpenFlowPorts names or numbers for a given bridge
 func GetOpenFlowPorts(bridgeName string, namedPorts bool) ([]string, error) {
 	stdout, stderr, err := RunOVSOfctl("show", bridgeName)
 	if err != nil {

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -82,13 +82,13 @@ if [ "$ENABLE_MULTI_NET" != "true" ]; then
   SKIPPED_TESTS+="Multi Homing"
 fi
 
-# Only run Node IP address migration tests if they are explicitly requested
-IP_MIGRATION_TESTS="Node IP address migration"
+# Only run Node IP/MAC address migration tests if they are explicitly requested
+IP_MIGRATION_TESTS="Node IP and MAC address migration"
 if [ "${WHAT}" != "${IP_MIGRATION_TESTS}" ]; then
   if [ "$SKIPPED_TESTS" != "" ]; then
 	SKIPPED_TESTS+="|"
   fi
-  SKIPPED_TESTS+="Node IP address migration"
+  SKIPPED_TESTS+="Node IP and MAC address migration"
 fi
 
 # Only run Multi node zones interconnect tests if they are explicitly requested


### PR DESCRIPTION
If the MAC changes on the interface used in OVS and the OVS bridge, OVN may still retain the old MAC on its GR. This can cause OVN and the host to both respond with different MACs for the same IP address, leading to network disruption. A common scenario for this is a server with a bond. When the node is rebooted, the bond MAC may change depending on which slave comes up first. When this happens, ovnkube-node starts up and is unable to sync its informers and proceed to full start up, due to disruption with kapi.

Note, this can be avoided by setting the MAC specifically for the bond to always be the mac of the first slave.

This PR adds port security in a sense to the breth0/br-ex bridge. It drops any traffic sent from the OVN patch port that has a MAC other than the one we expect by modifying the flows that OFManager installs. 

Additionally, at start up there can be only a normal flow on the switch. This is common on node reboot. When this happens in the scenario above, ovnkube-node cannot get to the part of the code that starts the OFManager, because it is blocked waiting for the informers to sync. For this purpose, a new bootstrap function is added which will install these basic security flows if only a single flow exists in the bridge at start up.

I looked at moving OFManager to start earlier, but it is tightly coupled with gateway initialization and kapi objects, so rather than introducing a new regression there I created a simple bootstrap function. The bootstrap flows are wiped when OFManager starts and syncs its new flows (which include the security flows anyway).

How to test:
1. Launch kind
2. docker exec -it ovn-worker /bin/bash
3. crictl exec -it <ovs pod> /bin/bash
4. Inside ovs, create flows.txt with the content: priority=0, table=0, actions=output:NORMAL
5. ovs-ofctl -O openflow13 replace-flows breth0 flows.txt
6. quickly crictl stop the ovnkube-node pod
7. ovs-ofctl -O openflow13 replace-flows breth0 flows.txt
8. while true; do echo "##########" >> output.txt && ovs-ofctl -O openflow13 dump-flows breth0 >> output.txt && sleep .5; done
9. check output.txt to see that the bootstrap detected the normal flow correctly and configured the right flows:

```
##########
OFPST_FLOW reply (OF1.3) (xid=0x2): 
 cookie=0x0, duration=686.264s, table=0, n_packets=2142, n_bytes=941544, priority=0 actions=NORMAL
##########
OFPST_FLOW reply (OF1.3) (xid=0x2):
 cookie=0xdeff105, duration=0.203s, table=0, n_packets=0, n_bytes=0, priority=10,in_port=2,dl_src=02:42:ac:12:00:03 actions=NORMAL
 cookie=0xdeff105, duration=0.203s, table=0, n_packets=0, n_bytes=0, priority=9,in_port=2 actions=drop
 cookie=0x0, duration=686.768s, table=0, n_packets=2167, n_bytes=944776, priority=0 actions=NORMAL
##########
OFPST_FLOW reply (OF1.3) (xid=0x2): 
 cookie=0xdeff105, duration=0.429s, table=0, n_packets=0, n_bytes=0, priority=500,ip,in_port=2,nw_src=172.18.0.3,nw_dst=169.254.169.2 actions=ct(commit,table=4,zone=64001,nat(dst=172.18.0.3))
 cookie=0xdeff105, duration=0.429s, table=0, n_packets=0, n_bytes=0, priority=500,ip,in_port=LOCAL,nw_dst=169.254.169.1 actions=ct(table=5,zone=64002,nat)
 cookie=0xdeff105, duration=0.429s, table=0, n_packets=0, n_bytes=0, priority=500,ip,in_port=LOCAL,nw_dst=10.96.0.0/16 actions=ct(commit,table=2,zone=64001,nat(src=169.254.169.2))
 cookie=0xdeff105, duration=0.429s, table=0, n_packets=0, n_bytes=0, priority=105,ip,in_port=2,nw_dst=10.96.0.0/16 actions=drop
 cookie=0xdeff105, duration=0.429s, table=0, n_packets=0, n_bytes=0, priority=500,ip,in_port=2,nw_src=10.96.0.0/16,nw_dst=169.254.169.2 actions=ct(table=3,zone=64001,nat)
 cookie=0xdeff105, duration=0.429s, table=0, n_packets=0, n_bytes=0, priority=205,udp,in_port=1,dl_dst=02:42:ac:12:00:03,tp_dst=6081 actions=LOCAL
 cookie=0xdeff105, duration=0.429s, table=0, n_packets=0, n_bytes=0, priority=200,udp,in_port=1,tp_dst=6081 actions=NORMAL
 cookie=0xdeff105, duration=0.429s, table=0, n_packets=0, n_bytes=0, priority=200,udp,in_port=LOCAL,tp_dst=6081 actions=output:1

```