### PR TITLE
kubevirt: Ignore completed virt-launcher pods

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -123,11 +123,14 @@ func EnsurePodAnnotationForVM(watchFactory *factory.WatchFactory, kube *kube.Kub
 	return podAnnotation, nil
 }
 
-// IsMigratedSourcePodStale return true if there are other pods related to
-// to it and any of them has newer creation timestamp.
+// IsMigratedSourcePodStale return false if the pod is live migratable,
+// not completed and is the running VM pod with newest creation timestamp
 func IsMigratedSourcePodStale(client *factory.WatchFactory, pod *corev1.Pod) (bool, error) {
 	if !IsPodLiveMigratable(pod) {
 		return false, nil
+	}
+	if util.PodCompleted(pod) {
+		return true, nil
 	}
 	vmPods, err := findVMRelatedPods(client, pod)
 	if err != nil {


### PR DESCRIPTION

**- What this PR does and why is it needed**
When a live migration fails at completed virt-launcher pod with newer
creation timestamp is lingering in the system so the virt-launcher that
is really running the VM is hidden by it and routes are wrongly
reconstructed. This change take into account if the pod is completed to
ignore it marking it as stale.

Closes https://issues.redhat.com/browse/OCPBUGS-22767

**- How to verify it**
It includes a unit test that emulate the result of failing migration, completed virt-launcher pod with newer creation timestamp.


**- Description for the changelog**
kubevirt: Ignore completed virt-launcher pods
