### PR TITLE
APB External Route: Add IP validation in CR schema for static hop IP

### DIFF
--- a/dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
+++ b/dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
@@ -248,6 +248,7 @@ spec:
                         ip:
                           description: IP defines the static IP to be used for egress
                             traffic. The IP can be either IPv4 or IPv6.
+                          format: ip
                           type: string
                       required:
                       - ip

--- a/go-controller/pkg/crd/adminpolicybasedroute/v1/types.go
+++ b/go-controller/pkg/crd/adminpolicybasedroute/v1/types.go
@@ -67,6 +67,7 @@ type ExternalNextHops struct {
 type StaticHop struct {
 	//IP defines the static IP to be used for egress traffic. The IP can be either IPv4 or IPv6.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Format=ip
 	// +required
 	IP string `json:"ip"`
 	// BFDEnabled determines if the interface implements the Bidirectional Forward Detection protocol. Defaults to false.


### PR DESCRIPTION
Adds IP validation for the static hop IP field in the schema.

@trozet @npinaeva @jcaamano PTAL.

/Jordi