### PR TITLE
Prevent multiple encap-ips per single chassis

### DIFF
--- a/go-controller/pkg/libovsdb/ops/chassis.go
+++ b/go-controller/pkg/libovsdb/ops/chassis.go
@@ -151,7 +151,8 @@ func CreateOrUpdateChassis(sbClient libovsdbclient.Client, chassis *sbdb.Chassis
 		},
 		{
 			Model:            chassis,
-			OnModelMutations: []interface{}{&chassis.OtherConfig, &chassis.Encaps},
+			OnModelMutations: []interface{}{&chassis.OtherConfig},
+			OnModelUpdates:   []interface{}{&chassis.Encaps},
 			ErrNotFound:      false,
 			BulkOp:           false,
 		},


### PR DESCRIPTION
For each chassis, there should only be only 1 encap-ip. However the OVN database allows for multiple encap-ips per chassis. In order to recover from a situation where the database already has an existing encap-ip for a chassis and there is a different encap-ip being added to the chassis; we introduce this fix to use "OnModelUpdates" to override the chassis encaps instead of previously appending to it.

Note: This can happen in the case of the DPU because the DPU can have the incorrect encap-ip stored in the SBDB because converting the cluster to DPU-aware may not be a Day0/1 operation but rather a Day2 operation.
