### PR TITLE
APB: Ensure last transition time is always updated in status regardless of success or failure

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -139,12 +139,12 @@ func (c *ExternalGatewayMasterController) GetStaticGatewayIPsForTargetNamespace(
 }
 
 func updateStatus(route *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute, gwIPs string, err error) {
+	route.Status.LastTransitionTime = metav1.Time{Time: time.Now()}
 	if err != nil {
 		route.Status.Status = adminpolicybasedrouteapi.FailStatus
 		route.Status.Messages = append(route.Status.Messages, fmt.Sprintf("Failed to apply policy: %v", err.Error()))
 		return
 	}
-	route.Status.LastTransitionTime = metav1.Time{Time: time.Now()}
 	route.Status.Status = adminpolicybasedrouteapi.SuccessStatus
 	route.Status.Messages = append(route.Status.Messages, fmt.Sprintf("Configured external gateway IPs: %s", gwIPs))
 	klog.V(4).Infof("Updating Admin Policy Based External Route %s with Status: %s, Message: %s", route.Name, route.Status.Status, route.Status.Messages[len(route.Status.Messages)-1])


### PR DESCRIPTION
When an APB fails to apply, the status fails to update because the `LastTransitionTime` is nil. The logs show the following:
```
Failed to update AdminPolicyBasedExternalRoutes duplicated-first-policy status: failed to update AdminPolicyBasedExternalRoutes duplicated-first-policy status: AdminPolicyBasedExternalRoute.k8s.ovn.org "duplicated-first-policy" is invalid: [status.lastTransitionTime: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```

I added a new e2e test case to cover this scenario because in the unit tests, the field `LastTransitionTime` comes populated when the object is retrieved by the controller, so it's not possible to reproduce it there.

@npinaeva @trozet @jcaamano PTAL.

With this change, the status now shows correctly even when failed:
```bash
$> oc get apbexternalroute
NAME         LAST UPDATE   STATUS
duplicated   9m4s          Fail
valid        20m           Success
```