### PR TITLE
Dockerfile.ubuntu fixes

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -25,7 +25,7 @@ RUN mkdir -p /var/run/openvswitch
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg
 RUN mkdir -p /usr/libexec/cni/
-COPY ovnkube ovn-kube-util ovndbchecker hybrid-overlay-node /usr/bin/
+COPY ovnkube ovn-kube-util ovndbchecker hybrid-overlay-node ovnkube-identity /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 
 # ovnkube.sh is the entry point. This script examines environment

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -8,7 +8,7 @@
 #
 # So this file will change over time.
 
-FROM ubuntu:22.04
+FROM ubuntu:23.10
 
 USER root
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
-->
This PR contains fixes for the dist/image/Dockerfile.ubuntu.
One includes the newly created binary `ovnkube-identity` and another bumps image version to install a newer version of OVN packages

**- Special notes for reviewers**
<!--
-->
Based on commits:
https://github.com/ovn-org/ovn-kubernetes/commit/50a5c60140956e0c4444500f3304784bb1263757
https://github.com/ovn-org/ovn-kubernetes/commit/7dc48048a346f175772fe5c2839b083f7a20c597


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Build and run a docker image based on the Dockefile: dist/image/Dockerfile.ubuntu

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Dockerfile.ubuntu: include ovnkube-identity binary and bump the image version which contain newer OVN packages