### PR TITLE
sriovnet_linux: Make GetVdpaDeviceByPci errors non fatal

### DIFF
--- a/go-controller/pkg/util/sriovnet_linux.go
+++ b/go-controller/pkg/util/sriovnet_linux.go
@@ -158,8 +158,7 @@ func GetNetdevNameFromDeviceId(deviceId string, deviceInfo nadapi.DeviceInfo) (s
 			return vdpaDevice.VirtioNet().NetDev(), nil
 		}
 		if err != nil {
-			klog.Errorf("Error when searching for the virtio/vdpa netdev: ", err)
-			return "", err
+			klog.Warningf("Error when searching for the virtio/vdpa netdev: ", err)
 		}
 
 		netdevices, err = GetSriovnetOps().GetNetDevicesFromPci(deviceId)


### PR DESCRIPTION
If `GetVdpaDeviceByPci` returns an error we should log the result and allow `GetSriovnetOps` to run instead of bailing out.

This patch makes `GetVdpaDeviceByPci()` errors non fatal.

Found while testing on a ConnectX environment.
