### PR TITLE
Add ovnkube_app_name ovnkube node in dpu mode[.yaml]

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -547,6 +547,56 @@ ovn_image=${ovnkube_image} \
   ovnkube_app_name=ovnkube-node \
   jinjanate ../templates/ovnkube-node.yaml.j2 -o ${output_dir}/ovnkube-node.yaml
 
+ovn_image=${ovnkube_image} \
+  ovnkube_compact_mode_enable=${ovnkube_compact_mode_enable} \
+  ovn_image_pull_policy=${image_pull_policy} \
+  ovn_unprivileged_mode=${ovn_unprivileged_mode} \
+  ovn_gateway_mode=${ovn_gateway_mode} \
+  ovn_gateway_opts=${ovn_gateway_opts} \
+  ovn_dummy_gateway_bridge=${ovn_dummy_gateway_bridge} \
+  ovnkube_node_loglevel=${node_loglevel} \
+  ovn_loglevel_controller=${ovn_loglevel_controller} \
+  ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
+  ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
+  ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
+  ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
+  ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_disable_forwarding=${ovn_disable_forwarding} \
+  ovn_encap_port=${ovn_encap_port} \
+  ovn_disable_pkt_mtu_check=${ovn_disable_pkt_mtu_check} \
+  ovn_v4_join_subnet=${ovn_v4_join_subnet} \
+  ovn_v6_join_subnet=${ovn_v6_join_subnet} \
+  ovn_v4_masquerade_subnet=${ovn_v4_masquerade_subnet} \
+  ovn_v6_masquerade_subnet=${ovn_v6_masquerade_subnet} \
+  ovn_multicast_enable=${ovn_multicast_enable} \
+  ovn_admin_network_policy_enable=${ovn_admin_network_policy_enable} \
+  ovn_egress_ip_enable=${ovn_egress_ip_enable} \
+  ovn_egress_ip_healthcheck_port=${ovn_egress_ip_healthcheck_port} \
+  ovn_multi_network_enable=${ovn_multi_network_enable} \
+  ovn_egress_service_enable=${ovn_egress_service_enable} \
+  ovn_ssl_en=${ovn_ssl_en} \
+  ovn_remote_probe_interval=${ovn_remote_probe_interval} \
+  ovn_monitor_all=${ovn_monitor_all} \
+  ovn_ofctrl_wait_before_clear=${ovn_ofctrl_wait_before_clear} \
+  ovn_enable_lflow_cache=${ovn_enable_lflow_cache} \
+  ovn_lflow_cache_limit=${ovn_lflow_cache_limit} \
+  ovn_lflow_cache_limit_kb=${ovn_lflow_cache_limit_kb} \
+  ovn_netflow_targets=${ovn_netflow_targets} \
+  ovn_sflow_targets=${ovn_sflow_targets} \
+  ovn_ipfix_targets=${ovn_ipfix_targets} \
+  ovn_ipfix_sampling=${ovn_ipfix_sampling} \
+  ovn_ipfix_cache_max_flows=${ovn_ipfix_cache_max_flows} \
+  ovn_ipfix_cache_active_timeout=${ovn_ipfix_cache_active_timeout} \
+  ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
+  ovn_disable_ovn_iface_id_ver=${ovn_disable_ovn_iface_id_ver} \
+  ovnkube_node_mgmt_port_netdev=${ovnkube_node_mgmt_port_netdev} \
+  ovn_enable_interconnect=${ovn_enable_interconnect} \
+  ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
+  ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
+  ovnkube_app_name=ovnkube-node-dpu \
+  jinjanate ../templates/ovnkube-node.yaml.j2 -o ${output_dir}/ovnkube-node-dpu.yaml
+
 # ovnkube node for dpu-host daemonset
 # TODO: we probably dont need all of these when running on dpu host
 ovn_image=${image} \

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -87,7 +87,7 @@ spec:
         - mountPath: /var/run/netns
           name: host-netns
           mountPropagation: Bidirectional
-       {%- if ovnkube_app_name=="ovnkube-node" %}
+       {%- if ovnkube_app_name!="ovnkube-node-dpu-host" %}
         # ovnkube-node only mounts (non dpu related)
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
@@ -102,7 +102,7 @@ spec:
         - mountPath: /etc/ovn/
           name: host-var-lib-ovs
           readOnly: true
-        {%- elif ovnkube_app_name=="ovnkube-node-dpu-host" %}
+        {%- else %}
         # ovnkube-node dpu-host mounts
         - mountPath: /var/run/ovn
           name: var-run-ovn
@@ -209,7 +209,7 @@ spec:
           value: "{{ ovn_ex_gw_networking_interface }}"
         - name: OVN_ENABLE_OVNKUBE_IDENTITY
           value: "{{ ovn_enable_ovnkube_identity }}"
-        {% if ovnkube_app_name=="ovnkube-node" -%}
+        {% if ovnkube_app_name!="ovnkube-node-dpu-host" -%}
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
         - name: OVN_DISABLE_OVN_IFACE_ID_VER
@@ -236,6 +236,10 @@ spec:
         {% if ovnkube_app_name=="ovnkube-node-dpu-host" -%}
         - name: OVNKUBE_NODE_MODE
           value: "dpu-host"
+        {% endif -%}
+        {% if ovnkube_app_name=="ovnkube-node-dpu" -%}
+        - name: OVNKUBE_NODE_MODE
+          value: "dpu"
         {% endif -%}
         - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
           value: "{{ ovnkube_node_mgmt_port_netdev }}"
@@ -359,6 +363,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
         k8s.ovn.org/dpu-host: ""
+      {% elif ovnkube_app_name=="ovnkube-node-dpu" -%}
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        k8s.ovn.org/dpu: ""
       {% else -%}
       nodeSelector:
         kubernetes.io/os: "linux"
@@ -368,6 +376,8 @@ spec:
             nodeSelectorTerms:
             - matchExpressions:
               - key: k8s.ovn.org/dpu-host
+                operator: DoesNotExist
+              - key: k8s.ovn.org/dpu
                 operator: DoesNotExist
       {% endif -%}
       volumes:
@@ -396,7 +406,7 @@ spec:
       - name: host-netns
         hostPath:
           path: /var/run/netns
-      {%- if ovnkube_app_name=="ovnkube-node" %}
+      {%- if ovnkube_app_name!="ovnkube-node-dpu-host" %}
       # non DPU related volumes
       - name: host-var-log-ovs
         hostPath:
@@ -417,7 +427,7 @@ spec:
       - name: host-etc-ovs
         hostPath:
           path: /etc/openvswitch
-      {%- elif ovnkube_app_name=="ovnkube-node-dpu-host" %}
+      {%- else %}
       - name: var-run-ovn
         emptyDir: {}
       {%- endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR introduces a new `ovnkube_app_name`: `ovnkube-node-dpu` together with its corresponding yaml.
This helps deployment on DPU nodes, allowing custom variables to be defined only for that specific mode.


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Deploy ovn-kubernetes over a Kubernetes cluster that has a DPU node. 