### PR TITLE
ovnkube-node: Make service conntrack zone configurable

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -93,6 +93,7 @@ fi
 # OVN_METRICS_WORKER_PORT - metrics port which will be exposed by ovnkube-node (default 9410)
 # OVN_METRICS_BIND_PORT - port for the OVN metrics server to serve on (default 9476)
 # OVN_METRICS_EXPORTER_PORT - ovs-metrics exporter port (default 9310)
+# OVN_KUBERNETES_CONNTRACK_ZONE - Conntrack zone number used for openflow rules (default 64000)
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -290,6 +291,8 @@ ovnkube_config_duration_enable=${OVNKUBE_CONFIG_DURATION_ENABLE:-false}
 ovnkube_metrics_scale_enable=${OVNKUBE_METRICS_SCALE_ENABLE:-false}
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node
 ovn_encap_ip=${OVN_ENCAP_IP:-}
+# OVN_KUBERNETES_CONNTRACK_ZONE - conntrack zone number used for openflow rules (default 64000)
+ovn_conntrack_zone=${OVN_KUBERNETES_CONNTRACK_ZONE:-64000}
 
 ovn_ex_gw_network_interface=${OVN_EX_GW_NETWORK_INTERFACE:-}
 # OVNKUBE_COMPACT_MODE_ENABLE indicate if ovnkube run master and node in one process
@@ -599,6 +602,7 @@ display_env() {
   echo OVN_DAEMONSET_VERSION ${ovn_daemonset_version}
   echo OVNKUBE_NODE_MODE ${ovnkube_node_mode}
   echo OVN_ENCAP_IP ${ovn_encap_ip}
+  echo OVN_KUBERNETES_CONNTRACK_ZONE ${ovn_conntrack_zone}
   echo ovnkube.sh version ${ovnkube_version}
   echo OVN_HOST_NETWORK_NAMESPACE ${ovn_host_network_namespace}
 }
@@ -2395,6 +2399,12 @@ ovn-node() {
   fi
   echo "ovnkube_node_certs_flags=${ovnkube_node_certs_flags}"
 
+  ovn_conntrack_zone_flag=
+  if [[ ${ovn_conntrack_zone} != "" ]]; then
+     ovn_conntrack_zone_flag="--conntrack-zone=${ovn_conntrack_zone}"
+  fi
+  echo "ovn_conntrack_zone_flag=${ovn_conntrack_zone_flag}"
+
   echo "=============== ovn-node   --init-node"
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
         ${anp_enabled_flag} \
@@ -2420,6 +2430,7 @@ ovn-node() {
         ${ovn_dbs} \
         ${ovn_encap_ip_flag} \
         ${ovn_encap_port_flag} \
+        ${ovn_conntrack_zone_flag} \
         ${ovnkube_enable_interconnect_flag} \
         ${ovnkube_enable_multi_external_gateway_flag} \
         ${ovnkube_metrics_tls_opts} \

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -57,11 +57,13 @@ const (
 	ovnKubeNodeSNATMark = "0x3f0"
 )
 
-var (
-	HostMasqCTZone     = config.Default.ConntrackZone + 1 //64001
-	OVNMasqCTZone      = HostMasqCTZone + 1               //64002
-	HostNodePortCTZone = config.Default.ConntrackZone + 3 //64003
-)
+var HostMasqCTZone, OVNMasqCTZone, HostNodePortCTZone, HostXDPCTZone int
+
+func initCTZones() {
+	HostMasqCTZone = util.GetConntrackZone() + 1
+	OVNMasqCTZone = util.GetConntrackZone() + 2
+	HostNodePortCTZone = util.GetConntrackZone() + 3
+}
 
 // nodePortWatcherIptables manages iptables rules for shared gateway
 // to ensure that services using NodePorts are accessible.
@@ -1691,6 +1693,8 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 	watchFactory factory.NodeWatchFactory, routeManager *routemanager.Controller) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
+	klog.Info("Initializing the ovn-kubernetes conntrack zones")
+	initCTZones()
 
 	gwBridge, exGwBridge, err := gatewayInitInternal(
 		nodeName, gwIntf, egressGWIntf, gwNextHops, gwIPs, nodeAnnotator)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -906,3 +906,7 @@ func IsHostEndpoint(endpointIPstr string) bool {
 	}
 	return true
 }
+
+func GetConntrackZone() int {
+	return config.Default.ConntrackZone
+}


### PR DESCRIPTION
Ovnkube allows the service conntrack zone to be configurable.

This PR exposes that flag via ovnkube.sh

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR is needed to allow two instances of `ovnkube-node`  to run on the same node.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Setup a Kubernetes cluster with ovn-kubernetes and set `OVN_KUBERNETES_CONNTRACK_ZONE` in ovnkube-node yaml to a different value than `64000`
