### PR TITLE
go-controller/Makefile: Fix make check on Ubuntu

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -26,7 +26,7 @@ OVN_SCHEMA_VERSION ?= v23.06.0
 ifeq ($(NOROOT),TRUE)
 C_ARGS = -e NOROOT=TRUE
 else
-C_ARGS = --cap-add=NET_ADMIN --cap-add=SYS_ADMIN
+C_ARGS = --cap-add=NET_ADMIN --cap-add=SYS_ADMIN --privileged
 endif
 export NOROOT
 


### PR DESCRIPTION
Running make check as root on Ubuntu 22.04, make complains with the following:


  /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/gateway_init_linux_test.go:1387                                                        [42/9265]    sets up a shared interface gateway DPU host
    /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/testing.go:18

    Unexpected error:
        <*errors.errorString | 0xc000c0be50>:
        mount --make-rshared /var/run/netns failed: "permission denied"
        {
            s: "mount --make-rshared /var/run/netns failed: \"permission denied\"",
        }
    occurred

This patch runs container in privileged mode to overcome all permissions.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->