### PR TITLE
Significantly reduce shared informer memory usage

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -57,6 +57,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	knet "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -191,6 +192,23 @@ func NewMasterWatchFactory(ovnClientset *util.OVNMasterClientset) (*WatchFactory
 	return wf, nil
 }
 
+// Informer transform to trim object fields for memory efficiency.
+func informerObjectTrim(obj interface{}) (interface{}, error) {
+	if accessor, err := meta.Accessor(obj); err == nil {
+		accessor.SetManagedFields(nil)
+	}
+	if pod, ok := obj.(*kapi.Pod); ok {
+		pod.Spec.Volumes = []kapi.Volume{}
+		for i := range pod.Spec.Containers {
+			pod.Spec.Containers[i].Command = nil
+			pod.Spec.Containers[i].Args = nil
+			pod.Spec.Containers[i].Env = nil
+			pod.Spec.Containers[i].VolumeMounts = nil
+		}
+	}
+	return obj, nil
+}
+
 // NewOVNKubeControllerWatchFactory initializes a new watch factory for the ovnkube controller process
 func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClientset) (*WatchFactory, error) {
 	// resync time is 12 hours, none of the resources being watched in ovn-kubernetes have
@@ -200,7 +218,7 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 	// the downside of making it tight (like 10 minutes) is needless spinning on all resources
 	// However, AddEventHandlerWithResyncPeriod can specify a per handler resync period
 	wf := &WatchFactory{
-		iFactory:             informerfactory.NewSharedInformerFactory(ovnClientset.KubeClient, resyncInterval),
+		iFactory:             informerfactory.NewSharedInformerFactoryWithOptions(ovnClientset.KubeClient, resyncInterval, informerfactory.WithTransform(informerObjectTrim)),
 		anpFactory:           anpinformerfactory.NewSharedInformerFactory(ovnClientset.ANPClient, resyncInterval),
 		eipFactory:           egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
 		efFactory:            egressfirewallinformerfactory.NewSharedInformerFactory(ovnClientset.EgressFirewallClient, resyncInterval),
@@ -427,7 +445,7 @@ func (wf *WatchFactory) Start() error {
 // of the localPodSelector or figure out how to deal with selecting all pods everywhere.
 func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (*WatchFactory, error) {
 	wf := &WatchFactory{
-		iFactory:             informerfactory.NewSharedInformerFactory(ovnClientset.KubeClient, resyncInterval),
+		iFactory:             informerfactory.NewSharedInformerFactoryWithOptions(ovnClientset.KubeClient, resyncInterval, informerfactory.WithTransform(informerObjectTrim)),
 		egressServiceFactory: egressserviceinformerfactory.NewSharedInformerFactory(ovnClientset.EgressServiceClient, resyncInterval),
 		eipFactory:           egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
 		apbRouteFactory:      adminbasedpolicyinformerfactory.NewSharedInformerFactory(ovnClientset.AdminPolicyRouteClient, resyncInterval),
@@ -545,7 +563,7 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 // mode process.
 func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset) (*WatchFactory, error) {
 	wf := &WatchFactory{
-		iFactory:             informerfactory.NewSharedInformerFactory(ovnClientset.KubeClient, resyncInterval),
+		iFactory:             informerfactory.NewSharedInformerFactoryWithOptions(ovnClientset.KubeClient, resyncInterval, informerfactory.WithTransform(informerObjectTrim)),
 		eipFactory:           egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
 		cpipcFactory:         ocpcloudnetworkinformerfactory.NewSharedInformerFactory(ovnClientset.CloudNetworkClient, resyncInterval),
 		egressServiceFactory: egressserviceinformerfactory.NewSharedInformerFactoryWithOptions(ovnClientset.EgressServiceClient, resyncInterval),

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -2085,6 +2085,8 @@ var _ = Describe("Watch Factory Operations", func() {
 			})
 
 		pods = append(pods, pod)
+		podCopy := pod.DeepCopy()
+		podCopy2 := pod.DeepCopy()
 
 		// Pod doesn't pass filter; shouldn't be added
 		podWatch.Add(pod)
@@ -2093,7 +2095,6 @@ var _ = Describe("Watch Factory Operations", func() {
 		// Update pod to pass filter; should be treated as add.  Need
 		// to deep-copy pod when modifying because it's a pointer all
 		// the way through when using FakeClient
-		podCopy := pod.DeepCopy()
 		podCopy.ObjectMeta.Labels["blah"] = "foobar"
 		pods = []*v1.Pod{podCopy}
 		equalPod = podCopy
@@ -2101,8 +2102,8 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(c.getAdded, 2).Should(Equal(1))
 
 		// Update pod to fail filter; should be treated as delete
-		pod.ObjectMeta.Labels["blah"] = "baz"
-		podWatch.Modify(pod)
+		podCopy2.ObjectMeta.Labels["blah"] = "baz"
+		podWatch.Modify(podCopy2)
 		Eventually(c.getDeleted, 2).Should(Equal(1))
 		Consistently(c.getAdded, 2).Should(Equal(1))
 		Consistently(c.getUpdated, 2).Should(Equal(0))

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	ref "k8s.io/client-go/tools/reference"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -420,33 +419,6 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 	}
 
 	return bnc.lsManager.AddOrUpdateSwitch(logicalSwitch.Name, hostSubnets, migratableIPsByPod...)
-}
-
-// UpdateNodeAnnotationWithRetry update node's annotation with the given node annotations.
-func (cnci *CommonNetworkControllerInfo) UpdateNodeAnnotationWithRetry(nodeName string,
-	nodeAnnotations map[string]string) error {
-	// Retry if it fails because of potential conflict which is transient. Return error in the
-	// case of other errors (say temporary API server down), and it will be taken care of by the
-	// retry mechanism.
-	resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		// Informer cache should not be mutated, so get a copy of the object
-		node, err := cnci.watchFactory.GetNode(nodeName)
-		if err != nil {
-			return err
-		}
-
-		cnode := node.DeepCopy()
-		for k, v := range nodeAnnotations {
-			cnode.Annotations[k] = v
-		}
-		// It is possible to update the node annotations using status subresource
-		// because changes to metadata via status subresource are not restricted for nodes.
-		return cnci.kube.UpdateNodeStatus(cnode)
-	})
-	if resultErr != nil {
-		return fmt.Errorf("failed to update node %s annotation", nodeName)
-	}
-	return nil
 }
 
 // deleteNodeLogicalNetwork removes the logical switch and logical router port associated with the node

--- a/go-controller/vendor/k8s.io/client-go/informers/factory.go
+++ b/go-controller/vendor/k8s.io/client-go/informers/factory.go
@@ -60,6 +60,7 @@ type sharedInformerFactory struct {
 	lock             sync.Mutex
 	defaultResync    time.Duration
 	customResync     map[reflect.Type]time.Duration
+	transform        cache.TransformFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -94,6 +95,14 @@ func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFu
 func WithNamespace(namespace string) SharedInformerOption {
 	return func(factory *sharedInformerFactory) *sharedInformerFactory {
 		factory.namespace = namespace
+		return factory
+	}
+}
+
+// WithTransform sets a transform on all informers.
+func WithTransform(transform cache.TransformFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.transform = transform
 		return factory
 	}
 }
@@ -202,6 +211,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	}
 
 	informer = newFunc(f.client, resyncPeriod)
+	informer.SetTransform(f.transform)
 	f.informers[informerType] = informer
 
 	return informer


### PR DESCRIPTION
Kubernetes client-go v0.29 (not yet released) adds a WithTransform() option to shared informer factories that lets callers modify objects before they are added to the cache. Since we cache lots of objects (every pod, service, endpoint, node, etc) we can nil out a bunch of fields we don't care about, and save a lot of memory. This reduces ovn-kube memory usage by about 30% at high scale (250 nodes, 60,000 pods, 30,000 services)

The only catch is we need to carry a client-go patch until we can bump to v0.29 next year. But it's really small.