### PR TITLE
Use /usr/sbin/iptables instead of /sbin/iptables

### DIFF
--- a/dist/images/iptables-scripts/iptables
+++ b/dist/images/iptables-scripts/iptables
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /sbin/iptables "$@"
+exec chroot /host /usr/sbin/iptables "$@"

--- a/dist/images/iptables-scripts/iptables-restore
+++ b/dist/images/iptables-scripts/iptables-restore
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /sbin/iptables-restore "$@"
+exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/dist/images/iptables-scripts/iptables-save
+++ b/dist/images/iptables-scripts/iptables-save
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /sbin/iptables-save "$@"
+exec chroot /host /usr/sbin/iptables-save "$@"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

/usr/sbin/iptables is the de facto path for iptables in most distributions. Notably, since kind switched to Debian 11-based images, ovn-kubernetes fails to deploy there because Debian 11 provides iptables *only* in /usr/sbin.

On Ubuntu and Fedora, /sbin and /usr/sbin are the same directory, so iptables is available in both location and nothing changes there. Debian 12 and later also have the same setup.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

Deploy clusters with kind 0.20 with ovn-kubernetes; `ovn-kube-pod` fails to start with

```
failed to start node network manager: failed to start default node network controller: failed to create IPTablesHelper for proto 0: could not get iptables version: exit status 127
```

Applying this fix allows the pod to start.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix deployment on kind and other environments with `iptables` in `/usr/sbin` only.