### PR TITLE
Use /usr/sbin/iptables6 instead of /sbin/iptables6

### DIFF
--- a/dist/images/iptables-scripts/ip6tables
+++ b/dist/images/iptables-scripts/ip6tables
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /sbin/ip6tables "$@"
+exec chroot /host /usr/sbin/ip6tables "$@"

--- a/dist/images/iptables-scripts/ip6tables-restore
+++ b/dist/images/iptables-scripts/ip6tables-restore
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /sbin/ip6tables-restore "$@"
+exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/dist/images/iptables-scripts/ip6tables-save
+++ b/dist/images/iptables-scripts/ip6tables-save
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /sbin/ip6tables-save "$@"
+exec chroot /host /usr/sbin/ip6tables-save "$@"


### PR DESCRIPTION
Same as https://github.com/ovn-org/ovn-kubernetes/pull/4015
This is needed to use KIND 1.20.0 which is needed for the kube 1.28 rebase: https://github.com/ovn-org/ovn-kubernetes/pull/3978