### PR TITLE
Replace j2 for jinjanate

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -440,10 +440,10 @@ command_exists() {
   command -v ${cmd} >/dev/null 2>&1
 }
 
-install_j2_renderer() {
-  # ensure j2 renderer installed
+install_jinjanator_renderer() {
+  # ensure jinjanator renderer installed
   pip install wheel --user
-  pip freeze | grep j2cli || pip install j2cli[yaml] --user
+  pip freeze | grep jinjanator || pip install jinjanator[yaml] --user
   export PATH=~/.local/bin:$PATH
 }
 
@@ -473,13 +473,13 @@ check_dependencies() {
     exit 1
   fi
 
-  if ! command_exists j2 ; then
+  if ! command_exists jinjanate ; then
     if ! command_exists pip ; then
-      echo "Dependency not met: 'j2' not installed and cannot install with 'pip'"
+      echo "Dependency not met: 'jinjanator' not installed and cannot install with 'pip'"
       exit 1
     fi
-    echo "'j2' not found, installing with 'pip'"
-    install_j2_renderer
+    echo "'jinjanate' not found, installing with 'pip'"
+    install_jinjanator_renderer
   fi
 
   if ! command_exists docker && ! command_exists podman; then
@@ -726,7 +726,7 @@ EOF
 }
 
 create_kind_cluster() {
-  # Output of the j2 command
+  # Output of the jinjanate command
   KIND_CONFIG_LCL=${DIR}/kind-${KIND_CLUSTER_NAME}.yaml
 
   ovn_ip_family=${IP_FAMILY} \
@@ -740,7 +740,7 @@ create_kind_cluster() {
   cluster_log_level=${KIND_CLUSTER_LOGLEVEL:-4} \
   kind_local_registry_port=${KIND_LOCAL_REGISTRY_PORT} \
   kind_local_registry_name=${KIND_LOCAL_REGISTRY_NAME} \
-  j2 "${KIND_CONFIG}" -o "${KIND_CONFIG_LCL}"
+  jinjanate "${KIND_CONFIG}" -o "${KIND_CONFIG_LCL}"
 
   # Create KIND cluster. For additional debug, add '--verbosity <int>': 0 None .. 3 Debug
   if kind get clusters | grep ovn; then

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -4,23 +4,23 @@
 #Always exit on errors
 set -e
 
-install_j2_renderer() {
-  # ensure j2 renderer installed
+install_jinjanator_renderer() {
+  # ensure jinjanator renderer installed
   pip install wheel --user
-  pip freeze | grep j2cli || pip install "j2cli[yaml]" --user
+  pip freeze | grep jinjanator || pip install "jinjanator[yaml]" --user
   export PATH=~/.local/bin:$PATH
 }
 
 # The script renders j2 templates into yaml files in ../yaml/
 
-# ensure j2 renderer installed
-if ! command -v j2 >/dev/null 2>&1 ; then
+# ensure jinjanator renderer installed
+if ! command -v jinjanate >/dev/null 2>&1 ; then
   if ! command -v pip >/dev/null 2>&1 ; then
-    echo "Dependency not met: 'j2' not installed and cannot install with 'pip'"
+    echo "Dependency not met: 'jinjanator' not installed and cannot install with 'pip'"
     exit 1
   fi
-  echo "'j2' not found, installing with 'pip'"
-  install_j2_renderer
+  echo "'jinjanate' not found, installing with 'pip'"
+  install_jinjanator_renderer
 fi
 
 OVN_OUTPUT_DIR=""
@@ -545,7 +545,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
   ovnkube_app_name=ovnkube-node \
-  j2 ../templates/ovnkube-node.yaml.j2 -o ${output_dir}/ovnkube-node.yaml
+  jinjanate ../templates/ovnkube-node.yaml.j2 -o ${output_dir}/ovnkube-node.yaml
 
 # ovnkube node for dpu-host daemonset
 # TODO: we probably dont need all of these when running on dpu host
@@ -586,7 +586,7 @@ ovn_image=${image} \
   ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
   ovnkube_node_mgmt_port_netdev=${ovnkube_node_mgmt_port_netdev} \
   ovnkube_app_name=ovnkube-node-dpu-host \
-  j2 ../templates/ovnkube-node.yaml.j2 -o ${output_dir}/ovnkube-node-dpu-host.yaml
+  jinjanate ../templates/ovnkube-node.yaml.j2 -o ${output_dir}/ovnkube-node-dpu-host.yaml
 
 ovn_image=${ovnkube_image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -629,7 +629,7 @@ ovn_image=${ovnkube_image} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
-  j2 ../templates/ovnkube-master.yaml.j2 -o ${output_dir}/ovnkube-master.yaml
+  jinjanate ../templates/ovnkube-master.yaml.j2 -o ${output_dir}/ovnkube-master.yaml
 
 ovn_image=${ovnkube_image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -665,7 +665,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_interconnect=${ovn_enable_interconnect} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
-  j2 ../templates/ovnkube-control-plane.yaml.j2 -o ${output_dir}/ovnkube-control-plane.yaml
+  jinjanate ../templates/ovnkube-control-plane.yaml.j2 -o ${output_dir}/ovnkube-control-plane.yaml
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -675,7 +675,7 @@ ovn_image=${image} \
   ovn_nb_port=${ovn_nb_port} \
   ovn_sb_port=${ovn_sb_port} \
   enable_ipsec=${enable_ipsec} \
-  j2 ../templates/ovnkube-db.yaml.j2 -o ${output_dir}/ovnkube-db.yaml
+  jinjanate ../templates/ovnkube-db.yaml.j2 -o ${output_dir}/ovnkube-db.yaml
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -694,7 +694,7 @@ ovn_image=${image} \
   ovn_nb_raft_port=${ovn_nb_raft_port} \
   ovn_sb_raft_port=${ovn_sb_raft_port} \
   enable_ipsec=${enable_ipsec} \
-  j2 ../templates/ovnkube-db-raft.yaml.j2 -o ${output_dir}/ovnkube-db-raft.yaml
+  jinjanate ../templates/ovnkube-db-raft.yaml.j2 -o ${output_dir}/ovnkube-db-raft.yaml
 
 ovn_image=${ovnkube_image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -750,7 +750,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_interconnect=${ovn_enable_interconnect} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
-  j2 ../templates/ovnkube-single-node-zone.yaml.j2 -o ${output_dir}/ovnkube-single-node-zone.yaml
+  jinjanate ../templates/ovnkube-single-node-zone.yaml.j2 -o ${output_dir}/ovnkube-single-node-zone.yaml
 
 ovn_image=${ovnkube_image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -806,12 +806,12 @@ ovn_image=${ovnkube_image} \
   ovn_enable_interconnect=${ovn_enable_interconnect} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
-  j2 ../templates/ovnkube-zone-controller.yaml.j2 -o ${output_dir}/ovnkube-zone-controller.yaml
+  jinjanate ../templates/ovnkube-zone-controller.yaml.j2 -o ${output_dir}/ovnkube-zone-controller.yaml
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
-  j2 ../templates/ovs-node.yaml.j2 -o ${output_dir}/ovs-node.yaml
+  jinjanate ../templates/ovs-node.yaml.j2 -o ${output_dir}/ovs-node.yaml
 
 ovnkube_certs_dir="/tmp/ovnkube-certs"
 ovnkube_webhook_name="ovnkube-webhook"
@@ -836,11 +836,11 @@ ovn_image=${ovnkube_image} \
   webhook_cert=$(cat "${path_prefix}.crt" | base64 -w0) \
   ovn_enable_multi_node_zone=${ovn_enable_multi_node_zone} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
-  j2 ../templates/ovnkube-identity.yaml.j2 -o ${output_dir}/ovnkube-identity.yaml
+  jinjanate ../templates/ovnkube-identity.yaml.j2 -o ${output_dir}/ovnkube-identity.yaml
 
 if ${enable_ipsec}; then
   ovn_image=${image} \
-    j2 ../templates/ovn-ipsec.yaml.j2 -o ${output_dir}/ovn-ipsec.yaml
+    jinjanate ../templates/ovn-ipsec.yaml.j2 -o ${output_dir}/ovn-ipsec.yaml
 fi
 
 # ovn-setup.yaml
@@ -861,11 +861,11 @@ net_cidr=${net_cidr} svc_cidr=${svc_cidr} \
   mtu_value=${mtu} k8s_apiserver=${k8s_apiserver} \
   host_network_namespace=${host_network_namespace} \
   in_upgrade=${in_upgrade} \
-  j2 ../templates/ovn-setup.yaml.j2 -o ${output_dir}/ovn-setup.yaml
+  jinjanate ../templates/ovn-setup.yaml.j2 -o ${output_dir}/ovn-setup.yaml
 
 ovn_enable_interconnect=${ovn_enable_interconnect} \
 ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
-  j2 ../templates/rbac-ovnkube-node.yaml.j2 -o ${output_dir}/rbac-ovnkube-node.yaml
+  jinjanate ../templates/rbac-ovnkube-node.yaml.j2 -o ${output_dir}/rbac-ovnkube-node.yaml
 
 cp ../templates/rbac-ovnkube-identity.yaml.j2 ${output_dir}/rbac-ovnkube-identity.yaml
 cp ../templates/rbac-ovnkube-master.yaml.j2 ${output_dir}/rbac-ovnkube-master.yaml


### PR DESCRIPTION
Signed-off-by: josecastillolema josecastillolema@gmail.com

**- What this PR does and why is it needed**
j2 dependency uses the [imp module](https://docs.python.org/3/library/imp.html) which has been deprecated since Python 3.4 and removed in 3.12 (see https://github.com/kolypto/j2cli/issues/80).

j2 authors have published  [Jinjanator](https://pypi.org/project/jinjanator/) as the new alternative, which resolves this issue by adding a much more flexible and less invasive plugin mechanism.

Closes https://github.com/ovn-org/ovn-kubernetes/issues/4011


**- How to verify it**
Manually verified on Python 3.12.0.
Should be tested in previous Python versions (guess the CI will already do that?)


**- Description for the changelog**
Python 3.12 support by replacing j2 for jinjanate