### PR TITLE
Add e2e test for DisablePacketMTUCheck

### DIFF
--- a/test/e2e/gateway_mtu.go
+++ b/test/e2e/gateway_mtu.go
@@ -1,0 +1,35 @@
+package e2e
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+var _ = ginkgo.Describe("Check whether gateway-mtu-support annotation on node is set based on disable-pkt-mtu-check value", func() {
+	var nodes *v1.NodeList
+	f := wrappedTestFramework("gateway-mtu-support")
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		ginkgo.By("Get all nodes")
+		nodes, err = e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+	ginkgo.When("DisablePacketMTUCheck is either not set or set to false", func() {
+		ginkgo.It("Verify whether gateway-mtu-support annotation is not set on nodes when DisablePacketMTUCheck is either not set or set to false", func() {
+			if !isDisablePacketMTUCheckEnabled() {
+				for _, node := range nodes.Items {
+					supported := getGatewayMTUSupport(&node)
+					gomega.Expect(supported).To(gomega.Equal(true))
+
+				}
+			} else {
+				ginkgo.Skip("DisablePacketMTUCheck is set to true")
+			}
+		})
+	})
+})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -39,6 +39,8 @@ const (
 	ovnNodeSubnets = "k8s.ovn.org/node-subnets"
 	// ovnNodeZoneNameAnnotation is the node annotation name to store the node zone name.
 	ovnNodeZoneNameAnnotation = "k8s.ovn.org/zone-name"
+	// ovnGatewayMTUSupport annotation determines if options:gateway_mtu shall be set for a node's gateway router
+	ovnGatewayMTUSupport = "k8s.ovn.org/gateway-mtu-support"
 )
 
 var containerRuntime = "docker"
@@ -1220,4 +1222,21 @@ func CaptureContainerOutput(ctx context.Context, c clientset.Interface, namespac
 	}
 
 	return matchMap, nil
+}
+
+// It checks whether config.DisablePacketMTUCheck is set or not
+func isDisablePacketMTUCheckEnabled() bool {
+	val, present := os.LookupEnv("OVN_DISABLE_PKT_MTU_CHECK")
+	return present && val == "true"
+}
+
+// getGatewayMTUSupport returns true if gateway-mtu-support annotataion
+// is not set on the node, otherwise it returns false as the value of the
+// annotation also get set to false
+func getGatewayMTUSupport(node *v1.Node) bool {
+	_, ok := node.Annotations[ovnGatewayMTUSupport]
+	if !ok {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
**- What this PR does and why is it needed**
This e2e test verifies whether 'k8s.ovn.org/gateway-mtu-support' annotation is being added to all nodes and being set to 'false' when `disable-pkt-mtu-check` is set to 'true'. This annotation should be absent from node objects when either `disable-pkt-mtu-check` is unset or set to 'false'.

**- Special notes for reviewers**
closes #3928 


**- How to verify it**
Run control-plane CI test in local kind environment. Make sure to set `OVN_DISABLE_PKT_MTU_CHECK` environment variable to either 'true'  or 'false' while running this test.  


**- Description for the changelog**
- Added gateway_mtu.go containg main test cases
- Added couple of functions in util.go 