### PR TITLE
Reverts setting MTU on GR external port

### DIFF
--- a/go-controller/pkg/clustermanager/zone_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/zone_cluster_controller.go
@@ -384,7 +384,7 @@ func (h *zoneClusterControllerEventHandler) AreResourcesEqual(obj1, obj2 interfa
 	return false, nil
 }
 
-// getResourceFromInformerCache returns the latest state of the object from the informers cache
+// GetResourceFromInformerCache returns the latest state of the object from the informers cache
 // given an object key and its type
 func (h *zoneClusterControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
 	var obj interface{}

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -779,7 +779,7 @@ func (bnc *BaseNetworkController) isLayer2Interconnect() bool {
 }
 
 func (bnc *BaseNetworkController) nodeZoneClusterChanged(oldNode, newNode *kapi.Node, newNodeIsLocalZone bool) bool {
-	// Check if the annotations have changed. Use network topology and local params to skip unecessary checks
+	// Check if the annotations have changed. Use network topology and local params to skip unnecessary checks
 
 	// NodeIDAnnotationChanged and NodeTransitSwitchPortAddrAnnotationChanged affects local and remote nodes
 	if util.NodeIDAnnotationChanged(oldNode, newNode) {

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -266,8 +266,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 		l3GatewayConfig.MACAddress.String(),
 		types.PhysicalNetworkName,
 		l3GatewayConfig.IPAddresses,
-		l3GatewayConfig.VLANID,
-		enableGatewayMTU); err != nil {
+		l3GatewayConfig.VLANID); err != nil {
 		return err
 	}
 
@@ -279,8 +278,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 			l3GatewayConfig.EgressGWMACAddress.String(),
 			types.PhysicalNetworkExGwName,
 			l3GatewayConfig.EgressGWIPAddresses,
-			nil,
-			enableGatewayMTU); err != nil {
+			nil); err != nil {
 			return err
 		}
 	}
@@ -483,10 +481,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 
 // addExternalSwitch creates a switch connected to the external bridge and connects it to
 // the gateway router
-// enableGatewayMTU enables options:gateway_mtu for gateway routers. Setting it on
-// the external ports of the GR will mimic the older behaviour of using br-ex flows
-func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRouter, macAddress, physNetworkName string,
-	ipAddresses []*net.IPNet, vlanID *uint, enableGatewayMTU bool) error {
+func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRouter, macAddress, physNetworkName string, ipAddresses []*net.IPNet, vlanID *uint) error {
 	// Create the GR port that connects to external_switch with mac address of
 	// external interface and that IP address. In the case of `local` gateway
 	// mode, whenever ovnkube-node container restarts a new br-local bridge will
@@ -497,12 +492,6 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 	for _, ip := range ipAddresses {
 		externalRouterPortNetworks = append(externalRouterPortNetworks, ip.String())
 	}
-	var options map[string]string
-	if enableGatewayMTU {
-		options = map[string]string{
-			"gateway_mtu": strconv.Itoa(config.Default.MTU),
-		}
-	}
 	externalLogicalRouterPort := nbdb.LogicalRouterPort{
 		MAC: macAddress,
 		ExternalIDs: map[string]string{
@@ -510,14 +499,12 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 		},
 		Networks: externalRouterPortNetworks,
 		Name:     externalRouterPort,
-		Options:  options,
 	}
 	logicalRouter := nbdb.LogicalRouter{Name: gatewayRouter}
 
 	err := libovsdbops.CreateOrUpdateLogicalRouterPort(oc.nbClient, &logicalRouter,
 		&externalLogicalRouterPort, nil, &externalLogicalRouterPort.MAC,
-		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs,
-		&externalLogicalRouterPort.Options)
+		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs)
 	if err != nil {
 		return fmt.Errorf("failed to add logical router port %+v to router %s: %v", externalLogicalRouterPort, gatewayRouter, err)
 	}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -181,7 +181,6 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 			"gateway-physical-ip": "yes",
 		},
 		Networks: networks,
-		Options:  options,
 	})
 
 	natUUIDs := make([]string, 0, len(clusterIPSubnets))

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1258,11 +1258,12 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = append(expectedNBDatabaseState,
 				newNodeSNAT("stale-nodeNAT-UUID-3", "10.0.0.3", externalIP.String()), // won't be deleted since pod exists on this node
 				newNodeSNAT("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3"))       // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
+			newNodeSNAT("nat-join-0-UUID", node1.LrpIP, externalIP.String()) // join subnet SNAT won't be affected by sync
 			for _, testObj := range expectedNBDatabaseState {
 				uuid := reflect.ValueOf(testObj).Elem().FieldByName("UUID").Interface().(string)
 				if uuid == types.GWRouterPrefix+node1.Name+"-UUID" {
 					GR := testObj.(*nbdb.LogicalRouter)
-					GR.Nat = []string{"stale-nodeNAT-UUID-3", "stale-nodeNAT-UUID-4"}
+					GR.Nat = []string{"stale-nodeNAT-UUID-3", "stale-nodeNAT-UUID-4", "nat-join-0-UUID"}
 					*testObj.(*nbdb.LogicalRouter) = *GR
 					break
 				}

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -446,7 +446,7 @@ func createPrimaryIfAddrAnnotation(annotationName string, nodeAnnotation map[str
 	return nodeAnnotation, nil
 }
 
-// CreateNodeGatewayRouterLRPAddrAnnotation sets the IPv4 / IPv6 values of the node's Gatewary Router LRP to join switch.
+// CreateNodeGatewayRouterLRPAddrAnnotation sets the IPv4 / IPv6 values of the node's Gateway Router LRP to join switch.
 func CreateNodeGatewayRouterLRPAddrAnnotation(nodeAnnotation map[string]interface{}, nodeIPNetv4,
 	nodeIPNetv6 *net.IPNet) (map[string]interface{}, error) {
 	return createPrimaryIfAddrAnnotation(ovnNodeGRLRPAddr, nodeAnnotation, nodeIPNetv4, nodeIPNetv6)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1079,6 +1079,11 @@ func isInterconnectEnabled() bool {
 	return present && val == "true"
 }
 
+func isLocalGWModeEnabled() bool {
+	val, present := os.LookupEnv("OVN_GATEWAY_MODE")
+	return present && val == "local"
+}
+
 func singleNodePerZone() bool {
 	if singleNodePerZoneResult == nil {
 		args := []string{"get", "pods", "--selector=app=ovnkube-node", "-o", "jsonpath={.items[0].spec.containers[*].name}"}


### PR DESCRIPTION
https://github.com/ovn-org/ovn-kubernetes/pull/3886 introduced a regression. By setting the MTU of the pod network on the external facing interface of the gateway router, now any large host->service->host UDP traffic will cause ICMP needs frag and install an MTU route cache entry between nodes.

This PR reverts the commit to configure MTU on the GR RTOE interface, adds testing to ensure it doesn't happen again, and the original issue that #3886 was added for is addressed by an OVN fix that we already have:

https://github.com/ovn-org/ovn/commit/0e49f49c73d67ba4869d658a5b9dfd8114513e7c