### PR TITLE
first pass to simplify testing

### DIFF
--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -105,10 +105,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 	clusterRouterDbSetup := libovsdbtest.TestSetup{
 		NBData: []libovsdbtest.TestData{
-			&nbdb.LogicalRouter{
-				Name: ovntypes.OVNClusterRouter,
-				UUID: ovntypes.OVNClusterRouter + "-UUID",
-			},
+			clusterRouter(),
 		},
 	}
 
@@ -291,10 +288,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node1.Name,
 							Networks: []string{nodeLogicalRouterIfAddrV4},
 						},
-						&nbdb.LogicalRouter{
-							Name: ovntypes.OVNClusterRouter,
-							UUID: ovntypes.OVNClusterRouter + "-UUID",
-						},
+						clusterRouter(),
 						&nbdb.LogicalRouter{
 							Name: ovntypes.GWRouterPrefix + node1.Name,
 							UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -457,10 +451,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node1.Name,
 							Networks: []string{nodeLogicalRouterIfAddrV4},
 						},
-						&nbdb.LogicalRouter{
-							Name: ovntypes.OVNClusterRouter,
-							UUID: ovntypes.OVNClusterRouter + "-UUID",
-						},
+						clusterRouter(),
 						&nbdb.LogicalRouter{
 							Name: ovntypes.GWRouterPrefix + node1.Name,
 							UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -635,10 +626,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node1.Name,
 									Networks: []string{nodeLogicalRouterIfAddrV4},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1.Name,
 									UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -886,10 +874,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name,
 								Networks: []string{node3LogicalRouterIfAddrV4},
 							},
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -1214,10 +1199,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node3.Name,
 								Networks: []string{node3LogicalRouterIfAddrV4},
 							},
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -1545,10 +1527,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 									Networks: []string{node2LogicalRouterIfAddrV4},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1.Name,
 									UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -1836,10 +1815,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 									Networks: []string{node2LogicalRouterIfAddrV4},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1.Name,
 									UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -2193,10 +2169,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 									Networks: []string{node2LogicalRouterIfAddrV4},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1.Name,
 									UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -2592,10 +2565,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 									Networks: []string{node2LogicalRouterIfAddrV4},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1.Name,
 									UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -2866,10 +2836,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
 									Networks: []string{node2LogicalRouterIfAddrV6, node2LogicalRouterIfAddrV6},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1Name,
 									UUID: ovntypes.GWRouterPrefix + node1Name + "-UUID",
@@ -3096,10 +3063,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
 									Networks: []string{node2LogicalRouterIfAddrV6},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1Name,
 									UUID: ovntypes.GWRouterPrefix + node1Name + "-UUID",
@@ -3282,10 +3246,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
 								Networks: []string{nodeLogicalRouterIfAddrV6},
 							},
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1Name,
 								UUID: ovntypes.GWRouterPrefix + node1Name + "-UUID",
@@ -3486,10 +3447,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalSwitchPort{
 								UUID:      "k8s-" + node2Name + "-UUID",
 								Name:      "k8s-" + node2Name,
@@ -3608,10 +3566,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
 									Networks: []string{node2LogicalRouterIfAddrV6},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1Name,
 									UUID: ovntypes.GWRouterPrefix + node1Name + "-UUID",
@@ -3836,10 +3791,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
 									Networks: []string{node2LogicalRouterIfAddrV6},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1Name,
 									UUID: ovntypes.GWRouterPrefix + node1Name + "-UUID",
@@ -3960,10 +3912,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState = []libovsdbtest.TestData{
-						&nbdb.LogicalRouter{
-							Name: ovntypes.OVNClusterRouter,
-							UUID: ovntypes.OVNClusterRouter + "-UUID",
-						},
+						clusterRouter(),
 						&nbdb.LogicalRouterPort{
 							UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name + "-UUID",
 							Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
@@ -4026,10 +3975,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
 									Networks: []string{nodeLogicalRouterIfAddrV6},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1Name,
 									UUID: ovntypes.GWRouterPrefix + node1Name + "-UUID",
@@ -4169,10 +4115,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedDatabaseState = []libovsdbtest.TestData{
-						&nbdb.LogicalRouter{
-							Name: ovntypes.OVNClusterRouter,
-							UUID: ovntypes.OVNClusterRouter + "-UUID",
-						},
+						clusterRouter(),
 						&nbdb.LogicalRouterPort{
 							UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name + "-UUID",
 							Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
@@ -4235,10 +4178,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
 									Networks: []string{node2LogicalRouterIfAddrV6},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1Name,
 									UUID: ovntypes.GWRouterPrefix + node1Name + "-UUID",
@@ -4373,10 +4313,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Eventually(getEgressIPStatusLen(eIP.Name)).Should(gomega.Equal(1))
 
 					expectedDatabaseState = []libovsdbtest.TestData{
-						&nbdb.LogicalRouter{
-							Name: ovntypes.OVNClusterRouter,
-							UUID: ovntypes.OVNClusterRouter + "-UUID",
-						},
+						clusterRouter(),
 						&nbdb.LogicalRouterPort{
 							UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name + "-UUID",
 							Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
@@ -4552,10 +4489,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node1.Name,
 									Networks: []string{nodeLogicalRouterIfAddrV4},
 								},
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								&nbdb.LogicalRouter{
 									Name: ovntypes.GWRouterPrefix + node1.Name,
 									UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -4953,10 +4887,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2Name,
 								Networks: []string{node2LogicalRouterIfAddrV6},
 							},
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1Name,
 								UUID: ovntypes.GWRouterPrefix + node1Name + "-UUID",
@@ -5226,10 +5157,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node2 := getNodeObj(node2Name, annotations, map[string]string{})
 				fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
-						&nbdb.LogicalRouter{
-							Name: ovntypes.OVNClusterRouter,
-							UUID: ovntypes.OVNClusterRouter + "-UUID",
-						},
+						clusterRouter(),
 						&nbdb.LogicalRouter{
 							Name: ovntypes.GWRouterPrefix + node1.Name,
 							UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -5385,10 +5313,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
-						&nbdb.LogicalRouter{
-							Name: ovntypes.OVNClusterRouter,
-							UUID: ovntypes.OVNClusterRouter + "-UUID",
-						},
+						clusterRouter(),
 						&nbdb.LogicalRouter{
 							Name: ovntypes.GWRouterPrefix + node.Name,
 							UUID: ovntypes.GWRouterPrefix + node.Name + "-UUID",
@@ -5548,10 +5473,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -5857,10 +5779,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -6253,10 +6172,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
-								&nbdb.LogicalRouter{
-									Name: ovntypes.OVNClusterRouter,
-									UUID: ovntypes.OVNClusterRouter + "-UUID",
-								},
+								clusterRouter(),
 								node1GR, node2GR,
 								node1LSP, node2LSP,
 								&nbdb.LogicalRouterPort{
@@ -6813,10 +6729,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node.Name,
 								UUID: ovntypes.GWRouterPrefix + node.Name + "-UUID",
@@ -7017,10 +6930,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -7172,10 +7082,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -7814,10 +7721,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							node1GR,
 							node1LSP,
 							&nbdb.LogicalRouterPort{
@@ -7982,10 +7886,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -8273,10 +8174,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -8618,10 +8516,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							node1GR,
 							node1LSP,
 							&nbdb.LogicalRouterPort{
@@ -8799,10 +8694,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							node1GR,
 							node1LSP,
 							&nbdb.LogicalRouterPort{
@@ -9030,10 +8922,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",
@@ -9770,10 +9659,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node2.Name,
 								Networks: []string{node2LogicalRouterIfAddrV4},
 							},
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 							&nbdb.LogicalRouter{
 								Name: ovntypes.GWRouterPrefix + node1.Name,
 								UUID: ovntypes.GWRouterPrefix + node1.Name + "-UUID",

--- a/go-controller/pkg/ovn/external_gateway_apb_test.go
+++ b/go-controller/pkg/ovn/external_gateway_apb_test.go
@@ -2379,10 +2379,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + "node1",
 								Networks: []string{"100.64.0.4/32"},
 							},
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 						},
 					},
 				)
@@ -2454,10 +2451,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 								UUID: "GR_node1-UUID",
 								Name: "GR_node1",
 							},
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 						},
 					},
 					&v1.NamespaceList{
@@ -2591,10 +2585,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + "node1",
 								Networks: []string{"100.64.0.4/32"},
 							},
-							&nbdb.LogicalRouter{
-								Name: ovntypes.OVNClusterRouter,
-								UUID: ovntypes.OVNClusterRouter + "-UUID",
-							},
+							clusterRouter(),
 						},
 					},
 				)
@@ -2950,10 +2941,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 				_, err = fakeOvn.asf.NewAddressSet(asIndex, []net.IP{net.ParseIP("10.128.1.3"), net.ParseIP("1.1.1.1")})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				finalNB := []libovsdbtest.TestData{
-					&nbdb.LogicalRouter{
-						Name: ovntypes.OVNClusterRouter,
-						UUID: ovntypes.OVNClusterRouter + "-UUID",
-					},
+					clusterRouter(),
 					&nbdb.LogicalRouter{
 						UUID: "GR_node1-UUID",
 						Name: "GR_node1",

--- a/go-controller/pkg/ovn/helpers_test.go
+++ b/go-controller/pkg/ovn/helpers_test.go
@@ -1,0 +1,172 @@
+package ovn
+
+import (
+	"fmt"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// helper functions to make testing easier and remove redundant code
+func clusterRouter(policies ...string) *nbdb.LogicalRouter {
+	clusterRouter := &nbdb.LogicalRouter{
+		UUID:     ovntypes.OVNClusterRouter + "-UUID",
+		Name:     ovntypes.OVNClusterRouter,
+		Policies: policies,
+	}
+	return clusterRouter
+
+}
+
+// Please use following subnets for various networks that we have
+// 172.16.1.0/24 -- physical network that k8s nodes connect to
+// 100.64.0.0/16 -- the join subnet that connects all the L3 gateways with the distributed router
+// 169.254.33.0/24 -- the subnet that connects OVN logical network to physical network
+// 10.1.0.0/16 -- the overlay subnet that Pods connect to.
+
+type tNode struct {
+	Name                 string
+	NodeIP               string
+	NodeLRPMAC           string
+	LrpIP                string
+	LrpIPv6              string
+	DrLrpIP              string
+	PhysicalBridgeMAC    string
+	SystemID             string
+	NodeSubnet           string
+	GWRouter             string
+	ClusterIPNet         string
+	ClusterCIDR          string
+	GatewayRouterIPMask  string
+	GatewayRouterIP      string
+	GatewayRouterNextHop string
+	PhysicalBridgeName   string
+	NodeGWIP             string
+	NodeMgmtPortIP       string
+	NodeMgmtPortMAC      string
+	DnatSnatIP           string
+
+	//new variables for generating database components
+	StaticRoutes           []string
+	Nat                    []string
+	Ports                  []string
+	LoadBalancerGroupUUIDs []string
+}
+
+const (
+	// ovnNodeID is the id (of type integer) of a node. It is set by cluster-manager.
+	ovnNodeID = "k8s.ovn.org/node-id"
+
+	// ovnNodeGRLRPAddr is the CIDR form representation of Gate Router LRP IP address to join switch (i.e: 100.64.0.5/24)
+	ovnNodeGRLRPAddr     = "k8s.ovn.org/node-gateway-router-lrp-ifaddr"
+	ovnNodePrimaryIfAddr = "k8s.ovn.org/node-primary-ifaddr"
+)
+
+func (n tNode) k8sNode(nodeID string) v1.Node {
+	node := v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: n.Name,
+			Annotations: map[string]string{
+				ovnNodeID:             nodeID,
+				ovnNodeGRLRPAddr:      "{\"ipv4\": \"100.64.0." + nodeID + "/16\"}",
+				util.OVNNodeHostCIDRs: fmt.Sprintf("[\"%s\"]", fmt.Sprintf("%s/24", n.NodeIP)),
+				ovnNodePrimaryIfAddr:  fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", fmt.Sprintf("%s/24", n.NodeIP), ""),
+			},
+		},
+		Status: kapi.NodeStatus{
+			Addresses: []kapi.NodeAddress{{Type: kapi.NodeExternalIP, Address: n.NodeIP}},
+		},
+	}
+
+	return node
+}
+
+func (n tNode) ifaceID() string {
+	return n.PhysicalBridgeName + "_" + n.Name
+}
+
+func (n tNode) gatewayConfig(gatewayMode config.GatewayMode, vlanID uint) *util.L3GatewayConfig {
+	return &util.L3GatewayConfig{
+		Mode:           gatewayMode,
+		ChassisID:      n.SystemID,
+		InterfaceID:    n.ifaceID(),
+		MACAddress:     ovntest.MustParseMAC(n.PhysicalBridgeMAC),
+		IPAddresses:    ovntest.MustParseIPNets(n.GatewayRouterIPMask),
+		NextHops:       ovntest.MustParseIPs(n.GatewayRouterNextHop),
+		NodePortEnable: true,
+		VLANID:         &vlanID,
+	}
+}
+
+func (n tNode) logicalSwitch() *nbdb.LogicalSwitch {
+	return &nbdb.LogicalSwitch{
+		UUID:              n.Name + "-UUID",
+		Name:              n.Name,
+		OtherConfig:       map[string]string{"subnet": n.NodeSubnet},
+		LoadBalancerGroup: n.LoadBalancerGroupUUIDs,
+		Ports:             n.Ports,
+	}
+}
+
+func (n tNode) nodeGWRouter() *nbdb.LogicalRouter {
+	return &nbdb.LogicalRouter{
+		UUID:         fmt.Sprintf("GR_%s-UUID", n.Name),
+		Name:         fmt.Sprintf("GR_%s", n.Name),
+		StaticRoutes: n.StaticRoutes,
+		Nat:          n.Nat,
+	}
+}
+
+func (n *tNode) generateLogicalSwitchPortAddToNode(pod testPod) (*nbdb.LogicalSwitchPort, error) {
+	// make sure we are adding the pod to the right node
+	if n.Name != pod.nodeName {
+		return nil, fmt.Errorf("pod and node names do not match")
+	}
+
+	lspUUID := fmt.Sprintf("%s_%s-UUID", pod.namespace, pod.podName)
+
+	n.Ports = append(n.Ports, lspUUID)
+	return &nbdb.LogicalSwitchPort{
+		UUID:      lspUUID,
+		Addresses: []string{fmt.Sprintf("%s %s", pod.podMAC, pod.podIP)},
+		ExternalIDs: map[string]string{
+			"pod":       "true",
+			"namespace": pod.namespace,
+		},
+		Name: fmt.Sprintf("%s_%s", pod.namespace, pod.podName),
+		Options: map[string]string{
+			"iface-id-ver":      pod.podName,
+			"requested-chassis": pod.nodeName,
+		},
+		PortSecurity: []string{fmt.Sprintf("%s %s", pod.podMAC, pod.podIP)},
+	}, nil
+
+}
+
+func (n *tNode) deleteLogicalSwitchPortFromNode(pod testPod) {
+	lspUUID := fmt.Sprintf("%s_%s-UUID", pod.namespace, pod.podName)
+
+	for index, lspPort := range n.Ports {
+		if lspPort == lspUUID {
+			n.Ports = append(n.Ports[:index], n.Ports[index+1:]...)
+			return
+		}
+	}
+
+	return
+
+}
+
+func nodeGWRouter(nodeName string, staticRoutes []string) *nbdb.LogicalRouter {
+	return &nbdb.LogicalRouter{
+		UUID:         fmt.Sprintf("GR_%s-UUID", nodeName),
+		Name:         fmt.Sprintf("GR_%s", nodeName),
+		StaticRoutes: staticRoutes,
+	}
+}

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -344,14 +344,15 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedClusterLBGroup := newLoadBalancerGroup(types.ClusterLBGroupName)
 			expectedSwitchLBGroup := newLoadBalancerGroup(types.ClusterSwitchLBGroupName)
 			expectedRouterLBGroup := newLoadBalancerGroup(types.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
+			expectedOVNClusterRouter := clusterRouter()
 			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
 				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
 				Networks: []string{"100.64.0.1/16"},
 				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
 			}
 			expectedOVNClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
+			node1.LoadBalancerGroupUUIDs = []string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID}
+			expectedNodeSwitch := node1.logicalSwitch()
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
 
@@ -610,14 +611,15 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedClusterLBGroup := newLoadBalancerGroup(types.ClusterLBGroupName)
 			expectedSwitchLBGroup := newLoadBalancerGroup(types.ClusterSwitchLBGroupName)
 			expectedRouterLBGroup := newLoadBalancerGroup(types.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
+			expectedOVNClusterRouter := clusterRouter()
 			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
 				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
 				Networks: []string{"100.64.0.1/16"},
 				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
 			}
 			expectedOVNClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
+			node1.LoadBalancerGroupUUIDs = []string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID}
+			expectedNodeSwitch := node1.logicalSwitch()
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
 
@@ -804,14 +806,15 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedClusterLBGroup := newLoadBalancerGroup(types.ClusterLBGroupName)
 			expectedSwitchLBGroup := newLoadBalancerGroup(types.ClusterSwitchLBGroupName)
 			expectedRouterLBGroup := newLoadBalancerGroup(types.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
+			expectedOVNClusterRouter := clusterRouter()
 			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
 				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
 				Networks: []string{"100.64.0.1/16"},
 				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
 			}
 			expectedOVNClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
+			node1.LoadBalancerGroupUUIDs = []string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID}
+			expectedNodeSwitch := node1.logicalSwitch()
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
 
@@ -1087,14 +1090,15 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedClusterLBGroup := newLoadBalancerGroup(types.ClusterLBGroupName)
 			expectedSwitchLBGroup := newLoadBalancerGroup(types.ClusterSwitchLBGroupName)
 			expectedRouterLBGroup := newLoadBalancerGroup(types.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
+			expectedOVNClusterRouter := clusterRouter()
 			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
 				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
 				Networks: []string{"100.64.0.1/16"},
 				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
 			}
 			expectedOVNClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
+			node1.LoadBalancerGroupUUIDs = []string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID}
+			expectedNodeSwitch := node1.logicalSwitch()
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
 
@@ -1288,14 +1292,15 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedClusterLBGroup := newLoadBalancerGroup(types.ClusterLBGroupName)
 			expectedSwitchLBGroup := newLoadBalancerGroup(types.ClusterSwitchLBGroupName)
 			expectedRouterLBGroup := newLoadBalancerGroup(types.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
+			expectedOVNClusterRouter := clusterRouter()
 			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
 				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
 				Networks: []string{"100.64.0.1/16"},
 				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
 			}
 			expectedOVNClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
+			node1.LoadBalancerGroupUUIDs = []string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID}
+			expectedNodeSwitch := node1.logicalSwitch()
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
 
@@ -1468,14 +1473,15 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedClusterLBGroup := newLoadBalancerGroup(types.ClusterLBGroupName)
 			expectedSwitchLBGroup := newLoadBalancerGroup(types.ClusterSwitchLBGroupName)
 			expectedRouterLBGroup := newLoadBalancerGroup(types.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
+			expectedOVNClusterRouter := clusterRouter()
 			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
 				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
 				Networks: []string{"100.64.0.1/16"},
 				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
 			}
 			expectedOVNClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
+			node1.LoadBalancerGroupUUIDs = []string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID}
+			expectedNodeSwitch := node1.logicalSwitch()
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
 
@@ -1675,14 +1681,15 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedClusterLBGroup := newLoadBalancerGroup(types.ClusterLBGroupName)
 			expectedSwitchLBGroup := newLoadBalancerGroup(types.ClusterSwitchLBGroupName)
 			expectedRouterLBGroup := newLoadBalancerGroup(types.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
+			expectedOVNClusterRouter := clusterRouter()
 			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
 				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
 				Networks: []string{"100.64.0.1/16"},
 				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
 			}
 			expectedOVNClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
+			node1.LoadBalancerGroupUUIDs = []string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID}
+			expectedNodeSwitch := node1.logicalSwitch()
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
 

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -251,8 +251,9 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			expectedClusterLBGroup := newLoadBalancerGroup(ovntypes.ClusterLBGroupName)
 			expectedSwitchLBGroup := newLoadBalancerGroup(ovntypes.ClusterSwitchLBGroupName)
 			expectedRouterLBGroup := newLoadBalancerGroup(ovntypes.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
+			expectedOVNClusterRouter := clusterRouter()
+			node1.LoadBalancerGroupUUIDs = []string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID}
+			expectedNodeSwitch := node1.logicalSwitch()
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
 

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -594,61 +594,6 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod, _ := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
 				gomega.Expect(pod).To(gomega.BeNil())
 
-				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
-					newPod(t.namespace, t.podName, t.nodeName, t.podIP), metav1.CreateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				gomega.Eventually(func() string {
-					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
-				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
-
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-
-		ginkgo.It("allows allocation after pods are completed", func() {
-			app.Action = func(ctx *cli.Context) error {
-				namespaceT := *newNamespace("namespace1")
-				t := newTPod(
-					"node1",
-					"10.128.1.0/24",
-					"10.128.1.2",
-					"10.128.1.1",
-					"myPod",
-					"10.128.1.3",
-					"0a:58:0a:80:01:03",
-					namespaceT.Name,
-				)
-
-				fakeOvn.startWithDBSetup(initialDB,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespaceT,
-						},
-					},
-					&v1.NodeList{
-						Items: []v1.Node{
-							*newNode(node1Name, "192.168.126.202/24"),
-						},
-					},
-					&v1.PodList{
-						Items: []v1.Pod{},
-					},
-				)
-
-				t.populateLogicalSwitchCache(fakeOvn)
-				err := fakeOvn.controller.WatchNamespaces()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = fakeOvn.controller.WatchPods()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				pod, _ := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
-				gomega.Expect(pod).To(gomega.BeNil())
-
 				myPod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(),
 					myPod, metav1.CreateOptions{})


### PR DESCRIPTION
Currently it seems like every test file is organized completely differently each containing there own way of doing things. I wish to make the testing easier to read and work on.

Here is a simple example, that is unfinished but I would like some buy in before continuing. I think we can have testing helper functions in one place so that people writing tests know where to find them. Here is an example for clusterRouters.

TODO: make the function take an argument so that it can fill in policies.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->