### PR TITLE
Various upstream fixes

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1063,11 +1063,12 @@ install_metallb() {
   echo $kind_network
   local client_network=$(echo $frr_ips | cut -d '#' -f 1)
   echo $client_network
-  local subnet=$(echo ${client_network%?}0)
-  echo $subnet
+  # The following only works for single stack, to be modified if dualstack is to be supported:
+  local client_subnet=$(docker network inspect clientnet -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}')
+  echo $client_subnet
   KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
   for n in $KIND_NODES; do
-    docker exec "$n" ip route add $subnet/16 via $kind_network
+    docker exec "$n" ip route add $client_subnet via $kind_network
   done
   # TODO(tssurya): expand this to be more dynamic in the future when needed.
   # for now, we only run one test with metalLB load balancer for which this

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1056,7 +1056,7 @@ install_metallb() {
   docker network connect clientnet frr
   docker run  --cap-add NET_ADMIN --user 0  -d --network clientnet  --rm  --name lbclient  quay.io/itssurya/dev-images:metallb-lbservice
   popd
-  sudo rm -rf metallb
+  delete_metallb_dir
   local frr_ips=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}#{{end}}' frr)
   echo $frr_ips
   local kind_network=$(echo $frr_ips | cut -d '#' -f 2)
@@ -1096,7 +1096,16 @@ destroy_metallb() {
   docker stop lbclient || true # its possible the lbclient doesn't exist which is fine, ignore error
   docker stop frr || true # its possible the lbclient doesn't exist which is fine, ignore error
   docker network rm clientnet || true # its possible the clientnet network doesn't exist which is fine, ignore error
-  sudo rm -rf metallb || true # this repo is removed in install_metallb(), but in case of trouble it may still be around
+  delete_metallb_dir
+}
+
+delete_metallb_dir() {
+  # The build directory will contain read only directories after building. Files cannot be deleted, even by the owner.
+  # Therefore, set all dirs to u+rwx.
+  if [ -d "${DIR}/../metallb" ]; then
+      find "${DIR}/../metallb" -type d -exec chmod u+rwx "{}" \;
+      rm -rf "${DIR}/../metallb"
+  fi
 }
 
 install_multus() {

--- a/dist/images/.gitignore
+++ b/dist/images/.gitignore
@@ -6,3 +6,4 @@ ovnkube-identity
 ovndbchecker
 hybrid-overlay-node
 git_info
+ovnkube-ipsec

--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -271,8 +271,8 @@ var _ = Describe("Egress Service Operations", func() {
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
 						"OVN-KUBE-EGRESS-SVC": []string{
-							"-m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
-							"-s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
+							"-A OVN-KUBE-EGRESS-SVC -m mark --mark 0x3f0 -m comment --comment DoNotSNAT -j RETURN",
+							"-A OVN-KUBE-EGRESS-SVC -s 10.128.0.3 -m comment --comment namespace1/service1 -j SNAT --to-source 5.5.5.5",
 						},
 					},
 					"filter": {},

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -138,6 +138,9 @@ func (f *FakeIPTables) List(tableName, chainName string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	for i := range chain {
+		chain[i] = fmt.Sprintf("-A %s %s", chainName, chain[i])
+	}
 	return chain, nil
 }
 

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -1758,7 +1758,7 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				setupIperf3Client := func(container, address string, port int) {
 					// note iperf3 even when using udp also spawns tcp connection first; so we indirectly also have the tcp connection when using "-u" flag
 					cmd := []string{containerRuntime, "exec", container, "iperf3", "-u", "-c", address, "-p", fmt.Sprintf("%d", port), "-b", "1M", "-i", "1", "-t", "3", "&"}
-					klog.Infof("run command %+v", cmd)
+					klog.Infof("Run command %+v", cmd)
 					_, err := runCommand(cmd...)
 					framework.ExpectNoError(err, "failed to setup iperf3 client for %s", container)
 				}

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -445,7 +445,7 @@ var _ = ginkgo.Describe("Services", func() {
 			gomega.Expect(pods.Items).To(gomega.HaveLen(1))
 			clientPod := &pods.Items[0]
 			cmd := fmt.Sprintf(`ip addr del %s dev lo || true`, extraCIDR)
-			_, err = e2epodoutput.RunHostCmdWithRetries(clientPod.Namespace, clientPod.Name, cmd, framework.Poll, 30*time.Second)
+			_, _ = e2epodoutput.RunHostCmdWithRetries(clientPod.Namespace, clientPod.Name, cmd, framework.Poll, 30*time.Second)
 		}
 
 		ginkgo.By("Starting a UDP server listening on the additional IP")
@@ -536,7 +536,11 @@ var _ = ginkgo.Describe("Services", func() {
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.It("of type NodePort should listen on each host addresses", func() {
+	ginkgo.Context("of type NodePort", func() {
+		var nodes *v1.NodeList
+		var err error
+		nodeIPs := make(map[string]map[int]string)
+
 		const (
 			endpointHTTPPort    = 80
 			endpointUDPPort     = 90
@@ -545,130 +549,163 @@ var _ = ginkgo.Describe("Services", func() {
 			clientContainerName = "npclient"
 		)
 
-		endPoints := make([]*v1.Pod, 0)
-		endpointsSelector := map[string]string{"servicebackend": "true"}
-		nodesHostnames := sets.NewString()
-
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
-		framework.ExpectNoError(err)
-
-		if len(nodes.Items) < 3 {
-			framework.Failf(
-				"Test requires >= 3 Ready nodes, but there are only %v nodes",
-				len(nodes.Items))
-		}
-
-		ginkgo.By("Creating the endpoints pod, one for each worker")
-		for _, node := range nodes.Items {
-			args := []string{
-				"netexec",
-				fmt.Sprintf("--http-port=%d", endpointHTTPPort),
-				fmt.Sprintf("--udp-port=%d", endpointUDPPort),
+		ginkgo.AfterEach(func() {
+			ginkgo.By("Cleaning up external container")
+			deleteClusterExternalContainer(clientContainerName)
+			ginkgo.By("Deleting additional IP addresses from nodes")
+			for nodeName, ipFamilies := range nodeIPs {
+				for _, ip := range ipFamilies {
+					_, err := runCommand(containerRuntime, "exec", nodeName, "ip", "addr", "delete",
+						fmt.Sprintf("%s/32", ip), "dev", "breth0")
+					if err != nil && !strings.Contains(err.Error(),
+						"RTNETLINK answers: Cannot assign requested address") {
+						framework.Failf("failed to remove ip address %s from node %s, err: %q", ip, nodeName, err)
+					}
+				}
 			}
-			pod, err := createPod(f, node.Name+"-ep", node.Name, f.Namespace.Name, []string{},
-				endpointsSelector, func(p *v1.Pod) {
-					p.Spec.Containers[0].Args = args
-				})
+		})
+
+		ginkgo.It("should listen on each host addresses", func() {
+			endPoints := make([]*v1.Pod, 0)
+			endpointsSelector := map[string]string{"servicebackend": "true"}
+			nodesHostnames := sets.NewString()
+
+			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
 			framework.ExpectNoError(err)
 
-			endPoints = append(endPoints, pod)
-			nodesHostnames.Insert(pod.Name)
-		}
-
-		ginkgo.By("Creating an external container to send the traffic from")
-		createClusterExternalContainer(clientContainerName, agnhostImage,
-			[]string{"--network", "kind", "-P"},
-			[]string{"netexec", "--http-port=80"})
-
-		// If `kindexgw` exists, connect client container to it
-		runCommand(containerRuntime, "network", "connect", "kindexgw", clientContainerName)
-
-		ginkgo.By("Adding ip addresses to each node")
-		// add new secondary IP from node subnet to all nodes, if the cluster is v6 add an ipv6 address
-		toCurlAddresses := sets.NewString()
-		for i, node := range nodes.Items {
-
-			addrAnnotation, ok := node.Annotations["k8s.ovn.org/host-cidrs"]
-			gomega.Expect(ok).To(gomega.BeTrue())
-
-			var addrs []string
-			err := json.Unmarshal([]byte(addrAnnotation), &addrs)
-			framework.ExpectNoError(err, "failed to parse node[%s] host-address annotation[%s]", node.Name, addrAnnotation)
-			for i, addr := range addrs {
-				addrSplit := strings.Split(addr, "/")
-				gomega.Expect(addrSplit).Should(gomega.HaveLen(2))
-				addrs[i] = addrSplit[0]
-			}
-			toCurlAddresses.Insert(addrs...)
-
-			var newIP string
-			if utilnet.IsIPv6String(e2enode.GetAddresses(&node, v1.NodeInternalIP)[0]) {
-				newIP = "fc00:f853:ccd:e794::" + strconv.Itoa(i)
-			} else {
-				newIP = "172.18.1." + strconv.Itoa(i+1)
-			}
-			// manually add the a secondary IP to each node
-			_, err = runCommand(containerRuntime, "exec", node.Name, "ip", "addr", "add", newIP, "dev", "breth0")
-			if err != nil {
-				framework.Failf("failed to add new Addresses to node %s: %v", node.Name, err)
+			if len(nodes.Items) < 3 {
+				framework.Failf(
+					"Test requires >= 3 Ready nodes, but there are only %v nodes",
+					len(nodes.Items))
 			}
 
-			nodeName := node.Name
-			defer func() {
-				runCommand(containerRuntime, "exec", nodeName, "ip", "addr", "delete", newIP+"/32", "dev", "breth0")
-				framework.ExpectNoError(err, "failed to remove ip address %s from node %s", newIP, nodeName)
-			}()
-
-			toCurlAddresses.Insert(newIP)
-		}
-
-		defer deleteClusterExternalContainer(clientContainerName)
-
-		isIPv6Cluster := IsIPv6Cluster(f.ClientSet)
-
-		ginkgo.By("Creating NodePort services")
-
-		etpLocalServiceName := "etp-local-svc"
-		etpLocalSvc := nodePortServiceSpecFrom(etpLocalServiceName, v1.IPFamilyPolicyPreferDualStack, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector, v1.ServiceExternalTrafficPolicyTypeLocal)
-		etpLocalSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), etpLocalSvc, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		etpClusterServiceName := "etp-cluster-svc"
-		etpClusterSvc := nodePortServiceSpecFrom(etpClusterServiceName, v1.IPFamilyPolicyPreferDualStack, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector, v1.ServiceExternalTrafficPolicyTypeCluster)
-		etpClusterSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), etpClusterSvc, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Waiting for the endpoints to pop up")
-
-		err = framework.WaitForServiceEndpointsNum(context.TODO(), f.ClientSet, f.Namespace.Name, etpLocalServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
-		framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", etpLocalServiceName, f.Namespace.Name)
-
-		err = framework.WaitForServiceEndpointsNum(context.TODO(), f.ClientSet, f.Namespace.Name, etpClusterServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
-		framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", etpClusterServiceName, f.Namespace.Name)
-
-		for _, serviceSpec := range []*v1.Service{etpLocalSvc, etpClusterSvc} {
-			tcpNodePort, udpNodePort := nodePortsFromService(serviceSpec)
-
-			for _, protocol := range []string{"http", "udp"} {
-				toCurlPort := int32(tcpNodePort)
-				if protocol == "udp" {
-					toCurlPort = int32(udpNodePort)
+			ginkgo.By("Creating the endpoints pod, one for each worker")
+			for _, node := range nodes.Items {
+				args := []string{
+					"netexec",
+					fmt.Sprintf("--http-port=%d", endpointHTTPPort),
+					fmt.Sprintf("--udp-port=%d", endpointUDPPort),
 				}
+				pod, err := createPod(f, node.Name+"-ep", node.Name, f.Namespace.Name, []string{},
+					endpointsSelector, func(p *v1.Pod) {
+						p.Spec.Containers[0].Args = args
+					})
+				framework.ExpectNoError(err)
 
-				for _, address := range toCurlAddresses.List() {
-					if !isIPv6Cluster && utilnet.IsIPv6String(address) {
-						continue
+				endPoints = append(endPoints, pod)
+				nodesHostnames.Insert(pod.Name)
+			}
+
+			ginkgo.By("Creating an external container to send the traffic from")
+			createClusterExternalContainer(clientContainerName, agnhostImage,
+				[]string{"--network", "kind", "-P"},
+				[]string{"netexec", "--http-port=80"})
+
+			// If `kindexgw` exists, connect client container to it
+			runCommand(containerRuntime, "network", "connect", "kindexgw", clientContainerName)
+
+			ginkgo.By("Selecting additional IP addresses for each node")
+			// add new secondary IP from node subnet to all nodes, if the cluster is v6 add an ipv6 address
+			toCurlAddresses := sets.NewString()
+			for i, node := range nodes.Items {
+
+				addrAnnotation, ok := node.Annotations["k8s.ovn.org/host-cidrs"]
+				gomega.Expect(ok).To(gomega.BeTrue())
+
+				var addrs []string
+				err := json.Unmarshal([]byte(addrAnnotation), &addrs)
+				framework.ExpectNoError(err, "failed to parse node[%s] host-address annotation[%s]", node.Name,
+					addrAnnotation)
+				for i, addr := range addrs {
+					addrSplit := strings.Split(addr, "/")
+					gomega.Expect(addrSplit).Should(gomega.HaveLen(2))
+					addrs[i] = addrSplit[0]
+				}
+				toCurlAddresses.Insert(addrs...)
+
+				// Calculate and store for AfterEach new target IP addresses.
+				var newIP string
+				if nodeIPs[node.Name] == nil {
+					nodeIPs[node.Name] = make(map[int]string)
+				}
+				if utilnet.IsIPv6String(e2enode.GetAddresses(&node, v1.NodeInternalIP)[0]) {
+					newIP = "fc00:f853:ccd:e794::" + strconv.Itoa(i)
+					nodeIPs[node.Name][6] = newIP
+				} else {
+					newIP = "172.18.1." + strconv.Itoa(i+1)
+					nodeIPs[node.Name][4] = newIP
+				}
+			}
+
+			ginkgo.By("Adding additional IP addresses to each node")
+			for nodeName, ipFamilies := range nodeIPs {
+				for _, ip := range ipFamilies {
+					// manually add the a secondary IP to each node
+					_, err = runCommand(containerRuntime, "exec", nodeName, "ip", "addr", "add", ip, "dev", "breth0")
+					if err != nil {
+						framework.Failf("failed to add new IP address %s to node %s: %v", ip, nodeName, err)
+					}
+					toCurlAddresses.Insert(ip)
+				}
+			}
+
+			isIPv6Cluster := IsIPv6Cluster(f.ClientSet)
+
+			ginkgo.By("Creating NodePort services")
+
+			etpLocalServiceName := "etp-local-svc"
+			etpLocalSvc := nodePortServiceSpecFrom(etpLocalServiceName, v1.IPFamilyPolicyPreferDualStack,
+				endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector,
+				v1.ServiceExternalTrafficPolicyTypeLocal)
+			etpLocalSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), etpLocalSvc,
+				metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			etpClusterServiceName := "etp-cluster-svc"
+			etpClusterSvc := nodePortServiceSpecFrom(etpClusterServiceName, v1.IPFamilyPolicyPreferDualStack,
+				endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector,
+				v1.ServiceExternalTrafficPolicyTypeCluster)
+			etpClusterSvc, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(),
+				etpClusterSvc, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for the endpoints to pop up")
+
+			err = framework.WaitForServiceEndpointsNum(context.TODO(), f.ClientSet, f.Namespace.Name,
+				etpLocalServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s",
+				etpLocalServiceName, f.Namespace.Name)
+
+			err = framework.WaitForServiceEndpointsNum(context.TODO(), f.ClientSet, f.Namespace.Name,
+				etpClusterServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s",
+				etpClusterServiceName, f.Namespace.Name)
+
+			for _, serviceSpec := range []*v1.Service{etpLocalSvc, etpClusterSvc} {
+				tcpNodePort, udpNodePort := nodePortsFromService(serviceSpec)
+
+				for _, protocol := range []string{"http", "udp"} {
+					toCurlPort := int32(tcpNodePort)
+					if protocol == "udp" {
+						toCurlPort = int32(udpNodePort)
 					}
 
-					ginkgo.By("Hitting service " + serviceSpec.Name + " on " + address + " via " + protocol)
-					gomega.Eventually(func() bool {
-						epHostname := pokeEndpoint("", clientContainerName, protocol, address, toCurlPort, "hostname")
-						// Expect to receive a valid hostname
-						return nodesHostnames.Has(epHostname)
-					}, "20s", "1s").Should(gomega.BeTrue())
+					for _, address := range toCurlAddresses.List() {
+						if !isIPv6Cluster && utilnet.IsIPv6String(address) {
+							continue
+						}
+
+						ginkgo.By("Hitting service " + serviceSpec.Name + " on " + address + " via " + protocol)
+						gomega.Eventually(func() bool {
+							epHostname := pokeEndpoint("", clientContainerName, protocol, address, toCurlPort,
+								"hostname")
+							// Expect to receive a valid hostname
+							return nodesHostnames.Has(epHostname)
+						}, "20s", "1s").Should(gomega.BeTrue())
+					}
 				}
 			}
-		}
+		})
 	})
 })
 


### PR DESCRIPTION

**- What this PR does and why is it needed**
a) Add ovnkube-ipsec to .gitignore
b) Fixes implementation of mock function `func (f *FakeIPTables) List(...)` in `pkg/util/iptables.go` is not correct.  See: https://github.com/ovn-org/ovn-kubernetes/issues/4026
c) Fixes style of klog.Infof in `test/e2e/external_gateway.go` (the linter flagged that for me for some reason whereas it seems to have gone unnoticed)
d) Fixes `sudo rm -rf metallb` in `kind.sh` and instead replaces it with a `chmod` to make directories `u+rwx`
e) Fixes issues with netmask for `client_network` network for `ip route add` (hardcoded `/16` even though the netmask can be different). See https://github.com/ovn-org/ovn-kubernetes/issues/4028
f) Fixes broken cleanup logic of test `of type NodePort should listen on each host addresses`. See https://github.com/ovn-org/ovn-kubernetes/issues/4029

**- Special notes for reviewers**
I found these issues while implementing something else. Because the list of commits has become quite long, and because it's easier to review these small commits, I decided to push them as their own PR.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->