### PR TITLE
Fix issue with eatmydata (test)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,6 +277,7 @@ jobs:
 
     - name: Free up disk space
       run: |
+        sudo apt-get update
         sudo eatmydata apt-get purge --auto-remove -y \
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \
           google-chrome-stable \
@@ -427,6 +428,7 @@ jobs:
 
     - name: Free up disk space
       run: |
+        sudo apt-get update
         sudo eatmydata apt-get purge --auto-remove -y \
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \
           google-chrome-stable \
@@ -636,7 +638,9 @@ jobs:
     steps:
 
       - name: Free up disk space
-        run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
+        run: |
+          sudo apt-get update
+          sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
 
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
**- What this PR does and why is it needed**
Since earlier today, `sudo eatmydata apt-get purge --auto-remove -y ` fails when trying to install openjdk (as a dependency):
```
The following additional packages will be installed:
  ca-certificates-java default-jre-headless libpcsclite1
  openjdk-11-jre-headless
```

Here's the failure message:
```
  php8.1-xdebug* php8.1-xml* php8.1-xsl* php8.1-yaml* php8.1-zip* php8.1-zmq*
  powershell* python3-lldb-14* referenceassemblies-pcl* shtool*
  sound-theme-freedesktop* temurin-11-jdk* temurin-17-jdk* temurin-21-jdk*
  temurin-8-jdk* xul-ext-ubufox*
The following NEW packages will be installed:
  ca-certificates-java default-jre-headless libpcsclite1
  openjdk-11-jre-headless
0 upgraded, 4 newly installed, 365 to remove and 1 not upgraded.
Need to get 42.5 MB of archives.
After this operation, 7047 MB disk space will be freed.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 ca-certificates-java all 20190909ubuntu1.2 [12.1 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libpcsclite1 amd64 1.9.5-3ubuntu1 [19.8 kB]
Ign:4 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 openjdk-11-jre-headless amd64 11.0.20.1+1-0ubuntu1~22.04
Get:5 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 default-jre-headless amd64 2:1.11-72build2 [3042 B]
Ign:4 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 openjdk-11-jre-headless amd64 11.0.20.1+1-0ubuntu1~22.04
Ign:4 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 openjdk-11-jre-headless amd64 11.0.20.1+1-0ubuntu1~22.04
Err:4 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 openjdk-11-jre-headless amd64 11.0.20.1+1-0ubuntu1~22.04
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/o/openjdk-lts/openjdk-11-jre-headless_11.0.20.1%2b1-0ubuntu1%7e22.04_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 35.0 kB in 1s (41.4 kB/s)
```

E.g., from https://github.com/ovn-org/ovn-kubernetes/pull/4032

Checking of `apt-get update` fixes this ...
> "The command apt-get update is used to update the package index files on the system, which contain information about available packages and their versions. It downloads the most recent package information from the sources listed in the "/etc/apt/sources. list" file that contains your sources list" (https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwix4PeAsOyCAxWE1AIHHZhbDY4QFnoECA0QAw&url=https%3A%2F%2Fblog.packagecloud.io%2Fyou-need-apt-get-update-and-apt-get-upgrade%2F&usg=AOvVaw20qWUZ_md8th3bjrfd3tza&opi=89978449)