### PR TITLE
Clear RTOE GR MTU on upgrade

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -561,7 +561,8 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 
 	err := libovsdbops.CreateOrUpdateLogicalRouterPort(oc.nbClient, &logicalRouter,
 		&externalLogicalRouterPort, nil, &externalLogicalRouterPort.MAC,
-		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs)
+		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs,
+		&externalLogicalRouterPort.Options)
 	if err != nil {
 		return fmt.Errorf("failed to add logical router port %+v to router %s: %v", externalLogicalRouterPort, gatewayRouter, err)
 	}


### PR DESCRIPTION
While https://github.com/ovn-org/ovn-kubernetes/pull/4025 reverted setting the MTU on the rtoe GR port, it did not address upgrades and clearing the value. This commit fixes it and adds a test case.
