### PR TITLE
WIP: policy peer AddressSet emptied out if ovnkube-master restart

### DIFF
--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -31,8 +31,9 @@ type FakeAddressSetFactory struct {
 	asf            *ovnAddressSetFactory
 	sync.Mutex
 	// maps address set name to object
-	sets                map[string]*fakeAddressSets
-	errOnNextNewAddrSet bool
+	sets                   map[string]*fakeAddressSets
+	errOnNextNewAddrSet    bool
+	errOnNextEnsureAddrSet bool
 }
 
 // fakeFactory implements the AddressSetFactory interface
@@ -43,6 +44,11 @@ const FakeASFError = "fake asf error"
 // ErrOnNextNewASCall will make FakeAddressSetFactory return FakeASFError on the next NewAddressSet call
 func (f *FakeAddressSetFactory) ErrOnNextNewASCall() {
 	f.errOnNextNewAddrSet = true
+}
+
+// ErrOnNextEnsureASCall will make FakeAddressSetFactory return FakeASFError on the next NewAddressSet call
+func (f *FakeAddressSetFactory) ErrOnNextEnsureASCall() {
+	f.errOnNextEnsureAddrSet = true
 }
 
 // NewAddressSet returns a new address set object
@@ -93,6 +99,10 @@ func (f *FakeAddressSetFactory) NewAddressSetOps(dbIDs *libovsdbops.DbObjectIDs,
 
 // EnsureAddressSet returns set object
 func (f *FakeAddressSetFactory) EnsureAddressSet(dbIDs *libovsdbops.DbObjectIDs) (AddressSet, error) {
+	if f.errOnNextEnsureAddrSet {
+		f.errOnNextEnsureAddrSet = false
+		return nil, fmt.Errorf(FakeASFError)
+	}
 	if err := f.asf.validateDbIDs(dbIDs); err != nil {
 		return nil, fmt.Errorf("failed to ensure address set: %w", err)
 	}

--- a/go-controller/pkg/ovn/network_controller_policy_event_handler.go
+++ b/go-controller/pkg/ovn/network_controller_policy_event_handler.go
@@ -123,7 +123,7 @@ func (h *networkControllerPolicyEventHandler) AddResource(obj interface{}, fromR
 	switch h.objType {
 	case factory.AddressSetPodSelectorType:
 		peerAS := h.extraParameters.(*PodSelectorAddrSetHandlerInfo)
-		return h.bnc.handlePodAddUpdate(peerAS, obj)
+		return h.bnc.handlePodAddUpdate(peerAS, false, obj)
 
 	case factory.AddressSetNamespaceAndPodSelectorType:
 		peerAS := h.extraParameters.(*PodSelectorAddrSetHandlerInfo)
@@ -161,7 +161,7 @@ func (h *networkControllerPolicyEventHandler) UpdateResource(oldObj, newObj inte
 	switch h.objType {
 	case factory.AddressSetPodSelectorType:
 		peerAS := h.extraParameters.(*PodSelectorAddrSetHandlerInfo)
-		return h.bnc.handlePodAddUpdate(peerAS, newObj)
+		return h.bnc.handlePodAddUpdate(peerAS, false, newObj)
 
 	case factory.LocalPodSelectorType:
 		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)

--- a/go-controller/pkg/ovn/pod_selector_address_set_test.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set_test.go
@@ -240,8 +240,8 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 			"", "label1", true, true)
 		peer := networkPolicy.Spec.Ingress[0].From[0]
 
-		// make asf return error on the next NewAddressSet call
-		fakeOvn.asf.ErrOnNextNewASCall()
+		// make asf return error on the next EnsureAddressSet call
+		fakeOvn.asf.ErrOnNextEnsureASCall()
 		peerASKey, _, _, err := fakeOvn.controller.EnsurePodSelectorAddressSet(
 			peer.PodSelector, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy))
 		// error should happen on address set add
@@ -271,8 +271,8 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 			"", "label1", true, true)
 		peer := networkPolicy.Spec.Ingress[0].From[0]
 
-		// make asf return error on the next NewAddressSet call
-		fakeOvn.asf.ErrOnNextNewASCall()
+		// make asf return error on the next EnsureAddressSet call
+		fakeOvn.asf.ErrOnNextEnsureASCall()
 		peerASKey, _, _, err := fakeOvn.controller.EnsurePodSelectorAddressSet(
 			peer.PodSelector, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy))
 		// error should happen on address set add


### PR DESCRIPTION
Network policy misbehave for a short period time when ovnkube-master restarts, because its associated peer AddressSet is emptied out before selected Pods IPs are added back. The issue becomes particularly serious if ovnkube-master leader switched in between.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->