### PR TITLE
Update namespace-owned port group (that used to be managed by multicast)

### DIFF
--- a/go-controller/pkg/libovsdb/ops/portgroup.go
+++ b/go-controller/pkg/libovsdb/ops/portgroup.go
@@ -75,6 +75,20 @@ func CreateOrUpdatePortGroups(nbClient libovsdbclient.Client, pgs ...*nbdb.PortG
 	return err
 }
 
+// CreatePortGroup creates the provided port group if it doesn't exist
+func CreatePortGroup(nbClient libovsdbclient.Client, portGroup *nbdb.PortGroup) error {
+	opModel := operationModel{
+		Model:          portGroup,
+		OnModelUpdates: onModelUpdatesNone(),
+		ErrNotFound:    false,
+		BulkOp:         false,
+	}
+
+	m := newModelClient(nbClient)
+	_, err := m.CreateOrUpdate(opModel)
+	return err
+}
+
 // GetPortGroup looks up a port group from the cache
 func GetPortGroup(nbClient libovsdbclient.Client, pg *nbdb.PortGroup) (*nbdb.PortGroup, error) {
 	found := []*nbdb.PortGroup{}

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -1148,25 +1148,3 @@ func (bnc *BaseNetworkController) wasPodReleasedBeforeStartup(uid, nad string) b
 	}
 	return bnc.releasedPodsBeforeStartup[nad].Has(uid)
 }
-
-func (bnc *BaseNetworkController) getNamespaceLSPs(ns string) ([]*nbdb.LogicalSwitchPort, error) {
-	ports := []*nbdb.LogicalSwitchPort{}
-	pods, err := bnc.watchFactory.GetPods(ns)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pods for namespace %q: %v", ns, err)
-	}
-	for _, pod := range pods {
-		if util.PodCompleted(pod) {
-			continue
-		}
-		portInfoMap, err := bnc.logicalPortCache.getAll(pod)
-		if err != nil {
-			klog.Errorf(err.Error())
-		} else {
-			for _, portInfo := range portInfoMap {
-				ports = append(ports, &nbdb.LogicalSwitchPort{UUID: portInfo.uuid})
-			}
-		}
-	}
-	return ports, nil
-}


### PR DESCRIPTION
to only create port group if it doesn't exist and don't update ports or acls, since they should be updated by other handlers (pod/multicast/ egressfirewall/etc).
Add namespace and pod unit tests to cover new port group functionality.

The problem was that namespace handler on initial sync would delete all ports (because logical port cache where it got lsp UUIDs wasn't populated) and all acls (they were just set to nil). Even though both ports and acls will be re-added by the corresponding handlers, it may cause disruption.
It was missed, because multicast handler that was used before, had to create port groups when the corresponding namespace requested multicast (so after lsps were already added to the namespace), but the new implementation creates this port group on namespace creation, so there is no need to manually add all existing ports, since they will be added in the same transaction with lsp creation by pod handler.