### PR TITLE
Fixed CNI plugins compilation issue in kind.sh

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1081,7 +1081,7 @@ install_metallb() {
 install_plugins() {
   git clone https://github.com/containernetworking/plugins.git
   pushd plugins
-  ./build_linux.sh
+  CGO_ENABLED=0 ./build_linux.sh
   KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
   # Opted for not overwritting the existing plugins
   for node in $KIND_NODES; do


### PR DESCRIPTION
**- What this PR does and why is it needed**
Go on Linux dynamically links C libraries to have faster and smaller builds.
This was causing GLIBC mismatches with the [plugins](https://github.com/containernetworking/plugins.git).
This PR exports CGO_ENABLED=0 to disable CGo and get rid of the dependencies.