### PR TITLE
Deprecate IPv6 host masq IP in-order to use it for svc only

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1432,7 +1432,11 @@ func upgradeServiceRoute(routeManager *routemanager.Controller, bridgeName strin
 	}
 	for _, serviceCIDR := range config.Kubernetes.ServiceCIDRs {
 		serviceCIDR := *serviceCIDR
-		routeManager.Add(netlink.Route{LinkIndex: link.Attrs().Index, Dst: &serviceCIDR})
+		srcIP := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP
+		if utilnet.IsIPv6CIDR(&serviceCIDR) {
+			srcIP = config.Gateway.MasqueradeIPs.V6HostMasqueradeIP
+		}
+		routeManager.Add(netlink.Route{LinkIndex: link.Attrs().Index, Dst: &serviceCIDR, Src: srcIP})
 	}
 
 	// add route via OVS bridge

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1592,6 +1592,7 @@ var _ = Describe("Gateway unit tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			config.Kubernetes.ServiceCIDRs = []*net.IPNet{ipnet}
 			gwIPs := []net.IP{net.ParseIP("10.0.0.11")}
+			srcIP := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP
 			lnk := &linkMock.Link{}
 			lnkAttr := &netlink.LinkAttrs{
 				Name:  "ens1f0",
@@ -1603,6 +1604,7 @@ var _ = Describe("Gateway unit tests", func() {
 				Scope:     netlink.SCOPE_UNIVERSE,
 				Gw:        gwIPs[0],
 				MTU:       config.Default.MTU - 100,
+				Src:       srcIP,
 			}
 
 			expectedRoute := &netlink.Route{
@@ -1611,6 +1613,7 @@ var _ = Describe("Gateway unit tests", func() {
 				Scope:     netlink.SCOPE_UNIVERSE,
 				Gw:        gwIPs[0],
 				MTU:       config.Default.MTU,
+				Src:       srcIP,
 			}
 
 			lnk.On("Attrs").Return(lnkAttr)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -3,6 +3,7 @@ package node
 import (
 	"fmt"
 	"hash/fnv"
+	"math"
 	"net"
 	"reflect"
 	"strings"
@@ -99,8 +100,10 @@ type serviceConfig struct {
 }
 
 type cidrAndFlags struct {
-	ipNet *net.IPNet
-	flags int
+	ipNet             *net.IPNet
+	flags             int
+	preferredLifetime int
+	validLifetime     int
 }
 
 func (npw *nodePortWatcher) updateGatewayIPs(addressManager *addressManager) {
@@ -2016,13 +2019,43 @@ func setNodeMasqueradeIPOnExtBridge(extBridgeName string) error {
 	if config.IPv6Mode {
 		_, masqIPNet, _ := net.ParseCIDR(config.Gateway.V6MasqueradeSubnet)
 		masqIPNet.IP = config.Gateway.MasqueradeIPs.V6HostMasqueradeIP
-		bridgeCIDRs = append(bridgeCIDRs, cidrAndFlags{ipNet: masqIPNet, flags: unix.IFA_F_NODAD})
+		// Deprecate the IPv6 host masquerade IP address to ensure its not used in source address selection except
+		// if a route explicitly sets its src IP as this masquerade IP. See RFC 3484 for more details for linux src address selection.
+		// Currently, we set a route with destination as the service CIDR with source IP as the host masquerade IP.
+		// Also, ideally we would only set the preferredLifetime to 0, but because this is the default value of this type, the netlink lib
+		// will only propagate preferred lifetime to netlink if either preferred lifetime or valid lifetime is set greater than 0.
+		// Set valid lifetime to max will achieve our goal of setting preferred lifetime 0.
+		bridgeCIDRs = append(bridgeCIDRs, cidrAndFlags{ipNet: masqIPNet, flags: unix.IFA_F_NODAD, preferredLifetime: 0,
+			validLifetime: math.MaxUint32})
 	}
 
 	for _, bridgeCIDR := range bridgeCIDRs {
 		if exists, err := util.LinkAddrExist(extBridge, bridgeCIDR.ipNet); err == nil && !exists {
-			if err := util.LinkAddrAdd(extBridge, bridgeCIDR.ipNet, bridgeCIDR.flags); err != nil {
-				return err
+			if err := util.LinkAddrAdd(extBridge, bridgeCIDR.ipNet, bridgeCIDR.flags, bridgeCIDR.preferredLifetime,
+				bridgeCIDR.validLifetime); err != nil {
+				return fmt.Errorf("failed to set node masq IP on bridge %s because unable to add address %s: %v",
+					extBridgeName, bridgeCIDR.ipNet.String(), err)
+			}
+		} else if err == nil && exists && utilnet.IsIPv6(bridgeCIDR.ipNet.IP) {
+			// FIXME(mk): remove this logic when it is no longer possible to upgrade from a version which doesn't have
+			// a deprecated ipv6 host masq addr
+
+			// Deprecate IPv6 address to prevent connections from using it as its source address. For connections towards
+			// a service VIP, routes exist to explicitly add this address as source.
+			isDeprecated, err := util.IsDeprecatedAddr(extBridge, bridgeCIDR.ipNet)
+			if err != nil {
+				return fmt.Errorf("failed to set node masq IP on bridge %s because unable to detect if address %s is deprecated: %v",
+					extBridgeName, bridgeCIDR.ipNet.String(), err)
+			}
+			if !isDeprecated {
+				if err = util.LinkAddrDel(extBridge, bridgeCIDR.ipNet); err != nil {
+					klog.Warningf("Failed to delete stale masq IP %s on bridge %s because unable to delete it: %v",
+						bridgeCIDR.ipNet.String(), extBridgeName, err)
+				}
+				if err = util.LinkAddrAdd(extBridge, bridgeCIDR.ipNet, bridgeCIDR.flags, bridgeCIDR.preferredLifetime,
+					bridgeCIDR.validLifetime); err != nil {
+					return err
+				}
 			}
 		} else if err != nil {
 			return fmt.Errorf(

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -185,7 +185,7 @@ func setupManagementPortIPFamilyConfig(routeManager *routemanager.Controller, mp
 		// disappearing
 		warnings = append(warnings, fmt.Sprintf("missing IP address %s on the interface %s, adding it...",
 			cfg.ifAddr, mpcfg.ifName))
-		err = util.LinkAddrAdd(mpcfg.link, cfg.ifAddr, 0)
+		err = util.LinkAddrAdd(mpcfg.link, cfg.ifAddr, 0, 0, 0)
 	}
 	if err != nil {
 		return warnings, err

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -326,7 +326,7 @@ func TestLinkAddrAdd(t *testing.T) {
 
 			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
 			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
-			err := LinkAddrAdd(tc.inputLink, tc.inputNewAddr, tc.inputFlags)
+			err := LinkAddrAdd(tc.inputLink, tc.inputNewAddr, tc.inputFlags, 0, 0)
 			t.Log(err)
 			if tc.errExp {
 				assert.Error(t, err)


### PR DESCRIPTION
Currently, the host masq IP is selected as src IP when a workload residing in the host net ns attempts to connect to a svc IP.

But users may not config any routes that match a particular destination. This may happen if a user configures addresses on a link with noprefixroute or if the destination is not covered by any route.

For IPv6, there is an increased chance of the host masq IP being selected as src IP for destinations that do not fall within the svc CIDR if a user does not have appropriate routes configured to ensure the host masq IP is not selected and we have to use the following algorithm for V6 addrs: (rfc-3484)

1. Prefer same address.
2. Prefer appropriate scope.
3. Avoid deprecated addresses.
4. Prefer home addresses.
5. Prefer outgoing interface
6. Prefer matching label.
7. Prefer public addresses.
8. Use longest matching prefix.

If theres a tie break, linux uses the last address added, and that can end up being the host masq IP.

We want to only use the host masq IP if the dst is a a service IP and never use it otherwise.

We cannot change the scope of the address because the host IP masq IP falls within the global scope range as defined by IANA special registry and it wouldnt totally solve the problem anyway, just make it less likely to occur.

Deprecating the address was not meant for this purpose but it partially achieve our goal of only using this IP as src IP for svcs as long as we have the correct service routes configured with the correct src IP.

I state partially, because step 3. in the algo, only states to "avoid" dep addresses.

Issue: https://issues.redhat.com/browse/OCPBUGS-17207
