### PR TITLE
Don't use namespace address sets for network policy peers

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -159,7 +159,6 @@ var (
 	AdminNetworkPolicyType                reflect.Type = reflect.TypeOf(&anpapi.AdminNetworkPolicy{})
 	BaselineAdminNetworkPolicyType        reflect.Type = reflect.TypeOf(&anpapi.BaselineAdminNetworkPolicy{})
 	AddressSetNamespaceAndPodSelectorType reflect.Type = reflect.TypeOf(&addressSetNamespaceAndPodSelector{})
-	PeerNamespaceSelectorType             reflect.Type = reflect.TypeOf(&peerNamespaceSelector{})
 	AddressSetPodSelectorType             reflect.Type = reflect.TypeOf(&addressSetPodSelector{})
 	LocalPodSelectorType                  reflect.Type = reflect.TypeOf(&localPodSelector{})
 	NetworkAttachmentDefinitionType       reflect.Type = reflect.TypeOf(&nadapi.NetworkAttachmentDefinition{})
@@ -747,8 +746,6 @@ func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority int) 
 		return 3
 	case EgressIPNamespaceType:
 		return 1
-	case PeerNamespaceSelectorType:
-		return 2
 	case AddressSetNamespaceAndPodSelectorType:
 		return 3
 	case EgressNodeType:
@@ -799,7 +796,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting, priority)
 		}, nil
 
-	case AddressSetNamespaceAndPodSelectorType, PeerNamespaceSelectorType, EgressIPNamespaceType:
+	case AddressSetNamespaceAndPodSelectorType, EgressIPNamespaceType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
 			return wf.AddFilteredNamespaceHandler(namespace, sel, funcs, processExisting, priority)

--- a/go-controller/pkg/ovn/network_controller_policy_event_handler.go
+++ b/go-controller/pkg/ovn/network_controller_policy_event_handler.go
@@ -72,8 +72,7 @@ func (h *networkControllerPolicyEventHandler) AreResourcesEqual(obj1, obj2 inter
 		// so pretend they're always different so that the update code gets executed
 		return false, nil
 
-	case factory.PeerNamespaceSelectorType, //
-		factory.AddressSetNamespaceAndPodSelectorType: //
+	case factory.AddressSetNamespaceAndPodSelectorType: //
 		// For these types there is no update code, so pretend old and new
 		// objs are always equivalent and stop processing the update event.
 		return true, nil
@@ -105,8 +104,7 @@ func (h *networkControllerPolicyEventHandler) GetResourceFromInformerCache(key s
 		factory.LocalPodSelectorType:
 		obj, err = h.watchFactory.GetPod(namespace, name)
 
-	case factory.AddressSetNamespaceAndPodSelectorType,
-		factory.PeerNamespaceSelectorType:
+	case factory.AddressSetNamespaceAndPodSelectorType:
 		obj, err = h.watchFactory.GetNamespace(name)
 
 	default:
@@ -128,10 +126,6 @@ func (h *networkControllerPolicyEventHandler) AddResource(obj interface{}, fromR
 	case factory.AddressSetNamespaceAndPodSelectorType:
 		peerAS := h.extraParameters.(*PodSelectorAddrSetHandlerInfo)
 		return h.bnc.handleNamespaceAddUpdate(peerAS, obj)
-
-	case factory.PeerNamespaceSelectorType:
-		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)
-		return h.bnc.handlePeerNamespaceSelectorAdd(extraParameters.np, extraParameters.gp, obj)
 
 	case factory.LocalPodSelectorType:
 		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)
@@ -185,10 +179,6 @@ func (h *networkControllerPolicyEventHandler) DeleteResource(obj, cachedObj inte
 		peerAS := h.extraParameters.(*PodSelectorAddrSetHandlerInfo)
 		return h.bnc.handleNamespaceDel(peerAS, obj)
 
-	case factory.PeerNamespaceSelectorType:
-		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)
-		return h.bnc.handlePeerNamespaceSelectorDel(extraParameters.np, extraParameters.gp, obj)
-
 	case factory.LocalPodSelectorType:
 		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)
 		return h.bnc.handleLocalPodSelectorDelFunc(
@@ -210,8 +200,7 @@ func (h *networkControllerPolicyEventHandler) SyncFunc(objs []interface{}) error
 		switch h.objType {
 		case factory.LocalPodSelectorType,
 			factory.AddressSetNamespaceAndPodSelectorType,
-			factory.AddressSetPodSelectorType,
-			factory.PeerNamespaceSelectorType:
+			factory.AddressSetPodSelectorType:
 			syncFunc = nil
 
 		default:


### PR DESCRIPTION
This is WIP, may be used as an idea if an urgent fix is required.

Namespace address sets don't have hostNetwork pod ips. Network policies do add hostNetwork pods to their address sets, therefore namespace address sets can't be used in that case. The fix is to use pod-selector address sets for network policies always.

You may wonder how it worked before, the answer is this little piece https://github.com/openshift/ovn-kubernetes/blob/release-4.12/go-controller/pkg/ovn/policy.go#L1222 that used to skip namespace address sets if podSelector is not nil (though empty and nil should have the same effect)

So a peer 
```
to:
    - namespaceSelector: <ns selector>
      podSelector: {}
```
would not use namespace address sets, but
```
to:
    - namespaceSelector: <ns selector>
```
would. 
And therefore the former would include host network pod ips, but the latter wouldn't.

Updating network policy ACLs to reuse namespace address sets was tricky, that is why a lot of code can be deleted if we won't use it. 
Unit tests need to be fixed for the new ACL format.
