### PR TITLE
when node reboot, ignoring cmdDel request

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -170,6 +170,11 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 		return nil, fmt.Errorf("required CNI variable missing")
 	}
 
+	if pr.Netns == "" {
+		klog.Infof("The cmdDel request for pod %s/%s Netns is nil. Ignoring this request.", namespace, podName)
+		return response, nil
+	}
+
 	netdevName := ""
 	if pr.CNIConf.DeviceID != "" {
 		if config.OvnKubeNode.Mode == types.NodeModeDPUHost {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->
when node reboot, ignoring cmdDel request
**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Created a pod, yaml is as follows, when the node restarted, kubelet will continuously delete the pause container several times, all down the execution, and when the node restarted the pod re-created, the pod's sleep time is up, the kubelet will also delete the pause container, and after that, down the execution until the report of the error.

This modification omits unnecessary deletion operations.
```
apiVersion: v1
kind: Pod
metadata:
  namespace: ovn-poc
  name: wang
  annotations:
    v1.multus-cni.io/default-network: kube-system/test
    ovn.kubernetes.io/logical_switch: ovn-default
spec:
  nodeName: k8snode1
  containers:
  - name: iperf3
    image: docker.io/library/ubuntu1
    imagePullPolicy: IfNotPresent
    command:
    - sleep
    - "1d"
```
The logs are as follows:
when node reboot:
```
I1208 03:14:31.210278    1846 cni.go:296] [ovn-poc/wang1 1f2c424482d339a10f4ad12699163e465edebac0a27c811a8f24d932552b653e] DEL starting CNI request [ovn-poc/wang1 1f2c424482d339a10f4ad12699163e465edebac0a27c811a8f24d932552b653e]

I1208 03:14:31.221273    1846 cni.go:317] [ovn-poc/wang1 1f2c424482d339a10f4ad12699163e465edebac0a27c811a8f24d932552b653e] DEL finished CNI request [ovn-poc/wang1 1f2c424482d339a10f4ad12699163e465edebac0a27c811a8f24d932552b653e], result "", err failed to get container namespace for pod ovn-poc/wang1: failed to Statfs "": no such file or directory
```
The pod sleep time is up and cni reports an error:
```
I1208 03:22:31.446310    1846 cni.go:296] [ovn-poc/wang1 958e8f0fee39c4422048ce4cc225849885fcd60f8dcf09a74cefc8662fcffcce] DEL starting CNI request [ovn-poc/wang1 958e8f0fee39c4422048ce4cc225849885fcd60f8dcf09a74cefc8662fcffcce]

I1208 03:22:31.456791    1846 cni.go:317] [ovn-poc/wang1 958e8f0fee39c4422048ce4cc225849885fcd60f8dcf09a74cefc8662fcffcce] DEL finished CNI request [ovn-poc/wang1 958e8f0fee39c4422048ce4cc225849885fcd60f8dcf09a74cefc8662fcffcce], result "", err failed to get container namespace for pod ovn-poc/wang1: failed to Statfs "": no such file or directory
```
Environmental information:
```
kubelet --version
Kubernetes v1.24.2

containerd --version
containerd github.com/containerd/containerd v1.6.19 1e1ea6e986c6c86565bc33d52e34b81b3e2bc71f

kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.2", GitCommit:"f66044f4361b9f1f96f0053dd46cb7dce5e990a8", GitTreeState:"clean", BuildDate:"2022-06-15T14:20:54Z", GoVersion:"go1.18.3", Compiler:"gc", Platform:"linux/amd64"}
```

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
When calling cmdDel, determine if podRequest.NetNs is empty, and Ignoring this request.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Creating a pod, reboot the work node, when pod sleeping time has come, The question appeared.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
when node reboot, ignoring cmdDel request