### PR TITLE
flakey test: Informer Event Handler Tests adds existing pod and processes an update event

### DIFF
--- a/go-controller/pkg/informer/informer_test.go
+++ b/go-controller/pkg/informer/informer_test.go
@@ -267,6 +267,11 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			return pod != nil, nil
 		}, 2).Should(BeTrue())
 
+		// Make sure the initial 'add' took place. This is important because the worker may take a
+		// while to get started and synced from the informer. If that happened, the add and the update
+		// performed below would be combined into a single 'add' event.
+		Eventually(func() int32 { return atomic.LoadInt32(&adds) }).Should(Equal(int32(1)), "adds")
+
 		pod.Annotations = map[string]string{"bar": "baz"}
 		pod.ResourceVersion = "11"
 

--- a/go-controller/pkg/informer/informer_test.go
+++ b/go-controller/pkg/informer/informer_test.go
@@ -109,13 +109,16 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			e.Run(1, stopChan)
 		}()
 
-		wait.PollImmediate(
+		err = wait.PollUntilContextTimeout(
+			context.Background(),
 			500*time.Millisecond,
 			5*time.Second,
-			func() (bool, error) {
+			true,
+			func(context.Context) (done bool, err error) {
 				return e.Synced(), nil
 			},
 		)
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (bool, error) {
 			ns, err := k.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
@@ -172,13 +175,16 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			e.Run(1, stopChan)
 		}()
 
-		wait.PollImmediate(
+		err = wait.PollUntilContextTimeout(
+			context.Background(),
 			500*time.Millisecond,
 			5*time.Second,
-			func() (bool, error) {
+			true,
+			func(context.Context) (done bool, err error) {
 				return e.Synced(), nil
 			},
 		)
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (bool, error) {
 			ns, err := k.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
@@ -324,13 +330,16 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			e.Run(1, stopChan)
 		}()
 
-		wait.PollImmediate(
+		err = wait.PollUntilContextTimeout(
+			context.Background(),
 			500*time.Millisecond,
 			5*time.Second,
-			func() (bool, error) {
+			true,
+			func(context.Context) (done bool, err error) {
 				return e.Synced(), nil
 			},
 		)
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (bool, error) {
 			pod, err := k.CoreV1().Pods(namespace).Get(context.TODO(), "foo", metav1.GetOptions{})
@@ -395,13 +404,16 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			e.Run(1, stopChan)
 		}()
 
-		wait.PollImmediate(
+		err = wait.PollUntilContextTimeout(
+			context.Background(),
 			500*time.Millisecond,
 			5*time.Second,
-			func() (bool, error) {
+			true,
+			func(context.Context) (done bool, err error) {
 				return e.Synced(), nil
 			},
 		)
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (bool, error) {
 			pod, err := k.CoreV1().Pods(namespace).Get(context.TODO(), "foo", metav1.GetOptions{})
@@ -466,13 +478,16 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			e.Run(1, stopChan)
 		}()
 
-		wait.PollImmediate(
+		err = wait.PollUntilContextTimeout(
+			context.Background(),
 			500*time.Millisecond,
 			5*time.Second,
-			func() (bool, error) {
+			true,
+			func(context.Context) (done bool, err error) {
 				return e.Synced(), nil
 			},
 		)
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() (bool, error) {
 			pod, err := k.CoreV1().Pods(namespace).Get(context.TODO(), "foo", metav1.GetOptions{})


### PR DESCRIPTION
When starting the informer factory and the worker thread, a delay may occur between the informer being deemed synced and the worker completely starting. Due to this, the test could fail as add and update pod events might coalesce into a single event for the worker. This change proposes a fix that ensures the worker is fully initialized before updating the pod.


PR also related to this issue:  https://github.com/ovn-org/ovn-kubernetes/pull/3772

This PR also addresses replacing deprecated wait.PollImmediate with wait.PollUntilContextTimeout

When flake did not happen, you would see:
```
Informer Event Handler Tests
  adds existing pod and processes an update event
  /home/vagrant/dev/ovn-kubernetes.git/go-controller/pkg/informer/informer_test.go:209
I0102 22:04:39.868546  349898 informer.go:207] Starting test informer queue
I0102 22:04:39.868653  349898 informer.go:209] Waiting for test informer caches to sync
I0102 22:04:39.868961  349898 informer.go:215] Starting 1 test queue workers
I0102 22:04:39.869020  349898 informer.go:226] Started test queue workers   <----- started worker BEFORE add and update. 2 events will be enqueued
I0102 22:04:39.869070  349898 informer.go:103] flavioXXX1: Object test/foo is ADDED: add handler
I0102 22:04:39.869121  349898 informer.go:323] Successfully synced 'test/foo'
I0102 22:04:40.368518  349898 informer.go:124] flavioXXX4: Object test/foo is UPDATED: enqueue!!!
I0102 22:04:40.368573  349898 informer.go:323] Successfully synced 'test/foo'
I0102 22:04:40.469274  349898 informer.go:230] Shutting down test queue workers
I0102 22:04:40.469440  349898 informer.go:233] Shut down test queue workers
```

When flake happened you would see:
```
Informer Event Handler Tests
  adds existing pod and processes an update event
  /home/vagrant/dev/ovn-kubernetes.git/go-controller/pkg/informer/informer_test.go:209
I0102 22:04:48.217161  354299 informer.go:207] Starting test informer queue
I0102 22:04:48.217282  354299 informer.go:209] Waiting for test informer caches to sync
I0102 22:04:48.217897  354299 informer.go:103] flavioXXX1: Object test/foo is ADDED: add handler
I0102 22:04:48.218337  354299 informer.go:124] flavioXXX4: Object test/foo is UPDATED: enqueue!!!
I0102 22:04:48.317809  354299 informer.go:215] Starting 1 test queue workers
I0102 22:04:48.317926  354299 informer.go:226] Started test queue workers   <----- started worker AFTER add and update. add and update combined as one in sync
I0102 22:04:48.318018  354299 informer.go:323] Successfully synced 'test
```


To reproduce flake:

```
cd .../ovn-kubernetes.git/go-controller

while : ; do go test -mod=vendor -test.v \
-race  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer -ginkgo.v \
-ginkgo.focus='adds existing pod and processes an update event' \
-ginkgo.reportFile /dev/null && echo ok || break ; sleep 1 ; done
```