### PR TITLE
WIP - e2e, multi-net policies: ensure ingress denyall has no impact on egress

### DIFF
--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -831,7 +831,7 @@ var _ = Describe("Multi Homing", func() {
 						By("asserting the *client* pod can contact the underlay service after deleting the policy")
 						Expect(connectToServer(clientPodConfig, underlayServiceIP, servicePort)).To(Succeed())
 					},
-						Entry(
+						XEntry(
 							"minimal ingress denyall",
 							multiNetIngressDenyAllPolicy(
 								denyAllIngress,

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -354,6 +354,47 @@ func multiNetEgressLimitingIPBlockPolicy(
 	}
 }
 
+func multiNetIngressDenyAllPolicy(
+	policyName string,
+	policyFor string,
+	appliesFor metav1.LabelSelector,
+) *mnpapi.MultiNetworkPolicy {
+	return &mnpapi.MultiNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+			Annotations: map[string]string{
+				PolicyForAnnotation: policyFor,
+			},
+		},
+		Spec: mnpapi.MultiNetworkPolicySpec{
+			PodSelector: appliesFor,
+			PolicyTypes: []mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress},
+		},
+	}
+}
+
+func multiNetIngressDenyAllEgressAllowAllPolicy(
+	policyName string,
+	policyFor string,
+	appliesFor metav1.LabelSelector,
+) *mnpapi.MultiNetworkPolicy {
+	return &mnpapi.MultiNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+			Annotations: map[string]string{
+				PolicyForAnnotation: policyFor,
+			},
+		},
+		Spec: mnpapi.MultiNetworkPolicySpec{
+			PodSelector: appliesFor,
+			PolicyTypes: []mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress},
+			Egress: []mnpapi.MultiNetworkPolicyEgressRule{
+				mnpapi.MultiNetworkPolicyEgressRule{},
+			},
+		},
+	}
+}
+
 func doesPolicyFeatAnIPBlock(policy *mnpapi.MultiNetworkPolicy) bool {
 	for _, rule := range policy.Spec.Ingress {
 		for _, peer := range rule.From {


### PR DESCRIPTION
This commit adds an e2e test that proves an ingress deny-all policy will have no impact on egress traffic.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This commit adds an e2e test that proves an ingress deny-all policy will have no
impact on egress traffic.

As can be seen by the added tests, a minimal ingress deny-all policy,
represented by the following yaml
```yaml
apiVersion: k8s.cni.cncf.io/v1beta1
kind: MultiNetworkPolicy
metadata:
  annotations:
    k8s.v1.cni.cncf.io/policy-for: tenant-blue
  name: deny-all-ingress
spec:
  podSelector: {}
  policyTypes:
  - Ingress
```
fails the test, while the following passes:
```yaml
apiVersion: k8s.cni.cncf.io/v1beta1
kind: MultiNetworkPolicy
metadata:
  annotations:
    k8s.v1.cni.cncf.io/policy-for: tenant-blue
  name: deny-all-ingress
spec:
  egress:
  - {}
  podSelector: {}
  policyTypes:
  - Ingress
```

Both these should pass, since a policy of type `Ingress` should not
interfere with the egres ruleset (or behavior).
Fixes: https://issues.redhat.com/browse/OCPBUGS-25928

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
This PR currently only adds 2 e2e tests showing the weird behavior.

The test exposing the un-expected behavior is skipped, and a fix for the reported [bug](https://issues.redhat.com/browse/OCPBUGS-25928) should remove the skip. 

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->