### PR TITLE
Don't delete QOS rows that might be referenced

### DIFF
--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -397,12 +397,6 @@ func (oc *DefaultNetworkController) repairEgressQoSes() error {
 	if len(existingQoSes) > 0 {
 		allOps := []ovsdb.Operation{}
 
-		ops, err := libovsdbops.DeleteQoSesOps(oc.nbClient, nil, existingQoSes...)
-		if err != nil {
-			return err
-		}
-		allOps = append(allOps, ops...)
-
 		logicalSwitches, err := oc.egressQoSSwitches()
 		if err != nil {
 			return err

--- a/go-controller/pkg/ovn/egressqos_test.go
+++ b/go-controller/pkg/ovn/egressqos_test.go
@@ -159,6 +159,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				node1Switch.QOSRules = []string{qos1.UUID, qos2.UUID}
 				node2Switch.QOSRules = []string{qos1.UUID, qos2.UUID}
 				expectedDatabaseState := []libovsdbtest.TestData{
+					staleQoS,
 					qos1,
 					qos2,
 					node1Switch,
@@ -190,6 +191,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				node1Switch.QOSRules = []string{qos3.UUID}
 				node2Switch.QOSRules = []string{qos3.UUID}
 				expectedDatabaseState = []libovsdbtest.TestData{
+					staleQoS,
 					qos3,
 					node1Switch,
 					node2Switch,
@@ -204,6 +206,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				node1Switch.QOSRules = []string{}
 				node2Switch.QOSRules = []string{}
 				expectedDatabaseState = []libovsdbtest.TestData{
+					staleQoS,
 					node1Switch,
 					node2Switch,
 					joinSwitch,
@@ -340,6 +343,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				node1Switch.QOSRules = []string{qos1.UUID, qos2.UUID}
 				node2Switch.QOSRules = []string{qos1.UUID, qos2.UUID}
 				expectedDatabaseState := []libovsdbtest.TestData{
+					staleQoS,
 					qos1,
 					qos2,
 					node1Switch,
@@ -376,6 +380,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				node1Switch.QOSRules = []string{qos3.UUID}
 				node2Switch.QOSRules = []string{qos3.UUID}
 				expectedDatabaseState = []libovsdbtest.TestData{
+					staleQoS,
 					qos3,
 					node1Switch,
 					node2Switch,
@@ -390,6 +395,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				node1Switch.QOSRules = []string{}
 				node2Switch.QOSRules = []string{}
 				expectedDatabaseState = []libovsdbtest.TestData{
+					staleQoS,
 					node1Switch,
 					node2Switch,
 					joinSwitch,


### PR DESCRIPTION
QOS rows are strongly referenced from switches so they should not be deleted without deleting also the references which we are already doing just a few lines below. Garbage collection takes care of removing the QOS rows.
