### PR TITLE
Fix LGW ETP=Local on IPv6

### DIFF
--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -600,7 +600,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 						mvip := conf.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
 						targetsETP := joinHostsPort(switchV4targetips, config.eps.Port)
 						if isv6 {
-							mvip = conf.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String()
+							mvip = conf.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
 							targetsETP = joinHostsPort(switchV6targetips, config.eps.Port)
 						}
 						switchRules = append(switchRules, LBRule{


### PR DESCRIPTION
The service's node_switch LB was using the wrong address, breaking IPv6 ETP=Local services.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
I guess this wasn't caught by CI because control-plane e2es aren't enabled on IPv6?


**- How to verify it**
ETP=Local LB Service (using MetalLB only to assign the IP), setting static routes for the vips on an external client to a node hosting a pod:
curl to both the IPv4 and the IPv6 VIP works (without the fix IPv6 doesn't work)


**- Description for the changelog**
Fix LGW ETP=Local on IPv6
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->