### PR TITLE
Use kernel local port range for all NAT objs

### DIFF
--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -869,6 +869,7 @@ func buildNAT(
 	logicalIP string,
 	logicalPort string,
 	externalMac string,
+	externalPortRange string,
 	externalIDs map[string]string,
 ) *nbdb.NAT {
 	nat := &nbdb.NAT{
@@ -887,6 +888,9 @@ func buildNAT(
 		nat.ExternalMAC = &externalMac
 	}
 
+	if externalPortRange != "" {
+		nat.ExternalPortRange = externalPortRange
+	}
 	return nat
 }
 
@@ -895,6 +899,7 @@ func BuildSNAT(
 	externalIP *net.IP,
 	logicalIP *net.IPNet,
 	logicalPort string,
+	externalPortRange string,
 	externalIDs map[string]string,
 ) *nbdb.NAT {
 	externalIPStr := ""
@@ -907,7 +912,7 @@ func BuildSNAT(
 	if logicalIPMask != 32 && logicalIPMask != 128 {
 		logicalIPStr = logicalIP.String()
 	}
-	return buildNAT(nbdb.NATTypeSNAT, externalIPStr, logicalIPStr, logicalPort, "", externalIDs)
+	return buildNAT(nbdb.NATTypeSNAT, externalIPStr, logicalIPStr, logicalPort, "", externalPortRange, externalIDs)
 }
 
 // BuildDNATAndSNAT builds a logical router DNAT/SNAT
@@ -916,6 +921,7 @@ func BuildDNATAndSNAT(
 	logicalIP *net.IPNet,
 	logicalPort string,
 	externalMac string,
+	externalPortRange string,
 	externalIDs map[string]string,
 ) *nbdb.NAT {
 	externalIPStr := ""
@@ -932,7 +938,9 @@ func BuildDNATAndSNAT(
 		logicalIPStr,
 		logicalPort,
 		externalMac,
-		externalIDs)
+		externalPortRange,
+		externalIDs,
+	)
 }
 
 // isEquivalentNAT if it has same uuid. Otherwise, check if types match.

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -82,6 +82,10 @@ type DefaultNetworkController struct {
 	// Includes all node gateway routers.
 	routerLoadBalancerGroupUUID string
 
+	// Cluster wide external source port range. See external_port_range field within
+	// NB DB NAT table.
+	externalPortRange string
+
 	// Cluster-wide router default Control Plane Protection (COPP) UUID
 	defaultCOPPUUID string
 
@@ -184,6 +188,11 @@ func newDefaultNetworkControllerCommon(cnci *CommonNetworkControllerInfo,
 		return nil, fmt.Errorf("unable to create new admin policy based external route controller while creating new default network controller :%w", err)
 	}
 
+	portRange, err := util.GetExternalPortRange()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get TCP/UDP local port range: %v", err)
+	}
+
 	oc := &DefaultNetworkController{
 		BaseNetworkController: BaseNetworkController{
 			CommonNetworkControllerInfo: *cnci,
@@ -216,6 +225,7 @@ func newDefaultNetworkControllerCommon(cnci *CommonNetworkControllerInfo,
 		clusterLoadBalancerGroupUUID: "",
 		switchLoadBalancerGroupUUID:  "",
 		routerLoadBalancerGroupUUID:  "",
+		externalPortRange:            portRange,
 		svcController:                svcController,
 		zoneChassisHandler:           zoneChassisHandler,
 		apbExternalRouteController:   apbExternalRouteController,

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -3021,11 +3021,12 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				)
 				finalNB := []libovsdbtest.TestData{
 					&nbdb.NAT{
-						UUID:       "nat-UUID",
-						ExternalIP: "169.254.33.2",
-						LogicalIP:  "10.128.1.3",
-						Options:    map[string]string{"stateless": "false"},
-						Type:       nbdb.NATTypeSNAT,
+						UUID:              "nat-UUID",
+						ExternalIP:        "169.254.33.2",
+						LogicalIP:         "10.128.1.3",
+						ExternalPortRange: "32000-65535",
+						Options:           map[string]string{"stateless": "false"},
+						Type:              nbdb.NATTypeSNAT,
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + nodeName,
@@ -3053,7 +3054,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 				_, fullMaskPodNet, _ := net.ParseCIDR("10.128.1.3/32")
 				gomega.Expect(
-					addOrUpdatePodSNAT(fakeOvn.controller.nbClient, pod[0].Spec.NodeName, extIPs, []*net.IPNet{fullMaskPodNet}),
+					addOrUpdatePodSNAT(fakeOvn.controller.nbClient, pod[0].Spec.NodeName, "32000-65535", extIPs, []*net.IPNet{fullMaskPodNet}),
 				).To(gomega.Succeed())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{

--- a/go-controller/pkg/ovn/external_gateway_apb_test.go
+++ b/go-controller/pkg/ovn/external_gateway_apb_test.go
@@ -3030,11 +3030,12 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 
 				finalNB := []libovsdbtest.TestData{
 					&nbdb.NAT{
-						UUID:       "nat-UUID",
-						ExternalIP: "169.254.33.2",
-						LogicalIP:  "10.128.1.3",
-						Options:    map[string]string{"stateless": "false"},
-						Type:       nbdb.NATTypeSNAT,
+						UUID:              "nat-UUID",
+						ExternalIP:        "169.254.33.2",
+						LogicalIP:         "10.128.1.3",
+						ExternalPortRange: "32000-65535",
+						Options:           map[string]string{"stateless": "false"},
+						Type:              nbdb.NATTypeSNAT,
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + nodeName,
@@ -3064,7 +3065,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 
 				_, fullMaskPodNet, _ := net.ParseCIDR("10.128.1.3/32")
 				gomega.Expect(
-					addOrUpdatePodSNAT(fakeOvn.controller.nbClient, pod[0].Spec.NodeName, extIPs, []*net.IPNet{fullMaskPodNet}),
+					addOrUpdatePodSNAT(fakeOvn.controller.nbClient, pod[0].Spec.NodeName, "32000-65535", extIPs, []*net.IPNet{fullMaskPodNet}),
 				).To(gomega.Succeed())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -92,7 +92,8 @@ func (oc *DefaultNetworkController) delPbrAndNatRules(nodeName string, lrpTypes 
 	// Note: we don't need to delete any MAC bindings that are dynamically learned from OVN SB DB
 	// because there will be none since this NAT is only for outbound traffic and not for inbound
 	mgmtPortName := types.K8sPrefix + nodeName
-	nat := libovsdbops.BuildDNATAndSNAT(nil, nil, mgmtPortName, "", nil)
+	// empty port range is ok because we do not inspect this field when selecting a NAT to delete
+	nat := libovsdbops.BuildDNATAndSNAT(nil, nil, mgmtPortName, "", "", nil)
 	logicalRouter := nbdb.LogicalRouter{
 		Name: types.OVNClusterRouter,
 	}

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -488,7 +488,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 		if err != nil {
 			return fmt.Errorf("failed to parse full CIDR mask for join subnet IP: %s", gwLRPIP)
 		}
-		nat := libovsdbops.BuildSNAT(&externalIP[0], joinIPNet, "", nil)
+		nat := libovsdbops.BuildSNAT(&externalIP[0], joinIPNet, "", oc.externalPortRange, nil)
 		joinNATs = append(joinNATs, nat)
 	}
 	err = libovsdbops.CreateOrUpdateNATs(oc.nbClient, &logicalRouter, joinNATs...)
@@ -507,7 +507,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 				return fmt.Errorf("failed to create default SNAT rules for gateway router %s: %v",
 					gatewayRouter, err)
 			}
-			nat = libovsdbops.BuildSNAT(&externalIP[0], entry, "", nil)
+			nat = libovsdbops.BuildSNAT(&externalIP[0], entry, "", oc.externalPortRange, nil)
 			nats = append(nats, nat)
 		}
 		err := libovsdbops.CreateOrUpdateNATs(oc.nbClient, &logicalRouter, nats...)
@@ -517,7 +517,8 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 	} else {
 		// ensure we do not have any leftover SNAT entries after an upgrade
 		for _, logicalSubnet := range clusterIPSubnet {
-			nat = libovsdbops.BuildSNAT(nil, logicalSubnet, "", nil)
+			// no need to populate port range because we do not inspect this field when deleting NATs
+			nat = libovsdbops.BuildSNAT(nil, logicalSubnet, "", "", nil)
 			nats = append(nats, nat)
 		}
 		err := libovsdbops.DeleteNATs(oc.nbClient, &logicalRouter, nats...)

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -153,12 +153,16 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 	const (
 		clusterIPNet string = "10.1.0.0"
 		clusterCIDR  string = clusterIPNet + "/16"
+		portStart           = 35000
+		portEnd             = 65535
 	)
+
+	var portRange = fmt.Sprintf("%d-%d", portStart, portEnd)
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
-
+		util.MockPortRangeFileSystemOps(ginkgo.GinkgoT(), portStart, portEnd)
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
@@ -172,7 +176,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-
 		close(stopChan)
 		wg.Wait()
 		if libovsdbCleanup != nil {
@@ -180,6 +183,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 		}
 		f.Shutdown()
 		wg.Wait()
+		util.SetFileSystemOps(util.GetDefaultFileSystemOps())
 	})
 
 	const hybridOverlayClusterCIDR string = "11.1.0.0/16/24"
@@ -423,7 +427,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
-				node1.NodeMgmtPortIP, "1400")
+				node1.NodeMgmtPortIP, "1400", portRange)
 
 			hybridSubnetStaticRoute1, hybridLogicalRouterStaticRoute, hybridSubnetLRP1, hybridSubnetLRP2, hybridLogicalSwitchPort := setupHybridOverlayOVNObjects(node1, "", hoSubnet, nodeHOIP, nodeHOMAC)
 
@@ -635,7 +639,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
-				node1.NodeMgmtPortIP, "1400")
+				node1.NodeMgmtPortIP, "1400", portRange)
 
 			hybridSubnetStaticRoute1, hybridLogicalRouterStaticRoute, hybridSubnetLRP1, hybridSubnetLRP2, hybridLogicalSwitchPort := setupHybridOverlayOVNObjects(node1, "", hoSubnet, nodeHOIP, nodeHOMAC)
 
@@ -875,7 +879,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
-				node1.NodeMgmtPortIP, "1400")
+				node1.NodeMgmtPortIP, "1400", portRange)
 
 			hybridSubnetStaticRoute1, hybridLogicalRouterStaticRoute, hybridSubnetLRP1, hybridSubnetLRP2, hybridLogicalSwitchPort := setupHybridOverlayOVNObjects(node1, winNodeName, winNodeSubnet, nodeHOIP, nodeHOMAC)
 
@@ -1530,7 +1534,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
-				node1.NodeMgmtPortIP, "1400")
+				node1.NodeMgmtPortIP, "1400", portRange)
 
 			hybridSubnetStaticRoute1, hybridLogicalRouterStaticRoute, hybridSubnetLRP1, hybridSubnetLRP2, hybridLogicalSwitchPort := setupHybridOverlayOVNObjects(node1, "", hoSubnet, nodeHOIP, nodeHOMAC)
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -946,12 +946,16 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		clusterCIDR   string = clusterIPNet + "/16"
 		clusterv6CIDR string = "aef0::/48"
 		vlanID               = 1024
+		portStart            = 35000
+		portEnd              = 65535
 	)
+
+	var portRange = fmt.Sprintf("%d-%d", portStart, portEnd)
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
-
+		util.MockPortRangeFileSystemOps(ginkgo.GinkgoT(), portStart, portEnd)
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
@@ -1086,6 +1090,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		f.Shutdown()
 		close(recorder.Events)
 		wg.Wait()
+		util.SetFileSystemOps(util.GetDefaultFileSystemOps())
 	})
 
 	ginkgo.It("sets up a local gateway", func() {
@@ -1114,7 +1119,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", portRange)
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
 			return nil
@@ -1161,7 +1166,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", portRange)
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
 			return nil
@@ -1191,7 +1196,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", portRange)
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
 			return nil
@@ -1235,7 +1240,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", portRange)
 
 			// add stale SNATs from pods to nodes on wrong node
 			staleNats := []*nbdb.NAT{
@@ -1293,7 +1298,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", portRange)
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
 			ginkgo.By("modifying the node and triggering an update")
@@ -1338,7 +1343,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", portRange)
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
 			ginkgo.By("Bringing down NBDB")

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -251,7 +251,7 @@ func (oc *DefaultNetworkController) updateNamespace(old, newer *kapi.Namespace) 
 				} else {
 					if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 						errors = append(errors, err)
-					} else if err = addOrUpdatePodSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, podAnnotation.IPs); err != nil {
+					} else if err = addOrUpdatePodSNAT(oc.nbClient, pod.Spec.NodeName, oc.externalPortRange, extIPs, podAnnotation.IPs); err != nil {
 						errors = append(errors, err)
 					}
 				}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -263,7 +263,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 		// namespace annotations to go through external egress router
 		if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 			return err
-		} else if ops, err = addOrUpdatePodSNATOps(oc.nbClient, pod.Spec.NodeName, extIPs, podAnnotation.IPs, ops); err != nil {
+		} else if ops, err = addOrUpdatePodSNATOps(oc.nbClient, pod.Spec.NodeName, oc.externalPortRange, extIPs, podAnnotation.IPs, ops); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/util/filesystem_linux.go
+++ b/go-controller/pkg/util/filesystem_linux.go
@@ -4,16 +4,25 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
+
+	"github.com/onsi/ginkgo"
 )
 
-var (
-	sysClassNetDir = filepath.Join("/", "sys", "class", "net")
+const (
+	sysClassNetDir          = "/sys/class/net"
+	PortRangeKernelFilePath = "/proc/sys/net/ipv4/ip_local_port_range"
+	portRangeMin            = 1
+	portRangeMax            = 65535
 )
 
 type FileSystemOps interface {
 	Readlink(path string) (string, error)
+	ReadFile(path string) (string, error)
 }
 
 type defaultFileSystemOps struct {
@@ -25,12 +34,23 @@ func SetFileSystemOps(mockInst FileSystemOps) {
 	fileSystemOps = mockInst
 }
 
-func GetFileSystemOps() FileSystemOps {
-	return fileSystemOps
+func GetDefaultFileSystemOps() FileSystemOps {
+	return &defaultFileSystemOps{}
+}
+
+func MockPortRangeFileSystemOps(t ginkgo.GinkgoTInterface, startRange, endRange int) {
+	m := mocks.NewFileSystemOps(t)
+	m.Mock.On("ReadFile", PortRangeKernelFilePath).Return(fmt.Sprintf("%d\t%d", startRange, endRange), nil)
+	SetFileSystemOps(m)
 }
 
 func (defaultFileSystemOps) Readlink(path string) (string, error) {
 	return os.Readlink(path)
+}
+
+func (defaultFileSystemOps) ReadFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	return string(data), err
 }
 
 // GetDeviceIDFromNetdevice retrieves device ID for passed netdevice which is PCI address for regular
@@ -42,4 +62,25 @@ func GetDeviceIDFromNetdevice(netdev string) (string, error) {
 		return "", err
 	}
 	return filepath.Base(realPath), nil
+}
+
+// GetExternalPortRange attempts to get external port range from the TCP/UDP local port range (net.ipv4.ip_local_port_range)
+// and converts it into a format consumable by NB DB NAT field external_port_range.
+func GetExternalPortRange() (string, error) {
+	portRange, err := fileSystemOps.ReadFile(PortRangeKernelFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %v", err)
+	}
+	var start, end int
+	n, err := fmt.Sscanf(portRange, "%d\t%d", &start, &end)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse contents: %v", err)
+	}
+	if n != 2 {
+		return "", fmt.Errorf("unexpected number of items parsed. Expected 2 but found %d", n)
+	}
+	if start > end || start > portRangeMax || end < portRangeMin {
+		return "", fmt.Errorf("invalid range found: %d-%d", start, end)
+	}
+	return fmt.Sprintf("%d-%d", start, end), nil
 }

--- a/go-controller/pkg/util/filesystem_linux_test.go
+++ b/go-controller/pkg/util/filesystem_linux_test.go
@@ -62,3 +62,54 @@ func TestGetDeviceIDFromNetdevice(t *testing.T) {
 		})
 	}
 }
+
+func TestGetExternalPortRange(t *testing.T) {
+	mockFsOps := mocks.NewFileSystemOps(t)
+	SetFileSystemOps(mockFsOps)
+
+	mockErr := fmt.Errorf("mock error")
+	tests := []struct {
+		desc        string
+		expErr      error
+		expVal      string
+		fsOpsHelper []ovntest.TestifyMockHelper
+	}{
+		{
+			desc:   "Correct output",
+			expErr: nil,
+			expVal: "32000-65535",
+			fsOpsHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "ReadFile", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"32000\t65535", nil}},
+			},
+		},
+		{
+			desc:   "File read error",
+			expErr: fmt.Errorf("failed to read file: %s", mockErr.Error()),
+			expVal: "",
+			fsOpsHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "ReadFile", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", mockErr}},
+			},
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockFsOps.Mock, tc.fsOpsHelper)
+
+			ret, err := GetExternalPortRange()
+			if tc.expVal != ret {
+				t.Errorf("Expected - '%v', got - '%v'", tc.expVal, ret)
+			}
+			if tc.expErr == nil && err != nil {
+				t.Errorf("Expected not to fail, got error: %v", err)
+			} else if tc.expErr != nil && err == nil {
+				t.Errorf("Expected to fail with: %v", tc.expErr)
+			} else if tc.expErr == nil && err == nil {
+				// all good
+			} else if tc.expErr.Error() != err.Error() {
+				t.Errorf("Expected - '%v', got - '%v'", tc.expErr, err)
+			}
+
+			mockFsOps.AssertExpectations(t)
+		})
+	}
+}

--- a/go-controller/pkg/util/mocks/FileSystemOps.go
+++ b/go-controller/pkg/util/mocks/FileSystemOps.go
@@ -9,6 +9,30 @@ type FileSystemOps struct {
 	mock.Mock
 }
 
+// ReadFile provides a mock function with given fields: path
+func (_m *FileSystemOps) ReadFile(path string) (string, error) {
+	ret := _m.Called(path)
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(path)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Readlink provides a mock function with given fields: path
 func (_m *FileSystemOps) Readlink(path string) (string, error) {
 	ret := _m.Called(path)

--- a/test/e2e/nat.go
+++ b/test/e2e/nat.go
@@ -1,0 +1,115 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	"k8s.io/utils/pointer"
+)
+
+var _ = ginkgo.Describe("NAT", ginkgo.Serial, func() {
+	const (
+		natTestName           = "natvalidation"
+		externalContainerName = "e2e-" + natTestName
+		externalContainerPort = 8080
+		clusterNetPodName     = "e2e-" + natTestName + "cluster-networked"
+	)
+	var externalContainerIP string
+	f := wrappedTestFramework(natTestName)
+
+	ginkgo.BeforeEach(func() {
+		externalNodeIPV4, externalNodeIPV6 := createClusterExternalContainer(
+			externalContainerName,
+			agnhostImage,
+			[]string{"--privileged", "--network", "kind"},
+			[]string{"netexec", fmt.Sprintf("--http-port=%d", externalContainerPort)},
+		)
+		if IsIPv6Cluster(f.ClientSet) {
+			externalContainerIP = externalNodeIPV6
+		} else {
+			externalContainerIP = externalNodeIPV4
+		}
+	})
+
+	ginkgo.AfterEach(func() {
+		deleteClusterExternalContainer(externalContainerName)
+	})
+
+	// Sends a request to an agnhost destination's /clientip which returns the src port of the packet.
+	getSrcPort := func(namespace, pod string, srcPort int, dstIP string, dstPort int) (int, error) {
+		dst := net.JoinHostPort(dstIP, strconv.Itoa(dstPort))
+		curlCmd := fmt.Sprintf("curl --local-port %d -s --retry-connrefused --retry 2 --max-time 0.5 --connect-timeout 0.5 --retry-delay 1 http://%s/clientip", srcPort, dst)
+		out, err := e2epodoutput.RunHostCmd(namespace, pod, curlCmd)
+		if err != nil {
+			return 0, fmt.Errorf("failed to curl agnhost on %s from %s, err: %w", dstIP, pod, err)
+		}
+		_, srcPortFoundStr, err := net.SplitHostPort(out)
+		if err != nil {
+			return 0, fmt.Errorf("failed to split agnhost's clientip host:port response, err: %w", err)
+		}
+		srcPort, err = strconv.Atoi(srcPortFoundStr)
+		if err != nil {
+			return 0, fmt.Errorf("failed to convert found src port %q to integer: %v", srcPortFoundStr, err)
+		}
+		return srcPort, nil
+	}
+
+	// Validate that the node source port is port address translated when a cluster networked pod selects a source port outside
+	// a port range as defined by Linux net.ipv4.ip_local_port_range
+	// Assumption - all nodes within the cluster have equal net.ipv4.ip_local_port_range values.
+	// 1. Create cluster networked pod and gather local port range (privilege required)
+	// 2. Picked a source port number outside kernel port range
+	// 3. Ensure source port was port address translated
+	ginkgo.It("Should limit external source port range for cluster networked pods in shared gateway mode", func() {
+		if IsGatewayModeLocal() {
+			ginkgo.Skip("local gateway mode does not need to limit source port range")
+		}
+		// pods get a copy of the sysfs file system on the host and we assume all nodes have equivilent port ranges, therefore
+		// we can read the local port range from the pods sysfs.
+		pod, err := createPod(f, clusterNetPodName, "", f.Namespace.Name, []string{}, map[string]string{}, func(pod *corev1.Pod) {
+			// privileged is required to read /proc/sys/net/ipv4/ip_local_port_range
+			pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{Privileged: pointer.Bool(true)}
+		})
+		framework.ExpectNoError(err, "unable to create privileged pod")
+		ginkgo.By("1. Create cluster networked pod and gather local port range (privilege required)")
+		podExec := ForPod(pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
+		kernelLocalPortRange, err := podExec.Exec("cat", "/proc/sys/net/ipv4/ip_local_port_range")
+		framework.ExpectNoError(err, "unable to get ip_local_port_range")
+		gomega.Expect(kernelLocalPortRange).ShouldNot(gomega.BeEmpty())
+		var kernelPortRangeStart, kernelPortRangeEnd int
+		_, err = fmt.Sscanf(kernelLocalPortRange, "%d\t%d", &kernelPortRangeStart, &kernelPortRangeEnd)
+		framework.ExpectNoError(err, fmt.Sprintf("unable to extract port range from %q", kernelLocalPortRange))
+		podSrcPortOutsidePortRange := kernelPortRangeStart - 1
+		gomega.Expect(podSrcPortOutsidePortRange).Should(gomega.BeNumerically(">", 0))
+		ginkgo.By("2. Picked a source port number outside kernel port range")
+		var curlErr error
+		var podSrcPortObservedExternally int
+		_ = wait.PollUntilContextTimeout(
+			context.Background(),
+			retryInterval,
+			retryTimeout,
+			true,
+			func(ctx context.Context) (bool, error) {
+				podSrcPortObservedExternally, curlErr = getSrcPort(pod.Namespace, pod.Name, podSrcPortOutsidePortRange, externalContainerIP, externalContainerPort)
+				return curlErr == nil, nil
+			},
+		)
+		framework.ExpectNoError(curlErr, "source port check to the external kind container failed: %v", curlErr)
+		ginkgo.By("3. Ensure source port was port address translated")
+		if podSrcPortObservedExternally == podSrcPortOutsidePortRange {
+			framework.Failf("Statically set source source port %d is not within the port range %s and was expected to"+
+				" be port address translated but was not", podSrcPortOutsidePortRange, kernelLocalPortRange)
+		}
+		if podSrcPortObservedExternally < kernelPortRangeStart || podSrcPortObservedExternally > kernelPortRangeEnd {
+			framework.Failf("Statically set source source port %d is not within the port range %s", podSrcPortOutsidePortRange, kernelLocalPortRange)
+		}
+	})
+})


### PR DESCRIPTION
ovnkube controller will inspect the local tcp/udp port range and mirror the range for any NAT objects created within NB DB.

If port range is updated during runtime, restart of ovnkube controller is required.

/cc @trozet 