### PR TITLE
Update netpol namespace address sets usage to the old ways

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -1045,6 +1045,14 @@ func (bnc *BaseNetworkController) createNetworkPolicy(policy *knet.NetworkPolicy
 	return np, err
 }
 
+// this method makes nil and empty PodSelectors behave differently (it shouldn't be the case,
+// but this is a legacy behaviour that customers rely on).
+// nil selector will use namespace address sets, a side-effect of this is hostNetwork pods won't be selected, and
+// config.Kubernetes.HostNetworkNamespace will be included with empty NamespaceSelector.
+func useNamespaceAddrSet(peer knet.NetworkPolicyPeer) bool {
+	return peer.NamespaceSelector != nil && peer.PodSelector == nil
+}
+
 func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressPolicy,
 	peer knet.NetworkPolicyPeer) (*policyHandler, error) {
 	// Add IPBlock to ingress network policy
@@ -1059,54 +1067,30 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 	}
 	gp.hasPeerSelector = true
 
+	if useNamespaceAddrSet(peer) {
+		// namespace selector, use namespace address sets
+		handler := &policyHandler{
+			gress:             gp,
+			namespaceSelector: peer.NamespaceSelector,
+		}
+		return handler, nil
+	}
+	// use podSelector address set
 	podSelector := peer.PodSelector
 	if podSelector == nil {
 		// nil pod selector is equivalent to empty pod selector, which selects all
 		podSelector = &metav1.LabelSelector{}
 	}
-	podSel, err := metav1.LabelSelectorAsSelector(podSelector)
+	// np.namespace will be used when fromJSON.NamespaceSelector = nil
+	asKey, ipv4as, ipv6as, err := bnc.EnsurePodSelectorAddressSet(
+		podSelector, peer.NamespaceSelector, np.namespace, np.getKeyWithKind())
+	// even if GetPodSelectorAddressSet failed, add key for future cleanup or retry.
+	np.peerAddressSets = append(np.peerAddressSets, asKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to ensure pod selector address set %s: %v", asKey, err)
 	}
-	nsSel, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
-	if err != nil {
-		return nil, err
-	}
-	if podSel.Empty() && (peer.NamespaceSelector == nil || !nsSel.Empty()) {
-		// namespace-based filtering
-		if peer.NamespaceSelector == nil {
-			// nil namespace selector means same namespace
-			_, err := gp.addNamespaceAddressSet(np.namespace, bnc.addressSetFactory)
-			if err != nil {
-				return nil, fmt.Errorf("failed to add namespace address set for gress policy: %w", err)
-			}
-		} else if !nsSel.Empty() {
-			// namespace selector, use namespace address sets
-			handler := &policyHandler{
-				gress:             gp,
-				namespaceSelector: peer.NamespaceSelector,
-			}
-			return handler, nil
-		}
-	} else {
-		// use podSelector address set
-		// np.namespace will be used when fromJSON.NamespaceSelector = nil
-		asKey, ipv4as, ipv6as, err := bnc.EnsurePodSelectorAddressSet(
-			podSelector, peer.NamespaceSelector, np.namespace, np.getKeyWithKind())
-		// even if GetPodSelectorAddressSet failed, add key for future cleanup or retry.
-		np.peerAddressSets = append(np.peerAddressSets, asKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to ensure pod selector address set %s: %v", asKey, err)
-		}
-		gp.addPeerAddressSets(ipv4as, ipv6as)
-	}
-	if podSel.Empty() && nsSel.Empty() && config.Kubernetes.HostNetworkNamespace != "" {
-		// all namespaces selector, add hostnetwork address set
-		_, err := gp.addNamespaceAddressSet(config.Kubernetes.HostNetworkNamespace, bnc.addressSetFactory)
-		if err != nil {
-			return nil, fmt.Errorf("failed to add namespace address set for gress policy: %w", err)
-		}
-	}
+	gp.addPeerAddressSets(ipv4as, ipv6as)
+
 	return nil, nil
 }
 

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -875,7 +875,7 @@ func (bnc *BaseNetworkController) createNetworkPolicy(policy *knet.NetworkPolicy
 	// then corresponding egress/ingress policies will be added as stateful OVN ACL's.
 	var statelessNetPol bool
 	if config.OVNKubernetesFeature.EnableStatelessNetPol {
-		// look for stateless annotation if the statlessNetPol feature flag is enabled
+		// look for stateless annotation if the statelessNetPol feature flag is enabled
 		val, ok := policy.Annotations[ovnStatelessNetPolAnnotationName]
 		if ok && val == "true" {
 			statelessNetPol = true

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -45,8 +45,8 @@ var (
 )
 
 const (
-	namespace       = "egressip-namespace"
-	namespace2      = "egressip-namespace2"
+	eipNamespace    = "egressip-namespace"
+	eipNamespace2   = "egressip-namespace2"
 	podV4IP         = "10.128.0.15"
 	podV4IP2        = "10.128.0.16"
 	podV4IP3        = "10.128.1.3"
@@ -252,8 +252,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			node1IPv4NonOVNManaged2 := "5.5.5.10/24"
 			node1IPv4Addresses := []string{node1IPv4OVNManaged, node1IPv4NonOVNManaged1, node1IPv4NonOVNManaged2}
 
-			egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-			egressNamespace := newNamespace(namespace)
+			egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+			egressNamespace := newNamespace(eipNamespace)
 			nodes := getIPv4Nodes([]nodeInfo{{node1IPv4Addresses, zone, node1IPv4TranSwitchIP}})
 			node1 := nodes[0]
 			node1.Labels = map[string]string{
@@ -418,8 +418,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			_, node1Subnet, _ := net.ParseCIDR(v4Node1Subnet)
 			node1IPv4Addresses := []string{node1IPv4OVNManaged, node1IPv4NonOVNManaged1, node1IPv4NonOVNManaged2}
 
-			egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-			egressNamespace := newNamespace(namespace)
+			egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+			egressNamespace := newNamespace(eipNamespace)
 			nodes := getIPv4Nodes([]nodeInfo{{node1IPv4Addresses, zone, node1IPv4TranSwitchIP}})
 			node1 := nodes[0]
 			node1.Labels = map[string]string{
@@ -589,8 +589,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					node1IPv4Addresses := []string{node1IPv4OVNManaged, node1IPv4NonOVNManaged1, node1IPv4NonOVNManaged2}
 					node2IPv4Addresses := []string{node2IPv4OVNManaged, node2IPv4NonOVNManaged1, node2IPv4NonOVNManaged2}
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 					nodes := getIPv4Nodes([]nodeInfo{{node1IPv4Addresses, zone, node1IPv4TranSwitchIP},
 						{node2IPv4Addresses, zone, node2IPv4TranSwitchIP}})
 					node1 := nodes[0]
@@ -849,8 +849,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					node2 := nodes[1]
 					node3 := nodes[2]
 					config.IPv4Mode = true
-					egressPod := *newPodWithLabels(namespace, podName, node3Name, podV4IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node3Name, podV4IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 
 					eIP := egressipv1.EgressIP{
 						ObjectMeta: newEgressIPMeta(egressIPName),
@@ -1177,8 +1177,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					node2 := nodes[1]
 					node3 := nodes[2]
 					config.IPv4Mode = true
-					egressPod := *newPodWithLabels(namespace, podName, node3Name, podV4IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node3Name, podV4IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 
 					eIP := egressipv1.EgressIP{
 						ObjectMeta: newEgressIPMeta(egressIPName),
@@ -1511,8 +1511,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					if node2Zone != "global" {
 						node2.Annotations["k8s.ovn.org/remote-zone-migrated"] = node2Zone // used only for ic=true test
 					}
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 
 					eIP := egressipv1.EgressIP{
 						ObjectMeta: newEgressIPMeta(egressIPName),
@@ -1780,12 +1780,12 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						"k8s.ovn.org/egress-assignable": "",
 					}
 					node2 := nodes[1]
-					egressNamespace := newNamespace(namespace)
-					egressNamespace2 := newNamespace(namespace2)
-					egressPod1Node1 := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-					egressPod2Node1 := *newPodWithLabels(namespace2, podName, node1Name, podV4IP2, egressPodLabel)
-					egressPod3Node2 := *newPodWithLabels(namespace, podName2, node2Name, podV4IP3, egressPodLabel)
-					egressPod4Node2 := *newPodWithLabels(namespace2, podName2, node2Name, podV4IP4, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
+					egressNamespace2 := newNamespace(eipNamespace2)
+					egressPod1Node1 := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+					egressPod2Node1 := *newPodWithLabels(eipNamespace2, podName, node1Name, podV4IP2, egressPodLabel)
+					egressPod3Node2 := *newPodWithLabels(eipNamespace, podName2, node2Name, podV4IP3, egressPodLabel)
+					egressPod4Node2 := *newPodWithLabels(eipNamespace2, podName2, node2Name, podV4IP4, egressPodLabel)
 
 					eIPOVNManaged := egressipv1.EgressIP{
 						ObjectMeta: newEgressIPMeta(egressIPName),
@@ -2133,8 +2133,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					_, node1Subnet, _ := net.ParseCIDR(v4Node1Subnet)
 					_, node2Subnet, _ := net.ParseCIDR(v4Node2Subnet)
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 					annotations := map[string]string{
 						"k8s.ovn.org/node-primary-ifaddr":             fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
 						"k8s.ovn.org/node-subnets":                    fmt.Sprintf("{\"default\":\"%s\"}", v4Node1Subnet),
@@ -2547,8 +2547,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					_, node1Subnet, _ := net.ParseCIDR(v4Node1Subnet)
 					_, node2Subnet, _ := net.ParseCIDR(v4Node2Subnet)
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 
 					node1IPv4Addresses := []string{node1IPv4OVNManaged, node1IPv4NonOVNManaged}
 					node2IPv4Addresses := []string{node2IPv4OVNManaged}
@@ -2814,8 +2814,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 					egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 					node1IPv4 := "192.168.126.210/24"
 					_, node1SubnetV4, _ := net.ParseCIDR(v4Node1Subnet)
 					_, node1SubnetV6, _ := net.ParseCIDR(v6Node1Subnet)
@@ -3007,7 +3007,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(nodes[0]).To(gomega.Equal(node2Name))
 					gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP.String()))
 
-					podUpdate := newPod(namespace, podName, node1Name, podV6IP)
+					podUpdate := newPod(eipNamespace, podName, node1Name, podV6IP)
 
 					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(egressPod.Namespace).Update(context.TODO(), podUpdate, metav1.UpdateOptions{})
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -3072,8 +3072,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 					egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0f")
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 					nodes := getIPv6Nodes([]nodeInfo{
 						{[]string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, podZone, "100.88.0.2/16"},
 						{[]string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, "global", "100.88.0.3/16"},
@@ -3220,7 +3220,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(assignedNodes[0]).To(gomega.Equal(node2Name))
 					gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP.String()))
 
-					podUpdate := newPod(namespace, podName, node1Name, podV6IP)
+					podUpdate := newPod(eipNamespace, podName, node1Name, podV6IP)
 					ginkgo.By("Bringing down NBDB")
 					// inject transient problem, nbdb is down
 					fakeOvn.controller.nbClient.Close()
@@ -3269,8 +3269,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 
-				egressPod := *newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
-				egressNamespace := newNamespace(namespace)
+				egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, egressPodLabel)
+				egressNamespace := newNamespace(eipNamespace)
 				_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 				_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
 
@@ -3414,7 +3414,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(nodes[0]).To(gomega.Equal(node2Name))
 				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP.String()))
 
-				podUpdate := newPodWithLabels(namespace, podName, node1Name, podV6IP, map[string]string{
+				podUpdate := newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, map[string]string{
 					"egress": "needed",
 					"some":   "update",
 				})
@@ -3596,8 +3596,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 					egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, "", egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, "", egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 					_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 					_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
 					fakeOvn.startWithDBSetup(
@@ -3678,7 +3678,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(nodes[0]).To(gomega.Equal(node2Name))
 					gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP.String()))
 
-					podUpdate := newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
+					podUpdate := newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, egressPodLabel)
 					podUpdate.Annotations = map[string]string{
 						"k8s.ovn.org/pod-networks": fmt.Sprintf("{\"default\":{\"ip_addresses\":[\"%s/23\"],\"mac_address\":\"0a:58:0a:83:00:0f\",\"gateway_ips\":[\"%s\"],\"ip_address\":\"%s/23\",\"gateway_ip\":\"%s\"}}", podV6IP, v6GatewayIP, podV6IP, v6GatewayIP),
 					}
@@ -3751,8 +3751,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 
-				egressPod := *newPodWithLabels(namespace, podName, node1Name, "", egressPodLabel)
-				egressNamespace := newNamespace(namespace)
+				egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, "", egressPodLabel)
+				egressNamespace := newNamespace(eipNamespace)
 				fakeOvn.startWithDBSetup(clusterRouterDbSetup,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{*egressNamespace},
@@ -3818,8 +3818,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 					egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
-					egressNamespace := newNamespaceWithLabels(namespace, egressPodLabel)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, egressPodLabel)
+					egressNamespace := newNamespaceWithLabels(eipNamespace, egressPodLabel)
 					// pod lives on node 1, therefore set the zone
 					node1 := newNodeGlobalZoneNotEgressableV6Only(node1Name, "0:0:0:0:0:feff:c0a8:8e0c/64")
 					node1.Annotations["k8s.ovn.org/zone-name"] = podZone
@@ -4008,8 +4008,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 					egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
-					egressNamespace := newNamespaceWithLabels(namespace, egressPodLabel)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, egressPodLabel)
+					egressNamespace := newNamespaceWithLabels(eipNamespace, egressPodLabel)
 					// pod is host by node 1 therefore we set its zone
 					node1 := newNodeGlobalZoneNotEgressableV6Only(node1Name, "0:0:0:0:0:fedf:c0a8:8e0c/64")
 					node1.Annotations["k8s.ovn.org/zone-name"] = podZone
@@ -4217,8 +4217,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 					egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
-					egressNamespace := newNamespaceWithLabels(namespace, egressPodLabel)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, egressPodLabel)
+					egressNamespace := newNamespaceWithLabels(eipNamespace, egressPodLabel)
 					// pod is hosted by node 1 therefore we set its zone
 					node1 := newNodeGlobalZoneNotEgressableV6Only(node1Name, "0:0:0:0:0:feff:c0a8:8e0c/64")
 					node1.Annotations["k8s.ovn.org/zone-name"] = podZone
@@ -4366,7 +4366,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(nodes[0]).To(gomega.Equal(node2Name))
 					gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP.String()))
 
-					namespaceUpdate := newNamespace(namespace)
+					namespaceUpdate := newNamespace(eipNamespace)
 
 					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), namespaceUpdate, metav1.UpdateOptions{})
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -4419,8 +4419,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 
-				egressPod := *newPodWithLabels(namespace, podName, node1Name, "", egressPodLabel)
-				egressNamespace := newNamespaceWithLabels(namespace, egressPodLabel)
+				egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, "", egressPodLabel)
+				egressNamespace := newNamespaceWithLabels(eipNamespace, egressPodLabel)
 				fakeOvn.startWithDBSetup(clusterRouterDbSetup,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{*egressNamespace},
@@ -4465,7 +4465,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(nodes[0]).To(gomega.Equal(node2Name))
 				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP.String()))
 
-				namespaceUpdate := newNamespace(namespace)
+				namespaceUpdate := newNamespace(eipNamespace)
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), namespaceUpdate, metav1.UpdateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -4492,8 +4492,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					node2IPv4 := "192.168.126.51"
 					node2IPv4CIDR := node2IPv4 + "/24"
 					_, node1Subnet, _ := net.ParseCIDR(v4Node1Subnet)
-					egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 					annotations := map[string]string{
 						"k8s.ovn.org/node-primary-ifaddr":             fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4CIDR, ""),
 						"k8s.ovn.org/node-subnets":                    fmt.Sprintf("{\"default\":\"%s\"}", v4Node1Subnet),
@@ -4940,8 +4940,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				egressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8e0d")
 				updatedEgressIP := net.ParseIP("0:0:0:0:0:feff:c0a8:8ffd")
 
-				egressPod := *newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
-				egressNamespace := newNamespaceWithLabels(namespace, egressPodLabel)
+				egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV6IP, egressPodLabel)
+				egressNamespace := newNamespaceWithLabels(eipNamespace, egressPodLabel)
 				_, node1Subnet, _ := net.ParseCIDR(v6Node1Subnet)
 				_, node2Subnet, _ := net.ParseCIDR(v6Node2Subnet)
 
@@ -5131,7 +5131,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				// Remove pod and ensure LRP and SNAT are removed as well
 				ginkgo.By("Deleting the completed pod should update EIPs SNATs")
-				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(eipNamespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedDatabaseState2 := []libovsdbtest.TestData{
@@ -5504,8 +5504,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1IPv4 := "192.168.126.12"
 				node1IPv4CIDR := node1IPv4 + "/24"
 				_, node1Subnet, _ := net.ParseCIDR(v4Node1Subnet)
-				egressPod1 := *newPodWithLabels(namespace, podName, node1Name, "", egressPodLabel)
-				egressNamespace := newNamespace(namespace)
+				egressPod1 := *newPodWithLabels(eipNamespace, podName, node1Name, "", egressPodLabel)
+				egressNamespace := newNamespace(eipNamespace)
 				annotations := map[string]string{
 					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4CIDR),
 					"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4Node1Subnet),
@@ -5810,10 +5810,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1IPv4CIDR := node1IPv4 + "/24"
 				_, node1Subnet, _ := net.ParseCIDR(v4Node1Subnet)
 				oldEgressPodIP := "10.128.0.50"
-				egressPod1 := newPodWithLabels(namespace, podName, node1Name, "", egressPodLabel)
+				egressPod1 := newPodWithLabels(eipNamespace, podName, node1Name, "", egressPodLabel)
 				oldAnnotation := map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["10.128.0.50/24"],"mac_address":"0a:58:0a:80:00:05","gateway_ips":["10.128.0.1"],"routes":[{"dest":"10.128.0.0/24","nextHop":"10.128.0.1"}],"ip_address":"10.128.0.50/24","gateway_ip":"10.128.0.1"}}`}
 				egressPod1.Annotations = oldAnnotation
-				egressNamespace := newNamespace(namespace)
+				egressNamespace := newNamespace(eipNamespace)
 
 				annotations := map[string]string{
 					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4CIDR),
@@ -6070,7 +6070,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				// recreate pod with same name immediately;
 				ginkgo.By("should add egress IP setup for the NEW pod which exists in logicalPortCache")
 				newEgressPodIP := "10.128.0.60"
-				egressPod1 = newPodWithLabels(namespace, podName, node1Name, newEgressPodIP, egressPodLabel)
+				egressPod1 = newPodWithLabels(eipNamespace, podName, node1Name, newEgressPodIP, egressPodLabel)
 				egressPod1.Annotations = map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["10.128.0.60/24"],"mac_address":"0a:58:0a:80:00:06","gateway_ips":["10.128.0.1"],"routes":[{"dest":"10.128.0.0/24","nextHop":"10.128.0.1"}],"ip_address":"10.128.0.60/24","gateway_ip":"10.128.0.1"}}`}
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(egressPod1.Namespace).Create(context.TODO(), egressPod1, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -6154,8 +6154,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					node2IPv4Net := "192.168.126.0/24"
 					node2IPv4CIDR := node2IPv4 + "/24"
 
-					egressPod1 := *newPodWithLabels(namespace, podName, node1Name, "", egressPodLabel)
-					egressNamespace := newNamespace(namespace)
+					egressPod1 := *newPodWithLabels(eipNamespace, podName, node1Name, "", egressPodLabel)
+					egressNamespace := newNamespace(eipNamespace)
 					annotations := map[string]string{
 						"k8s.ovn.org/node-primary-ifaddr":             fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4CIDR),
 						"k8s.ovn.org/node-subnets":                    fmt.Sprintf("{\"default\":\"%s\"}", v4Node1Subnet),
@@ -7361,8 +7361,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node2IPv4Net := "192.168.126.0/24"
 				node2IPv4CIDR := node2IPv4 + "/24"
 
-				egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-				egressNamespace := newNamespace(namespace)
+				egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+				egressNamespace := newNamespace(eipNamespace)
 				annotations := map[string]string{
 					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4CIDR, ""),
 					"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4Node1Subnet),
@@ -7591,7 +7591,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1IPv4 := "192.168.126.51"
 				node1IPv4CIDR := node1IPv4 + "/24"
 
-				egressNamespace := newNamespace(namespace)
+				egressNamespace := newNamespace(eipNamespace)
 
 				annotations := map[string]string{
 					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4CIDR, ""),
@@ -7762,8 +7762,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1IPv4Net := "192.168.126.0/24"
 				node1IPv4CIDR := node1IPv4 + "/24"
 
-				egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-				egressNamespace := newNamespace(namespace)
+				egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+				egressNamespace := newNamespace(eipNamespace)
 
 				annotations := map[string]string{
 					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4CIDR),
@@ -8553,9 +8553,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1IPv4Net := "192.168.126.0/24"
 				node1IPv4CIDR := node1IPv4 + "/24"
 
-				egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
+				egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
 				egressPod.Status.Phase = v1.PodSucceeded
-				egressNamespace := newNamespace(namespace)
+				egressNamespace := newNamespace(eipNamespace)
 
 				node1 := v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
@@ -8735,8 +8735,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1IPv4Net := "192.168.126.0/24"
 				node1IPv4CIDR := node1IPv4 + "/24"
 
-				egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-				egressNamespace := newNamespace(namespace)
+				egressPod := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+				egressNamespace := newNamespace(eipNamespace)
 
 				node1 := v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
@@ -8989,9 +8989,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node2IPv4 := "192.168.126.51"
 				node2IPv4CIDR := node2IPv4 + "/24"
 
-				egressPod1 := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
-				egressPod2 := *newPodWithLabels(namespace, "egress-pod2", node2Name, "10.128.0.16", egressPodLabel)
-				egressNamespace := newNamespace(namespace)
+				egressPod1 := *newPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+				egressPod2 := *newPodWithLabels(eipNamespace, "egress-pod2", node2Name, "10.128.0.16", egressPodLabel)
+				egressNamespace := newNamespace(eipNamespace)
 				annotations := map[string]string{
 					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4CIDR),
 					"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4Node1Subnet),

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -219,13 +219,13 @@ func getExpectedDataPodsAndSwitchesForSecondaryNetwork(fakeOvn *FakeOVN, pods []
 func getMultiPolicyData(networkPolicy *knet.NetworkPolicy, localPortUUIDs []string, peerNamespaces []string,
 	tcpPeerPorts []int32, netInfo util.NetInfo) []libovsdb.TestData {
 	return getPolicyDataHelper(networkPolicy, localPortUUIDs, peerNamespaces, tcpPeerPorts, "",
-		false, false, netInfo)
+		false, netInfo)
 }
 
 func getMultiDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string, netInfo util.NetInfo) []libovsdb.TestData {
 	policyTypeIngress, policyTypeEgress := getPolicyType(networkPolicy)
 	return getDefaultDenyDataHelper(networkPolicy.Namespace, policyTypeIngress, policyTypeEgress,
-		ports, "", "", netInfo)
+		ports, "", netInfo)
 }
 
 var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -216,12 +216,6 @@ func getExpectedDataPodsAndSwitchesForSecondaryNetwork(fakeOvn *FakeOVN, pods []
 	return data
 }
 
-func getMultiPolicyData(networkPolicy *knet.NetworkPolicy, localPortUUIDs []string, peerNamespaces []string,
-	tcpPeerPorts []int32, netInfo util.NetInfo) []libovsdb.TestData {
-	return getPolicyDataHelper(networkPolicy, localPortUUIDs, peerNamespaces, tcpPeerPorts, "",
-		false, netInfo)
-}
-
 func getMultiDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string, netInfo util.NetInfo) []libovsdb.TestData {
 	policyTypeIngress, policyTypeEgress := getPolicyType(networkPolicy)
 	return getDefaultDenyDataHelper(networkPolicy.Namespace, policyTypeIngress, policyTypeEgress,
@@ -470,8 +464,8 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 				ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
 				ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName2)
 
-				gressPolicyExpectedData := getMultiPolicyData(policy, nil, []string{namespace2.Name},
-					nil, netInfo)
+				gressPolicyExpectedData := getPolicyData(newNetpolDataParams(policy).
+					withPeerNamespaces(namespace2.Name).withNetInfo(netInfo))
 				defaultDenyExpectedData := getMultiDefaultDenyData(policy, nil, netInfo)
 				expectedData := initialDB.NBData
 				expectedData = append(expectedData, gressPolicyExpectedData...)
@@ -514,8 +508,8 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
 
-				gressPolicyExpectedData1 := getPolicyData(networkPolicy, []string{nPodTest.portUUID},
-					nil, []int32{portNum})
+				gressPolicyExpectedData1 := getPolicyData(newNetpolDataParams(networkPolicy).
+					withLocalPortUUIDs(nPodTest.portUUID).withTCPPeerPorts(portNum))
 				defaultDenyExpectedData1 := getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID})
 				initData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData1 := append(initData, gressPolicyExpectedData1...)
@@ -539,8 +533,8 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 				gomega.Expect(portInfo).NotTo(gomega.Equal(nil))
 				ocInfo.asf.ExpectAddressSetWithIPs(namespaceName1, []string{portInfo.podIP})
 
-				gressPolicyExpectedData2 := getMultiPolicyData(networkPolicy, []string{portInfo.portUUID}, nil,
-					[]int32{portNum}, netInfo)
+				gressPolicyExpectedData2 := getPolicyData(newNetpolDataParams(networkPolicy).
+					withLocalPortUUIDs(portInfo.portUUID).withTCPPeerPorts(portNum).withNetInfo(netInfo))
 				defaultDenyExpectedData2 := getMultiDefaultDenyData(networkPolicy, []string{portInfo.portUUID}, netInfo)
 				expectedData2 := append(expectedData1, gressPolicyExpectedData2...)
 				expectedData2 = append(expectedData2, defaultDenyExpectedData2...)

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -216,12 +216,6 @@ func getExpectedDataPodsAndSwitchesForSecondaryNetwork(fakeOvn *FakeOVN, pods []
 	return data
 }
 
-func getMultiDefaultDenyData(networkPolicy *knet.NetworkPolicy, ports []string, netInfo util.NetInfo) []libovsdb.TestData {
-	policyTypeIngress, policyTypeEgress := getPolicyType(networkPolicy)
-	return getDefaultDenyDataHelper(networkPolicy.Namespace, policyTypeIngress, policyTypeEgress,
-		ports, "", netInfo)
-}
-
 var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 	const (
 		namespaceName1              = "namespace1"
@@ -464,13 +458,11 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 				ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
 				ocInfo.asf.EventuallyExpectEmptyAddressSetExist(namespaceName2)
 
-				gressPolicyExpectedData := getPolicyData(newNetpolDataParams(policy).
-					withPeerNamespaces(namespace2.Name).withNetInfo(netInfo))
-				defaultDenyExpectedData := getMultiDefaultDenyData(policy, nil, netInfo)
-				expectedData := initialDB.NBData
-				expectedData = append(expectedData, gressPolicyExpectedData...)
-				expectedData = append(expectedData, defaultDenyExpectedData...)
-
+				expectedData := getNamespaceWithSinglePolicyExpectedData(
+					newNetpolDataParams(policy).
+						withPeerNamespaces(namespace2.Name).
+						withNetInfo(netInfo),
+					initialDB.NBData)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData))
 				return nil
 			}
@@ -508,9 +500,11 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
 
-				gressPolicyExpectedData1 := getPolicyData(newNetpolDataParams(networkPolicy).
-					withLocalPortUUIDs(nPodTest.portUUID).withTCPPeerPorts(portNum))
-				defaultDenyExpectedData1 := getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID})
+				dataParams := newNetpolDataParams(networkPolicy).
+					withLocalPortUUIDs(nPodTest.portUUID).
+					withTCPPeerPorts(portNum)
+				gressPolicyExpectedData1 := getPolicyData(dataParams)
+				defaultDenyExpectedData1 := getDefaultDenyData(dataParams)
 				initData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData1 := append(initData, gressPolicyExpectedData1...)
 				expectedData1 = append(expectedData1, defaultDenyExpectedData1...)
@@ -533,9 +527,12 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 				gomega.Expect(portInfo).NotTo(gomega.Equal(nil))
 				ocInfo.asf.ExpectAddressSetWithIPs(namespaceName1, []string{portInfo.podIP})
 
-				gressPolicyExpectedData2 := getPolicyData(newNetpolDataParams(networkPolicy).
-					withLocalPortUUIDs(portInfo.portUUID).withTCPPeerPorts(portNum).withNetInfo(netInfo))
-				defaultDenyExpectedData2 := getMultiDefaultDenyData(networkPolicy, []string{portInfo.portUUID}, netInfo)
+				dataParams2 := newNetpolDataParams(networkPolicy).
+					withLocalPortUUIDs(portInfo.portUUID).
+					withTCPPeerPorts(portNum).
+					withNetInfo(netInfo)
+				gressPolicyExpectedData2 := getPolicyData(dataParams2)
+				defaultDenyExpectedData2 := getDefaultDenyData(dataParams2)
 				expectedData2 := append(expectedData1, gressPolicyExpectedData2...)
 				expectedData2 = append(expectedData2, defaultDenyExpectedData2...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData2...))

--- a/go-controller/pkg/ovn/policy_stale_test.go
+++ b/go-controller/pkg/ovn/policy_stale_test.go
@@ -1,0 +1,348 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	v1 "k8s.io/api/core/v1"
+	knet "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Legacy const, should only be used in sync and tests
+const (
+	// arpAllowPolicySuffix is the suffix used when creating default ACLs for a namespace
+	arpAllowPolicySuffix = "ARPallowPolicy"
+)
+
+func getStaleDefaultDenyACL(netpolName, namespace, match string, deny, egress bool) *nbdb.ACL {
+	fakeController := getFakeBaseController(&util.DefaultNetInfo{})
+	direction := libovsdbutil.ACLEgress
+	if !egress {
+		direction = libovsdbutil.ACLIngress
+	}
+	aclIDs := fakeController.getDefaultDenyPolicyACLIDs(namespace, direction, defaultDenyACL)
+	priority := types.DefaultDenyPriority
+	action := nbdb.ACLActionDrop
+	// stale deny name
+	name := namespace + "_" + netpolName
+	if !deny {
+		aclIDs = fakeController.getDefaultDenyPolicyACLIDs(namespace, direction, arpAllowACL)
+		priority = types.DefaultAllowPriority
+		action = nbdb.ACLActionAllow
+		name = getStaleARPAllowACLName(namespace)
+	}
+	acl := libovsdbops.BuildACL(
+		name,
+		nbdb.ACLDirectionToLport,
+		priority,
+		match,
+		action,
+		types.OvnACLLoggingMeter,
+		"",
+		false,
+		aclIDs.GetExternalIDs(),
+		nil,
+		types.PlaceHolderACLTier,
+	)
+	acl.UUID = aclIDs.String() + "-UUID"
+	return acl
+}
+
+func getStaleARPAllowACLName(ns string) string {
+	return libovsdbutil.JoinACLName(ns, arpAllowPolicySuffix)
+}
+
+// getStaleDefaultDenyData builds stale ACLs and port groups for given netpol
+func getStaleDefaultDenyData(networkPolicy *knet.NetworkPolicy) []libovsdbtest.TestData {
+	namespace := networkPolicy.Namespace
+	netpolName := networkPolicy.Name
+	fakeController := getFakeBaseController(&util.DefaultNetInfo{})
+
+	egressPGName := fakeController.defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
+	egressDenyACL := getStaleDefaultDenyACL(netpolName, namespace, "inport == @"+egressPGName, true, true)
+	egressAllowACL := getStaleDefaultDenyACL(netpolName, namespace, "inport == @"+egressPGName+" && "+arpAllowPolicyMatch, false, true)
+
+	ingressPGName := fakeController.defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
+	ingressDenyACL := getStaleDefaultDenyACL(netpolName, namespace, "outport == @"+ingressPGName, true, false)
+	ingressAllowACL := getStaleDefaultDenyACL(netpolName, namespace, "outport == @"+ingressPGName+" && "+arpAllowPolicyMatch, false, false)
+
+	egressDenyPG := fakeController.buildPortGroup(
+		egressPGName,
+		egressPGName,
+		nil,
+		[]*nbdb.ACL{egressDenyACL, egressAllowACL},
+	)
+	egressDenyPG.UUID = egressDenyPG.Name + "-UUID"
+
+	ingressDenyPG := fakeController.buildPortGroup(
+		ingressPGName,
+		ingressPGName,
+		nil,
+		[]*nbdb.ACL{ingressDenyACL, ingressAllowACL},
+	)
+	ingressDenyPG.UUID = ingressDenyPG.Name + "-UUID"
+
+	return []libovsdbtest.TestData{
+		egressDenyACL,
+		egressAllowACL,
+		ingressDenyACL,
+		ingressAllowACL,
+		egressDenyPG,
+		ingressDenyPG,
+	}
+}
+
+// getStalePolicyACLs builds stale ACLs for given peers
+func getStalePolicyACLs(gressIdx int, namespace, policyName string, peerNamespaces []string,
+	peers []knet.NetworkPolicyPeer, policyType knet.PolicyType, netInfo util.NetInfo) []*nbdb.ACL {
+	fakeController := getFakeBaseController(netInfo)
+	pgName, _ := fakeController.getNetworkPolicyPGName(namespace, policyName)
+	controllerName := netInfo.GetNetworkName() + "-network-controller"
+	var portDir string
+	var ipDir string
+	acls := []*nbdb.ACL{}
+	if policyType == knet.PolicyTypeEgress {
+		portDir = "inport"
+		ipDir = "dst"
+	} else {
+		portDir = "outport"
+		ipDir = "src"
+	}
+	hashedASNames := []string{}
+	for _, nsName := range peerNamespaces {
+		hashedASName, _ := getMultinetNsAddrSetHashNames(nsName, controllerName)
+		hashedASNames = append(hashedASNames, hashedASName)
+	}
+	for _, peer := range peers {
+		// follow the algorithm from setupGressPolicy
+		if !useNamespaceAddrSet(peer) {
+			podSelector := peer.PodSelector
+			if podSelector == nil {
+				// nil pod selector is equivalent to empty pod selector, which selects all
+				podSelector = &metav1.LabelSelector{}
+			}
+			peerIndex := getPodSelectorAddrSetDbIDs(getPodSelectorKey(podSelector, peer.NamespaceSelector, namespace), controllerName)
+			asv4, _ := addressset.GetHashNamesForAS(peerIndex)
+			hashedASNames = append(hashedASNames, asv4)
+		}
+	}
+	gp := gressPolicy{
+		policyNamespace: namespace,
+		policyName:      policyName,
+		policyType:      policyType,
+		idx:             gressIdx,
+		controllerName:  controllerName,
+	}
+	if len(hashedASNames) > 0 {
+		gressAsMatch := asMatch(hashedASNames)
+		match := fmt.Sprintf("ip4.%s == {%s} && %s == @%s", ipDir, gressAsMatch, portDir, pgName)
+		action := nbdb.ACLActionAllowRelated
+		dbIDs := gp.getNetpolACLDbIDs(emptyIdx, emptyProtocol)
+		staleName := namespace + "_" + policyName + "_0"
+		// build the most ancient ACL version, which includes
+		// - old name
+		// - no options for Egress ACLs
+		// - wrong direction for egress ACLs
+		// - non-nil Severity when Log is false
+		acl := libovsdbops.BuildACL(
+			staleName,
+			nbdb.ACLDirectionToLport,
+			types.DefaultAllowPriority,
+			match,
+			action,
+			types.OvnACLLoggingMeter,
+			nbdb.ACLSeverityInfo,
+			false,
+			dbIDs.GetExternalIDs(),
+			nil,
+			types.PlaceHolderACLTier,
+		)
+		acl.UUID = dbIDs.String() + "-UUID"
+		acls = append(acls, acl)
+	}
+	return acls
+}
+
+func getStalePolicyData(networkPolicy *knet.NetworkPolicy, peerNamespaces []string) []libovsdbtest.TestData {
+	netInfo := &util.DefaultNetInfo{}
+	acls := []*nbdb.ACL{}
+
+	for i, ingress := range networkPolicy.Spec.Ingress {
+		acls = append(acls, getStalePolicyACLs(i, networkPolicy.Namespace, networkPolicy.Name,
+			peerNamespaces, ingress.From, knet.PolicyTypeIngress, netInfo)...)
+	}
+	for i, egress := range networkPolicy.Spec.Egress {
+		acls = append(acls, getStalePolicyACLs(i, networkPolicy.Namespace, networkPolicy.Name,
+			peerNamespaces, egress.To, knet.PolicyTypeEgress, netInfo)...)
+	}
+
+	fakeController := getFakeBaseController(netInfo)
+	pgName, readableName := fakeController.getNetworkPolicyPGName(networkPolicy.Namespace, networkPolicy.Name)
+	pg := fakeController.buildPortGroup(
+		pgName,
+		readableName,
+		nil,
+		acls,
+	)
+	pg.UUID = pg.Name + "-UUID"
+
+	data := []libovsdbtest.TestData{}
+	for _, acl := range acls {
+		data = append(data, acl)
+	}
+	data = append(data, pg)
+	return data
+}
+
+var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
+	const (
+		namespaceName1 = "namespace1"
+		namespaceName2 = "namespace2"
+		netPolicyName1 = "networkpolicy1"
+	)
+	var (
+		fakeOvn   *FakeOVN
+		initialDB libovsdbtest.TestSetup
+	)
+
+	ginkgo.BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.PrepareTestConfig()
+		fakeOvn = NewFakeOVN(true)
+
+		initialData := getHairpinningACLsV4AndPortGroup()
+		initialDB = libovsdbtest.TestSetup{
+			NBData: initialData,
+		}
+	})
+
+	ginkgo.AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy) {
+		fakeOvn.startWithDBSetup(dbSetup,
+			&v1.NamespaceList{
+				Items: namespaces,
+			},
+			&knet.NetworkPolicyList{
+				Items: networkPolicies,
+			},
+		)
+		var err error
+		if namespaces != nil {
+			err = fakeOvn.controller.WatchNamespaces()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		err = fakeOvn.controller.WatchNetworkPolicy()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	ginkgo.Context("on startup", func() {
+
+		ginkgo.It("reconciles an existing networkPolicy updating stale ACLs", func() {
+			namespace1 := *newNamespace(namespaceName1)
+			namespace2 := *newNamespace(namespaceName2)
+			networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
+				namespace2.Name, "", true, true)
+			// start with stale ACLs
+			gressPolicyInitialData := getStalePolicyData(networkPolicy, []string{namespace2.Name})
+			defaultDenyInitialData := getStaleDefaultDenyData(networkPolicy)
+			initialData := initialDB.NBData
+			initialData = append(initialData, gressPolicyInitialData...)
+			initialData = append(initialData, defaultDenyInitialData...)
+			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []v1.Namespace{namespace1, namespace2},
+				[]knet.NetworkPolicy{*networkPolicy})
+
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
+
+			_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+				Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// make sure stale ACLs were updated
+			expectedData := getNamespaceWithSinglePolicyExpectedData(
+				networkPolicy, nil, []string{namespace2.Name}, nil,
+				initialDB.NBData)
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+		})
+
+		ginkgo.It("reconciles an existing networkPolicy updating stale ACLs with long names", func() {
+			longNamespaceName63 := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk" // longest allowed namespace name
+			namespace1 := *newNamespace(longNamespaceName63)
+			namespace2 := *newNamespace(namespaceName2)
+			networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
+				namespace2.Name, "", true, true)
+			// start with stale ACLs
+			gressPolicyInitialData := getStalePolicyData(networkPolicy, []string{namespace2.Name})
+			defaultDenyInitialData := getStaleDefaultDenyData(networkPolicy)
+			initialData := initialDB.NBData
+			initialData = append(initialData, gressPolicyInitialData...)
+			initialData = append(initialData, defaultDenyInitialData...)
+			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []v1.Namespace{namespace1, namespace2},
+				[]knet.NetworkPolicy{*networkPolicy})
+
+			fakeOvn.asf.ExpectEmptyAddressSet(longNamespaceName63)
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
+
+			_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+				Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// make sure stale ACLs were updated
+			expectedData := getNamespaceWithSinglePolicyExpectedData(
+				networkPolicy, nil, []string{namespace2.Name}, nil,
+				initialDB.NBData)
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+		})
+
+		ginkgo.It("reconciles an existing networkPolicy updating stale address sets", func() {
+			namespace1 := *newNamespace(namespaceName1)
+			namespace2 := *newNamespace(namespaceName2)
+			networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
+				namespace2.Name, "", false, true)
+			// start with stale ACLs
+			staleAddrSetIDs := getStaleNetpolAddrSetDbIDs(networkPolicy.Namespace, networkPolicy.Name,
+				"egress", "0", DefaultNetworkControllerName)
+			localASName, _ := addressset.GetHashNamesForAS(staleAddrSetIDs)
+			peerASName, _ := getNsAddrSetHashNames(namespace2.Name)
+			fakeController := getFakeController(DefaultNetworkControllerName)
+			pgName, _ := fakeController.getNetworkPolicyPGName(networkPolicy.Namespace, networkPolicy.Name)
+			initialData := getPolicyData(networkPolicy, nil, []string{namespace2.Name}, nil)
+			staleACL := initialData[0].(*nbdb.ACL)
+			staleACL.Match = fmt.Sprintf("ip4.dst == {$%s, $%s} && inport == @%s", localASName, peerASName, pgName)
+
+			defaultDenyInitialData := getStaleDefaultDenyData(networkPolicy)
+			initialData = append(initialData, defaultDenyInitialData...)
+			initialData = append(initialData, initialDB.NBData...)
+			_, err := fakeOvn.asf.NewAddressSet(staleAddrSetIDs, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []v1.Namespace{namespace1, namespace2},
+				[]knet.NetworkPolicy{*networkPolicy})
+
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
+			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
+
+			// make sure stale ACLs were updated
+			expectedData := getNamespaceWithSinglePolicyExpectedData(
+				networkPolicy, nil, []string{namespace2.Name}, nil,
+				initialDB.NBData)
+			fakeOvn.asf.ExpectEmptyAddressSet(staleAddrSetIDs)
+
+			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+		})
+	})
+})

--- a/go-controller/pkg/ovn/policy_stale_test.go
+++ b/go-controller/pkg/ovn/policy_stale_test.go
@@ -275,7 +275,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// make sure stale ACLs were updated
 			expectedData := getNamespaceWithSinglePolicyExpectedData(
-				networkPolicy, nil, []string{namespace2.Name}, nil,
+				newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
 				initialDB.NBData)
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 		})
@@ -303,7 +303,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// make sure stale ACLs were updated
 			expectedData := getNamespaceWithSinglePolicyExpectedData(
-				networkPolicy, nil, []string{namespace2.Name}, nil,
+				newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
 				initialDB.NBData)
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 		})
@@ -320,7 +320,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			peerASName, _ := getNsAddrSetHashNames(namespace2.Name)
 			fakeController := getFakeController(DefaultNetworkControllerName)
 			pgName, _ := fakeController.getNetworkPolicyPGName(networkPolicy.Namespace, networkPolicy.Name)
-			initialData := getPolicyData(networkPolicy, nil, []string{namespace2.Name}, nil)
+			initialData := getPolicyData(newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name))
 			staleACL := initialData[0].(*nbdb.ACL)
 			staleACL.Match = fmt.Sprintf("ip4.dst == {$%s, $%s} && inport == @%s", localASName, peerASName, pgName)
 
@@ -338,7 +338,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 
 			// make sure stale ACLs were updated
 			expectedData := getNamespaceWithSinglePolicyExpectedData(
-				networkPolicy, nil, []string{namespace2.Name}, nil,
+				newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
 				initialDB.NBData)
 			fakeOvn.asf.ExpectEmptyAddressSet(staleAddrSetIDs)
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -298,16 +298,12 @@ func getGressACLs(gressIdx int, namespace, policyName string, peerNamespaces []s
 	ipBlocks := []string{}
 	for _, peer := range peers {
 		// follow the algorithm from setupGressPolicy
-		podSelector := peer.PodSelector
-		if podSelector == nil {
-			// nil pod selector is equivalent to empty pod selector, which selects all
-			podSelector = &metav1.LabelSelector{}
-		}
-		podSel, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		nsSel, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		if !((peer.PodSelector == nil || podSel.Empty()) && (peer.NamespaceSelector == nil || !nsSel.Empty())) {
+		if (peer.NamespaceSelector != nil || peer.PodSelector != nil) && !useNamespaceAddrSet(peer) {
+			podSelector := peer.PodSelector
+			if podSelector == nil {
+				// nil pod selector is equivalent to empty pod selector, which selects all
+				podSelector = &metav1.LabelSelector{}
+			}
 			peerIndex := getPodSelectorAddrSetDbIDs(getPodSelectorKey(podSelector, peer.NamespaceSelector, namespace), controllerName)
 			asv4, _ := addressset.GetHashNamesForAS(peerIndex)
 			hashedASNames = append(hashedASNames, asv4)
@@ -668,13 +664,16 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		format.MaxLength = gomegaFormatMaxLength
 	})
 
-	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
-		pods []testPod, podLabels map[string]string) {
+	startOvnWithHostNetPods := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
+		pods []testPod, podLabels map[string]string, hostNetPods bool) {
 		var podsList []v1.Pod
 		for _, testPod := range pods {
 			knetPod := newPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
 			if len(podLabels) > 0 {
 				knetPod.Labels = podLabels
+			}
+			if hostNetPods {
+				knetPod.Spec.HostNetwork = true
 			}
 			podsList = append(podsList, *knetPod)
 		}
@@ -708,6 +707,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		}
 		err = fakeOvn.controller.WatchNetworkPolicy()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
+		pods []testPod, podLabels map[string]string) {
+		startOvnWithHostNetPods(dbSetup, namespaces, networkPolicies, pods, podLabels, false)
 	}
 
 	getUpdatedInitialDB := func(tPods []testPod) []libovsdbtest.TestData {
@@ -1084,11 +1088,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					initialDB.NBData)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 			},
-			table.Entry("for empty pod selector => use netpol namespace address set",
+			table.Entry("empty pod selector => use pod selector",
 				knet.NetworkPolicyPeer{
 					PodSelector: &metav1.LabelSelector{},
-				}, []string{namespaceName1}),
-			table.Entry("namespace selector with empty pod selector => use a set of selected namespace address sets",
+				}, nil),
+			table.Entry("namespace selector with nil pod selector => use a set of selected namespace address sets",
 				knet.NetworkPolicyPeer{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -1820,7 +1824,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		ginkgo.It("references all namespace address sets for empty namespace selector, even if they don't have pods (HostNetworkNamespace)", func() {
 			app.Action = func(ctx *cli.Context) error {
 				hostNamespaceName := "host-network"
-				config.Kubernetes.HostNetworkNamespace = hostNamespaceName
 				hostNamespace := *newNamespace(hostNamespaceName)
 
 				namespace1 := *newNamespace(namespaceName1)
@@ -1856,7 +1859,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.asf.ExpectAddressSetWithIPs(hostNamespaceName, []string{"10.244.0.2"})
 
 				gressPolicyExpectedData := getPolicyData(networkPolicy, []string{nPodTest.portUUID},
-					[]string{hostNamespace.Name}, nil)
+					[]string{hostNamespace.Name, namespaceName1}, nil)
 				defaultDenyExpectedData := getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID})
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
 				expectedData = append(expectedData, gressPolicyExpectedData...)
@@ -1903,6 +1906,99 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Eventually(func() int {
 					return runtime.NumGoroutine()
 				}).Should(gomega.Equal(goroutinesNumInit))
+
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		})
+
+		ginkgo.It("correctly creates networkpolicy targeting hostNetwork pods with non-nil podSelector", func() {
+			// check useNamespaceAddrSet function comments to explain this behaviour
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				namespace1.Labels = map[string]string{labelName: labelVal}
+				nPodTest := getTestPod(namespace1.Name, nodeName)
+
+				networkPolicy := newNetworkPolicy(netPolicyName1, namespace1.Name,
+					metav1.LabelSelector{},
+					nil,
+					[]knet.NetworkPolicyEgressRule{{
+						To: []knet.NetworkPolicyPeer{{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{labelName: labelVal},
+							},
+							PodSelector: &metav1.LabelSelector{},
+						}},
+					}},
+					knet.PolicyTypeEgress,
+				)
+
+				startOvnWithHostNetPods(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+					[]testPod{nPodTest}, nil, true)
+
+				ginkgo.By("Check networkPolicy includes hostNetwork")
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// namespaced address set won't have hostNet pod ip
+				fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
+				// netpol peer address set will
+				eventuallyExpectAddressSetsWithIP(fakeOvn, networkPolicy.Spec.Egress[0].To[0],
+					networkPolicy.Namespace, nPodTest.podIP)
+
+				gressPolicy1ExpectedData := getPolicyData(networkPolicy, nil, nil, nil)
+				defaultDenyExpectedData := getDefaultDenyData(networkPolicy, nil)
+				expectedData := initialDB.NBData
+				expectedData = append(expectedData, gressPolicy1ExpectedData...)
+				expectedData = append(expectedData, defaultDenyExpectedData...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
+
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		})
+
+		ginkgo.It("correctly creates networkpolicy ignoring hostNetwork pods with nil podSelector", func() {
+			// check useNamespaceAddrSet function comments to explain this behaviour
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				namespace1.Labels = map[string]string{labelName: labelVal}
+				nPodTest := getTestPod(namespace1.Name, nodeName)
+
+				networkPolicy := newNetworkPolicy(netPolicyName1, namespace1.Name,
+					metav1.LabelSelector{},
+					nil,
+					[]knet.NetworkPolicyEgressRule{{
+						To: []knet.NetworkPolicyPeer{{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{labelName: labelVal},
+							},
+						}},
+					}},
+					knet.PolicyTypeEgress,
+				)
+
+				startOvnWithHostNetPods(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+					[]testPod{nPodTest}, nil, true)
+
+				ginkgo.By("Check networkPolicy doesn't select hostNetwork pods")
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// namespaced address set won't have hostNet pod ip
+				fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(namespaceName1)
+				// netpol peer address set doesn't exist
+				eventuallyExpectNoAddressSets(fakeOvn, networkPolicy.Spec.Egress[0].To[0],
+					networkPolicy.Namespace)
+
+				gressPolicy1ExpectedData := getPolicyData(networkPolicy, nil, []string{namespace1.Name}, nil)
+				defaultDenyExpectedData := getDefaultDenyData(networkPolicy, nil)
+				expectedData := initialDB.NBData
+				expectedData = append(expectedData, gressPolicy1ExpectedData...)
+				expectedData = append(expectedData, defaultDenyExpectedData...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
 			}


### PR DESCRIPTION
Namespace address sets don't have hostNetwork pod ips, while Network
Policies do add hostNetwork pods to their own address sets. An attempt
to unify this behaviour ended up breaking customers relying on the
previous logic, so we have to keep it.
The logic on when to use namespace address sets was restored. It is
applied when podSelector is nil. That means that peer
```
to:
    - namespaceSelector: <ns selector>
```
won't include hostNetwork pods, while peer
```
to:
    - namespaceSelector: <ns selector>
      podSelector: {}
```
will.
the source of the previous behaviour is here https://github.com/openshift/ovn-kubernetes/blob/release-4.12/go-controller/pkg/ovn/policy.go#L1222-L1240, you can see that nil and empty podselectors are handled differently.
You can find 2 new unit tests verifying this behaviour.

The last 4 commits is a refactoring of netpol unit tests, to simplify future changes and separate stale sync tests.