### PR TITLE
Ignore hybrid-overlay nodes from EgressIP controller

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1400,6 +1400,10 @@ func (eIPC *egressIPClusterController) isEgressIPAddrConflict(egressIP net.IP) (
 	// iterate through the nodes and ensure no host IP address conflicts with EIP. Note that host-cidrs annotation
 	// does not contain EgressIPs that are assigned to interfaces.
 	for _, node := range nodes {
+		// EgressIP is not supported on hybrid overlay nodes, and OVNNodeHostCIDRs annotation is not present
+		if util.NoHostSubnet(node) {
+			continue
+		}
 		nodeHostAddrsSet, err := util.ParseNodeHostCIDRsDropNetMask(node)
 		if err != nil {
 			return false, "", fmt.Errorf("failed to parse node host cidrs for node %s: %v", node.Name, err)

--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -31,6 +31,11 @@ func (h *egressIPClusterControllerEventHandler) AddResource(obj interface{}, fro
 	switch h.objType {
 	case factory.EgressNodeType:
 		node := obj.(*v1.Node)
+		// EgressIP is not supported on hybrid overlay nodes
+		if util.NoHostSubnet(node) {
+			return nil
+		}
+
 		// Initialize the allocator on every update,
 		// ovnkube-node/cloud-network-config-controller will make sure to
 		// annotate the node with the egressIPConfig, but that might have
@@ -80,6 +85,12 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 	case factory.EgressNodeType:
 		oldNode := oldObj.(*v1.Node)
 		newNode := newObj.(*v1.Node)
+
+		// EgressIP is not supported on hybrid overlay nodes
+		if util.NoHostSubnet(newNode) {
+			return nil
+		}
+
 		// Initialize the allocator on every update,
 		// ovnkube-node/cloud-network-config-controller will make sure to
 		// annotate the node with the egressIPConfig, but that might have
@@ -162,6 +173,10 @@ func (h *egressIPClusterControllerEventHandler) DeleteResource(obj, cachedObj in
 		return h.eIPC.reconcileEgressIP(eIP, nil)
 	case factory.EgressNodeType:
 		node := obj.(*v1.Node)
+		// EgressIP is not supported on hybrid overlay nodes
+		if util.NoHostSubnet(node) {
+			return nil
+		}
 		h.eIPC.deleteNodeForEgress(node)
 		nodeEgressLabel := util.GetNodeEgressLabel()
 		nodeLabels := node.GetLabels()


### PR DESCRIPTION
EgressIP is not supported on hybrid-overlay nodes. 
Exclude hybrid-overlay nodes from EgressIP controller to avoid issues related to missing annotations.

/cc @martinkennelly 