### PR TITLE
OCPBUGS-27215: Replace routes from kubevirt live migration to prevent ECMP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -406,8 +406,8 @@ jobs:
           - {"target": "multi-node-zones",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-multi-node-zones", "num-workers": "3", "num-nodes-per-zone": "2"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
-          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled", "num-workers": "3"}
+          - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3"}
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
     needs: [ build-pr ]
     env:

--- a/go-controller/pkg/kubevirt/router.go
+++ b/go-controller/pkg/kubevirt/router.go
@@ -150,7 +150,7 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 			},
 		}
 		if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient, types.OVNClusterRouter, &ingressRoute, func(item *nbdb.LogicalRouterStaticRoute) bool {
-			matches := item.IPPrefix == ingressRoute.IPPrefix && item.Nexthop == ingressRoute.Nexthop && item.Policy != nil && *item.Policy == *ingressRoute.Policy
+			matches := item.IPPrefix == ingressRoute.IPPrefix && item.Policy != nil && *item.Policy == *ingressRoute.Policy
 			return matches
 		}); err != nil {
 			return fmt.Errorf("failed adding static route: %v", err)
@@ -227,7 +227,7 @@ func EnsureRemoteZonePodAddressesToNodeRoute(controllerName string, watchFactory
 			},
 		}
 		if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient, types.OVNClusterRouter, &route, func(item *nbdb.LogicalRouterStaticRoute) bool {
-			matches := item.IPPrefix == route.IPPrefix && item.Nexthop == route.Nexthop && item.Policy != nil && *item.Policy == *route.Policy
+			matches := item.IPPrefix == route.IPPrefix && item.Policy != nil && *item.Policy == *route.Policy
 			return matches
 		}); err != nil {
 			return fmt.Errorf("failed adding static route to remote pod: %v", err)


### PR DESCRIPTION
**- What this PR does and why is it needed**
Kubevirt live migration between nodes that do not own the VM subnet are
creating wrongly at ECMP route since is not replacing the point to point
routes, this breaks traffic.

This change use just just IPPrefix and Policy at the point to
point routes predicate to prevent ECMP.

closes [#OCPBUGS-27215](https://issues.redhat.com/browse/OCPBUGS-27215)

**- Special notes for reviewers**
This is tested at unit and e2e tests, for unit a new test is added that sets the virt-launcher at a third node that do not own the subnet and create a target virt-launcher at different one not owning the subnet either.

For e2e instead of doing two migrations, where we migrate back to the node owning the subnet, a extra migration is added to migrate between two nodes not owning the subnet.

A e2e migration example with subnbets
- node1 subnet is 192.168.1.0/24
- node2 subnet is 192.168.2.0/24
- node3 subnet is 192.168.3.0/24

Vm is created at node1 so it gets the IP 192.168.1.2
- First migration do a migration from node1 to node2 so it has to create point to point routes for the first time at local and remote zones
- Second migration is done from node2 to node3 so it will have to replace the remote zone ptp routes to local ones since now VM is running there (this is what this PR is fixing)
- Third migration goes back to node1 and since it's running at the original node ptp routes are not needed and normal ovn-k routing is fine.



**- Description for the changelog**
Replace live migration routes to prevent ECMP.