### PR TITLE
docs, multi-homing: layer2/localnet topologies are supported in IC

### DIFF
--- a/docs/multi-homing.md
+++ b/docs/multi-homing.md
@@ -116,7 +116,6 @@ spec:
   network will only provide layer 2 communication, and the users must configure
   IPs for the pods. Port security will only prevent MAC spoofing.
 - switched - layer2 - secondary networks **only** allow for east/west traffic.
-- this topology is not supported when Interconnect feature is enabled with multiple zones.
 
 ### Switched - localnet - topology
 This topology interconnects the workloads via a cluster-wide logical switch to
@@ -167,7 +166,6 @@ localnet network.
 - when the subnets attribute is omitted, the logical switch implementing the
   network will only provide layer 2 communication, and the users must configure
   IPs for the pods. Port security will only prevent MAC spoofing.
-- this topology is not supported when Interconnect feature is enabled with multiple zones.
 
 ## Pod configuration
 The user must specify the secondary network attachments via the


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR removes sentences from the docs stating the `layer2` and `localnet` topologies are not
supported when interconnect is used. 

This is no longer true.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove documentation indicating layer2/localnet topologies are not supported in interconnect mode