### PR TITLE
Run ipv6 lane in control plane jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -395,10 +395,12 @@ jobs:
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
-          - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
+          - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
+          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
@@ -506,7 +508,9 @@ jobs:
           make -C test control-plane WHAT="Kubevirt Virtual Machines"
         else
           make -C test ${{ matrix.target }}
-          make -C test conformance
+          if [ "${{ matrix.ipfamily }}" != "ipv6" ]; then
+            make -C test conformance
+          fi
         fi
 
     - name: Export kind logs

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -757,6 +757,9 @@ func pokeAllPodIPs(fr *framework.Framework, srcPodName string, dstPod *v1.Pod) e
 }
 
 func pokeExternalHostFromPod(fr *framework.Framework, namespace string, srcPodName, dstIp string, dstPort int) error {
+	if utilnet.IsIPv6String(dstIp) {
+		dstIp = fmt.Sprintf("[%s]", dstIp)
+	}
 	stdout, stderr, err := ExecShellInPodWithFullOutput(
 		fr,
 		namespace,


### PR DESCRIPTION

**- What this PR does and why is it needed**
This commit fixes things here and there
in e2e's to make control planes run on
v6 as well. Note that some tests are
skipped since they cannot be run on
github runners with v6 enabled.

NOTE: One of the multicast test is moved
from e2e.go to multicast.go where it belongs.

**- Special notes for reviewers**
We must re-enable all the skipped tests: https://github.com/ovn-org/ovn-kubernetes/labels/ci-ipv6 

Supercedes https://github.com/ovn-org/ovn-kubernetes/pull/3512

- What this PR does and why is it needed
I was trying to review https://github.com/ovn-org/ovn-kubernetes/pull/3503 (that got merged already so too late) but then was thinking why this wasn't caught in CI and @trozet pointed out that we are indeed not running v6 in control plane? LOL. I swear we used to.. Wondering at which point this changed, either ways don't want to git blame. Let's fix that.

- Special notes for reviewers
NOTE: Some of these tests that check connectivity to internet cannot be run. See https://github.com/actions/runner-images/issues/668#issuecomment-1480921915 for details.
There were some past efforts to re-enable some of these skipped tests, but that never happened and they are
still failing v6 lane: https://github.com/ovn-org/ovn-kubernetes/pull/2505, https://github.com/ovn-org/ovn-kubernetes/pull/2524, https://github.com/ovn-org/ovn-kubernetes/pull/2287; https://github.com/ovn-org/ovn-kubernetes/pull/2276; so going to skip them again.