### PR TITLE
github: Update all the deprecated actions and features.

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Re-Test Action
         uses: ./.github/actions/retest-action

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,14 +21,15 @@ jobs:
     name: Build Images
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Log in to the GH Container registry
       uses: docker/login-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Log in to the GH Container registry
-      uses: docker/login-action@v1.12.0
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -62,22 +62,22 @@ jobs:
         popd 
     
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@master
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: all
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@master
+      uses: docker/setup-buildx-action@v3
 
     - name: Extract metadata (tags, labels) for fedora ovn-k image
       id: meta-fedora
-      uses: docker/metadata-action@v3.6.2
+      uses: docker/metadata-action@v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REPOSITORY }}/${{ env.FEDORA_IMAGE_NAME }}
 
     - name: Build and push Fedora based Docker image
-      uses: docker/build-push-action@v2.9.0
+      uses: docker/build-push-action@v5
       with:
         builder: ${{ steps.buildx.outputs.name }}
         context: ./dist/images
@@ -89,12 +89,12 @@ jobs:
 
     - name: Extract metadata (tags, labels) for ubuntu ovn-k image
       id: meta-ubuntu
-      uses: docker/metadata-action@v3.6.2
+      uses: docker/metadata-action@v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REPOSITORY }}/${{ env.UBUNTU_IMAGE_NAME }}
 
     - name: Build and push Ubuntu based Docker image
-      uses: docker/build-push-action@v2.9.0
+      uses: docker/build-push-action@v5
       with:
         builder: ${{ steps.buildx.outputs.name }}
         context: ./dist/images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Log in to the GH Container registry
       uses: docker/login-action@v1.12.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,14 +77,14 @@ jobs:
         if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz ]; then
             cp ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ${CI_IMAGE_MASTER_TAR}.gz
             gunzip ${CI_IMAGE_MASTER_TAR}.gz
-            echo "::set-output name=MASTER_IMAGE_RESTORED_FROM_CACHE::true"
+            echo "MASTER_IMAGE_RESTORED_FROM_CACHE=true" >> "$GITHUB_OUTPUT"
             exit 0
         fi
 
         if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master; then
             docker tag ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master ovn-daemonset-f:dev
 
-            echo "::set-output name=MASTER_IMAGE_RESTORED_FROM_GHCR::true"
+            echo "MASTER_IMAGE_RESTORED_FROM_GHCR=true" >> "$GITHUB_OUTPUT"
             exit 0
         fi
     # only run the following steps if the master image was not found in the cache
@@ -164,7 +164,7 @@ jobs:
             mkdir -p ${CI_DIST_IMAGES_OUTPUT}
             cp ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}.gz
             gunzip ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}.gz
-            echo "::set-output name=PR_IMAGE_RESTORED::true"
+            echo "PR_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
         fi
 
     # only run the following steps if the PR image was not found in the cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -61,7 +61,7 @@ jobs:
     # Create a cache for the built master image
     - name: Restore master image cache
       id: image_cache_master
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ env.CI_IMAGE_CACHE }}
@@ -90,14 +90,14 @@ jobs:
     # only run the following steps if the master image was not found in the cache
     - name: Set up Go
       if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory - from master branch
       if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: master
 
@@ -137,7 +137,7 @@ jobs:
         gzip ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
 
     # run the following always if none of the steps before failed
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: test-image-master
         path: ${{ env.CI_IMAGE_MASTER_TAR }}
@@ -149,7 +149,7 @@ jobs:
     # Create a cache for the build PR image
     - name: Restore PR image cache
       id: image_cache_pr
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ env.CI_IMAGE_CACHE }}
@@ -170,14 +170,14 @@ jobs:
     # only run the following steps if the PR image was not found in the cache
     - name: Set up Go
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build and Test - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
@@ -237,7 +237,7 @@ jobs:
         gzip ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
 
     # run the following if none of the previous steps failed
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: test-image-pr
         path: ${{ env.CI_DIST_IMAGES_OUTPUT }}/${{ env.CI_IMAGE_PR_TAR }}
@@ -264,7 +264,7 @@ jobs:
       OVN_MULTICAST_ENABLE:  "false"
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -286,7 +286,7 @@ jobs:
           powershell temurin-* zulu-*
 
     - name: Download test-image-master
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: test-image-master
 
@@ -302,7 +302,7 @@ jobs:
 
     - name: Check out code into the Go module directory - from Master branch
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           ref: master
 
@@ -324,13 +324,13 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
 
     - name: Download test-image-pr
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: test-image-pr
 
@@ -339,7 +339,7 @@ jobs:
         docker load --input ${CI_IMAGE_PR_TAR} && rm -rf ${CI_IMAGE_PR_TAR}
 
     - name: Check out code into the Go module directory - from PR branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: ovn upgrade
       run: |
@@ -358,7 +358,7 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}-after-upgrade
         path: /tmp/kind/logs-kind-pr-branch
@@ -440,13 +440,13 @@ jobs:
           powershell temurin-* zulu-*
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up environment
       run: |
@@ -465,7 +465,7 @@ jobs:
         sudo ufw disable
 
     - name: Download test-image-pr
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: test-image-pr
 
@@ -509,7 +509,7 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
@@ -542,13 +542,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up environment
       run: |
@@ -563,7 +563,7 @@ jobs:
         sudo ufw disable
 
     - name: Download test-image-pr
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: test-image-pr
 
@@ -596,7 +596,7 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
@@ -613,7 +613,7 @@ jobs:
 
     - name: Upload ovn dbs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kind-ovndbs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/ovndbs
@@ -646,13 +646,13 @@ jobs:
           sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up environment
         run: |
@@ -664,7 +664,7 @@ jobs:
         # Not needed for KIND deployments, so just disable all the time.
         run: |
           sudo ufw disable
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-image-pr
       - name: Load docker image
@@ -684,7 +684,7 @@ jobs:
           kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
       id: go
 
     - name: Verify
@@ -87,18 +88,19 @@ jobs:
             exit 0
         fi
     # only run the following steps if the master image was not found in the cache
-    - name: Set up Go
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
-      id: go
-
     - name: Check out code into the Go module directory - from master branch
       if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
       uses: actions/checkout@v4
       with:
         ref: master
+
+    - name: Set up Go
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
+      id: go
 
     - name: Build - from master branch
       if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
@@ -167,16 +169,17 @@ jobs:
         fi
 
     # only run the following steps if the PR image was not found in the cache
+    - name: Check out code into the Go module directory - from current pr branch
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
+      uses: actions/checkout@v4
+
     - name: Set up Go
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
       id: go
-
-    - name: Check out code into the Go module directory - from current pr branch
-      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
-      uses: actions/checkout@v4
 
     - name: Build and Test - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
@@ -262,10 +265,16 @@ jobs:
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_MULTICAST_ENABLE:  "false"
     steps:
+    - name: Check out code into the Go module directory - from Master branch
+      uses: actions/checkout@v4
+      with:
+          ref: master
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
       id: go
 
     - name: Set up environment
@@ -298,12 +307,6 @@ jobs:
     - name: Load docker image
       run: |
         docker load --input ${CI_IMAGE_MASTER_TAR} && rm -rf ${CI_IMAGE_MASTER_TAR}
-
-    - name: Check out code into the Go module directory - from Master branch
-      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
-      uses: actions/checkout@v4
-      with:
-          ref: master
 
     - name: kind setup
       run: |
@@ -438,14 +441,15 @@ jobs:
           msbuild mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Set up environment
       run: |
@@ -539,15 +543,15 @@ jobs:
       KIND_NUM_ZONES: "${{ matrix.num-zones }}"
       KIND_NUM_NODES_PER_ZONE: "${{ matrix.num-nodes-per-zone }}"
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Set up environment
       run: |
@@ -644,14 +648,15 @@ jobs:
           sudo apt-get update
           sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
         id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
 
       - name: Set up environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
         version: v1.52
         working-directory: go-controller
         args: --modules-download-mode=vendor --timeout=15m0s --verbose
-        skip-go-installation: true
 
   build-master:
     name: Build-master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,18 +78,19 @@ jobs:
             cp ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ${CI_IMAGE_MASTER_TAR}.gz
             gunzip ${CI_IMAGE_MASTER_TAR}.gz
             echo "MASTER_IMAGE_RESTORED_FROM_CACHE=true" >> "$GITHUB_OUTPUT"
+            echo "MASTER_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
             exit 0
         fi
 
         if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master; then
             docker tag ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master ovn-daemonset-f:dev
 
-            echo "MASTER_IMAGE_RESTORED_FROM_GHCR=true" >> "$GITHUB_OUTPUT"
+            echo "MASTER_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
             exit 0
         fi
     # only run the following steps if the master image was not found in the cache
     - name: Check out code into the Go module directory - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
       uses: actions/checkout@v4
       with:
         ref: master
@@ -103,7 +104,7 @@ jobs:
       id: go
 
     - name: Build - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
       run: |
         set -x
         pushd go-controller
@@ -112,7 +113,7 @@ jobs:
         popd
 
     - name: Build docker image - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
       run: |
         pushd dist/images
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: master
 
@@ -54,7 +54,7 @@ jobs:
           docker save ovn-daemonset-f:dev > _output/image.tar
         popd
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: test-image
         path: dist/images/_output/image.tar
@@ -72,7 +72,7 @@ jobs:
         echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
 
@@ -108,13 +108,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up environment
       run: |
@@ -136,7 +136,7 @@ jobs:
         sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
         sudo chmod +x /usr/local/bin/kind
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: test-image
    
@@ -161,7 +161,7 @@ jobs:
 
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -60,28 +60,6 @@ jobs:
         name: test-image
         path: dist/images/_output/image.tar
 
-  k8s:
-    if: github.repository == 'ovn-org/ovn-kubernetes' || github.event_name == 'workflow_dispatch'
-    name: Build k8s
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Set up environment
-      run: |
-        export GOPATH=$(go env GOPATH)
-        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
-        echo "$GOPATH/bin" >> $GITHUB_PATH
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
-
-    - name: Install KIND
-      run: |
-        sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
-        sudo chmod +x /usr/local/bin/kind
-        
   e2e-dual:
     if: github.repository == 'ovn-org/ovn-kubernetes' || github.event_name == 'workflow_dispatch'
     name: e2e-dual

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -24,16 +24,17 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
-      id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
       with:
         ref: master
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
+      id: go
 
     - name: Build
       run: |
@@ -106,15 +107,15 @@ jobs:
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Set up environment
       run: |

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -110,11 +110,6 @@ jobs:
           msbuild mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*
 
-    - name: Install KIND
-      run: |
-        sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
-        sudo chmod +x /usr/local/bin/kind
-
     - uses: actions/download-artifact@v4
       with:
         name: test-image


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

Most of the GitHub actions that ovn-kubernetes is using are deprecated, since they are using outdated versions of Node.js: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
Also, `set-output` feature is deprecated for a long time: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

These generate a lot of warnings on every build and may actually stop working eventually:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20:
actions/setup-go@v3, actions/checkout@v3, docker/login-action@v1.12.0, docker/metadata-action@v3.6.2,
docker/build-push-action@v2.9.0.

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using
Environment Files.
```

Updating all the actions to the most recent versions to pick up Node.js 20 updates.
And switching from `set-output` to `GITHUB_OUTPUT` environment file, which is a new way of passing the outputs between jobs.

Note: golangci/golangci-lint-action doesn't have a version based on Node.js 20 yet (https://github.com/golangci/golangci-lint-action/issues/953), so this one warning will remain for now.

`setup-go@v5` also wants to cache all the go dependencies by default, so providing paths to `go.sum` files for it, otherwise it throws a warning that `go.sum` is not found.

Additionally fixed the logic around `MASTER_IMAGE_RESTORED` as it was causing warnings with caching and removed `Build k8s` periodic job as it doesn't actually do anything useful, AFAICT, as well as `Install KIND` step.

<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**

Some of the docker actions were pinned to specific minor releases for unclear reasons, but they have to be updated anyway due to Node.js dependencies.  So bumping those to the latest major versions.
Some docker actions were following the `master` versions, which is strange.  Probably because they needed an unreleased functionality at the time of introduction. Those switched to the latest stable releases as well.

<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->