### PR TITLE
Wait for ovnkube controller to start before checking result error.

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -461,17 +461,17 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 			defer clusterManagerWatchFactory.Shutdown()
 		}
 
-		cm, err := clustermanager.NewClusterManager(ovnClientset.GetClusterManagerClientset(), clusterManagerWatchFactory,
+		clusterManager, err := clustermanager.NewClusterManager(ovnClientset.GetClusterManagerClientset(), clusterManagerWatchFactory,
 			runMode.identity, wg, eventRecorder)
 		if err != nil {
 			return fmt.Errorf("failed to create new cluster manager: %w", err)
 		}
 		metrics.RegisterClusterManagerFunctional()
-		err = cm.Start(ctx)
+		err = clusterManager.Start(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to start cluster manager: %w", err)
 		}
-		defer cm.Stop()
+		defer clusterManager.Stop()
 
 		// record delay until ready
 		metrics.MetricClusterManagerReadyDuration.Set(time.Since(startTime).Seconds())
@@ -490,7 +490,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 			return fmt.Errorf("error when trying to initialize libovsdb SB client: %v", err)
 		}
 
-		cm, err := controllerManager.NewNetworkControllerManager(ovnClientset, masterWatchFactory, libovsdbOvnNBClient, libovsdbOvnSBClient, eventRecorder, wg)
+		networkControllerManager, err := controllerManager.NewNetworkControllerManager(ovnClientset, masterWatchFactory, libovsdbOvnNBClient, libovsdbOvnSBClient, eventRecorder, wg)
 		if err != nil {
 			return err
 		}
@@ -502,7 +502,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		ovnkubeControllerWG.Add(1)
 		go func() {
 			defer ovnkubeControllerWG.Done()
-			err = cm.Start(ctx)
+			err = networkControllerManager.Start(ctx)
 			if err != nil {
 				ovnkubeControllerStartErr = fmt.Errorf("failed to start ovnkube controller: %w", err)
 				klog.Error(ovnkubeControllerStartErr)
@@ -516,7 +516,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		defer func() {
 			ovnkubeControllerWG.Wait()
 			if ovnkubeControllerStartErr == nil {
-				cm.Stop()
+				networkControllerManager.Stop()
 			}
 		}()
 	}


### PR DESCRIPTION
Otherwise, on node start failure, ovnkube controller may not be started yet, and ovnkubeControllerStartErr will be nil just because it is unassigned yet.
Besides not cleaning up, there is a possible deadlock on `masterWatchFactory.Shutdown()`. WatchFactory closes the channel https://github.com/ovn-org/ovn-kubernetes/blob/12681a716a4c98d8337c7815f15966cc5bba3502/go-controller/pkg/factory/factory.go#L663 and locks every informer before deletion. https://github.com/ovn-org/ovn-kubernetes/blob/12681a716a4c98d8337c7815f15966cc5bba3502/go-controller/pkg/factory/handler.go#L476 On handler add every informer is also locked https://github.com/ovn-org/ovn-kubernetes/blob/12681a716a4c98d8337c7815f15966cc5bba3502/go-controller/pkg/factory/factory.go#L861 If the informer is queued, it will use initial add queue https://github.com/ovn-org/ovn-kubernetes/blob/12681a716a4c98d8337c7815f15966cc5bba3502/go-controller/pkg/factory/handler.go#L577 that stops processing events when the channel is closed https://github.com/ovn-org/ovn-kubernetes/blob/12681a716a4c98d8337c7815f15966cc5bba3502/go-controller/pkg/factory/handler.go#L246 Since the queue is limited https://github.com/ovn-org/ovn-kubernetes/blob/12681a716a4c98d8337c7815f15966cc5bba3502/go-controller/pkg/factory/handler.go#L231, informer will lock after adding 10 elements, and add handler will never return. WatchFactory will wait for informer lock, that will never be released.