### PR TITLE
fedora: Update OVN to latest version ovn-23.09.0-112.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -407,6 +407,8 @@ jobs:
           - {"target": "multi-node-zones",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-multi-node-zones", "num-workers": "3", "num-nodes-per-zone": "2"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
+          - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled", "num-workers": "3"}
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3"}
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-23.09.0-100.fc39
+ARG ovnver=ovn-23.09.0-112.fc39
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -25,6 +25,7 @@ import (
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/kubernetes/test/e2e/framework/skipper"
+	utilnet "k8s.io/utils/net"
 )
 
 // This is the image used for the containers acting as externalgateways, built
@@ -780,8 +781,14 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				podConnEntriesWithMACLabelsSet = pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
 				totalPodConnEntries = pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, nil)
 				if protocol == "udp" {
-					gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(1)) // we still have the conntrack entry for the remaining gateway
-					gomega.Expect(totalPodConnEntries).To(gomega.Equal(5))            // 6-1
+					// FIXME(trozet): for ipv6 we flush all mac label flows due to no support for IPv6 NDP
+					if utilnet.IsIPv4String(addresses.gatewayIPs[0]) {
+						gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(1)) // we still have the conntrack entry for the remaining gateway
+						gomega.Expect(totalPodConnEntries).To(gomega.Equal(5))            // 6-1
+					} else {
+						gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(0))
+						gomega.Expect(totalPodConnEntries).To(gomega.Equal(4)) // 6-2
+					}
 				} else {
 					gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(2))
 					gomega.Expect(totalPodConnEntries).To(gomega.Equal(6))
@@ -871,8 +878,14 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				podConnEntriesWithMACLabelsSet = pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
 				totalPodConnEntries = pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, nil)
 				if protocol == "udp" {
-					gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(1)) // we still have the conntrack entry for the remaining gateway
-					gomega.Expect(totalPodConnEntries).To(gomega.Equal(5))            // 6-1
+					// FIXME(trozet): for ipv6 we flush all mac label flows due to no support for IPv6 NDP
+					if utilnet.IsIPv4String(addresses.gatewayIPs[0]) {
+						gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(1)) // we still have the conntrack entry for the remaining gateway
+						gomega.Expect(totalPodConnEntries).To(gomega.Equal(5))            // 6-1
+					} else {
+						gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(0))
+						gomega.Expect(totalPodConnEntries).To(gomega.Equal(4)) // 6-2
+					}
 				} else {
 					gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(2))
 					gomega.Expect(totalPodConnEntries).To(gomega.Equal(6))
@@ -1376,7 +1389,7 @@ var _ = ginkgo.Describe("External Gateway", func() {
 					if addresses.srcPodIP == "" || addresses.nodeIP == "" {
 						skipper.Skipf("Skipping as pod ip / node ip are not set pod ip %s node ip %s", addresses.srcPodIP, addresses.nodeIP)
 					}
-					createAPBExternalRouteCRWithDynamicHop(defaultPolicyName, f.Namespace.Name, servingNamespace, false, addressesv4.gatewayIPs)
+					createAPBExternalRouteCRWithDynamicHop(defaultPolicyName, f.Namespace.Name, servingNamespace, false, addresses.gatewayIPs)
 
 					ginkgo.By(fmt.Sprintf("Verifying connectivity to the pod [%s] from external gateways", addresses.srcPodIP))
 					for _, gwContainer := range gwContainers {
@@ -1708,8 +1721,14 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				ginkgo.By("Check if conntrack entries for ECMP routes are removed for the deleted external gateway if traffic is UDP")
 				updateAPBExternalRouteCRWithStaticHop(defaultPolicyName, f.Namespace.Name, false, addresses.gatewayIPs[0])
 				if protocol == "udp" {
-					podConnEntriesWithMACLabelsSet = 1 // we still have the conntrack entry for the remaining gateway
-					totalPodConnEntries = 5            // 6-1
+					// FIXME(trozet): for ipv6 we flush all mac label flows due to no support for IPv6 NDP
+					if utilnet.IsIPv4String(addresses.gatewayIPs[0]) {
+						podConnEntriesWithMACLabelsSet = 1 // we still have the conntrack entry for the remaining gateway
+						totalPodConnEntries = 5            // 6-1
+					} else {
+						podConnEntriesWithMACLabelsSet = 0
+						totalPodConnEntries = 4 // 6-2
+					}
 				}
 
 				gomega.Eventually(func() int {
@@ -1753,7 +1772,7 @@ var _ = ginkgo.Describe("External Gateway", func() {
 					annotateMultusNetworkStatusInPodGateway(gwPod, servingNamespace, []string{addresses.gatewayIPs[i], addresses.gatewayIPs[i]})
 				}
 
-				createAPBExternalRouteCRWithDynamicHop(defaultPolicyName, f.Namespace.Name, servingNamespace, false, addressesv4.gatewayIPs)
+				createAPBExternalRouteCRWithDynamicHop(defaultPolicyName, f.Namespace.Name, servingNamespace, false, addresses.gatewayIPs)
 
 				setupIperf3Client := func(container, address string, port int) {
 					// note iperf3 even when using udp also spawns tcp connection first; so we indirectly also have the tcp connection when using "-u" flag
@@ -1792,8 +1811,14 @@ var _ = ginkgo.Describe("External Gateway", func() {
 
 				ginkgo.By("Check if conntrack entries for ECMP routes are removed for the deleted external gateway if traffic is UDP")
 				if protocol == "udp" {
-					podConnEntriesWithMACLabelsSet = 1
-					totalPodConnEntries = 5
+					// FIXME(trozet): for ipv6 we flush all mac label flows due to no support for IPv6 NDP
+					if utilnet.IsIPv4String(addresses.gatewayIPs[0]) {
+						podConnEntriesWithMACLabelsSet = 1
+						totalPodConnEntries = 5
+					} else {
+						podConnEntriesWithMACLabelsSet = 0
+						totalPodConnEntries = 4
+					}
 				}
 				gomega.Eventually(func() int {
 					n := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
@@ -2483,22 +2508,38 @@ var _ = ginkgo.Describe("External Gateway", func() {
 					// in hex without leading 0s.
 					macAddressGW[i] = strings.TrimLeft(strings.Replace(macAddressExtGW.String(), ":", "", -1), "0")
 				}
+
+				nodeName := getPod(f, srcPodName).Spec.NodeName
+				expectedTotalEntries := 6
+				expectedMACEntries := 2
+				ginkgo.By("Check to ensure initial conntrack entries are 2 mac address label, and 6 total entries")
+				gomega.Eventually(func() int {
+					n := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
+					klog.Infof("Number of entries with macAddressGW %s:%d", macAddressGW, n)
+					return n
+				}, time.Minute, 5).Should(gomega.Equal(expectedMACEntries))
+				gomega.Expect(pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, nil)).To(gomega.Equal(expectedTotalEntries)) // total conntrack entries for this pod/protocol
+
 				ginkgo.By("Removing the namespace annotations to leave only the CR policy active")
 				annotateNamespaceForGateway(f.Namespace.Name, false, "")
 
-				ginkgo.By("Check if conntrack entries for ECMP routes are created for the 2 external gateways")
-				nodeName := getPod(f, srcPodName).Spec.NodeName
-				podConnEntriesWithMACLabelsSet := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
-				gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(2))
+				ginkgo.By("Check if conntrack entries for ECMP routes still exist for the 2 external gateways")
+				if protocol == "udp" {
+					// FIXME(trozet): for ipv6 we flush all mac label flows due to no support for IPv6 NDP
+					if utilnet.IsIPv6String(addresses.gatewayIPs[0]) {
+						expectedTotalEntries = 4
+						expectedMACEntries = 0
+					}
+				}
+
+				gomega.Eventually(func() int {
+					n := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
+					klog.Infof("Number of entries with macAddressGW %s:%d", macAddressGW, n)
+					return n
+				}, time.Minute, 5).Should(gomega.Equal(expectedMACEntries))
+
 				totalPodConnEntries := pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, nil)
-				gomega.Expect(totalPodConnEntries).To(gomega.Equal(6)) // total conntrack entries for this pod/protocol
-
-				ginkgo.By("Check if conntrack entries for ECMP routes are removed for the deleted external gateway if traffic is UDP")
-				podConnEntriesWithMACLabelsSet = pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
-				totalPodConnEntries = pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, nil)
-
-				gomega.Expect(podConnEntriesWithMACLabelsSet).To(gomega.Equal(2))
-				gomega.Expect(totalPodConnEntries).To(gomega.Equal(6))
+				gomega.Expect(totalPodConnEntries).To(gomega.Equal(expectedTotalEntries)) // total conntrack entries for this pod/protocol
 
 			},
 				ginkgo.Entry("IPV4 udp", &addressesv4, "udp"),
@@ -2506,7 +2547,8 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				ginkgo.Entry("IPV6 udp", &addressesv6, "udp"),
 				ginkgo.Entry("IPV6 tcp", &addressesv6, "tcp"))
 
-			ginkgo.DescribeTable("ExternalGWPod annotation: Should validate conntrack entry remains unchanged when deleting the annotation in the pods while the CR dynamic hop still references the same pods with the pod selector", func(addresses *gatewayTestIPs, protocol string) {
+			ginkgo.DescribeTable("ExternalGWPod annotation: Should validate conntrack entry remains unchanged when deleting the annotation in the pods while the CR dynamic hop still "+
+				"references the same pods with the pod selector", func(addresses *gatewayTestIPs, protocol string) {
 				if addresses.srcPodIP == "" || addresses.nodeIP == "" {
 					skipper.Skipf("Skipping as pod ip / node ip are not set pod ip %s node ip %s", addresses.srcPodIP, addresses.nodeIP)
 				}
@@ -2518,13 +2560,13 @@ var _ = ginkgo.Describe("External Gateway", func() {
 					}
 					annotatePodForGateway(gwPod, servingNamespace, f.Namespace.Name, networkIPs, false)
 				}
-				createAPBExternalRouteCRWithDynamicHop(defaultPolicyName, f.Namespace.Name, servingNamespace, false, addressesv4.gatewayIPs)
+				createAPBExternalRouteCRWithDynamicHop(defaultPolicyName, f.Namespace.Name, servingNamespace, false, addresses.gatewayIPs)
 				// ensure the conntrack deletion tracker annotation is updated
 				if !isInterconnectEnabled() {
 					ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
 					err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 						ns := getNamespace(f, f.Namespace.Name)
-						return (ns.Annotations[externalGatewayPodIPsAnnotation] == fmt.Sprintf("%s,%s", addresses.gatewayIPs[0], addresses.gatewayIPs[1])), nil
+						return ns.Annotations[externalGatewayPodIPsAnnotation] == fmt.Sprintf("%s,%s", addresses.gatewayIPs[0], addresses.gatewayIPs[1]), nil
 					})
 					framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
 				}
@@ -2692,9 +2734,13 @@ func setupGatewayContainers(f *framework.Framework, nodes *v1.NodeList, containe
 
 	if addressesv6.srcPodIP != "" && addressesv6.nodeIP != "" {
 		testIPv6 = true
+	} else {
+		addressesv6 = gatewayTestIPs{}
 	}
 	if addressesv4.srcPodIP != "" && addressesv4.nodeIP != "" {
 		testIPv4 = true
+	} else {
+		addressesv4 = gatewayTestIPs{}
 	}
 	if !testIPv4 && !testIPv6 {
 		framework.Fail("No ipv4 nor ipv6 addresses found in nodes and src pod")
@@ -2764,9 +2810,19 @@ func setupAnnotatedGatewayPods(f *framework.Framework, nodes *v1.NodeList, pod1,
 	}
 
 	for i, gwPod := range gwPods {
-		networkIPs := fmt.Sprintf("\"%s\"", addressesv4.gatewayIPs[i])
+		var networkIPs string
+		if len(addressesv4.gatewayIPs) > 0 {
+			// IPv4
+			networkIPs = fmt.Sprintf("\"%s\"", addressesv4.gatewayIPs[i])
+		}
 		if addressesv6.srcPodIP != "" && addressesv6.nodeIP != "" {
-			networkIPs = fmt.Sprintf("\"%s\", \"%s\"", addressesv4.gatewayIPs[i], addressesv6.gatewayIPs[i])
+			if len(networkIPs) > 0 {
+				// IPv4 and IPv6
+				networkIPs = fmt.Sprintf("%s, \"%s\"", networkIPs, addressesv6.gatewayIPs[i])
+			} else {
+				// IPv6 only
+				networkIPs = fmt.Sprintf("\"%s\"", addressesv6.gatewayIPs[i])
+			}
 		}
 		annotatePodForGateway(gwPod, ns, f.Namespace.Name, networkIPs, bfd)
 	}
@@ -2786,7 +2842,14 @@ func setupPolicyBasedGatewayPods(f *framework.Framework, nodes *v1.NodeList, pod
 	}
 
 	for i, gwPod := range gwPods {
-		annotateMultusNetworkStatusInPodGateway(gwPod, ns, []string{addressesv4.gatewayIPs[i]})
+		gwIPs := []string{}
+		if len(addressesv4.gatewayIPs) > 0 {
+			gwIPs = append(gwIPs, addressesv4.gatewayIPs[i])
+		}
+		if len(addressesv6.gatewayIPs) > 0 {
+			gwIPs = append(gwIPs, addressesv6.gatewayIPs[i])
+		}
+		annotateMultusNetworkStatusInPodGateway(gwPod, ns, gwIPs)
 	}
 
 	return gwPods

--- a/test/e2e/pod.go
+++ b/test/e2e/pod.go
@@ -243,3 +243,134 @@ var _ = ginkgo.Describe("Pod to external server PMTUD", func() {
 		})
 	})
 })
+
+var _ = ginkgo.Describe("Pod to pod TCP with low MTU", func() {
+	const (
+		echoServerPodNameTemplate = "echo-server-pod-%d"
+		echoClientPodName         = "echo-client-pod"
+		serverPodPort             = 9899
+		mtu                       = 1400
+		primaryNetworkName        = "kind"
+	)
+
+	f := wrappedTestFramework("pod2pod-tcp-low-mtu")
+	cleanupFn := func() {}
+
+	ginkgo.AfterEach(func() {
+		cleanupFn()
+	})
+
+	ginkgo.When("a client ovnk pod targeting an ovnk pod server(running on another node) with low mtu", func() {
+		var serverPod *v1.Pod
+		var serverPodNodeName string
+		var serverPodName string
+		var serverNode v1.Node
+		var clientNode v1.Node
+		var serverNodeInternalIPs []string
+		var clientNodeInternalIPs []string
+
+		var clientPod *v1.Pod
+		var clientPodNodeName string
+
+		payload := fmt.Sprintf("%01360d", 1)
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Selecting 2 schedulable nodes")
+			nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 1))
+
+			ginkgo.By("Selecting nodes for client pod and server host-networked pod")
+			serverPodNodeName = nodes.Items[0].Name
+			serverNode = nodes.Items[0]
+			clientPodNodeName = nodes.Items[1].Name
+			clientNode = nodes.Items[1]
+
+			ginkgo.By("Creating hostNetwork:false (ovnk) client pod")
+			clientPod = e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
+			clientPod.Spec.NodeName = clientPodNodeName
+			for k := range clientPod.Spec.Containers {
+				if clientPod.Spec.Containers[k].Name == "agnhost-container" {
+					clientPod.Spec.Containers[k].Command = []string{
+						"sleep",
+						"infinity",
+					}
+				}
+			}
+			e2epod.NewPodClient(f).CreateSync(context.TODO(), clientPod)
+
+			ginkgo.By("Creating hostNetwork:false (ovnk) server pod")
+			serverPodName = fmt.Sprintf(echoServerPodNameTemplate, serverPodPort)
+			serverPod = e2epod.NewAgnhostPod(f.Namespace.Name, serverPodName, nil, nil, nil,
+				"netexec",
+				"--http-port", fmt.Sprintf("%d", serverPodPort),
+				"--udp-port", fmt.Sprintf("%d", serverPodPort),
+			)
+			serverPod.ObjectMeta.Labels = map[string]string{
+				"app": serverPodName,
+			}
+			serverPod.Spec.NodeName = serverPodNodeName
+			serverPod = e2epod.NewPodClient(f).CreateSync(context.TODO(), serverPod)
+
+			ginkgo.By("Getting all InternalIP addresses of the server node")
+			serverNodeInternalIPs = e2enode.GetAddresses(&serverNode, v1.NodeInternalIP)
+			gomega.Expect(len(serverNodeInternalIPs)).To(gomega.BeNumerically(">", 0))
+
+			ginkgo.By("Getting all InternalIP addresses of the client node")
+			clientNodeInternalIPs = e2enode.GetAddresses(&clientNode, v1.NodeInternalIP)
+			gomega.Expect(len(serverNodeInternalIPs)).To(gomega.BeNumerically(">", 0))
+
+			ginkgo.By("Lowering the MTU route from server -> client")
+			fmt.Println(clientNodeInternalIPs)
+			err = addRouteToNode(serverPodNodeName, clientNodeInternalIPs, mtu)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Lowering the MTU route from client -> server")
+			fmt.Println(serverNodeInternalIPs)
+			err = addRouteToNode(clientPodNodeName, serverNodeInternalIPs, mtu)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			cleanupFn = func() {
+				err = delRouteToNode(serverPodNodeName, clientNodeInternalIPs)
+				err = delRouteToNode(clientPodNodeName, serverNodeInternalIPs)
+			}
+
+		})
+
+		// Lower the MTU between the two nodes to 1400, this will cause pod->pod 1400 byte packets
+		// to be too big for geneve encapsulation
+		ginkgo.When("MTU is lowered between the two nodes", func() {
+			ginkgo.It("large queries to the server pod on another node shall work for TCP", func() {
+				for _, serverPodIP := range serverPod.Status.PodIPs {
+					ginkgo.By(fmt.Sprintf("Sending TCP large payload to server IP %s "+
+						"and expecting to receive the same payload", serverPodIP))
+					cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s:%d/echo?msg=%s",
+						serverPodIP.IP,
+						serverPodPort,
+						payload,
+					)
+					framework.Logf("Testing large TCP segments with command %q", cmd)
+					stdout, err := e2epodoutput.RunHostCmdWithRetries(
+						clientPod.Namespace,
+						clientPod.Name,
+						cmd,
+						framework.Poll,
+						30*time.Second)
+					framework.ExpectNoError(err, "Sending large TCP payload from client failed")
+					gomega.Expect(stdout).To(gomega.Equal(payload),
+						"Received TCP payload from server does not equal expected payload")
+
+					cmd = fmt.Sprintf("ip route get %s", serverPodIP.IP)
+					stdout, err = e2epodoutput.RunHostCmd(
+						clientPod.Namespace,
+						clientPod.Name,
+						cmd)
+					framework.ExpectNoError(err, "Checking ip route cache output failed")
+					framework.Logf(" ip route output in client pod: %s", stdout)
+					gomega.Expect(stdout).To(gomega.MatchRegexp("mtu 1342"))
+				}
+			})
+
+		})
+	})
+})

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -917,6 +917,7 @@ var _ = ginkgo.Describe("Load Balancer Service Tests with MetalLB", func() {
 		svcName          = "lbservice-test"
 		backendName      = "lb-backend-pod"
 		endpointHTTPPort = 80
+		endpointUDPPort  = 10001
 		loadBalancerYaml = "loadbalancer.yaml"
 		bgpAddYaml       = "bgpAdd.yaml"
 		bgpEmptyYaml     = "bgpEmptyAdd.yaml"
@@ -988,6 +989,13 @@ spec:
         ports:
         - name: http
           containerPort: 80
+      - name: udp-server
+        image: quay.io/itssurya/dev-images:udp-server-srcip-printer
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 10001
+          protocol: UDP
+          name: udp
       nodeSelector:
         kubernetes.io/hostname: ` + backendNodeName + `
 
@@ -1002,6 +1010,10 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 80
+  - name: udp
+    port: 10001
+    protocol: UDP
+    targetPort: 10001
   selector:
     app: nginx
   type: LoadBalancer
@@ -1205,7 +1217,7 @@ metadata:
 		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
 
 		numberOfETPRules := pokeIPTableRules(backendNodeName, "OVN-KUBE-EXTERNALIP")
-		framework.ExpectEqual(numberOfETPRules, 4)
+		framework.ExpectEqual(numberOfETPRules, 5)
 
 		// curl the LB service from the client container to trigger BGP route advertisement
 		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
@@ -1339,12 +1351,12 @@ spec:
 		}
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(2, "OVN-KUBE-ETP"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(4, "OVN-KUBE-EXTERNALIP"))
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(5, "OVN-KUBE-EXTERNALIP"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(3, "OVN-KUBE-SNAT-MGMTPORT"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
 
-		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 
 		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
 		framework.ExpectNoError(err, "failed to curl load balancer service")
@@ -1365,12 +1377,12 @@ spec:
 
 		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
 
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(6, "OVN-KUBE-ETP"))
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(10, "OVN-KUBE-ETP"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(7, "OVN-KUBE-SNAT-MGMTPORT"))
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(11, "OVN-KUBE-SNAT-MGMTPORT"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
 
-		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 
 		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
 		framework.ExpectNoError(err, "failed to curl load balancer service")
@@ -1386,13 +1398,13 @@ spec:
 		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an endpoint, err: %v", svcName, err))
 
 		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
-		// number of iptable rules should have decreased by 1
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(5, "OVN-KUBE-ETP"))
+		// number of iptable rules should have decreased by 2
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(8, "OVN-KUBE-ETP"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
-		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(6, "OVN-KUBE-SNAT-MGMTPORT"))
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(9, "OVN-KUBE-SNAT-MGMTPORT"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
 
-		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 
 		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
 		framework.ExpectNoError(err, "failed to curl load balancer service")
@@ -1402,6 +1414,105 @@ spec:
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-SNAT-MGMTPORT"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
 
+	})
+
+	ginkgo.It("Should ensure load balancer service works when ETP=local and session affinity is set", func() {
+
+		err := framework.WaitForServiceEndpointsNum(context.TODO(), f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*120)
+		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an enpoint, err: %v", svcName, err))
+
+		ginkgo.By("patching service " + svcName + " to externalTrafficPolicy=local")
+		err = patchServiceStringValue(f.ClientSet, svcName, "default", "/spec/externalTrafficPolicy", "Local")
+		framework.ExpectNoError(err)
+		output := e2ekubectl.RunKubectlOrDie("default", "get", "svc", svcName, "-o=jsonpath='{.spec.externalTrafficPolicy}'")
+		framework.ExpectEqual(output, "'Local'")
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		ginkgo.By("1 nodeIP route is advertised correctly by metalb BGP routes")
+		// since ETP=local; ensure only this node's IP route is advertised correctly by metalb BGP routes
+		// sample:
+		// 192.168.10.0 nhid 31 via 172.19.0.4 dev eth0 proto bgp metric 20
+		nodeIP, err := getNodeIP(f.ClientSet, backendNodeName)
+		framework.ExpectNoError(err, fmt.Sprintf("failed to get nodes's %s node ip address", backendNodeName))
+		framework.Logf("NodeIP of node %s is %s", backendNodeName, nodeIP)
+		cmd := []string{containerRuntime, "exec", routerContainer}
+		bgpRouteCommand := strings.Split("ip route show 192.168.10.0", " ")
+		cmd = append(cmd, bgpRouteCommand...)
+		gomega.Eventually(func() bool {
+			routes, err := runCommand(cmd...)
+			framework.ExpectNoError(err, "failed to get BGP routes from intermediary router")
+			framework.Logf("Routes in FRR %s", routes)
+			routeCount := 0
+			matchedRoute := ""
+			for _, route := range strings.Split(routes, "\n") {
+				match := strings.Contains(route, nodeIP)
+				if match {
+					framework.Logf("DEBUG: Matched route %s for pattern %s", route, nodeIP)
+					matchedRoute = route
+				}
+				if strings.Contains(route, "via") {
+					routeCount++
+				}
+			}
+			return routeCount == 1 && strings.Contains(matchedRoute, nodeIP)
+		}, 60*time.Second).Should(gomega.BeTrue())
+
+		ginkgo.By("by sending a UDP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
+		netcatCmd := fmt.Sprintf("echo hostname | nc -uv -w2 %s %d",
+			svcIP,
+			endpointUDPPort,
+		)
+		cmd = []string{containerRuntime, "exec", clientContainer, "bash", "-x", "-c", netcatCmd}
+		framework.Logf("netcat command %s", cmd)
+		output, err = runCommand(cmd...)
+		framework.ExpectNoError(err, "failed to connect to load balancer service")
+		framework.Logf("netcat command output %s", output)
+
+		ginkgo.By("ensure the sourceIP of the external container is preserved!")
+		// Check that sourceIP of the LBService is preserved
+		targetPodLogs, err := e2ekubectl.RunKubectl("default", "logs", "-l", "app=nginx", "--container", "udp-server")
+		framework.ExpectNoError(err, "failed to inspect logs in backend pods")
+		framework.Logf("%v", targetPodLogs)
+		lbClientIPv4, _ := getContainerAddressesForNetwork(clientContainer, "clientnet")
+		framework.Logf("%v", lbClientIPv4)
+		if strings.Contains(targetPodLogs, lbClientIPv4) {
+			framework.Logf("found the expected srcIP %s!", lbClientIPv4)
+		} else {
+			framework.Failf("could not get expected srcIP!")
+		}
+
+		ginkgo.By("patching service " + svcName + " to sessionAffinity=ClientIP at default timeout of 10800")
+		err = patchServiceStringValue(f.ClientSet, svcName, "default", "/spec/sessionAffinity", "ClientIP")
+		framework.ExpectNoError(err)
+		output = e2ekubectl.RunKubectlOrDie("default", "get", "svc", svcName, "-o=jsonpath='{.spec.sessionAffinity}'")
+		framework.ExpectEqual(output, "'ClientIP'")
+		output = e2ekubectl.RunKubectlOrDie("default", "get", "svc", svcName, "-o=jsonpath='{.spec.sessionAffinityConfig.clientIP.timeoutSeconds}'")
+		framework.ExpectEqual(output, "'10800'")
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		ginkgo.By("by sending a UDP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
+		// OVN drops the 1st packet so this one does nothing basically.
+		// See https://issues.redhat.com/browse/FDP-223 for details
+		output, err = runCommand(cmd...)
+		framework.ExpectNoError(err, "failed to connect to load balancer service")
+		framework.Logf("netcat command output %s", output)
+		time.Sleep(time.Second * 10) // buffer to ensure all learn flows are created correctly after the previous drop
+
+		// OVN drops the 1st packet so let's be sure to another set of netcat connections at least to check the srcIP
+		output, err = runCommand(cmd...)
+		framework.ExpectNoError(err, "failed to connect to load balancer service")
+		framework.Logf("netcat command output %s", output)
+
+		// Check that sourceIP of the LBService is preserved
+		ginkgo.By("ensure the sourceIP of the external container is preserved!")
+		targetPodLogs, err = e2ekubectl.RunKubectl("default", "logs", "-l", "app=nginx", "--container", "udp-server")
+		framework.ExpectNoError(err, "failed to inspect logs in backend pods")
+		framework.Logf("%v", targetPodLogs)
+		if strings.Count(targetPodLogs, lbClientIPv4) >= 2 {
+			framework.Logf("found the expected srcIP %s!", lbClientIPv4)
+		} else {
+			framework.Failf("could not get expected srcIP!")
+		}
 	})
 
 })

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1115,4 +1116,43 @@ func getNodeZone(node *v1.Node) (string, error) {
 	}
 
 	return nodeZone, nil
+}
+
+// adds route to a docker node with a full mask
+func addRouteToNode(nodeName string, ips []string, mtu int) error {
+	return routeToNode(nodeName, ips, mtu, true)
+}
+
+// removes a route on a docker node
+func delRouteToNode(nodeName string, ips []string) error {
+	return routeToNode(nodeName, ips, 0, false)
+}
+
+// executes route commands on a node, if add is true, the route is added
+// otherwise removed
+func routeToNode(nodeName string, ips []string, mtu int, add bool) error {
+	ipOp := "del"
+	if add {
+		ipOp = "add"
+	}
+	for _, ip := range ips {
+		mask := 32
+		ipCmd := []string{"ip"}
+		if utilnet.IsIPv6String(ip) {
+			mask = 128
+			ipCmd = []string{"ip", "-6"}
+		}
+		var err error
+		cmd := []string{"docker", "exec", nodeName}
+		cmd = append(cmd, ipCmd...)
+		cmd = append(cmd, "route", ipOp, fmt.Sprintf("%s/%d", ip, mask), "dev", "breth0")
+		if mtu != 0 {
+			cmd = append(cmd, "mtu", strconv.Itoa(mtu))
+		}
+		_, err = runCommand(cmd...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This includes the following relevant changes:
- actions: Use random port selection for SNAT with external_port_range.
  [https://github.com/ovn-org/ovn/commit/7ee483a45df1]
  [https://issues.redhat.com/browse/FDP-301]
  [https://issues.redhat.com/browse/RFE-4980]
- northd: Make sure that affinity flows match on VIP.
  [https://github.com/ovn-org/ovn/commit/859e8d917408]
  [https://issues.redhat.com/browse/FDP-290]
- ovn: Add tunnel PMTUD support.
  [https://github.com/ovn-org/ovn/commit/6d2f9d60760a]
  [https://bugzilla.redhat.com/show_bug.cgi?id=2241711]
- northd: Use proper field for lookup_nd
  [https://github.com/ovn-org/ovn/commit/8e25c1c37aa3]
  [https://issues.redhat.com/browse/FDP-283]
  [https://issues.redhat.com/browse/OCPBUGS-27093]
- northd: Remove the protocol match from ECMP symmetric reply flows.
  [https://github.com/ovn-org/ovn/commit/a36f2955be67]
  [https://issues.redhat.com/browse/FDP-358]
- northd: Explicitly handle SNAT for ICMP need frag.
  [https://github.com/ovn-org/ovn/commit/6a4c412f43d5]
  [https://issues.redhat.com/browse/FDP-159]