### PR TITLE
Use masquerade default gateway when no default gw is found

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1857,7 +1857,6 @@ var _ = Describe("Gateway unit tests", func() {
 				gwIPs := []net.IP{config.Gateway.MasqueradeIPs.V4DummyNextHopMasqueradeIP}
 				config.Gateway.Interface = dummyBridgeName
 				config.Gateway.Mode = config.GatewayModeLocal
-				config.Gateway.AllowNoUplink = true
 
 				gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When no default gateway is found, OVNK will still come up. This behavior was intentional: 3eeb930791e04824b76b03172f64a1db21d9c377

The goal was that with design changes, host->service traffic would work without the need for a default gateway to be detected. This works, in most cases, but there is a case we did not consider. If a user has deployed a cluster with local gateway mode, and is using a different interface/network for kapi traffic (not the gateway bridge interface), then endpoints to the kubernetes service will reside on this other network. In this case when a host tries to talk to kube API service, the traffic would go to the GR, it would be DNAT'ed to an IP address not on any known network, and be dropped by OVN routing when there is no default gateway route.

When the configuration parameter AllowNoUplink is set, we will set the default route to be the masquerade IP, which solves this problem. This commit changes the behavior to not require AllowNoUplink to be set in order to achieve the same behavior, as services should work in this scenario even without a default gw.

