### PR TITLE
actions: Remove android sdk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,6 +286,7 @@ jobs:
 
     - name: Free up disk space
       run: |
+        sudo rm -rf /usr/local/lib/android/sdk
         sudo apt-get update
         sudo eatmydata apt-get purge --auto-remove -y \
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -435,6 +435,7 @@ jobs:
 
     - name: Free up disk space
       run: |
+        sudo rm -rf /usr/local/lib/android/sdk
         sudo apt-get update
         sudo eatmydata apt-get purge --auto-remove -y \
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \


### PR DESCRIPTION
**- What this PR does and why is it needed**
There were some storage issues at github actions, looks like android-sdk is using 8gb, this change remove that to prevent those issues.
