### PR TITLE
Kubevirt e2e stabilizing refactor

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -56,6 +56,9 @@ func newControllerRuntimeClient() (crclient.Client, error) {
 		return nil, err
 	}
 	return crclient.New(config, crclient.Options{
+		WarningHandler: crclient.WarningHandlerOptions{
+			SuppressWarnings: true,
+		},
 		Scheme: scheme,
 	})
 }

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -76,6 +76,23 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 		butane                     = `
 variant: fcos
 version: 1.4.0
+systemd:
+  units:
+    - name: systemd-resolved.service
+      mask: true
+    - name: replace-resolved.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Replace systemd resolvd with NetworkManager
+        Wants=network-online.target
+        After=network-online.target
+        [Service]
+        ExecStart=rm -f /etc/resolv.conf
+        ExecStart=systemctl restart NetworkManager
+        Type=oneshot
+        [Install]
+        WantedBy=multi-user.target
 passwd:
   users:
   - name: core

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -334,12 +334,12 @@ passwd:
 			step = by(vmName, stage+": Check n/s tcp traffic")
 			output := ""
 			Eventually(func() error {
-				output, err = kubevirt.RunCommand(vmi, "curl -kL https://www.ovn.org", polling)
+				output, err = kubevirt.RunCommand(vmi, "curl -kL https://kubernetes.default.svc.cluster.local", polling)
 				return err
 			}).
 				WithOffset(1).
 				WithPolling(polling).
-				WithTimeout(timeout).
+				WithTimeout(timeout*2).
 				Should(Succeed(), func() string { return step + ": " + output })
 		}
 

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
-	"net/http"
-	"net/http/httptrace"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,8 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
@@ -66,19 +66,23 @@ func newControllerRuntimeClient() (crclient.Client, error) {
 var _ = Describe("Kubevirt Virtual Machines", func() {
 
 	var (
-		fr                         = wrappedTestFramework("kv-live-migration")
-		crClient                   crclient.Client
-		namespace                  string
-		httpServerPort             = int32(9900)
-		isDualStack                = false
-		wg                         sync.WaitGroup
-		selectedNodes              = []corev1.Node{}
-		httpServerTestPods         = []*corev1.Pod{}
-		singleConnectionHTTPClient *http.Client
-		clientSet                  kubernetes.Interface
-		butane                     = `
+		fr                 = wrappedTestFramework("kv-live-migration")
+		crClient           crclient.Client
+		namespace          string
+		tcpServerPort      = int32(9900)
+		isDualStack        = false
+		wg                 sync.WaitGroup
+		selectedNodes      = []corev1.Node{}
+		httpServerTestPods = []*corev1.Pod{}
+		clientSet          kubernetes.Interface
+		butane             = fmt.Sprintf(`
 variant: fcos
 version: 1.4.0
+storage:
+  files:
+    - path: /root/test/server.go
+      contents:
+        local: kubevirt/echoserver/main.go
 systemd:
   units:
     - name: systemd-resolved.service
@@ -96,11 +100,22 @@ systemd:
         Type=oneshot
         [Install]
         WantedBy=multi-user.target
+    - name: echoserver.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Golang echo server
+        Wants=replace-resolved.service
+        After=replace-resolved.service
+        [Service]
+        ExecStart=podman run --name tcpserver --tls-verify=false --privileged --net=host -v /root/test:/test:z registry.access.redhat.com/ubi9/go-toolset:1.20 go run /test/server.go %d
+        [Install]
+        WantedBy=multi-user.target
 passwd:
   users:
   - name: core
     password_hash: $y$j9T$b7RFf2LW7MUOiF4RyLHKA0$T.Ap/uzmg8zrTcUNXyXvBvT26UgkC6zZUVg3UKXeEp5
-`
+`, tcpServerPort)
 		labelNode = func(nodeName, label string) error {
 			patch := fmt.Sprintf(`{"metadata": {"labels": {"%s": ""}}}`, label)
 			_, err := fr.ClientSet.CoreV1().Nodes().Patch(context.Background(), nodeName, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
@@ -186,12 +201,6 @@ passwd:
 			Expect(labelNode(node.Name, namespace)).To(Succeed())
 		}
 
-		singleConnectionHTTPClient = &http.Client{
-			Transport: &http.Transport{
-				MaxConnsPerHost: 1,
-			},
-			Timeout: 2 * time.Second,
-		}
 	})
 
 	AfterEach(func() {
@@ -207,53 +216,78 @@ passwd:
 	}
 
 	var (
-		sendEchoWithConnectionCheck = func(addrs []string, checkConnectionBroken bool) error {
-			for _, addr := range addrs {
-				connectionBroken := true
-				clientTrace := &httptrace.ClientTrace{
-					GotConn: func(info httptrace.GotConnInfo) {
-						connectionBroken = !info.Reused
-					},
-				}
-				traceCtx := httptrace.WithClientTrace(context.Background(), clientTrace)
-				req, err := http.NewRequestWithContext(traceCtx, http.MethodGet, fmt.Sprintf("http://%s/echo?msg=pong", addr), nil)
-				if err != nil {
-					return err
-				}
-				res, err := singleConnectionHTTPClient.Do(req)
-				if err != nil {
-					return err
-				}
-				if checkConnectionBroken && connectionBroken {
-					return fmt.Errorf("http connection to virtual machine was broken")
-				}
-				//TODO: Check pong
-				if _, err := io.Copy(io.Discard, res.Body); err != nil {
-					return err
-				}
-				res.Body.Close()
+		sendEcho = func(conn *net.TCPConn) error {
+			strEcho := "Halo"
 
+			if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+				return fmt.Errorf("failed configuring connection deadline: %w", err)
+			}
+			_, err := conn.Write([]byte(strEcho))
+			if err != nil {
+				return fmt.Errorf("failed Write to server: %w", err)
+			}
+
+			reply := make([]byte, 1024)
+
+			_, err = conn.Read(reply)
+			if err != nil {
+				return fmt.Errorf("failed Read to server: %w", err)
+			}
+
+			if strings.Compare(string(reply), strEcho) == 0 {
+				return fmt.Errorf("unexpected reply '%s'", string(reply))
 			}
 			return nil
 		}
 
-		sendEcho = func(addrs []string) error {
-			return sendEchoWithConnectionCheck(addrs, false)
+		sendEchos = func(conns []*net.TCPConn) error {
+			for _, conn := range conns {
+				if err := sendEcho(conn); err != nil {
+					return err
+				}
+			}
+			return nil
 		}
 
-		sendEchoAndCheckConnection = func(addrs []string) error {
-			return sendEchoWithConnectionCheck(addrs, true)
+		dial = func(addr string) (*net.TCPConn, error) {
+			tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+			if err != nil {
+				return nil, fmt.Errorf("failed ResolveTCPAddr: %w", err)
+			}
+			backoff := wait.Backoff{
+				Steps:    4,
+				Duration: 10 * time.Millisecond,
+				Factor:   5.0,
+				Jitter:   0.1,
+			}
+			allErrors := func(error) bool { return true }
+			var conn *net.TCPConn
+			return conn, retry.OnError(backoff, allErrors, func() error {
+				conn, err = net.DialTCP("tcp", nil, tcpAddr)
+				if err != nil {
+					return fmt.Errorf("failed DialTCP: %w", err)
+				}
+				return nil
+			})
 		}
 
-		serviceEndpoints = func(svc *corev1.Service) ([]string, error) {
+		dialServiceNodePort = func(svc *corev1.Service) ([]*net.TCPConn, error) {
 			worker, err := fr.ClientSet.CoreV1().Nodes().Get(context.TODO(), "ovn-worker", metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
-			endpoints := []string{}
+			endpoints := []*net.TCPConn{}
 			for _, address := range worker.Status.Addresses {
 				if address.Type != corev1.NodeHostName {
-					endpoints = append(endpoints, net.JoinHostPort(address.Address, fmt.Sprintf("%d", svc.Spec.Ports[0].NodePort)))
+					addr := net.JoinHostPort(address.Address, fmt.Sprintf("%d", svc.Spec.Ports[0].NodePort))
+					conn, err := dial(addr)
+					if err != nil {
+						return endpoints, err
+					}
+					if err := conn.SetKeepAlive(true); err != nil {
+						return nil, err
+					}
+					endpoints = append(endpoints, conn)
 				}
 			}
 			return endpoints, nil
@@ -300,7 +334,7 @@ passwd:
 			return fr.ClientSet.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), policy, metav1.CreateOptions{})
 		}
 
-		checkConnectivity = func(vmName string, endpoints []string, stage string) {
+		checkConnectivity = func(vmName string, endpoints []*net.TCPConn, stage string) {
 			by(vmName, "Check connectivity "+stage)
 			vmi := &kubevirtv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
@@ -313,7 +347,7 @@ passwd:
 			polling := 15 * time.Second
 			timeout := time.Minute
 			step := by(vmName, stage+": Check tcp connection is not broken")
-			Eventually(func() error { return sendEchoAndCheckConnection(endpoints) }).
+			Eventually(func() error { return sendEchos(endpoints) }).
 				WithPolling(polling).
 				WithTimeout(timeout).
 				WithOffset(1).
@@ -346,14 +380,14 @@ passwd:
 				Should(Succeed(), func() string { return step + ": " + output })
 		}
 
-		checkConnectivityAndNetworkPolicies = func(vmName string, endpoints []string, stage string) {
+		checkConnectivityAndNetworkPolicies = func(vmName string, endpoints []*net.TCPConn, stage string) {
 			checkConnectivity(vmName, endpoints, stage)
 			step := by(vmName, stage+": Create deny all network policy")
 			policy, err := createDenyAllPolicy(vmName)
 			Expect(err).ToNot(HaveOccurred(), step)
 
 			step = by(vmName, stage+": Check connectivity block after create deny all network policy")
-			Eventually(func() error { return sendEcho(endpoints) }).
+			Eventually(func() error { return sendEchos(endpoints) }).
 				WithPolling(time.Second).
 				WithTimeout(5*time.Second).
 				ShouldNot(Succeed(), step)
@@ -363,8 +397,8 @@ passwd:
 			// Wait some time for network policy removal to take effect
 			time.Sleep(1 * time.Second)
 
-			step = by(vmName, stage+": Check connectivity block after create deny all network policy")
-			Expect(sendEcho(endpoints)).To(Succeed(), step)
+			step = by(vmName, stage+": Check connectivity is restored after delete deny all network policy")
+			Expect(sendEchos(endpoints)).To(Succeed(), step)
 		}
 
 		composeAgnhostPod = func(name, namespace, nodeName string, args ...string) *v1.Pod {
@@ -492,7 +526,15 @@ passwd:
 
 		}
 		fcosVM = func(idx int, labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
-			ignition, _, err := butaneconfig.TranslateBytes([]byte(butane), butanecommon.TranslateBytesOptions{})
+			workingDirectory, err := os.Getwd()
+			if err != nil {
+				return nil, err
+			}
+			ignition, _, err := butaneconfig.TranslateBytes([]byte(butane), butanecommon.TranslateBytesOptions{
+				TranslateOptions: butanecommon.TranslateOptions{
+					FilesDir: workingDirectory,
+				},
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -594,7 +636,7 @@ passwd:
 			}
 			return vms, nil
 		}
-		liveMigrateAndCheck = func(vmName string, migrationMode kubevirtv1.MigrationMode, endpoints []string, step string) {
+		liveMigrateAndCheck = func(vmName string, migrationMode kubevirtv1.MigrationMode, endpoints []*net.TCPConn, step string) {
 			liveMigrateVirtualMachine(vmName, migrationMode)
 			checkLiveMigrationSucceeded(vmName, migrationMode)
 			checkConnectivityAndNetworkPolicies(vmName, endpoints, step)
@@ -633,22 +675,20 @@ passwd:
 					})
 			}
 
-			step = by(vm.Name, "Start httpServer")
-			httpServerCommand := fmt.Sprintf("podman run -d --tls-verify=false --privileged --net=host %s netexec --http-port %d", agnhostImage, httpServerPort)
-			output, err := kubevirt.RunCommand(vmi, httpServerCommand, time.Minute)
-			Expect(err).ToNot(HaveOccurred(), step+": "+output)
-
-			step = by(vm.Name, "Expose httpServer as a service")
-			svc, err := fr.ClientSet.CoreV1().Services(namespace).Create(context.TODO(), composeService("httpserver", vm.Name, httpServerPort), metav1.CreateOptions{})
+			step = by(vm.Name, "Expose tcpServer as a service")
+			svc, err := fr.ClientSet.CoreV1().Services(namespace).Create(context.TODO(), composeService("tcpserver", vm.Name, tcpServerPort), metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred(), step)
-			endpoints, err := serviceEndpoints(svc)
-			Expect(err).ToNot(HaveOccurred(), step)
+			defer func() {
+				output, err := kubevirt.RunCommand(vmi, "podman logs tcpserver", 10*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+				fmt.Printf("%s tcpserver logs: %s", vmi.Name, output)
+			}()
 
-			step = by(vm.Name, "Send first echo to populate connection pool")
-			Eventually(func() error { return sendEcho(endpoints) }).
-				WithPolling(1*time.Second).
-				WithTimeout(5*time.Second).
-				Should(Succeed(), step)
+			By("Wait some time for service to settle")
+			time.Sleep(2 * time.Second)
+
+			endpoints, err := dialServiceNodePort(svc)
+			Expect(err).ToNot(HaveOccurred(), step)
 
 			checkConnectivityAndNetworkPolicies(vm.Name, endpoints, "before live migration")
 			// Do just one migration that will fail
@@ -787,7 +827,6 @@ passwd:
 				return vm.Status.Ready
 			}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(BeTrue())
 		}
-
 		wg.Add(int(td.numberOfVMs))
 		for _, vm := range vms {
 			go runTest(td, vm)

--- a/test/e2e/kubevirt/echoserver/main.go
+++ b/test/e2e/kubevirt/echoserver/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+)
+
+func main() {
+	bind_address := fmt.Sprintf(":%s", os.Args[1])
+
+	listener, err := net.Listen("tcp", bind_address)
+	if err != nil {
+		panic(fmt.Errorf("failed listening to %s: %w", bind_address, err))
+	}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			panic(fmt.Errorf("failed accepting connection: %w", err))
+		}
+
+		go handleConnection(conn)
+	}
+}
+
+func handleConnection(conn net.Conn) {
+	log.Printf("Handling connection %s\n", conn.RemoteAddr())
+	defer func() {
+		log.Printf("Closing connection %s\n", conn.RemoteAddr())
+		conn.Close()
+	}()
+	for {
+		receivedMsg := make([]byte, 1024)
+		_, err := conn.Read(receivedMsg)
+		if err != nil {
+			if err != nil {
+				if err != io.EOF {
+					log.Printf("EOF")
+				} else {
+					log.Printf("failed reading data: %v\n", err)
+				}
+				return
+			}
+		}
+		conn.Write(receivedMsg)
+	}
+}


### PR DESCRIPTION
**- What this PR does and why is it needed**
The kubevirt e2e tests are flaky, sometimes the persistent connection between tests and VM get broken and others the curl to ovn.org to check north soutgh traffic fail.

To fix those the following changes are introduced:
- Replace agnhost http server with a simple tcp server and configure tcp client with keepalive
- Replace systemd-resolved at the VM
- Replace `ovn.org` with `kubernetes.default.svc.cluster.local` to verify north/south traffic without external domain dependency.

Closes https://github.com/ovn-org/ovn-kubernetes/issues/3986

**- Special notes for reviewers**
This PR has being tested with 12 jobs in parallel run two time at author's fork
https://github.com/qinqon/ovn-kubernetes/actions/runs/7830706778/job/21366399247?pr=10



**- Description for the changelog**
Stabilize kubeirt e2e tests