### PR TITLE
ovnkube-node: eliminate `ovs-vsctl find Interface` failure log

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -198,13 +198,13 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 			netdevName = dpuCD.VfNetdevName
 		} else {
 			// Find the hostInterface name
-			condString := "external-ids:sandbox=" + pr.SandboxID
+			condString := []string{"external-ids:sandbox=" + pr.SandboxID}
 			if pr.netName != types.DefaultNetworkName {
-				condString += fmt.Sprintf(" external_ids:%s=%s", types.NADExternalID, pr.nadName)
+				condString = append(condString, fmt.Sprintf(" external_ids:%s=%s", types.NADExternalID, pr.nadName))
 			} else {
-				condString += fmt.Sprintf(" external_ids:%s{=}[]", types.NADExternalID)
+				condString = append(condString, fmt.Sprintf(" external_ids:%s{=}[]", types.NADExternalID))
 			}
-			ovsIfNames, err := ovsFind("Interface", "name", condString)
+			ovsIfNames, err := ovsFind("Interface", "name", condString...)
 			if err != nil || len(ovsIfNames) != 1 {
 				klog.Warningf("Couldn't find the OVS interface for pod %s/%s NAD %s: %v",
 					pr.PodNamespace, pr.PodName, pr.nadName, err)

--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -101,8 +101,9 @@ func ovsGet(table, record, column, key string) (string, error) {
 }
 
 // Returns the given column of records that match the condition
-func ovsFind(table, column, condition string) ([]string, error) {
-	output, err := ovsExec("--no-heading", "--format=csv", "--data=bare", "--columns="+column, "find", table, condition)
+func ovsFind(table, column string, conditions ...string) ([]string, error) {
+	args := append([]string{"--no-heading", "--format=csv", "--data=bare", "--columns=" + column, "find", table}, conditions...)
+	output, err := ovsExec(args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There are some "unexpected \":\" parsing set of strings\n" errors in the ovnkube-node log, because ovs-vsctl takes two condition strings as a single string argument.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->