### PR TITLE
ESVC/EIP E2Es: stop sharing node IP address across multiple nodes

### DIFF
--- a/test/e2e/egress_services.go
+++ b/test/e2e/egress_services.go
@@ -383,6 +383,7 @@ spec:
 			if protocol == v1.IPv6Protocol {
 				otherDstIP = "fc00:f853:ccd:e793:ffff::1"
 			} else {
+				// TODO(mk): replace with non-repeating IP allocator
 				otherDstIP = "172.18.1.1"
 			}
 			_, err = runCommand(containerRuntime, "exec", dstNode.Name, "ip", "addr", "add", otherDstIP, "dev", "breth0")

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -761,7 +761,8 @@ spec:
 		if utilnet.IsIPv6String(egress2Node.nodeIP) {
 			otherDstIP = "fc00:f853:ccd:e793:ffff::1"
 		} else {
-			otherDstIP = "172.18.1.1"
+			// TODO(mk): replace with non-repeating IP allocator
+			otherDstIP = "172.18.1.99"
 		}
 		_, err := runCommand(containerRuntime, "exec", egress2Node.name, "ip", "addr", "add", otherDstIP, "dev", "breth0")
 		if err != nil {


### PR DESCRIPTION
Two e2es shared the node IP 172.18.1.1 and assigned them to different nodes. This caused some e2es to timeout due to stale mac binding entry.

See the issue below for full details.

Fixes: https://github.com/ovn-org/ovn-kubernetes/issues/4127
