### PR TITLE
Build Pod SNAT: remove risk of adding nil pointer and later panicking

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -660,24 +660,21 @@ func (oc *DefaultNetworkController) deletePodSNAT(nodeName string, extIPs, podIP
 // buildPodSNAT builds per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
 func buildPodSNAT(extIPs, podIPNets []*net.IPNet) ([]*nbdb.NAT, error) {
 	nats := make([]*nbdb.NAT, 0, len(extIPs)*len(podIPNets))
-	var nat *nbdb.NAT
-
 	for _, podIPNet := range podIPNets {
 		fullMaskPodNet := &net.IPNet{
 			IP:   podIPNet.IP,
 			Mask: util.GetIPFullMask(podIPNet.IP),
 		}
 		if len(extIPs) == 0 {
-			nat = libovsdbops.BuildSNAT(nil, fullMaskPodNet, "", nil)
+			nats = append(nats, libovsdbops.BuildSNAT(nil, fullMaskPodNet, "", nil))
 		} else {
 			for _, gwIPNet := range extIPs {
 				if utilnet.IsIPv6CIDR(gwIPNet) != utilnet.IsIPv6CIDR(podIPNet) {
 					continue
 				}
-				nat = libovsdbops.BuildSNAT(&gwIPNet.IP, fullMaskPodNet, "", nil)
+				nats = append(nats, libovsdbops.BuildSNAT(&gwIPNet.IP, fullMaskPodNet, "", nil))
 			}
 		}
-		nats = append(nats, nat)
 	}
 	return nats, nil
 }


### PR DESCRIPTION
We cannot always depend on there being an external IP family that matches the pod IP family.
For example, if we are converting from dualstack to single stack. In that scenario, a panic may occur because we depend on non-nil entries within the nat slices.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->