### PR TITLE
e2e, multi-net policies: Add ingress allow all and deny all tests

### DIFF
--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -1328,6 +1328,138 @@ var _ = Describe("Multi Homing", func() {
 					),
 				),
 			)
+
+			ginkgo.DescribeTable(
+				"multi-network ingress allow all",
+				func(netConfigParams networkAttachmentConfigParams, clientPodConfig podConfiguration, serverPodConfig podConfiguration, policy *mnpapi.MultiNetworkPolicy) {
+					netConfig := newNetworkAttachmentConfig(netConfigParams)
+
+					By("setting up the localnet underlay")
+					nodes := ovsPods(cs)
+					Expect(nodes).NotTo(BeEmpty())
+					defer func() {
+						By("tearing down the localnet underlay")
+						Expect(teardownUnderlay(nodes)).To(Succeed())
+					}()
+					const secondaryInterfaceName = "eth1"
+					Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+
+					Expect(createNads(f, nadClient, extraNamespace, netConfig)).NotTo(HaveOccurred())
+
+					kickstartPodInNamespace(cs, &clientPodConfig, f.Namespace.Name, extraNamespace.Name)
+					kickstartPodInNamespace(cs, &serverPodConfig, f.Namespace.Name, extraNamespace.Name)
+
+					serverIP, err := podIPForAttachment(cs, serverPodConfig.namespace, serverPodConfig.name, netConfig.name, 0)
+					Expect(err).NotTo(HaveOccurred())
+					assertServerPodIPInRange(netConfig.cidr, serverIP, netPrefixLengthPerNode)
+
+					Expect(createMultiNetworkPolicy(mnpClient, f.Namespace.Name, policy)).To(Succeed())
+
+					By("asserting the *client* pod can contact the server pod exposed endpoint")
+					Eventually(func() error {
+						return reachToServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+					}, 2*time.Minute, 6*time.Second).Should(Succeed())
+				},
+				ginkgo.Entry(
+					"for a localnet topology when the multi-net policy is ingress allow-all",
+					networkAttachmentConfigParams{
+						name:     secondaryNetworkName,
+						topology: "localnet",
+						cidr:     secondaryLocalnetNetworkCIDR,
+					},
+					podConfiguration{
+						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:        allowedClient(clientPodName),
+						labels: map[string]string{
+							"app":  "client",
+							"role": "trusted",
+						},
+					},
+					podConfiguration{
+						attachments:  []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:         podName,
+						containerCmd: httpServerContainerCmd(port),
+						labels:       map[string]string{"app": "stuff-doer"},
+					},
+					multiNetPolicy(
+						"allow-all-ingress",
+						secondaryNetworkName,
+						metav1.LabelSelector{},
+						[]mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress},
+						[]mnpapi.MultiNetworkPolicyIngressRule{
+							mnpapi.MultiNetworkPolicyIngressRule{},
+						},
+						nil,
+					),
+				),
+				ginkgo.XEntry(
+					"for a localnet topology when the multi-net policy is egress deny-all, should not affect ingress",
+					networkAttachmentConfigParams{
+						name:     secondaryNetworkName,
+						topology: "localnet",
+						cidr:     secondaryLocalnetNetworkCIDR,
+					},
+					podConfiguration{
+						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:        allowedClient(clientPodName),
+						labels: map[string]string{
+							"app":  "client",
+							"role": "trusted",
+						},
+					},
+					podConfiguration{
+						attachments:  []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:         podName,
+						containerCmd: httpServerContainerCmd(port),
+						labels:       map[string]string{"app": "stuff-doer"},
+					},
+					multiNetPolicy(
+						"deny-all-egress",
+						secondaryNetworkName,
+						metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "stuff-doer"},
+						},
+						[]mnpapi.MultiPolicyType{mnpapi.PolicyTypeEgress},
+						nil,
+						nil,
+					),
+					Label("BUG", "OCPBUGS-25928"),
+				),
+				ginkgo.Entry(
+					"for a localnet topology when the multi-net policy is egress deny-all, ingress allow-all",
+					networkAttachmentConfigParams{
+						name:     secondaryNetworkName,
+						topology: "localnet",
+						cidr:     secondaryLocalnetNetworkCIDR,
+					},
+					podConfiguration{
+						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:        allowedClient(clientPodName),
+						labels: map[string]string{
+							"app":  "client",
+							"role": "trusted",
+						},
+					},
+					podConfiguration{
+						attachments:  []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:         podName,
+						containerCmd: httpServerContainerCmd(port),
+						labels:       map[string]string{"app": "stuff-doer"},
+					},
+					multiNetPolicy(
+						"deny-all-egress-allow-all-ingress",
+						secondaryNetworkName,
+						metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "stuff-doer"},
+						},
+						[]mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress, mnpapi.PolicyTypeEgress},
+						[]mnpapi.MultiNetworkPolicyIngressRule{
+							mnpapi.MultiNetworkPolicyIngressRule{},
+						},
+						nil,
+					),
+				),
+			)
 		})
 	})
 

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -861,7 +861,7 @@ var _ = Describe("Multi Homing", func() {
 								metav1.LabelSelector{
 									MatchLabels: allPodsSelector,
 								},
-								[]mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress},
+								[]mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress, mnpapi.PolicyTypeEgress},
 								nil,
 								[]mnpapi.MultiNetworkPolicyEgressRule{
 									mnpapi.MultiNetworkPolicyEgressRule{},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Add multi network policy ingress allow all and deny all e2e tests.

Add a test that shows a bug: egress deny-all affects ingress
(reverse case of #4156), and a test that shows the workaround for it:
add ingress wildcard.

<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->