### PR TITLE
Fix ensureTransitSwitch from failing if there are no nodes

### DIFF
--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -176,6 +176,9 @@ func (zic *ZoneInterconnectHandler) createOrUpdateTransitSwitch(networkID int) e
 // ensureTransitSwitch sets up the global transit switch required for interoperability with other zones
 // Must wait for network id to be annotated to any node by cluster manager
 func (zic *ZoneInterconnectHandler) ensureTransitSwitch(nodes []*corev1.Node) error {
+	if len(nodes) == 0 { // nothing to do
+		return nil
+	}
 	start := time.Now()
 
 	// first try to get the network ID from the current state of the nodes


### PR DESCRIPTION
**- What this PR does and why is it needed**
 Functionally this makes 0 difference, honestly I just want to start a unit test with 0 nodes without getting stuck on syncNodes with the error:
```
E0214 15:34:52.882353  704419 factory.go:876] Failed (will retry) while processing existing *v1.Node items: zoneICHandler failed to sync nodes: error: failed to find network ID: could not find network ID: %!w(<nil>)
```
Is that too much to ask :) => I guess with IC it is, because technically speaking you can't really have IC with 0 nodes.
In `syncNodes` we except to find networkID from the nodes and then use that to create transit switch.

**- Special notes for reviewers**
Don't add too much logic to this, this is something needed only for testing purposes. Came while doing UTs for https://github.com/ovn-org/ovn-kubernetes/pull/4128


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->