### PR TITLE
e2e, multi-net policies: ensure ingress denyall has no impact on egress, and add egress allow/deny all tests

### DIFF
--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -831,7 +831,7 @@ var _ = Describe("Multi Homing", func() {
 						By("asserting the *client* pod can contact the underlay service after deleting the policy")
 						Expect(connectToServer(clientPodConfig, underlayServiceIP, servicePort)).To(Succeed())
 					},
-						Entry(
+						XEntry(
 							"minimal ingress denyall",
 							multiNetIngressDenyAllPolicy(
 								denyAllIngress,

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -354,10 +354,13 @@ func multiNetEgressLimitingIPBlockPolicy(
 	}
 }
 
-func multiNetIngressDenyAllPolicy(
+func multiNetPolicy(
 	policyName string,
 	policyFor string,
 	appliesFor metav1.LabelSelector,
+	policyTypes []mnpapi.MultiPolicyType,
+	ingress []mnpapi.MultiNetworkPolicyIngressRule,
+	egress []mnpapi.MultiNetworkPolicyEgressRule,
 ) *mnpapi.MultiNetworkPolicy {
 	return &mnpapi.MultiNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -368,29 +371,9 @@ func multiNetIngressDenyAllPolicy(
 		},
 		Spec: mnpapi.MultiNetworkPolicySpec{
 			PodSelector: appliesFor,
-			PolicyTypes: []mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress},
-		},
-	}
-}
-
-func multiNetIngressDenyAllEgressAllowAllPolicy(
-	policyName string,
-	policyFor string,
-	appliesFor metav1.LabelSelector,
-) *mnpapi.MultiNetworkPolicy {
-	return &mnpapi.MultiNetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: policyName,
-			Annotations: map[string]string{
-				PolicyForAnnotation: policyFor,
-			},
-		},
-		Spec: mnpapi.MultiNetworkPolicySpec{
-			PodSelector: appliesFor,
-			PolicyTypes: []mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress},
-			Egress: []mnpapi.MultiNetworkPolicyEgressRule{
-				mnpapi.MultiNetworkPolicyEgressRule{},
-			},
+			PolicyTypes: policyTypes,
+			Ingress:     ingress,
+			Egress:      egress,
 		},
 	}
 }

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -354,6 +354,47 @@ func multiNetEgressLimitingIPBlockPolicy(
 	}
 }
 
+func multiNetIngressDenyAllPolicy(
+	policyName string,
+	policyFor string,
+	appliesFor metav1.LabelSelector,
+) *mnpapi.MultiNetworkPolicy {
+	return &mnpapi.MultiNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+			Annotations: map[string]string{
+				PolicyForAnnotation: policyFor,
+			},
+		},
+		Spec: mnpapi.MultiNetworkPolicySpec{
+			PodSelector: appliesFor,
+			PolicyTypes: []mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress},
+		},
+	}
+}
+
+func multiNetIngressDenyAllEgressAllowAllPolicy(
+	policyName string,
+	policyFor string,
+	appliesFor metav1.LabelSelector,
+) *mnpapi.MultiNetworkPolicy {
+	return &mnpapi.MultiNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+			Annotations: map[string]string{
+				PolicyForAnnotation: policyFor,
+			},
+		},
+		Spec: mnpapi.MultiNetworkPolicySpec{
+			PodSelector: appliesFor,
+			PolicyTypes: []mnpapi.MultiPolicyType{mnpapi.PolicyTypeIngress},
+			Egress: []mnpapi.MultiNetworkPolicyEgressRule{
+				mnpapi.MultiNetworkPolicyEgressRule{},
+			},
+		},
+	}
+}
+
 func doesPolicyFeatAnIPBlock(policy *mnpapi.MultiNetworkPolicy) bool {
 	for _, rule := range policy.Spec.Ingress {
 		for _, peer := range rule.From {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
First 2 commits based on https://github.com/ovn-org/ovn-kubernetes/pull/4071
It Adds an e2e test that proves an ingress deny-all policy will have no impact on egress traffic
(see please link for more info)

In addition, add egress allow all / deny all tests.

<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->