### PR TITLE
Fix unneeded wait group add on node network controller

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1168,7 +1168,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to create egress IP controller: %v", err)
 		}
-		nc.wg.Add(1)
 		if err = c.Run(nc.stopChan, nc.wg, 1); err != nil {
 			return fmt.Errorf("failed to run egress IP controller: %v", err)
 		}


### PR DESCRIPTION
That prevented it from closing up properly.

As a side note, oh how would I like if we didn't pass wait groups around.

@martinkennelly PTAL
cc @npinaeva 

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->