### PR TITLE
Share common code between ANP/BANP

### DIFF
--- a/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
@@ -273,7 +273,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					expectedDatabaseState = append(expectedDatabaseState, acl)
 				}
 				expectedDatabaseState = append(expectedDatabaseState, getExpectedDataPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
-				peerASIngressRule0v4, peerASIngressRule0v6 = buildBANPAddressSets(banp, 0, []net.IP{testing.MustParseIP(t2.podIP)}, libovsdbutil.ACLIngress) // address-set will be empty since no pods match it
+				peerASIngressRule0v4, peerASIngressRule0v6 = buildBANPAddressSets(banp, 0, []net.IP{testing.MustParseIP(t2.podIP)}, libovsdbutil.ACLIngress) // podIP should be added to v4 address-set
 				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v4)
 				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v6)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy.go
@@ -147,107 +147,12 @@ func (c *Controller) ensureAdminNetworkPolicy(anp *anpapi.AdminNetworkPolicy) er
 		c.anpCache[anp.Name] = desiredANPState
 		return nil
 	}
-	var ops []ovsdb.Operation
 	// ANP state existed in the cache, which means its either an ANP update or pod/namespace add/update/delete
 	klog.V(3).Infof("Admin network policy %s/%d was found in cache...Syncing it", currentANPState.name, currentANPState.anpPriority)
 	hasPriorityChanged := (currentANPState.anpPriority != desiredANPState.anpPriority)
-	// Did ANP.Spec.Ingress Change (rule inserts/deletes)? && || Did ANP.Spec.Egress Change (rule inserts/deletes)? && ||
-	// If yes we need to fully recompute the acls present in our ANP's port group; Let's do a full recompute and return.
-	// Reason behind a full recompute: Each rule has precendence based on its position and priority of ANP; if any of that changes
-	// better to delete and recreate ACLs rather than figure out from caches
-	// TODO(tssurya): Investigate if we can be smarter about which ACLs to delete and which to add
-	// rather than always cleaning up everything and recreating them. But this is tricky since rules have precendence
-	// from their ordering.
-	// NOTE: Changes to admin policies should be a rare action (can be improved post user feedback) - usually churn would be around namespaces and pods
-	fullPeerRecompute := (len(currentANPState.egressRules) != len(desiredANPState.egressRules) ||
-		len(currentANPState.ingressRules) != len(desiredANPState.ingressRules))
-	if fullPeerRecompute {
-		// full recompute
-		// which means update all ACLs and address-sets
-		klog.V(3).Infof("ANP %s with priority (old %d, new %d) was updated", desiredANPState.name, currentANPState.anpPriority, desiredANPState.anpPriority)
-		ops, err = c.constructOpsForRuleChanges(desiredANPState, false)
-		if err != nil {
-			return fmt.Errorf("failed to create update ANP ops %s: %v", desiredANPState.name, err)
-		}
-	}
-
-	// Did ANP.Spec.Ingress rules get updated?
-	// (at this stage the length of ANP.Spec.Ingress hasn't changed, so individual rules either got updated at their values or positions are switched)
-	// The fields that we care about for rebuilding ACLs are
-	// (i) `ports` (ii) `actions` (iii) priority for a given rule
-	// The changes to peer labels, peer pod label updates, namespace label updates etc can be inferred
-	// from the podIPs cache we store.
-	// Did the ANP.Spec.Ingress.Peers Change?
-	// 1) ANP.Spec.Ingress.Peers.Namespaces changed && ||
-	// 2) ANP.Spec.Ingress.Peers.Pods changed && ||
-	// 3) A namespace started or stopped matching the peer && ||
-	// 4) A pod started or stopped matching the peer
-	// If yes we need to recompute the IPs present in our ANP's peer's address-sets
-	if !fullPeerRecompute && !reflect.DeepEqual(desiredANPState.ingressRules, currentANPState.ingressRules) {
-		addrOps, err := c.constructOpsForPeerChanges(desiredANPState.ingressRules,
-			currentANPState.ingressRules, desiredANPState.name, false)
-		if err != nil {
-			return fmt.Errorf("failed to create ops for changes to ANP ingress peers: %v", err)
-		}
-		ops = append(ops, addrOps...)
-	}
-
-	// Did ANP.Spec.Egress rules get updated?
-	// (at this stage the length of ANP.Spec.Egress hasn't changed, so individual rules either got updated at their values or positions are switched)
-	// The fields that we care about for rebuilding ACLs are
-	// (i) `ports` (ii) `actions` (iii) priority for a given rule
-	// Did the ANP.Spec.Egress.Peers Change?
-	// 1) ANP.Spec.Egress.Peers.Namespaces changed && ||
-	// 2) ANP.Spec.Egress.Peers.Pods changed && ||
-	// 3) A namespace started or stopped matching the peer && ||
-	// 4) A pod started or stopped matching the peer
-	// If yes we need to recompute the IPs present in our ANP's peer's address-sets
-	if !fullPeerRecompute && !reflect.DeepEqual(desiredANPState.egressRules, currentANPState.egressRules) {
-		addrOps, err := c.constructOpsForPeerChanges(desiredANPState.egressRules,
-			currentANPState.egressRules, desiredANPState.name, false)
-		if err != nil {
-			return fmt.Errorf("failed to create ops for changes to ANP egress peers: %v", err)
-		}
-		ops = append(ops, addrOps...)
-	}
-	// TODO(tssurya): Check if we can be more efficient by narrowing down exactly which ACL needs a change
-	// The rules which didn't change -> those updates will be no-ops thanks to libovsdb
-	// The rules that changed in terms of their `getACLMutableFields`
-	// will be simply updated since externalIDs will remain the same for these ACLs
-	// No delete ACLs action is required for this scenario
-	// the stale ACLs will automatically be taken care of if they are not references by the port group
-	// (1) fullPeerRecompute=true which means the rules were of different lengths (involved deletion or appending of gress rules)
-	// (2) atLeastOneRuleUpdated=true which means the gress rules were of same lengths but action or ports changed on at least one rule
-	// (3) hasPriorityChanged=true which means we should update acl.Priority for every ACL
-	if fullPeerRecompute || atLeastOneRuleUpdated || hasPriorityChanged {
-		klog.V(3).Infof("ANP %s with priority %d was updated", desiredANPState.name, desiredANPState.anpPriority)
-		// now update the acls to the desired ones
-		ops, err = libovsdbops.CreateOrUpdateACLsOps(c.nbClient, ops, desiredACLs...)
-		if err != nil {
-			return fmt.Errorf("failed to create new ACL ops for anp %s: %v", desiredANPState.name, err)
-		}
-		// since we update the portgroup with the new set of ACLs, any unreferenced set of ACLs
-		// will be automatically removed
-		ops, err = libovsdbops.UpdatePortGroupSetACLsOps(c.nbClient, ops, portGroupName, desiredACLs)
-		if err != nil {
-			return fmt.Errorf("failed to create ACL-on-PG update ops for anp %s: %v", desiredANPState.name, err)
-		}
-	}
-
-	// Did the ANP.Spec.Subject Change?
-	// 1) ANP.Spec.Namespaces changed && ||
-	// 2) ANP.Spec.Pods changed && ||
-	// 3) A namespace started or stopped matching the subject && ||
-	// 4) A pod started or stopped matching the subject
-	// If yes we need to recompute the ports present in our ANP's port group
-	subjectOps, err := c.constructOpsForSubjectChanges(currentANPState, desiredANPState, portGroupName)
+	err = c.updateExistingANP(currentANPState, desiredANPState, atLeastOneRuleUpdated, hasPriorityChanged, false, desiredACLs)
 	if err != nil {
-		return fmt.Errorf("failed to create ops for changes to ANP %s subject: %v", desiredANPState.name, err)
-	}
-	ops = append(ops, subjectOps...)
-	_, err = libovsdbops.TransactAndCheck(c.nbClient, ops)
-	if err != nil {
-		return fmt.Errorf("failed to run ovsdb txn to update ANP %s: %v", desiredANPState.name, err)
+		return fmt.Errorf("failed to update ANP %s: %v", desiredANPState.name, err)
 	}
 	// We also need to update c.anpPriorityMap cache
 	if hasPriorityChanged {
@@ -543,6 +448,112 @@ func (c *Controller) createNewANP(desiredANPState *adminNetworkPolicyState, desi
 	_, err = libovsdbops.TransactAndCheck(c.nbClient, ops)
 	if err != nil {
 		return fmt.Errorf("failed to run ovsdb txn to add ports to port group: %v", err)
+	}
+	return nil
+}
+
+func (c *Controller) updateExistingANP(currentANPState, desiredANPState *adminNetworkPolicyState, atLeastOneRuleUpdated,
+	hasPriorityChanged, isBanp bool, desiredACLs []*nbdb.ACL) error {
+	var ops []ovsdb.Operation
+	var err error
+	portGroupName, _ := getAdminNetworkPolicyPGName(desiredANPState.name, isBanp)
+	// Did ANP.Spec.Ingress Change (rule inserts/deletes)? && || Did ANP.Spec.Egress Change (rule inserts/deletes)? && ||
+	// If yes we need to fully recompute the acls present in our ANP's port group; Let's do a full recompute and return.
+	// Reason behind a full recompute: Each rule has precedence based on its position and priority of ANP; if any of that changes
+	// better to delete and recreate ACLs rather than figure out from caches
+	// TODO(tssurya): Investigate if we can be smarter about which ACLs to delete and which to add
+	// rather than always cleaning up everything and recreating them. But this is tricky since rules have precedence
+	// from their ordering.
+	// NOTE: Changes to admin policies should be a rare action (can be improved post user feedback) - usually churn would be around namespaces and pods
+	fullPeerRecompute := (len(currentANPState.egressRules) != len(desiredANPState.egressRules) ||
+		len(currentANPState.ingressRules) != len(desiredANPState.ingressRules))
+	if fullPeerRecompute {
+		// full recompute
+		// which means update all ACLs and address-sets
+		klog.V(3).Infof("ANP %s with priority (old %d, new %d) was updated", desiredANPState.name, currentANPState.anpPriority, desiredANPState.anpPriority)
+		ops, err = c.constructOpsForRuleChanges(desiredANPState, isBanp)
+		if err != nil {
+			return fmt.Errorf("failed to create update ANP ops %s: %v", desiredANPState.name, err)
+		}
+	}
+
+	// Did ANP.Spec.Ingress rules get updated?
+	// (at this stage the length of ANP.Spec.Ingress hasn't changed, so individual rules either got updated at their values or positions are switched)
+	// The fields that we care about for rebuilding ACLs are
+	// (i) `ports` (ii) `actions` (iii) priority for a given rule
+	// The changes to peer labels, peer pod label updates, namespace label updates etc can be inferred
+	// from the podIPs cache we store.
+	// Did the ANP.Spec.Ingress.Peers Change?
+	// 1) ANP.Spec.Ingress.Peers.Namespaces changed && ||
+	// 2) ANP.Spec.Ingress.Peers.Pods changed && ||
+	// 3) A namespace started or stopped matching the peer && ||
+	// 4) A pod started or stopped matching the peer
+	// If yes we need to recompute the IPs present in our ANP's peer's address-sets
+	if !fullPeerRecompute && !reflect.DeepEqual(desiredANPState.ingressRules, currentANPState.ingressRules) {
+		addrOps, err := c.constructOpsForPeerChanges(desiredANPState.ingressRules,
+			currentANPState.ingressRules, desiredANPState.name, isBanp)
+		if err != nil {
+			return fmt.Errorf("failed to create ops for changes to ANP ingress peers: %v", err)
+		}
+		ops = append(ops, addrOps...)
+	}
+
+	// Did ANP.Spec.Egress rules get updated?
+	// (at this stage the length of ANP.Spec.Egress hasn't changed, so individual rules either got updated at their values or positions are switched)
+	// The fields that we care about for rebuilding ACLs are
+	// (i) `ports` (ii) `actions` (iii) priority for a given rule
+	// Did the ANP.Spec.Egress.Peers Change?
+	// 1) ANP.Spec.Egress.Peers.Namespaces changed && ||
+	// 2) ANP.Spec.Egress.Peers.Pods changed && ||
+	// 3) A namespace started or stopped matching the peer && ||
+	// 4) A pod started or stopped matching the peer
+	// If yes we need to recompute the IPs present in our ANP's peer's address-sets
+	if !fullPeerRecompute && !reflect.DeepEqual(desiredANPState.egressRules, currentANPState.egressRules) {
+		addrOps, err := c.constructOpsForPeerChanges(desiredANPState.egressRules,
+			currentANPState.egressRules, desiredANPState.name, isBanp)
+		if err != nil {
+			return fmt.Errorf("failed to create ops for changes to ANP egress peers: %v", err)
+		}
+		ops = append(ops, addrOps...)
+	}
+	// TODO(tssurya): Check if we can be more efficient by narrowing down exactly which ACL needs a change
+	// The rules which didn't change -> those updates will be no-ops thanks to libovsdb
+	// The rules that changed in terms of their `getACLMutableFields`
+	// will be simply updated since externalIDs will remain the same for these ACLs
+	// No delete ACLs action is required for this scenario
+	// the stale ACLs will automatically be taken care of if they are not references by the port group
+	// (1) fullPeerRecompute=true which means the rules were of different lengths (involved deletion or appending of gress rules)
+	// (2) atLeastOneRuleUpdated=true which means the gress rules were of same lengths but action or ports changed on at least one rule
+	// (3) hasPriorityChanged=true which means we should update acl.Priority for every ACL
+	if fullPeerRecompute || atLeastOneRuleUpdated || hasPriorityChanged {
+		klog.V(3).Infof("ANP %s with priority %d was updated", desiredANPState.name, desiredANPState.anpPriority)
+		// now update the acls to the desired ones
+		ops, err = libovsdbops.CreateOrUpdateACLsOps(c.nbClient, ops, desiredACLs...)
+		if err != nil {
+			return fmt.Errorf("failed to create new ACL ops for anp %s: %v", desiredANPState.name, err)
+		}
+		// since we update the portgroup with the new set of ACLs, any unreferenced set of ACLs
+		// will be automatically removed
+		ops, err = libovsdbops.UpdatePortGroupSetACLsOps(c.nbClient, ops, portGroupName, desiredACLs)
+		if err != nil {
+			return fmt.Errorf("failed to create ACL-on-PG update ops for anp %s: %v", desiredANPState.name, err)
+		}
+	}
+
+	// Did the ANP.Spec.Subject Change?
+	// 1) ANP.Spec.Namespaces changed && ||
+	// 2) ANP.Spec.Pods changed && ||
+	// 3) A namespace started or stopped matching the subject && ||
+	// 4) A pod started or stopped matching the subject
+	// If yes we need to recompute the ports present in our ANP's port group
+	subjectOps, err := c.constructOpsForSubjectChanges(currentANPState, desiredANPState, portGroupName)
+	if err != nil {
+		return fmt.Errorf("failed to create ops for changes to ANP %s subject: %v", desiredANPState.name, err)
+	}
+	ops = append(ops, subjectOps...)
+	_, err = libovsdbops.TransactAndCheck(c.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("failed to run ovsdb txn to update ANP %s: %v", desiredANPState.name, err)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ovn-org/libovsdb/ovsdb"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -154,104 +153,11 @@ func (c *Controller) ensureBaselineAdminNetworkPolicy(banp *anpapi.BaselineAdmin
 		c.banpCache = desiredBANPState
 		return nil
 	}
-	var ops []ovsdb.Operation
 	// BANP state existed in the cache, which means its either a BANP update or pod/namespace add/update/delete
 	klog.V(3).Infof("Baseline Admin network policy %s was found in cache...Syncing it", currentBANPState.name)
-	// Did BANP.Spec.Ingress Change (rule inserts/deletes)? && || Did BANP.Spec.Egress Change (rule inserts/deletes)? && ||
-	// If yes we need to fully recompute the acls present in our BANP's port group; Let's do a full recompute and return.
-	// Reason behind a full recompute: Each rule has precendence based on its position and priority of BANP; if any of that changes
-	// better to delete and recreate ACLs rather than figure out from caches
-	// TODO(tssurya): Investigate if we can be smarter about which ACLs to delete and which to add
-	// rather than always cleaning up everything and recreating them. But this is tricky since rules have precendence
-	// from their ordering.
-	// NOTE: Changes to admin policies should be a rare action (can be improved post user feedback) - usually churn would be around namespaces and pods
-	fullPeerRecompute := (len(currentBANPState.egressRules) != len(desiredBANPState.egressRules) ||
-		len(currentBANPState.ingressRules) != len(desiredBANPState.ingressRules))
-	if fullPeerRecompute {
-		// full recompute
-		// which means update all ACLs and address-sets
-		klog.V(3).Infof("BANP %s with priority (old %d, new %d) was updated", desiredBANPState.name, currentBANPState.anpPriority, desiredBANPState.anpPriority)
-		ops, err = c.constructOpsForRuleChanges(desiredBANPState, true)
-		if err != nil {
-			return fmt.Errorf("failed to create update BANP ops %s: %v", desiredBANPState.name, err)
-		}
-	}
-
-	// Did BANP.Spec.Ingress rules get updated?
-	// (at this stage the length of BANP.Spec.Ingress hasn't changed, so individual rules either got updated at their values or positions are switched)
-	// The fields that we care about for rebuilding ACLs are
-	// (i) `ports` (ii) `actions` (iii) priority for a given rule
-	// The changes to peer labels, peer pod label updates, namespace label updates etc can be inferred
-	// from the podIPs cache we store.
-	// Did the BANP.Spec.Ingress.Peers Change?
-	// 1) BANP.Spec.Ingress.Peers.Namespaces changed && ||
-	// 2) BANP.Spec.Ingress.Peers.Pods changed && ||
-	// 3) A namespace started or stopped matching the peer && ||
-	// 4) A pod started or stopped matching the peer
-	// If yes we need to recompute the IPs present in our BANP's peer's address-sets
-	if !fullPeerRecompute && len(desiredBANPState.ingressRules) == len(currentBANPState.ingressRules) {
-		addrOps, err := c.constructOpsForPeerChanges(desiredBANPState.ingressRules,
-			currentBANPState.ingressRules, desiredBANPState.name, true)
-		if err != nil {
-			return fmt.Errorf("failed to create ops for changes to BANP %s ingress peers: %v", desiredBANPState.name, err)
-		}
-		ops = append(ops, addrOps...)
-	}
-
-	// Did BANP.Spec.Egress rules get updated?
-	// (at this stage the length of BANP.Spec.Egress hasn't changed, so individual rules either got updated at their values or positions are switched)
-	// The fields that we care about for rebuilding ACLs are
-	// (i) `ports` (ii) `actions` (iii) priority for a given rule
-	// Did the BANP.Spec.Egress.Peers Change?
-	// 1) BANP.Spec.Egress.Peers.Namespaces changed && ||
-	// 2) BANP.Spec.Egress.Peers.Pods changed && ||
-	// 3) A namespace started or stopped matching the peer && ||
-	// 4) A pod started or stopped matching the peer
-	// If yes we need to recompute the IPs present in our BANP's peer's address-sets
-	if !fullPeerRecompute && len(desiredBANPState.egressRules) == len(currentBANPState.egressRules) {
-		addrOps, err := c.constructOpsForPeerChanges(desiredBANPState.egressRules,
-			currentBANPState.egressRules, desiredBANPState.name, true)
-		if err != nil {
-			return fmt.Errorf("failed to create ops for changes to BANP %s egress peers: %v", desiredBANPState.name, err)
-		}
-		ops = append(ops, addrOps...)
-	}
-	// TODO(tssurya): Check if we can be more efficient by narrowing down exactly which ACL needs a change
-	// The rules which didn't change -> those updates will be no-ops thanks to libovsdb
-	// The rules that changed in terms of their `getACLMutableFields`
-	// will be simply updated since externalIDs will remain the same for these ACLs
-	// No delete ACLs action is required for this scenario
-	// If full aclRecompute=true was done above already, we don't care about individual rule updates...
-	// that will automatically be taken care of in the above transactions
-	if fullPeerRecompute || atLeastOneRuleUpdated {
-		klog.V(3).Infof("BANP %s was updated", desiredBANPState.name)
-		ops, err = libovsdbops.CreateOrUpdateACLsOps(c.nbClient, ops, desiredACLs...)
-		if err != nil {
-			return fmt.Errorf("failed to create ACL ops for banp %s: %v", desiredBANPState.name, err)
-		}
-		// since we update the portgroup with the new set of ACLs, any unreferenced set of ACLs
-		// will be automatically removed
-		ops, err = libovsdbops.UpdatePortGroupSetACLsOps(c.nbClient, ops, portGroupName, desiredACLs)
-		if err != nil {
-			return fmt.Errorf("failed to create ops to add port to a port group for banp %s: %v", desiredBANPState.name, err)
-		}
-	}
-
-	// Did the BANP.Spec.Subject Change?
-	// 1) BANP.Spec.Namespaces changed && ||
-	// 2) BANP.Spec.Pods changed && ||
-	// 3) A namespace started or stopped matching the subject && ||
-	// 4) A pod started or stopped matching the subject
-	// If yes we need to recompute the ports present in our ANP's port group
-	subjectOps, err := c.constructOpsForSubjectChanges(currentBANPState, desiredBANPState, portGroupName)
+	err = c.updateExistingANP(currentBANPState, desiredBANPState, atLeastOneRuleUpdated, false, true, desiredACLs)
 	if err != nil {
-		return fmt.Errorf("failed to create ops for changes to BANP %s subject: %v", desiredBANPState.name, err)
-	}
-	ops = append(ops, subjectOps...)
-
-	_, err = libovsdbops.TransactAndCheck(c.nbClient, ops)
-	if err != nil {
-		return fmt.Errorf("failed to run ovsdb txn to update BANP %s: %v", desiredBANPState.name, err)
+		return fmt.Errorf("failed to update ANP %s: %v", desiredBANPState.name, err)
 	}
 	// since transact was successful we can finally replace the currentBANPState in the cache with the latest desired one
 	c.banpCache = desiredBANPState

--- a/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
@@ -127,16 +127,16 @@ func (c *Controller) ensureBaselineAdminNetworkPolicy(banp *anpapi.BaselineAdmin
 	// 2) Construct Address-sets with IPs of the peers in the rules
 	// 3) Construct ACLs using AS-es and PGs
 	portGroupName, _ := getAdminNetworkPolicyPGName(desiredBANPState.name, true)
-	desiredPorts, err := c.getPortsOfSubject(desiredBANPState.subject)
+	desiredPorts, err := c.convertANPSubjectToLSPs(desiredBANPState.subject)
 	if err != nil {
 		return fmt.Errorf("unable to fetch ports for banp %s: %v", desiredBANPState.name, err)
 	}
-	err = c.constructIPSetOfPeers(desiredBANPState)
+	err = c.convertANPPeersToIPs(desiredBANPState)
 	if err != nil {
 		return fmt.Errorf("unable to build IPsets for banp %s: %v", desiredBANPState.name, err)
 	}
 	atLeastOneRuleUpdated := false
-	desiredACLs := c.getACLsOfRules(desiredBANPState, currentBANPState, portGroupName, &atLeastOneRuleUpdated, true)
+	desiredACLs := c.convertANPRulesToACLs(desiredBANPState, currentBANPState, portGroupName, &atLeastOneRuleUpdated, true)
 
 	// Comparing names for figuring out if cache is populated or not is safe
 	// because the singleton BANP will always be called "default" in any cluster


### PR DESCRIPTION
This commit creates updateExistingANP function
which can then be called from both ANP and BANP
ensure it functions similar to createNewANP.

Functionally no changes, internal cleanup which addresses review comment: https://github.com/ovn-org/ovn-kubernetes/pull/3659#discussion_r1289862089

We will be adding new peers in future PRs which will build on top of this