### PR TITLE
ANP: Add Support for Nodes as Egress Peers

### DIFF
--- a/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
@@ -75,15 +75,30 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 	)
 
 	const (
-		banpSubjectNamespaceName = "banp-subject-namespace"
-		banpPeerNamespaceName    = "banp-peer-namespace"
-		banpSubjectPodName       = "banp-subject-pod"
-		banpPodV4IP              = "10.128.1.3"
-		banpPodMAC               = "0a:58:0a:80:01:03"
-		banpPodV4IP2             = "10.128.1.4"
-		banpPodMAC2              = "0a:58:0a:80:01:04"
-		banpPeerPodName          = "banp-peer-pod"
-		node1Name                = "node1"
+		banpSubjectNamespaceName        = "banp-subject-namespace"
+		banpPeerNamespaceName           = "banp-peer-namespace"
+		banpSubjectPodName              = "banp-subject-pod"
+		banpPodV4IP                     = "10.128.1.3"
+		banpPodV6IP                     = "fe00:10:128:1::3"
+		banpPodMAC                      = "0a:58:0a:80:01:03"
+		banpPodV4IP2                    = "10.128.1.4"
+		banpPodV6IP2                    = "fe00:10:128:1::4"
+		banpPodMAC2                     = "0a:58:0a:80:01:04"
+		banpPeerPodName                 = "banp-peer-pod"
+		node1Name                string = "node1"
+		node1IPv4                string = "100.100.100.0"
+		node1IPv6                string = "fc00:f853:ccd:e793::1"
+		node1IPv4Subnet          string = "10.128.1.0/24"
+		node1IPv6Subnet          string = "fe00:10:128:1::/64"
+		node1transitIPv4         string = "100.88.0.2"
+		node1transitIPv6         string = "fd97::2"
+		node2Name                string = "node2"
+		node2IPv4                string = "200.200.200.0"
+		node2IPv6                string = "fc00:f853:ccd:e793::2"
+		node2IPv4Subnet          string = "10.128.2.0/24"
+		node2IPv6Subnet          string = "fe00:10:128:2::/64"
+		node2transitIPv4         string = "100.88.0.3"
+		node2transitIPv6         string = "fd97::3"
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -845,7 +860,7 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				ginkgo.By("3. Update BANP by deleting the ACL logging annotation and ensure its honoured")
 				banp.ResourceVersion = "3"
 				banp.Annotations = map[string]string{}
-				banp, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Update(context.TODO(), banp, metav1.UpdateOptions{})
+				_, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Update(context.TODO(), banp, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				for _, acl := range expectedDatabaseState[1:3] {
 					acl := acl.(*nbdb.ACL)
@@ -854,6 +869,282 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					acl.Severity = nil
 				}
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+		ginkgo.It("egress node peers: should create/update/delete address-sets, acls, port-groups correctly", func() {
+			app.Action = func(ctx *cli.Context) error {
+				banpNamespaceSubject := *newNamespaceWithLabels(banpSubjectNamespaceName, anpLabel)
+				banpNamespacePeer := *newNamespaceWithLabels(banpPeerNamespaceName, peerDenyLabel)
+				config.IPv4Mode = true
+				config.IPv6Mode = true
+				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet, node1transitIPv4, node1transitIPv6)
+				node1Switch := &nbdb.LogicalSwitch{
+					Name: node1Name,
+					UUID: node1Name + "-UUID",
+				}
+				t := newTPod(
+					node1Name,
+					node1IPv4Subnet+" "+node1IPv6Subnet,
+					"10.128.1.2",
+					"10.128.1.1"+" "+"fe00:10:128:1::1",
+					banpSubjectPodName,
+					banpPodV4IP+" "+banpPodV6IP,
+					banpPodMAC,
+					banpSubjectNamespaceName,
+				)
+				anpSubjectPod := *newPod(banpSubjectNamespaceName, banpSubjectPodName, node1Name, t.podIP)
+				// pinning annotations because between subject and peer pods IPAM isunpredictable
+				anpSubjectPod.Annotations = map[string]string{}
+				anpSubjectPod.Annotations["k8s.ovn.org/pod-networks"] = `{"default":{"ip_addresses":["10.128.1.3/24","fe00:10:128:1::3/64"],` +
+					`"mac_address":"0a:58:0a:80:01:03","gateway_ips":["10.128.1.1","fe00:10:128:1::1"],"routes":[{"dest":"10.128.1.0/24","nextHop":"10.128.1.1"}],` +
+					`"ip_address":"10.128.1.3/24","gateway_ip":"10.128.1.1"}}`
+				t2 := newTPod(
+					node1Name,
+					node1IPv4Subnet+" "+node1IPv6Subnet,
+					"10.128.1.2",
+					"10.128.1.1"+" "+"fe00:10:128:1::1",
+					banpPeerPodName,
+					banpPodV4IP2+" "+banpPodV6IP2,
+					banpPodMAC2,
+					banpPeerNamespaceName,
+				)
+				anpPeerPod := *newPod(banpPeerNamespaceName, banpPeerPodName, node1Name, t2.podIP)
+				// pinning annotations because between subject and peer pods IPAM isunpredictable
+				anpPeerPod.Annotations = map[string]string{}
+				anpPeerPod.Annotations["k8s.ovn.org/pod-networks"] = `{"default":{"ip_addresses":["10.128.1.4/24","fe00:10:128:1::4/64"],` +
+					`"mac_address":"0a:58:0a:80:01:04","gateway_ips":["10.128.1.1","fe00:10:128:1::1"],"routes":[{"dest":"10.128.1.0/24","nextHop":"10.128.1.1"}],` +
+					`"ip_address":"10.128.1.4/24","gateway_ip":"10.128.1.1"}}`
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						node1Switch,
+					},
+				}
+				fakeOVN.startWithDBSetup(dbSetup,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							banpNamespaceSubject,
+							banpNamespacePeer,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							*node1,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							anpSubjectPod, // subject pod ("house": "gryffindor")
+							anpPeerPod,    // peer pod ("house": "slytherin")
+						},
+					},
+				)
+
+				fakeOVN.controller.zone = node1Name // ensure we set the controller's zone as the node's zone
+				t.portName = util.GetLogicalPortName(t.namespace, t.podName)
+				t.populateLogicalSwitchCache(fakeOVN)
+				t2.portName = util.GetLogicalPortName(t2.namespace, t2.podName)
+				t2.populateLogicalSwitchCache(fakeOVN)
+				err := fakeOVN.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOVN.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOVN.InitAndRunANPController()
+
+				fakeOVN.fakeClient.ANPClient.(*anpfake.Clientset).PrependReactor("update", "baselineadminnetworkpolicies", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					update := action.(clienttesting.UpdateAction)
+					// Since fake client (NewSimpleClientset) does not differentiate between
+					// an update and updatestatus, updatestatus in tests updates the spec as
+					// well causing race conditions. Thus adding a hack here to ensure update
+					// status is caught and processed by the reactor while update spec is
+					// delegated to the main code for handling
+					if action.GetSubresource() == "status" {
+						klog.Infof("Got an update status action for %v", update.GetObject())
+						return true, update.GetObject(), nil
+					}
+					klog.Infof("Got an update spec action for %v", update.GetObject())
+					return false, update.GetObject(), nil
+				})
+
+				ginkgo.By("1. creating a baseline admin network policy with 2 egress rules that have node peers")
+				banpSubject := newANPSubjectObject(
+					&metav1.LabelSelector{
+						MatchLabels: anpLabel,
+					},
+					nil,
+				)
+				// NOTE: Logically speaking the rules don't make sense because we match on the same node, but goal here is to verify the match
+				egressRules := []anpapi.BaselineAdminNetworkPolicyEgressRule{
+					{
+						Name:   "deny-traffic-to-slytherin-and-linux-nodes-from-gryffindor",
+						Action: anpapi.BaselineAdminNetworkPolicyRuleActionDeny,
+						To: []anpapi.AdminNetworkPolicyEgressPeer{
+							{
+								Namespaces: &anpapi.NamespacedPeer{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: peerDenyLabel,
+									},
+								},
+							},
+							{
+								Nodes: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"kubernetes.io/os": "linux"},
+								},
+							},
+						},
+					},
+					{
+						Name:   "allow-traffic-to-hufflepuff-and--all-nodes-from-gryffindor",
+						Action: anpapi.BaselineAdminNetworkPolicyRuleActionAllow,
+						To: []anpapi.AdminNetworkPolicyEgressPeer{
+							{
+								Pods: &anpapi.NamespacedPodPeer{ // test different kind of peer expression
+									Namespaces: anpapi.NamespacedPeer{
+										NamespaceSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "house",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"slytherin", "hufflepuff"},
+												},
+											},
+										},
+									},
+									PodSelector: metav1.LabelSelector{
+										MatchLabels: peerAllowLabel,
+									},
+								},
+							},
+							{
+								Nodes: &metav1.LabelSelector{
+									MatchLabels: map[string]string{}, // empty selector, all nodes
+								},
+							},
+						},
+						Ports: &[]anpapi.AdminNetworkPolicyPort{ // test different ports combination
+							{
+								PortNumber: &anpapi.Port{
+									Protocol: v1.ProtocolTCP,
+									Port:     int32(12345),
+								},
+							},
+							{
+								PortRange: &anpapi.PortRange{
+									Protocol: v1.ProtocolUDP,
+									Start:    int32(12345),
+									End:      int32(65000),
+								},
+							},
+							{
+								PortNumber: &anpapi.Port{
+									Protocol: v1.ProtocolSCTP,
+									Port:     int32(12345),
+								},
+							},
+						},
+					},
+				}
+				banp := newBANPObject("harry-potter", banpSubject, []anpapi.BaselineAdminNetworkPolicyIngressRule{}, egressRules)
+				banp.ResourceVersion = "1"
+				banp, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Create(context.TODO(), banp, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				acls := getACLsForBANPRules(banp)
+				pg := getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, acls, true)
+				subjectNSASIPv4, subjectNSASIPv6 := buildNamespaceAddressSets(banpSubjectNamespaceName,
+					[]net.IP{testing.MustParseIP(banpPodV4IP), testing.MustParseIP(banpPodV6IP)})
+				peerNSASIPv4, peerNSASIPv6 := buildNamespaceAddressSets(banpPeerNamespaceName,
+					[]net.IP{testing.MustParseIP(banpPodV4IP2), testing.MustParseIP(banpPodV6IP2)})
+				expectedDatabaseState := []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
+				expectedDatabaseState = append(expectedDatabaseState, getExpectedDataPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
+				for _, acl := range acls {
+					acl := acl
+					expectedDatabaseState = append(expectedDatabaseState, acl)
+				}
+				// egressRule AddressSets
+				peerASEgressRule0v4, peerASEgressRule0v6 := buildBANPAddressSets(banp,
+					0, []net.IP{testing.MustParseIP(banpPodV4IP2), testing.MustParseIP(banpPodV6IP2)}, libovsdbutil.ACLEgress) // address-set will contain matching peer nodes, kubernetes.io/hostname doesn't match node1 so no node peers here
+				expectedDatabaseState = append(expectedDatabaseState, peerASEgressRule0v4)
+				expectedDatabaseState = append(expectedDatabaseState, peerASEgressRule0v6)
+				peerASEgressRule1v4, peerASEgressRule1v6 := buildBANPAddressSets(banp,
+					1, []net.IP{testing.MustParseIP(node1IPv4), testing.MustParseIP(node1IPv6)}, libovsdbutil.ACLEgress) // address-set will contain all nodeIPs (empty selector match)
+				expectedDatabaseState = append(expectedDatabaseState, peerASEgressRule1v4)
+				expectedDatabaseState = append(expectedDatabaseState, peerASEgressRule1v6)
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+
+				ginkgo.By("2. creating another node2 that will act as peer of baseline admin network policy; check if IP is added to address-set")
+				node2 := nodeFor(node2Name, node2IPv4, node2IPv6, node2IPv4Subnet, node2IPv6Subnet, node2transitIPv4, node2transitIPv6)
+				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), node2, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState[len(expectedDatabaseState)-1].(*nbdb.AddressSet).Addresses = []string{node2IPv6, node1IPv6} // nodeIP should be added to v6 allow address-set
+				expectedDatabaseState[len(expectedDatabaseState)-2].(*nbdb.AddressSet).Addresses = []string{node2IPv4, node1IPv4} // nodeIP should be added to v4 allow address-set
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("3. update the labels of node2 such that it starts to match the DENY RULE peer selector; check if IPs are updated in address-sets")
+				node2.ResourceVersion = "2"
+				node2.Labels["kubernetes.io/os"] = "linux" // node should not match the 1st anp deny rule peer
+				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState[len(expectedDatabaseState)-3].(*nbdb.AddressSet).Addresses = []string{
+					banpPodV6IP2, node2IPv6} // nodeIP should be added to v6 deny address-set
+				expectedDatabaseState[len(expectedDatabaseState)-4].(*nbdb.AddressSet).Addresses = []string{
+					banpPodV4IP2, node2IPv4} // nodeIP should be added to v4 deny address-set
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("4. update the hostCIDR annotation of node2; check if IPs are updated in address-sets")
+				node2.ResourceVersion = "3"
+				node2.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\",\"%s\"]", "200.100.100.0/24", "fc00:f853:ccd:e793::2/64")
+				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState[len(expectedDatabaseState)-2].(*nbdb.AddressSet).Addresses = []string{
+					"200.100.100.0", node1IPv4} // nodeIP should be updated in v4 allow address-set
+				expectedDatabaseState[len(expectedDatabaseState)-4].(*nbdb.AddressSet).Addresses = []string{
+					banpPodV4IP2, "200.100.100.0"} // nodeIP should be updated in v4 deny address-set
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("5. update the peer selector of rule1 in admin network policy so that node1 stops matching; check if address-set is updated")
+				egressRules[1].To[1].Nodes = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/hostname": "node2"},
+				}
+				banp.ResourceVersion = "5"
+				banp.Spec.Egress = egressRules
+				_, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Update(context.TODO(), banp, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState[len(expectedDatabaseState)-1].(*nbdb.AddressSet).Addresses = []string{node2IPv6}       // node1IP should be removed from v6 allow address-set
+				expectedDatabaseState[len(expectedDatabaseState)-2].(*nbdb.AddressSet).Addresses = []string{"200.100.100.0"} // node1IP should be removed from v4 allow address-set
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("6. delete node matching peer selector; check if IPs are updated in address-sets")
+				err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node2Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState[len(expectedDatabaseState)-3].(*nbdb.AddressSet).Addresses = []string{banpPodV6IP2} // node2IP should be removed from v6 deny address-set
+				expectedDatabaseState[len(expectedDatabaseState)-4].(*nbdb.AddressSet).Addresses = []string{banpPodV4IP2} // node2IP should be removed to v4 deny address-set
+				expectedDatabaseState[len(expectedDatabaseState)-1].(*nbdb.AddressSet).Addresses = []string{}             // node2IP should be removed from v6 allow address-set
+				expectedDatabaseState[len(expectedDatabaseState)-2].(*nbdb.AddressSet).Addresses = []string{}             // node2IP should be removed to v4 allow address-set
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("7. update the BANP by deleting all rules; check if all objects are deleted correctly")
+				banp.Spec.Egress = []anpapi.BaselineAdminNetworkPolicyEgressRule{}
+				banp.ResourceVersion = "7"
+				banp, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Update(context.TODO(), banp, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				pg = getDefaultPGForANPSubject(banp.Name, []string{t.portUUID}, nil, true)
+				expectedDatabaseState = []libovsdbtest.TestData{pg, subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6}
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState = append(expectedDatabaseState, getExpectedDataPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("8. delete the BANP; check if all objects are deleted correctly")
+				banp.ResourceVersion = "8"
+				err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Delete(context.TODO(), banp.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState = []libovsdbtest.TestData{subjectNSASIPv4, subjectNSASIPv6, peerNSASIPv4, peerNSASIPv6} // port group should be deleted
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState = append(expectedDatabaseState, getExpectedDataPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
 				return nil
 			}
 			err := app.Run([]string{app.Name})

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
@@ -56,7 +56,6 @@ type Controller struct {
 	// we consider it remote - this is ok for this controller as this variable is only used to
 	// determine if we need to add pod's port to port group or not - future updates should
 	// take care of reconciling the state of the cluster
-	// TODO(tssurya): Revisit this in future uniformly across the code base if needed.
 	isPodScheduledinLocalZone func(*v1.Pod) bool
 	// store's the name of the zone that this controller belongs to
 	zone string

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
@@ -121,7 +121,7 @@ func NewController(
 		banpCache:                 &adminNetworkPolicyState{}, // safe to initialise pointer to empty struct than nil
 	}
 
-	klog.Info("Setting up event handlers for Admin Network Policy")
+	klog.V(5).Info("Setting up event handlers for Admin Network Policy")
 	// setup anp informers, listers, queue
 	c.anpLister = anpInformer.Lister()
 	c.anpCacheSynced = anpInformer.Informer().HasSynced
@@ -139,7 +139,7 @@ func NewController(
 
 	}
 
-	klog.Info("Setting up event handlers for Baseline Admin Network Policy")
+	klog.V(5).Info("Setting up event handlers for Baseline Admin Network Policy")
 	// setup banp informers, listers, queue
 	c.banpLister = banpInformer.Lister()
 	c.banpCacheSynced = banpInformer.Informer().HasSynced
@@ -156,7 +156,7 @@ func NewController(
 		return nil, fmt.Errorf("could not add Event Handler for banpInformer during admin network policy controller initialization, %w", err)
 	}
 
-	klog.Info("Setting up event handlers for Namespaces in Admin Network Policy controller")
+	klog.V(5).Info("Setting up event handlers for Namespaces in Admin Network Policy controller")
 	c.anpNamespaceLister = namespaceInformer.Lister()
 	c.anpNamespaceSynced = namespaceInformer.Informer().HasSynced
 	c.anpNamespaceQueue = workqueue.NewNamedRateLimitingQueue(
@@ -172,7 +172,7 @@ func NewController(
 		return nil, fmt.Errorf("could not add Event Handler for namespace Informer during admin network policy controller initialization, %w", err)
 	}
 
-	klog.Info("Setting up event handlers for Pods in Admin Network Policy controller")
+	klog.V(5).Info("Setting up event handlers for Pods in Admin Network Policy controller")
 	c.anpPodLister = podInformer.Lister()
 	c.anpPodSynced = podInformer.Informer().HasSynced
 	c.anpPodQueue = workqueue.NewNamedRateLimitingQueue(
@@ -188,7 +188,7 @@ func NewController(
 		return nil, fmt.Errorf("could not add Event Handler for pod Informer during admin network policy controller initialization, %w", err)
 	}
 
-	klog.Info("Setting up event handlers for Nodes in Admin Network Policy controller")
+	klog.V(5).Info("Setting up event handlers for Nodes in Admin Network Policy controller")
 	c.anpNodeLister = nodeInformer.Lister()
 	c.anpNodeSynced = podInformer.Informer().HasSynced
 	c.anpNodeQueue = workqueue.NewNamedRateLimitingQueue(
@@ -218,7 +218,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 	klog.Infof("Starting controller %s", c.controllerName)
 
 	// Wait for the caches to be synced
-	klog.Info("Waiting for informer caches to sync")
+	klog.V(5).Info("Waiting for informer caches to sync")
 	if !util.WaitForInformerCacheSyncWithTimeout(c.controllerName, stopCh, c.anpCacheSynced, c.banpCacheSynced, c.anpNamespaceSynced, c.anpPodSynced) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for admin network policy caches to sync"))
 		klog.Errorf("Error syncing caches for admin network policy and baseline admin network policy")
@@ -238,7 +238,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 
 	wg := &sync.WaitGroup{}
 	// Start the workers after the repair loop to avoid races
-	klog.Info("Starting Admin Network Policy workers")
+	klog.V(5).Info("Starting Admin Network Policy workers")
 	for i := 0; i < threadiness; i++ {
 		wg.Add(1)
 		go func() {
@@ -249,7 +249,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 		}()
 	}
 
-	klog.Info("Starting Baseline Admin Network Policy workers")
+	klog.V(5).Info("Starting Baseline Admin Network Policy workers")
 	for i := 0; i < threadiness; i++ {
 		wg.Add(1)
 		go func() {
@@ -260,7 +260,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 		}()
 	}
 
-	klog.Info("Starting Namespace Admin Network Policy workers")
+	klog.V(5).Info("Starting Namespace Admin Network Policy workers")
 	for i := 0; i < threadiness; i++ {
 		wg.Add(1)
 		go func() {
@@ -271,7 +271,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 		}()
 	}
 
-	klog.Info("Starting Pod Admin Network Policy workers")
+	klog.V(5).Info("Starting Pod Admin Network Policy workers")
 	for i := 0; i < threadiness; i++ {
 		wg.Add(1)
 		go func() {
@@ -282,7 +282,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 		}()
 	}
 
-	klog.Info("Starting Node Admin Network Policy workers")
+	klog.V(5).Info("Starting Node Admin Network Policy workers")
 	for i := 0; i < threadiness; i++ {
 		wg.Add(1)
 		go func() {
@@ -438,7 +438,7 @@ func (c *Controller) onANPNamespaceAdd(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	klog.V(4).Infof("Adding Namespace in Admin Network Policy controller %s", key)
+	klog.V(5).Infof("Adding Namespace in Admin Network Policy controller %s", key)
 	c.anpNamespaceQueue.Add(key)
 }
 
@@ -460,7 +460,7 @@ func (c *Controller) onANPNamespaceUpdate(oldObj, newObj interface{}) {
 	}
 	key, err := cache.MetaNamespaceKeyFunc(newObj)
 	if err == nil {
-		klog.V(4).Infof("Updating Namespace in Admin Network Policy controller %s: "+
+		klog.V(5).Infof("Updating Namespace in Admin Network Policy controller %s: "+
 			"namespaceLabels: %v", key, newNamespaceLabels)
 		c.anpNamespaceQueue.Add(key)
 	}
@@ -473,7 +473,7 @@ func (c *Controller) onANPNamespaceDelete(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	klog.V(4).Infof("Deleting Namespace in Admin Network Policy %s", key)
+	klog.V(5).Infof("Deleting Namespace in Admin Network Policy %s", key)
 	c.anpNamespaceQueue.Add(key)
 }
 
@@ -484,7 +484,7 @@ func (c *Controller) onANPPodAdd(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	klog.V(4).Infof("Adding Pod in Admin Network Policy controller %s", key)
+	klog.V(5).Infof("Adding Pod in Admin Network Policy controller %s", key)
 	c.anpPodQueue.Add(key)
 }
 
@@ -519,7 +519,7 @@ func (c *Controller) onANPPodUpdate(oldObj, newObj interface{}) {
 	}
 	key, err := cache.MetaNamespaceKeyFunc(newObj)
 	if err == nil {
-		klog.V(4).Infof("Updating Pod in Admin Network Policy controller %s: "+
+		klog.V(5).Infof("Updating Pod in Admin Network Policy controller %s: "+
 			"podLabels %v, podIPs: %v, PodStatus: %v, PodCompleted?: %v", key, newPodLabels,
 			newPodIPs, newPodRunning, newPodCompleted)
 		c.anpPodQueue.Add(key)
@@ -533,7 +533,7 @@ func (c *Controller) onANPPodDelete(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	klog.V(4).Infof("Deleting Pod Admin Network Policy %s", key)
+	klog.V(5).Infof("Deleting Pod Admin Network Policy %s", key)
 	c.anpPodQueue.Add(key)
 }
 
@@ -544,7 +544,7 @@ func (c *Controller) onANPNodeAdd(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	klog.V(4).Infof("Adding Node in Admin Network Policy controller %s", key)
+	klog.V(5).Infof("Adding Node in Admin Network Policy controller %s", key)
 	c.anpNodeQueue.Add(key)
 }
 
@@ -568,7 +568,7 @@ func (c *Controller) onANPNodeUpdate(oldObj, newObj interface{}) {
 	}
 	key, err := cache.MetaNamespaceKeyFunc(newObj)
 	if err == nil {
-		klog.V(4).Infof("Updating Node in Admin Network Policy controller %s: "+
+		klog.V(5).Infof("Updating Node in Admin Network Policy controller %s: "+
 			"nodeLabels %v, isHostCIDRsAltered?: %v", key, newNodeLabels, isHostCIDRsAltered)
 		c.anpNodeQueue.Add(key)
 	}
@@ -581,6 +581,6 @@ func (c *Controller) onANPNodeDelete(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	klog.V(4).Infof("Deleting Node Admin Network Policy %s", key)
+	klog.V(5).Infof("Deleting Node Admin Network Policy %s", key)
 	c.anpNodeQueue.Add(key)
 }

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_namespace.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_namespace.go
@@ -50,10 +50,10 @@ func (c *Controller) syncAdminNetworkPolicyNamespace(key string) error {
 	if err != nil {
 		return err
 	}
-	klog.V(4).Infof("Processing sync for Namespace %s in Admin Network Policy controller", name)
+	klog.V(5).Infof("Processing sync for Namespace %s in Admin Network Policy controller", name)
 
 	defer func() {
-		klog.V(4).Infof("Finished syncing Namespace %s Admin Network Policy controller: took %v", name, time.Since(startTime))
+		klog.V(5).Infof("Finished syncing Namespace %s Admin Network Policy controller: took %v", name, time.Since(startTime))
 	}()
 	namespace, err := c.anpNamespaceLister.Get(name)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -147,7 +147,7 @@ func (c *Controller) setNamespaceForANP(namespace *v1.Namespace, anpCache *admin
 	// namespace matches the last rule's peer in egress in which we case we go through everything (max: 20,000 gress rules).
 	// case(i)
 	if _, ok := anpCache.subject.namespaces[namespace.Name]; ok {
-		klog.V(4).Infof("Namespace %s used to match ANP %s subject, requeuing...", namespace.Name, anpCache.name)
+		klog.V(5).Infof("Namespace %s used to match ANP %s subject, requeuing...", namespace.Name, anpCache.name)
 		queue.Add(anpCache.name)
 		return
 	}
@@ -163,7 +163,7 @@ func (c *Controller) setNamespaceForANP(namespace *v1.Namespace, anpCache *admin
 		for _, peer := range rule.peers {
 			// case(iii)
 			if _, ok := peer.namespaces[namespace.Name]; ok {
-				klog.V(4).Infof("Namespace %s used to match ANP %s ingress rule %d peer, requeuing...", namespace.Name, anpCache.name, rule.priority)
+				klog.V(5).Infof("Namespace %s used to match ANP %s ingress rule %d peer, requeuing...", namespace.Name, anpCache.name, rule.priority)
 				queue.Add(anpCache.name)
 				return
 			}
@@ -180,7 +180,7 @@ func (c *Controller) setNamespaceForANP(namespace *v1.Namespace, anpCache *admin
 		for _, peer := range rule.peers {
 			// case(v)
 			if _, ok := peer.namespaces[namespace.Name]; ok {
-				klog.V(4).Infof("Namespace %s used to match ANP %s egress rule %d peer, requeuing...", namespace.Name, anpCache.name, rule.priority)
+				klog.V(5).Infof("Namespace %s used to match ANP %s egress rule %d peer, requeuing...", namespace.Name, anpCache.name, rule.priority)
 				queue.Add(anpCache.name)
 				return
 			}

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_namespace.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_namespace.go
@@ -43,7 +43,6 @@ func (c *Controller) processNextANPNamespaceWorkItem(wg *sync.WaitGroup) bool {
 // syncAdminNetworkPolicyNamespace decides the main logic everytime
 // we dequeue a key from the anpNamespaceQueue cache
 func (c *Controller) syncAdminNetworkPolicyNamespace(key string) error {
-	// TODO(tssurya): This global lock will be inefficient, we will do perf runs and improve if needed
 	c.Lock()
 	defer c.Unlock()
 	startTime := time.Now()

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_node.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_node.go
@@ -52,10 +52,10 @@ func (c *Controller) syncAdminNetworkPolicyNode(key string) error {
 	if err != nil {
 		return err
 	}
-	klog.V(4).Infof("Processing sync for Node %s in Admin Network Policy controller", name)
+	klog.V(5).Infof("Processing sync for Node %s in Admin Network Policy controller", name)
 
 	defer func() {
-		klog.V(4).Infof("Finished syncing Node %s Admin Network Policy controller: took %v", name, time.Since(startTime))
+		klog.V(5).Infof("Finished syncing Node %s Admin Network Policy controller: took %v", name, time.Since(startTime))
 	}()
 	node, err := c.anpNodeLister.Get(name)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -134,7 +134,7 @@ func (c *Controller) setNodeForANP(node *v1.Node, anpCache *adminNetworkPolicySt
 		for _, peer := range rule.peers {
 			// case(i)
 			if peer.nodes.Has(node.Name) {
-				klog.V(4).Infof("Node %s used to match ANP %s egress rule %d peer, requeuing...", node.Name, anpCache.name, rule.priority)
+				klog.V(5).Infof("Node %s used to match ANP %s egress rule %d peer, requeuing...", node.Name, anpCache.name, rule.priority)
 				queue.Add(anpCache.name)
 				return
 			}

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_node.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_node.go
@@ -1,0 +1,39 @@
+package adminnetworkpolicy
+
+import (
+	"fmt"
+	"sync"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+func (c *Controller) processNextANPNodeWorkItem(wg *sync.WaitGroup) bool {
+	wg.Add(1)
+	defer wg.Done()
+	anpNodeKey, quit := c.anpNodeQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.anpNodeQueue.Done(anpNodeKey)
+	err := c.syncAdminNetworkPolicyNode(anpNodeKey.(string))
+	if err == nil {
+		c.anpNodeQueue.Forget(anpNodeKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", anpNodeKey, err))
+
+	if c.anpNodeQueue.NumRequeues(anpNodeKey) < maxRetries {
+		c.anpNodeQueue.AddRateLimited(anpNodeKey)
+		return true
+	}
+
+	c.anpNodeQueue.Forget(anpNodeKey)
+	return true
+}
+
+// syncAdminNetworkPolicyNode decides the main logic everytime
+// we dequeue a key from the anpNodeQueue cache
+func (c *Controller) syncAdminNetworkPolicyNode(key string) error {
+	return nil
+}

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_node.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_node.go
@@ -3,8 +3,15 @@ package adminnetworkpolicy
 import (
 	"fmt"
 	"sync"
+	"time"
 
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 )
 
 func (c *Controller) processNextANPNodeWorkItem(wg *sync.WaitGroup) bool {
@@ -35,5 +42,110 @@ func (c *Controller) processNextANPNodeWorkItem(wg *sync.WaitGroup) bool {
 // syncAdminNetworkPolicyNode decides the main logic everytime
 // we dequeue a key from the anpNodeQueue cache
 func (c *Controller) syncAdminNetworkPolicyNode(key string) error {
+	// TODO(tssurya): This global lock will be inefficient, we will do perf runs and improve if needed
+	c.Lock()
+	defer c.Unlock()
+	startTime := time.Now()
+	// Iterate all ANPs and check if this node start/stops matching
+	// any ANP and add/remove the setup accordingly. Nodes can match multiple
+	// ANPs objects, so continue iterating all ANP objects before finishing.
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	klog.V(4).Infof("Processing sync for Node %s in Admin Network Policy controller", name)
+
+	defer func() {
+		klog.V(4).Infof("Finished syncing Node %s Admin Network Policy controller: took %v", name, time.Since(startTime))
+	}()
+	node, err := c.anpNodeLister.Get(name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	// (i) node add
+	// (ii) node update because node's labels changed OR node's HostCIDR annotation changed
+	// (iii) node delete
+	// In all these cases check which ANPs were managing this pod and enqueue them back to anpQueue
+	existingANPs, err := c.anpLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	// case(iii)
+	if node == nil {
+		for _, anp := range existingANPs {
+			anpObj, loaded := c.anpCache[anp.Name]
+			if !loaded {
+				continue
+			}
+			c.clearNodeForANP(name, anpObj, c.anpQueue)
+		}
+		banpObj := c.banpCache
+		if banpObj.name == "" { // empty struct, BANP is not setup yet
+			return nil
+		}
+		c.clearNodeForANP(name, banpObj, c.banpQueue)
+		return nil
+	}
+	// case (i)/(ii)
+	for _, anp := range existingANPs {
+		anpObj, loaded := c.anpCache[anp.Name]
+		if !loaded {
+			continue
+		}
+		c.setNodeForANP(node, anpObj, c.anpQueue)
+	}
+	banpObj := c.banpCache
+	if banpObj.name == "" { // empty struct, BANP is not setup yet
+		return nil
+	}
+	c.setNodeForANP(node, banpObj, c.banpQueue)
 	return nil
+}
+
+// clearNodeFor(B)ANP will handle the logic for figuring out if the provided node name
+// used to match the given anpCache.name policy. If so, it will requeue the anpCache.name key back
+// into the main (b)anpQueue cache for reconciling the db objects. If not, function is a no-op.
+func (c *Controller) clearNodeForANP(name string, anpCache *adminNetworkPolicyState, queue workqueue.RateLimitingInterface) {
+	// (i) check if it used to match any of the .Spec.Egress.Peers requeue it and return
+	for _, rule := range anpCache.egressRules {
+		for _, peer := range rule.peers {
+			if peer.nodes.Has(name) {
+				klog.V(4).Infof("Node %s used to match ANP %s egress rule %d peer, requeuing...", name, anpCache.name, rule.priority)
+				queue.Add(anpCache.name)
+				return
+			}
+		}
+	}
+}
+
+// setNodeForANP will handle the logic for figuring out if the provided node name
+// used to match the given anpCache.name policy or if it started matching the given anpCache.name.
+// If so, it will requeue the anpCache.name key back into the main (b)anpQueue cache for reconciling
+// the db objects. If not, function is a no-op.
+func (c *Controller) setNodeForANP(node *v1.Node, anpCache *adminNetworkPolicyState, queue workqueue.RateLimitingInterface) {
+	// (i) if above conditions are are false, check if it used to match any of the .Spec.Egress.Peers requeue it and return OR
+	// (ii) check if it started to match any of the .Spec.Egress.Peers requeue it and return
+	// The goal is to check if this node matches the ANP in at least one of the above ways, we immediately add key
+	// and return. We don't really need to process all the rules and all the combinations. But worst case is if
+	// node matches the last rule's peer in egress in which we case we go through everything (max: 20,000 gress rules).
+	// case(i)/(ii)
+	nodeLabels := labels.Set(node.Labels)
+	// case(i)/(ii)
+	for _, rule := range anpCache.egressRules {
+		for _, peer := range rule.peers {
+			// case(i)
+			if peer.nodes.Has(node.Name) {
+				klog.V(4).Infof("Node %s used to match ANP %s egress rule %d peer, requeuing...", node.Name, anpCache.name, rule.priority)
+				queue.Add(anpCache.name)
+				return
+			}
+			// case(ii)
+			if peer.nodeSelector.Matches(nodeLabels) {
+				klog.V(4).Infof("Node %s  started to match ANP %s egress rule %d peer, requeuing...", node.Name, anpCache.name, rule.priority)
+				queue.Add(anpCache.name)
+				return
+			}
+		}
+	}
+	// if nothing matched this node, then its a no-op
 }

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_node.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_node.go
@@ -42,7 +42,6 @@ func (c *Controller) processNextANPNodeWorkItem(wg *sync.WaitGroup) bool {
 // syncAdminNetworkPolicyNode decides the main logic everytime
 // we dequeue a key from the anpNodeQueue cache
 func (c *Controller) syncAdminNetworkPolicyNode(key string) error {
-	// TODO(tssurya): This global lock will be inefficient, we will do perf runs and improve if needed
 	c.Lock()
 	defer c.Unlock()
 	startTime := time.Now()

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_pod.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_pod.go
@@ -48,7 +48,7 @@ func (c *Controller) syncAdminNetworkPolicyPod(key string) error {
 	defer c.Unlock()
 	startTime := time.Now()
 	// Iterate all ANPs and check if this namespace start/stops matching
-	// any and add/remove the setup accordingly. Namespaces can match multiple
+	// any ANP and add/remove the setup accordingly. Namespaces can match multiple
 	// ANPs objects, so continue iterating all ANP objects before finishing.
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_pod.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_pod.go
@@ -53,10 +53,10 @@ func (c *Controller) syncAdminNetworkPolicyPod(key string) error {
 	if err != nil {
 		return err
 	}
-	klog.V(4).Infof("Processing sync for Pod %s/%s in Admin Network Policy controller", namespace, name)
+	klog.V(5).Infof("Processing sync for Pod %s/%s in Admin Network Policy controller", namespace, name)
 
 	defer func() {
-		klog.V(4).Infof("Finished syncing Pod %s/%s Admin Network Policy controller: took %v", namespace, name, time.Since(startTime))
+		klog.V(5).Infof("Finished syncing Pod %s/%s Admin Network Policy controller: took %v", namespace, name, time.Since(startTime))
 	}()
 	ns, err := c.anpNamespaceLister.Get(namespace)
 	if err != nil {
@@ -175,7 +175,7 @@ func (c *Controller) setPodForANP(pod *v1.Pod, anpCache *adminNetworkPolicyState
 	// case(i)
 	if podCache, ok := anpCache.subject.namespaces[pod.Namespace]; ok {
 		if podCache.Has(pod.Name) {
-			klog.V(4).Infof("Pod %s/%s used to match ANP %s subject, requeuing...", pod.Namespace, pod.Name, anpCache.name)
+			klog.V(5).Infof("Pod %s/%s used to match ANP %s subject, requeuing...", pod.Namespace, pod.Name, anpCache.name)
 			queue.Add(anpCache.name)
 			return
 		}
@@ -193,7 +193,7 @@ func (c *Controller) setPodForANP(pod *v1.Pod, anpCache *adminNetworkPolicyState
 			// case(iii)
 			if podCache, ok := peer.namespaces[pod.Namespace]; ok {
 				if podCache.Has(pod.Name) {
-					klog.V(4).Infof("Pod %s/%s used to match ANP %s ingress rule %d peer, requeuing...", pod.Namespace, pod.Name, anpCache.name, rule.priority)
+					klog.V(5).Infof("Pod %s/%s used to match ANP %s ingress rule %d peer, requeuing...", pod.Namespace, pod.Name, anpCache.name, rule.priority)
 					queue.Add(anpCache.name)
 					return
 				}
@@ -212,7 +212,7 @@ func (c *Controller) setPodForANP(pod *v1.Pod, anpCache *adminNetworkPolicyState
 			// case(v)
 			if podCache, ok := peer.namespaces[pod.Namespace]; ok {
 				if podCache.Has(pod.Name) {
-					klog.V(4).Infof("Pod %s/%s used to match ANP %s egress rule %d peer, requeuing...", pod.Namespace, pod.Name, anpCache.name, rule.priority)
+					klog.V(5).Infof("Pod %s/%s used to match ANP %s egress rule %d peer, requeuing...", pod.Namespace, pod.Name, anpCache.name, rule.priority)
 					queue.Add(anpCache.name)
 					return
 				}

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_pod.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_pod.go
@@ -43,7 +43,6 @@ func (c *Controller) processNextANPPodWorkItem(wg *sync.WaitGroup) bool {
 // syncAdminNetworkPolicyPod decides the main logic everytime
 // we dequeue a key from the anpPodQueue cache
 func (c *Controller) syncAdminNetworkPolicyPod(key string) error {
-	// TODO(tssurya): This global lock will be inefficient, we will do perf runs and improve if needed
 	c.Lock()
 	defer c.Unlock()
 	startTime := time.Now()

--- a/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
@@ -49,10 +49,10 @@ func (c *Controller) syncBaselineAdminNetworkPolicy(key string) error {
 	if err != nil {
 		return err
 	}
-	klog.V(4).Infof("Processing sync for Baseline Admin Network Policy %s", banpName)
+	klog.V(5).Infof("Processing sync for Baseline Admin Network Policy %s", banpName)
 
 	defer func() {
-		klog.V(4).Infof("Finished syncing Baseline Admin Network Policy %s : %v", banpName, time.Since(startTime))
+		klog.V(5).Infof("Finished syncing Baseline Admin Network Policy %s : %v", banpName, time.Since(startTime))
 	}()
 
 	banp, err := c.banpLister.Get(banpName)
@@ -153,7 +153,7 @@ func (c *Controller) ensureBaselineAdminNetworkPolicy(banp *anpapi.BaselineAdmin
 		return nil
 	}
 	// BANP state existed in the cache, which means its either a BANP update or pod/namespace add/update/delete
-	klog.V(3).Infof("Baseline Admin network policy %s was found in cache...Syncing it", currentBANPState.name)
+	klog.V(5).Infof("Baseline Admin network policy %s was found in cache...Syncing it", currentBANPState.name)
 	err = c.updateExistingANP(currentBANPState, desiredBANPState, atLeastOneRuleUpdated, false, true, desiredACLs)
 	if err != nil {
 		return fmt.Errorf("failed to update ANP %s: %v", desiredBANPState.name, err)

--- a/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
@@ -42,7 +42,6 @@ func (c *Controller) processNextBANPWorkItem(wg *sync.WaitGroup) bool {
 // syncBaselineAdminNetworkPolicy decides the main logic everytime
 // we dequeue a key from the banpQueue cache
 func (c *Controller) syncBaselineAdminNetworkPolicy(key string) error {
-	// TODO(tssurya): This global lock will be inefficient, we will do perf runs and improve if needed
 	c.Lock()
 	defer c.Unlock()
 	startTime := time.Now()
@@ -143,7 +142,7 @@ func (c *Controller) ensureBaselineAdminNetworkPolicy(banp *anpapi.BaselineAdmin
 	if currentBANPState.name == "" { // empty struct, no BANP exists
 		// this is a fresh BANP create
 		klog.Infof("Creating baseline admin network policy %s", banp.Name)
-		// 4) Create the PG/ACL/AS in same transact (TODO: See if batching is more efficient after scale runs)
+		// 4) Create the PG/ACL/AS in same transact
 		// 6) Update the ANP caches to store all the created things if transact was successful
 		err = c.createNewANP(desiredBANPState, desiredACLs, desiredPorts, true)
 		if err != nil {

--- a/go-controller/pkg/ovn/controller/admin_network_policy/repair.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/repair.go
@@ -23,10 +23,6 @@ import (
 // We fetch PGs and AddressSets that are owned by ANP objectIDs based on
 // externalIDs match from the NBDB. Using predicate search we check if
 // the relevant ANP still exists for these objects and if not we delete them
-// TODO (tssurya): Handle cleaning up stale IPs in the address-sets by fetching all the relevant
-// peer pods that are being served by ANPs - pods could stop matching when ovnkube-controller is down
-// TODO2 (tssurya): Handle cleaning up stale ports from PGs by fetching all the relevant
-// subject pods that are being served by ANPs - pods could stop matching when ovnkube-controller is down
 func (c *Controller) repairAdminNetworkPolicies() error {
 	start := time.Now()
 	defer func() {
@@ -104,10 +100,6 @@ func (c *Controller) repairAdminNetworkPolicies() error {
 // We fetch PGs and AddressSets that are owned by BANP objectIDs based on
 // externalIDs match from the NBDB. Using predicate search we check if
 // the relevant BANP still exists for these objects and if not we delete them
-// TODO (tssurya): Handle cleaning up stale IPs in the address-sets by fetching all the relevant
-// peer pods that are being served by BANP - pods could stop matching when ovnkube-controller is down
-// TODO2 (tssurya): Handle cleaning up stale ports from PGs by fetching all the relevant
-// pods that are being served by BANP - pods could stop matching when ovnkube-controller is down
 func (c *Controller) repairBaselineAdminNetworkPolicy() error {
 	start := time.Now()
 	defer func() {

--- a/go-controller/pkg/ovn/controller/admin_network_policy/status.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/status.go
@@ -65,7 +65,7 @@ func (c *Controller) updateANPStatusToReady(anp *anpapi.AdminNetworkPolicy, zone
 	if err != nil {
 		return fmt.Errorf("unable to update the status of ANP %s, err: %v", anp.Name, err)
 	}
-	klog.Infof("Patched the status of ANP %v with condition type %v/%v",
+	klog.V(5).Infof("Patched the status of ANP %v with condition type %v/%v",
 		anp.Name, policyReadyStatusType+zone, metav1.ConditionTrue)
 	return nil
 }
@@ -94,7 +94,7 @@ func (c *Controller) updateANPStatusToNotReady(anp *anpapi.AdminNetworkPolicy, z
 	if err != nil {
 		return fmt.Errorf("unable update the status of ANP %s, err: %v", anp.Name, err)
 	}
-	klog.Infof("Patched the status of ANP %v with condition type %v/%v and reason %s/%s",
+	klog.V(3).Infof("Patched the status of ANP %v with condition type %v/%v and reason %s/%s",
 		anp.Name, policyReadyStatusType+zone, metav1.ConditionFalse, policyNotReadyReason, message)
 	return nil
 }
@@ -120,7 +120,7 @@ func (c *Controller) updateBANPStatusToReady(banp *anpapi.BaselineAdminNetworkPo
 	if err != nil {
 		return fmt.Errorf("unable to update the status of BANP %s, err: %v", banp.Name, err)
 	}
-	klog.Infof("Patched the status of BANP %v with condition type %v/%v",
+	klog.V(5).Infof("Patched the status of BANP %v with condition type %v/%v",
 		banp.Name, policyReadyStatusType+zone, metav1.ConditionTrue)
 	return nil
 }
@@ -149,7 +149,7 @@ func (c *Controller) updateBANPStatusToNotReady(banp *anpapi.BaselineAdminNetwor
 	if err != nil {
 		return fmt.Errorf("unable update the status of BANP %s, err: %v", banp.Name, err)
 	}
-	klog.Infof("Patched the status of BANP %v with condition type %v/%v and reason %s",
+	klog.V(3).Infof("Patched the status of BANP %v with condition type %v/%v and reason %s",
 		banp.Name, policyReadyStatusType+zone, metav1.ConditionFalse, policyNotReadyReason)
 	return nil
 }

--- a/go-controller/pkg/ovn/controller/admin_network_policy/status_test.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/status_test.go
@@ -122,6 +122,7 @@ func newANPControllerWithDBSetup(dbSetup libovsdbtest.TestSetup, initANPs anpapi
 		watcher.BANPInformer(),
 		watcher.NamespaceCoreInformer(),
 		watcher.PodCoreInformer(),
+		watcher.NodeCoreInformer(),
 		addressSetFactory,
 		nil, // we don't care about pods in this test
 		"global",

--- a/go-controller/pkg/ovn/controller/admin_network_policy/types.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/types.go
@@ -24,7 +24,6 @@ const (
 	BANPExternalIDKey               = "BaselineAdminNetworkPolicy" // key set on port-groups to identify which BANP it belongs to
 )
 
-// TODO: Double check how empty selector means all labels match works
 type adminNetworkPolicySubject struct {
 	namespaceSelector labels.Selector
 	podSelector       labels.Selector
@@ -37,12 +36,10 @@ type adminNetworkPolicySubject struct {
 	// current set of UUIDs and desired set of UUIDs and do one set of
 	// transact ops calculation. If not, for every pod/namespace update
 	// we would need to do a lookup in the libovsdb cache for the ns_name
-	// LSP index. TODO(tssurya): Do performance runs to see if there is
-	// effect on MEM footprint for storing this information.
+	// LSP index.
 	podPorts sets.Set[string]
 }
 
-// TODO: Implement sameLabels & notSameLabels
 type adminNetworkPolicyPeer struct {
 	namespaceSelector labels.Selector
 	podSelector       labels.Selector
@@ -204,14 +201,12 @@ func newAdminNetworkPolicyPeer(rawNamespaces *anpapi.NamespacedPeer, rawPods *an
 		if !peerNamespaceSelector.Empty() {
 			anpPeer = &adminNetworkPolicyPeer{
 				namespaceSelector: peerNamespaceSelector,
-				// TODO: See if it makes sense to just use the namespace address-sets we have in case the podselector is empty meaning all pods.
-				podSelector: labels.Everything(), // it means match all pods within the provided namespaces
+				podSelector:       labels.Everything(), // it means match all pods within the provided namespaces
 			}
 		} else {
 			anpPeer = &adminNetworkPolicyPeer{
 				namespaceSelector: labels.Everything(), // it means match all namespaces in the cluster
-				// TODO: See if it makes sense to just use the namespace address-sets we have in case the podselector is empty meaning all pods.
-				podSelector: labels.Everything(), // it means match all pods within the provided namespaces
+				podSelector:       labels.Everything(), // it means match all pods within the provided namespaces
 			}
 		}
 	} else if rawPods != nil {

--- a/go-controller/pkg/ovn/controller/admin_network_policy/types.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/types.go
@@ -128,7 +128,7 @@ func newAdminNetworkPolicyState(raw *anpapi.AdminNetworkPolicy) (*adminNetworkPo
 		addErrors = errors.Wrapf(addErrors, "error: cannot parse ANP ACL logging annotation, disabling it for ANP %v - %v",
 			raw.Name, err)
 	}
-	klog.V(4).Infof("Logging parameters for ANP %s are Allow=%s/Deny=%s/Pass=%s", raw.Name,
+	klog.V(5).Infof("Logging parameters for ANP %s are Allow=%s/Deny=%s/Pass=%s", raw.Name,
 		anp.aclLoggingParams.Allow, anp.aclLoggingParams.Deny, anp.aclLoggingParams.Pass)
 	if addErrors.Error() == "" {
 		addErrors = nil
@@ -363,7 +363,7 @@ func newBaselineAdminNetworkPolicyState(raw *anpapi.BaselineAdminNetworkPolicy) 
 		addErrors = errors.Wrapf(addErrors, "error: cannot parse BANP ACL logging annotation, disabling it for BANP %v - %v",
 			raw.Name, err)
 	}
-	klog.V(4).Infof("Logging parameters for BANP %s are Allow=%s/Deny=%s", raw.Name,
+	klog.V(5).Infof("Logging parameters for BANP %s are Allow=%s/Deny=%s", raw.Name,
 		banp.aclLoggingParams.Allow, banp.aclLoggingParams.Deny)
 	if addErrors.Error() == "" {
 		addErrors = nil

--- a/go-controller/pkg/ovn/controller/admin_network_policy/types.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/types.go
@@ -66,8 +66,8 @@ type gressRule struct {
 	action string
 	peers  []*adminNetworkPolicyPeer
 	ports  []*libovsdbutil.NetworkPolicyPort
-	// all the podIPs of the peer pods selected by this ANP Rule
-	podIPs sets.Set[string]
+	// all the peerIPs of the peer entities (pods, nodes) selected by this ANP Rule
+	peerIPs sets.Set[string]
 }
 
 // adminNetworkPolicyState is the cache that keeps the state of a single

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -497,6 +497,7 @@ func (oc *DefaultNetworkController) newANPController() error {
 		oc.watchFactory.BANPInformer(),
 		oc.watchFactory.NamespaceCoreInformer(),
 		oc.watchFactory.PodCoreInformer(),
+		oc.watchFactory.NodeCoreInformer(),
 		oc.addressSetFactory,
 		oc.isPodScheduledinLocalZone,
 		oc.zone,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This PR adds support for `node` Egress peer in ANP and BANP.
API changes added as part of: https://github.com/kubernetes-sigs/network-policy-api/commit/23d3882d5c8bc280c2f1c7b590c11e1d3509a6b0

**- Special notes for reviewers**

**- How to verify it**
unit tests and e2e's have been added (e2e's will run and merge as part of https://github.com/ovn-org/ovn-kubernetes/pull/4235)

**- Description for the changelog**

`allow support for selecting nodes as egress peers`