### PR TITLE
Add config for BFD rate limiting

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -49,6 +49,8 @@ OVNKUBE_LOGFILE_MAXBACKUPS=""
 OVNKUBE_LOGFILE_MAXAGE=""
 OVNKUBE_LIBOVSDB_CLIENT_LOGFILE=""
 OVN_ACL_LOGGING_RATE_LIMIT=""
+OVN_BFD_RATE_LIMIT=""
+OVN_DEFAULT_RATE_LIMIT=""
 OVN_MASTER_COUNT=""
 OVN_REMOTE_PROBE_INTERVAL=""
 OVN_MONITOR_ALL=""
@@ -189,6 +191,12 @@ while [ "$1" != "" ]; do
     ;;
   --acl-logging-rate-limit)
     OVN_ACL_LOGGING_RATE_LIMIT=$VALUE
+    ;;
+  --bfd-rate-limit)
+    OVN_BFD_RATE_LIMIT=$VALUE
+    ;;
+  --default-rate-limit)
+    OVN_DEFAULT_RATE_LIMIT=$VALUE
     ;;
   --ssl)
     OVN_SSL_ENABLE="yes"
@@ -395,6 +403,10 @@ ovnkube_libovsdb_client_logfile=${OVNKUBE_LIBOVSDB_CLIENT_LOGFILE}
 echo "ovnkube_libovsdb_client_logfile: ${ovnkube_libovsdb_client_logfile}"
 ovn_acl_logging_rate_limit=${OVN_ACL_LOGGING_RATE_LIMIT:-"20"}
 echo "ovn_acl_logging_rate_limit: ${ovn_acl_logging_rate_limit}"
+ovn_bfd_rate_limit=${OVN_BFD_RATE_LIMIT:-"50"}
+echo "ovn_bfd_rate_limit: ${ovn_bfd_rate_limit}"
+ovn_default_rate_limit=${OVN_DEFAULT_RATE_LIMIT:-"25"}
+echo "ovn_default_rate_limit: ${ovn_default_rate_limit}"
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE}
 echo "ovn_hybrid_overlay_enable: ${ovn_hybrid_overlay_enable}"
 ovn_admin_network_policy_enable=${OVN_ADMIN_NETWORK_POLICY_ENABLE}
@@ -650,6 +662,8 @@ ovn_image=${ovnkube_image} \
   ovnkube_config_duration_enable=${ovnkube_config_duration_enable} \
   ovnkube_metrics_scale_enable=${ovnkube_metrics_scale_enable} \
   ovn_acl_logging_rate_limit=${ovn_acl_logging_rate_limit} \
+  ovn_bfd_rate_limit=${ovn_bfd_rate_limit} \
+  ovn_default_rate_limit=${ovn_default_rate_limit} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
@@ -797,6 +811,8 @@ ovn_image=${ovnkube_image} \
   ovn_loglevel_northd=${ovn_loglevel_northd} \
   ovn_loglevel_nbctld=${ovn_loglevel_nbctld} \
   ovn_acl_logging_rate_limit=${ovn_acl_logging_rate_limit} \
+  ovn_bfd_rate_limit=${ovn_bfd_rate_limit} \
+  ovn_default_rate_limit=${ovn_default_rate_limit} \
   ovn_empty_lb_events=${ovn_empty_lb_events} \
   ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
   ovn_enable_interconnect=${ovn_enable_interconnect} \
@@ -853,6 +869,8 @@ ovn_image=${ovnkube_image} \
   ovn_loglevel_northd=${ovn_loglevel_northd} \
   ovn_loglevel_nbctld=${ovn_loglevel_nbctld} \
   ovn_acl_logging_rate_limit=${ovn_acl_logging_rate_limit} \
+  ovn_bfd_rate_limit=${ovn_bfd_rate_limit} \
+  ovn_default_rate_limit=${ovn_default_rate_limit} \
   ovn_empty_lb_events=${ovn_empty_lb_events} \
   ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
   ovn_enable_interconnect=${ovn_enable_interconnect} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -61,6 +61,8 @@ fi
 # OVNKUBE_LOGFILE_MAXAGE - log file max age in days (default 5 days)
 # OVNKUBE_LIBOVSDB_CLIENT_LOGFILE - separate log file for libovsdb client (default: do not separate from logfile)
 # OVN_ACL_LOGGING_RATE_LIMIT - specify default ACL logging rate limit in messages per second (default: 20)
+# OVN_BFD_RATE_LIMIT - specify default BFD rate limit in packets per second (default: 50)
+# OVN_default_RATE_LIMIT - specify default rate limit in packets per second (default: 25)
 # OVN_NB_PORT - ovn north db port (default 6641)
 # OVN_SB_PORT - ovn south db port (default 6642)
 # OVN_NB_RAFT_PORT - ovn north db raft port (default 6643)
@@ -260,6 +262,8 @@ ovn_disable_ovn_iface_id_ver=${OVN_DISABLE_OVN_IFACE_ID_VER:-false}
 #OVN_MULTI_NETWORK_ENABLE - enable multiple network support for ovn-kubernetes
 ovn_multi_network_enable=${OVN_MULTI_NETWORK_ENABLE:-false}
 ovn_acl_logging_rate_limit=${OVN_ACL_LOGGING_RATE_LIMIT:-"20"}
+ovn_bfd_logging_rate_limit=${OVN_BFD_RATE_LIMIT:-"50"}
+ovn_default_logging_rate_limit=${OVN_DEFAULT_RATE_LIMIT:-"25"}
 ovn_netflow_targets=${OVN_NETFLOW_TARGETS:-}
 ovn_sflow_targets=${OVN_SFLOW_TARGETS:-}
 ovn_ipfix_targets=${OVN_IPFIX_TARGETS:-}
@@ -1149,6 +1153,16 @@ ovn-master() {
       ovn_acl_logging_rate_limit_flag="--acl-logging-rate-limit ${ovn_acl_logging_rate_limit}"
   fi
 
+  ovn_bfd_rate_limit_flag=
+  if [[ -n ${ovn_bfd_rate_limit} ]]; then
+      ovn_bfd_rate_limit_flag="--bfd-rate-limit ${ovn_bfd_rate_limit}"
+  fi
+
+  ovn_default_rate_limit_flag=
+  if [[ -n ${ovn_default_rate_limit} ]]; then
+      ovn_default_rate_limit_flag="--default-rate-limit ${ovn_default_rate_limit}"
+  fi
+
   multicast_enabled_flag=
   if [[ ${ovn_multicast_enable} == "true" ]]; then
       multicast_enabled_flag="--enable-multicast"
@@ -1251,6 +1265,8 @@ ovn-master() {
     ${multicast_enabled_flag} \
     ${multi_network_enabled_flag} \
     ${ovn_acl_logging_rate_limit_flag} \
+    ${ovn_bfd_rate_limit_flag} \
+    ${ovn_default_rate_limit_flag} \
     ${ovnkube_config_duration_enable_flag} \
     ${ovnkube_enable_multi_external_gateway_flag} \
     ${ovnkube_metrics_scale_enable_flag} \
@@ -1384,6 +1400,18 @@ ovnkube-controller() {
   fi
   echo "ovn_acl_logging_rate_limit_flag=${ovn_acl_logging_rate_limit_flag}"
 
+  ovn_bfd_rate_limit_flag=
+  if [[ -n ${ovn_bfd_rate_limit} ]]; then
+      ovn_bfd_rate_limit_flag="--bfd-rate-limit ${ovn_bfd_rate_limit}"
+  fi
+  echo "ovn_bfd_rate_limit_flag=${ovn_bfd_rate_limit_flag}"
+
+  ovn_default_rate_limit_flag=
+  if [[ -n ${ovn_default_rate_limit} ]]; then
+      ovn_default_rate_limit_flag="--default-rate-limit ${ovn_default_rate_limit}"
+  fi
+  echo "ovn_default_rate_limit_flag=${ovn_default_rate_limit_flag}"
+
   multicast_enabled_flag=
   if [[ ${ovn_multicast_enable} == "true" ]]; then
       multicast_enabled_flag="--enable-multicast"
@@ -1509,6 +1537,8 @@ ovnkube-controller() {
     ${multicast_enabled_flag} \
     ${multi_network_enabled_flag} \
     ${ovn_acl_logging_rate_limit_flag} \
+    ${ovn_bfd_rate_limit_flag} \
+    ${ovn_default_rate_limit_flag} \
     ${ovn_dbs} \
     ${ovnkube_config_duration_enable_flag} \
     ${ovnkube_enable_interconnect_flag} \
@@ -1644,6 +1674,18 @@ ovnkube-controller-with-node() {
       ovn_acl_logging_rate_limit_flag="--acl-logging-rate-limit ${ovn_acl_logging_rate_limit}"
   fi
   echo "ovn_acl_logging_rate_limit_flag=${ovn_acl_logging_rate_limit_flag}"
+
+  ovn_bfd_rate_limit_flag=
+  if [[ -n ${ovn_bfd_rate_limit} ]]; then
+      ovn_bfd_rate_limit_flag="--bfd-rate-limit ${ovn_bfd_rate_limit}"
+  fi
+  echo "ovn_bfd_rate_limit_flag=${ovn_bfd_rate_limit_flag}"
+
+  ovn_default_rate_limit_flag=
+  if [[ -n ${ovn_default_rate_limit} ]]; then
+      ovn_default_rate_limit_flag="--default-rate-limit ${ovn_default_rate_limit}"
+  fi
+  echo "ovn_default_rate_limit_flag=${ovn_default_rate_limit_flag}"
 
   multicast_enabled_flag=
   if [[ ${ovn_multicast_enable} == "true" ]]; then
@@ -1899,6 +1941,8 @@ ovnkube-controller-with-node() {
     ${netflow_targets} \
     ${ofctrl_wait_before_clear} \
     ${ovn_acl_logging_rate_limit_flag} \
+    ${ovn_bfd_rate_limit_flag} \
+    ${ovn_default_rate_limit_flag} \
     ${ovn_dbs} \
     ${ovn_encap_ip_flag} \
     ${ovn_encap_port_flag} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -287,6 +287,10 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_ACL_LOGGING_RATE_LIMIT
           value: "{{ ovn_acl_logging_rate_limit }}"
+        - name: OVN_BFD_RATE_LIMIT
+          value: "{{ ovn_bfd_rate_limit }}"
+        - name: OVN_DEFAULT_RATE_LIMIT
+          value: "{{ ovn_default_rate_limit }}"
         - name: OVN_STATELESS_NETPOL_ENABLE
           value: "{{ ovn_stateless_netpol_enable }}"
         - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -426,6 +426,10 @@ spec:
           value: "{{ ovn_empty_lb_events }}"
         - name: OVN_ACL_LOGGING_RATE_LIMIT
           value: "{{ ovn_acl_logging_rate_limit }}"
+        - name: OVN_BFD_RATE_LIMIT
+          value: "{{ ovn_bfd_rate_limit }}"
+        - name: OVN_DEFAULT_RATE_LIMIT
+          value: "{{ ovn_default_rate_limit }}"
         - name: OVN_HOST_NETWORK_NAMESPACE
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -360,6 +360,10 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_ACL_LOGGING_RATE_LIMIT
           value: "{{ ovn_acl_logging_rate_limit }}"
+        - name: OVN_BFD_RATE_LIMIT
+          value: "{{ ovn_bfd_rate_limit }}"
+        - name: OVN_DEFAULT_RATE_LIMIT
+          value: "{{ ovn_default_rate_limit }}"
         - name: OVN_ENABLE_INTERCONNECT
           value: "{{ ovn_enable_interconnect }}"
         - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -133,6 +133,11 @@ var (
 	// OvnSouth holds southbound OVN database client and server authentication and location details
 	OvnSouth OvnAuthConfig
 
+	PktRateLimiter = PktRateLimiterConfig{
+		DefaultRateLimit: 25,
+		BFDRateLimit:     50,
+	}
+
 	// Gateway holds node gateway-related parsed config file parameters and command-line overrides
 	Gateway = GatewayConfig{
 		V4JoinSubnet:       "100.64.0.0/16",
@@ -395,6 +400,16 @@ type OVNKubernetesFeatureConfig struct {
 	EnableStatelessNetPol           bool `gcfg:"enable-stateless-netpol"`
 	EnableInterconnect              bool `gcfg:"enable-interconnect"`
 	EnableMultiExternalGateway      bool `gcfg:"enable-multi-external-gateway"`
+}
+
+// PktRateLimiterConfig holds packet-rate-limiter related configs used to define
+// MeterBands in OVN for CoPP via OVNK Routers
+type PktRateLimiterConfig struct {
+	// DefaultRateLimit holds the allowed rate of packets per second to be delivered to OVN Controller for protocols
+	// which don't have specific limits set. Currently this value is used for arp, icmp, event-elb, svc-monitor, rejects, resets
+	DefaultRateLimit int `gcfg:"default-rate-limit"`
+	// BFDRateLimit holds the allowed rate of BFD packets per second to be delivered to OVN Controller
+	BFDRateLimit int `gcfg:"bfd-rate-limit"`
 }
 
 // GatewayMode holds the node gateway mode

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -588,6 +588,7 @@ var _ = Describe("Config Operations", func() {
 			"enable-multi-external-gateway=true",
 			"enable-admin-network-policy=true",
 			"zone=foo",
+			"bfd-rate-limit=75",
 		)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -605,6 +606,8 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Logging.File).To(gomega.Equal("/var/log/ovnkube.log"))
 			gomega.Expect(Logging.Level).To(gomega.Equal(5))
 			gomega.Expect(Logging.ACLLoggingRateLimit).To(gomega.Equal(20))
+			gomega.Expect(PktRateLimiter.BFDRateLimit).To(gomega.Equal(75))
+			gomega.Expect(PktRateLimiter.DefaultRateLimit).To(gomega.Equal(25))
 			gomega.Expect(Monitoring.RawNetFlowTargets).To(gomega.Equal("2.2.2.2:2055"))
 			gomega.Expect(Monitoring.RawSFlowTargets).To(gomega.Equal("2.2.2.2:2056"))
 			gomega.Expect(Monitoring.RawIPFIXTargets).To(gomega.Equal("2.2.2.2:2057"))
@@ -713,6 +716,8 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Logging.File).To(gomega.Equal("/some/logfile"))
 			gomega.Expect(Logging.Level).To(gomega.Equal(3))
 			gomega.Expect(Logging.ACLLoggingRateLimit).To(gomega.Equal(30))
+			gomega.Expect(PktRateLimiter.BFDRateLimit).To(gomega.Equal(50))
+			gomega.Expect(PktRateLimiter.DefaultRateLimit).To(gomega.Equal(25))
 			gomega.Expect(CNI.ConfDir).To(gomega.Equal("/some/cni/dir"))
 			gomega.Expect(CNI.Plugin).To(gomega.Equal("a-plugin"))
 			gomega.Expect(Kubernetes.Kubeconfig).To(gomega.Equal(kubeconfigFile))

--- a/go-controller/pkg/libovsdb/ops/meter_test.go
+++ b/go-controller/pkg/libovsdb/ops/meter_test.go
@@ -48,7 +48,7 @@ func TestCreateMeterBandOps(t *testing.T) {
 			t.Cleanup(cleanup.Cleanup)
 
 			meterBand := tt.inputMeterBand.DeepCopy()
-			_, err = CreateMeterBandOps(nbClient, nil, meterBand)
+			_, err = CreateMeterBandOps(nbClient, nil, []*nbdb.MeterBand{meterBand})
 			if err != nil {
 				t.Fatal(fmt.Errorf("%s: got unexpected error: %v", tt.desc, err))
 			}

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -243,7 +243,7 @@ func (cm *NetworkControllerManager) createACLLoggingMeter() error {
 		Action: ovntypes.MeterAction,
 		Rate:   config.Logging.ACLLoggingRateLimit,
 	}
-	ops, err := libovsdbops.CreateMeterBandOps(cm.nbClient, nil, band)
+	ops, err := libovsdbops.CreateMeterBandOps(cm.nbClient, nil, []*nbdb.MeterBand{band})
 	if err != nil {
 		return fmt.Errorf("can't create meter band %v: %v", band, err)
 	}

--- a/go-controller/pkg/ovn/copp_test.go
+++ b/go-controller/pkg/ovn/copp_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -19,7 +20,12 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 	meterBand := &nbdb.MeterBand{
 		UUID:   "meter-band-UUID",
 		Action: types.MeterAction,
-		Rate:   int(25), // hard-coding for now. TODO(tssurya): make this configurable if needed
+		Rate:   config.PktRateLimiter.DefaultRateLimit,
+	}
+	bfdBand := &nbdb.MeterBand{
+		UUID:   "bfd-meter-band-UUID",
+		Action: types.MeterAction,
+		Rate:   config.PktRateLimiter.BFDRateLimit,
 	}
 
 	var meters []*nbdb.Meter
@@ -32,6 +38,9 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Unit:  types.PacketsPerSecond,
 			Bands: []string{meterBand.UUID},
 		})
+		if defaultProtocolNames[i] == OVNBFDRateLimiter {
+			meters[len(meters)-1].Bands = []string{bfdBand.UUID}
+		}
 	}
 
 	expectedNBData := []libovsdbtest.TestData{
@@ -41,6 +50,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Meters: meterMap,
 		},
 		meterBand,
+		bfdBand,
 	}
 	for _, m := range meters {
 		expectedNBData = append(expectedNBData, m)
@@ -53,6 +63,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Meters: meterMap,
 		},
 		meterBand,
+		bfdBand,
 	}
 	for _, m := range meters {
 		existingNamedCOPPNBData = append(existingNamedCOPPNBData, m)
@@ -72,6 +83,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Meters: meterMap,
 		},
 		meterBand,
+		bfdBand,
 	}
 	for _, m := range meters {
 		multipleEmptyCOPPNameNBData = append(multipleEmptyCOPPNameNBData, m)
@@ -96,6 +108,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Meters: meterMap,
 		},
 		meterBand,
+		bfdBand,
 	}
 	for _, m := range meters {
 		multipleEmptyAndNamedCOPPNBData = append(multipleEmptyAndNamedCOPPNBData, m)
@@ -160,7 +173,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 				t.Fatal(fmt.Errorf("EnsureDefaultCOPP() error = %v", err))
 			}
 
-			matcher := libovsdbtest.HaveData(tt.expectedNbdb.NBData)
+			matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedNbdb.NBData)
 			success, err := matcher.Match(nbClient)
 
 			if !success {


### PR DESCRIPTION
HOLD FROM REVIEWS, This was discussed during team meeting and decided to explore the way of "dynamically determining the rate band every time a new BFD session is created per node"

Concern was around exposing such a low level value for users to configure and they might mess it up ?

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->