### PR TITLE
Add dynamic BFD rate limiter

### DIFF
--- a/go-controller/pkg/libovsdb/ops/meter.go
+++ b/go-controller/pkg/libovsdb/ops/meter.go
@@ -1,6 +1,7 @@
 package ops
 
 import (
+	"context"
 	"reflect"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
@@ -8,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 func equalsMeterBand(a, b *nbdb.MeterBand) bool {
@@ -17,31 +19,47 @@ func equalsMeterBand(a, b *nbdb.MeterBand) bool {
 		reflect.DeepEqual(a.ExternalIDs, b.ExternalIDs)
 }
 
-// CreateMeterBandOps creates the provided meter band if it does not exist
-func CreateMeterBandOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, meterBand *nbdb.MeterBand) ([]ovsdb.Operation, error) {
+// CreateOrUpdateMeterBandOps creates or updates the provided meter bands
+func CreateOrUpdateMeterBandOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, meterBands []*nbdb.MeterBand) ([]ovsdb.Operation, error) {
 	bands := []*nbdb.MeterBand{}
-	opModel := operationModel{
-		Model:          meterBand,
-		ModelPredicate: func(item *nbdb.MeterBand) bool { return equalsMeterBand(item, meterBand) },
-		OnModelUpdates: onModelUpdatesNone(),
-		ExistingResult: &bands,
-		DoAfter: func() {
-			// in case we have multiple equal bands, pick the first one for
-			// convergence, OVSDB will remove unreferenced ones
-			if len(bands) > 0 {
-				uuids := sets.NewString()
-				for _, band := range bands {
-					uuids.Insert(band.UUID)
+	opModels := make([]operationModel, 0, len(meterBands))
+	for i := range meterBands {
+		meterBand := meterBands[i]
+		opModel := operationModel{
+			Model:          meterBand,
+			ModelPredicate: func(item *nbdb.MeterBand) bool { return equalsMeterBand(item, meterBand) },
+			OnModelUpdates: onModelUpdatesAllNonDefault(),
+			ExistingResult: &bands,
+			DoAfter: func() {
+				// in case we have multiple equal bands, pick the first one for
+				// convergence, OVSDB will remove unreferenced ones
+				if len(bands) > 0 {
+					uuids := sets.NewString()
+					for _, band := range bands {
+						uuids.Insert(band.UUID)
+					}
+					meterBand.UUID = uuids.List()[0]
 				}
-				meterBand.UUID = uuids.List()[0]
-			}
-		},
-		ErrNotFound: false,
-		BulkOp:      true,
+			},
+			ErrNotFound: false,
+			BulkOp:      true,
+		}
+		opModels = append(opModels, opModel)
 	}
 
 	m := newModelClient(nbClient)
-	return m.CreateOrUpdateOps(ops, opModel)
+	return m.CreateOrUpdateOps(ops, opModels...)
+}
+
+type MeterBandPredicate func(*nbdb.MeterBand) bool
+
+// FindBFDWithPredicate looks up MeterBands from the cache based on a given predicate
+func FindMeterBandWithPredicate(nbClient libovsdbclient.Client, p MeterBandPredicate) ([]*nbdb.MeterBand, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	found := []*nbdb.MeterBand{}
+	err := nbClient.WhereCache(p).List(ctx, &found)
+	return found, err
 }
 
 // CreateOrUpdateMeterOps creates or updates the provided meter associated to

--- a/go-controller/pkg/libovsdb/ops/meter_test.go
+++ b/go-controller/pkg/libovsdb/ops/meter_test.go
@@ -48,7 +48,7 @@ func TestCreateMeterBandOps(t *testing.T) {
 			t.Cleanup(cleanup.Cleanup)
 
 			meterBand := tt.inputMeterBand.DeepCopy()
-			_, err = CreateMeterBandOps(nbClient, nil, meterBand)
+			_, err = CreateOrUpdateMeterBandOps(nbClient, nil, []*nbdb.MeterBand{meterBand})
 			if err != nil {
 				t.Fatal(fmt.Errorf("%s: got unexpected error: %v", tt.desc, err))
 			}

--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -818,6 +818,17 @@ func LookupBFD(nbClient libovsdbclient.Client, bfd *nbdb.BFD) (*nbdb.BFD, error)
 	return found[0], nil
 }
 
+type BFDPredicate func(*nbdb.BFD) bool
+
+// FindBFDWithPredicate looks up BFDs from the cache based on a given predicate
+func FindBFDWithPredicate(nbClient libovsdbclient.Client, p BFDPredicate) ([]*nbdb.BFD, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	found := []*nbdb.BFD{}
+	err := nbClient.WhereCache(p).List(ctx, &found)
+	return found, err
+}
+
 // LB OPs
 
 // AddLoadBalancersToLogicalRouterOps adds the provided load balancers to the

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -243,7 +243,7 @@ func (cm *NetworkControllerManager) createACLLoggingMeter() error {
 		Action: ovntypes.MeterAction,
 		Rate:   config.Logging.ACLLoggingRateLimit,
 	}
-	ops, err := libovsdbops.CreateMeterBandOps(cm.nbClient, nil, band)
+	ops, err := libovsdbops.CreateOrUpdateMeterBandOps(cm.nbClient, nil, []*nbdb.MeterBand{band})
 	if err != nil {
 		return fmt.Errorf("can't create meter band %v: %v", band, err)
 	}

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -417,6 +417,46 @@ func (nb *northBoundClient) createOrUpdateBFDStaticRoute(bfdEnabled bool, gw str
 		return fmt.Errorf("error transacting static route: %v", err)
 	}
 
+	if bfdEnabled {
+		// determine if the BFD rate limits need to be increased (we need to do this only if the BFD Create/Update succeeded)
+		// Fetch all current BFD ECMP routes on this GR
+		newPredicate := func(item *nbdb.BFD) bool {
+			return item.LogicalPort == port
+		}
+		bfds, err := libovsdbops.FindBFDWithPredicate(nb.nbClient, newPredicate)
+		if err != nil {
+			return fmt.Errorf("failed to list bfds for %s: %w", gr, err)
+		}
+		p := func(item *nbdb.MeterBand) bool {
+			return item.ExternalIDs["bfd-"+types.OvnRateLimitingMeter] == "true"
+		}
+		bfdBands, err := libovsdbops.FindMeterBandWithPredicate(nb.nbClient, p)
+		if err != nil {
+			return fmt.Errorf("failed to list bfd band for %s: %w", gr, err)
+		}
+		if len(bfdBands) == 0 {
+			return nil // nothing to do
+		}
+		currentRate := bfdBands[0].Rate
+
+		if len(bfds) > currentRate {
+			// we need to adjust the meterband accordingly
+			// In OVN BFD heartbeats are configured at 1sec interval by default
+			// That means rate of BFD packets per second = number of BFD's configured on the given GR
+			bfdBands[0].Rate = len(bfds)
+			ops, err := libovsdbops.CreateOrUpdateMeterBandOps(nb.nbClient, ops, []*nbdb.MeterBand{bfdBands[0]})
+			if err != nil {
+				return fmt.Errorf("can't update meter band %v: %v", bfdBands[0], err)
+			}
+			_, err = libovsdbops.TransactAndCheck(nb.nbClient, ops)
+			if err != nil {
+				return fmt.Errorf("error transacting static route: %v", err)
+			}
+			return nil
+		}
+
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/ovn/copp.go
+++ b/go-controller/pkg/ovn/copp.go
@@ -43,6 +43,13 @@ func getMeterNameForProtocol(protocol string) string {
 	return protocol + "-" + types.OvnRateLimitingMeter
 }
 
+func getMeterBand(rate int) *nbdb.MeterBand {
+	return &nbdb.MeterBand{
+		Action: types.MeterAction,
+		Rate:   rate,
+	}
+}
+
 // EnsureDefaultCOPP creates the default COPP that needs to be added to each GR
 // if not already present. Also cleans up old COPP entries if required.
 func EnsureDefaultCOPP(nbClient libovsdbclient.Client) (string, error) {
@@ -54,13 +61,12 @@ func EnsureDefaultCOPP(nbClient libovsdbclient.Client) (string, error) {
 		return "", fmt.Errorf("failed to delete duplicate COPPs: %w", err)
 	}
 
-	band := &nbdb.MeterBand{
-		Action: types.MeterAction,
-		Rate:   int(25), // hard-coding for now. TODO(tssurya): make this configurable if needed
-	}
-	ops, err = libovsdbops.CreateMeterBandOps(nbClient, ops, band)
+	defaultBand := getMeterBand(types.DefaultRateLimit)
+	bfdBand := getMeterBand(types.BFDRateLimit)
+	bfdBand.ExternalIDs = map[string]string{getMeterNameForProtocol(OVNBFDRateLimiter): "true"}
+	ops, err = libovsdbops.CreateOrUpdateMeterBandOps(nbClient, ops, []*nbdb.MeterBand{defaultBand, bfdBand})
 	if err != nil {
-		return "", fmt.Errorf("can't create meter band %v: %v", band, err)
+		return "", fmt.Errorf("can't create meter bands %v/%v: %v", defaultBand, bfdBand, err)
 	}
 
 	meterNames := make(map[string]string, len(defaultProtocolNames))
@@ -75,8 +81,13 @@ func EnsureDefaultCOPP(nbClient libovsdbclient.Client) (string, error) {
 			Fair: &meterFairness,
 			Unit: types.PacketsPerSecond,
 		}
-		ops, err = libovsdbops.CreateOrUpdateMeterOps(nbClient, ops, meter, []*nbdb.MeterBand{band},
-			&meter.Bands, &meter.Fair, &meter.Unit)
+		if protocol == OVNBFDRateLimiter {
+			ops, err = libovsdbops.CreateOrUpdateMeterOps(nbClient, ops, meter, []*nbdb.MeterBand{bfdBand},
+				&meter.Bands, &meter.Fair, &meter.Unit)
+		} else {
+			ops, err = libovsdbops.CreateOrUpdateMeterOps(nbClient, ops, meter, []*nbdb.MeterBand{defaultBand},
+				&meter.Bands, &meter.Fair, &meter.Unit)
+		}
 		if err != nil {
 			return "", fmt.Errorf("can't create meter %v: %v", meter, err)
 		}

--- a/go-controller/pkg/ovn/copp_test.go
+++ b/go-controller/pkg/ovn/copp_test.go
@@ -19,7 +19,13 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 	meterBand := &nbdb.MeterBand{
 		UUID:   "meter-band-UUID",
 		Action: types.MeterAction,
-		Rate:   int(25), // hard-coding for now. TODO(tssurya): make this configurable if needed
+		Rate:   types.DefaultRateLimit,
+	}
+	bfdBand := &nbdb.MeterBand{
+		UUID:        "bfd-meter-band-UUID",
+		Action:      types.MeterAction,
+		Rate:        types.BFDRateLimit,
+		ExternalIDs: map[string]string{getMeterNameForProtocol(OVNBFDRateLimiter): "true"},
 	}
 
 	var meters []*nbdb.Meter
@@ -32,6 +38,9 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Unit:  types.PacketsPerSecond,
 			Bands: []string{meterBand.UUID},
 		})
+		if defaultProtocolNames[i] == OVNBFDRateLimiter {
+			meters[len(meters)-1].Bands = []string{bfdBand.UUID}
+		}
 	}
 
 	expectedNBData := []libovsdbtest.TestData{
@@ -41,6 +50,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Meters: meterMap,
 		},
 		meterBand,
+		bfdBand,
 	}
 	for _, m := range meters {
 		expectedNBData = append(expectedNBData, m)
@@ -53,6 +63,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Meters: meterMap,
 		},
 		meterBand,
+		bfdBand,
 	}
 	for _, m := range meters {
 		existingNamedCOPPNBData = append(existingNamedCOPPNBData, m)
@@ -72,6 +83,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Meters: meterMap,
 		},
 		meterBand,
+		bfdBand,
 	}
 	for _, m := range meters {
 		multipleEmptyCOPPNameNBData = append(multipleEmptyCOPPNameNBData, m)
@@ -96,6 +108,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 			Meters: meterMap,
 		},
 		meterBand,
+		bfdBand,
 	}
 	for _, m := range meters {
 		multipleEmptyAndNamedCOPPNBData = append(multipleEmptyAndNamedCOPPNBData, m)
@@ -160,7 +173,7 @@ func TestEnsureDefaultCOPP(t *testing.T) {
 				t.Fatal(fmt.Errorf("EnsureDefaultCOPP() error = %v", err))
 			}
 
-			matcher := libovsdbtest.HaveData(tt.expectedNbdb.NBData)
+			matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedNbdb.NBData)
 			success, err := matcher.Match(nbClient)
 
 			if !success {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -115,6 +115,8 @@ const (
 	OvnRateLimitingMeter = "rate-limiter"
 	PacketsPerSecond     = "pktps"
 	MeterAction          = "drop"
+	BFDRateLimit         = 50
+	DefaultRateLimit     = 25
 
 	// OVN-K8S Topology Versions
 	OvnSingleJoinSwitchTopoVersion = 1


### PR DESCRIPTION
This commit adds logic to dynamically
determine the meterBand for BFD packets.
By default it is set to 50 and every time
we add a new BFD session this will get
adjusted.

NOTE: We have not added logic to reduce the
band as that doesn't seem to make much sense.
Goal is to catch the upper bound, not lower bound.

