### PR TITLE
Node IP handler: Fix (include) keepalived VIPs

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -63,6 +63,7 @@ func newAddressManagerInternal(nodeName string, k kube.Interface, config *manage
 	}
 	mgr.nodeAnnotator = kube.NewNodeAnnotator(k, nodeName)
 	mgr.sync()
+
 	return mgr
 }
 

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -33,7 +33,7 @@ type addressManager struct {
 	// useNetlink indicates the addressManager should use machine
 	// information from netlink. Set to false for testcases.
 	useNetlink bool
-
+	syncPeriod time.Duration
 	// compare node primary IP change
 	nodePrimaryAddr net.IP
 	gatewayBridge   *bridgeConfiguration
@@ -59,6 +59,7 @@ func newAddressManagerInternal(nodeName string, k kube.Interface, config *manage
 		gatewayBridge:  gwBridge,
 		OnChanged:      func() {},
 		useNetlink:     useNetlink,
+		syncPeriod:     30 * time.Second,
 	}
 	mgr.nodeAnnotator = kube.NewNodeAnnotator(k, nodeName)
 	mgr.sync()
@@ -145,7 +146,7 @@ func (c *addressManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) {
 // Event 2: Ticker events which is used to trigger a sync func. This is required in-case address change events are missed.
 // Event 3: Stop events which stops event watching and returns.
 func (c *addressManager) runInternal(stopChan <-chan struct{}, subscribe subscribeFn) {
-	addressSyncTimer := time.NewTicker(30 * time.Second)
+	addressSyncTimer := time.NewTicker(c.syncPeriod)
 	defer addressSyncTimer.Stop()
 
 	subscribed, addrChan, err := subscribe()
@@ -156,7 +157,7 @@ func (c *addressManager) runInternal(stopChan <-chan struct{}, subscribe subscri
 	for {
 		select {
 		case a, ok := <-addrChan:
-			addressSyncTimer.Reset(30 * time.Second)
+			addressSyncTimer.Reset(c.syncPeriod)
 			if !ok {
 				if subscribed, addrChan, err = subscribe(); err != nil {
 					klog.Errorf("Error during netlink re-subscribe due to channel closing for IP Manager: %v", err)

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -125,7 +125,11 @@ var _ = Describe("Node IP Handler tests", func() {
 			tc.ipManager.sync()
 			return true, tc.addrChan, nil
 		}
-		tc.ipManager.runInternal(tc.stopCh, tc.doneWg, subscribe)
+		tc.doneWg.Add(1)
+		go func() {
+			tc.ipManager.runInternal(tc.stopCh, subscribe)
+			tc.doneWg.Done()
+		}()
 		Eventually(func() bool {
 			return atomic.LoadUint32(&tc.subscribed) == 1
 		}, 5).Should(BeTrue())

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -187,6 +187,8 @@ var _ = Describe("Node IP Handler tests", func() {
 			Output: dummyBrInternalIPv4,
 		})
 		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
+		config.IPv4Mode = true
+		config.IPv6Mode = true
 		tc = configureKubeOVNContextWithNs(nodeName)
 		tc.ipManager.syncPeriod = 10 * time.Millisecond
 		tc.doneWg.Add(1)
@@ -307,7 +309,7 @@ func configureKubeOVNContextWithNs(nodeName string) *testCtx {
 		if err = netlink.AddrAdd(link, &netlink.Addr{IPNet: ovntest.MustParseIPNet("10.1.1.10/24")}); err != nil {
 			return err
 		}
-		return nil
+		return netlink.AddrAdd(link, &netlink.Addr{IPNet: ovntest.MustParseIPNet("2001:db8::10/64")})
 	}
 	Expect(testNs.Do(func(netNS ns.NetNS) error {
 		return setupPrimaryInfFn()
@@ -332,7 +334,7 @@ func configureKubeOVNContext(nodeName string, useNetlink bool) *testCtx {
 			},
 		},
 		Status: corev1.NodeStatus{
-			Addresses: []corev1.NodeAddress{{Address: "10.1.1.10", Type: corev1.NodeInternalIP}},
+			Addresses: []corev1.NodeAddress{{Address: "10.1.1.10", Type: corev1.NodeInternalIP}, {Address: "2001:db8::10", Type: corev1.NodeInternalIP}},
 		},
 	}
 

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -69,6 +69,12 @@ var _ = Describe("Node IP Handler event tests", func() {
 	)
 
 	BeforeEach(func() {
+		fexec := ovntest.NewFakeExec()
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
+			Output: "10.1.1.10",
+		})
+		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
 		useNetlink := false
 		tc = configureKubeOVNContext(nodeName, useNetlink)
 		// We need to wait until the ipManager's goroutine runs the subscribe
@@ -96,6 +102,7 @@ var _ = Describe("Node IP Handler event tests", func() {
 		tc.doneWg.Wait()
 		tc.watchFactory.Shutdown()
 		close(tc.addrChan)
+		util.ResetRunner()
 	})
 
 	Describe("Changing node addresses", func() {


### PR DESCRIPTION
#4040 introduced a constraint to filter VIPs. Remove that.
Also remove the external call to get these addresses. 
Previously, we needed to use an external pkg func call because we wanted to filter EIPs but that is no longer needed so get the IP addrs locally and filter the addresses locally, and dont do it in two places which is confusing.