### PR TITLE
kubevirt: Disable guest console log container

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1352,6 +1352,7 @@ function install_kubevirt() {
       if ! is_nested_virt_enabled; then
         kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
       fi
+      kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"virtualMachineOptions":{"disableSerialConsoleLog":{}}}}}'
     fi
     if ! kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m; then
         kubectl get pod -n kubevirt -l || true


### PR DESCRIPTION
**- What this PR does and why is it needed**
There is a bug [1] at kubevirt where source and target pods are not ready after successful live migration, this make endpoints slices move not ready and ovn-k do some ovs/ovn cleanup that breaks connections.

This change reduce the chance to have a not ready source pod by disabling one of the optional containers that is more eager to fail.

[1] https://issues.redhat.com/browse/CNV-38604

**- Special notes for reviewers**
This improve the situation for https://github.com/ovn-org/ovn-kubernetes/issues/3986, but proper fix need to land at kubevirt.

**- Description for the changelog**
Disable kubevirt guest-console-logs at "kind" installation