### PR TITLE
EgressQoS: Ignore remote pod update event

### DIFF
--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -719,7 +719,7 @@ func (oc *DefaultNetworkController) syncEgressQoSPod(key string) error {
 
 	klog.V(5).Infof("Pod %s retrieved from lister: %v", pod.Name, pod)
 
-	if util.PodWantsHostNetwork(pod) { // we don't handle HostNetworked pods
+	if util.PodWantsHostNetwork(pod) || !oc.isPodScheduledinLocalZone(pod) { // we don't handle HostNetworked or remote zone pods
 		return nil
 	}
 


### PR DESCRIPTION
This fixes pod update event to be ignored appropriately as it belongs to different zone, otherwise QoS rules are unnecessarily programmed in local zone's nbdb in which pod is not actually present.