### PR TITLE
ANP: Support ACL logging

### DIFF
--- a/go-controller/pkg/libovsdb/util/acl.go
+++ b/go-controller/pkg/libovsdb/util/acl.go
@@ -166,6 +166,7 @@ func GetACLMatch(portGroupName, match string, aclDir ACLDirection) string {
 type ACLLoggingLevels struct {
 	Allow string `json:"allow,omitempty"`
 	Deny  string `json:"deny,omitempty"`
+	Pass  string `json:"pass,omitempty"`
 }
 
 func getLogSeverity(action string, aclLogging *ACLLoggingLevels) (log bool, severity string) {
@@ -175,6 +176,8 @@ func getLogSeverity(action string, aclLogging *ACLLoggingLevels) (log bool, seve
 			severity = aclLogging.Allow
 		} else if action == nbdb.ACLActionDrop || action == nbdb.ACLActionReject {
 			severity = aclLogging.Deny
+		} else if action == nbdb.ACLActionPass {
+			severity = aclLogging.Pass
 		}
 	}
 	log = severity != ""

--- a/go-controller/pkg/libovsdb/util/acl.go
+++ b/go-controller/pkg/libovsdb/util/acl.go
@@ -127,9 +127,8 @@ func BuildACL(dbIDs *libovsdbops.DbObjectIDs, priority int, match, action string
 	return ACL
 }
 
-func BuildANPACL(dbIDs *libovsdbops.DbObjectIDs, priority int, match, action string, aclT ACLPipelineType) *nbdb.ACL {
-	// TODO(tssurya): Logging related parameters are nil for now, will fix this in future PRs when I add support for ANP-Logging
-	anpACL := BuildACL(dbIDs, priority, match, action, nil, aclT)
+func BuildANPACL(dbIDs *libovsdbops.DbObjectIDs, priority int, match, action string, aclT ACLPipelineType, logLevels *ACLLoggingLevels) *nbdb.ACL {
+	anpACL := BuildACL(dbIDs, priority, match, action, logLevels, aclT)
 	anpACL.Tier = GetACLTier(dbIDs)
 	return anpACL
 }

--- a/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/klog/v2"
+	utilpointer "k8s.io/utils/pointer"
 	anpapi "sigs.k8s.io/network-policy-api/apis/v1alpha1"
 	anpfake "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/fake"
 )
@@ -730,6 +731,129 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				expectedDatabaseState = append(expectedDatabaseState, getExpectedDataPodsAndSwitches([]testPod{t, t2}, []string{node1Name})...)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+		ginkgo.It("ACL Logging for BANP", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.IPv4Mode = true
+				config.IPv6Mode = true
+				fakeOVN.start()
+				fakeOVN.InitAndRunANPController()
+				fakeOVN.fakeClient.ANPClient.(*anpfake.Clientset).PrependReactor("update", "baselineadminnetworkpolicies", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					update := action.(clienttesting.UpdateAction)
+					// Since fake client (NewSimpleClientset) does not differentiate between
+					// an update and updatestatus, updatestatus in tests updates the spec as
+					// well causing race conditions. Thus adding a hack here to ensure update
+					// status is caught and processed by the reactor while update spec is
+					// delegated to the main code for handling
+					if action.GetSubresource() == "status" {
+						klog.Infof("Got an update status action for %v", update.GetObject())
+						return true, update.GetObject(), nil
+					}
+					klog.Infof("Got an update spec action for %v", update.GetObject())
+					return false, update.GetObject(), nil
+				})
+				ginkgo.By("1. Create BANP with 1 ingress rule and 1 egress rule with the ACL logging annotation and ensure its honoured")
+				anpSubject := newANPSubjectObject(
+					&metav1.LabelSelector{
+						MatchLabels: anpLabel,
+					},
+					nil,
+				)
+				banp := newBANPObject("default", anpSubject,
+					[]anpapi.BaselineAdminNetworkPolicyIngressRule{
+						{
+							Name:   "deny-traffic-from-slytherin-to-gryffindor",
+							Action: anpapi.BaselineAdminNetworkPolicyRuleActionDeny,
+							From: []anpapi.AdminNetworkPolicyIngressPeer{
+								{
+									Namespaces: &anpapi.NamespacedPeer{
+										NamespaceSelector: &metav1.LabelSelector{
+											MatchLabels: peerDenyLabel,
+										},
+									},
+								},
+							},
+						},
+					},
+					[]anpapi.BaselineAdminNetworkPolicyEgressRule{
+						{
+							Name:   "allow-traffic-to-hufflepuff-from-gryffindor",
+							Action: anpapi.BaselineAdminNetworkPolicyRuleActionAllow,
+							To: []anpapi.AdminNetworkPolicyEgressPeer{
+								{
+									Namespaces: &anpapi.NamespacedPeer{
+										NamespaceSelector: &metav1.LabelSelector{
+											MatchLabels: peerAllowLabel,
+										},
+									},
+								},
+							},
+						},
+					},
+				)
+				banp.ResourceVersion = "1"
+				banp.Annotations = map[string]string{
+					util.AclLoggingAnnotation: fmt.Sprintf(`{ "deny": "%s", "allow": "%s"}`, nbdb.ACLSeverityAlert, nbdb.ACLSeverityInfo),
+				}
+				banp, err := fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Create(context.TODO(), banp, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				acls := getACLsForBANPRules(banp)
+				pg := getDefaultPGForANPSubject(banp.Name, []string{}, acls, true)
+				expectedDatabaseState := []libovsdbtest.TestData{pg}
+				for _, acl := range acls {
+					acl := acl
+					// update ACL logging information
+					acl.Log = true
+					if acl.Action == nbdb.ACLActionDrop {
+						acl.Severity = utilpointer.String(nbdb.ACLSeverityAlert)
+					} else if acl.Action == nbdb.ACLActionAllowRelated {
+						acl.Severity = utilpointer.String(nbdb.ACLSeverityInfo)
+					}
+					expectedDatabaseState = append(expectedDatabaseState, acl)
+				}
+				peerASIngressRule0v4, peerASIngressRule0v6 := buildBANPAddressSets(banp, 0, []net.IP{}, libovsdbutil.ACLIngress) // address-set will be empty since no pods match it yet
+				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v4)
+				expectedDatabaseState = append(expectedDatabaseState, peerASIngressRule0v6)
+				peerASEgressRule0v4, peerASEgressRule0v6 := buildBANPAddressSets(banp, 0, []net.IP{}, libovsdbutil.ACLEgress)
+				expectedDatabaseState = append(expectedDatabaseState, peerASEgressRule0v4)
+				expectedDatabaseState = append(expectedDatabaseState, peerASEgressRule0v6)
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+
+				ginkgo.By("2. Update BANP by changing severity on the ACL logging annotation and ensure its honoured")
+				banp.ResourceVersion = "2"
+				banp.Annotations = map[string]string{
+					util.AclLoggingAnnotation: fmt.Sprintf(`{"deny": "%s", "allow": "%s"}`, nbdb.ACLSeverityWarning, nbdb.ACLSeverityDebug),
+				}
+				banp, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Update(context.TODO(), banp, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, acl := range expectedDatabaseState[1:3] {
+					acl := acl.(*nbdb.ACL)
+					// update ACL logging information
+					acl.Log = true
+					if acl.Action == nbdb.ACLActionDrop {
+						acl.Severity = utilpointer.String(nbdb.ACLSeverityWarning)
+					} else if acl.Action == nbdb.ACLActionAllowRelated {
+						acl.Severity = utilpointer.String(nbdb.ACLSeverityDebug)
+					}
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+
+				ginkgo.By("3. Update BANP by deleting the ACL logging annotation and ensure its honoured")
+				banp.ResourceVersion = "3"
+				banp.Annotations = map[string]string{}
+				banp, err = fakeOVN.fakeClient.ANPClient.PolicyV1alpha1().BaselineAdminNetworkPolicies().Update(context.TODO(), banp, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, acl := range expectedDatabaseState[1:3] {
+					acl := acl.(*nbdb.ACL)
+					// update ACL logging information
+					acl.Log = false
+					acl.Severity = nil
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
 				return nil
 			}
 			err := app.Run([]string{app.Name})

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy.go
@@ -181,7 +181,7 @@ func (c *Controller) convertANPRulesToACLs(desiredANPState, currentANPState *adm
 		len(currentANPState.ingressRules) == len(desiredANPState.ingressRules) &&
 		len(currentANPState.egressRules) == len(desiredANPState.egressRules))
 	for i, ingressRule := range desiredANPState.ingressRules {
-		acl := c.convertANPRuleToACL(ingressRule, pgName, desiredANPState.name, isBanp)
+		acl := c.convertANPRuleToACL(ingressRule, pgName, desiredANPState.name, desiredANPState.aclLoggingParams, isBanp)
 		acls = append(acls, acl...)
 		if isAtLeastOneRuleUpdatedCheckRequired &&
 			!*atLeastOneRuleUpdated &&
@@ -191,7 +191,7 @@ func (c *Controller) convertANPRulesToACLs(desiredANPState, currentANPState *adm
 		}
 	}
 	for i, egressRule := range desiredANPState.egressRules {
-		acl := c.convertANPRuleToACL(egressRule, pgName, desiredANPState.name, isBanp)
+		acl := c.convertANPRuleToACL(egressRule, pgName, desiredANPState.name, desiredANPState.aclLoggingParams, isBanp)
 		acls = append(acls, acl...)
 		if isAtLeastOneRuleUpdatedCheckRequired &&
 			!*atLeastOneRuleUpdated &&
@@ -206,7 +206,7 @@ func (c *Controller) convertANPRulesToACLs(desiredANPState, currentANPState *adm
 
 // convertANPRuleToACL takes the given gressRule and converts it into an ACL(0 ports rule) or
 // multiple ACLs(ports are set) and returns those ACLs for a given gressRule
-func (c *Controller) convertANPRuleToACL(rule *gressRule, pgName, anpName string, isBanp bool) []*nbdb.ACL {
+func (c *Controller) convertANPRuleToACL(rule *gressRule, pgName, anpName string, aclLoggingParams *libovsdbutil.ACLLoggingLevels, isBanp bool) []*nbdb.ACL {
 	// create address-set
 	// TODO (tssurya): Revisit this logic to see if its better to do one address-set per peer
 	// and join them with OR if that is more perf efficient. Had briefly discussed this OVN team
@@ -234,6 +234,7 @@ func (c *Controller) convertANPRuleToACL(rule *gressRule, pgName, anpName string
 			match,
 			rule.action,
 			libovsdbutil.ACLDirectionToACLPipeline(libovsdbutil.ACLDirection(rule.gressPrefix)),
+			aclLoggingParams,
 		)
 		acls = append(acls, acl)
 	}

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
@@ -319,15 +319,18 @@ func (c *Controller) onANPUpdate(oldObj, newObj interface{}) {
 		!newANP.GetDeletionTimestamp().IsZero() {
 		return
 	}
-	if reflect.DeepEqual(oldANP.Spec, newANP.Spec) {
+	oldANPACLAnnotation := oldANP.Annotations[util.AclLoggingAnnotation]
+	newANPACLAnnotation := newANP.Annotations[util.AclLoggingAnnotation]
+	if reflect.DeepEqual(oldANP.Spec, newANP.Spec) && oldANPACLAnnotation == newANPACLAnnotation {
 		return
 	}
 	key, err := cache.MetaNamespaceKeyFunc(newObj)
 	if err == nil {
 		// updates to ANP object should be very rare, once put in place they usually stay the same
 		klog.V(4).Infof("Updating Admin Network Policy %s: "+
-			"anpPriority: %v, anpSubject %v, anpIngress %v, anpEgress %v", key,
-			newANP.Spec.Priority, newANP.Spec.Subject, newANP.Spec.Ingress, newANP.Spec.Egress)
+			"anpPriority: %v, anpSubject %v, anpIngress %v, anpEgress %v"+
+			"aclAnnotation: %v", key, newANP.Spec.Priority, newANP.Spec.Subject, newANP.Spec.Ingress,
+			newANP.Spec.Egress, newANPACLAnnotation)
 		c.anpQueue.Add(key)
 	}
 }
@@ -364,16 +367,18 @@ func (c *Controller) onBANPUpdate(oldObj, newObj interface{}) {
 		!newBANP.GetDeletionTimestamp().IsZero() {
 		return
 	}
-
-	if reflect.DeepEqual(oldBANP.Spec, newBANP.Spec) {
+	oldBANPACLAnnotation := oldBANP.Annotations[util.AclLoggingAnnotation]
+	newBANPACLAnnotation := newBANP.Annotations[util.AclLoggingAnnotation]
+	if reflect.DeepEqual(oldBANP.Spec, newBANP.Spec) && oldBANPACLAnnotation == newBANPACLAnnotation {
 		return
 	}
 
 	key, err := cache.MetaNamespaceKeyFunc(newObj)
 	if err == nil {
 		klog.V(4).Infof("Updating Baseline Admin Network Policy %s: "+
-			"anpSubject %v, anpIngress %v, anpEgress %v", key,
-			newBANP.Spec.Subject, newBANP.Spec.Ingress, newBANP.Spec.Egress)
+			"banpSubject %v, banpIngress %v, banpEgress %v"+
+			"aclAnnotation: %v", key, newBANP.Spec.Subject, newBANP.Spec.Ingress,
+			newBANP.Spec.Egress, newBANPACLAnnotation)
 		c.banpQueue.Add(key)
 	}
 }

--- a/go-controller/pkg/ovn/controller/admin_network_policy/types.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/types.go
@@ -312,7 +312,7 @@ func newBaselineAdminNetworkPolicyState(raw *anpapi.BaselineAdminNetworkPolicy) 
 	for i, rule := range raw.Spec.Ingress {
 		banpRule, err := newBaselineAdminNetworkPolicyIngressRule(rule, int32(i), BANPFlowPriority-int32(i))
 		if err != nil {
-			addErrors = errors.Wrapf(addErrors, "error: cannot create banp ingress Rule %d in ANP %s - %v",
+			addErrors = errors.Wrapf(addErrors, "error: cannot create banp ingress Rule %d in BANP %s - %v",
 				i, raw.Name, err)
 			continue
 		}
@@ -321,7 +321,7 @@ func newBaselineAdminNetworkPolicyState(raw *anpapi.BaselineAdminNetworkPolicy) 
 	for i, rule := range raw.Spec.Egress {
 		banpRule, err := newBaselineAdminNetworkPolicyEgressRule(rule, int32(i), BANPFlowPriority-int32(i))
 		if err != nil {
-			addErrors = errors.Wrapf(addErrors, "error: cannot create banp egress Rule %d in ANP %s - %v",
+			addErrors = errors.Wrapf(addErrors, "error: cannot create banp egress Rule %d in BANP %s - %v",
 				i, raw.Name, err)
 			continue
 		}

--- a/go-controller/pkg/ovn/controller/admin_network_policy/types.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/types.go
@@ -125,7 +125,7 @@ func newAdminNetworkPolicyState(raw *anpapi.AdminNetworkPolicy) (*adminNetworkPo
 	}
 	anp.aclLoggingParams, err = getACLLoggingLevelsForANP(raw.Annotations)
 	if err != nil {
-		addErrors = errors.Wrapf(addErrors, "error: cannot parse anp ACL logging annotation, disabling it for ANP %v - %v",
+		addErrors = errors.Wrapf(addErrors, "error: cannot parse ANP ACL logging annotation, disabling it for ANP %v - %v",
 			raw.Name, err)
 	}
 	klog.V(4).Infof("Logging parameters for ANP %s are Allow=%s/Deny=%s/Pass=%s", raw.Name,
@@ -339,7 +339,7 @@ func newBaselineAdminNetworkPolicyState(raw *anpapi.BaselineAdminNetworkPolicy) 
 	}
 	banp.aclLoggingParams, err = getACLLoggingLevelsForANP(raw.Annotations)
 	if err != nil {
-		addErrors = errors.Wrapf(addErrors, "error: cannot parse anp ACL logging annotation, disabling it for BANP %v - %v",
+		addErrors = errors.Wrapf(addErrors, "error: cannot parse BANP ACL logging annotation, disabling it for BANP %v - %v",
 			raw.Name, err)
 	}
 	klog.V(4).Infof("Logging parameters for BANP %s are Allow=%s/Deny=%s", raw.Name,

--- a/go-controller/pkg/ovn/controller/admin_network_policy/utils_test.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/utils_test.go
@@ -1,0 +1,132 @@
+package adminnetworkpolicy
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func TestGetACLLoggingLevelsForANP(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    *libovsdbutil.ACLLoggingLevels
+		err         string
+	}{
+		{
+			name:        "empty annotations: logging disabled",
+			annotations: map[string]string{},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "", Deny: "", Pass: "",
+			},
+			err: "",
+		},
+		{
+			name: "empty string valued annotation: logging disabled",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: "",
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "", Deny: "", Pass: "",
+			},
+			err: "",
+		},
+		{
+			name: "empty paranthesis valued annotation: logging disabled",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: "{}",
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "", Deny: "", Pass: "",
+			},
+			err: "",
+		},
+		{
+			name: "incorrect annotation: logging disabled",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: "foobar",
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "", Deny: "", Pass: "",
+			},
+			err: "could not unmarshal ANP ACL annotation",
+		},
+		{
+			name: "partially filled annotation; missing pass: logging enabled partially",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: fmt.Sprintf(`{ "deny": "%s", "allow": "%s" }`, nbdb.ACLSeverityAlert, nbdb.ACLSeverityNotice),
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "notice", Deny: "alert", Pass: "",
+			},
+			err: "",
+		},
+		{
+			name: "correctly filled annotation for anp: logging enabled",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: fmt.Sprintf(`{ "deny": "%s", "allow": "%s", "pass": "%s" }`, nbdb.ACLSeverityAlert, nbdb.ACLSeverityNotice, nbdb.ACLSeverityInfo),
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "notice", Deny: "alert", Pass: "info",
+			},
+			err: "",
+		},
+		{
+			name: "correctly filled annotation for banp: logging enabled",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: fmt.Sprintf(`{ "deny": "%s", "allow": "%s"}`, nbdb.ACLSeverityAlert, nbdb.ACLSeverityNotice),
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "notice", Deny: "alert", Pass: "",
+			},
+			err: "",
+		},
+		{
+			name: "incorrectly filled deny value annotation: logging partially enabled",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: fmt.Sprintf(`{ "deny": "%s", "allow": "%s", "pass": "%s" }`, "foobar", nbdb.ACLSeverityNotice, nbdb.ACLSeverityInfo),
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "notice", Deny: "", Pass: "info",
+			},
+			err: "disabling deny logging due to an invalid deny annotation",
+		},
+		{
+			name: "incorrectly filled allow value annotation: logging partially enabled",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: fmt.Sprintf(`{ "deny": "%s", "allow": "%s", "pass": "%s" }`, nbdb.ACLSeverityNotice, "foobar", nbdb.ACLSeverityInfo),
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "", Deny: "notice", Pass: "info",
+			},
+			err: "disabling allow logging due to an invalid allow annotation",
+		},
+		{
+			name: "incorrectly filled pass value annotation: logging partially enabled",
+			annotations: map[string]string{
+				util.AclLoggingAnnotation: fmt.Sprintf(`{ "deny": "%s", "allow": "%s", "pass": "%s" }`, nbdb.ACLSeverityNotice, nbdb.ACLSeverityInfo, "foobar"),
+			},
+			expected: &libovsdbutil.ACLLoggingLevels{
+				Allow: "info", Deny: "notice", Pass: "",
+			},
+			err: "disabling pass logging due to an invalid pass annotation",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			aclLogLevel, err := getACLLoggingLevelsForANP(tt.annotations)
+			g.Expect(aclLogLevel).To(gomega.Equal(tt.expected))
+			if err != nil {
+				g.Expect(strings.Contains(err.Error(), tt.err)).To(gomega.BeTrue())
+			}
+		})
+	}
+
+}

--- a/test/e2e/acl_logging.go
+++ b/test/e2e/acl_logging.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	logSeverityNamespaceAnnotation = "k8s.ovn.org/acl-logging"
-	maxPokeRetries                 = 15
-	ovnControllerLogPath           = "/var/log/openvswitch/ovn-controller.log"
-	pokeInterval                   = 1 * time.Second
+	logSeverityAnnotation = "k8s.ovn.org/acl-logging"
+	maxPokeRetries        = 15
+	ovnControllerLogPath  = "/var/log/openvswitch/ovn-controller.log"
+	pokeInterval          = 1 * time.Second
 )
 
 var _ = Describe("ACL Logging for NetworkPolicy", func() {
@@ -163,6 +163,328 @@ var _ = Describe("ACL Logging for NetworkPolicy", func() {
 	})
 })
 
+var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPolicy", func() {
+	const (
+		initialDenyACLSeverity  = "alert"
+		initialAllowACLSeverity = "notice"
+		initialPassACLSeverity  = "warning"
+		denyACLVerdict          = "drop"
+		allowACLVerdict         = "allow"
+		anpName                 = "harry-potter"
+	)
+	fr := wrappedTestFramework("anp-subject")
+	var (
+		pods    []v1.Pod
+		nsNames [4]string
+	)
+	BeforeEach(func() {
+		By("creating an admin network policy")
+		err := makeAdminNetworkPolicy(anpName, "10", fr.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("configuring the ACL logging level for the ANP")
+		Expect(setANPACLLogSeverity(anpName, initialDenyACLSeverity, initialAllowACLSeverity, initialPassACLSeverity)).To(Succeed())
+
+		By("creating peer namespaces that are selected by the admin network policy")
+		nsNames[0] = fr.Namespace.Name
+		nsNames[1] = "anp-peer-restricted"
+		nsNames[2] = "anp-peer-open"
+		nsNames[3] = "anp-peer-unknown"
+		for _, ns := range nsNames[1:] {
+			_, err = e2ekubectl.RunKubectl("default", "create", "ns", ns)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("creating pods in subject and peer namespaces")
+		cmd := []string{"/bin/bash", "-c", "/agnhost netexec --http-port 8000"}
+		for _, ns := range nsNames {
+			pod := newAgnhostPod(ns, fmt.Sprintf("pod-%s", ns), cmd...)
+			pod = e2epod.PodClientNS(fr, ns).CreateSync(context.TODO(), pod)
+			Expect(waitForACLLoggingPod(fr, ns, pod.GetName())).To(Succeed())
+			pods = append(pods, *pod)
+			framework.Logf("Created %s in namespace %s", pod.Name, pod.Namespace)
+		}
+	})
+	AfterEach(func() {
+		By("deleting the admin network policy")
+		_, err := e2ekubectl.RunKubectl("default", "delete", "anp", anpName, "--ignore-not-found=true")
+		Expect(err).NotTo(HaveOccurred())
+		By("deleting the baseline admin network policy")
+		_, err = e2ekubectl.RunKubectl("default", "delete", "banp", "default", "--ignore-not-found=true")
+		Expect(err).NotTo(HaveOccurred())
+		By("deleting subject and peer namespaces that are selected by the admin network policy")
+		for _, ns := range nsNames {
+			_, err := e2ekubectl.RunKubectl("default", "delete", "ns", ns, "--ignore-not-found=true")
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	It("the ANP ACL logs have the expected log level", func() {
+
+		By("sending traffic between acl-logging test pods we trigger ALLOW ACL logging")
+		clientPod := pods[0] // subject pod
+		pokedPod := pods[1]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).NotTo(HaveOccurred(),
+			"traffic should be allowed since we use an ALLOW all traffic policy rule")
+
+		By("verify the ALLOW ACL log level at Tier1")
+		clientPodScheduledPodName := pods[0].Spec.NodeName
+		// Retry here in the case where OVN acls have not been programmed yet
+		composedPolicyNameRegex := fmt.Sprintf("ANP:%s:Egress:0", anpName)
+		Eventually(func() (bool, error) {
+			return assertACLLogs(
+				clientPodScheduledPodName,
+				composedPolicyNameRegex,
+				allowACLVerdict,
+				initialAllowACLSeverity)
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+
+		By("sending traffic between acl-logging test pods we trigger DENY ACL logging")
+		clientPod = pods[0] // subject pod
+		pokedPod = pods[2]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
+			"traffic should be denied since we use an DENY all traffic policy rule")
+
+		By("verify the DENY ACL log level at Tier1")
+		clientPodScheduledPodName = pods[0].Spec.NodeName
+		// Retry here in the case where OVN acls have not been programmed yet
+		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:1", anpName)
+		Eventually(func() (bool, error) {
+			return assertACLLogs(
+				clientPodScheduledPodName,
+				composedPolicyNameRegex,
+				denyACLVerdict,
+				initialDenyACLSeverity)
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+
+		By("sending traffic between acl-logging test pods we trigger PASS ACL logging")
+		clientPod = pods[0] // subject pod
+		pokedPod = pods[3]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).NotTo(HaveOccurred(),
+			"traffic should be allowed since we only use an PASS all traffic policy rule")
+
+		By("verify the PASS ACL log level at Tier1")
+		clientPodScheduledPodName = pods[0].Spec.NodeName
+		// Retry here in the case where OVN acls have not been programmed yet
+		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
+		time.Sleep(time.Hour)
+		Eventually(func() (bool, error) {
+			return assertACLLogs(
+				clientPodScheduledPodName,
+				composedPolicyNameRegex,
+				allowACLVerdict,
+				initialPassACLSeverity)
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+
+		By("creating a baseline admin network policy")
+		err := makeBaselineAdminNetworkPolicy(fr.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("configuring the ACL logging level for the BANP")
+		Expect(setBANPACLLogSeverity(initialDenyACLSeverity, initialAllowACLSeverity)).To(Succeed())
+
+		// BANP Deny will be hit
+		By("sending traffic between acl-logging test pods we trigger PASS ACL logging followed by DENY ACL logging(BANP)")
+		clientPod = pods[0] // subject pod
+		pokedPod = pods[3]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
+			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
+
+		By("verify the DENY ACL log level at Tier3")
+		clientPodScheduledPodName = pods[0].Spec.NodeName
+		composedPolicyNameRegex = "BANP:default:Egress:1"
+		// Retry here in the case where OVN acls have not been programmed yet
+		Eventually(func() (bool, error) {
+			return assertACLLogs(
+				clientPodScheduledPodName,
+				composedPolicyNameRegex,
+				denyACLVerdict,
+				initialDenyACLSeverity)
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+
+		By("updating the ACL logging level for the ANP")
+		Expect(setANPACLLogSeverity(anpName, "warning", "info", "notice")).To(Succeed())
+
+		By("updating the ACL logging level for the BANP")
+		Expect(setBANPACLLogSeverity("warning", "info")).To(Succeed())
+
+		By("sending traffic between acl-logging test pods we trigger ALLOW ACL logging")
+		clientPod = pods[0] // subject pod
+		pokedPod = pods[1]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).NotTo(HaveOccurred(),
+			"traffic should be allowed since we use an ALLOW all traffic policy rule")
+
+		By("verify the ALLOW ACL log level at Tier1")
+		clientPodScheduledPodName = pods[0].Spec.NodeName
+		// Retry here in the case where OVN acls have not been programmed yet
+		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:0", anpName)
+		Eventually(func() (bool, error) {
+			return assertACLLogs(
+				clientPodScheduledPodName,
+				composedPolicyNameRegex,
+				allowACLVerdict,
+				"info")
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+
+		By("sending traffic between acl-logging test pods we trigger DENY ACL logging")
+		clientPod = pods[0] // subject pod
+		pokedPod = pods[2]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
+			"traffic should be denied since we use an DENY all traffic policy rule")
+
+		By("verify the DENY ACL log level at Tier1")
+		clientPodScheduledPodName = pods[0].Spec.NodeName
+		// Retry here in the case where OVN acls have not been programmed yet
+		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:1", anpName)
+		Eventually(func() (bool, error) {
+			return assertACLLogs(
+				clientPodScheduledPodName,
+				composedPolicyNameRegex,
+				denyACLVerdict,
+				"warning")
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+
+		By("sending traffic between acl-logging test pods we trigger PASS ACL logging")
+		clientPod = pods[0] // subject pod
+		pokedPod = pods[3]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
+			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
+
+		By("verify the PASS ACL log level at Tier1")
+		clientPodScheduledPodName = pods[0].Spec.NodeName
+		// Retry here in the case where OVN acls have not been programmed yet
+		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
+		time.Sleep(time.Hour)
+		Eventually(func() (bool, error) {
+			return assertACLLogs(
+				clientPodScheduledPodName,
+				composedPolicyNameRegex,
+				allowACLVerdict,
+				"notice")
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+
+		// BANP Deny will be hit
+		By("verify the DENY ACL log level at Tier3")
+		clientPodScheduledPodName = pods[0].Spec.NodeName
+		composedPolicyNameRegex = "BANP:default:Egress:1"
+		// Retry here in the case where OVN acls have not been programmed yet
+		Eventually(func() (bool, error) {
+			return assertACLLogs(
+				clientPodScheduledPodName,
+				composedPolicyNameRegex,
+				denyACLVerdict,
+				"warning")
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+
+		By("disabling the ACL logging for the ANP")
+		Expect(setANPACLLogSeverity(anpName, "", "", "")).To(Succeed())
+
+		By("disabling the ACL logging for the BANP")
+		Expect(setBANPACLLogSeverity("", "")).To(Succeed())
+
+		By("sending traffic between acl-logging test pods we trigger NO ACL logging")
+		clientPod = pods[0] // subject pod
+		pokedPod = pods[3]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
+			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
+
+		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
+		Consistently(func() (bool, error) {
+			return isCountUpdatedAfterPokePod(fr, &clientPod, &pokedPod, composedPolicyNameRegex, denyACLVerdict, "")
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeFalse())
+
+		composedPolicyNameRegex = "BANP:default:Egress:1"
+		Consistently(func() (bool, error) {
+			return isCountUpdatedAfterPokePod(fr, &clientPod, &pokedPod, composedPolicyNameRegex, denyACLVerdict, "")
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeFalse())
+
+		By("invalid ACL logging for the ANP")
+		Expect(setANPACLLogSeverity(anpName, "pooh", "poop", "peep")).To(Succeed())
+
+		By("invalid ACL logging for the BANP")
+		Expect(setBANPACLLogSeverity("boop", "beep")).To(Succeed())
+
+		By("sending traffic between acl-logging test pods we trigger NO ACL logging")
+		clientPod = pods[0] // subject pod
+		pokedPod = pods[3]  // peer pod
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
+			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
+
+		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
+		Consistently(func() (bool, error) {
+			return isCountUpdatedAfterPokePod(fr, &clientPod, &pokedPod, composedPolicyNameRegex, denyACLVerdict, "")
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeFalse())
+
+		composedPolicyNameRegex = "BANP:default:Egress:1"
+		Consistently(func() (bool, error) {
+			return isCountUpdatedAfterPokePod(fr, &clientPod, &pokedPod, composedPolicyNameRegex, denyACLVerdict, "")
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeFalse())
+	})
+})
+
 var _ = Describe("ACL Logging for EgressFirewall", func() {
 	const (
 		denyAllPolicyName        = "default-deny-all"
@@ -195,14 +517,14 @@ var _ = Describe("ACL Logging for EgressFirewall", func() {
 		// your OpenShift Container Platform cluster."
 		// Because the egress firewall feature only affects traffic leaving the cluster, we will not log for on-cluster targets.
 		allowedDstIP = "172.18.0.1"
-		deniedDstIP  = "172.19.0.10"
-		mask         := "32"
-		denyCIDR     := "0.0.0.0/0"
+		deniedDstIP = "172.19.0.10"
+		mask := "32"
+		denyCIDR := "0.0.0.0/0"
 		if IsIPv6Cluster(fr.ClientSet) {
 			allowedDstIP = "2001:4860:4860::8888"
-			deniedDstIP  = "2001:4860:4860::8844"
-			mask         = "128"
-			denyCIDR     = "::/0"
+			deniedDstIP = "2001:4860:4860::8844"
+			mask = "128"
+			denyCIDR = "::/0"
 		}
 		By("configuring the ACL logging level within the namespace")
 		nsName = fr.Namespace.Name
@@ -575,7 +897,7 @@ var _ = Describe("ACL Logging for EgressFirewall", func() {
 					namespaceToUpdate.ObjectMeta.Annotations = map[string]string{}
 				}
 
-				namespaceToUpdate.Annotations[logSeverityNamespaceAnnotation] = "cannot-be-parsed"
+				namespaceToUpdate.Annotations[logSeverityAnnotation] = "cannot-be-parsed"
 				_, err = fr.ClientSet.CoreV1().Namespaces().Update(context.TODO(), namespaceToUpdate, metav1.UpdateOptions{})
 				return err
 			})).To(Succeed())
@@ -630,13 +952,105 @@ func makeDenyAllPolicy(f *framework.Framework, ns string, policyName string) (*k
 	return f.ClientSet.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), policy, metav1.CreateOptions{})
 }
 
+func makeAdminNetworkPolicy(anpName, priority, anpSubjectNS string) error {
+	anpYaml := "anp.yaml"
+	var anpConfig = fmt.Sprintf(`apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: %s
+spec:
+  priority: %s
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: %s
+  egress:
+  - name: "allow-to-restricted"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: anp-peer-restricted
+  - name: "deny-to-open"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: anp-peer-open
+  - name: "pass-to-unknown"
+    action: "Pass"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: anp-peer-unknown
+`, anpName, priority, anpSubjectNS)
+
+	if err := os.WriteFile(anpYaml, []byte(anpConfig), 0644); err != nil {
+		framework.Failf("Unable to write CRD config to disk: %v", err)
+	}
+
+	defer func() {
+		if err := os.Remove(anpYaml); err != nil {
+			framework.Logf("Unable to remove the CRD config from disk: %v", err)
+		}
+	}()
+
+	_, err := e2ekubectl.RunKubectl("default", "create", "-f", anpYaml)
+	return err
+}
+
+func makeBaselineAdminNetworkPolicy(banpSubjectNS string) error {
+	banpYaml := "banp.yaml"
+	var banpConfig = fmt.Sprintf(`apiVersion: policy.networking.k8s.io/v1alpha1
+kind: BaselineAdminNetworkPolicy
+metadata:
+  name: default
+spec:
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: %s
+  egress:
+  - name: "allow-to-restricted"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: anp-peer-restricted
+  - name: "deny-to-unknown"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: anp-peer-unknown
+`, banpSubjectNS)
+
+	if err := os.WriteFile(banpYaml, []byte(banpConfig), 0644); err != nil {
+		framework.Failf("Unable to write CRD config to disk: %v", err)
+	}
+
+	defer func() {
+		if err := os.Remove(banpYaml); err != nil {
+			framework.Logf("Unable to remove the CRD config from disk: %v", err)
+		}
+	}()
+
+	_, err := e2ekubectl.RunKubectl("default", "create", "-f", banpYaml)
+	return err
+}
+
 func makeEgressFirewall(ns, allowedDstIP, mask, denyCIDR string) error {
 	egressFirewallYaml := "egressfirewall.yaml"
 	var egressFirewallConfig = fmt.Sprintf(`apiVersion: k8s.ovn.org/v1
 kind: EgressFirewall
 metadata:
   name: default
-  namespace: ` + ns + `
+  namespace: `+ns+`
 spec:
   egress:
   - type: Allow
@@ -749,27 +1163,49 @@ func setNamespaceACLLogSeverity(fr *framework.Framework, nsName string, desiredD
 		if removeOption == aclRemoveOptionEmptyString || desiredDenyLogLevel != "" && desiredAllowLogLevel != "" {
 			aclLogSeverity = fmt.Sprintf(`{ "deny": "%s", "allow": "%s" }`, desiredDenyLogLevel, desiredAllowLogLevel)
 			By(fmt.Sprintf("updating the namespace's ACL logging severity to %s", aclLogSeverity))
-			namespaceToUpdate.Annotations[logSeverityNamespaceAnnotation] = aclLogSeverity
+			namespaceToUpdate.Annotations[logSeverityAnnotation] = aclLogSeverity
 		} else if removeOption == aclRemoveOptionEmptyMap && desiredDenyLogLevel == "" && desiredAllowLogLevel == "" {
 			aclLogSeverity = "{}"
 			By(fmt.Sprintf("updating the namespace's ACL logging severity to %s", aclLogSeverity))
-			namespaceToUpdate.Annotations[logSeverityNamespaceAnnotation] = aclLogSeverity
+			namespaceToUpdate.Annotations[logSeverityAnnotation] = aclLogSeverity
 		} else {
 			if desiredDenyLogLevel != "" {
 				aclLogSeverity = fmt.Sprintf(`{ "deny": "%s" }`, desiredDenyLogLevel)
 				By(fmt.Sprintf("updating the namespace's ACL logging severity to %s", aclLogSeverity))
-				namespaceToUpdate.Annotations[logSeverityNamespaceAnnotation] = aclLogSeverity
+				namespaceToUpdate.Annotations[logSeverityAnnotation] = aclLogSeverity
 			} else if desiredAllowLogLevel != "" {
 				aclLogSeverity = fmt.Sprintf(`{ "allow": "%s" }`, desiredAllowLogLevel)
 				By(fmt.Sprintf("updating the namespace's ACL logging severity to %s", aclLogSeverity))
-				namespaceToUpdate.Annotations[logSeverityNamespaceAnnotation] = aclLogSeverity
+				namespaceToUpdate.Annotations[logSeverityAnnotation] = aclLogSeverity
 			} else {
 				By("removing the namespace's ACL logging severity annotation if it exists")
-				delete(namespaceToUpdate.Annotations, logSeverityNamespaceAnnotation)
+				delete(namespaceToUpdate.Annotations, logSeverityAnnotation)
 			}
 		}
 
 		_, err = fr.ClientSet.CoreV1().Namespaces().Update(context.TODO(), namespaceToUpdate, metav1.UpdateOptions{})
 		return err
 	})
+}
+
+// setANPACLLogSeverity updates ANP with the deny, pass and allow annotations, e.g. k8s.ovn.org/acl-logging={ "deny": "%s", "allow": "%s", "pass": "%s" }.
+func setANPACLLogSeverity(anpName, desiredDenyLogLevel, desiredAllowLogLevel, desiredPassLogLevel string) error {
+	_, err := e2ekubectl.RunKubectl("default", "annotate", "anp", anpName,
+		fmt.Sprintf(`%s={ "deny": "%s", "allow": "%s", "pass": "%s" }`, logSeverityAnnotation, desiredDenyLogLevel, desiredAllowLogLevel, desiredPassLogLevel),
+		"--overwrite=true")
+	if err != nil {
+		return fmt.Errorf("unable to annotate admin network policy %s: err %v", anpName, err)
+	}
+	return nil
+}
+
+// setBANPACLLogSeverity updates BANP with the deny and allow annotations, e.g. k8s.ovn.org/acl-logging={ "deny": "%s", "allow": "%s" }.
+func setBANPACLLogSeverity(desiredDenyLogLevel, desiredAllowLogLevel string) error {
+	_, err := e2ekubectl.RunKubectl("default", "annotate", "banp", "default",
+		fmt.Sprintf(`%s={ "deny": "%s", "allow": "%s" }`, logSeverityAnnotation, desiredDenyLogLevel, desiredAllowLogLevel),
+		"--overwrite=true")
+	if err != nil {
+		return fmt.Errorf("unable to annotate baseline admin network policy default: err %v", err)
+	}
+	return nil
 }

--- a/test/e2e/acl_logging.go
+++ b/test/e2e/acl_logging.go
@@ -284,7 +284,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).NotTo(HaveOccurred(),
 			"traffic should be allowed since we only use an PASS all traffic policy rule")
 
-		By("verify the PASS ACL log level at Tier1")
+		// Re-enable when https://issues.redhat.com/browse/FDP-442 is fixed
+		/*By("verify the PASS ACL log level at Tier1")
 		clientPodScheduledPodName = pods[0].Spec.NodeName
 		// Retry here in the case where OVN acls have not been programmed yet
 		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
@@ -295,7 +296,7 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 				composedPolicyNameRegex,
 				allowACLVerdict,
 				initialPassACLSeverity)
-		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())*/
 
 		By("creating a baseline admin network policy")
 		err := makeBaselineAdminNetworkPolicy(fr.Namespace.Name)
@@ -399,7 +400,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
 			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
 
-		By("verify the PASS ACL log level at Tier1")
+		// Re-enable when https://issues.redhat.com/browse/FDP-442 is fixed
+		/*By("verify the PASS ACL log level at Tier1")
 		clientPodScheduledPodName = pods[0].Spec.NodeName
 		// Retry here in the case where OVN acls have not been programmed yet
 		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
@@ -410,7 +412,7 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 				composedPolicyNameRegex,
 				allowACLVerdict,
 				"notice")
-		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())*/
 
 		// BANP Deny will be hit
 		By("verify the DENY ACL log level at Tier3")
@@ -444,10 +446,11 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
 			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
 
-		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
+		// Re-enable when https://issues.redhat.com/browse/FDP-442 is fixed
+		/*composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
 		Consistently(func() (bool, error) {
 			return isCountUpdatedAfterPokePod(fr, &clientPod, &pokedPod, composedPolicyNameRegex, denyACLVerdict, "")
-		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeFalse())
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeFalse())*/
 
 		composedPolicyNameRegex = "BANP:default:Egress:1"
 		Consistently(func() (bool, error) {
@@ -473,10 +476,11 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
 			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
 
-		composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
+		// Re-enable when https://issues.redhat.com/browse/FDP-442 is fixed
+		/*composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
 		Consistently(func() (bool, error) {
 			return isCountUpdatedAfterPokePod(fr, &clientPod, &pokedPod, composedPolicyNameRegex, denyACLVerdict, "")
-		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeFalse())
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeFalse())*/
 
 		composedPolicyNameRegex = "BANP:default:Egress:1"
 		Consistently(func() (bool, error) {


### PR DESCRIPTION
~HOLD, Need to add tests~ DONE! Open for reviews!

**- What this PR does and why is it needed**
This PR adds support for ACL Logging for ANP&BANP features.
This adopts the existing ACL Logging framework used by NetworkPolicies
and EgressFirewalls. No surprises.

**- Special notes for reviewers**
Only difference is that an anp annotation will look like:
```
Annotations:  k8s.ovn.org/acl-logging: { "deny": "alert", "allow": "alert", "pass": "warning" }
```
to include pass
while BANP will look like:
```
Annotations:  k8s.ovn.org/acl-logging: { "deny": "alert", "allow": "alert" }
```

**- How to verify it**
Added unit tests and e2e's and found an OVN bug https://issues.redhat.com/browse/FDP-442 due to which some aspects of the e2e's are disabled ATM.

**- Description for the changelog**
`Add support for ACL logging in ANP&BANP`