### PR TITLE
Kubevirt e2e ipamclaim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,7 +437,7 @@ jobs:
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
-      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' }}"
+      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' }}"
       KIND_INSTALL_KUBEVIRT: "${{ matrix.target == 'kv-live-migration' }}"
       OVN_COMPACT_MODE: "${{ matrix.target == 'compact-mode' }}"
       OVN_DUMMY_GATEWAY_BRIDGE: "${{ matrix.target == 'compact-mode' }}"

--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -372,3 +372,15 @@ install_kubevirt() {
 
     chmod +x ./bin/virtctl
 }
+
+install_kubevirt_ipam_claims() {
+  local cert_manager_version="v1.14.4"
+  echo "Installing cert-manager ..."
+  manifest="https://github.com/cert-manager/cert-manager/releases/download/${cert_manager_version}/cert-manager.yaml"
+  run_kubectl apply -f "$manifest"
+
+  echo "Installing KubeVirt IPAM manager ..."
+  manifest="https://raw.githubusercontent.com/maiqueb/kubevirt-ipam-claims/main/dist/install.yaml"
+  run_kubectl apply -f "$manifest"
+  kubectl wait -n kubevirt-ipam-claims-system deployment kubevirt-ipam-claims-controller-manager --for condition=Available --timeout 2m
+}

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1193,4 +1193,5 @@ if [ "$KIND_INSTALL_PLUGINS" == true ]; then
 fi
 if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
   install_kubevirt
+  install_kubevirt_ipam_claims
 fi

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/google/go-cmp v0.6.0
+	github.com/k8snetworkplumbingwg/ipamclaims v0.4.0-alpha
 	github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20230301165931-f1873dc329c6
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/ginkgo/v2 v2.13.0

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -272,6 +272,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/k8snetworkplumbingwg/ipamclaims v0.4.0-alpha h1:ss+EP77GlQmh90hGKpnAG4Q3VVxRlB7GoncemaPtO4g=
+github.com/k8snetworkplumbingwg/ipamclaims v0.4.0-alpha/go.mod h1:qlR+sKxQ2OGfwhFCuXSd7rJ/GgC38vQBeHKQ7f2YnpI=
 github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20230301165931-f1873dc329c6 h1:KliAwTu2G07C1UYX8DoLoIy80Giy436XrhO4MX8FChM=
 github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20230301165931-f1873dc329c6/go.mod h1:kEJ4WM849yNmXekuSXLRwb+LaZ9usC06O8JgoAIq+f4=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -589,12 +591,16 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 			By(fmt.Sprintf("Waiting for readiness at virtual machine %s", vmi.Name))
 			Eventually(func() []kubevirtv1.VirtualMachineInstanceCondition {
 				err := crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vmi), vmi)
-				Expect(err).To(SatisfyAny(WithTransform(apierrors.IsNotFound, BeTrue()), Succeed()))
+				Expect(err).To(SatisfyAny(
+					WithTransform(apierrors.IsNotFound, BeTrue()),
+					Succeed(),
+				))
 				return vmi.Status.Conditions
-			}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(ContainElement(SatisfyAll(
-				HaveField("Type", kubevirtv1.VirtualMachineInstanceReady),
-				HaveField("Status", corev1.ConditionTrue),
-			)))
+			}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(
+				ContainElement(SatisfyAll(
+					HaveField("Type", kubevirtv1.VirtualMachineInstanceReady),
+					HaveField("Status", corev1.ConditionTrue),
+				)))
 		}
 
 		waitVirtualMachineAddresses = func(vmi *kubevirtv1.VirtualMachineInstance) []kubevirt.Address {
@@ -881,160 +887,420 @@ passwd:
 			}
 
 		}
-	)
-	DescribeTable("when live migration", func(td liveMigrationTestData) {
-		if td.mode == kubevirtv1.MigrationPostCopy && os.Getenv("GITHUB_ACTIONS") == "true" {
-			Skip("Post copy live migration not working at github actions")
-		}
-		var (
-			err error
-		)
 
-		Expect(err).ToNot(HaveOccurred())
-
-		d.ConntrackDumpingDaemonSet()
-		d.OVSFlowsDumpingDaemonSet("breth0")
-		d.IPTablesDumpingDaemonSet()
-
-		bandwidthPerMigration := resource.MustParse("40Mi")
-		forcePostCopyMigrationPolicy := &kvmigrationsv1alpha1.MigrationPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "force-post-copy",
-			},
-			Spec: kvmigrationsv1alpha1.MigrationPolicySpec{
-				AllowPostCopy:           pointer.Bool(true),
-				CompletionTimeoutPerGiB: pointer.Int64(1),
-				BandwidthPerMigration:   &bandwidthPerMigration,
-				Selectors: &kvmigrationsv1alpha1.Selectors{
-					VirtualMachineInstanceSelector: kvmigrationsv1alpha1.LabelSelector{
-						"test-live-migration": "post-copy",
-					},
-				},
-			},
-		}
-		if td.mode == kubevirtv1.MigrationPostCopy {
-			err = crClient.Create(context.TODO(), forcePostCopyMigrationPolicy)
-			Expect(err).ToNot(HaveOccurred())
-			defer func() {
-				Expect(crClient.Delete(context.TODO(), forcePostCopyMigrationPolicy)).To(Succeed())
-			}()
+		checkPodHasIPAtStatus = func(g Gomega, pod *corev1.Pod) {
+			g.Expect(pod.Status.PodIP).ToNot(BeEmpty(), "pod %s has no valid IP address yet", pod.Name)
 		}
 
-		By("Creating a test pod at all worker nodes")
-		for _, selectedNode := range selectedNodes {
-			httpServerTestPod := composeAgnhostPod(
-				"testpod-"+selectedNode.Name,
-				namespace,
-				selectedNode.Name,
-				"netexec", "--http-port", "8000")
-			httpServerTestPod = e2epod.NewPodClient(fr).CreateSync(context.TODO(), httpServerTestPod)
+		createHTTPServerPods = func(annotations map[string]string) []*corev1.Pod {
+			var pods []*corev1.Pod
+			for _, selectedNode := range selectedNodes {
+				pod := composeAgnhostPod(
+					"testpod-"+selectedNode.Name,
+					namespace,
+					selectedNode.Name,
+					"netexec", "--http-port", "8000")
+				pod.Annotations = annotations
+				pods = append(pods, e2epod.NewPodClient(fr).CreateSync(context.TODO(), pod))
+			}
+			return pods
 		}
 
-		By("Waiting until both pods have an IP address")
-		for _, httpServerTestPod := range httpServerTestPods {
-			Eventually(func(g Gomega) {
+		waitForPodsCondition = func(pods []*corev1.Pod, conditionFn func(g Gomega, pod *corev1.Pod)) {
+			for _, pod := range pods {
+				Eventually(func(g Gomega) {
+					var err error
+					pod, err = fr.ClientSet.CoreV1().Pods(fr.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+					g.Expect(err).ToNot(HaveOccurred())
+					conditionFn(g, pod)
+				}).
+					WithTimeout(time.Minute).
+					WithPolling(time.Second).
+					Should(Succeed())
+			}
+		}
+
+		updatePods = func(pods []*corev1.Pod) []*corev1.Pod {
+			for i, pod := range pods {
 				var err error
-				httpServerTestPod, err = fr.ClientSet.CoreV1().Pods(fr.Namespace.Name).Get(context.TODO(), httpServerTestPod.Name, metav1.GetOptions{})
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(httpServerTestPod.Status.PodIP).ToNot(BeEmpty(), "pod %s has no valid IP address yet", httpServerTestPod.Name)
-			}).
-				WithTimeout(time.Minute).
-				WithPolling(time.Second).
-				Should(Succeed())
-			httpServerTestPods = append(httpServerTestPods, httpServerTestPod)
-		}
-
-		vmLabels := map[string]string{}
-		if td.mode == kubevirtv1.MigrationPostCopy {
-			vmLabels = forcePostCopyMigrationPolicy.Spec.Selectors.VirtualMachineInstanceSelector
-		}
-		vms, err := composeVMs(td.numberOfVMs, vmLabels)
-		Expect(err).ToNot(HaveOccurred())
-
-		for _, vm := range vms {
-			By(fmt.Sprintf("Create virtual machine %s", vm.Name))
-			vmCreationRetries := 0
-			Eventually(func() error {
-				if vmCreationRetries > 0 {
-					// retry due to unknown issue where kubevirt webhook gets stuck reading the request body
-					// https://github.com/ovn-org/ovn-kubernetes/issues/3902#issuecomment-1750257559
-					By(fmt.Sprintf("Retrying vm %s creation", vm.Name))
-				}
-				err = crClient.Create(context.Background(), vm)
-				vmCreationRetries++
-				return err
-			}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
-		}
-
-		if td.shouldExpectFailure {
-			By("annotating the VMI with `fail fast`")
-			vmKey := types.NamespacedName{Namespace: namespace, Name: "worker1"}
-			var vmi kubevirtv1.VirtualMachineInstance
-			Eventually(func() error {
-				return crClient.Get(context.TODO(), vmKey, &vmi)
-			}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
-
-			vmi.ObjectMeta.Annotations[kubevirtv1.FuncTestLauncherFailFastAnnotation] = "true"
-
-			Expect(crClient.Update(context.TODO(), &vmi)).To(Succeed())
-		}
-
-		for _, vm := range vms {
-			By(fmt.Sprintf("Waiting for readiness at virtual machine %s", vm.Name))
-			Eventually(func() bool {
-				err = crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vm), vm)
+				pod, err = fr.ClientSet.CoreV1().Pods(fr.Namespace.Name).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				return vm.Status.Ready
-			}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(BeTrue())
+				pods[i] = pod
+			}
+			return pods
 		}
-		wg.Add(int(td.numberOfVMs))
-		for _, vm := range vms {
-			go runTest(td, vm)
-		}
-		wg.Wait()
-	},
-		Entry("with pre-copy succeeds, should keep connectivity", liveMigrationTestData{
-			mode:        kubevirtv1.MigrationPreCopy,
-			numberOfVMs: 1,
-		}),
-		Entry("with post-copy succeeds, should keep connectivity", liveMigrationTestData{
-			mode:        kubevirtv1.MigrationPostCopy,
-			numberOfVMs: 1,
-		}),
-		Entry("with pre-copy fails, should keep connectivity", liveMigrationTestData{
-			mode:                kubevirtv1.MigrationPreCopy,
-			numberOfVMs:         1,
-			shouldExpectFailure: true,
-		}),
-	)
-})
 
-func vmiMigrations(client crclient.Client) ([]kubevirtv1.VirtualMachineInstanceMigration, error) {
-	unstructuredVMIMigrations := &unstructured.UnstructuredList{}
-	unstructuredVMIMigrations.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   kubevirtv1.GroupVersion.Group,
-		Kind:    "VirtualMachineInstanceMigrationList",
-		Version: kubevirtv1.GroupVersion.Version,
+		prepareHTTPServerPods = func(annotations map[string]string, conditionFn func(g Gomega, pod *corev1.Pod)) {
+			By("Preparing HTTP server pods")
+			httpServerTestPods = createHTTPServerPods(annotations)
+			waitForPodsCondition(httpServerTestPods, conditionFn)
+			httpServerTestPods = updatePods(httpServerTestPods)
+		}
+	)
+	BeforeEach(func() {
+		namespace = fr.Namespace.Name
+		// So we can use it at AfterEach, since fr.ClientSet is nil there
+		clientSet = fr.ClientSet
+
+		var err error
+		crClient, err = newControllerRuntimeClient()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
-	if err := client.List(context.Background(), unstructuredVMIMigrations); err != nil {
-		return nil, err
-	}
-	if len(unstructuredVMIMigrations.Items) == 0 {
-		return nil, fmt.Errorf("empty migration list")
-	}
+	Context("with default pod network", func() {
 
-	var migrations []kubevirtv1.VirtualMachineInstanceMigration
-	for i := range unstructuredVMIMigrations.Items {
-		var vmiMigration kubevirtv1.VirtualMachineInstanceMigration
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
-			unstructuredVMIMigrations.Items[i].Object,
-			&vmiMigration,
-		); err != nil {
-			return nil, err
+		BeforeEach(func() {
+			workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
+			Expect(err).ToNot(HaveOccurred())
+			nodesByOVNZone := map[string][]corev1.Node{}
+			for _, workerNode := range workerNodeList.Items {
+				ovnZone, ok := workerNode.Labels["k8s.ovn.org/zone-name"]
+				if !ok {
+					ovnZone = "global"
+				}
+				_, ok = nodesByOVNZone[ovnZone]
+				if !ok {
+					nodesByOVNZone[ovnZone] = []corev1.Node{}
+				}
+				nodesByOVNZone[ovnZone] = append(nodesByOVNZone[ovnZone], workerNode)
+			}
+
+			selectedNodes = []corev1.Node{}
+			// If there is one global zone select the first three for the
+			// migration
+			if len(nodesByOVNZone) == 1 {
+				selectedNodes = []corev1.Node{
+					workerNodeList.Items[0],
+					workerNodeList.Items[1],
+					workerNodeList.Items[2],
+				}
+				// Otherwise select a pair of nodes from different OVN zones
+			} else {
+				for _, nodes := range nodesByOVNZone {
+					selectedNodes = append(selectedNodes, nodes[0])
+					if len(selectedNodes) == 3 {
+						break // we want just three of them
+					}
+				}
+			}
+
+			Expect(selectedNodes).To(HaveLen(3), "at least three nodes in different zones are needed for interconnect scenarios")
+
+			// Label the selected nodes with the generated namespaces, so we can
+			// configure VM nodeSelector with it and live migration will take only
+			// them into consideration
+			for _, node := range selectedNodes {
+				Expect(labelNode(node.Name, namespace)).To(Succeed())
+			}
+
+			prepareHTTPServerPods(map[string]string{}, checkPodHasIPAtStatus)
+
+		})
+
+		AfterEach(func() {
+			for _, node := range selectedNodes {
+				unlabelNode(node.Name, namespace)
+			}
+		})
+
+		DescribeTable("when live migration", func(td liveMigrationTestData) {
+			if td.mode == kubevirtv1.MigrationPostCopy && os.Getenv("GITHUB_ACTIONS") == "true" {
+				Skip("Post copy live migration not working at github actions")
+			}
+			var (
+				err error
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+
+			d.ConntrackDumpingDaemonSet()
+			d.OVSFlowsDumpingDaemonSet("breth0")
+			d.IPTablesDumpingDaemonSet()
+
+			bandwidthPerMigration := resource.MustParse("40Mi")
+			forcePostCopyMigrationPolicy := &kvmigrationsv1alpha1.MigrationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "force-post-copy",
+				},
+				Spec: kvmigrationsv1alpha1.MigrationPolicySpec{
+					AllowPostCopy:           pointer.Bool(true),
+					CompletionTimeoutPerGiB: pointer.Int64(1),
+					BandwidthPerMigration:   &bandwidthPerMigration,
+					Selectors: &kvmigrationsv1alpha1.Selectors{
+						VirtualMachineInstanceSelector: kvmigrationsv1alpha1.LabelSelector{
+							"test-live-migration": "post-copy",
+						},
+					},
+				},
+			}
+			if td.mode == kubevirtv1.MigrationPostCopy {
+				err = crClient.Create(context.TODO(), forcePostCopyMigrationPolicy)
+				Expect(err).ToNot(HaveOccurred())
+				defer func() {
+					Expect(crClient.Delete(context.TODO(), forcePostCopyMigrationPolicy)).To(Succeed())
+				}()
+			}
+
+			vmLabels := map[string]string{}
+			if td.mode == kubevirtv1.MigrationPostCopy {
+				vmLabels = forcePostCopyMigrationPolicy.Spec.Selectors.VirtualMachineInstanceSelector
+			}
+			vms, err := composeDefaultNetworkLiveMigratableVMs(td.numberOfVMs, vmLabels)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, vm := range vms {
+				By(fmt.Sprintf("Create virtual machine %s", vm.Name))
+				vmCreationRetries := 0
+				Eventually(func() error {
+					if vmCreationRetries > 0 {
+						// retry due to unknown issue where kubevirt webhook gets stuck reading the request body
+						// https://github.com/ovn-org/ovn-kubernetes/issues/3902#issuecomment-1750257559
+						By(fmt.Sprintf("Retrying vm %s creation", vm.Name))
+					}
+					err = crClient.Create(context.Background(), vm)
+					vmCreationRetries++
+					return err
+				}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+			}
+
+			if td.shouldExpectFailure {
+				By("annotating the VMI with `fail fast`")
+				vmKey := types.NamespacedName{Namespace: namespace, Name: "worker1"}
+				var vmi kubevirtv1.VirtualMachineInstance
+				Eventually(func() error {
+					return crClient.Get(context.TODO(), vmKey, &vmi)
+				}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+
+				vmi.ObjectMeta.Annotations[kubevirtv1.FuncTestLauncherFailFastAnnotation] = "true"
+
+				Expect(crClient.Update(context.TODO(), &vmi)).To(Succeed())
+			}
+
+			for _, vm := range vms {
+				By(fmt.Sprintf("Waiting for readiness at virtual machine %s", vm.Name))
+				Eventually(func() bool {
+					err = crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vm), vm)
+					Expect(err).ToNot(HaveOccurred())
+					return vm.Status.Ready
+				}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(BeTrue())
+			}
+			wg.Add(int(td.numberOfVMs))
+			for _, vm := range vms {
+				go runLiveMigrationTest(td, vm)
+			}
+			wg.Wait()
+		},
+			Entry("with pre-copy succeeds, should keep connectivity", liveMigrationTestData{
+				mode:        kubevirtv1.MigrationPreCopy,
+				numberOfVMs: 1,
+			}),
+			Entry("with post-copy succeeds, should keep connectivity", liveMigrationTestData{
+				mode:        kubevirtv1.MigrationPostCopy,
+				numberOfVMs: 1,
+			}),
+			Entry("with pre-copy fails, should keep connectivity", liveMigrationTestData{
+				mode:                kubevirtv1.MigrationPreCopy,
+				numberOfVMs:         1,
+				shouldExpectFailure: true,
+			}),
+		)
+	})
+	Context("with secondary network and persistent ips configured", func() {
+		type testCommand struct {
+			description string
+			cmd         func()
 		}
-		migrations = append(migrations, vmiMigration)
-	}
+		type resourceCommand struct {
+			description string
+			cmd         func() string
+		}
+		var (
+			nad              *nadv1.NetworkAttachmentDefinition
+			vm               *kubevirtv1.VirtualMachine
+			vmi              *kubevirtv1.VirtualMachineInstance
+			cidrIPv4         = "10.128.0.0/24"
+			cidrIPv6         = "2010:100:200::0/60"
+			expectedAddreses []string
+			restart          = testCommand{
+				description: "restart",
+				cmd: func() {
+					By("Restarting vm")
+					output, err := exec.Command("virtctl", "restart", "-n", namespace, vmi.Name).CombinedOutput()
+					Expect(err).ToNot(HaveOccurred(), output)
 
-	return migrations, nil
-}
+					By("Wait some time to vmi conditions to catch up after restart")
+					time.Sleep(3 * time.Second)
+
+					waitVirtualMachineInstanceReadiness(vmi)
+				},
+			}
+			liveMigrate = testCommand{
+				description: "live migration",
+				cmd: func() {
+					liveMigrateVirtualMachine(vmi.Name)
+					checkLiveMigrationSucceeded(vmi.Name, kubevirtv1.MigrationPreCopy)
+				},
+			}
+			butane = `
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+  - name: core
+    password_hash: $y$j9T$b7RFf2LW7MUOiF4RyLHKA0$T.Ap/uzmg8zrTcUNXyXvBvT26UgkC6zZUVg3UKXeEp5
+`
+			virtualMachine = resourceCommand{
+				description: "VirtualMachine",
+				cmd: func() string {
+					var err error
+					vm, err = fcosVM(1, nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
+						Multus: &kubevirtv1.MultusNetwork{
+							NetworkName: nad.Name,
+						},
+					}, butane)
+					Expect(err).ToNot(HaveOccurred())
+					createVirtualMachine(vm)
+					return vm.Name
+				},
+			}
+
+			virtualMachineInstance = resourceCommand{
+				description: "VirtualMachineInstance",
+				cmd: func() string {
+					var err error
+					vmi, err = fcosVMI(1, nil /*labels*/, nil /*annotations*/, nil /*nodeSelector*/, kubevirtv1.NetworkSource{
+						Multus: &kubevirtv1.MultusNetwork{
+							NetworkName: nad.Name,
+						},
+					}, butane)
+					Expect(err).ToNot(HaveOccurred())
+					createVirtualMachineInstance(vmi)
+					return vmi.Name
+				},
+			}
+			filterOutIPv6 = func(ips map[string][]string) map[string][]string {
+				filteredOutIPs := map[string][]string{}
+				for podName, podIPs := range ips {
+					for _, podIP := range podIPs {
+						if !utilnet.IsIPv6String(podIP) {
+							_, ok := filteredOutIPs[podName]
+							if !ok {
+								filteredOutIPs[podName] = []string{}
+							}
+							filteredOutIPs[podName] = append(filteredOutIPs[podName], podIP)
+						}
+					}
+				}
+				return filteredOutIPs
+			}
+		)
+		type testData struct {
+			description string
+			resource    resourceCommand
+			test        testCommand
+			topology    string
+		}
+		DescribeTable("should keep ip", func(td testData) {
+			netConfig := newNetworkAttachmentConfig(
+				networkAttachmentConfigParams{
+					namespace:          namespace,
+					name:               "net1",
+					topology:           td.topology,
+					cidr:               strings.Join([]string{cidrIPv4, cidrIPv6}, ","),
+					allowPersistentIPs: true,
+				})
+
+			if td.topology == "localnet" {
+				By("setting up the localnet underlay")
+				nodes := ovsPods(clientSet)
+				Expect(nodes).NotTo(BeEmpty())
+				defer func() {
+					By("tearing down the localnet underlay")
+					Expect(teardownUnderlay(nodes)).To(Succeed())
+				}()
+
+				const secondaryInterfaceName = "eth1"
+				Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+			}
+
+			By("Creating NetworkAttachmentDefinition")
+			nad = generateNAD(netConfig)
+			Expect(crClient.Create(context.Background(), nad)).To(Succeed())
+			workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
+			Expect(err).ToNot(HaveOccurred())
+			selectedNodes = workerNodeList.Items
+			networkName := fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
+			prepareHTTPServerPods(map[string]string{
+				"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[{"name": %q}]`, nad.Name),
+			}, checkPodHasIPsAtNetwork(networkName, 2 /*expectedNumberOfAddresses*/))
+
+			vmiName := td.resource.cmd()
+			vmi = &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      vmiName,
+				},
+			}
+			waitVirtualMachineInstanceReadiness(vmi)
+			Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
+
+			step := by(vmi.Name, "Login to virtual machine for the first time")
+			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
+			expectedAddreses = virtualMachineAddressesFromStatus(vmi, 2 /*two addresses, dual stack*/)
+
+			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic before %s %s", td.resource.description, td.test.description))
+			testPodsIPs := httpServerTestPodsMultusNetworkIPs(networkName)
+
+			// kubevirt secondary IPAM do not support IPv6, so guest is not
+			// going to have an ipv6 address at the interface
+			testPodsIPs = filterOutIPv6(testPodsIPs)
+
+			checkEastWestTraffic(vmi, testPodsIPs, step)
+
+			by(vmi.Name, fmt.Sprintf("Running %s for %s", td.test.description, td.resource.description))
+			td.test.cmd()
+
+			step = by(vm.Name, fmt.Sprintf("Login to virtual machine after %s %s", td.resource.description, td.test.description))
+			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
+			obtainedAddresses := virtualMachineAddressesFromStatus(vmi, 2 /*two addresses, dual stack*/)
+			Expect(obtainedAddresses).To(Equal(expectedAddreses))
+
+			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic after %s %s", td.resource.description, td.test.description))
+			checkEastWestTraffic(vmi, testPodsIPs, step)
+		},
+			func(td testData) string {
+				return fmt.Sprintf("after %s of %s with %s", td.test.description, td.resource.description, td.topology)
+			},
+			Entry(nil, testData{
+				resource: virtualMachine,
+				test:     restart,
+				topology: "localnet",
+			}),
+			Entry(nil, testData{
+				resource: virtualMachine,
+				test:     restart,
+				topology: "layer2",
+			}),
+			Entry(nil, testData{
+				resource: virtualMachine,
+				test:     liveMigrate,
+				topology: "localnet",
+			}),
+			Entry(nil, testData{
+				resource: virtualMachine,
+				test:     liveMigrate,
+				topology: "layer2",
+			}),
+			Entry(nil, testData{
+				resource: virtualMachineInstance,
+				test:     liveMigrate,
+				topology: "localnet",
+			}),
+			Entry(nil, testData{
+				resource: virtualMachineInstance,
+				test:     liveMigrate,
+				topology: "layer2",
+			}),
+		)
+	})
+})

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -17,12 +17,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/kubevirt"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,6 +36,10 @@ import (
 
 	butaneconfig "github.com/coreos/butane/config"
 	butanecommon "github.com/coreos/butane/config/common"
+
+	ipamclaimsv1alpha1 "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kvmigrationsv1alpha1 "kubevirt.io/api/migrations/v1alpha1"
@@ -56,6 +59,14 @@ func newControllerRuntimeClient() (crclient.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = ipamclaimsv1alpha1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = nadv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
 	return crclient.New(config, crclient.Options{
 		Scheme: scheme,
 	})
@@ -68,54 +79,12 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 		crClient           crclient.Client
 		namespace          string
 		tcpServerPort      = int32(9900)
-		isDualStack        = false
 		wg                 sync.WaitGroup
 		selectedNodes      = []corev1.Node{}
 		httpServerTestPods = []*corev1.Pod{}
 		clientSet          kubernetes.Interface
 		// Systemd resolvd prevent resolving kube api service by fqdn, so
 		// we replace it here with NetworkManager
-		butane = fmt.Sprintf(`
-variant: fcos
-version: 1.4.0
-storage:
-  files:
-    - path: /root/test/server.go
-      contents:
-        local: kubevirt/echoserver/main.go
-systemd:
-  units:
-    - name: systemd-resolved.service
-      mask: true
-    - name: replace-resolved.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Replace systemd resolvd with NetworkManager
-        Wants=network-online.target
-        After=network-online.target
-        [Service]
-        ExecStart=rm -f /etc/resolv.conf
-        ExecStart=systemctl restart NetworkManager
-        Type=oneshot
-        [Install]
-        WantedBy=multi-user.target
-    - name: echoserver.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Golang echo server
-        Wants=replace-resolved.service
-        After=replace-resolved.service
-        [Service]
-        ExecStart=podman run --name tcpserver --tls-verify=false --privileged --net=host -v /root/test:/test:z registry.access.redhat.com/ubi9/go-toolset:1.20 go run /test/server.go %d
-        [Install]
-        WantedBy=multi-user.target
-passwd:
-  users:
-  - name: core
-    password_hash: $y$j9T$b7RFf2LW7MUOiF4RyLHKA0$T.Ap/uzmg8zrTcUNXyXvBvT26UgkC6zZUVg3UKXeEp5
-`, tcpServerPort)
 		labelNode = func(nodeName, label string) error {
 			patch := fmt.Sprintf(`{"metadata": {"labels": {"%s": ""}}}`, label)
 			_, err := fr.ClientSet.CoreV1().Nodes().Patch(context.Background(), nodeName, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
@@ -133,81 +102,25 @@ passwd:
 			}
 			return nil
 		}
+		isDualStack = func() bool {
+			GinkgoHelper()
+			nodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeList.Items).ToNot(BeEmpty())
+			hasIPv4Address, hasIPv6Address := false, false
+			for _, addr := range nodeList.Items[0].Status.Addresses {
+				if addr.Type == corev1.NodeInternalIP {
+					if utilnet.IsIPv4String(addr.Address) {
+						hasIPv4Address = true
+					}
+					if utilnet.IsIPv6String(addr.Address) {
+						hasIPv6Address = true
+					}
+				}
+			}
+			return hasIPv4Address && hasIPv6Address
+		}
 	)
-
-	BeforeEach(func() {
-		namespace = fr.Namespace.Name
-		// So we can use it at AfterEach, since fr.ClientSet is nil there
-		clientSet = fr.ClientSet
-
-		var err error
-		crClient, err = newControllerRuntimeClient()
-		Expect(err).ToNot(HaveOccurred())
-
-		workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(workerNodeList.Items).ToNot(BeEmpty())
-		hasIPv4Address, hasIPv6Address := false, false
-		for _, a := range workerNodeList.Items[0].Status.Addresses {
-			if a.Type == corev1.NodeInternalIP {
-				if utilnet.IsIPv4String(a.Address) {
-					hasIPv4Address = true
-				}
-				if utilnet.IsIPv6String(a.Address) {
-					hasIPv6Address = true
-				}
-			}
-		}
-		isDualStack = hasIPv4Address && hasIPv6Address
-
-		nodesByOVNZone := map[string][]corev1.Node{}
-		for _, workerNode := range workerNodeList.Items {
-			ovnZone, ok := workerNode.Labels["k8s.ovn.org/zone-name"]
-			if !ok {
-				ovnZone = "global"
-			}
-			_, ok = nodesByOVNZone[ovnZone]
-			if !ok {
-				nodesByOVNZone[ovnZone] = []corev1.Node{}
-			}
-			nodesByOVNZone[ovnZone] = append(nodesByOVNZone[ovnZone], workerNode)
-		}
-
-		selectedNodes = []corev1.Node{}
-		// If there is one global zone select the first three for the
-		// migration
-		if len(nodesByOVNZone) == 1 {
-			selectedNodes = []corev1.Node{
-				workerNodeList.Items[0],
-				workerNodeList.Items[1],
-				workerNodeList.Items[2],
-			}
-			// Otherwise select a pair of nodes from different OVN zones
-		} else {
-			for _, nodes := range nodesByOVNZone {
-				selectedNodes = append(selectedNodes, nodes[0])
-				if len(selectedNodes) == 3 {
-					break // we want just three of them
-				}
-			}
-		}
-
-		Expect(selectedNodes).To(HaveLen(3), "at least three nodes in different zones are needed for interconnect scenarios")
-
-		// Label the selected nodes with the generated namespaces, so we can
-		// configure VM nodeSelector with it and live migration will take only
-		// them into consideration
-		for _, node := range selectedNodes {
-			Expect(labelNode(node.Name, namespace)).To(Succeed())
-		}
-
-	})
-
-	AfterEach(func() {
-		for _, node := range selectedNodes {
-			unlabelNode(node.Name, namespace)
-		}
-	})
 
 	type liveMigrationTestData struct {
 		mode                kubevirtv1.MigrationMode
@@ -353,7 +266,63 @@ passwd:
 			return fr.ClientSet.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), policy, metav1.CreateOptions{})
 		}
 
+		checkEastWestTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
+			GinkgoHelper()
+			polling := 15 * time.Second
+			timeout := time.Minute
+			for podName, podIPs := range podIPsByName {
+				for _, podIP := range podIPs {
+					output := ""
+					Eventually(func() error {
+						var err error
+						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("curl http://%s", net.JoinHostPort(podIP, "8000")), polling)
+						return err
+					}).
+						WithPolling(polling).
+						WithTimeout(timeout).
+						Should(Succeed(), func() string { return stage + ": " + podName + ": " + output })
+				}
+			}
+		}
+
+		httpServerTestPodsDefaultNetworkIPs = func() map[string][]string {
+			ips := map[string][]string{}
+			for _, pod := range httpServerTestPods {
+				for _, podIP := range pod.Status.PodIPs {
+					ips[pod.Name] = append(ips[pod.Name], podIP.IP)
+				}
+			}
+			return ips
+		}
+
+		checkPodHasIPsAtNetwork = func(netName string, expectedNumberOfAddresses int) func(Gomega, *corev1.Pod) {
+			return func(g Gomega, pod *corev1.Pod) {
+				GinkgoHelper()
+				netStatus, err := podNetworkStatus(pod, func(status nadapi.NetworkStatus) bool {
+					return status.Name == netName
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(netStatus).To(HaveLen(1))
+				g.Expect(netStatus[0].IPs).To(HaveLen(expectedNumberOfAddresses))
+			}
+		}
+
+		httpServerTestPodsMultusNetworkIPs = func(netName string) map[string][]string {
+			GinkgoHelper()
+			ips := map[string][]string{}
+			for _, pod := range httpServerTestPods {
+				netStatus, err := podNetworkStatus(pod, func(status nadapi.NetworkStatus) bool {
+					return status.Name == netName
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(netStatus).To(HaveLen(1))
+				ips[pod.Name] = append(ips[pod.Name], netStatus[0].IPs...)
+			}
+			return ips
+		}
+
 		checkConnectivity = func(vmName string, endpoints []*net.TCPConn, stage string) {
+			GinkgoHelper()
 			by(vmName, "Check connectivity "+stage)
 			vmi := &kubevirtv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
@@ -369,23 +338,10 @@ passwd:
 			Eventually(func() error { return sendEchos(endpoints) }).
 				WithPolling(polling).
 				WithTimeout(timeout).
-				WithOffset(1).
 				Should(Succeed(), step)
 
-			step = by(vmName, stage+": Check e/w tcp traffic")
-			for _, pod := range httpServerTestPods {
-				for _, podIP := range pod.Status.PodIPs {
-					output := ""
-					Eventually(func() error {
-						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("curl http://%s", net.JoinHostPort(podIP.IP, "8000")), polling)
-						return err
-					}).
-						WithOffset(1).
-						WithPolling(polling).
-						WithTimeout(timeout).
-						Should(Succeed(), func() string { return step + ": " + pod.Name + ": " + output })
-				}
-			}
+			stage = by(vmName, stage+": Check e/w tcp traffic")
+			checkEastWestTraffic(vmi, httpServerTestPodsDefaultNetworkIPs(), stage)
 
 			step = by(vmName, stage+": Check n/s tcp traffic")
 			output := ""
@@ -393,13 +349,13 @@ passwd:
 				output, err = kubevirt.RunCommand(vmi, "curl -kL https://kubernetes.default.svc.cluster.local", polling)
 				return err
 			}).
-				WithOffset(1).
 				WithPolling(polling).
 				WithTimeout(timeout).
 				Should(Succeed(), func() string { return step + ": " + output })
 		}
 
 		checkConnectivityAndNetworkPolicies = func(vmName string, endpoints []*net.TCPConn, stage string) {
+			GinkgoHelper()
 			checkConnectivity(vmName, endpoints, stage)
 			step := by(vmName, stage+": Create deny all network policy")
 			policy, err := createDenyAllPolicy(vmName)
@@ -422,13 +378,14 @@ passwd:
 			Expect(sendEchos(endpoints)).To(Succeed(), step)
 		}
 
-		composeAgnhostPod = func(name, namespace, nodeName string, args ...string) *v1.Pod {
+		composeAgnhostPod = func(name, namespace, nodeName string, args ...string) *corev1.Pod {
 			agnHostPod := e2epod.NewAgnhostPod(namespace, name, nil, nil, nil, args...)
 			agnHostPod.Spec.NodeName = nodeName
 			return agnHostPod
 		}
 
-		liveMigrateVirtualMachine = func(vmName string, migrationMode kubevirtv1.MigrationMode) {
+		liveMigrateVirtualMachine = func(vmName string) {
+			GinkgoHelper()
 			vmimCreationRetries := 0
 			Eventually(func() error {
 				if vmimCreationRetries > 0 {
@@ -452,6 +409,7 @@ passwd:
 		}
 
 		checkLiveMigrationSucceeded = func(vmName string, migrationMode kubevirtv1.MigrationMode) {
+			GinkgoHelper()
 			By("checking the VM live-migrated correctly")
 			vmi := &kubevirtv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
@@ -467,30 +425,61 @@ passwd:
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
 				Expect(err).ToNot(HaveOccurred())
 				return vmi.Status.MigrationState
-			}).WithOffset(1).WithPolling(time.Second).WithTimeout(10*time.Minute).ShouldNot(BeNil(), "should have a MigrationState")
+			}).WithPolling(time.Second).WithTimeout(10*time.Minute).ShouldNot(BeNil(), "should have a MigrationState")
 			Eventually(func() string {
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
 				Expect(err).ToNot(HaveOccurred())
 				return vmi.Status.MigrationState.TargetNode
-			}).WithOffset(1).WithPolling(time.Second).WithTimeout(10*time.Minute).ShouldNot(Equal(currentNode), "should refresh MigrationState")
+			}).WithPolling(time.Second).WithTimeout(10*time.Minute).ShouldNot(Equal(currentNode), "should refresh MigrationState")
 			Eventually(func() bool {
 				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
 				Expect(err).ToNot(HaveOccurred())
 				return vmi.Status.MigrationState.Completed
-			}).WithOffset(1).WithPolling(time.Second).WithTimeout(20*time.Minute).Should(BeTrue(), "should complete migration")
+			}).WithPolling(time.Second).WithTimeout(20*time.Minute).Should(BeTrue(), "should complete migration")
 			err = crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
-			Expect(err).WithOffset(1).ToNot(HaveOccurred(), "should success retrieving vmi after migration")
-			Expect(vmi.Status.MigrationState.Failed).WithOffset(1).To(BeFalse(), func() string {
+			Expect(err).ToNot(HaveOccurred(), "should success retrieving vmi after migration")
+			Expect(vmi.Status.MigrationState.Failed).To(BeFalse(), func() string {
 				vmiJSON, err := json.Marshal(vmi)
 				if err != nil {
 					return fmt.Sprintf("failed marshaling migrated VM: %v", vmiJSON)
 				}
 				return fmt.Sprintf("should live migrate successfully: %s", string(vmiJSON))
 			})
-			Expect(vmi.Status.MigrationState.Mode).WithOffset(1).To(Equal(migrationMode), "should be the expected migration mode %s", migrationMode)
+			Expect(vmi.Status.MigrationState.Mode).To(Equal(migrationMode), "should be the expected migration mode %s", migrationMode)
+		}
+
+		vmiMigrations = func(client crclient.Client) ([]kubevirtv1.VirtualMachineInstanceMigration, error) {
+			unstructuredVMIMigrations := &unstructured.UnstructuredList{}
+			unstructuredVMIMigrations.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   kubevirtv1.GroupVersion.Group,
+				Kind:    "VirtualMachineInstanceMigrationList",
+				Version: kubevirtv1.GroupVersion.Version,
+			})
+
+			if err := client.List(context.Background(), unstructuredVMIMigrations); err != nil {
+				return nil, err
+			}
+			if len(unstructuredVMIMigrations.Items) == 0 {
+				return nil, fmt.Errorf("empty migration list")
+			}
+
+			var migrations []kubevirtv1.VirtualMachineInstanceMigration
+			for i := range unstructuredVMIMigrations.Items {
+				var vmiMigration kubevirtv1.VirtualMachineInstanceMigration
+				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+					unstructuredVMIMigrations.Items[i].Object,
+					&vmiMigration,
+				); err != nil {
+					return nil, err
+				}
+				migrations = append(migrations, vmiMigration)
+			}
+
+			return migrations, nil
 		}
 
 		checkLiveMigrationFailed = func(vmName string) {
+			GinkgoHelper()
 			By("checking the VM live-migrated failed to migrate")
 			vmi := &kubevirtv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
@@ -510,7 +499,7 @@ passwd:
 					return kubevirtv1.MigrationPhaseUnset, fmt.Errorf("expected one migration, got %d", len(migrations))
 				}
 				return migrations[0].Status.Phase, nil
-			}).WithOffset(1).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(
+			}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(
 				Equal(kubevirtv1.MigrationFailed),
 			)
 		}
@@ -546,7 +535,109 @@ passwd:
 			}
 
 		}
-		fcosVM = func(idx int, labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
+
+		addressesFromStatus = func(vmi *kubevirtv1.VirtualMachineInstance) func() ([]string, error) {
+			return func() ([]string, error) {
+				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
+				if err != nil {
+					return nil, err
+				}
+				var addresses []string
+				for _, iface := range vmi.Status.Interfaces {
+					for _, ip := range iface.IPs {
+						addresses = append(addresses, ip)
+					}
+				}
+				return addresses, nil
+			}
+		}
+
+		createVirtualMachine = func(vm *kubevirtv1.VirtualMachine) {
+			GinkgoHelper()
+			By(fmt.Sprintf("Create virtual machine %s", vm.Name))
+			vmCreationRetries := 0
+			Eventually(func() error {
+				if vmCreationRetries > 0 {
+					// retry due to unknown issue where kubevirt webhook gets stuck reading the request body
+					// https://github.com/ovn-org/ovn-kubernetes/issues/3902#issuecomment-1750257559
+					By(fmt.Sprintf("Retrying vm %s creation", vm.Name))
+				}
+				err := crClient.Create(context.Background(), vm)
+				vmCreationRetries++
+				return err
+			}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+		}
+
+		createVirtualMachineInstance = func(vmi *kubevirtv1.VirtualMachineInstance) {
+			GinkgoHelper()
+			By(fmt.Sprintf("Create virtual machine instance %s", vmi.Name))
+			vmiCreationRetries := 0
+			Eventually(func() error {
+				if vmiCreationRetries > 0 {
+					// retry due to unknown issue where kubevirt webhook gets stuck reading the request body
+					// https://github.com/ovn-org/ovn-kubernetes/issues/3902#issuecomment-1750257559
+					By(fmt.Sprintf("Retrying vmi %s creation", vmi.Name))
+				}
+				err := crClient.Create(context.Background(), vmi)
+				vmiCreationRetries++
+				return err
+			}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+		}
+
+		waitVirtualMachineInstanceReadiness = func(vmi *kubevirtv1.VirtualMachineInstance) {
+			GinkgoHelper()
+			By(fmt.Sprintf("Waiting for readiness at virtual machine %s", vmi.Name))
+			Eventually(func() []kubevirtv1.VirtualMachineInstanceCondition {
+				err := crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vmi), vmi)
+				Expect(err).To(SatisfyAny(WithTransform(apierrors.IsNotFound, BeTrue()), Succeed()))
+				return vmi.Status.Conditions
+			}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(ContainElement(SatisfyAll(
+				HaveField("Type", kubevirtv1.VirtualMachineInstanceReady),
+				HaveField("Status", corev1.ConditionTrue),
+			)))
+		}
+
+		waitVirtualMachineAddresses = func(vmi *kubevirtv1.VirtualMachineInstance) []kubevirt.Address {
+			GinkgoHelper()
+			step := by(vmi.Name, "Wait for virtual machine to receive IPv4 address from DHCP")
+			Eventually(addressByFamily(ipv4, vmi)).
+				WithPolling(time.Second).
+				WithTimeout(5*time.Minute).
+				Should(HaveLen(1), step)
+			addresses, err := addressByFamily(ipv4, vmi)()
+			Expect(err).ToNot(HaveOccurred())
+			if isDualStack() {
+				output, err := kubevirt.RunCommand(vmi, `echo '{"interfaces":[{"name":"enp1s0","type":"ethernet","state":"up","ipv4":{"enabled":true,"dhcp":true},"ipv6":{"enabled":true,"dhcp":true,"autoconf":false}}],"routes":{"config":[{"destination":"::/0","next-hop-interface":"enp1s0","next-hop-address":"fe80::1"}]}}' |nmstatectl apply`, 5*time.Second)
+				Expect(err).ToNot(HaveOccurred(), output)
+				step = by(vmi.Name, "Wait for virtual machine to receive IPv6 address from DHCP")
+				Eventually(addressByFamily(ipv6, vmi)).
+					WithPolling(time.Second).
+					WithTimeout(5*time.Minute).
+					Should(HaveLen(2), func() string {
+						output, _ := kubevirt.RunCommand(vmi, "journalctl -u nmstate", 2*time.Second)
+						return step + " -> journal nmstate: " + output
+					})
+				ipv6Addresses, err := addressByFamily(ipv6, vmi)()
+				Expect(err).ToNot(HaveOccurred())
+				addresses = append(addresses, ipv6Addresses...)
+			}
+			return addresses
+		}
+
+		virtualMachineAddressesFromStatus = func(vmi *kubevirtv1.VirtualMachineInstance, expectedNumberOfAddresses int) []string {
+			GinkgoHelper()
+			step := by(vmi.Name, "Wait for virtual machine to report addresses")
+			Eventually(addressesFromStatus(vmi)).
+				WithPolling(time.Second).
+				WithTimeout(10*time.Second).
+				Should(HaveLen(expectedNumberOfAddresses), step)
+
+			addresses, err := addressesFromStatus(vmi)()
+			Expect(err).ToNot(HaveOccurred())
+			return addresses
+		}
+
+		fcosVMI = func(idx int, labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachineInstance, error) {
 			workingDirectory, err := os.Getwd()
 			if err != nil {
 				return nil, err
@@ -556,6 +647,84 @@ passwd:
 					FilesDir: workingDirectory,
 				},
 			})
+			if err != nil {
+				return nil, fmt.Errorf("failed translating butane: %w", err)
+			}
+			return &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   namespace,
+					Name:        fmt.Sprintf("worker%d", idx),
+					Annotations: annotations,
+					Labels:      labels,
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					NodeSelector: nodeSelector,
+					Domain: kubevirtv1.DomainSpec{
+						Resources: kubevirtv1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+						Devices: kubevirtv1.Devices{
+							Disks: []kubevirtv1.Disk{
+								{
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{
+											Bus: kubevirtv1.DiskBusVirtio,
+										},
+									},
+									Name: "containerdisk",
+								},
+								{
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{
+											Bus: kubevirtv1.DiskBusVirtio,
+										},
+									},
+									Name: "cloudinitdisk",
+								},
+							},
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "net1",
+									InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+										Bridge: &kubevirtv1.InterfaceBridge{},
+									},
+								},
+							},
+							Rng: &kubevirtv1.Rng{},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name:          "net1",
+							NetworkSource: networkSource,
+						},
+					},
+					TerminationGracePeriodSeconds: pointer.Int64(5),
+					Volumes: []kubevirtv1.Volume{
+						{
+							Name: "containerdisk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								ContainerDisk: &kubevirtv1.ContainerDiskSource{
+									Image: "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50",
+								},
+							},
+						},
+						{
+							Name: "cloudinitdisk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
+									UserData: string(ignition),
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		}
+		fcosVM = func(idx int, labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachine, error) {
+			vmi, err := fcosVMI(idx, labels, annotations, nodeSelector, networkSource, butane)
 			if err != nil {
 				return nil, err
 			}
@@ -568,88 +737,74 @@ passwd:
 					Running: pointer.Bool(true),
 					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{
-								"kubevirt.io/allow-pod-bridge-network-live-migration": "",
-							},
-							Labels: labels,
+							Annotations: annotations,
+							Labels:      labels,
 						},
-						Spec: kubevirtv1.VirtualMachineInstanceSpec{
-							NodeSelector: map[string]string{
-								namespace: "",
-							},
-							Domain: kubevirtv1.DomainSpec{
-								Resources: kubevirtv1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("512Mi"),
-									},
-								},
-								Devices: kubevirtv1.Devices{
-									Disks: []kubevirtv1.Disk{
-										{
-											DiskDevice: kubevirtv1.DiskDevice{
-												Disk: &kubevirtv1.DiskTarget{
-													Bus: kubevirtv1.DiskBusVirtio,
-												},
-											},
-											Name: "containerdisk",
-										},
-										{
-											DiskDevice: kubevirtv1.DiskDevice{
-												Disk: &kubevirtv1.DiskTarget{
-													Bus: kubevirtv1.DiskBusVirtio,
-												},
-											},
-											Name: "cloudinitdisk",
-										},
-									},
-									Interfaces: []kubevirtv1.Interface{
-										{
-											Name: "pod",
-											InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
-												Bridge: &kubevirtv1.InterfaceBridge{},
-											},
-										},
-									},
-									Rng: &kubevirtv1.Rng{},
-								},
-							},
-							Networks: []kubevirtv1.Network{
-								{
-									Name: "pod",
-									NetworkSource: kubevirtv1.NetworkSource{
-										Pod: &kubevirtv1.PodNetwork{},
-									},
-								},
-							},
-							TerminationGracePeriodSeconds: pointer.Int64(5),
-							Volumes: []kubevirtv1.Volume{
-								{
-									Name: "containerdisk",
-									VolumeSource: kubevirtv1.VolumeSource{
-										ContainerDisk: &kubevirtv1.ContainerDiskSource{
-											Image: "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50",
-										},
-									},
-								},
-								{
-									Name: "cloudinitdisk",
-									VolumeSource: kubevirtv1.VolumeSource{
-										CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
-											UserData: string(ignition),
-										},
-									},
-								},
-							},
-						},
+						Spec: vmi.Spec,
 					},
 				},
 			}, nil
 		}
 
-		composeVMs = func(numberOfVMs int, labels map[string]string) ([]*kubevirtv1.VirtualMachine, error) {
+		composeDefaultNetworkLiveMigratableVM = func(idx int, labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
+			annotations := map[string]string{
+				"kubevirt.io/allow-pod-bridge-network-live-migration": "",
+			}
+			nodeSelector := map[string]string{
+				namespace: "",
+			}
+			networkSource := kubevirtv1.NetworkSource{
+				Pod: &kubevirtv1.PodNetwork{},
+			}
+			return fcosVM(idx, labels, annotations, nodeSelector, networkSource, butane)
+		}
+
+		composeDefaultNetworkLiveMigratableVMs = func(numberOfVMs int, labels map[string]string) ([]*kubevirtv1.VirtualMachine, error) {
+			butane := fmt.Sprintf(`
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+    - path: /root/test/server.go
+      contents:
+        local: kubevirt/echoserver/main.go
+systemd:
+  units:
+    - name: systemd-resolved.service
+      mask: true
+    - name: replace-resolved.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Replace systemd resolvd with NetworkManager
+        Wants=network-online.target
+        After=network-online.target
+        [Service]
+        ExecStart=rm -f /etc/resolv.conf
+        ExecStart=systemctl restart NetworkManager
+        Type=oneshot
+        [Install]
+        WantedBy=multi-user.target
+    - name: echoserver.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Golang echo server
+        Wants=replace-resolved.service
+        After=replace-resolved.service
+        [Service]
+        ExecStart=podman run --name tcpserver --tls-verify=false --privileged --net=host -v /root/test:/test:z registry.access.redhat.com/ubi9/go-toolset:1.20 go run /test/server.go %d
+        [Install]
+        WantedBy=multi-user.target
+passwd:
+  users:
+  - name: core
+    password_hash: $y$j9T$b7RFf2LW7MUOiF4RyLHKA0$T.Ap/uzmg8zrTcUNXyXvBvT26UgkC6zZUVg3UKXeEp5
+`, tcpServerPort)
+
 			vms := []*kubevirtv1.VirtualMachine{}
 			for i := 1; i <= numberOfVMs; i++ {
-				vm, err := fcosVM(i, labels, butane)
+				vm, err := composeDefaultNetworkLiveMigratableVM(i, labels, butane)
 				if err != nil {
 					return nil, err
 				}
@@ -658,12 +813,13 @@ passwd:
 			return vms, nil
 		}
 		liveMigrateAndCheck = func(vmName string, migrationMode kubevirtv1.MigrationMode, endpoints []*net.TCPConn, step string) {
-			liveMigrateVirtualMachine(vmName, migrationMode)
+			liveMigrateVirtualMachine(vmName)
 			checkLiveMigrationSucceeded(vmName, migrationMode)
 			checkConnectivityAndNetworkPolicies(vmName, endpoints, step)
 		}
 
-		runTest = func(td liveMigrationTestData, vm *kubevirtv1.VirtualMachine) {
+		runLiveMigrationTest = func(td liveMigrationTestData, vm *kubevirtv1.VirtualMachine) {
+			GinkgoHelper()
 			defer GinkgoRecover()
 			defer wg.Done()
 			step := by(vm.Name, "Login to virtual machine")
@@ -677,24 +833,7 @@ passwd:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
 
-			step = by(vm.Name, "Wait for virtual machine to receive IPv4 address from DHCP")
-			Eventually(addressByFamily(ipv4, vmi)).
-				WithPolling(time.Second).
-				WithTimeout(5*time.Minute).
-				Should(HaveLen(1), step)
-
-			if isDualStack {
-				output, err := kubevirt.RunCommand(vmi, `echo '{"interfaces":[{"name":"enp1s0","type":"ethernet","state":"up","ipv4":{"enabled":true,"dhcp":true},"ipv6":{"enabled":true,"dhcp":true,"autoconf":false}}],"routes":{"config":[{"destination":"::/0","next-hop-interface":"enp1s0","next-hop-address":"fe80::1"}]}}' |nmstatectl apply`, 5*time.Second)
-				Expect(err).ToNot(HaveOccurred(), output)
-				step = by(vm.Name, "Wait for virtual machine to receive IPv6 address from DHCP")
-				Eventually(addressByFamily(ipv6, vmi)).
-					WithPolling(time.Second).
-					WithTimeout(5*time.Minute).
-					Should(HaveLen(2), func() string {
-						output, _ := kubevirt.RunCommand(vmi, "journalctl -u nmstate", 2*time.Second)
-						return step + " -> journal nmstate: " + output
-					})
-			}
+			waitVirtualMachineAddresses(vmi)
 
 			step = by(vm.Name, "Expose tcpServer as a service")
 			svc, err := fr.ClientSet.CoreV1().Services(namespace).Create(context.TODO(), composeService("tcpserver", vm.Name, tcpServerPort), metav1.CreateOptions{})
@@ -714,22 +853,22 @@ passwd:
 			checkConnectivityAndNetworkPolicies(vm.Name, endpoints, "before live migration")
 			// Do just one migration that will fail
 			if td.shouldExpectFailure {
-				by(vm.Name, fmt.Sprintf("Live migrate virtual machine to check failed migration"))
-				liveMigrateVirtualMachine(vm.Name, td.mode)
+				by(vm.Name, "Live migrate virtual machine to check failed migration")
+				liveMigrateVirtualMachine(vm.Name)
 				checkLiveMigrationFailed(vm.Name)
 				checkConnectivityAndNetworkPolicies(vm.Name, endpoints, "after live migrate to check failed migration")
 			} else {
 				originalNode := vmi.Status.NodeName
-				by(vm.Name, fmt.Sprintf("Live migrate for the first time"))
+				by(vm.Name, "Live migrate for the first time")
 				liveMigrateAndCheck(vm.Name, td.mode, endpoints, "after live migrate for the first time")
 
-				by(vm.Name, fmt.Sprintf("Live migrate for the second time to a node not owning the subnet"))
+				by(vm.Name, "Live migrate for the second time to a node not owning the subnet")
 				// Remove the node selector label from original node to force
 				// live migration to a different one.
 				Expect(unlabelNode(originalNode, namespace)).To(Succeed())
 				liveMigrateAndCheck(vm.Name, td.mode, endpoints, "after live migration for the second time to node not owning subnet")
 
-				by(vm.Name, fmt.Sprintf("Live migrate for the third time to the node owning the subnet"))
+				by(vm.Name, "Live migrate for the third time to the node owning the subnet")
 				// Patch back the original node with the label and remove it
 				// from the rest of nodes to force live migration target to it.
 				Expect(labelNode(originalNode, namespace)).To(Succeed())

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -36,13 +36,14 @@ func getNetCIDRSubnet(netCIDR string) (string, error) {
 }
 
 type networkAttachmentConfigParams struct {
-	cidr         string
-	excludeCIDRs []string
-	namespace    string
-	name         string
-	topology     string
-	networkName  string
-	vlanID       int
+	cidr               string
+	excludeCIDRs       []string
+	namespace          string
+	name               string
+	topology           string
+	networkName        string
+	vlanID             int
+	allowPersistentIPs bool
 }
 
 type networkAttachmentConfig struct {
@@ -76,7 +77,8 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
         "excludeSubnets": %q,
         "mtu": 1300,
         "netAttachDefName": %q,
-        "vlanID": %d
+        "vlanID": %d,
+        "allowPersistentIPs": %t
 }
 `,
 		config.networkName,
@@ -85,6 +87,7 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
 		strings.Join(config.excludeCIDRs, ","),
 		namespacedName(config.namespace, config.name),
 		config.vlanID,
+		config.allowPersistentIPs,
 	)
 	return generateNetAttachDef(config.namespace, config.name, nadSpec)
 }


### PR DESCRIPTION
**- What this PR does and why is it needed**
kubevirt, e2e: Add persistent ips tests
To verify the ovn-kubernetes integration with IPAMClaim this change
add kubevirt VirtualMachines live migration and restart with
multi-homing and persistent ips tests.