### PR TITLE
Fix EgressService test race

### DIFF
--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -684,13 +684,6 @@ var _ = Describe("Egress Service Operations", func() {
 					return fakeOvnNode.fakeExec.CalledMatchesExpected()
 				}).Should(BeTrue())
 
-				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Eventually(func() error {
-					return f4.MatchState(expectedTables)
-				}).ShouldNot(HaveOccurred())
-
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
 					Err: nil,
@@ -699,6 +692,13 @@ var _ = Describe("Egress Service Operations", func() {
 					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table mynetwork",
 					Err: nil,
 				})
+
+				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() error {
+					return f4.MatchState(expectedTables)
+				}).ShouldNot(HaveOccurred())
 
 				Eventually(func() bool {
 					return fakeOvnNode.fakeExec.CalledMatchesExpected()


### PR DESCRIPTION
Call AddFakeCmd before deleting the EgressService object to avoid a scenario in which the fakeExec detects the iptables commands as unexpected.

Found in a downstream UT run:
```
I0228 13:45:27.898828   22142 egressservice_node.go:635] Processing sync for EgressService namespace1/service1
I0228 13:45:27.899037   22142 ovs.go:164] Exec(86): /fake-bin/ip -4 rule add prio 5000 from 10.129.0.2 table mynetwork
I0228 13:45:27.899076   22142 ovs.go:167] Exec(86): stdout: ""
I0228 13:45:27.899107   22142 ovs.go:168] Exec(86): stderr: ""
I0228 13:45:27.899174   22142 ovs.go:164] Exec(87): /fake-bin/ip -4 rule add prio 5000 from 10.128.0.3 table mynetwork
I0228 13:45:27.899207   22142 ovs.go:167] Exec(87): stdout: ""
I0228 13:45:27.899232   22142 ovs.go:168] Exec(87): stderr: ""
I0228 13:45:27.899261   22142 egressservice_node.go:638] Finished syncing EgressService service1 on namespace namespace1 : 480.367µs
I0228 13:45:27.899604   22142 egressservice_node.go:635] Processing sync for EgressService namespace1/service1
W0228 13:45:27.900761   22142 exec.go:265] Unexpected command: /fake-bin/ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork

Executed commands do not match expected commands!
Executed unexpected command /fake-bin/ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork

[00]   /fake-bin/ovs-vsctl --timeout=15 --no-heading --data=bare --format=csv --columns name list interface
[01]   /fake-bin/ip -4 --json rule show
[02]   /fake-bin/ip -4 rule add prio 5000 from 10.129.0.2 table mynetwork
[03]   /fake-bin/ip -4 rule add prio 5000 from 10.128.0.3 table mynetwork
goroutine 791 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x72
runtime/debug.PrintStack()
	/usr/local/go/src/runtime/debug/stack.go:16 +0x25
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing.(*FakeExec).Command(0xc0008730e0, {0xc000b12184, 0xc}, {0xc0008645a0, 0x9, 0x9})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/testing/exec.go:266 +0xd8a
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util.run({0xc000b12184, 0xc}, {0xc0008645a0, 0x9, 0x9})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/util/ovs.go:304 +0xbd
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util.RunIP({0xc0008645a0, 0x9, 0x9})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/util/ovs.go:607 +0x96
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.deleteIPRule({0x322b388, 0x2}, 0xe99608?, {0xc00086c086, 0xa}, {0x32375b4, 0x9})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:954 +0x3a9
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.(*Controller).clearServiceIPRules(0xc000168b88?, 0xc0001225f0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:901 +0x1a5
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.(*Controller).clearServiceRulesAndRequeue(0xc0009d86c0, {0xc000168b88, 0x13}, 0xc0001225f0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:922 +0x7e
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.(*Controller).syncEgressService(0xc0009d86c0, {0xc000168b88, 0x13})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:665 +0xcff
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.(*Controller).processNextEgressServiceWorkItem(0xc0009d86c0, 0xc00048f780)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:609 +0x1d6
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.(*Controller).runEgressServiceWorker(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:594
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.(*Controller).Run.func1.1()
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:197 +0x45
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000e36fb8)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x49
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x37701c0, 0xc0004e0030}, 0x1, 0xc000554c60)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xcf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x10e
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.(*Controller).Run.func1()
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:196 +0xf4
created by github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice.(*Controller).Run
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice/egressservice_node.go:194 +0x5af
```
https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/2089/pull-ci-openshift-ovn-kubernetes-master-unit/1762834261318045696/build-log.txt

/cc @tssurya @npinaeva 