### PR TITLE
kubevirt, e2e: Use simple tcp server

### DIFF
--- a/test/e2e/kubevirt/echoserver/main.go
+++ b/test/e2e/kubevirt/echoserver/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+)
+
+func main() {
+	bind_address := fmt.Sprintf(":%s", os.Args[1])
+
+	listener, err := net.Listen("tcp", bind_address)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("failed listening to %s: %w", bind_address, err))
+	}
+	defer listener.Close()
+
+	log.Println("Server is running on:", bind_address)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Println("failed accepting connection: %w", err)
+			continue
+		}
+
+		go handleConnection(conn)
+	}
+}
+
+func handleConnection(conn net.Conn) {
+	log.Printf("Handling connection %s\n", conn.RemoteAddr())
+	defer func() {
+		log.Printf("Closing connection %s\n", conn.RemoteAddr())
+		conn.Close()
+	}()
+	_, err := io.Copy(conn, conn)
+	if err != nil {
+		log.Printf("failed copying data: %v\n", err)
+	}
+}


### PR DESCRIPTION
**- What this PR does and why is it needed**
Using the "Reuse" golang http client connection attribute to check that the connection is not broken is a little hard to debug, this change replace the http client and http agnhost server with a simple golang TCP server injected using fedora coreos ignition, its simpler and test is faster.


**- Description for the changelog**
kubevirt, e2e: Use simple tcp server