### PR TITLE
Fix and enable MetalLB service tests for LGW mode with IPv6 

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -36,7 +36,7 @@ Should validate conntrack entry deletion for TCP/UDP traffic via multiple extern
 Should validate flow data of br-int is sent to an external gateway with netflow v5|\
 can retrieve multicast IGMP query|\
 test node readiness according to its defaults interface MTU size|\
-Load Balancer Service Tests with MetalLB|\
+Should ensure connectivity works on an external service when mtu changes in intermediate node|\
 egress IP validation|\
 e2e egress firewall policy validation|\
 OVS CPU affinity pinning|\


### PR DESCRIPTION
The PR doesn't fix the `Should ensure connectivity works on an external service when mtu changes in intermediate node` but it makes it retrieve the svc load balancer IP instead using the hardcoded value. 

Special thanks to @msherif1234 for the helping hand with metalb config!