### PR TITLE
Add Project Governance for ovn-kubernetes project

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement
+directly. Maintainers are identified in the [MAINTAINERS.md](MAINTAINERS.md) file and their contact information is on their GitHub profile page.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,235 +1,197 @@
-How to Submit Patches for ovn-kubernetes
-========================================
+# Contributing Guide
 
-Create github pull requests for the repo.  More details are included below.
+* [New Contributor Guide](#contributing-guide)
+  * [Ways to Contribute](#ways-to-contribute)
+  * [Find an Issue](#find-an-issue)
+  * [Ask for Help](#ask-for-help)
+  * [Pull Request Lifecycle](#pull-request-lifecycle)
+  * [Development Environment Setup](#development-environment-setup)
+  * [Sign Your Commits](#sign-your-commits)
+  * [Pull Request Checklist](#pull-request-checklist)
 
-Before You Start
-----------------
+Welcome! We are glad that you want to contribute to our project! 💖
 
-Before you send patches at all, make sure that each patch makes sense.
-In particular:
+As you get started, you are in the best position to give us feedback on areas of
+our project that we need help with including:
 
-  - A given patch should not break anything, even if later
-    patches fix the problems that it causes.  The source tree
-    should still work after each patch is applied.  (This enables
-    `git bisect` to work best.)
+* Problems found during setting up a new developer environment
+* Gaps in our Quickstart Guide or documentation
+* Bugs in our automation scripts
 
-  - A patch should make one logical change.  Don't make
-    multiple, logically unconnected changes to disparate
-    subsystems in a single patch.
+If anything doesn't make sense, or doesn't work when you run it, please open a
+bug report and let us know!
 
-  - A patch that adds or removes user-visible features should
-    also update the appropriate user documentation or manpages.
+## Ways to Contribute
 
-Commit Summary
--------------
+We welcome many different types of contributions including:
 
-The summary line of your commit should be in the following format:
-`<area>: <summary>`
+* New features
+* Builds, CI/CD
+* Bug fixes
+* Documentation
+* Issue Triage
+* Answering questions on Slack/Mailing List
+* Web design
+* Communications / Social Media / Blog Posts
+* Release management
 
-  - `<area>:` indicates the area of the ovn-kubernetes to which the
-    change applies (often the name of a source file or a
-    directory).  You may omit it if the change crosses multiple
-    distinct pieces of code.
+Not everything happens through a GitHub pull request. Please come to our
+[meetings](./MEETINGS.md) or [contact us](https://ovn-org.slack.com/archives/C010SQ5FSNL) and let's discuss how we can work
+together. 
 
-  - `<summary>` briefly describes the change.
+### Come to Meetings
 
-Commit Description
-------------------
+Absolutely everyone is welcome to come to any of our meetings. You never need an
+invite to join us. In fact, we want you to join us, even if you don’t have
+anything you feel like you want to contribute. Just being there is enough!
 
-The body of the commit message should start with a more thorough description of
-the change.  This becomes the body of the commit message, following
-the subject.  There is no need to duplicate the summary given in the
-subject.
+You can find out more about our meetings [here](./MEETINGS.md). You don’t have to turn on
+your video. The first time you come, introducing yourself is more than enough.
+Over time, we hope that you feel comfortable voicing your opinions, giving
+feedback on others’ ideas, and even sharing your own ideas, and experiences.
 
-Please limit lines in the description to 79 characters in width.
+## Find an Issue
 
-The description should include:
+We have good first issues for new contributors and help wanted issues suitable
+for any contributor. [good first issue](https://github.com/ovn-org/ovn-kubernetes/labels/good%20first%20issue) has extra information to
+help you make your first contribution. [help wanted](https://github.com/ovn-org/ovn-kubernetes/labels/help%20wanted) are issues
+suitable for someone who isn't a core maintainer and is good to move onto after
+your first pull request.
 
-  - The rationale for the change.
+Sometimes there won’t be any issues with these labels. That’s ok! There is
+likely still something for you to work on. If you want to contribute but you
+don’t know where to start or can't find a suitable issue, you can you can reach out to us on [Slack](https://ovn-org.slack.com/) and we will be happy to help.
 
-  - Design description and rationale (but this might be better
-    added as code comments).
+Once you see an issue that you'd like to work on, please post a comment saying
+that you want to work on it. Something like "I want to work on this" is fine.
 
-  - Testing that you performed (or testing that should be done
-    but you could not for whatever reason).
+## Ask for Help
 
-  - Tags (see below).
+The best way to reach us with a question when contributing is to ask on:
 
-There is no need to describe what the patch actually changed, if the
-reader can see it for himself.
+* The original github issue
+* The developer mailing list (mailing-list: https://groups.google.com/g/ovn-kubernetes)
+* Our Slack channel (workspace: https://ovn-org.slack.com/, channel: #ovn-kubernetes)
 
-If the patch refers to a commit already in the ovn-kubernetes
-repository, please include both the commit number and the subject of
-the patch, e.g. 'commit 632d136c (ovn-k8s-overlay: Flush the IP address
-of physical interface)
+## Pull Request Lifecycle
 
-Tags
-----
+1. When you open a PR a maintainer will automatically be assigned for review
+2. Make sure that your PR is passing CI - if you need help with failing checks please feel free to ask!
+3. Once it is passing all CI checks, a maintainer will review your PR and you may be asked to make changes.
+4. When you have received at least one approval from a maintainer, that maintainer will merge your PR.
 
-The description ends with a series of tags, written one to a line as
-the last paragraph of the email.  Each tag indicates some property of
-the patch in an easily machine-parseable manner.
+In some cases, other changes may conflict with your PR. If this happens, you will get notified by a comment in the issue that your PR requires a rebase, and the `needs-rebase` label will be applied. Once a rebase has been performed, this label will be automatically removed.
 
-Examples of common tags follow.
+## Development Environment Setup
 
-    Signed-off-by: Author Name <author.name@email.address...>
+You can easily setup a developer environment by following the instructions [here](https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/kind.md).
 
-        Informally, this indicates that Author Name is the author or
-        submitter of a patch and has the authority to submit it under
-        the terms of the license.  The formal meaning is to agree to
-        the Developer's Certificate of Origin (see below).
+## Sign Your Commits
 
-        If the author and submitter are different, each must sign off.
-        If the patch has more than one author, all must sign off.
+### DCO
+Licensing is important to open source projects. It provides some assurances that
+the software will continue to be available based under the terms that the
+author(s) desired. We require that contributors sign off on commits submitted to
+our project's repositories. The [Developer Certificate of Origin
+(DCO)](https://probot.github.io/apps/dco/) is a way to certify that you wrote and
+have the right to contribute the code you are submitting to the project.
 
-        Signed-off-by: Author Name <author.name@email.address...>
-        Signed-off-by: Submitter Name <submitter.name@email.address...>
+You sign-off by adding the following to your commit messages. Your sign-off must
+match the git user and email associated with the commit.
 
-    Co-authored-by: Author Name <author.name@email.address...>
+    This is my commit message
 
-        Git can only record a single person as the author of a given
-        patch.  In the rare event that a patch has multiple authors,
-        one must be given the credit in Git and the others must be
-        credited via Co-authored-by: tags.  (All co-authors must also
-        sign off.)
+    Signed-off-by: Your Name <your.name@example.com>
 
-    Acked-by: Reviewer Name <reviewer.name@email.address...>
+Git has a `-s` command line option to do this automatically:
 
-        Reviewers will often give an Acked-by: tag to code of which
-        they approve.  It is polite for the submitter to add the tag
-        before posting the next version of the patch or applying the
-        patch to the repository.  Quality reviewing is hard work, so
-        this gives a small amount of credit to the reviewer.
+    git commit -s -m 'This is my commit message'
 
-        Not all reviewers give Acked-by: tags when they provide
-        positive reviews.  It's customary only to add tags from
-        reviewers who actually provide them explicitly.
+If you forgot to do this and have not yet pushed your changes to the remote
+repository, you can amend your commit with the sign-off by running 
 
-    Tested-by: Tester Name <reviewer.name@email.address...>
+    git commit --amend -s 
 
-        When someone tests a patch, it is customary to add a
-        Tested-by: tag indicating that.  It's rare for a tester to
-        actually provide the tag; usually the patch submitter makes
-        the tag himself in response to an email indicating successful
-        testing results.
+## Logical Grouping of Commits
 
-    Tested-at: <URL>
+It is a recommended best practice to keep your changes as logically grouped as
+possible within individual commits. If while you're developing you prefer doing
+a number of commits that are "checkpoints" and don't represent a single logical
+change, please squash those together before asking for a review.
+When addressing review comments, please perform an interactive rebase and edit commits directly rather than adding new commits with messages like "Fix review comments".
 
-        When a test report is publicly available, this provides a way
-        to reference it.  Typical <URL>s would be build logs from
-        autobuilders or references to mailing list archives.
+## Commit message guidelines
 
-        Some autobuilders only retain their logs for a limited amount
-        of time.  It is less useful to cite these because they may be
-        dead links for a developer reading the commit message months
-        or years later.
+A good commit message should describe what changed and why.
 
-    Reported-by: Reporter Name <reporter.name@email.address...>
+1. The first line should:
+  
+* contain a short description of the change (preferably 50 characters or less,
+    and no more than 72 characters)
+* be entirely in lowercase with the exception of proper nouns, acronyms, and
+    the words that refer to code, like areas/function/variable names
+* be prefixed with the name of the sub component being changed
 
-        When a patch fixes a bug reported by some person, please
-        credit the reporter in the commit log in this fashion.  Please
-        also add the reporter's name and email address to the list of
-        people who provided helpful bug reports in the AUTHORS file at
-        the top of the source tree.
+  Examples:
 
-        Fairly often, the reporter of a bug also tests the fix.
-        Occasionally one sees a combined "Reported-and-tested-by:" tag
-        used to indicate this.  It is also acceptable, and more
-        common, to include both tags separately.
+  * networkpolicy: validate ipBlock strictly
+  * egressip: fix frequently rebalancing IPs
+  * services: fix etp=local + session-affnity integration
 
-        (If a bug report is received privately, it might not always be
-        appropriate to publicly credit the reporter.  If in doubt,
-        please ask the reporter.)
+2. Keep the second line blank.
+3. Wrap all other lines at 72 columns (except for long URLs).
+4. If your patch fixes an open issue, you can add a reference to it at the end
+   of the log. Use the `Fixes: #` prefix and the issue number. For other
+   references use `Refs: #`. `Refs` may include multiple issues, separated by a
+   comma.
 
-    Requested-by: Requester Name <requester.name@email.address...>
-    Suggested-by: Suggester Name <suggester.name@email.address...>
+   Examples:
 
-        When a patch implements a request or a suggestion made by some
-        person, please credit that person in the commit log in this
-        fashion.  For a helpful suggestion, please also add the
-        person's name and email address to the list of people who
-        provided suggestions in the AUTHORS file at the top of the
-        source tree.
+   * `Fixes: #1337`
+   * `Refs: #1234`
 
-        (If a suggestion or a request is received privately, it might
-        not always be appropriate to publicly give credit.  If in
-        doubt, please ask.)
+Sample complete commit message:
 
-    Reported-at: <URL>
+```txt
+subcomponent: explain the commit in one line
 
-        If a patch fixes or is otherwise related to a bug reported in
-        a public bug tracker, please include a reference to the bug in
-        the form of a URL to the specific bug, e.g.:
+Body of commit message is a few lines of text, explaining things
+in more detail, possibly giving some background about the issue
+being fixed, etc.
 
-        Reported-at: https://bugs.debian.org/743635
+The body of the commit message can be several paragraphs, and
+please do proper word-wrap and keep columns shorter than about
+72 characters or so. That way, `git log` will show things
+nicely even when it is indented.
 
-        This is also an appropriate way to refer to bug report emails
-        in public email archives, e.g.:
+Fixes: #1337
+Refs: #453, #154
+```
 
-        Reported-at: http://openvswitch.org/pipermail/dev/2014-June/040952.html
+## Pull Request Checklist
 
-    VMware-BZ: #1234567
-    ONF-JIRA: EXT-12345
+When you submit your pull request, or you push new commits to it, our automated
+systems will run some checks on your new code. We require that your pull request
+passes these checks, but we also have more criteria than just that before we can
+accept and merge it. We recommend that you check the following things locally
+before you submit your code:
 
-        If a patch fixes or is otherwise related to a bug reported in
-        a private bug tracker, you may include some tracking ID for
-        the bug for your own reference.  Please include some
-        identifier to make the origin clear, e.g. "VMware-BZ" refers
-        to VMware's internal Bugzilla instance and "ONF-JIRA" refers
-        to the Open Networking Foundation's JIRA bug tracker.
+* Verify that Go code has been formatted and linted
 
-    Fixes: 63bc9fb1c69f (“packets: Reorder CS_* flags to remove gap.”)
+```console
+cd ovn-kubernetes/go-controller/
+make lint
+```
 
-        If you would like to record which commit introduced a bug being fixed,
-        you may do that with a “Fixes” header.  This assists in determining
-        which OVS releases have the bug, so the patch can be applied to all
-        affected versions.  The easiest way to generate the header in the
-        proper format is with this git command:
+* If you are introducing new CRDs verify that Yaml files have been formatted (see
+  [codegen generator](https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/developer.md#generating-crd-yamls-using-codegen))
+* Verify that unit tests are passing locally
 
-        git log -1 --pretty=format:"Fixes: %h (\"%s\")" --abbrev=12 COMMIT_REF
+```console
+cd ovn-kubernetes/go-controller/
+make test
+```
 
-    Vulnerability: CVE-2016-2074
+* All modular changes must be accompanied by new unit tests if they don't exist already.
 
-        Specifies that the patch fixes or is otherwise related to a
-        security vulnerability with the given CVE identifier.  Other
-        identifiers in public vulnerability databases are also
-        suitable.
-
-        If the vulnerability was reported publicly, then it is also
-        appropriate to cite the URL to the report in a Reported-at
-        tag.  Use a Reported-by tag to acknowledge the reporters.
-
-Developer's Certificate of Origin
----------------------------------
-
-To help track the author of a patch as well as the submission chain,
-and be clear that the developer has authority to submit a patch for
-inclusion in openvswitch please sign off your work.  The sign off
-certifies the following:
-
-    Developer's Certificate of Origin 1.1
-
-    By making a contribution to this project, I certify that:
-
-    (a) The contribution was created in whole or in part by me and I
-        have the right to submit it under the open source license
-        indicated in the file; or
-
-    (b) The contribution is based upon previous work that, to the best
-        of my knowledge, is covered under an appropriate open source
-        license and I have the right under that license to submit that
-        work with modifications, whether created in whole or in part
-        by me, under the same open source license (unless I am
-        permitted to submit under a different license), as indicated
-        in the file; or
-
-    (c) The contribution was provided directly to me by some other
-        person who certified (a), (b) or (c) and I have not modified
-        it.
-
-    (d) I understand and agree that this project and the contribution
-        are public and that a record of the contribution (including all
-        personal information I submit with it, including my sign-off) is
-        maintained indefinitely and may be redistributed consistent with
-        this project or the open source license(s) involved.
+* All functional changes and new features must be accompanied by extensive end-to-end test coverage

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,142 @@
+# ovn-kubernetes Project Governance
+
+The ovn-kubernetes  project is dedicated to creating a robust Kubernetes Networking platform built from the ground up by leveraging Open vSwitch (OVS) as the data plane, and Open Virtual Network (OVN) as the SDN Controller. The project focuses strictly on enhancing networking for the Kubernetes platform and includes a wide variety of features that are critical to enterprise and telco users.
+
+This governance explains how the project is run.
+
+- [Values](#values)
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Meetings](#meetings)
+- [CNCF Resources](#cncf-resources)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Security Response Team](#security-response-team)
+- [Voting](#voting)
+- [Modifications](#modifying-this-charter)
+
+## Values
+
+The ovn-kubernetes and its leadership embrace the following values:
+
+* Openness: Communication and decision-making happens in the open and is discoverable for future
+  reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+
+* Fairness: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+
+* Community over Product or Company: Sustaining and growing our community takes
+  priority over shipping code or sponsors' organizational goals.  Each
+  contributor participates in the project as an individual.
+
+* Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be accomplished in a welcoming and respectful environment.
+
+* Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
+  positions.
+
+## Maintainers
+
+ovn-kubernetes Maintainers have write access to the [project GitHub repository](https://github.com/ovn-org/ovn-kubernetes).
+They can merge their own patches or patches from others. The current maintainers
+can be found in [MAINTAINERS.md](./MAINTAINERS.md).  Maintainers collectively manage the project's
+resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the ovn-kubernetes project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+The collective team of all Maintainers is known as the Maintainer Council, which
+is the governing body for the project.
+
+### Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate the following:
+
+  * commitment to the project:
+    * participate in discussions, contributions, code and documentation reviews
+      for 10 months or more,
+    * perform reviews for 10 non-trivial pull requests,
+    * contribute 15 non-trivial pull requests and have them merged,
+  * ability to write quality code and/or documentation,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc),
+  * understanding of the project's code base and coding and documentation style.
+
+A new Maintainer must be proposed by an existing maintainer by sending a message to the
+[developer mailing list](https://groups.google.com/g/ovn-kubernetes). A simple majority vote of existing Maintainers
+approves the application.  Maintainers nominations will be evaluated without prejudice
+to employer or demographics.
+
+Maintainers who are selected will be granted the necessary GitHub rights.
+
+### Removing a Maintainer
+
+Maintainers may resign at any time if they feel that they will not be able to
+continue fulfilling their project duties.
+
+Maintainers may also be removed after being inactive, failure to fulfill their 
+Maintainer responsibilities, violating the Code of Conduct, or other reasons.
+Inactivity is defined as a period of very low or no activity in the project 
+for a year or more, with no definite schedule to return to full Maintainer 
+activity.
+
+A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
+
+Depending on the reason for removal, a Maintainer may be converted to Emeritus
+status.  Emeritus Maintainers will still be consulted on some project matters,
+and can be rapidly returned to Maintainer status if their availability changes.
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the public
+developer meeting, details of which can be found
+[here](./MEETINGS.md).  
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations.  Such meetings should be scheduled by any
+Maintainer on receipt of a security issue or CoC report.  All current Maintainers
+must be invited to such closed meetings, except for any Maintainer who is
+accused of a CoC violation.
+
+## Code of Conduct
+
+[Code of Conduct](./CODE_OF_CONDUCT.md)
+violations by community members will be discussed and resolved
+on the private Slack Maintainer channel.
+
+## Security Response Team
+
+The Maintainers will appoint a Security Response Team to handle security reports.
+This committee may simply consist of the Maintainer Council themselves.  If this
+responsibility is delegated, the Maintainers will appoint a team of at least two 
+contributors to handle it.  The Maintainers will review who is assigned to this
+at least once a year.
+
+The Security Response Team is responsible for handling all reports of security
+holes and breaches according to the [security policy](./SECURITY.md).
+
+## Voting
+
+While most business in ovn-kubernetes is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
+periodically the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [the developer mailing list](https://groups.google.com/g/ovn-kubernetes) or
+the private Maintainer Slack Channel for security or conduct matters.  
+Votes may also be taken at [the developer meeting](./MEETINGS.md).  Any Maintainer may
+demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed, except where
+otherwise noted.  Two-thirds majority votes mean at least two-thirds of all 
+existing maintainers.
+
+## Modifying this Charter
+
+Changes to this Governance and its supporting documents may be approved by 
+a 2/3 vote of the Maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+The current Maintainers Group for the ovn-kubernetes Project consists of:
+
+| Name | Employer | Responsibilities |
+| ---- | -------- | ---------------- |
+| [Dan Williams](https://github.com/dcbw) | Red Hat  | All things ovnkube |
+| [Girish Moodalbail](https://github.com/girishmg) | NVIDIA | All things ovnkube |
+| [Jaime Caamaño Ruiz](https://github.com/jcaamano) | Red Hat | All things ovnkube |
+| [Surya Seetharaman](https://github.com/tssurya)   | Red Hat | All things ovnkube |
+| [Tim Rozet](https://github.com/trozet)   | Red Hat | All things ovnkube |
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for general contribution guidelines.
+See [GOVERNANCE.md](./GOVERNANCE.md) for governance guidelines and maintainer responsibilities.

--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -1,0 +1,22 @@
+# ovn-kubernetes Community Meetings
+
+## Information
+
+All are welcome to join our meetings! If you want to discuss something with the wider community, please add your items to the agenda. If you are starting to contribute but unsure of the first steps, please feel free to reach out to us during the meetings and introduce yourself!
+
+## Meeting time
+
+We meet alternate Monday's at 10:00 AM US Pacific Time.
+In order to figure out when our next meeting is, please check our agenda for previous meeting history.
+The meetings last up to 1 hour.
+
+## Meeting location
+
+* Video call link: <https://meet.google.com/tgr-pqke-cen>
+* Or dial: (DE) +49 30 300195060 PIN: 846 145 117 7213#
+* More phone numbers: <https://tel.meet/tgr-pqke-cen?pin=8461451177213>
+
+## Meeting agenda and minutes
+
+[Meeting agenda](https://docs.google.com/document/d/1ciZS1CajH07THAiH_9j4-6uX4HAJFEoUzwyRdjsQK1k)  - edit responsibly
+

--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,18 @@
 reviewers:
   - aserdean
-  - dcbw
-  - girishmg
-  - trozet
-  - cathy-zhou
-  - npinaeva
-  - jcaamano
-  - tssurya
-  - flavio-fernandes
-  - martinkennelly
-  - kyrtapz
-  - pperiyasamy
   - bpickard22
+  - cathy-zhou
+  - dcbw
+  - flavio-fernandes
+  - girishmg
+  - jcaamano
+  - kyrtapz
+  - martinkennelly
+  - npinaeva
+  - pperiyasamy
+  - ricky-rav
+  - trozet
+  - tssurya
 
 approvers:
   - dcbw

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,68 @@
+# Reviewing Guide
+
+This document covers who may review pull requests for this project, and provides guidance on how to perform code reviews that meet our community standards and code of conduct. All reviewers must read this document and agree to follow the project review guidelines. Reviewers who do not follow these guidelines may have their privileges revoked.
+
+## The Reviewer Role
+
+We welcome all contributors to wear their reviewer hats! The reviewer role is distinct from the approver/maintainer role. Anyone is welcome to be a reviewer and take on the reviewer role in our community. Reviewers can LGTM a pull request but they cannot merge it. A maintainer/approver handles the final approval and merging of the pull request. The current maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md).
+
+## Values
+
+All reviewers must abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and are also protected by it. A reviewer should not tolerate poor behavior and is encouraged to report any behavior that violates the Code of Conduct. All of our values listed above are distilled from our Code of Conduct.
+
+Below are concrete examples of how it applies to code review specifically:
+
+### Inclusion
+
+Be welcoming and inclusive. You should proactively ensure that the author is successful. While any particular pull request may not ultimately be merged, overall we want people to have a great experience and be willing to contribute again. Answer the questions they didn't know to ask or offer concrete help when they appear stuck.
+
+### Sustainability
+
+Avoid burnout by enforcing healthy boundaries. Here are some examples of how a reviewer is encouraged to act to take care of themselves:
+
+* Authors should meet baseline expectations when submitting a pull request, such as writing tests and relevant documentation.
+* If your availability changes, you can step down from a pull request and have someone else assigned.
+* If interactions with an author are not following code of conduct, raise it up with your Code of Conduct committee or point of contact. It's not your job to coax people into behaving.
+  * The code of conduct committee for this project is the same as the maintainers list for this project. The current maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md). If you face any issues please reach out to one of the maintainers on our slack channel (workspace: https://ovn-org.slack.com/, channel: #ovn-kubernetes)
+
+### Trust
+
+Be trustworthy. During a review, your actions both build and help maintain the trust that the community has placed in this project. Below are examples of ways that we build trust:
+
+* **Transparency** - If a pull request won't be merged or shouldn't be merged, clearly say why and tag a maintainer to close it. If a pull request won't be reviewed for a while, let the author know so they can set expectations and understand why it's blocked.
+* **Integrity** - Put the project's best interests ahead of personal relationships or company affiliations when deciding if a change should be merged.
+* **Stability** - Only LGTM when then change won't negatively impact project stability. It can be tempting to LGTM a pull request that doesn't meet our quality standards, for example when the review has been delayed, or because we are trying to deliver new features quickly, but regressions can significantly hurt trust in our project.
+
+## Process
+
+* Approvers are automatically assigned based on the [CODEOWNERS](./CODEOWNERS) file.
+* Reviewers should wait for automated checks to pass before reviewing
+* At least 1 approved review is required from a maintainer before a pull request can be merged
+* All CI checks must pass
+* If a PR is stuck for some reason it is down to the reviewer to determine the best course of action:
+  * PRs may be closed if they are no longer relevant
+  * A maintainer may choose to carry a PR forward on their own, but they should ALWAYS include the original author's commits
+  * A maintainer may choose to open additional PRs to help lay a foundation on which the stuck PR can be unstuck. They may either rebase the stuck PR themselves or leave this to the author
+* Maintainers should not merge their pull requests without a review
+* Maintainers should let the Mergify bot merge PRs and not merge PRs directly
+* In times of need, i.e. to fix pressing security issues or fix critical panic issues, the Maintainers may, at their discretion, merge PRs without review. They must add a comment to the PR explaining why they did so.
+
+
+## Checklist
+
+Below are a set of common questions that apply to all pull requests:
+
+- [ ] Is this PR targeting the correct branch?
+- [ ] Does the commit message provide an adequate description of the change?
+- [ ] Does the affected code have corresponding unit, end-to-end and feature integration tests?
+- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
+- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
+
+
+## Reading List
+
+Reviewers are encouraged to read the following articles for help with common reviewer tasks:
+
+* [The Art of Closing: How to closing an unfinished or rejected pull request](https://blog.jessfraz.com/post/the-art-of-closing/)
+* [Kindness and Code Reviews: Improving the Way We Give Feedback](https://product.voxmedia.com/2018/8/21/17549400/kindness-and-code-reviews-improving-the-way-we-give-feedback)
+* [Code Review Guidelines for Humans: Examples of good and back feedback](https://phauer.com/2018/code-review-guidelines/#code-reviews-guidelines-for-the-reviewer)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+OVNKubernetes repo uses the [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) which does automatic security updates by scanning the repo and opening PRs to update the effected libraries.
+
+## Reporting a Vulnerability
+
+To report a vulnerability, please use the [Private Vulnerability Reporting Feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+on GitHub. We will endevour to respond within 48hrs of reporting.
+If a vulnerability is reported but considered low priority it may be converted into an issue and handled on the public issue tracker.
+Should a vulnerability be considered severe we will endeavour to patch it within 48hrs of acceptance, and may ask for you to collaborate with us on a temporary private fork of the repository.

--- a/community-meeting-info.md
+++ b/community-meeting-info.md
@@ -1,5 +1,0 @@
- 
-**Community meeting:** Every alternate Monday starting May 15th, 2023 at 10AM US
-Pacific time. Location: https://meet.google.com/tgr-pqke-cen
-
-**Agenda and discussion document:** https://docs.google.com/document/d/1ciZS1CajH07THAiH_9j4-6uX4HAJFEoUzwyRdjsQK1k - edit responsibly


### PR DESCRIPTION

**- What this PR does and why is it needed**

Strictly follows the guidelines mentioned in https://contribute.cncf.io/maintainers/templates/ and all templates are copied from there.

**- Special notes for reviewers**

Must get approval from all maintainers: @girishmg @trozet @jcaamano @dcbw 
`SECURITY.md` file is not complete ATM, will get back to this round2.

**- How to verify it**
N/A

**- Description for the changelog**
N/A