### PR TITLE
Move custom conntrack zones to the config package

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -216,6 +216,12 @@ type DefaultConfig struct {
 	// that are initiated from the pods so that the reverse connections go back to the pods.
 	// This represents the conntrack zone used for the conntrack flow rules.
 	ConntrackZone int `gcfg:"conntrack-zone"`
+	// HostMasqConntrackZone is an unexposed config with the value of ConntrackZone+1
+	HostMasqConntrackZone int
+	// OVNMasqConntrackZone is an unexposed config with the value of ConntrackZone+2
+	OVNMasqConntrackZone int
+	// HostNodePortCTZone is an unexposed config with the value of ConntrackZone+3
+	HostNodePortConntrackZone int
 	// EncapType value defines the encapsulation protocol to use to transmit packets between
 	// hypervisors. By default the value is 'geneve'
 	EncapType string `gcfg:"encap-type"`
@@ -2053,6 +2059,9 @@ func completeDefaultConfig(allSubnets *configSubnets) error {
 		allSubnets.append(configSubnetCluster, subnet.CIDR)
 	}
 
+	Default.HostMasqConntrackZone = Default.ConntrackZone + 1
+	Default.OVNMasqConntrackZone = Default.ConntrackZone + 2
+	Default.HostNodePortConntrackZone = Default.ConntrackZone + 3
 	return nil
 }
 


### PR DESCRIPTION
This is a followup to 8bb2db42326ef2fe918644263d555dc3f39743a0 which missed setting the conntrack zone values in gateway modes other than shared.
Considering that the default conntrack zone is now configurable this PR makes all of the other values as unexposed config fields that are set when the config is parsed. 

/cc @tssurya @naserdean