### PR TITLE
Update codegen to explicitly set output-base 

### DIFF
--- a/dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
+++ b/dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: adminpolicybasedexternalroutes.k8s.ovn.org
 spec:
   group: k8s.ovn.org
@@ -26,21 +26,24 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: AdminPolicyBasedExternalRoute is a CRD allowing the cluster administrators
-          to configure policies for external gateway IPs to be applied to all the
-          pods contained in selected namespaces. Egress traffic from the pods that
-          belong to the selected namespaces to outside the cluster is routed through
-          these external gateway IPs.
+        description: |-
+          AdminPolicyBasedExternalRoute is a CRD allowing the cluster administrators to configure policies for external gateway IPs to be applied to all the pods contained in selected namespaces.
+          Egress traffic from the pods that belong to the selected namespaces to outside the cluster is routed through these external gateway IPs.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -60,25 +63,25 @@ spec:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -90,11 +93,10 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -110,12 +112,11 @@ spec:
                     description: DynamicHops defines a slices of DynamicHop. This
                       field is optional.
                     items:
-                      description: DynamicHop defines the configuration for a dynamic
-                        external gateway interface. These interfaces are wrapped around
-                        a pod object that resides inside the cluster. The field NetworkAttachmentName
-                        captures the name of the multus network name to use when retrieving
-                        the gateway IP to use. The PodSelector and the NamespaceSelector
-                        are mandatory fields.
+                      description: |-
+                        DynamicHop defines the configuration for a dynamic external gateway interface.
+                        These interfaces are wrapped around a pod object that resides inside the cluster.
+                        The field NetworkAttachmentName captures the name of the multus network name to use when retrieving the gateway IP to use.
+                        The PodSelector and the NamespaceSelector are mandatory fields.
                       properties:
                         bfdEnabled:
                           default: false
@@ -131,8 +132,8 @@ spec:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -140,17 +141,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -162,21 +162,18 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         networkAttachmentName:
                           default: ""
-                          description: NetworkAttachmentName determines the multus
-                            network name to use when retrieving the pod IPs that will
-                            be used as the gateway IP. When this field is empty, the
-                            logic assumes that the pod is configured with HostNetwork
-                            and is using the node's IP as gateway.
+                          description: |-
+                            NetworkAttachmentName determines the multus network name to use when retrieving the pod IPs that will be used as the gateway IP.
+                            When this field is empty, the logic assumes that the pod is configured with HostNetwork and is using the node's IP as gateway.
                           type: string
                         podSelector:
                           description: PodSelector defines the selector to filter
@@ -186,8 +183,8 @@ spec:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -195,17 +192,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -217,11 +213,10 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic

--- a/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: egressfirewalls.k8s.ovn.org
 spec:
   group: k8s.ovn.org
@@ -21,21 +21,27 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: EgressFirewall describes the current egress firewall for a Namespace.
-          Traffic from a pod to an IP address outside the cluster will be checked
-          against each EgressFirewallRule in the pod's namespace's EgressFirewall,
-          in order. If no rule matches (or no EgressFirewall is present) then the
-          traffic will be allowed by default.
+        description: |-
+          EgressFirewall describes the current egress firewall for a Namespace.
+          Traffic from a pod to an IP address outside the cluster will be checked against
+          each EgressFirewallRule in the pod's namespace's EgressFirewall, in
+          order. If no rule matches (or no EgressFirewall is present) then the traffic
+          will be allowed by default.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -93,16 +99,16 @@ spec:
                           pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
                           type: string
                         nodeSelector:
-                          description: nodeSelector will allow/deny traffic to the
-                            Kubernetes node IP of selected nodes. If this is set,
+                          description: |-
+                            nodeSelector will allow/deny traffic to the Kubernetes node IP of selected nodes. If this is set,
                             cidrSelector and DNSName must be unset.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -110,17 +116,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -132,11 +137,10 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic

--- a/dist/templates/k8s.ovn.org_egressips.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressips.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: egressips.k8s.ovn.org
 spec:
   group: k8s.ovn.org
@@ -29,19 +29,25 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: EgressIP is a CRD allowing the user to define a fixed source
-          IP for all egress traffic originating from any pods which match the EgressIP
-          resource according to its spec definition.
+        description: |-
+          EgressIP is a CRD allowing the user to define a fixed
+          source IP for all egress traffic originating from any pods which
+          match the EgressIP resource according to its spec definition.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -49,37 +55,39 @@ spec:
             description: Specification of the desired behavior of EgressIP.
             properties:
               egressIPs:
-                description: EgressIPs is the list of egress IP addresses requested.
-                  Can be IPv4 and/or IPv6. This field is mandatory.
+                description: |-
+                  EgressIPs is the list of egress IP addresses requested. Can be IPv4 and/or IPv6.
+                  This field is mandatory.
                 items:
                   type: string
                 type: array
               namespaceSelector:
-                description: NamespaceSelector applies the egress IP only to the namespace(s)
-                  whose label matches this definition. This field is mandatory.
+                description: |-
+                  NamespaceSelector applies the egress IP only to the namespace(s) whose label
+                  matches this definition. This field is mandatory.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -92,45 +100,45 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               podSelector:
-                description: 'PodSelector applies the egress IP only to the pods whose
-                  label matches this definition. This field is optional, and in case
-                  it is not set: results in the egress IP being applied to all pods
-                  in the namespace(s) matched by the NamespaceSelector. In case it
-                  is set: is intersected with the NamespaceSelector, thus applying
-                  the egress IP to the pods (in the namespace(s) already matched by
-                  the NamespaceSelector) which match this pod selector.'
+                description: |-
+                  PodSelector applies the egress IP only to the pods whose label
+                  matches this definition. This field is optional, and in case it is not set:
+                  results in the egress IP being applied to all pods in the namespace(s)
+                  matched by the NamespaceSelector. In case it is set: is intersected with
+                  the NamespaceSelector, thus applying the egress IP to the pods
+                  (in the namespace(s) already matched by the NamespaceSelector) which
+                  match this pod selector.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -143,11 +151,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic

--- a/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: egressqoses.k8s.ovn.org
 spec:
   group: k8s.ovn.org
@@ -17,21 +17,27 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: EgressQoS is a CRD that allows the user to define a DSCP value
-          for pods egress traffic on its namespace to specified CIDRs. Traffic from
-          these pods will be checked against each EgressQoSRule in the namespace's
-          EgressQoS, and if there is a match the traffic is marked with the relevant
-          DSCP value.
+        description: |-
+          EgressQoS is a CRD that allows the user to define a DSCP value
+          for pods egress traffic on its namespace to specified CIDRs.
+          Traffic from these pods will be checked against each EgressQoSRule in
+          the namespace's EgressQoS, and if there is a match the traffic is marked
+          with the relevant DSCP value.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -52,41 +58,42 @@ spec:
                       minimum: 0
                       type: integer
                     dstCIDR:
-                      description: DstCIDR specifies the destination's CIDR. Only
-                        traffic heading to this CIDR will be marked with the DSCP
-                        value. This field is optional, and in case it is not set the
-                        rule is applied to all egress traffic regardless of the destination.
+                      description: |-
+                        DstCIDR specifies the destination's CIDR. Only traffic heading
+                        to this CIDR will be marked with the DSCP value.
+                        This field is optional, and in case it is not set the rule is applied
+                        to all egress traffic regardless of the destination.
                       format: cidr
                       type: string
                     podSelector:
-                      description: PodSelector applies the QoS rule only to the pods
-                        in the namespace whose label matches this definition. This
-                        field is optional, and in case it is not set results in the
-                        rule being applied to all pods in the namespace.
+                      description: |-
+                        PodSelector applies the QoS rule only to the pods in the namespace whose label
+                        matches this definition. This field is optional, and in case it is not set
+                        results in the rule being applied to all pods in the namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -98,11 +105,10 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic

--- a/dist/templates/k8s.ovn.org_egressservices.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressservices.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: egressservices.k8s.ovn.org
 spec:
   group: k8s.ovn.org
@@ -17,22 +17,28 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: EgressService is a CRD that allows the user to request that the
-          source IP of egress packets originating from all of the pods that are endpoints
-          of the corresponding LoadBalancer Service would be its ingress IP. In addition,
-          it allows the user to request that egress packets originating from all of
-          the pods that are endpoints of the LoadBalancer service would use a different
+        description: |-
+          EgressService is a CRD that allows the user to request that the source
+          IP of egress packets originating from all of the pods that are endpoints
+          of the corresponding LoadBalancer Service would be its ingress IP.
+          In addition, it allows the user to request that egress packets originating from
+          all of the pods that are endpoints of the LoadBalancer service would use a different
           network than the main one.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -40,40 +46,40 @@ spec:
             description: EgressServiceSpec defines the desired state of EgressService
             properties:
               network:
-                description: The network which this service should send egress and
-                  corresponding ingress replies to. This is typically implemented
-                  as VRF mapping, representing a numeric id or string name of a routing
-                  table which by omission uses the default host routing.
+                description: |-
+                  The network which this service should send egress and corresponding ingress replies to.
+                  This is typically implemented as VRF mapping, representing a numeric id or string name
+                  of a routing table which by omission uses the default host routing.
                 type: string
               nodeSelector:
-                description: Allows limiting the nodes that can be selected to handle
-                  the service's traffic when sourceIPBy=LoadBalancerIP. When present
-                  only a node whose labels match the specified selectors can be selected
-                  for handling the service's traffic. When it is not specified any
-                  node in the cluster can be chosen to manage the service's traffic.
+                description: |-
+                  Allows limiting the nodes that can be selected to handle the service's traffic when sourceIPBy=LoadBalancerIP.
+                  When present only a node whose labels match the specified selectors can be selected
+                  for handling the service's traffic.
+                  When it is not specified any node in the cluster can be chosen to manage the service's traffic.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -86,22 +92,21 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               sourceIPBy:
-                description: Determines the source IP of egress traffic originating
-                  from the pods backing the LoadBalancer Service. When `LoadBalancerIP`
-                  the source IP is set to its LoadBalancer ingress IP. When `Network`
-                  the source IP is set according to the interface of the Network,
-                  leveraging the masquerade rules that are already in place. Typically
-                  these rules specify SNAT to the IP of the outgoing interface, which
-                  means the packet will typically leave with the IP of the node.
+                description: |-
+                  Determines the source IP of egress traffic originating from the pods backing the LoadBalancer Service.
+                  When `LoadBalancerIP` the source IP is set to its LoadBalancer ingress IP.
+                  When `Network` the source IP is set according to the interface of the Network,
+                  leveraging the masquerade rules that are already in place.
+                  Typically these rules specify SNAT to the IP of the outgoing interface,
+                  which means the packet will typically leave with the IP of the node.
                 enum:
                 - LoadBalancerIP
                 - Network
@@ -111,8 +116,9 @@ spec:
             description: EgressServiceStatus defines the observed state of EgressService
             properties:
               host:
-                description: The name of the node selected to handle the service's
-                  traffic. In case sourceIPBy=Network the field will be set to "ALL".
+                description: |-
+                  The name of the node selected to handle the service's traffic.
+                  In case sourceIPBy=Network the field will be set to "ALL".
                 type: string
             required:
             - host

--- a/go-controller/hack/update-codegen.sh
+++ b/go-controller/hack/update-codegen.sh
@@ -13,7 +13,7 @@ SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 olddir="${PWD}"
 builddir="$(mktemp -d)"
 cd "${builddir}"
-GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 BINS=(
     deepcopy-gen
     applyconfiguration-gen


### PR DESCRIPTION
for predictable output folder that doesn't depend on GOPATH.
Clean up generated folder after copying apis.
Specify code-generator version, as release-1.30 changes scripts parameters.
