### PR TITLE
Fix EgressIP initialization on IPv6 LGW clusters

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -115,7 +115,6 @@ if [ "$OVN_GATEWAY_MODE" == "local" ]; then
     fi
     SKIPPED_TESTS+="Should be allowed to node local host-networked endpoints by nodeport services|\
 EgressQoS validation|\
-e2e br-int flow monitoring export validation|\
 Should be allowed by nodeport services|\
 Should be allowed to node local cluster-networked endpoints by nodeport services with externalTrafficPolicy=local|\
 Should successfully create then remove a static pod|\


### PR DESCRIPTION
ovnkube-node fails here in ipv6 lgw clusters: https://github.com/ovn-org/ovn-kubernetes/blob/e5965ded4af0f0f6eb14cb7c2ada0713137ba4d5/go-controller/pkg/node/controllers/egressip/egressip.go#L287-L296
```
ovnkube.go:136] failed to run ovnkube: failed to start node network controller: failed to start default node network controller: failed to run egress IP controller: failed to create IP rule for node IPs: file exists 
```

This fails because in the current code the IP rule being added is always for ipv4.
Fix this by adding the rule with the appropriate family :family: 