### PR TITLE
TokenFile also has to be "" to fail new RestConfig

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -211,7 +211,7 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 		// uses the current context in kubeconfig
 		kconfig, err = clientcmd.BuildConfigFromFlags("", conf.Kubeconfig)
 	} else if strings.HasPrefix(conf.APIServer, "https") {
-		if (conf.Token == "" && conf.CertDir == "") || len(conf.CAData) == 0 {
+		if (conf.Token == "" && conf.TokenFile == "" && conf.CertDir == "") || len(conf.CAData) == 0 {
 			return nil, fmt.Errorf("TLS-secured apiservers require token/cert and CA certificate")
 		}
 		if _, err := cert.NewPoolFromBytes(conf.CAData); err != nil {


### PR DESCRIPTION
in the case that no Token && CertDir are "" (or empty CAData) we can still be ok if we have a TokenFile [0][1]

[0] https://github.com/ovn-org/ovn-kubernetes/blob/95c7a5eed5b6a3388b9d832dfdc9391d589b02b4/go-controller/vendor/k8s.io/client-go/rest/config.go#L74-L77
[1] https://github.com/ovn-org/ovn-kubernetes/blob/de6c98316ab8922b7940430239c3a849667b8064/go-controller/vendor/k8s.io/client-go/transport/round_trippers.go#L287