### PR TITLE
WIP: add Helm chart to deploy ovn-kubernetes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -702,3 +702,93 @@ jobs:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: /tmp/kind/logs
 
+  helm:
+    name: helm
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # Valid options are:
+        # ha: ["HA", "noHA"]
+        # ic: ["ic-disabled", "ic-single-node-zones", "ic-multi-node-zones"]
+        # num-workers : "<integer value>"
+        include:
+          - {"ha": "noHA", "ic": "ic-disabled", "num-workers": "3"}
+          - {"ha": "HA", "ic": "ic-disabled", "num-workers": "2"}
+    needs: [ build-pr ]
+    env:
+      USE_HELM: true
+      JOB_NAME: "helm-${{ matrix.ha }}-${{ matrix.ic }}-${{ matrix.num-workers }}workers"
+      OVN_HA: "${{ matrix.ha == 'HA' }}"
+      OVN_ENABLE_INTERCONNECT: "${{ matrix.ic == 'ic-single-node-zones' ||  matrix.ic == 'ic-multi-node-zones'}}"
+      KIND_NUM_WORKER: "${{ matrix.num-workers }}"
+    steps:
+
+    - name: Free up disk space
+      run: |
+        sudo rm -rf /usr/local/lib/android/sdk
+        sudo apt-get update
+        sudo eatmydata apt-get purge --auto-remove -y \
+          azure-cli aspnetcore-* dotnet-* ghc-* firefox \
+          google-chrome-stable \
+          llvm-* microsoft-edge-stable mono-* \
+          msbuild mysql-server-core-* php-* php7* \
+          powershell temurin-* zulu-*
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: "**/*.sum"
+      id: go
+
+    - name: Set up environment
+      run: |
+        export GOPATH=$(go env GOPATH)
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
+
+    - name: Disable ufw
+      # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
+      # Not needed for KIND deployments, so just disable all the time.
+      run: |
+        sudo ufw disable
+
+    - name: Download test-image-pr
+      uses: actions/download-artifact@v4
+      with:
+        name: test-image-pr
+
+    - name: Load docker image
+      run: |
+        docker load --input ${CI_IMAGE_PR_TAR} && rm -rf ${CI_IMAGE_PR_TAR}
+
+    - name: kind setup and deploy OVN via Helm
+      timeout-minutes: 30
+      run: |
+        export SKIP_OVN_IMAGE_REBUILD=true
+        export OVN_IMAGE="ovn-daemonset-f:pr"
+        make -C test install-kind
+
+    - name: Run Tests
+      timeout-minutes: 120
+      run: |
+        make -C test control-plane WHAT="test e2e inter-node connectivity between worker nodes"
+
+    - name: Export kind logs
+      if: always()
+      run: |
+        mkdir -p /tmp/kind/logs
+        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
+
+    - name: Upload kind logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: /tmp/kind/logs

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+set_default_params() {
+  # Set default values
+  export OVN_HA=${OVN_HA:-false}
+  export KIND_NUM_WORKER=${KIND_NUM_WORKER:-1}
+  export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
+  export OVN_IMAGE=${OVN_IMAGE:-'ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:helm'}
+
+  # Setup KUBECONFIG patch based on cluster-name
+  export KUBECONFIG=${KUBECONFIG:-${HOME}/${KIND_CLUSTER_NAME}.conf}
+}
+
+usage() {
+    echo "usage: kind-helm.sh [--delete]"
+    echo "       [ -ha | --ha-enabled ]"
+    echo "       [ -wk | --num-workers <num> ]"
+    echo "       [ -cn | --cluster-name ]"
+    echo "       [ -h ]"
+    echo ""
+    echo "--delete                            Delete current cluster"
+    echo "-ha  | --ha-enabled                 Enable high availability. DEFAULT: HA Disabled."
+    echo "-wk  | --num-workers                Number of worker nodes. DEFAULT: 1 worker"
+    echo "-cn  | --cluster-name               Configure the kind cluster's name"
+    echo "                                    nodes and no HA - 0 worker nodes."
+
+}
+
+parse_args() {
+    while [ "$1" != "" ]; do
+        case $1 in
+            --delete )                          delete
+                                                exit
+                                                ;;
+            -ha | --ha-enabled )                OVN_HA=true
+                                                ;;
+            -wk | --num-workers )               shift
+                                                if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+                                                    echo "Invalid num-workers: $1"
+                                                    usage
+                                                    exit 1
+                                                fi
+                                                KIND_NUM_WORKER=$1
+                                                ;;
+            -cn | --cluster-name )              shift
+                                                KIND_CLUSTER_NAME=$1
+                                                # Setup KUBECONFIG
+                                                set_default_params
+                                                ;;
+            * )                                 usage
+                                                exit 1
+        esac
+        shift
+    done
+}
+
+print_params() {
+     echo "Using these parameters to deploy KIND + helm"
+     echo ""
+     echo "KUBECONFIG = $KUBECONFIG"
+     echo "KIND_CLUSTER_NAME = $KIND_CLUSTER_NAME"
+     echo ""
+}
+
+command_exists() {
+  cmd="$1"
+  command -v ${cmd} >/dev/null 2>&1
+}
+
+check_dependencies() {
+    for cmd in docker kubectl kind helm go ; do \
+         if ! command_exists $cmd ; then
+           2&>1 echo "Dependency not met: $cmd"
+           exit 1
+        fi
+    done
+}
+
+helm_prereqs() {
+    # increate fs.inotify.max_user_watches
+    sudo sysctl fs.inotify.max_user_watches=524288
+    # increase fs.inotify.max_user_instances
+    sudo sysctl fs.inotify.max_user_instances=512
+}
+
+docker_disable_ipv6() {
+  # Docker disables IPv6 globally inside containers except in the eth0 interface.
+  # Kind enables IPv6 globally the containers ONLY for dual-stack and IPv6 deployments.
+  # Ovnkube-node tries to move all global addresses from the gateway interface to the
+  # bridge interface it creates. This breaks on KIND with IPv4 only deployments, because the new
+  # internal bridge has IPv6 disable and can't move the IPv6 from the eth0 interface.
+  # We can enable IPv6 always in the container, since the docker setup with IPv4 only
+  # is not very common.
+  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}" | grep -v external-load-balancer)
+  for n in $KIND_NODES; do
+    docker exec "$n" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
+    docker exec "$n" sysctl --ignore net.ipv6.conf.all.forwarding=1
+  done
+}
+
+build_ovn_image() {
+    if [ "${SKIP_OVN_IMAGE_REBUILD}" == "true" ]; then
+      echo "Explicitly instructed not to rebuild ovn image: ${OVN_IMAGE}"
+      return
+    fi
+
+    # Build ovn image
+    pushd ${SCRIPT_DIR}/../go-controller
+    make
+    popd
+
+    # Build ovn kube image
+    pushd ${SCRIPT_DIR}/../dist/images
+    # Find all built executables, but ignore the 'windows' directory if it exists
+    find ../../go-controller/_output/go/bin/ -maxdepth 1 -type f -exec cp -f {} . \;
+    echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
+    docker build -t "${OVN_IMAGE}" -f Dockerfile.fedora .
+    popd
+}
+
+get_image() {
+    local image_and_tag="${1:-$OVN_IMAGE}"  # Use $1 if provided, otherwise use $OVN_IMAGE
+    local image="${image_and_tag%%:*}"  # Extract everything before the first colon
+    echo "$image"
+}
+
+get_tag() {
+    local image_and_tag="${1:-$OVN_IMAGE}"  # Use $1 if provided, otherwise use $OVN_IMAGE
+    local tag="${image_and_tag##*:}"  # Extract everything after the last colon
+    echo "$tag"
+}
+
+coredns_patch() {
+  dns_server="8.8.8.8"
+  # No need for ipv6 nameserver for dual stack, it will ask for
+  # A and AAAA records
+  if [ "$IP_FAMILY" == "ipv6" ]; then
+    dns_server="2001:4860:4860::8888"
+  fi
+
+  # Patch CoreDNS to work
+  # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
+  # to work in an offline environment:
+  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
+  # 2. Github CI adds following domains to resolv.conf search field:
+  # .net.
+  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
+  # otherwise pods stops trying to resolve the domain.
+  # Get the current config
+  original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
+  echo "Original CoreDNS config:"
+  echo "${original_coredns}"
+  # Patch it
+  fixed_coredns=$(
+    printf '%s' "${original_coredns}" | sed \
+      -e 's/^.*kubernetes cluster\.local/& net/' \
+      -e '/^.*upstream$/d' \
+      -e '/^.*fallthrough.*$/d' \
+      -e 's/^\(.*forward \.\).*$/\1 '"$dns_server"' {/' \
+      -e '/^.*loop$/d' \
+  )
+  echo "Patched CoreDNS config:"
+  echo "${fixed_coredns}"
+  printf '%s' "${fixed_coredns}" | kubectl apply -f -
+}
+
+create_kind_cluster() {
+# Fetch the number of worker nodes and HA status from environment variables
+    kind_num_worker="${KIND_NUM_WORKER:-1}"  # Default to 1 if not set
+    ovn_ha="${OVN_HA:-false}"  # Default to false if not set
+
+    # Start of the kind configuration
+    kind_cluster_name=ovn-helm
+    cat <<EOT > /tmp/kind.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+EOT
+
+    # Add control-plane nodes based on OVN_HA status
+    echo "- role: control-plane" >> /tmp/kind.yaml  # Add a single control-plane node if not HA
+    if [ "$ovn_ha" = true ]; then
+        for i in {2..3}; do  # Add 3 control-plane nodes for HA
+            echo "- role: control-plane" >> /tmp/kind.yaml
+        done
+    fi
+
+    # Add worker nodes based on KIND_NUM_WORKER
+    for i in $(seq 1 $kind_num_worker); do
+        echo "- role: worker" >> /tmp/kind.yaml
+    done
+
+    # Add networking configuration
+    cat <<EOT >> /tmp/kind.yaml
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: none
+EOT
+
+    kind delete clusters $KIND_CLUSTER_NAME ||:
+    kind create cluster --name $KIND_CLUSTER_NAME --config /tmp/kind.yaml
+    kind load docker-image --name $KIND_CLUSTER_NAME $OVN_IMAGE
+
+    # When using HA, label controller nodes to host db
+    [ "${OVN_HA}" = "false" ] || \
+      kubectl label nodes k8s.ovn.org/ovnkube-db=true --overwrite \
+        -l node-role.kubernetes.io/control-plane
+}
+
+create_ovn_kubernetes() {
+    cd ${SCRIPT_DIR}/../helm/ovn-kubernetes
+
+    helm install ovn-kubernetes . -f values.yaml \
+        --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" \
+        --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) \
+        --set global.image.repository=$(get_image) \
+        --set global.image.tag=$(get_tag) \
+        --set tags.ovnkube-db-raft=$(if [ "${OVN_HA}" = "true" ]; then echo "true"; else echo "false"; fi) \
+        --set tags.ovnkube-db=$(if [ "${OVN_HA}" = "false" ]; then echo "true"; else echo "false"; fi)
+}
+
+delete() {
+  helm uninstall ovn-kubernetes && sleep 5 ||:
+  kind delete cluster --name "${KIND_CLUSTER_NAME:-ovn}"
+}
+
+coredns_patch() {
+  dns_server="8.8.8.8"
+  # No need for ipv6 nameserver for dual stack, it will ask for 
+  # A and AAAA records
+  if [ "$IP_FAMILY" == "ipv6" ]; then
+    dns_server="2001:4860:4860::8888"
+  fi
+
+  # Patch CoreDNS to work
+  # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
+  # to work in an offline environment:
+  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
+  # 2. Github CI adds following domains to resolv.conf search field:
+  # .net.
+  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
+  # otherwise pods stops trying to resolve the domain.
+  # Get the current config
+  original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
+  echo "Original CoreDNS config:"
+  echo "${original_coredns}"
+  # Patch it
+  fixed_coredns=$(
+    printf '%s' "${original_coredns}" | sed \
+      -e 's/^.*kubernetes cluster\.local/& net/' \
+      -e '/^.*upstream$/d' \
+      -e '/^.*fallthrough.*$/d' \
+      -e 's/^\(.*forward \.\).*$/\1 '"$dns_server"' {/' \
+      -e '/^.*loop$/d' \
+  )
+  echo "Patched CoreDNS config:"
+  echo "${fixed_coredns}"
+  printf '%s' "${fixed_coredns}" | kubectl apply -f -
+}
+
+# kubectl_wait_pods will set a total timeout of 300s for IPv4 and 480s for IPv6. It will first wait for all
+# DaemonSets to complete with kubectl rollout. This command will block until all pods of the DS are actually up.
+# Next, it iterates over all pods in ovn-kubernetes namespace and waits for them to post "Ready".
+# Last, it will do the same with all pods in the kube-system namespace.
+kubectl_wait_pods() {
+  local OVN_TIMEOUT=300
+
+  # We will make sure that we timeout all commands at current seconds + the desired timeout.
+  endtime=$(( SECONDS + OVN_TIMEOUT ))
+
+  dss=$(kubectl -n ovn-kubernetes get daemonset --no-headers --sort-by=.metadata.name -o jsonpath='{.items[*].metadata.name}')
+  for ds in ${dss}; do
+    timeout=$(calculate_timeout ${endtime})
+    echo "Waiting for k8s to launch all ${ds} pods (timeout ${timeout})..."
+    kubectl rollout status daemonset -n ovn-kubernetes ${ds} --timeout ${timeout}s
+  done
+
+  pods=$(kubectl -n ovn-kubernetes get pod --no-headers --sort-by=.metadata.name -o jsonpath='{.items[*].metadata.name}')
+  for pod in ${pods}; do
+    timeout=$(calculate_timeout ${endtime})
+    echo "Waiting for k8s to create pod ${pod} (timeout ${timeout})..."
+    if ! kubectl wait pod ${pod} -n ovn-kubernetes --for condition=Ready --timeout=${timeout}s ; then
+        >&2 echo "pod $pod in the ovn-kubernetes namespace is not ready after time out"
+        kubectl get pods -A -o wide || true
+        exit 1
+    fi
+  done
+
+  timeout=$(calculate_timeout ${endtime})
+  if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=${timeout}s ; then
+    >&2 echo "some pods in the system are not running"
+    kubectl get pods -A -o wide || true
+    exit 1
+  fi
+}
+
+# calculate_timeout takes an absolute endtime in seconds (based on bash script runtime, see
+# variable $SECONDS) and calculates a relative timeout value. Should the calculated timeout
+# be <= 0, return one second.
+calculate_timeout() {
+  endtime=$1
+  timeout=$(( endtime - SECONDS ))
+  if [ ${timeout} -le 0 ]; then
+      timeout=1
+  fi
+  echo ${timeout}
+}
+
+check_dependencies
+set_default_params
+parse_args "$@"
+helm_prereqs
+build_ovn_image
+create_kind_cluster
+docker_disable_ipv6
+coredns_patch
+create_ovn_kubernetes
+kubectl_wait_pods

--- a/docs/multi-homing.md
+++ b/docs/multi-homing.md
@@ -102,7 +102,7 @@ spec:
 - `name` (string, required): the name of the network. This attribute is **not** namespaced.
 - `type` (string, required): "ovn-k8s-cni-overlay".
 - `topology` (string, required): "layer2".
-  `subnets` (string, optional): a comma separated list of subnets. When multiple subnets
+- `subnets` (string, optional): a comma separated list of subnets. When multiple subnets
   are provided, the user will get an IP from each subnet.
 - `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 - `netAttachDefName` (string, required): must match `<namespace>/<net-attach-def name>`
@@ -301,4 +301,3 @@ OVN-K currently does **not** support:
 - the same attachment configured multiple times in the same pod - i.e.
   `k8s.v1.cni.cncf.io/networks: l3-network,l3-network` is invalid.
 - updates to the network selection elements lists - i.e. `k8s.v1.cni.cncf.io/networks` annotation
-- layer2 and localnet secondary networks when Interconnect feature is enabled with multiple zones.

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -211,7 +211,7 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 		// uses the current context in kubeconfig
 		kconfig, err = clientcmd.BuildConfigFromFlags("", conf.Kubeconfig)
 	} else if strings.HasPrefix(conf.APIServer, "https") {
-		if (conf.Token == "" && conf.CertDir == "") || len(conf.CAData) == 0 {
+		if (conf.Token == "" && conf.TokenFile == "" && conf.CertDir == "") || len(conf.CAData) == 0 {
 			return nil, fmt.Errorf("TLS-secured apiservers require token/cert and CA certificate")
 		}
 		if _, err := cert.NewPoolFromBytes(conf.CAData); err != nil {

--- a/helm/basic-deploy.sh
+++ b/helm/basic-deploy.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+ 
+# check docker
+docker info >/dev/null 2>&1
+if [ "$?" -eq 127 ]; then
+    echo "docker not found"
+    exit
+fi
+
+# check kubectl
+kubectl cluster-info >/dev/null 2>&1
+if [ "$?" -eq 127 ]; then
+    echo "kubectl not found"
+    exit
+fi
+
+# check kind
+kind version >/dev/null 2>&1
+if [ "$?" -eq 127 ]; then
+    echo "kind not found"
+    exit
+fi
+
+# check go
+go version >/dev/null 2>&1
+if [ "$?" -eq 127 ]; then
+    echo "go not found"
+    exit
+fi
+
+# Ensure that kind network does not have ip6 enabled
+enabled_ipv6=$(docker network inspect kind -f '{{.EnableIPv6}}' 2>/dev/null)
+[ "${enabled_ipv6}" = "false" ] || {
+   docker network rm kind 2>/dev/null || :
+   docker network create kind -o "com.docker.network.bridge.enable_ip_masquerade"="true" -o "com.docker.network.driver.mtu"="1500"
+}
+[ "${enabled_ipv6}" = "false" ] || { 2&>1 echo the kind network is not what we expected ; exit 1; }
+
+set -euxo pipefail
+# increate fs.inotify.max_user_watches
+sudo sysctl fs.inotify.max_user_watches=524288
+# increase fs.inotify.max_user_instances
+sudo sysctl fs.inotify.max_user_instances=512
+# build image
+cd ../dist/images
+make ubuntu
+docker tag ovn-kube-u:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+# create a cluster, with 1 controller and 1 worker node
+kind_cluster_name=ovn-helm
+cat <<EOT > /tmp/kind.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: none
+EOT
+kind delete clusters $kind_cluster_name
+kind create cluster --name $kind_cluster_name --config /tmp/kind.yaml
+kind load docker-image --name $kind_cluster_name ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+cd ../../helm/ovn-kubernetes
+helm install ovn-kubernetes . -f values.yaml \
+    --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" \
+    --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) \
+    --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u --set global.image.tag=master

--- a/helm/ovn-kubernetes/.helmignore
+++ b/helm/ovn-kubernetes/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/ovn-kubernetes/Chart.yaml
+++ b/helm/ovn-kubernetes/Chart.yaml
@@ -1,0 +1,60 @@
+apiVersion: v2
+name: ovn-kubernetes
+description: Helm chart to deploy ovn-kubernetes cni
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+home: https://www.ovn.org/
+icon: https://www.ovn.org/images/ovn-logo.png
+sources:
+  - https://github.com/ovn-org/ovn-kubernetes
+  - https://github.com/ovn-org/ovn
+dependencies:
+  - name: ovn-ipsec
+    version: 0.1.0
+    tags:
+      - ovn-ipsec
+  - name: ovnkube-control-plane
+    version: 0.1.0
+    tags:
+      - ovnkube-control-plane
+  - name: ovnkube-db
+    version: 0.1.0
+    tags:
+      - ovnkube-db
+  - name: ovnkube-db-raft
+    version: 0.1.0
+    tags:
+      - ovnkube-db-raft
+  - name: ovnkube-identity
+    version: 0.1.0
+    tags:
+      - ovnkube-identity
+  - name: ovnkube-master
+    version: 0.1.0
+    tags:
+      - ovnkube-master
+  - name: ovnkube-node
+    version: 0.1.0
+    tags:
+      - ovnkube-node
+  - name: ovnkube-node-dpu
+    version: 0.1.0
+    tags:
+      - ovnkube-node-dpu
+  - name: ovnkube-node-dpu-host
+    version: 0.1.0
+    tags:
+      - ovnkube-node-dpu-host
+  - name: ovnkube-single-node-zone
+    version: 0.1.0
+    tags:
+      - ovnkube-single-node-zone
+  - name: ovnkube-zone-controller
+    version: 0.1.0
+    tags:
+      - ovnkube-zone-controller
+  - name: ovs-node
+    version: 0.1.0
+    tags:
+      - ovs-node

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -1,0 +1,661 @@
+# ovn-kubernetes
+
+-----------------------
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+
+**Homepage:** <https://www.ovn.org/>
+
+## Source Code
+
+* <https://github.com/ovn-org/ovn-kubernetes>
+* <https://github.com/ovn-org/ovn>
+
+## Introduction
+
+This helm chart supports deploying OVN K8s CNI in a K8s cluster.
+
+Open Virtual Networking (OVN) Kubernetes CNI is an open source networking and
+network security solution for Kubernetes workloads. It leverages a distributed
+OVN SDN control plane and per-node Open vSwitch (OVS) to provide network
+virtualization and network connectivity to K8s Pods. It does so by creating a logical
+network topology using logical constructs such as logical switches (Layer 2) and
+logical routers (Layer 3). The Pod interfaces are represented by logical ports on
+the logical switches. On these logical switch ports, one can specify IP network
+information (IP address and MAC address), anti-spoofing rules (MAC and IP),
+Security Groups, QoS configuration, and so on.
+
+A port, either physical SR-IOV VF or virtual VETH, assigned to a Pod will be associated
+with a corresponding logical port, this will result in applying all the logical port
+configuration onto the physical port. The logical port becomes the API for
+configuring the physical port.
+
+In addition to providing overlay network connectivity for Pods in the K8s cluster,
+OVN K8s CNI supports a plethora of advanced networking features, such as
+
+```
+- Optimized and Accelerated K8s Network Policy on Pod's traffic
+- Optimized and Accelerated K8s Service Implementation (aka Load Balancers and NAT)
+- Optimized and Accelerated Policy Based Routing
+- Multi-Home Pods with an option for Secondary networks to be on a Layer-2
+  Overlay (flat network), Layer-2 Underlay (VLAN-based) on private or public
+  subnets.
+- Optimized and Accelerated K8s Network Policy on Pod's secondary networks
+```
+
+Most of these services are distributed and implemented via a pipeline (series
+of OpenFlow tables with OpenFlow flows) on local OVS switches. These OVS
+pipelines are very amenable to offloading to NIC hardware, which should result
+in the best possible networking performance and CPU savings on the host.
+
+The OVN K8s CNI architecture is a layered architecture with OVS at the bottom,
+followed by OVN, and finally OVN K8s CNI at the top. Each layer has several
+K8s components - deployments, daemonsets, and statefulsets. Each component at
+every layer is a subchart by itself. Based on the deployment needs, all or
+some of these subcharts are installed to provide the aforementioned OVN K8s
+CNI features, this can be done by editing `tags` section in values.yaml file.
+
+## Quickstart:
+Run script `helm/basic-deploy.sh` to set up a basic OVN/Kubernetes cluster.
+
+## Manual steps:
+- Disable IPv6 of `kind` docker network, otherwise ovnkube-node will fail to start
+```
+# docker network rm kind (delete `kind` network if it already exists)
+# docker network create kind -o "com.docker.network.bridge.enable_ip_masquerade"="true" -o "com.docker.network.driver.mtu"="1500"
+```
+
+- Launch a Kind cluster without CNI and kubeproxy (additional controle-plane or worker nodes can be added)
+```
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: none
+```
+
+- Optional: build local image and load it into Kind nodes
+```
+# cd dist/images
+# make ubuntu
+# docker tag ovn-kube-u:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+```
+
+- Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
+```
+# cd helm/ovn-kubernetes
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u --set global.image.tag=master
+```
+
+## Notes:
+- Only following scenarios were tested with Kind cluster
+  - ovs-node + ovnkube-node + ovnkube-db + ovnkube-master, with/without ovnkube-identity
+  - ovs-node + ovnkube-node + ovnkube-db-raft + ovnkube-master, with/without ovnkube-identity
+
+Following section describes the meaning of the values.
+
+## Values
+
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td>global.aclLoggingRateLimit</td>
+			<td>int</td>
+			<td><pre lang="json">
+20
+</pre>
+</td>
+			<td>The largest number of messages per second that gets logged before drop @default 20</td>
+		</tr>
+		<tr>
+			<td>global.disableForwarding</td>
+			<td>string</td>
+			<td><pre lang="">
+false
+</pre>
+</td>
+			<td>Controls if forwarding is allowed on OVNK controlled interfaces</td>
+		</tr>
+		<tr>
+			<td>global.disableIfaceIdVer</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Deprecated: iface-id-ver is always enabled</td>
+		</tr>
+		<tr>
+			<td>global.disablePacketMtuCheck</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Disables adding openflow flows to check packets too large to be delivered to OVN due to pod MTU being lower than NIC MTU</td>
+		</tr>
+		<tr>
+			<td>global.disableSnatMultipleGws</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws</td>
+		</tr>
+		<tr>
+			<td>global.egressIpHealthCheckPort</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Configure EgressIP node reachability using gRPC on this TCP port</td>
+		</tr>
+		<tr>
+			<td>global.emptyLbEvents</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>If set, then load balancers do not get deleted when all backends are removed</td>
+		</tr>
+		<tr>
+			<td>global.enableAdminNetworkPolicy</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Whether or not to use Admin Network Policy CRD feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
+			<td>global.enableCompactMode</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Indicate if ovnkube run master and node in one process</td>
+		</tr>
+		<tr>
+			<td>global.enableConfigDuration</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Enables monitoring OVN-Kubernetes master and OVN configuration duration</td>
+		</tr>
+		<tr>
+			<td>global.enableEgressFirewall</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Configure to use EgressFirewall CRD feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
+			<td>global.enableEgressIp</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Configure to use EgressIP CRD feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
+			<td>global.enableEgressQos</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Configure to use EgressQoS CRD feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
+			<td>global.enableEgressService</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Configure to use EgressService CRD feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
+			<td>global.enableHybridOverlay</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Whether or not to enable hybrid overlay functionality</td>
+		</tr>
+		<tr>
+			<td>global.enableInterConnect</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Configure to enable interconnecting multiple zones</td>
+		</tr>
+		<tr>
+			<td>global.enableIpsec</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Configure to enable IPsec</td>
+		</tr>
+		<tr>
+			<td>global.enableLFlowCache</td>
+			<td>bool</td>
+			<td><pre lang="">
+true
+</pre>
+</td>
+			<td>Indicates if ovn-controller should enable/disable the logical flow in-memory cache when processing Southbound database logical flow changes</td>
+		</tr>
+		<tr>
+			<td>global.enableMetricsScale</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Enables metrics related to scaling</td>
+		</tr>
+		<tr>
+			<td>global.enableMultiExternalGateway</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Configure to use AdminPolicyBasedExternalRoute CRD feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
+			<td>global.enableMultiNetwork</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
+			<td>global.enableMulticast</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Enables multicast support between the pods within the same namespace</td>
+		</tr>
+		<tr>
+			<td>global.enableOvnKubeIdentity</td>
+			<td>bool</td>
+			<td><pre lang="json">
+true
+</pre>
+</td>
+			<td>Whether or not enable ovnkube identity webhook</td>
+		</tr>
+		<tr>
+			<td>global.enableSsl</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Use SSL transport to NB/SB db and northd</td>
+		</tr>
+		<tr>
+			<td>global.enableStatelessNetworkPolicy</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Configure to use stateless network policy feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
+			<td>global.encapPort</td>
+			<td>int</td>
+			<td><pre lang="json">
+6081
+</pre>
+</td>
+			<td>GENEVE UDP port (default 6081)</td>
+		</tr>
+		<tr>
+			<td>global.extGatewayNetworkInterface</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>The interface on nodes that will be used for external gateway network traffic</td>
+		</tr>
+		<tr>
+			<td>global.gatewayMode</td>
+			<td>string</td>
+			<td><pre lang="json">
+"shared"
+</pre>
+</td>
+			<td>The gateway mode (shared or local), if not given, gateway functionality is disabled</td>
+		</tr>
+		<tr>
+			<td>global.gatewayOpts</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Optional extra gateway options</td>
+		</tr>
+		<tr>
+			<td>global.hybridOverlayNetCidr</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>A comma separated set of IP subnets and the associated hostsubnetlengths (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\") to use with the extended hybrid network</td>
+		</tr>
+		<tr>
+			<td>global.image.pullPolicy</td>
+			<td>string</td>
+			<td><pre lang="json">
+"IfNotPresent"
+</pre>
+</td>
+			<td>Image pull policy</td>
+		</tr>
+		<tr>
+			<td>global.image.repository</td>
+			<td>string</td>
+			<td><pre lang="json">
+"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u"
+</pre>
+</td>
+			<td>Image repository for ovn-kubernetes components</td>
+		</tr>
+		<tr>
+			<td>global.image.tag</td>
+			<td>string</td>
+			<td><pre lang="json">
+"master"
+</pre>
+</td>
+			<td>Specify image tag to run</td>
+		</tr>
+		<tr>
+			<td>global.ipfixCacheActiveTimeout</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Maximum period in seconds for which an IPFIX flow record is cached and aggregated before being sent @default 60</td>
+		</tr>
+		<tr>
+			<td>global.ipfixCacheMaxFlows</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Maximum number of IPFIX flow records that can be cached at a time @default 0, meaning disabled</td>
+		</tr>
+		<tr>
+			<td>global.ipfixSampling</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Rate at which packets should be sampled and sent to each target collector @default 400</td>
+		</tr>
+		<tr>
+			<td>global.ipfixTargets</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>A comma separated set of IPFIX collectors to export flow data</td>
+		</tr>
+		<tr>
+			<td>global.lFlowCacheLimit</td>
+			<td>string</td>
+			<td><pre lang="">
+unlimited
+</pre>
+</td>
+			<td>Maximum number of logical flow cache entries ovn-controller may create when the logical flow cache is enabled</td>
+		</tr>
+		<tr>
+			<td>global.lFlowCacheLimitKb</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Maximum size of the logical flow cache (in KB) ovn-controller may create when the logical flow cache is enabled</td>
+		</tr>
+		<tr>
+			<td>global.libovsdbClientLogFile</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Separate log file for libovsdb client </td>
+		</tr>
+		<tr>
+			<td>global.monitorAll</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Enable monitoring all data from SB DB instead of conditionally monitoring the data relevant to this node only @default true</td>
+		</tr>
+		<tr>
+			<td>global.nbPort</td>
+			<td>int</td>
+			<td><pre lang="json">
+6641
+</pre>
+</td>
+			<td>Port of north bound ovsdb</td>
+		</tr>
+		<tr>
+			<td>global.netFlowTargets</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>A comma separated set of NetFlow collectors to export flow data</td>
+		</tr>
+		<tr>
+			<td>global.nodeMgmtPortNetdev</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>The net device to be used for management port, will be renamed to ovn-k8s-mp0 and used to allow host network services and pods to access k8s pod and service networks</td>
+		</tr>
+		<tr>
+			<td>global.ofctrlWaitBeforeClear</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>ovn-controller wait time in ms before clearing OpenFlow rules during start up @default 0</td>
+		</tr>
+		<tr>
+			<td>global.remoteProbeInterval</td>
+			<td>int</td>
+			<td><pre lang="json">
+100000
+</pre>
+</td>
+			<td>OVN remote probe interval in ms  @default 100000</td>
+		</tr>
+		<tr>
+			<td>global.sbPort</td>
+			<td>int</td>
+			<td><pre lang="json">
+6642
+</pre>
+</td>
+			<td>Port of south bound ovsdb</td>
+		</tr>
+		<tr>
+			<td>global.sflowTargets</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>A comma separated set of SFlow collectors to export flow data</td>
+		</tr>
+		<tr>
+			<td>global.unprivilegedMode</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>This allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin</td>
+		</tr>
+		<tr>
+			<td>global.v4JoinSubnet</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>The v4 join subnet used for assigning join switch IPv4 addresses</td>
+		</tr>
+		<tr>
+			<td>global.v4MasqueradeSubnet</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>The v4 masquerade subnet used for assigning masquerade IPv4 addresses</td>
+		</tr>
+		<tr>
+			<td>global.v6JoinSubnet</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>The v6 join subnet used for assigning join switch IPv6 addresses</td>
+		</tr>
+		<tr>
+			<td>global.v6MasqueradeSubnet</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>The v6 masquerade subnet used for assigning masquerade IPv6 addresses</td>
+		</tr>
+		<tr>
+			<td>k8sAPIServer</td>
+			<td>string</td>
+			<td><pre lang="json">
+"https://172.25.0.2:6443"
+</pre>
+</td>
+			<td>Endpoint of Kubernetes api server</td>
+		</tr>
+		<tr>
+			<td>mtu</td>
+			<td>int</td>
+			<td><pre lang="json">
+1400
+</pre>
+</td>
+			<td>MTU of network interface in a Kubernetes pod</td>
+		</tr>
+		<tr>
+			<td>ovnkube-identity.replicas</td>
+			<td>int</td>
+			<td><pre lang="json">
+1
+</pre>
+</td>
+			<td>number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes</td>
+		</tr>
+		<tr>
+			<td>podNetwork</td>
+			<td>string</td>
+			<td><pre lang="json">
+"10.128.0.0/14/23"
+</pre>
+</td>
+			<td>IP range for Kubernetes pods, /14 is the top level range, under which each /23 range will be assigned to a node</td>
+		</tr>
+		<tr>
+			<td>serviceNetwork</td>
+			<td>string</td>
+			<td><pre lang="json">
+"172.30.0.0/16"
+</pre>
+</td>
+			<td>A comma-separated set of CIDR notation IP ranges from which k8s assigns service cluster IPs. This should be the same as the value provided for kube-apiserver "--service-cluster-ip-range" option</td>
+		</tr>
+		<tr>
+			<td>skipCallToK8s</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Whether or not call `lookup` Helm function, set it to `true` if you want to run `helm dry-run/template/lint`</td>
+		</tr>
+		<tr>
+			<td>tags</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "ovn-ipsec": false,
+  "ovnkube-control-plane": false,
+  "ovnkube-db-raft": false,
+  "ovnkube-node-dpu": false,
+  "ovnkube-node-dpu-host": false,
+  "ovnkube-single-node-zone": false,
+  "ovnkube-zone-controller": false
+}
+</pre>
+</td>
+			<td>list of dependent subcharts that need to be installed for the given deployment mode, these subcharts haven't been tested yet.</td>
+		</tr>
+	</tbody>
+</table>
+

--- a/helm/ovn-kubernetes/README.md.gotmpl
+++ b/helm/ovn-kubernetes/README.md.gotmpl
@@ -1,0 +1,98 @@
+{{ template "chart.header" . }}
+-----------------------
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+## Introduction
+
+This helm chart supports deploying OVN K8s CNI in a K8s cluster.
+
+Open Virtual Networking (OVN) Kubernetes CNI is an open source networking and
+network security solution for Kubernetes workloads. It leverages a distributed
+OVN SDN control plane and per-node Open vSwitch (OVS) to provide network
+virtualization and network connectivity to K8s Pods. It does so by creating a logical
+network topology using logical constructs such as logical switches (Layer 2) and
+logical routers (Layer 3). The Pod interfaces are represented by logical ports on
+the logical switches. On these logical switch ports, one can specify IP network
+information (IP address and MAC address), anti-spoofing rules (MAC and IP),
+Security Groups, QoS configuration, and so on.
+
+A port, either physical SR-IOV VF or virtual VETH, assigned to a Pod will be associated
+with a corresponding logical port, this will result in applying all the logical port
+configuration onto the physical port. The logical port becomes the API for
+configuring the physical port.
+
+In addition to providing overlay network connectivity for Pods in the K8s cluster,
+OVN K8s CNI supports a plethora of advanced networking features, such as
+
+```
+- Optimized and Accelerated K8s Network Policy on Pod's traffic
+- Optimized and Accelerated K8s Service Implementation (aka Load Balancers and NAT)
+- Optimized and Accelerated Policy Based Routing
+- Multi-Home Pods with an option for Secondary networks to be on a Layer-2
+  Overlay (flat network), Layer-2 Underlay (VLAN-based) on private or public
+  subnets.
+- Optimized and Accelerated K8s Network Policy on Pod's secondary networks
+```
+
+Most of these services are distributed and implemented via a pipeline (series
+of OpenFlow tables with OpenFlow flows) on local OVS switches. These OVS
+pipelines are very amenable to offloading to NIC hardware, which should result
+in the best possible networking performance and CPU savings on the host.
+
+The OVN K8s CNI architecture is a layered architecture with OVS at the bottom,
+followed by OVN, and finally OVN K8s CNI at the top. Each layer has several
+K8s components - deployments, daemonsets, and statefulsets. Each component at
+every layer is a subchart by itself. Based on the deployment needs, all or
+some of these subcharts are installed to provide the aforementioned OVN K8s
+CNI features, this can be done by editing `tags` section in values.yaml file.
+
+## Quickstart:
+Run script `helm/basic-deploy.sh` to set up a basic OVN/Kubernetes cluster.
+
+## Manual steps:
+- Disable IPv6 of `kind` docker network, otherwise ovnkube-node will fail to start
+```
+# docker network rm kind (delete `kind` network if it already exists)
+# docker network create kind -o "com.docker.network.bridge.enable_ip_masquerade"="true" -o "com.docker.network.driver.mtu"="1500"
+```
+
+- Launch a Kind cluster without CNI and kubeproxy (additional controle-plane or worker nodes can be added)
+```
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: none
+```
+
+- Optional: build local image and load it into Kind nodes
+```
+# cd dist/images
+# make ubuntu
+# docker tag ovn-kube-u:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+```
+
+- Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
+```
+# cd helm/ovn-kubernetes
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u --set global.image.tag=master
+```
+
+## Notes:
+- Only following scenarios were tested with Kind cluster
+  - ovs-node + ovnkube-node + ovnkube-db + ovnkube-master, with/without ovnkube-identity
+  - ovs-node + ovnkube-node + ovnkube-db-raft + ovnkube-master, with/without ovnkube-identity
+
+Following section describes the meaning of the values.
+{{ template "chart.valuesSectionHtml" . }}

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovn-ipsec
+description: Helm chart to deploy ovn ipsec
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
@@ -1,0 +1,274 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovn-ipsec
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn ipsec networking components for all nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovn-ipsec
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: ovn-ipsec
+        component: network
+        type: infra
+        openshift.io/component: network
+        kubernetes.io/os: "linux"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/dpu-host
+                operator: DoesNotExist
+      serviceAccountName: ovnkube-node
+      hostNetwork: true
+      dnsPolicy: Default
+      priorityClassName: "system-node-critical"
+      initContainers:
+      - name: ovn-keys
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -exuo pipefail
+
+          # Every time we restart this container, we will create a new key pair if
+          # we are close to key expiration or if we do not already have a signed key pair.
+          #
+          # Each node has a key pair which is used by OVS to encrypt/decrypt/authenticate traffic
+          # between each node. The CA cert is used as the root of trust for all certs so we need
+          # the CA to sign our certificate signing requests with the CA private key. In this way,
+          # we can validate that any signed certificates that we receive from other nodes are
+          # authentic.
+          echo "Configuring IPsec keys"
+
+          # If the certificate does not exist or it will expire in the next 6 months
+          # (15770000 seconds), we will generate a new one.
+          if [ ! -e /etc/openvswitch/keys/ipsec-cert.pem ] || [ ! openssl x509 -noout -dates -checkend 15770000 ];
+          then
+            # We use the system-id as the CN for our certificate signing request. This
+            # is a requirement by OVN.
+            cn=$(ovs-vsctl --retry -t 60 get Open_vSwitch . external-ids:system-id | tr -d "\"")
+
+            mkdir -p /etc/openvswitch/keys
+
+            # Generate an SSL private key and use the key to create a certitificate signing request
+            umask 077 && openssl genrsa -out /etc/openvswitch/keys/ipsec-privkey.pem 2048
+            openssl req -new -text \
+                        -extensions v3_req \
+                        -addext "subjectAltName = DNS:${cn}" \
+                        -subj "/C=US/O=ovnkubernetes/OU=kind/CN=${cn}" \
+                        -key /etc/openvswitch/keys/ipsec-privkey.pem \
+                        -out /etc/openvswitch/keys/ipsec-req.pem
+
+            csr_64=$(cat /etc/openvswitch/keys/ipsec-req.pem | base64 | tr -d "\n")
+
+            # The signer controller does not allow re-signing a key. We will
+            # delete the old key to be sure it is not there
+            kubectl delete --ignore-not-found=true csr/$(hostname)
+
+            # Request that our generated certificate signing request is
+            # signed by the "network.openshift.io/signer" signer that is
+            # implemented by the CNO signer controller. This will sign the
+            # certificate signing request using the signer-ca which has been
+            # set up by the OperatorPKI. In this way, we have a signed certificate
+            # and our private key has remained private on this host.
+            cat <<EOF | kubectl apply -f -
+            apiVersion: certificates.k8s.io/v1
+            kind: CertificateSigningRequest
+            metadata:
+              name: $(hostname)
+            spec:
+              request: ${csr_64}
+              signerName: network.openshift.io/signer
+              usages:
+              - ipsec tunnel
+          EOF
+
+            # Wait until the certificate signing request has been signed.
+            counter=0
+            until [ ! -z $(kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' 2>/dev/null) ]
+            do
+              counter=$((counter+1))
+              sleep 1
+              if [ $counter -gt 60 ];
+              then
+                      echo "Unable to sign certificate after $counter seconds"
+                      exit 1
+              fi
+            done
+
+            # Decode the signed certificate.
+            kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
+
+            kubectl delete csr/$(hostname)
+
+            # Get the CA certificate so we can authenticate peer nodes.
+            cat /signer-ca/ca-bundle.crt | openssl x509 -outform pem -text > /etc/openvswitch/keys/ipsec-cacert.pem
+          fi
+
+          # Configure OVS with the relevant keys for this node. This is required by ovs-monitor-ipsec.
+          #
+          # Updating the certificates does not need to be an atomic operation as
+          # the will get read and loaded into NSS by the ovs-monitor-ipsec process
+          # which has not started yet.
+          ovs-vsctl --retry -t 60 set Open_vSwitch . other_config:certificate=/etc/openvswitch/keys/ipsec-cert.pem \
+                                                     other_config:private_key=/etc/openvswitch/keys/ipsec-privkey.pem \
+                                                     other_config:ca_cert=/etc/openvswitch/keys/ipsec-cacert.pem
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /signer-ca
+          name: signer-ca
+        - mountPath: /etc/openvswitch
+          name: etc-openvswitch
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+      containers:
+      # ovs-monitor-ipsec and libreswan daemons
+      - name: ovn-ipsec
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -exuo pipefail
+
+          function cleanup()
+          {
+            # In order to maintain traffic flows during container restart, we
+            # need to ensure that xfrm state and policies are not flushed.
+
+            # Don't allow ovs monitor to cleanup persistent state
+            kill $(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null) 2>/dev/null || true
+            # Don't allow pluto to clear xfrm state and policies on exit
+            kill -9 $(cat /var/run/pluto/pluto.pid 2>/devnull) 2>/dev/null || true
+
+            /usr/sbin/ipsec --stopnflog
+            exit 0
+          }
+          trap cleanup SIGTERM
+
+          # Don't start IPsec until ovnkube-node has finished setting up the node
+          counter=0
+          until [ -f /etc/cni/net.d/10-ovn-kubernetes.conf ]
+          do
+            counter=$((counter+1))
+            sleep 1
+            if [ $counter -gt 300 ];
+            then
+                    echo "ovnkube-node pod has not started after $counter seconds"
+                    exit 1
+            fi
+          done
+          echo "ovnkube-node has configured node."
+
+          # After a restart of this container (or on initial startup), we flush xfrm state and policy
+          # before we start pluto and ovs-monitor-ipsec in order to start in a known good state. This
+          # will result in a small interruption in traffic until pluto and ovs-monitor-ipsec start again.
+          ip x s flush
+          ip x p flush
+
+          # Workaround for https://github.com/libreswan/libreswan/issues/373
+          ulimit -n 1024
+
+          /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
+          # Check kernel modules
+          /usr/libexec/ipsec/_stackmanager start
+          # Check nss database status
+          /usr/sbin/ipsec --checknss
+          # Start the pluto IKE daemon
+          /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --logfile /var/log/openvswitch/libreswan.log
+
+          # Start ovs-monitor-ipsec which will monitor for changes in the ovs
+          # tunnelling configuration (for example addition of a node) and configures
+          # libreswan appropriately.
+          # We are running this in the foreground so that the container will be restarted when ovs-monitor-ipsec fails.
+          # Upstream hack --ipsec-d for https://bugzilla.redhat.com/show_bug.cgi?id=1975039#c11
+          /usr/libexec/platform-python /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
+            --pidfile=/var/run/openvswitch/ovs-monitor-ipsec.pid --ike-daemon=libreswan --no-restart-ike-daemon \
+            --log-file --monitor unix:/var/run/openvswitch/db.sock \
+            --ipsec-d /var/lib/ipsec/nss
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        # To check that network setup is complete
+        - mountPath: /etc/cni/net.d
+          name: host-cni-netd
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /etc/openvswitch
+          name: etc-openvswitch
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              ipsec status
+          initialDelaySeconds: 15
+          periodSeconds: 60
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+          type: DirectoryOrCreate
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+          type: DirectoryOrCreate
+      - name: signer-ca
+        configMap:
+          name: signer-ca
+      - name: etc-openvswitch
+        hostPath:
+          path: /var/lib/openvswitch/etc
+          type: DirectoryOrCreate
+      - name: host-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/rbac.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ovn-kubernetes-csr-request
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovn-kubernetes-csr-request
+roleRef:
+  name: ovn-kubernetes-csr-request
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovnkube-node
+    namespace: ovn-kubernetes

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-control-plane
+description: Helm chart to deploy ovnkube-cluster-manager (only if interconnect is enabled)
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -1,0 +1,182 @@
+# ovnkube-control-plane
+# daemonset version 3
+# starts ovnkube-cluster-manager
+# it is run on the master(s).  Should be used only if interconnect is enabled.
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-control-plane
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This Deployment launches the ovn-kubernetes cluster manager networking component.
+spec:
+  progressDeadlineSeconds: 600
+  replicas: {{ default 1 .Values.replicas }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ovnkube-control-plane
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: ovnkube-control-plane
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovnkube-cluster-manager
+      hostNetwork: true
+      dnsPolicy: Default
+      # required to be scheduled on a linux node with node-role.kubernetes.io/control-plane label and
+      # only one instance of ovnkube-control-plane pod per node
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: In
+                    values:
+                      - ""
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+      containers:
+      - name: ovnkube-cluster-manager
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovn-cluster-manager"]
+        securityContext:
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: {{ default 4 .Values.logLevel | quote }}
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: {{ default 100 .Values.logFileMaxSize | quote }}
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: {{ default 5 .Values.logFileMaxBackups | quote }}
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: {{ default 5 .Values.logFileMaxAgent | quote }}
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+          value: {{ default "" .Values.global.enableConfigDuration | quote }}
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: {{ default "" .Values.global.enableHybridOverlay | quote }}
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: {{ default "" .Values.global.enableAdminNetworkPolicy | quote }}
+        - name: OVN_EGRESSIP_ENABLE
+          value: {{ default "" .Values.global.enableEgressIp | quote }}
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: {{ default "" .Values.global.enableEgressService | quote }}
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: {{ default "" .Values.global.enableEgressFirewall | quote }}
+        - name: OVN_EGRESSQOS_ENABLE
+          value: {{ default "" .Values.global.enableEgressQos | quote }}
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: {{ default "" .Values.disableSnatMultipleGws | quote }}
+        - name: OVN_EMPTY_LB_EVENTS
+          value: {{ default "" .Values.global.emptyLbEvents | quote }}
+        - name: OVN_V4_JOIN_SUBNET
+          value: {{ default "" .Values.global.v4JoinSubnet | quote }}
+        - name: OVN_V6_JOIN_SUBNET
+          value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_SSL_ENABLE
+          value: {{ hasKey .Values.global "enableSsl" | ternary .Values.global.enableSsl false | quote }}
+        - name: OVN_GATEWAY_MODE
+          value: {{ default "shared" .Values.global.gatewayMode }}
+        - name: OVN_MULTICAST_ENABLE
+          value: {{ default "" .Values.global.enableMulticast | quote }}
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: {{ default 20 .Values.global.aclLoggingRateLimit | quote }}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+        - name: OVN_ENABLE_INTERCONNECT
+          value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
+      # end of container
+      volumes:
+      # TODO: Need to check why we need this?
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -37,21 +37,9 @@ spec:
       serviceAccountName: ovnkube-cluster-manager
       hostNetwork: true
       dnsPolicy: Default
-      # required to be scheduled on a linux node with node-role.kubernetes.io/control-plane label and
-      # only one instance of ovnkube-control-plane pod per node
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: In
-                    values:
-                      - ""
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - "linux"
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       containers:
       - name: ovnkube-cluster-manager
         image: {{ include "getImage" . }}

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-cluster-manager
+    namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-cluster-manager
+roleRef:
+    name: ovnkube-cluster-manager
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-cluster-manager
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-cluster-manager-configmaps
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovn-k8s-configmap
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-cluster-manager
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-cluster-manager
+rules:
+    - apiGroups: [""]
+      resources:
+          - namespaces
+          - nodes
+          - pods
+          - services
+          - endpoints
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["discovery.k8s.io"]
+      resources:
+          - endpointslices
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - network-attachment-definitions
+          - multi-networkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressips
+          - egressservices
+          - adminpolicybasedexternalroutes
+          - egressfirewalls
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressips
+          - egressservices/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: [""]
+      resources:
+          - events
+      verbs: ["create", "patch", "update"]
+    - apiGroups: [""]
+      resources:
+          - pods/status # used in multi-homing: https://github.com/ovn-org/ovn-kubernetes/blob/a9beb6fd4f8ea32b264999a8ebec25cd6bdc2281/go-controller/pkg/util/pod.go#L49
+          - nodes/status
+          - services/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+        - adminpolicybasedexternalroutes/status
+        - egressfirewalls/status
+      verbs: [ "patch", "update" ]

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/values.yaml
@@ -1,0 +1,5 @@
+replicas: 1
+logLevel: 4
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/values.yaml
@@ -3,3 +3,27 @@ logLevel: 4
 logFileMaxSize: 100
 logFileMaxBackups: 5
 logFileMaxAge: 5
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Required to be scheduled on a linux node and only one instance of ovnkube-control-plane pod per node
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - "linux"
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: name
+          operator: In
+          values:
+          - ovnkube-control-plane
+      topologyKey: kubernetes.io/hostname

--- a/helm/ovn-kubernetes/charts/ovnkube-db-raft/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db-raft/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-db-raft
+description: Helm chart to build raft based ovnkube db
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/pdb.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/pdb.yaml
@@ -1,0 +1,12 @@
+# ovndb-raft PodDisruptBudget to prevent majority of ovnkube raft cluster
+# nodes from disruption
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ovndb-raft-pdb
+  namespace: ovn-kubernetes
+spec:
+  minAvailable: {{ div (add (default 3 .Values.replicas) 1) 2 }}
+  selector:
+    matchLabels:
+      name: ovnkube-db

--- a/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/service.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/service.yaml
@@ -1,0 +1,19 @@
+# service to expose the ovnkube-db pod
+apiVersion: v1
+kind: Service
+metadata:
+  name: ovnkube-db
+  namespace: ovn-kubernetes
+spec:
+  ports:
+  - name: north
+    port: {{ default 6641 .Values.global.nbPort }}
+    protocol: TCP
+    targetPort: {{ default 6641 .Values.global.nbPort }}
+  - name: south
+    port: {{ default 6642 .Values.global.sbPort }}
+    protocol: TCP
+    targetPort: {{ default 6642 .Values.global.sbPort }}
+  sessionAffinity: None
+  clusterIP: None
+  type: ClusterIP

--- a/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/statefulset.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db-raft/templates/statefulset.yaml
@@ -1,0 +1,291 @@
+# ovnkube-db raft statefulset
+# daemonset version 3
+# starts ovn NB/SB ovsdb daemons, each in a separate container
+#
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-db
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This statefulset launches the OVN Northbound/Southbound Database raft clusters.
+spec:
+  serviceName: ovnkube-db
+  podManagementPolicy: "Parallel"
+  replicas: {{ default 3 .Values.replicas }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ovnkube-db
+  template:
+    metadata:
+      labels:
+        ovn-db-pod: "true"
+        name: ovnkube-db
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      terminationGracePeriodSeconds: 30
+      imagePullSecrets:
+        - name: registry-credentials
+      serviceAccountName: ovnkube-db
+      hostNetwork: true
+      dnsPolicy: Default
+
+      # required to be scheduled on node with k8s.ovn.org/ovnkube-db=true label but can
+      # only have one instance per node
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: k8s.ovn.org/ovnkube-db
+                operator: In
+                values:
+                - "true"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - ovnkube-db
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      # nb-ovsdb - v3
+      - name: nb-ovsdb
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "nb-ovsdb-raft"]
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db-raft"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NB
+          value: {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: {{ default "" .Values.global.enableSsl | quote }}
+        - name: ENABLE_IPSEC
+          value: {{ hasKey .Values.global "enableIpsec" | ternary .Values.global.enableIpsec false | quote }}
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: {{ default 1000 .Values.nbElectionTimer | quote }}
+        - name: OVN_NB_PORT
+          value: {{ default 6641 .Values.global.nbPort | quote }}
+        - name: OVN_NB_RAFT_PORT
+          value: {{ default 6643 .Values.nbRaftPort | quote }}
+      # end of container
+
+      # sb-ovsdb - v3
+      - name: sb-ovsdb
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "sb-ovsdb-raft"]
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db-raft"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_SB
+          value: {{ default "-vconsole:info -vfile:info" .Values.sbLogLevel }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: {{ default "" .Values.enableSsl | quote }}
+        - name: OVN_SB_RAFT_ELECTION_TIMER
+          value: {{ default 1000 .Values.sbElectionTimer | quote }}
+        - name: OVN_SB_PORT
+          value: {{ default 6642 .Values.global.sbPort | quote }}
+        - name: OVN_SB_RAFT_PORT
+          value: {{ default 6644 .Values.sbRaftPort | quote }}
+      # end of container
+
+
+      # ovn-dbchecker - v3
+      - name: ovn-dbchecker
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovn-dbchecker"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: {{ default 4 .Values.dbCheckerLogLevel | quote }}
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: {{ default 100 .Values.logFileMaxSize | quote }}
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: {{ default 5 .Values.logFileMaxBackups | quote }}
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: {{ default 5 .Values.logFileMaxAge | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: {{ default "" .Values.global.enableSsl | quote }}
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: {{ default 1000 .Values.nbEletionTimer | quote }}
+        - name: OVN_NB_PORT
+          value: {{ default 6641 .Values.global.nbPort | quote }}
+        - name: OVN_NB_RAFT_PORT
+          value: {{ default 6643 .Values.nbRaftPort | quote }}
+      # end of container
+
+      volumes:
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-db-raft/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db-raft/values.yaml
@@ -1,0 +1,11 @@
+replicas: 3
+nbLogLevel: -vconsole:info -vfile:info
+nbRaftPort: 6643
+nbElectionTimer: 1000
+sbLogLevel: -vconsole:info -vfile:info
+sbRaftPort: 6644
+sbElectionTimer: 1000
+dbCheckerLogLevel: 4
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5

--- a/helm/ovn-kubernetes/charts/ovnkube-db/.helmignore
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/ovn-kubernetes/charts/ovnkube-db/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-db
+description: Helm chart for standalone ovnkube-db
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
@@ -171,9 +171,9 @@ spec:
 
       # end of container
 
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
-        kubernetes.io/os: "linux"
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       volumes:
       - name: host-var-lib-ovs
         hostPath:

--- a/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
@@ -1,0 +1,192 @@
+# ovnkube-db
+# daemonset version 3
+# starts ovn NB/SB ovsdb daemons, each in a separate container
+# it is running on master for now, but does not need to be the case
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-db
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemonset launches the OVN NB/SB ovsdb service components.
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ovnkube-db
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        ovn-db-pod: "true"
+        name: ovnkube-db
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovnkube-db
+      hostNetwork: true
+      dnsPolicy: Default
+      containers:
+      # firewall rules for ovn - assumed to be setup
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+
+      # nb-ovsdb - v3
+      - name: nb-ovsdb
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "nb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NB
+          value: {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_NB_PORT
+          value: {{ default 6641 .Values.global.nbPort | quote }}
+        - name: ENABLE_IPSEC
+          value: {{ hasKey .Values.global "enableIpsec" | ternary .Values.global.enableIpsec false | quote }}
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+      # sb-ovsdb - v3
+      - name: sb-ovsdb
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "sb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_SB
+          value: {{ default "-vconsole:info -vfile:info" .Values.sbLogLevel }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_SB_PORT
+          value: {{ default 6642 .Values.sbPort | quote }}
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+      # end of container
+
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+        kubernetes.io/os: "linux"
+      volumes:
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-db/templates/service.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/templates/service.yaml
@@ -1,0 +1,19 @@
+# service to expose the ovnkube-db pod
+apiVersion: v1
+kind: Service
+metadata:
+  name: ovnkube-db
+  namespace: ovn-kubernetes
+spec:
+  ports:
+  - name: north
+    port: {{ default 6641 .Values.global.nbPort }}
+    protocol: TCP
+    targetPort: {{ default 6641 .Values.global.nbPort }}
+  - name: south
+    port: {{ default 6642 .Values.global.sbPort}}
+    protocol: TCP
+    targetPort: {{ default 6642 .Values.global.sbPort }}
+  sessionAffinity: None
+  clusterIP: None
+  type: ClusterIP

--- a/helm/ovn-kubernetes/charts/ovnkube-db/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/values.yaml
@@ -1,0 +1,2 @@
+nbLogLevel: -vconsole:info -vfile:info
+sbLogLevel: -vconsole:info -vfile:info

--- a/helm/ovn-kubernetes/charts/ovnkube-db/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/values.yaml
@@ -1,2 +1,26 @@
 nbLogLevel: -vconsole:info -vfile:info
 sbLogLevel: -vconsole:info -vfile:info
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Required to be scheduled on a linux node and only one instance of ovnkube-db pod per node
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - "linux"
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: name
+          operator: In
+          values:
+          - ovnkube-db
+      topologyKey: kubernetes.io/hostname

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-identity
+description: Helm chart to deploy ovnkube identity
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -1,0 +1,97 @@
+{{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+# ovnkube-identity
+# starts ovnkube-identity
+# it is run on the master(s).
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-identity
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This Deployment launches the ovnkube-identity networking component.
+spec:
+  progressDeadlineSeconds: 600
+  replicas: {{ default 1 .Values.replicas }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ovnkube-identity
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-identity
+        name: ovnkube-identity
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: ovnkube-identity
+      hostNetwork: true
+      dnsPolicy: Default
+      # required to be scheduled on a linux node with node-role.kubernetes.io/control-plane label and
+      # only one instance of ovnkube-control-plane pod per node
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - ovnkube-identity
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: ovnkube-identity
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovnkube-identity"]
+        securityContext:
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        volumeMounts:
+          - mountPath: /etc/webhook-cert/
+            name: webhook-cert
+        env:
+          - name: OVN_DAEMONSET_VERSION
+            value: "3"
+          - name: K8S_APISERVER
+            valueFrom:
+              configMapKeyRef:
+                key: k8s_apiserver
+                name: ovn-config
+          - name: OVNKUBE_LOGLEVEL
+            value: {{ default 4 .Values.logLevel | quote }}
+          - name: OVN_ENABLE_INTERCONNECT
+            value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
+          - name: OVN_HYBRID_OVERLAY_ENABLE
+            value: {{ default "" .Values.global.enableHybridOverlay | quote }}
+      volumes:
+        - name: webhook-cert
+          secret:
+            secretName: ovnkube-webhook-cert
+      tolerations:
+      - operator: "Exists"
+{{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -36,29 +36,9 @@ spec:
       serviceAccountName: ovnkube-identity
       hostNetwork: true
       dnsPolicy: Default
-      # required to be scheduled on a linux node with node-role.kubernetes.io/control-plane label and
-      # only one instance of ovnkube-control-plane pod per node
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - "linux"
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: name
-                operator: In
-                values:
-                - ovnkube-identity
-            topologyKey: kubernetes.io/hostname
-
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       containers:
       - name: ovnkube-identity
         image: {{ include "getImage" . }}

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/rbac-ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/rbac-ovnkube-identity.yaml
@@ -1,0 +1,65 @@
+{{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-identity
+    namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-identity
+roleRef:
+    name: ovnkube-identity
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-identity
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-identity-configmaps
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovn-k8s-configmap
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-identity
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-identity
+rules:
+    - apiGroups: [""]
+      resources:
+          - nodes
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["certificates.k8s.io"]
+      resources:
+          - certificatesigningrequests
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["certificates.k8s.io"]
+      resources:
+          - certificatesigningrequests/approval
+      verbs: ["update"]
+    - apiGroups: [""]
+      resources:
+          - events
+      verbs: ["create", "patch", "update"]
+    - apiGroups: ["certificates.k8s.io"]
+      resources:
+          - signers
+      resourceNames:
+          - kubernetes.io/kube-apiserver-client
+      verbs: ["approve"]
+{{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/webhook.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/webhook.yaml
@@ -1,0 +1,57 @@
+{{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+# Create self signed CA and webhook cert
+# NOTE: The CA and certificate are not renewed after they expire, this should only be used in development environments
+{{- $ca := genCA "self-signed-ca" 400 }}
+{{- $cert := genSignedCert "localhost" nil (list "localhost") 365 $ca }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ovnkube-webhook-cert
+  namespace: ovn-kubernetes
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+type: kubernetes.io/tls
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: ovn-kubernetes-admission-webhook-node
+webhooks:
+  - name: ovn-kubernetes-admission-webhook-node.k8s.io
+    clientConfig:
+      url: https://localhost:9443/node
+      caBundle: {{ $ca.Cert | b64enc | quote }}
+    admissionReviewVersions: ['v1']
+    sideEffects: None
+    rules:
+      - operations: [ "UPDATE" ]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["nodes/status"] # Using /status subresource doesn't protect from other users changing the annotations
+        scope: "*"
+
+# in non-ic environments ovnkube-node doesn't have the permissions to update pods
+{{- if eq .Values.global.enableInterconnect true }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: ovn-kubernetes-admission-webhook-pod
+webhooks:
+  - name: ovn-kubernetes-admission-webhook-pod.k8s.io
+    clientConfig:
+      url: https://localhost:9443/pod
+      caBundle: {{ $ca.Cert | b64enc | quote }}
+    admissionReviewVersions: ['v1']
+    sideEffects: None
+    rules:
+      - operations: [ "UPDATE" ]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods/status"] # Using /status subresource doesn't protect from other users changing the annotations
+        scope: "*"
+{{- end }}
+{{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
@@ -1,0 +1,5 @@
+replicas: 1
+logLevel: 4
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
@@ -3,3 +3,27 @@ logLevel: 4
 logFileMaxSize: 100
 logFileMaxBackups: 5
 logFileMaxAge: 5
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Required to be scheduled on a linux node and only one instance of ovnkube-identity pod per node
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - "linux"
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: name
+          operator: In
+          values:
+          - ovnkube-identity
+      topologyKey: kubernetes.io/hostname

--- a/helm/ovn-kubernetes/charts/ovnkube-master/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-master
+description: Helm chart to deploy ovnkube-master
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -40,31 +40,9 @@ spec:
       {{- if and (hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false) (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) }}
       hostPID: true
       {{- end }}
-      # required to be scheduled on a linux node with node-role.kubernetes.io/control-plane label and
-      # only one instance of ovnkube-master pod per node
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: In
-                    values:
-                      - ""
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - "linux"
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: name
-                    operator: In
-                    values:
-                      - ovnkube-master
-              topologyKey: kubernetes.io/hostname
-
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       containers:
       # ovn-northd - v3
       - name: ovn-northd

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -1,0 +1,337 @@
+# ovnkube-master
+# daemonset version 3
+# starts master daemons (ovnkube-master and ovn-northd), each in a separate container
+# it is run on the master(s)
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-master
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This Deployment launches the ovn-kubernetes master networking components.
+spec:
+  progressDeadlineSeconds: 600
+  replicas: {{ default 1 .Values.replicas }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ovnkube-master
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: ovnkube-master
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovnkube-master
+      hostNetwork: true
+      dnsPolicy: Default
+      {{- if and (hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false) (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) }}
+      hostPID: true
+      {{- end }}
+      # required to be scheduled on a linux node with node-role.kubernetes.io/control-plane label and
+      # only one instance of ovnkube-master pod per node
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: In
+                    values:
+                      - ""
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                      - ovnkube-master
+              topologyKey: kubernetes.io/hostname
+
+      containers:
+      # ovn-northd - v3
+      - name: ovn-northd
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NORTHD
+          value: {{ default "-vconsole:info -vfile:info" .Values.northdLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+      - name: ovnkube-master
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        {{- if eq (hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false) true }}
+        command: ["/root/ovnkube.sh", "ovn-master"]
+        securityContext:
+          runAsUser: 0
+          {{- if not ( hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) }}
+          privileged: true
+          {{- else }}
+          capabilities:
+            add:
+            - NET_ADMIN
+          {{- end }}
+        {{- if eq (hasKey .Values.global "dummyGatewayBridge" | ternary .Values.global.dummyGatewayBridge false) true }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                #!/bin/bash
+                ovs-vsctl --may-exist add-br br-ex
+                ip a a dev br-ex 10.44.0.1/32 || /bin/true
+        {{- end }}
+        {{- else }}
+        command: ["/root/ovnkube.sh", "ovn-master"]
+        securityContext:
+          runAsUser: 0
+        {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        {{- if eq (hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false) true }}
+        # Common mounts
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        # CNI related mounts which we take over
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: HostToContainer
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+          readOnly: true
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        {{- end }}
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: {{ default 4 .Values.logLevel | quote }}
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: {{ default 100 .Values.logFileMaxSize | quote }}
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: {{ default 5 .Values.logFileMaxBackups | quote }}
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: {{ default 5 .Values.logFileMaxAgent | quote }}
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+          value: {{ default "" .Values.global.libovsdbClientLogFile | quote }}
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+          value: {{ default "" .Values.global.enableConfigDuration | quote }}
+        - name: OVNKUBE_METRICS_SCALE_ENABLE
+          value: {{ default "" .Values.global.enableMetricsScale | quote }}
+        - name: OVNKUBE_COMPACT_MODE_ENABLE
+          value: {{ hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false | quote }}
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: {{ default "" .Values.global.enableHybridOverlay | quote }}
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: {{ default "" .Values.global.enableAdminNetworkPolicy | quote }}
+        - name: OVN_EGRESSIP_ENABLE
+          value: {{ default "" .Values.global.enableEgressIp | quote }}
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: {{ default "" .Values.global.egressIpHealthCheckPort | quote }}
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: {{ default "" .Values.global.enableEgressFirewall | quote }}
+        - name: OVN_EGRESSQOS_ENABLE
+          value: {{ default "" .Values.global.enableEgressQos | quote }}
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: {{ default "" .Values.global.enableEgressService | quote }}
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: {{ default "" .Values.disableSnatMultipleGws | quote }}
+        - name: OVN_DISABLE_FORWARDING
+          value: {{ default "" .Values.global.disableForwarding | quote }}
+        - name: OVN_ENCAP_PORT
+          value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_EMPTY_LB_EVENTS
+          value: {{ default "" .Values.global.emptyLbEvents | quote }}
+        - name: OVN_V4_JOIN_SUBNET
+          value: {{ default "" .Values.global.v4JoinSubnet | quote }}
+        - name: OVN_V6_JOIN_SUBNET
+          value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v4MasqueradeSubnet | quote }}
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v6MasqueradeSubnet | quote }}
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_GATEWAY_MODE
+          value: {{ default "shared" .Values.global.gatewayMode }}
+        - name: OVN_GATEWAY_OPTS
+          value: {{ default "" .Values.global.gatewayOps | quote }}
+        - name: OVN_MULTICAST_ENABLE
+          value: {{ default "" .Values.global.enableMulticast | quote }}
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: {{ default 20 .Values.global.aclLoggingRateLimit | quote }}
+        - name: OVN_STATELESS_NETPOL_ENABLE
+          value: {{ hasKey .Values.global "enableStatelessNetworkPolicy" | ternary .Values.global.enableStatelessNetworkPolicy false | quote }}
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+      # end of container
+      volumes:
+      # TODO: Need to check why we need this?
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      {{- if eq (hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false) true }}
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      {{- end }}
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/rbac-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/rbac-ovnkube-master.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-master
+    namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-master
+roleRef:
+    name: ovnkube-master
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-master
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-master-configmaps
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovn-k8s-configmap
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-master
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-master-configmaps-update
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovn-k8s-configmap-update
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-master
+      namespace: ovn-kubernetes
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-master
+rules:
+    - apiGroups: [""]
+      resources:
+          - namespaces
+          - nodes
+          - pods
+          - services
+          - endpoints
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["discovery.k8s.io"]
+      resources:
+          - endpointslices
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["networking.k8s.io"]
+      resources:
+          - networkpolicies
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies
+          - baselineadminnetworkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressfirewalls
+          - egressips
+          - egressqoses
+          - egressservices
+          - adminpolicybasedexternalroutes
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - network-attachment-definitions
+          - multi-networkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies/status
+          - baselineadminnetworkpolicies/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressfirewalls/status
+          - egressips
+          - egressqoses
+          - egressservices/status
+          - adminpolicybasedexternalroutes/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: [""]
+      resources:
+          - events
+      verbs: ["create", "patch", "update"]
+    - apiGroups: [""]
+      resources:
+          - nodes/status
+          - pods/status
+          - services/status
+      verbs: [ "patch", "update" ]
+
+
+# https://github.com/ovn-org/ovn-kubernetes/blob/e1e7d40f9a6c6038b52696c1b8f8915a4d73160e/go-controller/pkg/ovn/topology_version.go#L28
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    namespace: ovn-kubernetes
+    name: ovn-k8s-configmap-update
+rules:
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["create", "patch", "update"]

--- a/helm/ovn-kubernetes/charts/ovnkube-master/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/values.yaml
@@ -5,3 +5,27 @@ northdLogLevel: "-vconsole:info -vfile:info"
 logFileMaxSize: 100
 logFileMaxBackups: 5
 logFileMaxAge: 5
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Required to be scheduled on a linux node and only one instance of ovnkube-master pod per node
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - "linux"
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: name
+              operator: In
+              values:
+                - ovnkube-master
+        topologyKey: kubernetes.io/hostname

--- a/helm/ovn-kubernetes/charts/ovnkube-master/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/values.yaml
@@ -1,0 +1,7 @@
+replicas: 1
+dummyGatewayBridge: ""
+logLevel: 4
+northdLogLevel: "-vconsole:info -vfile:info"
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-node-dpu-host
+description: Helm chart to deploy ovnkube-node-dpu-host
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -1,0 +1,246 @@
+# ovnkube-node-dpu-host
+# daemonset version 3
+# starts node daemons for ovn, each in a separate container
+# it is run on all nodes
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-node-dpu-host
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-node-dpu-host
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-node-dpu-host
+        name: ovnkube-node-dpu-host
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: ovnkube-node
+      hostNetwork: true
+      dnsPolicy: Default
+      {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+      hostPID: true
+      {{- end }}
+      containers:
+      {{- if eq (hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false) false }}
+      - name: ovnkube-node
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        {{- if eq (hasKey .Values.global "dummyGatewayBridge" | ternary .Values.global.dummyGatewayBridge false) true }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                #!/bin/bash
+                ovs-vsctl --may-exist add-br br-ex
+                ip a a dev br-ex 10.44.0.1/32 || /bin/true
+        {{- end }}
+        command: ["/root/ovnkube.sh", "ovn-node"]
+        securityContext:
+          runAsUser: 0
+          {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+          privileged: true
+          {{- else }}
+          capabilities:
+            add:
+            - NET_ADMIN
+          {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Common mounts
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+          # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        # ovnkube-node dpu-host mounts
+        - mountPath: /var/run/ovn
+          name: var-run-ovn
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: {{ default 4 .Values.logLevel | quote }}
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: {{ default 100 .Values.logFileMaxSize | quote }}
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: {{ default 5 .Values.logFileMaxBackups | quote }}
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value:  {{ default 5 .Values.logFileMaxAge | quote }}
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_GATEWAY_MODE
+          value: {{ default "shared" .Values.global.gatewayMode }}
+        - name: OVN_GATEWAY_OPTS
+          value: {{ default "" .Values.global.gatewayOps | quote }}
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: {{ default "" .Values.global.enableHybridOverlay | quote }}
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: {{ default "" .Values.global.enableAdminNetworkPolicy | quote }}
+        - name: OVN_EGRESSIP_ENABLE
+          value: {{ default "" .Values.global.enableEgressIp | quote }}
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: {{ default "" .Values.global.egressIpHealthCheckPort | quote }}
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: {{ default "" .Values.global.enableEgressService | quote }}
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: {{ default "" .Values.global.disableSnatMultipleGws | quote }}
+        - name: OVN_DISABLE_FORWARDING
+          value: {{ default "" .Values.global.disableForwarding | quote }}
+        - name: OVN_ENCAP_PORT
+          value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_DISABLE_PKT_MTU_CHECK
+          value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
+        - name: OVN_NETFLOW_TARGETS
+          value: {{ default "" .Values.global.netFlowTargets | quote }}
+        - name: OVN_SFLOW_TARGETS
+          value: {{ default "" .Values.global.sflowTargets | quote }}
+        - name: OVN_IPFIX_TARGETS
+          value: {{ default "" .Values.global.ipfixTargets | quote }}
+        - name: OVN_IPFIX_SAMPLING
+          value: {{ default "" .Values.global.ipfixSampling | quote }}
+        - name: OVN_IPFIX_CACHE_MAX_FLOWS
+          value: {{ default "" .Values.global.ipfixCacheMaxFlows | quote }}
+        - name: OVN_IPFIX_CACHE_ACTIVE_TIMEOUT
+          value: {{ default "" .Values.global.ipfixCacheActiveTimeout | quote }}
+        - name: OVN_V4_JOIN_SUBNET
+          value: {{ default "" .Values.global.v4JoinSubnet | quote }}
+        - name: OVN_V6_JOIN_SUBNET
+          value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v4MasqueradeSubnet | quote }}
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v6MasqueradeSubnet | quote }}
+        - name: OVN_MULTICAST_ENABLE
+          value: {{ default "" .Values.global.enableMulticast | quote }}
+        - name: OVN_UNPRIVILEGED_MODE
+          value: {{ include "isUnprivilegedMode" . | quote }}
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+          value: {{ default "" .Values.global.extGatewayNetworkInterface | quote }}
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: {{ hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true | quote }}
+        - name: OVNKUBE_NODE_MODE
+          value: "dpu-host"
+        - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
+          value: {{ default "" .Values.global.nodeMgmtPortNetdev | quote }}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      {{- end }}
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        k8s.ovn.org/dpu-host: ""
+      volumes:
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      - name: var-run-ovn
+        emptyDir: {}
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/values.yaml
@@ -1,0 +1,5 @@
+logLevel: 4
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5
+ovnControllerLogLevel: 4

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-node-dpu
+description: Helm chart to deploy ovnkube-node-dpu
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -1,0 +1,297 @@
+# ovnkube-node-dpu
+# daemonset version 3
+# starts node daemons for ovn, each in a separate container
+# it is run on all nodes
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-node-dpu
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-node-dpu
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-node-dpu
+        name: ovnkube-node-dpu
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: ovnkube-node
+      hostNetwork: true
+      dnsPolicy: Default
+      {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+      hostPID: true
+      {{- end }}
+      containers:
+      {{- if eq (hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false) false }}
+      - name: ovnkube-node
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        {{- if eq (hasKey .Values.global "dummyGatewayBridge" | ternary .Values.global.dummyGatewayBridge false) true }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                #!/bin/bash
+                ovs-vsctl --may-exist add-br br-ex
+                ip a a dev br-ex 10.44.0.1/32 || /bin/true
+        {{- end }}
+        command: ["/root/ovnkube.sh", "ovn-node"]
+        securityContext:
+          runAsUser: 0
+          {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+          privileged: true
+          {{- else }}
+          capabilities:
+            add:
+            - NET_ADMIN
+          {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Common mounts
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+          # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        # ovnkube-node only mounts (non dpu related)
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+          readOnly: true
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: {{ default 4 .Values.logLevel | quote }}
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: {{ default 100 .Values.logFileMaxSize | quote }}
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: {{ default 5 .Values.logFileMaxBackups | quote }}
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: {{ default 5 .Values.logFileMaxAge | quote }}
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_GATEWAY_MODE
+          value: {{ default "shared" .Values.global.gatewayMode }}
+        - name: OVN_GATEWAY_OPTS
+          value: {{ default "" .Values.global.gatewayOps | quote }}
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: {{ default "" .Values.global.enableHybridOverlay | quote }}
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: {{ default "" .Values.global.enableAdminNetworkPolicy | quote }}
+        - name: OVN_EGRESSIP_ENABLE
+          value: {{ default "" .Values.global.enableEgressIp | quote }}
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: {{ default "" .Values.global.enableEgressIp | quote }}
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: {{ default "" .Values.global.enableEgressService | quote }}
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: {{ default "" .Values.global.disableSnatMultipleGws | quote }}
+        - name: OVN_DISABLE_FORWARDING
+          value: {{ default "" .Values.global.disableForwarding | quote }}
+        - name: OVN_ENCAP_PORT
+          value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_DISABLE_PKT_MTU_CHECK
+          value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
+        - name: OVN_NETFLOW_TARGETS
+          value: {{ default "" .Values.global.netFlowTargets | quote }}
+        - name: OVN_SFLOW_TARGETS
+          value: {{ default "" .Values.global.sflowTargets | quote }}
+        - name: OVN_IPFIX_TARGETS
+          value: {{ default "" .Values.global.ipfixTargets | quote }}
+        - name: OVN_IPFIX_SAMPLING
+          value: {{ default "" .Values.global.ipfixSampling | quote }}
+        - name: OVN_IPFIX_CACHE_MAX_FLOWS
+          value: {{ default "" .Values.global.ipfixCacheMaxFlows | quote }}
+        - name: OVN_IPFIX_CACHE_ACTIVE_TIMEOUT
+          value: {{ default "" .Values.global.ipfixCacheActiveTimeout | quote }}
+        - name: OVN_V4_JOIN_SUBNET
+          value: {{ default "" .Values.global.v4JoinSubnet | quote }}
+        - name: OVN_V6_JOIN_SUBNET
+          value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v4MasqueradeSubnet | quote }}
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v6MasqueradeSubnet | quote }}
+        - name: OVN_MULTICAST_ENABLE
+          value: {{ default "" .Values.global.enableMulticast | quote }}
+        - name: OVN_UNPRIVILEGED_MODE
+          value: {{ include "isUnprivilegedMode" . | quote }}
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+          value: {{ default "" .Values.global.extGatewayNetworkInterface | quote }}
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: {{ hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true | quote }}
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_DISABLE_OVN_IFACE_ID_VER
+          value: {{ hasKey .Values.global "disableIfaceIdVer" | ternary .Values.global.disableIfaceIdVer false | quote }}
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: {{ default 100000 .Values.global.remoteProbeInterval | quote }}
+        - name: OVN_MONITOR_ALL
+          value: {{ default "" .Values.global.monitorAll | quote }}
+        - name: OVN_OFCTRL_WAIT_BEFORE_CLEAR
+          value: {{ default "" .Values.global.ofctrlWaitBeforeClear | quote }}
+        - name: OVN_ENABLE_LFLOW_CACHE
+          value: {{ hasKey .Values.global "enableLFlowCache" | ternary .Values.global.enableLFlowCache true | quote }}
+        - name: OVN_LFLOW_CACHE_LIMIT
+          value: {{ default "" .Values.global.lFlowCacheLimit | quote }}
+        - name: OVN_LFLOW_CACHE_LIMIT_KB
+          value: {{ default "" .Values.global.lFlowCacheLimitKb | quote }}
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_ENABLE_INTERCONNECT
+          value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
+        - name: OVNKUBE_NODE_MODE
+          value: "dpu"
+        - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
+          value: {{ default "" .Values.global.nodeMgmtPortNetdev | quote }}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      {{- end }}
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        k8s.ovn.org/dpu: ""
+      volumes:
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      # non DPU related volumes
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-etc-ovs
+        hostPath:
+          path: /etc/openvswitch
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/values.yaml
@@ -1,0 +1,5 @@
+logLevel: 4
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5
+ovnControllerLogLevel: 4

--- a/helm/ovn-kubernetes/charts/ovnkube-node/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: ovnkube-node
+description: Subchart for ovnkube-node
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -1,0 +1,388 @@
+# ovnkube-node
+# daemonset version 3
+# starts node daemons for ovn, each in a separate container
+# it is run on all nodes
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-node
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-node
+        name: ovnkube-node
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: ovnkube-node
+      hostNetwork: true
+      dnsPolicy: Default
+      {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+      hostPID: true
+      {{- end }}
+      containers:
+      {{- if eq (hasKey .Values.global "enableCompactMode" | ternary .Values.global.enableCompactMode false) false }}
+      - name: ovnkube-node
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        {{- if eq (hasKey .Values.global "dummyGatewayBridge" | ternary .Values.global.dummyGatewayBridge false) true }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                #!/bin/bash
+                ovs-vsctl --may-exist add-br br-ex
+                ip a a dev br-ex 10.44.0.1/32 || /bin/true
+        {{- end }}
+        command: ["/root/ovnkube.sh", "ovn-node"]
+        securityContext:
+          runAsUser: 0
+          {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+          privileged: true
+          {{- else }}
+          capabilities:
+            add:
+            - NET_ADMIN
+          {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Common mounts
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+          # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        # ovnkube-node only mounts (non dpu related)
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+          readOnly: true
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: {{ default 4 .Values.logLevel | quote }}
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: {{ default 100 .Values.logFileMaxSize | quote }}
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: {{ default 5 .Values.logFileMaxBackups | quote }}
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: {{ default 5 .Values.logFileMaxAge | quote }}
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_GATEWAY_MODE
+          value: {{ default "shared" .Values.global.gatewayMode }}
+        - name: OVN_GATEWAY_OPTS
+          value: {{ default "" .Values.global.gatewayOps | quote }}
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: {{ default "" .Values.global.enableHybridOverlay | quote }}
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: {{ default "" .Values.global.enableAdminNetworkPolicy | quote }}
+        - name: OVN_EGRESSIP_ENABLE
+          value: {{ default "" .Values.global.enableEgressIp | quote }}
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: {{ default "" .Values.global.egressIpHealthCheckPort | quote }}
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: {{ default "" .Values.global.enableEgressService | quote }}
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: {{ default "" .Values.global.disableSnatMultipleGws | quote }}
+        - name: OVN_DISABLE_FORWARDING
+          value: {{ default "" .Values.global.disableForwarding | quote }}
+        - name: OVN_ENCAP_PORT
+          value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_DISABLE_PKT_MTU_CHECK
+          value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
+        - name: OVN_NETFLOW_TARGETS
+          value: {{ default "" .Values.global.netFlowTargets | quote }}
+        - name: OVN_SFLOW_TARGETS
+          value: {{ default "" .Values.global.sflowTargets | quote }}
+        - name: OVN_IPFIX_TARGETS
+          value: {{ default "" .Values.global.ipfixTargets | quote }}
+        - name: OVN_IPFIX_SAMPLING
+          value: {{ default "" .Values.global.ipfixSampling | quote }}
+        - name: OVN_IPFIX_CACHE_MAX_FLOWS
+          value: {{ default "" .Values.global.ipfixCacheMaxFlows | quote }}
+        - name: OVN_IPFIX_CACHE_ACTIVE_TIMEOUT
+          value: {{ default "" .Values.global.ipfixCacheActiveTimeout | quote }}
+        - name: OVN_V4_JOIN_SUBNET
+          value: {{ default "" .Values.global.v4JoinSubnet | quote }}
+        - name: OVN_V6_JOIN_SUBNET
+          value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v4MasqueradeSubnet | quote }}
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v6MasqueradeSubnet | quote }}
+        - name: OVN_MULTICAST_ENABLE
+          value: {{ default "" .Values.global.enableMulticast | quote }}
+        - name: OVN_UNPRIVILEGED_MODE
+          value: {{ include "isUnprivilegedMode" . | quote }}
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+          value: {{ default "" .Values.global.extGatewayNetworkInterface | quote }}
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: {{ hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true | quote }}
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_DISABLE_OVN_IFACE_ID_VER
+          value: {{ hasKey .Values.global "disableIfaceIdVer" | ternary .Values.global.disableIfaceIdVer false | quote }}
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: {{ default 100000 .Values.global.remoteProbeInterval | quote }}
+        - name: OVN_MONITOR_ALL
+          value: {{ default "" .Values.global.monitorAll | quote }}
+        - name: OVN_OFCTRL_WAIT_BEFORE_CLEAR
+          value: {{ default "" .Values.global.ofctrlWaitBeforeClear | quote }}
+        - name: OVN_ENABLE_LFLOW_CACHE
+          value: {{ hasKey .Values.global "enableLFlowCache" | ternary .Values.global.enableLFlowCache true | quote }}
+        - name: OVN_LFLOW_CACHE_LIMIT
+          value: {{ default "" .Values.global.lFlowCacheLimit | quote }}
+        - name: OVN_LFLOW_CACHE_LIMIT_KB
+          value: {{ default "" .Values.global.lFlowCacheLimitKb | quote }}
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_ENABLE_INTERCONNECT
+          value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
+        - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
+          value: {{ default "" .Values.global.nodeMgmtPortNetdev | quote }}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      {{- end }}
+      - name: ovn-controller
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovn-controller"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_CONTROLLER
+          value: {{ default "-vconsole:info" .Values.ovnControllerLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-controller"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        # ovs-metrics-exporter - v3
+      - name: ovs-metrics-exporter
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovs-metrics"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        # end of container
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: k8s.ovn.org/dpu-host
+                operator: DoesNotExist
+              - key: k8s.ovn.org/dpu
+                operator: DoesNotExist
+      volumes:
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      # non DPU related volumes
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-etc-ovs
+        hostPath:
+          path: /etc/openvswitch
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-node/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/values.yaml
@@ -1,0 +1,5 @@
+logLevel: 4
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5
+ovnControllerLogLevel: "-vconsole:info"

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-single-node-zone
+description: Helm chart to deploy single node zone stack
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -1,0 +1,576 @@
+# ovnkube-node
+# daemonset version 3
+# starts node daemons for single node zone ovn stack, each in a separate container
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-node
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-node
+        name: ovnkube-node
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: ovnkube-node
+      hostNetwork: true
+      dnsPolicy: Default
+      {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+      hostPID: true
+      {{- end }}
+      containers:
+      # nb-ovsdb - v3
+      - name: nb-ovsdb
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "local-nb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NB
+          value: {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+      # sb-ovsdb - v3
+      - name: sb-ovsdb
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "local-sb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_SB
+          value: {{ default "-vconsole:info -vfile:info" .Values.sbLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+      # ovn-northd - v3
+      - name: ovn-northd
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NORTHD
+          value: {{ default "-vconsole:info -vfile:info" .Values.northdLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+      - name: ovnkube-controller
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovnkube-controller-with-node"]
+        securityContext:
+          runAsUser: 0
+          {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+          privileged: true
+          {{- else }}
+          capabilities:
+            add:
+            - NET_ADMIN
+          {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Common mounts
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /host-kubernetes
+          name: host-kubeconfig
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+          # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+          readOnly: true
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: {{ default "" .Values.global.enableEgressService | quote }}
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: {{ default 4 .Values.ovnkubeNodeLogLevel | quote }}
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: {{ default 100 .Values.logfileMaxSize | quote }}
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: {{ default 5 .Values.logFileMaxBackups | quote }}
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: {{ default 5 .Values.logFileMaxAge | quote }}
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+          value: {{ default "" .Values.global.libovsdbClientLogFile | quote }}
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+          value: {{ default "" .Values.global.enableConfigDuration | quote }}
+        - name: OVNKUBE_METRICS_SCALE_ENABLE
+          value: {{ default "" .Values.global.enableMetricsScale | quote }}
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_GATEWAY_MODE
+          value: {{ default "shared" .Values.global.gatewayMode }}
+        - name: OVN_GATEWAY_OPTS
+          value: {{ default "" .Values.global.gatewayOpts | quote }}
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: {{ default "" .Values.global.enableHybridOverlay | quote }}
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: {{ default "" .Values.global.enableAdminNetworkPolicy | quote }}
+        - name: OVN_EGRESSIP_ENABLE
+          value: {{ default "" .Values.global.enableEgressIp | quote }}
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: {{ default "" .Values.global.egressIpHealthCheckPort | quote }}
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: {{ default "" .Values.global.enableEgressFirewall | quote }}
+        - name: OVN_EGRESSQOS_ENABLE
+          value: {{ default "" .Values.global.enableEgressQos | quote }}
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: {{ default "" .Values.disableSnatMultipleGws | quote }}
+        - name: OVN_DISABLE_FORWARDING
+          value: {{ default "" .Values.global.disableForwarding | quote }}
+        - name: OVN_ENCAP_PORT
+          value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_DISABLE_PKT_MTU_CHECK
+          value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
+        - name: OVN_NETFLOW_TARGETS
+          value: {{ default "" .Values.global.netFlowTargets | quote }}
+        - name: OVN_SFLOW_TARGETS
+          value: {{ default "" .Values.global.sflowTargets | quote }}
+        - name: OVN_IPFIX_TARGETS
+          value: {{ default "" .Values.global.ipfixTargets | quote }}
+        - name: OVN_IPFIX_SAMPLING
+          value: {{ default "" .Values.global.ipfixSampling | quote }}
+        - name: OVN_IPFIX_CACHE_MAX_FLOWS
+          value: {{ default "" .Values.global.ipfixCacheMaxFlows | quote }}
+        - name: OVN_IPFIX_CACHE_ACTIVE_TIMEOUT
+          value: {{ default "" .Values.global.ipfixCacheActiveTimeout | quote }}
+        - name: OVN_V4_JOIN_SUBNET
+          value: {{ default "" .Values.global.v4JoinSubnet | quote }}
+        - name: OVN_V6_JOIN_SUBNET
+          value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_MULTICAST_ENABLE
+          value: {{ default "" .Values.global.enableMulticast | quote }}
+        - name: OVN_UNPRIVILEGED_MODE
+          value: {{ include "isUnprivilegedMode" . | quote }}
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+          value: {{ default "" .Values.global.extGatewayNetworkInterface | quote }}
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_DISABLE_OVN_IFACE_ID_VER
+          value: {{ hasKey .Values.global "disableIfaceIdVer" | ternary .Values.global.disableIfaceIdVer false | quote }}
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: {{ default 100000 .Values.global.remoteProbeInterval | quote }}
+        - name: OVN_MONITOR_ALL
+          value: {{ default "" .Values.global.monitorAll | quote }}
+        - name: OVN_OFCTRL_WAIT_BEFORE_CLEAR
+          value: {{ default "" .Values.global.ofctrlWaitBeforeClear | quote }}
+        - name: OVN_ENABLE_LFLOW_CACHE
+          value: {{ hasKey .Values.global "enableLFlowCache" | ternary .Values.global.enableLFlowCache true | quote }}
+        - name: OVN_LFLOW_CACHE_LIMIT
+          value: {{ default "" .Values.global.lFlowCacheLimit | quote }}
+        - name: OVN_LFLOW_CACHE_LIMIT_KB
+          value: {{ default "" .Values.global.lFlowCacheLimitKb | quote }}
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
+          value: {{ default "" .Values.global.nodeMgmtPortNetdev | quote }}
+        - name: OVN_EMPTY_LB_EVENTS
+          value: {{ default "" .Values.global.emptyLbEvents | quote }}
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: {{ default 20 .Values.global.aclLoggingRateLimit | quote }}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        - name: OVN_ENABLE_INTERCONNECT
+          value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: {{ hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true | quote }}
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: ovn-controller
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovn-controller"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_CONTROLLER
+          value: {{ default "-vconsole:info" .Values.ovnControllerLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: {{ default "" .Values.global.enableSsl | quote }}
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-controller"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        # ovs-metrics-exporter - v3
+      - name: ovs-metrics-exporter
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovs-metrics"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        # end of container
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: k8s.ovn.org/dpu-host
+                operator: DoesNotExist
+      volumes:
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-kubeconfig
+        hostPath:
+          path: /etc/kubernetes/
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-etc-ovs
+        hostPath:
+          path: /etc/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/values.yaml
@@ -1,0 +1,9 @@
+nbLogLevel: "-vconsole:info -vfile:info"
+sbLogLevel: "-vconsole:info -vfile:info"
+northdLogLevel: "-vconsole:info -vfile:info"
+ovnkubeNodeLogLevel: 4
+ovnControllerLogLevel: "-vconsole:info"
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5
+libovsdbClientLogFile: ""

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovnkube-zone-controller
+description: Helm chart to deploy zone controller
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -1,0 +1,397 @@
+# ovnkube-zone-controller
+# daemonset version 3
+# starts zone controller daemons - ovn dbs, ovn-northd and ovnkube-controller containers
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-zone-controller
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-zone-controller
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-zone-controller
+        name: ovnkube-zone-controller
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovnkube-node
+      hostNetwork: true
+      dnsPolicy: Default
+      {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+      hostPID: true
+      {{- end }}
+      # required to be scheduled on a linux node with node-role.kubernetes.io/zone-controller label
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/zone-controller
+                    operator: In
+                    values:
+                      - ""
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+      containers:
+      # nb-ovsdb - v3
+      - name: nb-ovsdb
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "nb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NB
+          value:  {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+      # sb-ovsdb - v3
+      - name: sb-ovsdb
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "sb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_SB
+          value: {{ default "-vconsole:info -vfile:info" .Values.sbLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+      # ovn-northd - v3
+      - name: ovn-northd
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NORTHD
+          value: {{ default "-vconsole:info -vfile:info" .Values.northdLogLevel | quote }}
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+      # zone controller
+      - name: ovnkube-controller
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovnkube-controller"]
+        securityContext:
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: {{ default 4 .Values.ovnkubeLocalLogLevel | quote }}
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: {{ default 100 .Values.logfileMaxSize | quote }}
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: {{ default 5 .Values.logFileMaxBackups | quote }}
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: {{ default 5 .Values.logFileMaxAge | quote }}
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+          value: {{ default "" .Values.global.libovsdbClientLogFile | quote }}
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+          value: {{ default "" .Values.global.enableConfigDuration | quote }}
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: {{ default "" .Values.global.enableHybridOverlay | quote }}
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: {{ default "" .Values.global.enableAdminNetworkPolicy | quote }}
+        - name: OVN_EGRESSIP_ENABLE
+          value: {{ default "" .Values.global.enableEgressIp | quote }}
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: {{ default "" .Values.global.egressIpHealthCheckPort | quote }}
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: {{ default "" .Values.global.enableEgressService | quote }}
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: {{ default "" .Values.global.enableEgressFirewall | quote }}
+        - name: OVN_EGRESSQOS_ENABLE
+          value: {{ default "" .Values.global.enableEgressQos | quote }}
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: {{ hasKey .Values.global "enableMultiNetwork" | ternary .Values.global.enableMultiNetwork false | quote }}
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: {{ default "" .Values.disableSnatMultipleGws | quote }}
+        - name: OVN_ENCAP_PORT
+          value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_EMPTY_LB_EVENTS
+          value: {{ default "" .Values.global.emptyLbEvents | quote }}
+        - name: OVN_V4_JOIN_SUBNET
+          value: {{ default "" .Values.global.v4JoinSubnet | quote }}
+        - name: OVN_V6_JOIN_SUBNET
+          value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_SSL_ENABLE
+          value: {{ include "isSslEnabled" . | quote }}
+        - name: OVN_GATEWAY_MODE
+          value: {{ default "shared" .Values.global.gatewayMode }}
+        - name: OVN_MULTICAST_ENABLE
+          value: {{ default "" .Values.global.enableMulticast | quote }}
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: {{ default 20 .Values.global.aclLoggingRateLimit | quote }}
+        - name: OVN_ENABLE_INTERCONNECT
+          value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+      # end of container
+      volumes:
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-etc-ovs
+        hostPath:
+          path: /etc/openvswitch
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -35,20 +35,9 @@ spec:
       {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
       hostPID: true
       {{- end }}
-      # required to be scheduled on a linux node with node-role.kubernetes.io/zone-controller label
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/zone-controller
-                    operator: In
-                    values:
-                      - ""
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - "linux"
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       containers:
       # nb-ovsdb - v3
       - name: nb-ovsdb

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/values.yaml
@@ -1,0 +1,8 @@
+nbLogLevel: "-vconsole:info -vfile:info"
+sbLogLevel: "-vconsole:info -vfile:info"
+northdLogLevel: "-vconsole:info -vfile:info"
+ovnkubeLocalLogLevel: 4
+logFileMaxSize: 100
+logFileMaxBackups: 5
+logFileMaxAge: 5
+libovsdbClientLogFile: ""

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/values.yaml
@@ -6,3 +6,27 @@ logFileMaxSize: 100
 logFileMaxBackups: 5
 logFileMaxAge: 5
 libovsdbClientLogFile: ""
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Required to be scheduled on a linux node and only one instance of ovnkube-zone-controller pod per node
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - "linux"
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: name
+          operator: In
+          values:
+          - ovnkube-zone-controller
+      topologyKey: kubernetes.io/hostname

--- a/helm/ovn-kubernetes/charts/ovs-node/Chart.yaml
+++ b/helm/ovn-kubernetes/charts/ovs-node/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ovs-node
+description: Helm chart to deploy ovs
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
@@ -1,0 +1,128 @@
+# ovs-node
+# daemonset version 3
+# starts node daemons for ovs
+# it is run on all nodes
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovs-node
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovs networking components for all nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovs-node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovs-node
+        name: ovs-node
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+    spec:
+      priorityClassName: "system-cluster-critical"
+      hostNetwork: true
+      dnsPolicy: Default
+      {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+      hostPID: true
+      {{- end }}
+      containers:
+      # ovsdb-server and ovs-switchd daemons
+      - name: ovs-daemons
+        image: {{ include "getImage" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.global.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovs-server"]
+        livenessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovs-daemons"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: host-modules
+          readOnly: true
+        - mountPath: /run/openvswitch
+          name: host-run-ovs
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /sys
+          name: host-sys
+        - mountPath: /etc/openvswitch
+          name: host-config-openvswitch
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/root/ovnkube.sh", "cleanup-ovs-server"]
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: k8s.ovn.org/dpu-host
+                operator: DoesNotExist
+      volumes:
+      - name: host-modules
+        hostPath:
+          path: /lib/modules
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-config-openvswitch
+        hostPath:
+          path: /etc/origin/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      tolerations:
+      - operator: "Exists"

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_adminpolicybasedexternalroutes.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_adminpolicybasedexternalroutes.yaml
@@ -1,0 +1,286 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: adminpolicybasedexternalroutes.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: AdminPolicyBasedExternalRoute
+    listKind: AdminPolicyBasedExternalRouteList
+    plural: adminpolicybasedexternalroutes
+    shortNames:
+    - apbexternalroute
+    singular: adminpolicybasedexternalroute
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.lastTransitionTime
+      name: Last Update
+      type: date
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AdminPolicyBasedExternalRoute is a CRD allowing the cluster administrators
+          to configure policies for external gateway IPs to be applied to all the
+          pods contained in selected namespaces. Egress traffic from the pods that
+          belong to the selected namespaces to outside the cluster is routed through
+          these external gateway IPs.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AdminPolicyBasedExternalRouteSpec defines the desired state
+              of AdminPolicyBasedExternalRoute
+            properties:
+              from:
+                description: From defines the selectors that will determine the target
+                  namespaces to this CR.
+                properties:
+                  namespaceSelector:
+                    description: NamespaceSelector defines a selector to be used to
+                      determine which namespaces will be targeted by this CR
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - namespaceSelector
+                type: object
+              nextHops:
+                description: 'NextHops defines two types of hops: Static and Dynamic.
+                  Each hop defines at least one external gateway IP.'
+                minProperties: 1
+                properties:
+                  dynamic:
+                    description: DynamicHops defines a slices of DynamicHop. This
+                      field is optional.
+                    items:
+                      description: DynamicHop defines the configuration for a dynamic
+                        external gateway interface. These interfaces are wrapped around
+                        a pod object that resides inside the cluster. The field NetworkAttachmentName
+                        captures the name of the multus network name to use when retrieving
+                        the gateway IP to use. The PodSelector and the NamespaceSelector
+                        are mandatory fields.
+                      properties:
+                        bfdEnabled:
+                          default: false
+                          description: BFDEnabled determines if the interface implements
+                            the Bidirectional Forward Detection protocol. Defaults
+                            to false.
+                          type: boolean
+                        namespaceSelector:
+                          description: NamespaceSelector defines a selector to filter
+                            the namespaces where the pod gateways are located.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        networkAttachmentName:
+                          default: ""
+                          description: NetworkAttachmentName determines the multus
+                            network name to use when retrieving the pod IPs that will
+                            be used as the gateway IP. When this field is empty, the
+                            logic assumes that the pod is configured with HostNetwork
+                            and is using the node's IP as gateway.
+                          type: string
+                        podSelector:
+                          description: PodSelector defines the selector to filter
+                            the pods that are external gateways.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - namespaceSelector
+                      - podSelector
+                      type: object
+                    type: array
+                  static:
+                    description: StaticHops defines a slice of StaticHop. This field
+                      is optional.
+                    items:
+                      description: StaticHop defines the configuration of a static
+                        IP that acts as an external Gateway Interface. IP field is
+                        mandatory.
+                      properties:
+                        bfdEnabled:
+                          default: false
+                          description: BFDEnabled determines if the interface implements
+                            the Bidirectional Forward Detection protocol. Defaults
+                            to false.
+                          type: boolean
+                        ip:
+                          description: IP defines the static IP to be used for egress
+                            traffic. The IP can be either IPv4 or IPv6.
+                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                type: object
+            required:
+            - from
+            - nextHops
+            type: object
+          status:
+            description: AdminPolicyBasedRouteStatus contains the observed status
+              of the AdminPolicyBased route types.
+            properties:
+              lastTransitionTime:
+                description: Captures the time when the last change was applied.
+                format: date-time
+                type: string
+              messages:
+                description: An array of Human-readable messages indicating details
+                  about the status of the object.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              status:
+                description: A concise indication of whether the AdminPolicyBasedRoute
+                  resource is applied with success
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_egressfirewalls.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_egressfirewalls.yaml
@@ -1,0 +1,172 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: egressfirewalls.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: EgressFirewall
+    listKind: EgressFirewallList
+    plural: egressfirewalls
+    singular: egressfirewall
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: EgressFirewall Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: EgressFirewall describes the current egress firewall for a Namespace.
+          Traffic from a pod to an IP address outside the cluster will be checked
+          against each EgressFirewallRule in the pod's namespace's EgressFirewall,
+          in order. If no rule matches (or no EgressFirewall is present) then the
+          traffic will be allowed by default.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+            properties:
+              name:
+                type: string
+                pattern: ^default$
+          spec:
+            description: Specification of the desired behavior of EgressFirewall.
+            properties:
+              egress:
+                description: a collection of egress firewall rule objects
+                items:
+                  description: EgressFirewallRule is a single egressfirewall rule
+                    object
+                  properties:
+                    ports:
+                      description: ports specify what ports and protocols the rule
+                        applies to
+                      items:
+                        description: EgressFirewallPort specifies the port to allow
+                          or deny traffic to
+                        properties:
+                          port:
+                            description: port that the traffic must match
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          protocol:
+                            description: protocol (tcp, udp, sctp) that the traffic
+                              must match.
+                            pattern: ^TCP|UDP|SCTP$
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                    to:
+                      description: to is the target that traffic is allowed/denied
+                        to
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        cidrSelector:
+                          description: cidrSelector is the CIDR range to allow/deny
+                            traffic to. If this is set, dnsName and nodeSelector must
+                            be unset.
+                          type: string
+                        dnsName:
+                          description: dnsName is the domain name to allow/deny traffic
+                            to. If this is set, cidrSelector and nodeSelector must
+                            be unset.
+                          pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                          type: string
+                        nodeSelector:
+                          description: nodeSelector will allow/deny traffic to the
+                            Kubernetes node IP of selected nodes. If this is set,
+                            cidrSelector and DNSName must be unset.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type:
+                      description: type marks this as an "Allow" or "Deny" rule
+                      pattern: ^Allow|Deny$
+                      type: string
+                  required:
+                  - to
+                  - type
+                  type: object
+                type: array
+            required:
+            - egress
+            type: object
+          status:
+            description: Observed status of EgressFirewall
+            properties:
+              messages:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              status:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_egressips.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_egressips.yaml
@@ -1,0 +1,186 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: egressips.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: EgressIP
+    listKind: EgressIPList
+    plural: egressips
+    shortNames:
+    - eip
+    singular: egressip
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.egressIPs[*]
+      name: EgressIPs
+      type: string
+    - jsonPath: .status.items[*].node
+      name: Assigned Node
+      type: string
+    - jsonPath: .status.items[*].egressIP
+      name: Assigned EgressIPs
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: EgressIP is a CRD allowing the user to define a fixed source
+          IP for all egress traffic originating from any pods which match the EgressIP
+          resource according to its spec definition.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of EgressIP.
+            properties:
+              egressIPs:
+                description: EgressIPs is the list of egress IP addresses requested.
+                  Can be IPv4 and/or IPv6. This field is mandatory.
+                items:
+                  type: string
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector applies the egress IP only to the namespace(s)
+                  whose label matches this definition. This field is mandatory.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelector:
+                description: 'PodSelector applies the egress IP only to the pods whose
+                  label matches this definition. This field is optional, and in case
+                  it is not set: results in the egress IP being applied to all pods
+                  in the namespace(s) matched by the NamespaceSelector. In case it
+                  is set: is intersected with the NamespaceSelector, thus applying
+                  the egress IP to the pods (in the namespace(s) already matched by
+                  the NamespaceSelector) which match this pod selector.'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - egressIPs
+            - namespaceSelector
+            type: object
+          status:
+            description: Observed status of EgressIP. Read-only.
+            properties:
+              items:
+                description: The list of assigned egress IPs and their corresponding
+                  node assignment.
+                items:
+                  description: The per node status, for those egress IPs who have
+                    been assigned.
+                  properties:
+                    egressIP:
+                      description: Assigned egress IP
+                      type: string
+                    node:
+                      description: Assigned node name
+                      type: string
+                  required:
+                  - egressIP
+                  - node
+                  type: object
+                type: array
+            required:
+            - items
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_egressqoses.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_egressqoses.yaml
@@ -1,0 +1,122 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: egressqoses.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: EgressQoS
+    listKind: EgressQoSList
+    plural: egressqoses
+    singular: egressqos
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: EgressQoS is a CRD that allows the user to define a DSCP value
+          for pods egress traffic on its namespace to specified CIDRs. Traffic from
+          these pods will be checked against each EgressQoSRule in the namespace's
+          EgressQoS, and if there is a match the traffic is marked with the relevant
+          DSCP value.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+            properties:
+              name:
+                type: string
+                pattern: ^default$
+          spec:
+            description: EgressQoSSpec defines the desired state of EgressQoS
+            properties:
+              egress:
+                description: a collection of Egress QoS rule objects
+                items:
+                  properties:
+                    dscp:
+                      description: DSCP marking value for matching pods' traffic.
+                      maximum: 63
+                      minimum: 0
+                      type: integer
+                    dstCIDR:
+                      description: DstCIDR specifies the destination's CIDR. Only
+                        traffic heading to this CIDR will be marked with the DSCP
+                        value. This field is optional, and in case it is not set the
+                        rule is applied to all egress traffic regardless of the destination.
+                      format: cidr
+                      type: string
+                    podSelector:
+                      description: PodSelector applies the QoS rule only to the pods
+                        in the namespace whose label matches this definition. This
+                        field is optional, and in case it is not set results in the
+                        rule being applied to all pods in the namespace.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - dscp
+                  type: object
+                type: array
+            required:
+            - egress
+            type: object
+          status:
+            description: EgressQoSStatus defines the observed state of EgressQoS
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_egressservices.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_egressservices.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: egressservices.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: EgressService
+    listKind: EgressServiceList
+    plural: egressservices
+    singular: egressservice
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: EgressService is a CRD that allows the user to request that the
+          source IP of egress packets originating from all of the pods that are endpoints
+          of the corresponding LoadBalancer Service would be its ingress IP. In addition,
+          it allows the user to request that egress packets originating from all of
+          the pods that are endpoints of the LoadBalancer service would use a different
+          network than the main one.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EgressServiceSpec defines the desired state of EgressService
+            properties:
+              network:
+                description: The network which this service should send egress and
+                  corresponding ingress replies to. This is typically implemented
+                  as VRF mapping, representing a numeric id or string name of a routing
+                  table which by omission uses the default host routing.
+                type: string
+              nodeSelector:
+                description: Allows limiting the nodes that can be selected to handle
+                  the service's traffic when sourceIPBy=LoadBalancerIP. When present
+                  only a node whose labels match the specified selectors can be selected
+                  for handling the service's traffic. When it is not specified any
+                  node in the cluster can be chosen to manage the service's traffic.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              sourceIPBy:
+                description: Determines the source IP of egress traffic originating
+                  from the pods backing the LoadBalancer Service. When `LoadBalancerIP`
+                  the source IP is set to its LoadBalancer ingress IP. When `Network`
+                  the source IP is set according to the interface of the Network,
+                  leveraging the masquerade rules that are already in place. Typically
+                  these rules specify SNAT to the IP of the outgoing interface, which
+                  means the packet will typically leave with the IP of the node.
+                enum:
+                - LoadBalancerIP
+                - Network
+                type: string
+            type: object
+          status:
+            description: EgressServiceStatus defines the observed state of EgressService
+            properties:
+              host:
+                description: The name of the node selected to handle the service's
+                  traffic. In case sourceIPBy=Network the field will be set to "ALL".
+                type: string
+            required:
+            - host
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/ovn-kubernetes/crds/monitoring.coreos.com_prometheusrule.yaml
+++ b/helm/ovn-kubernetes/crds/monitoring.coreos.com_prometheusrule.yaml
@@ -1,0 +1,118 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+    - prometheus-operator
+    kind: PrometheusRule
+    listKind: PrometheusRuleList
+    plural: prometheusrules
+    shortNames:
+    - promrule
+    singular: prometheusrule
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: PrometheusRule defines recording and alerting rules for a Prometheus instance
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of desired alerting rule definitions for Prometheus.
+            properties:
+              groups:
+                description: Content of Prometheus rule file
+                items:
+                  description: RuleGroup is a list of sequentially evaluated recording
+                    and alerting rules.
+                  properties:
+                    interval:
+                      description: Interval determines how often rules in the group
+                        are evaluated.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    limit:
+                      description: Limit the number of alerts an alerting rule and
+                        series a recording rule can produce. Limit is supported starting
+                        with Prometheus >= 2.31 and Thanos Ruler >= 0.24.
+                      type: integer
+                    name:
+                      description: Name of the rule group.
+                      minLength: 1
+                      type: string
+                    partial_response_strategy:
+                      description: 'PartialResponseStrategy is only used by ThanosRuler
+                        and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
+                      pattern: ^(?i)(abort|warn)?$
+                      type: string
+                    rules:
+                      description: List of alerting and recording rules.
+                      items:
+                        description: 'Rule describes an alerting or recording rule
+                          See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
+                          or [recording](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules)
+                          rule'
+                        properties:
+                          alert:
+                            description: Name of the alert. Must be a valid label
+                              value. Only one of `record` and `alert` must be set.
+                            type: string
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations to add to each alert. Only valid
+                              for alerting rules.
+                            type: object
+                          expr:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: PromQL expression to evaluate.
+                            x-kubernetes-int-or-string: true
+                          for:
+                            description: Alerts are considered firing once they have
+                              been returned for this long.
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels to add or overwrite.
+                            type: object
+                          record:
+                            description: Name of the time series to output to. Must
+                              be a valid metric name. Only one of `record` and `alert`
+                              must be set.
+                            type: string
+                        required:
+                        - expr
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object

--- a/helm/ovn-kubernetes/crds/monitoring.coreos.com_servicemonitor.yaml
+++ b/helm/ovn-kubernetes/crds/monitoring.coreos.com_servicemonitor.yaml
@@ -1,0 +1,705 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+    - prometheus-operator
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    shortNames:
+    - smon
+    singular: servicemonitor
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: ServiceMonitor defines monitoring for a set of services.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of desired Service selection for target discovery
+              by Prometheus.
+            properties:
+              attachMetadata:
+                description: Attaches node metadata to discovered targets. Requires
+                  Prometheus v2.37.0 and above.
+                properties:
+                  node:
+                    description: When set to true, Prometheus must have permissions
+                      to get Nodes.
+                    type: boolean
+                type: object
+              endpoints:
+                description: A list of endpoints allowed as part of this ServiceMonitor.
+                items:
+                  description: Endpoint defines a scrapeable endpoint serving Prometheus
+                    metrics.
+                  properties:
+                    authorization:
+                      description: Authorization section for this endpoint
+                      properties:
+                        credentials:
+                          description: The secret's key that contains the credentials
+                            of the request
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: Set the authentication type. Defaults to Bearer,
+                            Basic will cause an error
+                          type: string
+                      type: object
+                    basicAuth:
+                      description: 'BasicAuth allow an endpoint to authenticate over
+                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                      properties:
+                        password:
+                          description: The secret in the service monitor namespace
+                            that contains the password for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: The secret in the service monitor namespace
+                            that contains the username for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    bearerTokenFile:
+                      description: File to read bearer token for scraping targets.
+                      type: string
+                    bearerTokenSecret:
+                      description: Secret to mount to read bearer token for scraping
+                        targets. The secret needs to be in the same namespace as the
+                        service monitor and accessible by the Prometheus Operator.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    enableHttp2:
+                      description: Whether to enable HTTP2.
+                      type: boolean
+                    filterRunning:
+                      description: 'Drop pods that are not running. (Failed, Succeeded).
+                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                      type: boolean
+                    followRedirects:
+                      description: FollowRedirects configures whether scrape requests
+                        follow HTTP 3xx redirects.
+                      type: boolean
+                    honorLabels:
+                      description: HonorLabels chooses the metric's labels on collisions
+                        with target labels.
+                      type: boolean
+                    honorTimestamps:
+                      description: HonorTimestamps controls whether Prometheus respects
+                        the timestamps present in scraped data.
+                      type: boolean
+                    interval:
+                      description: Interval at which metrics should be scraped If
+                        not specified Prometheus' global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    metricRelabelings:
+                      description: MetricRelabelConfigs to apply to samples before
+                        ingestion.
+                      items:
+                        description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of Prometheus
+                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                        properties:
+                          action:
+                            default: replace
+                            description: Action to perform based on regex matching.
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: Modulus to take of the hash of the source
+                              label values.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: Regular expression against which the extracted
+                              value is matched. Default is '(.*)'
+                            type: string
+                          replacement:
+                            description: Replacement value against which a regex replace
+                              is performed if the regular expression matches. Regex
+                              capture groups are available. Default is '$1'
+                            type: string
+                          separator:
+                            description: Separator placed between concatenated source
+                              label values. default is ';'.
+                            type: string
+                          sourceLabels:
+                            description: The source labels select values from existing
+                              labels. Their content is concatenated using the configured
+                              separator and matched against the configured regular
+                              expression for the replace, keep, and drop actions.
+                            items:
+                              description: LabelName is a valid Prometheus label name
+                                which may only contain ASCII letters, numbers, as
+                                well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: Label to which the resulting value is written
+                              in a replace action. It is mandatory for replace actions.
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    oauth2:
+                      description: OAuth2 for the URL. Only valid in Prometheus versions
+                        2.27.0 and newer.
+                      properties:
+                        clientId:
+                          description: The secret or configmap containing the OAuth2
+                            client id
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: The secret containing the OAuth2 client secret
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: Parameters to append to the token URL
+                          type: object
+                        scopes:
+                          description: OAuth2 scopes used for the token request
+                          items:
+                            type: string
+                          type: array
+                        tokenUrl:
+                          description: The URL to fetch the token from
+                          minLength: 1
+                          type: string
+                      required:
+                      - clientId
+                      - clientSecret
+                      - tokenUrl
+                      type: object
+                    params:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Optional HTTP URL parameters
+                      type: object
+                    path:
+                      description: HTTP path to scrape for metrics. If empty, Prometheus
+                        uses the default value (e.g. `/metrics`).
+                      type: string
+                    port:
+                      description: Name of the service port this endpoint refers to.
+                        Mutually exclusive with targetPort.
+                      type: string
+                    proxyUrl:
+                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                        to proxy through this endpoint.
+                      type: string
+                    relabelings:
+                      description: 'RelabelConfigs to apply to samples before scraping.
+                        Prometheus Operator automatically adds relabelings for a few
+                        standard Kubernetes fields. The original scrape job''s name
+                        is available via the `__tmp_prometheus_job_name` label. More
+                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                      items:
+                        description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of Prometheus
+                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                        properties:
+                          action:
+                            default: replace
+                            description: Action to perform based on regex matching.
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: Modulus to take of the hash of the source
+                              label values.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: Regular expression against which the extracted
+                              value is matched. Default is '(.*)'
+                            type: string
+                          replacement:
+                            description: Replacement value against which a regex replace
+                              is performed if the regular expression matches. Regex
+                              capture groups are available. Default is '$1'
+                            type: string
+                          separator:
+                            description: Separator placed between concatenated source
+                              label values. default is ';'.
+                            type: string
+                          sourceLabels:
+                            description: The source labels select values from existing
+                              labels. Their content is concatenated using the configured
+                              separator and matched against the configured regular
+                              expression for the replace, keep, and drop actions.
+                            items:
+                              description: LabelName is a valid Prometheus label name
+                                which may only contain ASCII letters, numbers, as
+                                well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: Label to which the resulting value is written
+                              in a replace action. It is mandatory for replace actions.
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    scheme:
+                      description: HTTP scheme to use for scraping. `http` and `https`
+                        are the expected values unless you rewrite the `__scheme__`
+                        label via relabeling. If empty, Prometheus uses the default
+                        value `http`.
+                      enum:
+                      - http
+                      - https
+                      type: string
+                    scrapeTimeout:
+                      description: Timeout after which the scrape is ended If not
+                        specified, the Prometheus global scrape timeout is used unless
+                        it is less than `Interval` in which the latter is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    targetPort:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Name or number of the target port of the Pod behind
+                        the Service, the port must be specified with container port
+                        property. Mutually exclusive with port.
+                      x-kubernetes-int-or-string: true
+                    tlsConfig:
+                      description: TLS configuration to use when scraping the endpoint
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server
+                            certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        caFile:
+                          description: Path to the CA cert in the Prometheus container
+                            to use for the targets.
+                          type: string
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        certFile:
+                          description: Path to the client cert file in the Prometheus
+                            container for the targets.
+                          type: string
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keyFile:
+                          description: Path to the client key file in the Prometheus
+                            container for the targets.
+                          type: string
+                        keySecret:
+                          description: Secret containing the client key file for the
+                            targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              jobLabel:
+                description: "JobLabel selects the label from the associated Kubernetes
+                  service which will be used as the `job` label for all metrics. \n
+                  For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo:
+                  bar`, then the `job=\"bar\"` label is added to all metrics. \n If
+                  the value of this field is empty or if the label doesn't exist for
+                  the given Service, the `job` label of the metrics defaults to the
+                  name of the Kubernetes Service."
+                type: string
+              labelLimit:
+                description: Per-scrape limit on number of labels that will be accepted
+                  for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                format: int64
+                type: integer
+              labelNameLengthLimit:
+                description: Per-scrape limit on length of labels name that will be
+                  accepted for a sample. Only valid in Prometheus versions 2.27.0
+                  and newer.
+                format: int64
+                type: integer
+              labelValueLengthLimit:
+                description: Per-scrape limit on length of labels value that will
+                  be accepted for a sample. Only valid in Prometheus versions 2.27.0
+                  and newer.
+                format: int64
+                type: integer
+              namespaceSelector:
+                description: Selector to select which namespaces the Kubernetes Endpoints
+                  objects are discovered from.
+                properties:
+                  any:
+                    description: Boolean describing whether all namespaces are selected
+                      in contrast to a list restricting them.
+                    type: boolean
+                  matchNames:
+                    description: List of namespace names to select from.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              podTargetLabels:
+                description: PodTargetLabels transfers labels on the Kubernetes `Pod`
+                  onto the created metrics.
+                items:
+                  type: string
+                type: array
+              sampleLimit:
+                description: SampleLimit defines per-scrape limit on number of scraped
+                  samples that will be accepted.
+                format: int64
+                type: integer
+              selector:
+                description: Selector to select Endpoints objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              targetLabels:
+                description: TargetLabels transfers labels from the Kubernetes `Service`
+                  onto the created metrics.
+                items:
+                  type: string
+                type: array
+              targetLimit:
+                description: TargetLimit defines a limit on the number of scraped
+                  targets that will be accepted.
+                format: int64
+                type: integer
+            required:
+            - endpoints
+            - selector
+            type: object
+        required:
+        - spec
+        type: object

--- a/helm/ovn-kubernetes/templates/_helpers.tpl
+++ b/helm/ovn-kubernetes/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{/*
+Check if namespace spec is needed or not
+- if namespace doesn't exist, return "true"
+- if namespace exists but not managed by Helm, return "true", otherwise the namespace will be deleted
+*/}}
+{{- define "needNamespace" -}}
+{{- $ns := lookup "v1" "Namespace" "" . }}
+{{- if not $ns }}
+{{- print "true" }}
+{{- else }}
+{{- $managedBy := get $ns.metadata.labels "app.kubernetes.io/managed-by" }}
+  {{- if eq $managedBy "Helm" }}
+    {{- print "true" }}
+  {{- else }}
+    {{- print "false" }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate image
+*/}}
+{{- define "getImage" -}}
+  {{- $image := "" }}
+  {{- if and (ne .Values.global.image.repository "") (ne .Values.global.image.tag "") }}
+    {{- $image = printf "%s:%s" .Values.global.image.repository .Values.global.image.tag }}
+  {{- else if and (ne .Values.image.repository "") (ne .Values.image.tag "") }}
+    {{- $image = printf "%s:%s" .Values.image.repository .Values.image.tag }}
+  {{- end }}
+    {{- if eq $image "" }}
+      {{ fail "image not found" }}
+    {{- else }}
+      {{- print $image }}
+    {{- end }}
+{{- end }}
+
+{{/*
+Output "yes" if enableSsl is true, otherwise "no"
+*/}}
+{{- define "isSslEnabled" -}}
+{{- $sslEnabled := hasKey .Values.global "enableSsl" | ternary .Values.global.enableSsl false }}
+{{- if eq $sslEnabled true }}
+  {{- print "yes" }}
+{{- else }}
+  {{- print "no" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Output "yes" if unprivilegedMode is true, otherwise "no"
+*/}}
+{{- define "isUnprivilegedMode" -}}
+{{- $unprivilegedMode := hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false }}
+{{- if eq $unprivilegedMode true }}
+  {{- print "yes" }}
+{{- else }}
+  {{- print "no" }}
+{{- end }}
+{{- end }}

--- a/helm/ovn-kubernetes/templates/ovn-setup.yaml
+++ b/helm/ovn-kubernetes/templates/ovn-setup.yaml
@@ -1,0 +1,65 @@
+{{- if or .Values.skipCallToK8s (eq (include "needNamespace" "ovn-kubernetes") "true") }}
+---
+# ovn-namespace.yaml
+#
+# Setup for Kubernetes to support the ovn-kubernetes plugin
+#
+# Create the namespace for ovn-kubernetes.
+#
+# This provisioning is done as part of installation after the cluster is
+# up and before the ovn daemonsets are created.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ovn-kubernetes
+{{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: ovn-kubernetes
+  name: ovn-k8s-configmap
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+---
+
+{{- $hostNetworkNamespace := .Values.hostNetworkNamespace | default "ovn-host-network"}}
+# The network cidr and service cidr are set in the ovn-config configmap
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-config
+  namespace: ovn-kubernetes
+data:
+  net_cidr:      {{ .Values.podNetwork }}
+  svc_cidr:      {{ .Values.serviceNetwork }}
+  k8s_apiserver: {{ .Values.k8sAPIServer }}
+  mtu:           {{ .Values.mtu | default 1500 | quote }}
+  host_network_namespace: {{ $hostNetworkNamespace }}
+
+{{- if or .Values.global.skipCallToK8s (eq (include "needNamespace" $hostNetworkNamespace) "true") }}
+---
+# ovn-host-network-namespace.yaml
+#
+# Create the namespace for classifying host network traffic.
+#
+# This provisioning is done as part of installation after the cluster is
+# up and before the ovn daemonsets are created.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $hostNetworkNamespace }}
+{{- end }}

--- a/helm/ovn-kubernetes/templates/ovnkube-alerts.yaml
+++ b/helm/ovn-kubernetes/templates/ovnkube-alerts.yaml
@@ -1,0 +1,369 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: ovnkube-rules
+  namespace: ovn-kubernetes
+spec:
+  groups:
+  - name: general.rules
+    rules:
+    - alert: OvnKubeNoRunningManager
+      expr: absent(up{job="ovnkube-master", namespace="ovn-kubernetes"} == 1)
+      for: 4m
+      labels:
+       severity: critical
+      annotations:
+       description: There is no running ovnkube-manager
+
+    - alert: OvnKubeManagerMultipleLeaders
+      expr: sum(ovnkube_controller_leader) > 1
+      for: 4m
+      labels:
+       severity: critical
+      annotations:
+       description: There are multiple ovnkube-manager leaders
+
+    - alert: OvnKubeManagerNoLeader
+      expr: max(ovnkube_controller_leader) == 0
+      for: 4m
+      labels:
+        severity: critical
+      annotations:
+       description: There is no running ovnkube-manager leader
+
+    - alert: OvnKubePodRestarts
+      expr: |
+        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", container=~"ovnkube.*"}[15m]) * 60 * 5 > 0
+      for: 30m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} {{ $labels.container}} is restarting 
+         {{ printf "%.2f" $value }} times / 5 minutes.`}}        
+                
+    - alert: K8sNodeWithoutOvnKubeAgentRunning
+      expr: |
+        kube_node_info unless on(node)
+        (kube_pod_info{namespace="ovn-kubernetes", pod=~"ovnkube-node.*"}) > 0
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`All K8s nodes should be running OVN K8s Agent pods, 
+         but OVN K8s Agent pod is not running on {{ $labels.node }} node.`}}  
+
+    - alert: OvnKubeHighPodCreationLatency99thPercentile
+      expr: |
+        histogram_quantile(0.99,
+         sum by (le) (
+           rate(ovnkube_controller_pod_creation_latency_seconds_bucket[15m])
+         ) 
+        ) > 5
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`The pod creation latency value {{ $value }} aggregated across 
+         all masters for the last 15minutes is more than 5 seconds.`}}
+
+    - alert: OvnKubeIncreaseInPodCreationLatency99thPercentile
+      expr: |
+        histogram_quantile(0.99,
+         sum by (le) ( 
+          rate(ovnkube_controller_pod_creation_latency_seconds_bucket[15m] 
+          offset 15m)
+         )
+        )
+        -
+        histogram_quantile(0.99,
+         sum by (le) (
+          rate(ovnkube_controller_pod_creation_latency_seconds_bucket[15m])
+         )
+        ) > 5 
+     
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         The pod creation latency aggregated across all masters for the last 
+         15minutes is more than 5 seconds as compared to 15 minutes before last 15 minutes.
+
+    - alert: OvnKubeHighNBCliLatency99thPercentile
+      expr: |
+        histogram_quantile(0.99,
+          sum by (le) (
+            rate(ovnkube_controller_ovn_cli_latency_seconds_bucket{
+              command="ovn-nbctl"}[15m])
+          )
+        ) > 3 
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`The ovn-nbctl 99th percentile CLI latency {{ value }} aggregated 
+         across all masters for the last 15minutes is more than 3 seconds.`}}
+
+    - alert: OvnKubeHighSBCliLatency99thPercentile
+      expr: |
+        histogram_quantile(0.99,
+          sum by (le) (
+            rate(ovnkube_controller_ovn_cli_latency_seconds_bucket{
+              command="ovn-sbctl"}[15m])
+          )
+        ) > 3
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`The ovn-sbctl 99th percentile CLI latency {{ value }} aggregated
+         across all masters for the last 15minutes is more than 3 seconds.`}}
+
+    - alert: OvnKubeHighK8sNetworkPolicyUpdateLatency99thPercentile
+      expr: |
+        histogram_quantile(0.99,
+          sum by (le) (
+            rate(ovnkube_controller_resource_update_latency_seconds_bucket{
+              name="NetworkPolicy"}[15m])
+          )
+        ) > 1
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`The 99th percentile {{ $labels.name }} update latency {{ value }} aggregated 
+         across all masters for the last 15minutes is more than 1 seconds.`}}
+
+    - alert: OvnKubeHighK8sNamespaceUpdateLatency99thPercentile
+      expr: |
+        histogram_quantile(0.99,
+          sum by (le) (
+            rate(ovnkube_controller_resource_update_latency_seconds_bucket{
+              name="Namespace"}[15m])
+          )
+        ) > 1
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`The 99th percentile {{ $labels.name }} update latency {{ value }} 
+         aggregated across all masters for the last 15minutes is more than 1 seconds.`}}
+
+    - alert: OvnKubeHighK8sServiceUpdateLatency99thPercentile
+      expr: |
+        histogram_quantile(0.99,
+          sum by (le) (
+            rate(ovnkube_controller_resource_update_latency_seconds_bucket{
+              name="Service"}[15m])
+          )
+        ) > 1
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`The 99th percentile {{ $labels.name }} update latency {{ value }} aggregated 
+         across all masters for the last 15minutes is more than 1 seconds.`}}
+
+    - alert: OvnKubeHighK8sEndpointUpdateLatency99thPercentile
+      expr: |
+        histogram_quantile(0.99,
+          sum by (le) (
+            rate(ovnkube_controller_resource_update_latency_seconds_bucket{
+              name="Endpoint"}[15m])
+          )
+        ) > 1
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`The 99th percentile {{ $labels.name }} update latency {{ value }} aggregated
+         across all masters for the last 15minutes is more than 1 seconds.`}}
+
+    - alert: OvnNBDBStale
+      expr: time() - max(ovnkube_controller_nb_e2e_timestamp) > 120
+      for: 4m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         ovn-kubernetes has not written anything to the northbound database for too long
+
+    - alert: OvnSBDBStale
+      expr: max(ovnkube_controller_nb_e2e_timestamp) - max(ovnkube_controller_sb_e2e_timestamp) > 120
+      for: 4m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         ovn-northd has not successfully synced changes from northbound DB 
+         to the southbound DB for too long
+
+    - alert: OvnNBDBContainerRestarts
+      expr: |
+        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", container="nb-ovsdb"}[15m]) * 60 * 5 > 0
+      for: 30m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} nbdb container is 
+         restarting {{ printf "%.2f" $value }} times / 5 minutes`}}
+
+    - alert: OvnSBDBContainerRestarts
+      expr: |
+        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", container="sb-ovsdb"}[15m]) * 60 * 5 > 0
+      for: 30m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} sbdb container is 
+         restarting {{ printf "%.2f" $value }} times / 5 minutes.`}}
+
+    - alert: OvnNBDBMultipleLeaders
+      expr: sum(ovn_db_cluster_server_role{db_name="OVN_Northbound",server_role="leader"}) > 1
+      for: 4m
+      labels:
+       severity: critical
+      annotations:
+       description: There are multiple ovn-nbdb leaders
+
+    - alert: OvnNBDBNoLeader
+      expr: max(ovn_db_cluster_server_role{db_name="OVN_Northbound",server_role="leader"}) == 0
+      for: 4m
+      labels:
+        severity: critical
+      annotations:
+       description: There is no running ovn-nbdb leader
+
+    - alert: OvnSBDBMultipleLeaders
+      expr: sum(ovn_db_cluster_server_role{db_name="OVN_Southbound",server_role="leader"}) > 1
+      for: 4m
+      labels:
+       severity: critical
+      annotations:
+       description: There are multiple ovn-sbdb leaders
+
+    - alert: OvnSBDBNoLeader
+      expr: max(ovn_db_cluster_server_role{db_name="OVN_Southbound",server_role="leader"}) == 0
+      for: 4m
+      labels:
+        severity: critical
+      annotations:
+       description: There is no running ovn-sbdb leader
+
+    - alert: OvnNorthdContainerRestarts
+      expr: |
+        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", container="ovn-northd"}[15m]) * 60 * 5 > 0
+      for: 30m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-northd container is 
+         restarting {{ printf "%.2f" $value }} times / 5 minutes`}}
+
+    - alert: OvnNorthdNotActive
+      expr: sum(ovn_northd_status) != 1
+      for: 4m
+      labels:
+       severity: critical
+      annotations:
+       description: There is no running ovn-northd.
+
+    - alert: OvnNorthdTxnError
+      expr: |
+        rate(ovn_northd_txn_error{namespace="ovn-kubernetes",job="ovnkube-node"}[1m]) > 0
+      for: 10m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-northd containers
+         transaction error is {{ printf "%.2f" $value }} per second`}}
+
+    - alert: OvnNorthdTxnIncomplete
+      expr: |
+        rate(ovn_northd_txn_incomplete{namespace="ovn-kubernetes",job="ovnkube-node"}[1m]) > 1
+      for: 30m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-northd containers
+         transaction incomplete is {{ printf "%.2f" $value }} per second.`}}
+
+    - alert: OvnControllerContainerRestarts
+      expr: |
+        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", 
+        container="ovn-controller"}[15m]) * 60 * 5 > 0
+      for: 30m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-controller container 
+         is restarting {{ printf "%.2f" $value }} times / 5 minutes`}}
+
+    - alert: OvnControllerTxnError
+      expr: |
+        rate(ovn_controller_txn_error{namespace="ovn-kubernetes",job="ovnkube-node"}[1m]) > 0
+      for: 10m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-controller containers
+         transaction error is {{ printf "%.2f" $value }} per second.`}}
+
+    - alert: OvnControllerTxnIncomplete
+      expr: |
+        rate(ovn_controller_txn_incomplete{namespace="ovn-kubernetes",job="ovnkube-node"}[1m]) > 1
+      for: 30m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-controller containers
+         transaction incomplete is {{ printf "%.2f" $value }} per second`}}
+
+    - alert: OvnControllerLflowRun
+      expr: |
+        rate(ovn_controller_lflow_run{namespace="ovn-kubernetes",job="ovnkube-node"}[1m]) > 0
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-controller containers
+         logical flow table translation is {{ printf "%.2f" $value }} per second.`}}
+       
+    - alert: OvnControllerLowerGenevePortCount
+      expr: |
+        ovn_controller_integration_bridge_geneve_ports_total and 
+        (ovn_controller_integration_bridge_geneve_ports_total{job="ovnkube-node", namespace="ovn-kubernetes"} 
+        != scalar(count(kube_node_info)) - 1)
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       description: |
+         {{`The list of nodes that have a lower number of Geneve Ports
+         and counts they have 
+         {{ range query "ovn_controller_integration_bridge_geneve_ports_total{job='ovnkube-node', namespace='ovn-kubernetes'} !=  scalar(count(kube_node_info)) - 1" }}
+         {{ .Labels.instance }}: {{ .Value }}
+         {{ end }}.`}}
+ 
+

--- a/helm/ovn-kubernetes/templates/ovnkube-monitor.yaml
+++ b/helm/ovn-kubernetes/templates/ovnkube-monitor.yaml
@@ -1,0 +1,141 @@
+# define ServiceMontior and Service resources for ovnkube-cluster-manager,
+# ovnkube-master (or ovnkube-controller), ovnkube-node and ovnkube-db (required for prometheus monitoring)
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: ovnkube-master
+  name: monitor-ovnkube-master
+  namespace: ovn-kubernetes
+spec:
+  endpoints:
+  - interval: 30s
+    port: http-metrics
+    scheme: http
+    path: /metrics
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - ovn-kubernetes
+  selector:
+    matchLabels:
+      k8s-app: ovnkube-master
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: ovnkube-master
+  name: ovnkube-master-prometheus-discovery
+  namespace: ovn-kubernetes
+spec:
+  selector:
+    name: ovnkube-master
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: http-metrics
+    port: 9409
+    protocol: TCP
+    targetPort: 9409
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: ovnkube-node
+  name: monitor-ovnkube-node
+  namespace: ovn-kubernetes
+spec:
+  endpoints:
+  - interval: 30s
+    port: ovnkube-node-metrics
+    path: /metrics
+    scheme: http
+  - interval: 30s
+    port: ovs-metrics
+    path: /metrics
+    scheme: http
+  - interval: 30s
+    port: ovn-metrics
+    path: /metrics
+    scheme: http
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - ovn-kubernetes
+  selector:
+    matchLabels:
+      k8s-app: ovnkube-node
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: ovnkube-node
+  name: ovnkube-node-prometheus-discovery
+  namespace: ovn-kubernetes
+spec:
+  selector:
+    name: ovnkube-node
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: ovnkube-node-metrics
+    port: 9410
+    protocol: TCP
+    targetPort: 9410
+  - name: ovn-metrics
+    port: 9476
+    protocol: TCP
+    targetPort: 9476
+  - name: ovs-metrics
+    port: 9310
+    protocol: TCP
+    targetPort: 9310
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: ovnkube-cluster-manager
+  name: monitor-ovnkube-cluster-manager
+  namespace: ovn-kubernetes
+spec:
+  endpoints:
+  - interval: 30s
+    port: http-metrics
+    scheme: http
+    path: /metrics
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - ovn-kubernetes
+  selector:
+    matchLabels:
+      k8s-app: ovnkube-cluster-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: ovnkube-cluster-manager
+  name: ovnkube-cluster-manager-prometheus-discovery
+  namespace: ovn-kubernetes
+spec:
+  selector:
+    name: ovnkube-cluster-manager
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: http-metrics
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+---

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-db.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-db.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-db
+    namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-db
+roleRef:
+    name: ovnkube-db
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-db
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-db-ep
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovnkube-db-ep
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-db
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-db
+rules:
+    - apiGroups: [""]
+      resources:
+          - nodes
+          - namespaces
+      verbs: [ "get", "list", "watch" ]
+
+# ovnkube-db startup scripts create an endpoint:
+# https://github.com/ovn-org/ovn-kubernetes/blob/d3b10e87f7fffa38fdf4ad52f98bc8ba998df6c2/dist/images/ovnkube.sh#L699
+# in HA statefulsets/pods are inspected 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: ovnkube-db-ep
+    namespace: ovn-kubernetes
+rules:
+    - apiGroups: [""]
+      resources:
+          - endpoints
+      verbs: [ "get", "create" ]
+    - apiGroups: [""]
+      resources:
+          - pods
+      verbs: [ "get", "list" ]
+    - apiGroups: ["apps"]
+      resources:
+          - statefulsets
+      verbs: [ "get" ]

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
@@ -1,0 +1,215 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: ovnkube-node
+    namespace: ovn-kubernetes
+
+# When ovn_enable_ovnkube_identity is true, an ovnkube-node process will identify as a user in a system:ovn-nodes group,
+# not the ovnkube-node serviceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-node
+roleRef:
+    name: ovnkube-node
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - kind: Group
+      name: system:ovn-nodes
+      apiGroup: rbac.authorization.k8s.io
+    {{- else }}
+    - kind: ServiceAccount
+      name: ovnkube-node
+      namespace: ovn-kubernetes
+    {{- end }}
+
+
+# even when ovn_enable_ovnkube_identity is enabled, an ovnkube-node service account
+# is used in the ovnkube-node pod during initialization:
+# https://github.com/ovn-org/ovn-kubernetes/blob/c135b19e0b424c847e1de8bc214d884f8f905a8c/dist/images/ovnkube.sh#L2249
+# https://github.com/ovn-org/ovn-kubernetes/blob/c135b19e0b424c847e1de8bc214d884f8f905a8c/dist/images/ovnkube.sh#L748
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-node-status-reader
+roleRef:
+    name: ovnkube-node-status-reader
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-node
+      namespace: ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-node-configmaps
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovn-k8s-configmap
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - kind: Group
+      name: system:ovn-nodes
+      apiGroup: rbac.authorization.k8s.io
+    {{- else }}
+    - kind: ServiceAccount
+      name: ovnkube-node
+      namespace: ovn-kubernetes
+    {{- end }}
+
+# In IC ovnkube-node pod needs configmap access in ovn-k ns for topology version:
+# https://github.com/ovn-org/ovn-kubernetes/blob/e1e7d40f9a6c6038b52696c1b8f8915a4d73160e/go-controller/pkg/ovn/topology_version.go#L28
+{{- if eq (hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false) true }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-node-ic-configmaps-update
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovn-k8s-configmap-update
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - kind: Group
+      name: system:ovn-nodes
+      apiGroup: rbac.authorization.k8s.io
+    {{- else }}
+    - kind: ServiceAccount
+      name: ovnkube-node
+      namespace: ovn-kubernetes
+    {{- end }}
+{{- end }}
+
+# even when ovn_enable_ovnkube_identity is enabled, an ovnkube-node service account
+# is used in the ovnkube-node pod during initialization:
+# https://github.com/ovn-org/ovn-kubernetes/blob/c135b19e0b424c847e1de8bc214d884f8f905a8c/dist/images/ovnkube.sh#L366
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ovnkube-node-ep
+    namespace: ovn-kubernetes
+roleRef:
+    name: ovnkube-node-ep
+    kind: Role
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-node
+      namespace: ovn-kubernetes
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-node-status-reader
+rules:
+    - apiGroups: [""]
+      resources:
+          - nodes/status
+      verbs: [ "get" ]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-node
+rules:
+    - apiGroups: [""]
+      resources:
+          - namespaces
+          - nodes
+          - pods
+          - services
+          - endpoints
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["discovery.k8s.io"]
+      resources:
+          - endpointslices
+      verbs: [ "get", "list", "watch" ]
+    {{- if eq (hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false) true }}
+    - apiGroups: ["networking.k8s.io"]
+      resources:
+          - networkpolicies
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.cni.cncf.io"]
+      resources:
+          - network-attachment-definitions
+          - multi-networkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressfirewalls/status
+          - adminpolicybasedexternalroutes/status
+      verbs: [ "patch", "update" ]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies/status
+          - baselineadminnetworkpolicies/status
+      verbs: [ "patch", "update" ]
+    {{- end }}
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies
+          - baselineadminnetworkpolicies
+      verbs: ["list", "get", "watch"]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - egressfirewalls
+          - egressips
+          - egressqoses
+          - egressservices
+          - adminpolicybasedexternalroutes
+      verbs: [ "get", "list", "watch" ]
+    {{- if eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true }}
+    - apiGroups: ["certificates.k8s.io"]
+      resources:
+          - certificatesigningrequests
+      verbs:
+        - create
+        - get
+        - list
+        - watch
+    {{- end }}
+    - apiGroups: [""]
+      resources:
+          - events
+      verbs: ["create", "patch", "update"]
+    - apiGroups: [""]
+      resources:
+          {{- if eq (hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false) true }}
+          - namespaces/status #TODO(kyrtapz) all of the nodes update the exgw annotation on namespaces, we might need to change that
+          {{- end }}
+          - pods/status # In IC ovnkube-controller, and ovnkube-node in DPU mode updates pod annotations for local pods
+          - nodes/status
+      verbs: [ "patch", "update" ]
+
+# Without IC endpoints are read by ovnkube-node on startup
+# With IC endpoints are created by ovnkube-zone-controller/sb-ovsdb startup script in multinode-zone for IC
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: ovnkube-node-ep
+    namespace: ovn-kubernetes
+rules:
+    - apiGroups: [""]
+      resources:
+          - endpoints
+      verbs:
+          - get
+          {{- if eq (hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false) true }}
+          - create
+          {{- end }}

--- a/helm/ovn-kubernetes/values.yaml
+++ b/helm/ovn-kubernetes/values.yaml
@@ -1,0 +1,145 @@
+# Values for ovn-kubernetes.
+
+# -- list of dependent subcharts that need to be installed for the given deployment mode, these subcharts haven't been tested yet.
+tags:
+  ovn-ipsec: false
+  ovnkube-control-plane: false
+  ovnkube-db-raft: false
+  ovnkube-node-dpu: false
+  ovnkube-node-dpu-host: false
+  ovnkube-single-node-zone: false
+  ovnkube-zone-controller: false
+
+# -- Endpoint of Kubernetes api server
+k8sAPIServer: https://172.25.0.2:6443
+# -- IP range for Kubernetes pods, /14 is the top level range, under which each /23 range will be assigned to a node
+podNetwork: 10.128.0.0/14/23
+# -- A comma-separated set of CIDR notation IP ranges from which k8s assigns service cluster IPs. This should be the same as the value provided for kube-apiserver "--service-cluster-ip-range" option
+serviceNetwork: 172.30.0.0/16
+# -- MTU of network interface in a Kubernetes pod
+mtu: 1400
+# -- Whether or not call `lookup` Helm function, set it to `true` if you want to run `helm dry-run/template/lint`
+skipCallToK8s: false
+
+global:
+  # -- The net device to be used for management port, will be renamed to ovn-k8s-mp0 and used to allow host network services and pods to access k8s pod and service networks
+  nodeMgmtPortNetdev: ""
+  # -- The interface on nodes that will be used for external gateway network traffic
+  extGatewayNetworkInterface: ""
+  # -- GENEVE UDP port (default 6081)
+  encapPort: 6081
+  # -- The gateway mode (shared or local), if not given, gateway functionality is disabled
+  gatewayMode: shared
+  # -- Optional extra gateway options
+  gatewayOpts: ""
+  # -- This allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
+  unprivilegedMode: false
+  # -- The v4 join subnet used for assigning join switch IPv4 addresses
+  v4JoinSubnet: ""
+  # -- The v4 masquerade subnet used for assigning masquerade IPv4 addresses
+  v4MasqueradeSubnet: ""
+  # -- The v6 join subnet used for assigning join switch IPv6 addresses
+  v6JoinSubnet: ""
+  # -- The v6 masquerade subnet used for assigning masquerade IPv6 addresses
+  v6MasqueradeSubnet: ""
+  # -- Whether or not enable ovnkube identity webhook
+  enableOvnKubeIdentity: true
+  # -- Indicate if ovnkube run master and node in one process
+  enableCompactMode: false
+  # -- Whether or not to enable hybrid overlay functionality
+  enableHybridOverlay: ""
+  # -- A comma separated set of IP subnets and the associated hostsubnetlengths (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\") to use with the extended hybrid network
+  hybridOverlayNetCidr: ""
+  # -- Whether or not to use Admin Network Policy CRD feature with ovn-kubernetes
+  enableAdminNetworkPolicy: ""
+  # -- Configure to use EgressIP CRD feature with ovn-kubernetes
+  enableEgressIp: ""
+  # -- Configure EgressIP node reachability using gRPC on this TCP port
+  egressIpHealthCheckPort: ""
+  # -- Configure to use EgressService CRD feature with ovn-kubernetes
+  enableEgressService: ""
+  # -- Configure to use EgressFirewall CRD feature with ovn-kubernetes
+  enableEgressFirewall: ""
+  # -- Configure to use EgressQoS CRD feature with ovn-kubernetes
+  enableEgressQos: ""
+  # -- Enables multicast support between the pods within the same namespace
+  enableMulticast: ""
+  # -- Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes
+  enableMultiNetwork: false
+  # -- Configure to enable IPsec
+  enableIpsec: false
+  # -- Use SSL transport to NB/SB db and northd
+  enableSsl: false
+  # -- Configure to enable interconnecting multiple zones
+  enableInterConnect: false
+  # -- Configure to use AdminPolicyBasedExternalRoute CRD feature with ovn-kubernetes
+  enableMultiExternalGateway: false
+  # -- Configure to use stateless network policy feature with ovn-kubernetes
+  enableStatelessNetworkPolicy: false
+  # -- Enables metrics related to scaling
+  enableMetricsScale: ""
+  # -- Enables monitoring OVN-Kubernetes master and OVN configuration duration
+  enableConfigDuration: ""
+  # -- Indicates if ovn-controller should enable/disable the logical flow in-memory cache when processing Southbound database logical flow changes
+  # @default -- true
+  enableLFlowCache: true
+  # -- Maximum number of logical flow cache entries ovn-controller may create when the logical flow cache is enabled
+  # @default -- unlimited
+  lFlowCacheLimit: ""
+  # -- Maximum size of the logical flow cache (in KB) ovn-controller may create when the logical flow cache is enabled
+  lFlowCacheLimitKb: ""
+  # -- Whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
+  disableSnatMultipleGws: ""
+  # -- Controls if forwarding is allowed on OVNK controlled interfaces
+  # @default -- false
+  disableForwarding: ""
+  # -- Disables adding openflow flows to check packets too large to be delivered to OVN due to pod MTU being lower than NIC MTU
+  disablePacketMtuCheck: ""
+  # -- Deprecated: iface-id-ver is always enabled
+  disableIfaceIdVer: false
+  # -- The largest number of messages per second that gets logged before drop
+  # @default 20
+  aclLoggingRateLimit: 20
+  # -- If set, then load balancers do not get deleted when all backends are removed
+  emptyLbEvents: ""
+  # -- Port of north bound ovsdb
+  nbPort: 6641
+  # -- Port of south bound ovsdb
+  sbPort: 6642
+  # -- A comma separated set of NetFlow collectors to export flow data
+  netFlowTargets: ""
+  # -- A comma separated set of SFlow collectors to export flow data
+  sflowTargets: ""
+  # -- A comma separated set of IPFIX collectors to export flow data
+  ipfixTargets: ""
+  # -- Rate at which packets should be sampled and sent to each target collector
+  # @default 400
+  ipfixSampling: ""
+  # -- Maximum number of IPFIX flow records that can be cached at a time
+  # @default 0, meaning disabled
+  ipfixCacheMaxFlows: ""
+  # -- Maximum period in seconds for which an IPFIX flow record is cached and aggregated before being sent
+  # @default 60
+  ipfixCacheActiveTimeout: ""
+  # -- OVN remote probe interval in ms 
+  # @default 100000
+  remoteProbeInterval: 100000
+  # -- Enable monitoring all data from SB DB instead of conditionally monitoring the data relevant to this node only
+  # @default true
+  monitorAll: ""
+  # -- ovn-controller wait time in ms before clearing OpenFlow rules during start up
+  # @default 0
+  ofctrlWaitBeforeClear: ""
+  # -- Separate log file for libovsdb client 
+  libovsdbClientLogFile: ""
+  image:
+    # -- Image repository for ovn-kubernetes components
+    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u
+    # -- Specify image tag to run
+    tag: master
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+
+ovnkube-identity:
+    # -- number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes
+    replicas: 1

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -60,11 +60,26 @@ sudo mv kubernetes/test/bin/e2e.test /usr/local/bin/e2e.test
 sudo mv kubernetes/test/bin/ginkgo /usr/local/bin/ginkgo
 rm kubernetes-test-linux-${ARCH}.tar.gz
 
+if [ "$USE_HELM" == true ]; then
+    HELM_VERSION="v3.14.2"
+	# to get latest stable version: https://github.com/helm/helm/releases
+    curl -L  https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz -o helm-linux-${ARCH}.tar.gz
+	tar xvzf helm-linux-${ARCH}.tar.gz
+    chmod +x ./linux-${ARCH}/helm
+	sudo mv linux-${ARCH}/helm /usr/local/bin/
+	rm helm-linux-${ARCH}.tar.gz
+fi
+
 install_kind
 popd # go out of $TMP_DIR
 
 pushd $SCRIPT_DIR/../../contrib
-./kind.sh
+if [ "$USE_HELM" == true ]; then
+    ./kind-helm.sh
+else
+    ./kind.sh
+fi
+
 if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
     sudo mv ./bin/virtctl /usr/local/bin/virtctl
 fi


### PR DESCRIPTION
WIP: This is a rebase of https://github.com/ovn-org/ovn-kubernetes/pull/4103 that includes the test lane in github. We may prefer to use that PR once it merges the missing commits and gets rebased to master latest.

This commit adds a bundle of Helm charts to deploy ovn-kubernetes.
The specs are based on the yaml templates under dist/templates, but
only following scenarios were tested in Kind-built cluster:

ovs-node + ovnkube-node + ovnkube-db + ovnkube-master, with/without ovnkube-identity
ovs-node + ovnkube-node + ovnkube-db-raft + ovnkube-master, with/without ovnkube-identity
Inter-connect related charts were not tested due to insufficient knowledge.

Run script helm/basic-deploy.sh for a quick start.
```
$ ./basic-deploy.sh
$ helm ls
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ovn-kubernetes  default         1               2024-02-27 21:17:53.349478111 +0000 UTC deployed        ovn-kubernetes-0.1.0    1.16.0

$ helm show values ./ovn-kubernetes | grep repository
    # -- Image repository for ovn-kubernetes components
    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u
```

To clean up, do:
```
$ helm uninstall ovn-kubernetes
release "ovn-kubernetes" uninstalled
$ kind delete cluster --name ovn-helm
```