### PR TITLE
update golangci-lint-action v3->v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       id: go
 
     - name: Verify
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4
       with:
         version: v1.52
         working-directory: go-controller


### PR DESCRIPTION
per the warning in the actions CI dashboard, this updates the golangci-lint-action from v3 to v4 which moves from Node 16 to Node 20. Node 16 is EOL. see here:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/