### PR TITLE
ANP: Fix PortRange typo

### DIFF
--- a/go-controller/pkg/ovn/controller/admin_network_policy/types.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/types.go
@@ -174,7 +174,7 @@ func newAdminNetworkPolicyPort(raw anpapi.AdminNetworkPolicyPort) *libovsdbutil.
 	} else if raw.NamedPort != nil {
 		// TODO: Add support for this
 	} else {
-		anpPort = libovsdbutil.GetNetworkPolicyPort(raw.PortNumber.Protocol, raw.PortRange.Start, raw.PortRange.End)
+		anpPort = libovsdbutil.GetNetworkPolicyPort(raw.PortRange.Protocol, raw.PortRange.Start, raw.PortRange.End)
 	}
 	return anpPort
 }


### PR DESCRIPTION
**- What this PR does and why is it needed**

There was a typo when I did https://github.com/ovn-org/ovn-kubernetes/pull/4162 during the updates. 
s/portnumber/portrange

**- Special notes for reviewers**

Added test to capture this


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->