### PR TITLE
Enable status manager tests in lgw v6

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -117,7 +117,6 @@ EgressQoS validation|\
 Should be allowed by nodeport services|\
 Should be allowed to node local cluster-networked endpoints by nodeport services with externalTrafficPolicy=local|\
 Should successfully create then remove a static pod|\
-Status manager validation|\
 Should validate connectivity from a pod to a non-node host address on same node|\
 Should validate connectivity within a namespace of pods on separate nodes|\
 Services"


### PR DESCRIPTION
The failure might have been caused by the EIP issue, from the logs in the failed job:
```
F0221 10:40:35.977662   11123 ovnkube.go:136] failed to start node network manager: failed to start default node network controller: failed to run egress IP controller: failed to create IP rule for node IPs: file exists
F0221 10:40:35.977662   11123 ovnkube.go:136] failed to start node network manager: failed to start default node network controller: failed to run egress IP controller: failed to create IP rule for node IPs: file exists
F0221 10:40:35.977662   11123 ovnkube.go:136] failed to start node network manager: failed to start default node network controller: failed to run egress IP controller: failed to create IP rule for node IPs: file exists
F0221 10:40:35.977662   11123 ovnkube.go:136] failed to start node network manager: failed to start default node network controller: failed to run egress IP controller: failed to create IP rule for node IPs: file exists
```

Fixes https://github.com/ovn-org/ovn-kubernetes/issues/4184