### PR TITLE
kubevirt, e2e: Add diagnostics tools

### DIFF
--- a/test/e2e/diagnostics/conntrack.go
+++ b/test/e2e/diagnostics/conntrack.go
@@ -1,0 +1,22 @@
+package diagnostics
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func (d *Diagnostics) ConntrackDumpingDaemonSet() {
+	if !d.conntrack {
+		return
+	}
+	By("Creating conntrack dumping daemonsets")
+	daemonSets := []appsv1.DaemonSet{}
+	daemonSetName := fmt.Sprintf("dump-conntrack")
+	cmd := composePeriodicCmd("conntrack -L", 10)
+	daemonSets = append(daemonSets, d.composeDiagnosticsDaemonSet(daemonSetName, cmd, "conntrack"))
+	Expect(d.runDaemonSets(daemonSets)).To(Succeed())
+}

--- a/test/e2e/diagnostics/context.go
+++ b/test/e2e/diagnostics/context.go
@@ -1,0 +1,14 @@
+package diagnostics
+
+import "flag"
+
+var (
+	conntrack, iptables, ovsflows, tcpdump bool
+)
+
+func RegisterFlags(flags *flag.FlagSet) {
+	flags.BoolVar(&conntrack, "collect-contrack", false, "Start daemonset to collect conntrack during test")
+	flags.BoolVar(&iptables, "collect-iptables", false, "Start daemonset to collect iptables during test")
+	flags.BoolVar(&ovsflows, "collect-ovsflows", false, "Start daemonset to collect OVS flows during test")
+	flags.BoolVar(&tcpdump, "collect-tcpdump", false, "Start daemonset to collect tcpdump during test")
+}

--- a/test/e2e/diagnostics/daemonset.go
+++ b/test/e2e/diagnostics/daemonset.go
@@ -1,0 +1,122 @@
+package diagnostics
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
+)
+
+func composePeriodicCmd(cmd string, interval uint32) string {
+	return fmt.Sprintf("while true; do echo \\\"=== $(date) ===\\\" && %s && sleep %d; done", cmd, interval)
+}
+
+func (d *Diagnostics) composeDiagnosticsDaemonSet(name, cmd, tool string) appsv1.DaemonSet {
+	ovnImage := os.Getenv("OVN_IMAGE")
+	if ovnImage == "" {
+		ovnImage = "localhost/ovn-daemonset-f:dev"
+	}
+	return appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: d.fr.Namespace.Name,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: d.fr.Namespace.Name,
+					Labels: map[string]string{
+						"app":  name,
+						"tool": tool,
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:    "ovn-kube",
+						Image:   ovnImage,
+						Command: []string{"bash", "-c"},
+						Args:    []string{cmd},
+						SecurityContext: &v1.SecurityContext{
+							Privileged: pointer.Bool(true),
+						},
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "host-run-ovs",
+								MountPath: "/run/openvswitch",
+							},
+							{
+								Name:      "host-var-run-ovs",
+								MountPath: "/var/run/openvswitch",
+							},
+							{
+								Name:      "host",
+								MountPath: "/host",
+							},
+						},
+					}},
+					HostNetwork: true,
+					Volumes: []v1.Volume{
+						{
+							Name: "host-run-ovs",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/run/openvswitch",
+								},
+							},
+						},
+						{
+							Name: "host-var-run-ovs",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/var/run/openvswitch",
+								},
+							},
+						},
+						{
+							Name: "host",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *Diagnostics) runDaemonSets(daemonSets []appsv1.DaemonSet) error {
+	for _, daemonSet := range daemonSets {
+		_, err := d.fr.ClientSet.AppsV1().DaemonSets(daemonSet.Namespace).Create(context.Background(), &daemonSet, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	for _, daemonSet := range daemonSets {
+		err := wait.PollUntilContextTimeout(context.Background(), time.Second, 15*time.Second, true /*immediate*/, func(ctx context.Context) (bool, error) {
+			daemonSet, err := d.fr.ClientSet.AppsV1().DaemonSets(daemonSet.Namespace).Get(ctx, daemonSet.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return daemonSet.Status.NumberAvailable == daemonSet.Status.NumberReady, nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/e2e/diagnostics/diagnostics.go
+++ b/test/e2e/diagnostics/diagnostics.go
@@ -1,0 +1,20 @@
+package diagnostics
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+type Diagnostics struct {
+	fr                                     *framework.Framework
+	conntrack, iptables, ovsflows, tcpdump bool
+}
+
+func New(fr *framework.Framework) *Diagnostics {
+	return &Diagnostics{
+		fr:        fr,
+		conntrack: conntrack,
+		iptables:  iptables,
+		ovsflows:  ovsflows,
+		tcpdump:   tcpdump,
+	}
+}

--- a/test/e2e/diagnostics/doc.go
+++ b/test/e2e/diagnostics/doc.go
@@ -1,0 +1,35 @@
+/*
+The diagnostics package contains different tools to collect data they can be
+executed using the following flags at the test suite
+
+- `--collect-conntrack`: Call `conntrack -L`
+- `--collect-iptables`: Call `iptables -L -n`
+- `--collect-ovsflows`: Call `ovs-ofctl dump-flows` per interface
+- `--collect-tcpdump`: Call `tcpdump -vvv -nne` per interface and expression
+
+# To integratre them with new test first instance the diagnostics package with
+
+```golang
+fr                 = wrappedTestFramework("my-test-suite")
+d                  = diagnostics.New(fr)
+```
+
+# Then at the beginning of test initialize conntrack, ovsflows and iptables like
+
+```golang
+
+	d.ConntrackDumpingDaemonSet()
+	d.OVSFlowsDumpingDaemonSet("breth0")
+	d.IPTablesDumpingDaemonSet()
+
+```
+
+And add tcpdump to the test place where the expression can be composed, for example to dump tcpdump related to a service nodeport, the expression will be composed after creating the service, also specifying the interfaces.
+
+```golang
+
+	d.TCPDumpDaemonSet([]string{"any", "eth0", "breth0"}, fmt.Sprintf("port %s or port %s", port, nodePort))
+
+```
+*/
+package diagnostics

--- a/test/e2e/diagnostics/iptables.go
+++ b/test/e2e/diagnostics/iptables.go
@@ -1,0 +1,22 @@
+package diagnostics
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func (d *Diagnostics) IPTablesDumpingDaemonSet() {
+	if !d.iptables {
+		return
+	}
+	By("Creating iptables dumping daemonsets")
+	daemonSets := []appsv1.DaemonSet{}
+	daemonSetName := fmt.Sprintf("dump-iptables")
+	cmd := composePeriodicCmd("iptables -L -n", 10)
+	daemonSets = append(daemonSets, d.composeDiagnosticsDaemonSet(daemonSetName, cmd, "iptables"))
+	Expect(d.runDaemonSets(daemonSets)).To(Succeed())
+}

--- a/test/e2e/diagnostics/ovsflows.go
+++ b/test/e2e/diagnostics/ovsflows.go
@@ -1,0 +1,22 @@
+package diagnostics
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func (d *Diagnostics) OVSFlowsDumpingDaemonSet(iface string) {
+	if !d.ovsflows {
+		return
+	}
+	By("Creating OVS flows dumping daemonsets")
+	daemonSets := []appsv1.DaemonSet{}
+	daemonSetName := fmt.Sprintf("dump-ovs-flows-%s", iface)
+	cmd := composePeriodicCmd("ovs-ofctl dump-flows "+iface, 10)
+	daemonSets = append(daemonSets, d.composeDiagnosticsDaemonSet(daemonSetName, cmd, "ovs-flows"))
+	Expect(d.runDaemonSets(daemonSets)).To(Succeed())
+}

--- a/test/e2e/diagnostics/tcpdump.go
+++ b/test/e2e/diagnostics/tcpdump.go
@@ -1,0 +1,24 @@
+package diagnostics
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func (d *Diagnostics) TCPDumpDaemonSet(ifaces []string, expression string) {
+	if !d.tcpdump {
+		return
+	}
+	By("Creating tcpdump daemonsets")
+	daemonSets := []appsv1.DaemonSet{}
+	for _, iface := range ifaces {
+		daemonSetName := "node-tcpdump-" + iface
+		cmd := fmt.Sprintf("tcpdump -vvv -nne -i %s %s", iface, expression)
+		daemonSets = append(daemonSets, d.composeDiagnosticsDaemonSet(daemonSetName, cmd, "node-tcpdump"))
+	}
+	Expect(d.runDaemonSets(daemonSets)).To(Succeed())
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/ginkgo/v2/config"
 	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/diagnostics"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -25,6 +26,7 @@ import (
 func handleFlags() {
 	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
+	diagnostics.RegisterFlags(flag.CommandLine)
 	/*
 		Using framework.RegisterClusterFlags(flag.CommandLine) results in a panic:
 		"flag redefined: kubeconfig".


### PR DESCRIPTION
**- What this PR does and why is it needed**
This change add some daemonset to gather the following info from nodes
- conntrack
- tcpdump
- iptables
- ovsflows