### PR TITLE
(B)ANP: Add num_anp && num_banp metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -66,3 +66,4 @@ This list is to help notify if there are additions, changes or removals to metri
 - Add `ovnkube_master_egress_routing_via_host` (https://github.com/ovn-org/ovn-kubernetes/pull/2833)
 - Add `ovnkube_resource_retry_failures_total` (https://github.com/ovn-org/ovn-kubernetes/pull/3314)
 - Add `ovs_vswitchd_interfaces_total` and `ovs_vswitchd_interface_up_wait_seconds_total` (https://github.com/ovn-org/ovn-kubernetes/pull/3391)
+- Add `ovnkube_controller_admin_network_policy_custom_resource_total` and `ovnkube_controller_baseline_admin_network_policy_custom_resource_total` (https://github.com/ovn-org/ovn-kubernetes/pull/4239)

--- a/go-controller/pkg/metrics/ovnkube_controller.go
+++ b/go-controller/pkg/metrics/ovnkube_controller.go
@@ -269,6 +269,23 @@ var metricEgressFirewallCount = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help:      "The number of egress firewall policies",
 })
 
+/** AdminNetworkPolicyMetrics Begin**/
+var metricANPCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemController,
+	Name:      "admin_network_policy_custom_resource_total",
+	Help:      "The total number of admin network policies in the cluster",
+})
+
+var metricBANPCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemController,
+	Name:      "baseline_admin_network_policy_custom_resource_total",
+	Help:      "The total number of baseline admin network policies (0 or 1) in the cluster",
+})
+
+/** AdminNetworkPolicyMetrics End**/
+
 // metricFirstSeenLSPLatency is the time between a pod first seen in OVN-Kubernetes and its Logical Switch Port is created
 var metricFirstSeenLSPLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
@@ -406,6 +423,8 @@ func RegisterOVNKubeControllerFunctional() {
 	prometheus.MustRegister(metricEgressFirewallRuleCount)
 	prometheus.MustRegister(metricEgressFirewallCount)
 	prometheus.MustRegister(metricEgressRoutingViaHost)
+	prometheus.MustRegister(metricANPCount)
+	prometheus.MustRegister(metricBANPCount)
 	if err := prometheus.Register(MetricResourceRetryFailuresCount); err != nil {
 		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
 			panic(err)
@@ -577,6 +596,26 @@ func IncrementEgressFirewallCount() {
 // DecrementEgressFirewallCount decrements the number of Egress firewalls
 func DecrementEgressFirewallCount() {
 	metricEgressFirewallCount.Dec()
+}
+
+// IncrementANPCount increments the number of Admin Network Policies
+func IncrementANPCount() {
+	metricANPCount.Inc()
+}
+
+// DecrementANPCount decrements the number of Admin Network Policies
+func DecrementANPCount() {
+	metricANPCount.Dec()
+}
+
+// IncrementBANPCount increments the number of Baseline Admin Network Policies
+func IncrementBANPCount() {
+	metricBANPCount.Inc()
+}
+
+// DecrementBANPCount decrements the number of Baseline Admin Network Policies
+func DecrementBANPCount() {
+	metricBANPCount.Dec()
 }
 
 type (

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
@@ -145,6 +146,7 @@ func (c *Controller) ensureAdminNetworkPolicy(anp *anpapi.AdminNetworkPolicy) er
 		c.anpPriorityMap[desiredANPState.anpPriority] = anp.Name
 		// since transact was successful we can finally populate the cache
 		c.anpCache[anp.Name] = desiredANPState
+		metrics.IncrementANPCount()
 		return nil
 	}
 	// ANP state existed in the cache, which means its either an ANP update or pod/namespace add/update/delete
@@ -402,6 +404,7 @@ func (c *Controller) clearAdminNetworkPolicy(anpName string) error {
 	// we can delete the object from the cache now.
 	delete(c.anpPriorityMap, anp.anpPriority)
 	delete(c.anpCache, anpName)
+	metrics.DecrementANPCount()
 
 	return nil
 }

--- a/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/baseline_admin_network_policy.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -108,6 +109,7 @@ func (c *Controller) clearBaselineAdminNetworkPolicy(banpName string) error {
 	}
 	// we can delete the object from the cache now (set the cache back to empty value).
 	c.banpCache = &adminNetworkPolicyState{}
+	metrics.DecrementBANPCount()
 
 	return nil
 }
@@ -151,6 +153,7 @@ func (c *Controller) ensureBaselineAdminNetworkPolicy(banp *anpapi.BaselineAdmin
 		}
 		// since transact was successful we can finally populate the cache
 		c.banpCache = desiredBANPState
+		metrics.IncrementBANPCount()
 		return nil
 	}
 	// BANP state existed in the cache, which means its either a BANP update or pod/namespace add/update/delete


### PR DESCRIPTION
This commits adds two metrics to:

1. count number of admin network policies and (between 0 and 100)
2. number of baseline admin network policies in a cluster (0 or 1)

My goal with these two metrics are:

1. understand how the user is using this feature
2. how many admin network policies have they created (I plan to do future PRs for more fine-grained information)
3. is the user using baseline admin network policy in their cluster?

So its also for the user but more so for us.

I am starting out with the metrics stuff for ANP/BANP
PTAL @martinkennelly at this one for starters. I think this is simple enough to not need the monitoring team's purview but future PRs will need their help. WDYT?