### PR TITLE
Enable EgressQoS tests for IPv6 and LGW mode

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -468,6 +468,11 @@ func createPod(f *framework.Framework, podName, nodeSelector, namespace string, 
 	err = e2epod.WaitForPodRunningInNamespace(context.TODO(), f.ClientSet, res)
 
 	if err != nil {
+		res, err = podClient.Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to get pod %s %s", pod.Name, namespace)
+		}
+		framework.Logf("Warning: Failed to get pod running %v: %v", *res, err)
 		logs, logErr := e2epod.GetPodLogs(context.TODO(), f.ClientSet, namespace, pod.Name, contName)
 		if logErr != nil {
 			framework.Logf("Warning: Failed to get logs from pod %q: %v", pod.Name, logErr)

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -113,7 +113,6 @@ if [ "$OVN_GATEWAY_MODE" == "local" ]; then
         SKIPPED_TESTS+="|"
     fi
     SKIPPED_TESTS+="Should be allowed to node local host-networked endpoints by nodeport services|\
-EgressQoS validation|\
 Should be allowed by nodeport services|\
 Should be allowed to node local cluster-networked endpoints by nodeport services with externalTrafficPolicy=local|\
 Should successfully create then remove a static pod|\


### PR DESCRIPTION
To fix https://github.com/ovn-org/ovn-kubernetes/issues/4180.

/cc @tssurya 