### PR TITLE
Improves service iptables efficiency on start up

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -133,6 +133,7 @@ require (
 
 replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.20
+	github.com/coreos/go-iptables => github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 	github.com/j-keck/arping => github.com/JacobTanenbaum/arping v0.0.0-20240209152419-3987db83bd51
 )

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -217,10 +217,6 @@ github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgU
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
-github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
-github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
-github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -754,6 +750,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808 h1:dhannoFtRVRqYF22YA/M0iUD0IQhB9PmT9XRuynUWxg=
+github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -139,6 +140,8 @@ func (g *gateway) DeleteService(svc *kapi.Service) error {
 
 func (g *gateway) SyncServices(objs []interface{}) error {
 	var err error
+	klog.Infof("Starting gateway service sync")
+	start := time.Now()
 	if g.portClaimWatcher != nil {
 		err = g.portClaimWatcher.SyncServices(objs)
 	}
@@ -154,6 +157,7 @@ func (g *gateway) SyncServices(objs []interface{}) error {
 	if err != nil {
 		return fmt.Errorf("gateway sync services failed: %v", err)
 	}
+	klog.Infof("Gateway service sync done. Time taken: %s", time.Since(start))
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -186,31 +186,53 @@ func getITPLocalIPTRules(svcPort kapi.ServicePort, clusterIP string, svcHasLocal
 	}
 }
 
-// getNodePortETPLocalIPTRules returns the IPTable REDIRECT or RETURN rules for a service of type nodePort if ETP=local
+// getNodePortETPLocalIPTRule returns the IPTable REDIRECT or RETURN rules for a service of type nodePort if ETP=local
 // `svcPort` corresponds to port details for this service as specified in the service object
 // `targetIP` corresponds to svc.spec.ClusterIP
 // This function returns a RETURN rule in iptableMgmPortChain to prevent SNAT of sourceIP
-func getNodePortETPLocalIPTRules(svcPort kapi.ServicePort, targetIP string) []nodeipt.Rule {
-	return []nodeipt.Rule{
-		{
-			Table: "nat",
-			Chain: iptableMgmPortChain,
-			Args: []string{
-				"-p", string(svcPort.Protocol),
-				"--dport", fmt.Sprintf("%d", svcPort.NodePort),
-				"-j", "RETURN",
-			},
-			Protocol: getIPTablesProtocol(targetIP),
-		},
+func getNodePortETPLocalIPTRule(svcPort kapi.ServicePort, targetIP string) nodeipt.Rule {
+	return getSkipMgmtSNATRule(string(svcPort.Protocol), fmt.Sprintf("%d", svcPort.NodePort), "", getIPTablesProtocol(targetIP))
+}
+
+// getSkipMgmtSNATRule generates the return iptables rule for avoiding SNAT to mgmt port
+func getSkipMgmtSNATRule(protocol, port, destIP string, ipFamily iptables.Protocol) nodeipt.Rule {
+	args := make([]string, 0, 8)
+	args = append(args, "-p", protocol)
+	if len(destIP) > 0 {
+		args = append(args, "-d", destIP)
 	}
+	args = append(args, "--dport", port, "-j", "RETURN")
+	n := nodeipt.Rule{
+		Table:    "nat",
+		Chain:    iptableMgmPortChain,
+		Args:     args,
+		Protocol: ipFamily,
+	}
+	return n
 }
 
 func computeProbability(n, i int) string {
 	return fmt.Sprintf("%0.10f", 1.0/float64(n-i+1))
 }
 
-func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort kapi.ServicePort, externalIP string, service *kapi.Service, localEndpoints []string) []nodeipt.Rule {
-	var iptRules []nodeipt.Rule
+func generateSkipMgmtForLocalEndpoints(svcPort kapi.ServicePort, externalIP string, localEndpoints []string) []nodeipt.Rule {
+	iptRules := make([]nodeipt.Rule, 0, len(localEndpoints))
+	for _, localEndpoint := range localEndpoints {
+		if len(localEndpoint) == 0 {
+			continue
+		}
+		iptRules = append([]nodeipt.Rule{getSkipMgmtSNATRule(
+			string(svcPort.Protocol),
+			fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
+			localEndpoint,
+			getIPTablesProtocol(externalIP),
+		)}, iptRules...)
+	}
+	return iptRules
+}
+
+func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort kapi.ServicePort, externalIP string, localEndpoints []string) []nodeipt.Rule {
+	iptRules := make([]nodeipt.Rule, 0, len(localEndpoints))
 	if len(localEndpoints) == 0 {
 		// either its smart nic mode; etp&itp not implemented, OR
 		// fetching endpointSlices error-ed out prior to reaching here so nothing to do
@@ -231,17 +253,6 @@ func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort kapi.ServicePort, 
 					"-m", "statistic",
 					"--mode", "random",
 					"--probability", computeProbability(numLocalEndpoints, i+1),
-				},
-				Protocol: getIPTablesProtocol(externalIP),
-			},
-			{
-				Table: "nat",
-				Chain: iptableMgmPortChain,
-				Args: []string{
-					"-p", string(svcPort.Protocol),
-					"-d", ip,
-					"--dport", fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
-					"-j", "RETURN",
 				},
 				Protocol: getIPTablesProtocol(externalIP),
 			},
@@ -579,7 +590,7 @@ func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLo
 						rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
 					}
 					// add a skip SNAT rule to OVN-KUBE-SNAT-MGMTPORT to preserve sourceIP for etp=local traffic.
-					rules = append(rules, getNodePortETPLocalIPTRules(svcPort, clusterIP)...)
+					rules = append(rules, getNodePortETPLocalIPTRule(svcPort, clusterIP))
 				}
 				// case2 (see function description for details)
 				rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port, svcHasLocalHostNetEndPnt, false)...)
@@ -588,6 +599,7 @@ func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLo
 
 		externalIPs := util.GetExternalAndLBIPs(service)
 
+		snatRulesCreated := false
 		for _, externalIP := range externalIPs {
 			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
 			if err != nil {
@@ -600,7 +612,12 @@ func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLo
 					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
 					// service so no need to add skip SNAT rule to OVN-KUBE-SNAT-MGMTPORT since the corresponding nodePort svc would have one.
 					if !util.ServiceTypeHasNodePort(service) {
-						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, service, localEndpoints)...)
+						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, localEndpoints)...)
+						// These rules are per endpoint and should only be created one time per endpoint and port combination
+						if !snatRulesCreated {
+							rules = append(rules, generateSkipMgmtForLocalEndpoints(svcPort, externalIP, localEndpoints)...)
+							snatRulesCreated = true
+						}
 					} else {
 						rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
 					}

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -61,7 +61,7 @@ func insertIptRules(rules []nodeipt.Rule) error {
 // insertIptRulesFiltered adds the provided rules in an insert fashion with a filter for table/chain
 // i.e each rule gets added at the first position in the chain
 func insertIptRulesFiltered(rules []nodeipt.Rule, filter map[string]map[string]bool) error {
-	return nodeipt.AddRulesFiltered(rules, false, filter)
+	return nodeipt.AddRulesFiltered(rules, filter)
 }
 
 // appendIptRules adds the provided rules in an append fashion

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -58,6 +58,12 @@ func insertIptRules(rules []nodeipt.Rule) error {
 	return nodeipt.AddRules(rules, false)
 }
 
+// insertIptRulesFiltered adds the provided rules in an insert fashion with a filter for table/chain
+// i.e each rule gets added at the first position in the chain
+func insertIptRulesFiltered(rules []nodeipt.Rule, filter map[string]map[string]bool) error {
+	return nodeipt.AddRulesFiltered(rules, false, filter)
+}
+
 // appendIptRules adds the provided rules in an append fashion
 // i.e each rule gets added at the last position in the chain
 func appendIptRules(rules []nodeipt.Rule) error {
@@ -532,7 +538,8 @@ func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
 			errors = append(errors, fmt.Errorf("error clearing Chain: %s in Table: %s, err: %v", chain, table, err))
 		}
 	}
-	if err = insertIptRules(keepIPTRules); err != nil {
+	filter := map[string]map[string]bool{table: {chain: false}}
+	if err = insertIptRulesFiltered(keepIPTRules, filter); err != nil {
 		errors = append(errors, err)
 	}
 	return apierrors.NewAggregate(errors)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -18,6 +19,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
 
+	"github.com/coreos/go-iptables/iptables"
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -218,6 +220,12 @@ func addConntrackMocks(nlMock *mocks.NetLinkOps, filterDescs []ctFilterDesc) {
 	ovntest.ProcessMockFnList(&nlMock.Mock, ctMocks)
 }
 
+/*
+Note: all of the tests described below actually rely on OVNK node controller start up failing. This is
+because no node is actually added when the controller is started, so node start up fails querying kapi for its
+own node. This is either intentional or accidentally convenient as the node port watcher is then replaced with a fake
+one and started again to exercise the tests.
+*/
 var _ = Describe("Node Operations", func() {
 	var (
 		app                *cli.App
@@ -310,11 +318,18 @@ var _ = Describe("Node Operations", func() {
 				)
 				Expect(insertIptRules(fakeRules)).To(Succeed())
 
+				// Inject rules into SNAT MGMT chain that shouldn't exist and should be cleared on a restore, even if the chain has no rules
+				fakeRule := getSkipMgmtSNATRule("TCP", "1337", "8.8.8.8", iptables.ProtocolIPv4)
+				Expect(insertIptRules([]nodeipt.Rule{fakeRule})).To(Succeed())
+
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p UDP -d 10.10.10.10 --dport 27000 -j DNAT --to-destination 172.32.0.12:27000"),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+						iptableMgmPortChain: []string{
+							fmt.Sprintf("-p TCP -d 8.8.8.8 --dport 1337 -j RETURN"),
 						},
 					},
 					"filter": {},

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -633,7 +633,7 @@ var _ = Describe("Node Operations", func() {
 		It("inits iptables rules with LoadBalancer", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "1.1.1.1"
-				for i := 0; i < 6; i++ {
+				for i := 0; i < 3; i++ {
 					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 						Cmd: "ovs-ofctl show ",
 					})
@@ -1313,7 +1313,7 @@ var _ = Describe("Node Operations", func() {
 				clusterIPv4 := "10.129.0.2"
 				clusterIPv6 := "fd00:10:96::10"
 				fNPW.gatewayIPv6 = v6localnetGatewayIP
-				for i := 0; i < 6; i++ {
+				for i := 0; i < 3; i++ {
 					fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 						Cmd: "ovs-ofctl show ",
 					})
@@ -1768,7 +1768,6 @@ var _ = Describe("Node Operations", func() {
 				key, err := retry.GetResourceKey(&service)
 				Expect(err).NotTo(HaveOccurred())
 				retry.CheckRetryObjectEventually(key, true, nodePortWatcherRetry)
-
 				// check iptables
 				f4 := iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -852,6 +852,10 @@ var _ = Describe("Node Operations", func() {
 					Cmd: "ovs-ofctl show ",
 					Err: fmt.Errorf("deliberate error to fall back to output:LOCAL"),
 				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-ofctl show ",
+					Err: fmt.Errorf("deliberate error to fall back to output:LOCAL"),
+				})
 				service := *newServiceWithoutNodePortAllocation("service1", "namespace1", "10.129.0.2",
 					[]v1.ServicePort{
 						{

--- a/go-controller/pkg/node/iptables/iptables.go
+++ b/go-controller/pkg/node/iptables/iptables.go
@@ -17,12 +17,79 @@ type Rule struct {
 	Protocol iptables.Protocol
 }
 
+// AddRulesFiltered adds the given rules to iptables.
+// filter is a map[table][chain] of valid tables/chains to use for filtering rules to be added.
+func AddRulesFiltered(rules []Rule, append bool, filter map[string]map[string]bool) error {
+	addErrors := errors.New("")
+	var err error
+	var ipt util.IPTablesHelper
+	var exists bool
+
+	// stores valid table chains and whether they were already created or not
+	// key is ip protocol, table, chain
+	createdChains := map[iptables.Protocol]map[string]map[string]bool{
+		iptables.ProtocolIPv4: make(map[string]map[string]bool),
+		iptables.ProtocolIPv6: make(map[string]map[string]bool),
+	}
+
+	for _, r := range rules {
+		if _, ok := filter[r.Table][r.Chain]; !ok {
+			klog.V(5).Infof("Ignoring processing rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
+				r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
+			continue
+		}
+		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
+			r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
+		if ipt, err = util.GetIPTablesHelper(r.Protocol); err != nil {
+			addErrors = errors.Wrapf(addErrors,
+				"Failed to add iptables %s/%s rule %q: %v", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			continue
+		}
+		if _, ok := createdChains[r.Protocol][r.Table][r.Chain]; !ok {
+			klog.Infof("Creating table: %s chain: %s", r.Table, r.Chain)
+			if err = ipt.NewChain(r.Table, r.Chain); err != nil {
+				klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
+					r.Chain, r.Table, err)
+			}
+			// we assume an error means it was already created
+			if _, ok := createdChains[r.Protocol][r.Table]; !ok {
+				createdChains[r.Protocol][r.Table] = make(map[string]bool)
+			}
+			createdChains[r.Protocol][r.Table][r.Chain] = true
+		}
+		exists, err = ipt.Exists(r.Table, r.Chain, r.Args...)
+		if !exists && err == nil {
+			if append {
+				err = ipt.Append(r.Table, r.Chain, r.Args...)
+			} else {
+				err = ipt.Insert(r.Table, r.Chain, 1, r.Args...)
+			}
+		}
+		if err != nil {
+			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
+				r.Table, r.Chain, strings.Join(r.Args, " "), err)
+		}
+	}
+	if addErrors.Error() == "" {
+		addErrors = nil
+	}
+	return addErrors
+}
+
 // AddRules adds the given rules to iptables.
 func AddRules(rules []Rule, append bool) error {
 	addErrors := errors.New("")
 	var err error
 	var ipt util.IPTablesHelper
 	var exists bool
+
+	// stores valid chains and whether they were already created or not
+	// key is ip protocol, table, chain
+	createdChains := map[iptables.Protocol]map[string]map[string]bool{
+		iptables.ProtocolIPv4: make(map[string]map[string]bool),
+		iptables.ProtocolIPv6: make(map[string]map[string]bool),
+	}
+
 	for _, r := range rules {
 		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
 			r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
@@ -31,9 +98,17 @@ func AddRules(rules []Rule, append bool) error {
 				"Failed to add iptables %s/%s rule %q: %v", r.Table, r.Chain, strings.Join(r.Args, " "), err)
 			continue
 		}
-		if err = ipt.NewChain(r.Table, r.Chain); err != nil {
-			klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
-				r.Chain, r.Table, err)
+		if _, ok := createdChains[r.Protocol][r.Table][r.Chain]; !ok {
+			klog.Infof("Creating table: %s chain: %s", r.Table, r.Chain)
+			if err = ipt.NewChain(r.Table, r.Chain); err != nil {
+				klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
+					r.Chain, r.Table, err)
+			}
+			// we assume an error means it was already created
+			if _, ok := createdChains[r.Protocol][r.Table]; !ok {
+				createdChains[r.Protocol][r.Table] = make(map[string]bool)
+			}
+			createdChains[r.Protocol][r.Table][r.Chain] = true
 		}
 		exists, err = ipt.Exists(r.Table, r.Chain, r.Args...)
 		if !exists && err == nil {

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -34,6 +34,8 @@ type IPTablesHelper interface {
 	Append(string, string, ...string) error
 	// Delete removes rulespec in specified table/chain
 	Delete(string, string, ...string) error
+	// Restore uses iptables-restore to restore rules for multiple chains in a table at once
+	Restore(table string, rulesMap map[string][][]string) error
 }
 
 var helpers = make(map[iptables.Protocol]IPTablesHelper)
@@ -280,6 +282,22 @@ func (f *FakeIPTables) Delete(tableName, chainName string, rulespec ...string) e
 		if r == rule {
 			(*table)[chainName] = append(chain[:i], chain[i+1:]...)
 			break
+		}
+	}
+	return nil
+}
+
+func (f *FakeIPTables) Restore(tableName string, rulesMap map[string][][]string) error {
+	f.Lock()
+	defer f.Unlock()
+	table, err := f.getTable(tableName)
+	if err != nil {
+		return err
+	}
+	for chainName, rules := range rulesMap {
+		for _, rule := range rules {
+			chain, _ := table.getChain(chainName)
+			(*table)[chainName] = append([]string{strings.Join(rule, " ")}, chain...)
 		}
 	}
 	return nil

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -295,6 +295,7 @@ func (f *FakeIPTables) Restore(tableName string, rulesMap map[string][][]string)
 		return err
 	}
 	for chainName, rules := range rulesMap {
+		(*table)[chainName] = []string{}
 		for _, rule := range rules {
 			chain, _ := table.getChain(chainName)
 			(*table)[chainName] = append([]string{strings.Join(rule, " ")}, chain...)

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/containernetworking/plugins/pkg/ns
 github.com/containernetworking/plugins/pkg/testutils
 github.com/containernetworking/plugins/pkg/utils/buildversion
 github.com/containernetworking/plugins/pkg/utils/sysctl
-# github.com/coreos/go-iptables v0.6.0
+# github.com/coreos/go-iptables v0.6.0 => github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808
 ## explicit; go 1.16
 github.com/coreos/go-iptables/iptables
 # github.com/cpuguy83/go-md2man/v2 v2.0.2
@@ -1189,5 +1189,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.20
+# github.com/coreos/go-iptables => github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808
 # github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 # github.com/j-keck/arping => github.com/JacobTanenbaum/arping v0.0.0-20240209152419-3987db83bd51


### PR DESCRIPTION
When ovnk node gateway starts up, it will attempt to:
 - flush iptables chains
 - recreate all chains
 - add iptables rules back for all services

We were inefficiently:
 - Always trying to recreate the chain on every rule insertion
 - Recreating all rules over and over again as we iterate over different chains.

This would result in the same iptables rule attempting to be inserted 7 times:

trozet@fedora:~$ kubectl logs -n ovn-kubernetes ovnkube-node-ckkxd -c ovnkube-controller | grep "Adding rule" | grep 1.1.4.100
I0326 13:37:17.637007    8984 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 1.1.4.100 --dport 80 -j DNAT --to-destination 10.96.204.38:80" for protocol: 0
I0326 13:37:22.597245    8984 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 1.1.4.100 --dport 80 -j DNAT --to-destination 10.96.204.38:80" for protocol: 0
I0326 13:37:27.574101    8984 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 1.1.4.100 --dport 80 -j DNAT --to-destination 10.96.204.38:80" for protocol: 0
I0326 13:37:34.083807    8984 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 1.1.4.100 --dport 80 -j DNAT --to-destination 10.96.204.38:80" for protocol: 0
I0326 13:37:39.488761    8984 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 1.1.4.100 --dport 80 -j DNAT --to-destination 10.96.204.38:80" for protocol: 0
I0326 13:37:44.459587    8984 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 1.1.4.100 --dport 80 -j DNAT --to-destination 10.96.204.38:80" for protocol: 0
I0326 13:37:49.470141    8984 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 1.1.4.100 --dport 80 -j DNAT --to-destination 10.96.204.38:80" for protocol: 0

With 4 services having 250 external IPs each, I tested the sync time took around 41 seconds. With this commit, we reduce the time to around 7.5 seconds.

