### PR TITLE
Fix-flake: ACLlogging ANP/BANP test

### DIFF
--- a/test/e2e/acl_logging.go
+++ b/test/e2e/acl_logging.go
@@ -217,6 +217,9 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			_, err := e2ekubectl.RunKubectl("default", "delete", "ns", ns, "--ignore-not-found=true")
 			Expect(err).NotTo(HaveOccurred())
 		}
+		// reset caches
+		pods = nil
+		nsNames = [4]string{}
 	})
 
 	It("the ANP ACL logs have the expected log level", func() {

--- a/test/e2e/acl_logging.go
+++ b/test/e2e/acl_logging.go
@@ -233,9 +233,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).NotTo(HaveOccurred(),
-			"traffic should be allowed since we use an ALLOW all traffic policy rule")
+		err := pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("traffic should be allowed since we use an ALLOW all traffic policy rule, err: %v", err))
 
 		By("verify the ALLOW ACL log level at Tier1")
 		clientPodScheduledPodName := pods[0].Spec.NodeName
@@ -258,9 +257,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
-			"traffic should be denied since we use an DENY all traffic policy rule")
+		err = pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).To(HaveOccurred(), fmt.Sprintf("traffic should be denied since we use an DENY all traffic policy rule, err %v", err))
 
 		By("verify the DENY ACL log level at Tier1")
 		clientPodScheduledPodName = pods[0].Spec.NodeName
@@ -283,9 +281,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).NotTo(HaveOccurred(),
-			"traffic should be allowed since we only use an PASS all traffic policy rule")
+		err = pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("traffic should be allowed since we only use an PASS all traffic policy rule, err %v", err))
 
 		// Re-enable when https://issues.redhat.com/browse/FDP-442 is fixed
 		/*By("verify the PASS ACL log level at Tier1")
@@ -302,7 +299,7 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())*/
 
 		By("creating a baseline admin network policy")
-		err := makeBaselineAdminNetworkPolicy(fr.Namespace.Name)
+		err = makeBaselineAdminNetworkPolicy(fr.Namespace.Name)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("configuring the ACL logging level for the BANP")
@@ -318,9 +315,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
-			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
+		err = pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).To(HaveOccurred(), fmt.Sprintf("traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier, err %v", err))
 
 		By("verify the DENY ACL log level at Tier3")
 		clientPodScheduledPodName = pods[0].Spec.NodeName
@@ -349,9 +345,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).NotTo(HaveOccurred(),
-			"traffic should be allowed since we use an ALLOW all traffic policy rule")
+		err = pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("traffic should be allowed since we use an ALLOW all traffic policy rule, err %v", err))
 
 		By("verify the ALLOW ACL log level at Tier1")
 		clientPodScheduledPodName = pods[0].Spec.NodeName
@@ -374,9 +369,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
-			"traffic should be denied since we use an DENY all traffic policy rule")
+		err = pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).To(HaveOccurred(), fmt.Sprintf("traffic should be denied since we use an DENY all traffic policy rule, err %v", err))
 
 		By("verify the DENY ACL log level at Tier1")
 		clientPodScheduledPodName = pods[0].Spec.NodeName
@@ -399,9 +393,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
-			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
+		err = pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).To(HaveOccurred(), fmt.Sprintf("traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier, err %v", err))
 
 		// Re-enable when https://issues.redhat.com/browse/FDP-442 is fixed
 		/*By("verify the PASS ACL log level at Tier1")
@@ -445,9 +438,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
-			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
+		err = pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).To(HaveOccurred(), fmt.Sprintf("traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier, err %v", err))
 
 		// Re-enable when https://issues.redhat.com/browse/FDP-442 is fixed
 		/*composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)
@@ -475,9 +467,8 @@ var _ = Describe("ACL Logging for AdminNetworkPolicy and BaselineAdminNetworkPol
 			pokedPod.Spec.NodeName,
 			clientPod.GetName(),
 			clientPod.Spec.NodeName)
-		Expect(
-			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
-			"traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier")
+		err = pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
+		Expect(err).To(HaveOccurred(), fmt.Sprintf("traffic should be blocked since we use an PASS traffic policy followed by a deny at lower tier, err %v", err))
 
 		// Re-enable when https://issues.redhat.com/browse/FDP-442 is fixed
 		/*composedPolicyNameRegex = fmt.Sprintf("ANP:%s:Egress:2", anpName)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -738,6 +738,7 @@ func pokePod(fr *framework.Framework, srcPodName string, dstPodIP string) error 
 	if err == nil && stdout == "HTTP/1.1 200 OK" {
 		return nil
 	}
+	framework.Logf("HTTP request failed; stdout: %s, err: %v", stdout+stderr, err)
 	return fmt.Errorf("http request failed; stdout: %s, err: %v", stdout+stderr, err)
 }
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
 There are two parts to the flake, this is only fixing one part, I am still trying to figure out why the pod2pod communication though logged in ovn-controller as "allowed" doesn't end up working in v6 env in CI. I have also added some extra debug logs to see what happens when it fails
See https://github.com/ovn-org/ovn-kubernetes/issues/4242

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->