### PR TITLE
vendor: bump safchain/ethtool to v0.3.1-0.20231027162144-83e5e0097c91

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.5.0
-	github.com/safchain/ethtool v0.3.0
+	github.com/safchain/ethtool v0.3.1-0.20231027162144-83e5e0097c91
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.8.4
 	github.com/urfave/cli/v2 v2.2.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -691,8 +691,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
-github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP0=
-github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=
+github.com/safchain/ethtool v0.3.1-0.20231027162144-83e5e0097c91 h1:q815fjV3G+4JvXNo2VwT2m+/msMU0sUkCK68CgHV9Y8=
+github.com/safchain/ethtool v0.3.1-0.20231027162144-83e5e0097c91/go.mod h1:qIWCTaK0xQlXNlNlIVoZjKMZFopqfMZcg4JcRqGoYc0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -1034,8 +1034,8 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go-controller/vendor/github.com/safchain/ethtool/.yamllint
+++ b/go-controller/vendor/github.com/safchain/ethtool/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  document-start: disable
+  truthy:
+    check-keys: false

--- a/go-controller/vendor/github.com/safchain/ethtool/ethtool.go
+++ b/go-controller/vendor/github.com/safchain/ethtool/ethtool.go
@@ -47,33 +47,40 @@ const (
 
 // ethtool stats related constants.
 const (
-	ETH_GSTRING_LEN = 32
-	ETH_SS_STATS    = 1
-	ETH_SS_FEATURES = 4
+	ETH_GSTRING_LEN   = 32
+	ETH_SS_STATS      = 1
+	ETH_SS_PRIV_FLAGS = 2
+	ETH_SS_FEATURES   = 4
 
 	// CMD supported
+	ETHTOOL_GSET     = 0x00000001 /* Get settings. */
+	ETHTOOL_SSET     = 0x00000002 /* Set settings. */
 	ETHTOOL_GDRVINFO = 0x00000003 /* Get driver info. */
-	ETHTOOL_GSTRINGS = 0x0000001b /* get specified string set */
-	ETHTOOL_GSTATS   = 0x0000001d /* get NIC-specific statistics */
-	// other CMDs from ethtool-copy.h of ethtool-3.5 package
-	ETHTOOL_GSET      = 0x00000001 /* Get settings. */
-	ETHTOOL_SSET      = 0x00000002 /* Set settings. */
-	ETHTOOL_GMSGLVL   = 0x00000007 /* Get driver message level */
-	ETHTOOL_SMSGLVL   = 0x00000008 /* Set driver msg level. */
-	ETHTOOL_GCHANNELS = 0x0000003c /* Get no of channels */
-	ETHTOOL_SCHANNELS = 0x0000003d /* Set no of channels */
-	ETHTOOL_GCOALESCE = 0x0000000e /* Get coalesce config */
+	ETHTOOL_GMSGLVL  = 0x00000007 /* Get driver message level */
+	ETHTOOL_SMSGLVL  = 0x00000008 /* Set driver msg level. */
+
 	/* Get link status for host, i.e. whether the interface *and* the
-	 * physical port (if there is one) are up (ethtool_value). */
+	* physical port (if there is one) are up (ethtool_value). */
 	ETHTOOL_GLINK         = 0x0000000a
-	ETHTOOL_GMODULEINFO   = 0x00000042 /* Get plug-in module information */
-	ETHTOOL_GMODULEEEPROM = 0x00000043 /* Get plug-in module eeprom */
+	ETHTOOL_GCOALESCE     = 0x0000000e /* Get coalesce config */
+	ETHTOOL_GRINGPARAM    = 0x00000010 /* Get ring parameters */
+	ETHTOOL_SRINGPARAM    = 0x00000011 /* Set ring parameters. */
+	ETHTOOL_GPAUSEPARAM   = 0x00000012 /* Get pause parameters */
+	ETHTOOL_SPAUSEPARAM   = 0x00000013 /* Set pause parameters. */
+	ETHTOOL_GSTRINGS      = 0x0000001b /* Get specified string set */
+	ETHTOOL_GSTATS        = 0x0000001d /* Get NIC-specific statistics */
 	ETHTOOL_GPERMADDR     = 0x00000020 /* Get permanent hardware address */
+	ETHTOOL_GFLAGS        = 0x00000025 /* Get flags bitmap(ethtool_value) */
+	ETHTOOL_GPFLAGS       = 0x00000027 /* Get driver-private flags bitmap */
+	ETHTOOL_SPFLAGS       = 0x00000028 /* Set driver-private flags bitmap */
+	ETHTOOL_GSSET_INFO    = 0x00000037 /* Get string set info */
 	ETHTOOL_GFEATURES     = 0x0000003a /* Get device offload settings */
 	ETHTOOL_SFEATURES     = 0x0000003b /* Change device offload settings */
-	ETHTOOL_GFLAGS        = 0x00000025 /* Get flags bitmap(ethtool_value) */
-	ETHTOOL_GSSET_INFO    = 0x00000037 /* Get string set info */
+	ETHTOOL_GCHANNELS     = 0x0000003c /* Get no of channels */
+	ETHTOOL_SCHANNELS     = 0x0000003d /* Set no of channels */
 	ETHTOOL_GET_TS_INFO   = 0x00000041 /* Get time stamping and PHC info */
+	ETHTOOL_GMODULEINFO   = 0x00000042 /* Get plug-in module information */
+	ETHTOOL_GMODULEEEPROM = 0x00000043 /* Get plug-in module eeprom */
 )
 
 // MAX_GSTRINGS maximum number of stats entries that ethtool can
@@ -85,6 +92,41 @@ const (
 	PERMADDR_LEN       = 32
 )
 
+// ethtool sset_info related constants
+const (
+	MAX_SSET_INFO = 64
+)
+
+var supportedCapabilities = []struct {
+	name  string
+	mask  uint64
+	speed uint64
+}{
+	{"10baseT_Half", unix.ETHTOOL_LINK_MODE_10baseT_Half_BIT, 10_000_000},
+	{"10baseT_Full", unix.ETHTOOL_LINK_MODE_10baseT_Full_BIT, 10_000_000},
+	{"100baseT_Half", unix.ETHTOOL_LINK_MODE_100baseT_Half_BIT, 100_000_000},
+	{"100baseT_Full", unix.ETHTOOL_LINK_MODE_100baseT_Full_BIT, 100_000_000},
+	{"1000baseT_Half", unix.ETHTOOL_LINK_MODE_1000baseT_Half_BIT, 1_000_000_000},
+	{"1000baseT_Full", unix.ETHTOOL_LINK_MODE_1000baseT_Full_BIT, 1_000_000_000},
+	{"10000baseT_Full", unix.ETHTOOL_LINK_MODE_10000baseT_Full_BIT, 10_000_000_000},
+	{"2500baseT_Full", unix.ETHTOOL_LINK_MODE_2500baseT_Full_BIT, 2_500_000_000},
+	{"1000baseKX_Full", unix.ETHTOOL_LINK_MODE_1000baseKX_Full_BIT, 1_000_000_000},
+	{"10000baseKX_Full", unix.ETHTOOL_LINK_MODE_10000baseKX4_Full_BIT, 10_000_000_000},
+	{"10000baseKR_Full", unix.ETHTOOL_LINK_MODE_10000baseKR_Full_BIT, 10_000_000_000},
+	{"10000baseR_FEC", unix.ETHTOOL_LINK_MODE_10000baseR_FEC_BIT, 10_000_000_000},
+	{"20000baseMLD2_Full", unix.ETHTOOL_LINK_MODE_20000baseMLD2_Full_BIT, 20_000_000_000},
+	{"20000baseKR2_Full", unix.ETHTOOL_LINK_MODE_20000baseKR2_Full_BIT, 20_000_000_000},
+	{"40000baseKR4_Full", unix.ETHTOOL_LINK_MODE_40000baseKR4_Full_BIT, 40_000_000_000},
+	{"40000baseCR4_Full", unix.ETHTOOL_LINK_MODE_40000baseCR4_Full_BIT, 40_000_000_000},
+	{"40000baseSR4_Full", unix.ETHTOOL_LINK_MODE_40000baseSR4_Full_BIT, 40_000_000_000},
+	{"40000baseLR4_Full", unix.ETHTOOL_LINK_MODE_40000baseLR4_Full_BIT, 40_000_000_000},
+	{"56000baseKR4_Full", unix.ETHTOOL_LINK_MODE_56000baseKR4_Full_BIT, 56_000_000_000},
+	{"56000baseCR4_Full", unix.ETHTOOL_LINK_MODE_56000baseCR4_Full_BIT, 56_000_000_000},
+	{"56000baseSR4_Full", unix.ETHTOOL_LINK_MODE_56000baseSR4_Full_BIT, 56_000_000_000},
+	{"56000baseLR4_Full", unix.ETHTOOL_LINK_MODE_56000baseLR4_Full_BIT, 56_000_000_000},
+	{"25000baseCR_Full", unix.ETHTOOL_LINK_MODE_25000baseCR_Full_BIT, 25_000_000_000},
+}
+
 type ifreq struct {
 	ifr_name [IFNAMSIZ]byte
 	ifr_data uintptr
@@ -94,8 +136,8 @@ type ifreq struct {
 type ethtoolSsetInfo struct {
 	cmd       uint32
 	reserved  uint32
-	sset_mask uint32
-	data      uintptr
+	sset_mask uint64
+	data      [MAX_SSET_INFO]uint32
 }
 
 type ethtoolGetFeaturesBlock struct {
@@ -313,6 +355,27 @@ type ethtoolPermAddr struct {
 	cmd  uint32
 	size uint32
 	data [PERMADDR_LEN]byte
+}
+
+// Ring is a ring config for an interface
+type Ring struct {
+	Cmd               uint32
+	RxMaxPending      uint32
+	RxMiniMaxPending  uint32
+	RxJumboMaxPending uint32
+	TxMaxPending      uint32
+	RxPending         uint32
+	RxMiniPending     uint32
+	RxJumboPending    uint32
+	TxPending         uint32
+}
+
+// Pause is a pause config for an interface
+type Pause struct {
+	Cmd     uint32
+	Autoneg uint32
+	RxPause uint32
+	TxPause uint32
 }
 
 type Ethtool struct {
@@ -567,6 +630,54 @@ func (e *Ethtool) getModuleEeprom(intf string) (ethtoolEeprom, ethtoolModInfo, e
 	return eeprom, modInfo, nil
 }
 
+// GetRing retrieves ring parameters of the given interface name.
+func (e *Ethtool) GetRing(intf string) (Ring, error) {
+	ring := Ring{
+		Cmd: ETHTOOL_GRINGPARAM,
+	}
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&ring))); err != nil {
+		return Ring{}, err
+	}
+
+	return ring, nil
+}
+
+// SetRing sets ring parameters of the given interface name.
+func (e *Ethtool) SetRing(intf string, ring Ring) (Ring, error) {
+	ring.Cmd = ETHTOOL_SRINGPARAM
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&ring))); err != nil {
+		return Ring{}, err
+	}
+
+	return ring, nil
+}
+
+// GetPause retrieves pause parameters of the given interface name.
+func (e *Ethtool) GetPause(intf string) (Pause, error) {
+	pause := Pause{
+		Cmd: ETHTOOL_GPAUSEPARAM,
+	}
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&pause))); err != nil {
+		return Pause{}, err
+	}
+
+	return pause, nil
+}
+
+// SetPause sets pause parameters of the given interface name.
+func (e *Ethtool) SetPause(intf string, pause Pause) (Pause, error) {
+	pause.Cmd = ETHTOOL_SPAUSEPARAM
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&pause))); err != nil {
+		return Pause{}, err
+	}
+
+	return pause, nil
+}
+
 func isFeatureBitSet(blocks [MAX_FEATURE_BLOCKS]ethtoolGetFeaturesBlock, index uint) bool {
 	return (blocks)[index/32].active&(1<<(index%32)) != 0
 }
@@ -583,18 +694,19 @@ func setFeatureBit(blocks *[MAX_FEATURE_BLOCKS]ethtoolSetFeaturesBlock, index ui
 	}
 }
 
-// FeatureNames shows supported features by their name.
-func (e *Ethtool) FeatureNames(intf string) (map[string]uint, error) {
+func (e *Ethtool) getNames(intf string, mask int) (map[string]uint, error) {
 	ssetInfo := ethtoolSsetInfo{
 		cmd:       ETHTOOL_GSSET_INFO,
-		sset_mask: 1 << ETH_SS_FEATURES,
+		sset_mask: 1 << mask,
+		data:      [MAX_SSET_INFO]uint32{},
 	}
 
 	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&ssetInfo))); err != nil {
 		return nil, err
 	}
 
-	length := uint32(ssetInfo.data)
+	/* we only read data on first index because single bit was set in sset_mask(0x10) */
+	length := ssetInfo.data[0]
 	if length == 0 {
 		return map[string]uint{}, nil
 	} else if length > MAX_GSTRINGS {
@@ -603,7 +715,7 @@ func (e *Ethtool) FeatureNames(intf string) (map[string]uint, error) {
 
 	gstrings := ethtoolGStrings{
 		cmd:        ETHTOOL_GSTRINGS,
-		string_set: ETH_SS_FEATURES,
+		string_set: uint32(mask),
 		len:        length,
 		data:       [MAX_GSTRINGS * ETH_GSTRING_LEN]byte{},
 	}
@@ -612,7 +724,7 @@ func (e *Ethtool) FeatureNames(intf string) (map[string]uint, error) {
 		return nil, err
 	}
 
-	var result = make(map[string]uint)
+	result := make(map[string]uint)
 	for i := 0; i != int(length); i++ {
 		b := gstrings.data[i*ETH_GSTRING_LEN : i*ETH_GSTRING_LEN+ETH_GSTRING_LEN]
 		key := goString(b)
@@ -622,6 +734,11 @@ func (e *Ethtool) FeatureNames(intf string) (map[string]uint, error) {
 	}
 
 	return result, nil
+}
+
+// FeatureNames shows supported features by their name.
+func (e *Ethtool) FeatureNames(intf string) (map[string]uint, error) {
+	return e.getNames(intf, ETH_SS_FEATURES)
 }
 
 // Features retrieves features of the given interface name.
@@ -645,7 +762,7 @@ func (e *Ethtool) Features(intf string) (map[string]bool, error) {
 		return nil, err
 	}
 
-	var result = make(map[string]bool, length)
+	result := make(map[string]bool, length)
 	for key, index := range names {
 		result[key] = isFeatureBitSet(features.blocks, index)
 	}
@@ -676,6 +793,68 @@ func (e *Ethtool) Change(intf string, config map[string]bool) error {
 	}
 
 	return e.ioctl(intf, uintptr(unsafe.Pointer(&features)))
+}
+
+// PrivFlagsNames shows supported private flags by their name.
+func (e *Ethtool) PrivFlagsNames(intf string) (map[string]uint, error) {
+	return e.getNames(intf, ETH_SS_PRIV_FLAGS)
+}
+
+// PrivFlags retrieves private flags of the given interface name.
+func (e *Ethtool) PrivFlags(intf string) (map[string]bool, error) {
+	names, err := e.PrivFlagsNames(intf)
+	if err != nil {
+		return nil, err
+	}
+
+	length := uint32(len(names))
+	if length == 0 {
+		return map[string]bool{}, nil
+	}
+
+	var val ethtoolLink
+	val.cmd = ETHTOOL_GPFLAGS
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&val))); err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]bool, length)
+	for name, mask := range names {
+		result[name] = val.data&(1<<mask) != 0
+	}
+
+	return result, nil
+}
+
+// UpdatePrivFlags requests a change in the given device's private flags.
+func (e *Ethtool) UpdatePrivFlags(intf string, config map[string]bool) error {
+	names, err := e.PrivFlagsNames(intf)
+	if err != nil {
+		return err
+	}
+
+	var curr ethtoolLink
+	curr.cmd = ETHTOOL_GPFLAGS
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&curr))); err != nil {
+		return err
+	}
+
+	var update ethtoolLink
+	update.cmd = ETHTOOL_SPFLAGS
+	update.data = curr.data
+	for name, value := range config {
+		if index, ok := names[name]; ok {
+			if value {
+				update.data |= 1 << index
+			} else {
+				update.data &= ^(1 << index)
+			}
+		} else {
+			return fmt.Errorf("unsupported priv flag %q", name)
+		}
+	}
+
+	return e.ioctl(intf, uintptr(unsafe.Pointer(&update)))
 }
 
 // Get state of a link.
@@ -726,7 +905,7 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 		return nil, err
 	}
 
-	var result = make(map[string]uint64)
+	result := make(map[string]uint64)
 	for i := 0; i != int(drvinfo.n_stats); i++ {
 		b := gstrings.data[i*ETH_GSTRING_LEN : i*ETH_GSTRING_LEN+ETH_GSTRING_LEN]
 		strEnd := strings.Index(string(b), "\x00")
@@ -797,4 +976,37 @@ func PermAddr(intf string) (string, error) {
 	}
 	defer e.Close()
 	return e.PermAddr(intf)
+}
+
+func supportedSpeeds(mask uint64) (ret []struct {
+	name  string
+	mask  uint64
+	speed uint64
+}) {
+	for _, mode := range supportedCapabilities {
+		if ((1 << mode.mask) & mask) != 0 {
+			ret = append(ret, mode)
+		}
+	}
+	return ret
+}
+
+// SupportedLinkModes returns the names of the link modes supported by the interface.
+func SupportedLinkModes(mask uint64) []string {
+	var ret []string
+	for _, mode := range supportedSpeeds(mask) {
+		ret = append(ret, mode.name)
+	}
+	return ret
+}
+
+// SupportedSpeed returns the maximum capacity of this interface.
+func SupportedSpeed(mask uint64) uint64 {
+	var ret uint64
+	for _, mode := range supportedSpeeds(mask) {
+		if mode.speed > ret {
+			ret = mode.speed
+		}
+	}
+	return ret
 }

--- a/go-controller/vendor/github.com/safchain/ethtool/ethtool_cmd.go
+++ b/go-controller/vendor/github.com/safchain/ethtool/ethtool_cmd.go
@@ -83,28 +83,28 @@ func (f *EthtoolCmd) reflect(retv *map[string]uint64) {
 		typeField := val.Type().Field(i)
 
 		t := valueField.Interface()
-		//tt := reflect.TypeOf(t)
-		//fmt.Printf(" t %T %v  tt %T %v\n", t, t, tt, tt)
-		switch t.(type) {
+		// tt := reflect.TypeOf(t)
+		// fmt.Printf(" t %T %v  tt %T %v\n", t, t, tt, tt)
+		switch tt := t.(type) {
 		case uint32:
-			//fmt.Printf("    t is uint32\n")
-			(*retv)[typeField.Name] = uint64(t.(uint32))
+			// fmt.Printf("    t is uint32\n")
+			(*retv)[typeField.Name] = uint64(tt)
 		case uint16:
-			(*retv)[typeField.Name] = uint64(t.(uint16))
+			(*retv)[typeField.Name] = uint64(tt)
 		case uint8:
-			(*retv)[typeField.Name] = uint64(t.(uint8))
+			(*retv)[typeField.Name] = uint64(tt)
 		case int32:
-			(*retv)[typeField.Name] = uint64(t.(int32))
+			(*retv)[typeField.Name] = uint64(tt)
 		case int16:
-			(*retv)[typeField.Name] = uint64(t.(int16))
+			(*retv)[typeField.Name] = uint64(tt)
 		case int8:
-			(*retv)[typeField.Name] = uint64(t.(int8))
+			(*retv)[typeField.Name] = uint64(tt)
 		default:
 			(*retv)[typeField.Name+"_unknown_type"] = 0
 		}
 
-		//tag := typeField.Tag
-		//fmt.Printf("Field Name: %s,\t Field Value: %v,\t Tag Value: %s\n",
+		// tag := typeField.Tag
+		// fmt.Printf("Field Name: %s,\t Field Value: %v,\t Tag Value: %s\n",
 		//	typeField.Name, valueField.Interface(), tag.Get("tag_name"))
 	}
 }
@@ -185,7 +185,7 @@ func (e *Ethtool) CmdGetMapped(intf string) (map[string]uint64, error) {
 		return nil, ep
 	}
 
-	var result = make(map[string]uint64)
+	result := make(map[string]uint64)
 
 	// ref https://gist.github.com/drewolson/4771479
 	// Golang Reflection Example

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/russross/blackfriday/v2 v2.1.0
 ## explicit
 github.com/russross/blackfriday/v2
-# github.com/safchain/ethtool v0.3.0
+# github.com/safchain/ethtool v0.3.1-0.20231027162144-83e5e0097c91
 ## explicit; go 1.16
 github.com/safchain/ethtool
 # github.com/sirupsen/logrus v1.9.0


### PR DESCRIPTION
Update the version to include big-endianness fix to safchain/ethtools (https://github.com/safchain/ethtool/pull/69).

Steps done for this commit:
* replace: `github.com/safchain/ethtool v0.3.0` with `github.com/safchain/ethtool v0.3.1-0.20231027162144-83e5e0097c91` in go.mod, vendor/modules.txt
* `go mod tidy`
* `go mod vendor`

This is needed to allow changing interface options on s390x architecture.