### PR TITLE
Add Rule count metrics for (B)ANP feature

### DIFF
--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
@@ -41,7 +41,7 @@ type Controller struct {
 	// name of the controller that starts the ANP controller
 	// (values are default-network-controller, secondary-network-controller etc..)
 	controllerName string
-	sync.Mutex
+	sync.RWMutex
 	anpClientSet anpclientset.Interface
 
 	// libovsdb northbound client interface
@@ -292,6 +292,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 			}, time.Second, stopCh)
 		}()
 	}
+	c.setupMetricsCollector()
 
 	<-stopCh
 
@@ -301,6 +302,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {
 	c.anpNamespaceQueue.ShutDown()
 	c.anpPodQueue.ShutDown()
 	c.anpNodeQueue.ShutDown()
+	c.teardownMetricsCollector()
 	wg.Wait()
 }
 

--- a/go-controller/pkg/ovn/controller/admin_network_policy/metrics.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/metrics.go
@@ -1,0 +1,136 @@
+package adminnetworkpolicy
+
+import (
+	"fmt"
+
+	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/prometheus/client_golang/prometheus"
+	anpapi "sigs.k8s.io/network-policy-api/apis/v1alpha1"
+)
+
+// Descriptors used by the ANPControllerCollector below.
+var (
+	anpRuleCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(metrics.MetricOvnkubeNamespace, metrics.MetricOvnkubeSubsystemController, "admin_network_policies_rules"),
+		"The total number of rules across all admin network policies in the cluster",
+		[]string{
+			"direction", // direction is either "ingress" or "egress"; so cardinality is max 2 for this label
+			"action",    // action is either "Pass" or "Allow" or "Deny"; so cardinality is max 3 for this label
+		}, nil,
+	)
+	banpRuleCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(metrics.MetricOvnkubeNamespace, metrics.MetricOvnkubeSubsystemController, "baseline_admin_network_policies_rules"),
+		"The total number of rules across all baseline admin network policies in the cluster",
+		[]string{
+			"direction", // direction is either "ingress" or "egress"; so cardinality is max 2 for this label
+			"action",    // action is either "Allow" or "Deny"; so cardinality is max 2 for this label
+		}, nil,
+	)
+)
+
+func (c *Controller) setupMetricsCollector() {
+	prometheus.MustRegister(c)
+}
+
+func (c *Controller) teardownMetricsCollector() {
+	prometheus.Unregister(c)
+}
+
+// Describe is implemented with DescribeByCollect. That's possible because the
+// Collect method will always return the same two metrics with the same two
+// descriptors.
+func (c *Controller) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func (c *Controller) fetchANPRuleCountMetric(isBanp bool) map[string]map[string]int {
+	c.RLock()
+	defer c.RUnlock()
+	ruleCount := map[string]map[string]int{
+		string(libovsdbutil.ACLIngress): {
+			string(anpapi.AdminNetworkPolicyRuleActionAllow): 0,
+			string(anpapi.AdminNetworkPolicyRuleActionDeny):  0,
+		},
+		string(libovsdbutil.ACLEgress): {
+			string(anpapi.AdminNetworkPolicyRuleActionAllow): 0,
+			string(anpapi.AdminNetworkPolicyRuleActionDeny):  0,
+		},
+	}
+	if !isBanp {
+		// its ANP; so add Pass label and use the anpCache
+		ruleCount[string(libovsdbutil.ACLIngress)][string(anpapi.AdminNetworkPolicyRuleActionPass)] = 0
+		ruleCount[string(libovsdbutil.ACLEgress)][string(anpapi.AdminNetworkPolicyRuleActionPass)] = 0
+		for _, state := range c.anpCache {
+			allow, pass, deny := c.countRules(state.ingressRules)
+			ruleCount[string(libovsdbutil.ACLIngress)][string(anpapi.AdminNetworkPolicyRuleActionAllow)] += allow
+			ruleCount[string(libovsdbutil.ACLIngress)][string(anpapi.AdminNetworkPolicyRuleActionDeny)] += deny
+			ruleCount[string(libovsdbutil.ACLIngress)][string(anpapi.AdminNetworkPolicyRuleActionPass)] += pass
+			allow, pass, deny = c.countRules(state.egressRules)
+			ruleCount[string(libovsdbutil.ACLEgress)][string(anpapi.AdminNetworkPolicyRuleActionAllow)] += allow
+			ruleCount[string(libovsdbutil.ACLEgress)][string(anpapi.AdminNetworkPolicyRuleActionDeny)] += deny
+			ruleCount[string(libovsdbutil.ACLEgress)][string(anpapi.AdminNetworkPolicyRuleActionPass)] += pass
+		}
+	} else {
+		// its BANP; singleton use the banpCache
+		state := c.banpCache
+		allow, _, deny := c.countRules(state.ingressRules)
+		ruleCount[string(libovsdbutil.ACLIngress)][string(anpapi.AdminNetworkPolicyRuleActionAllow)] += allow
+		ruleCount[string(libovsdbutil.ACLIngress)][string(anpapi.AdminNetworkPolicyRuleActionDeny)] += deny
+		allow, _, deny = c.countRules(state.egressRules)
+		ruleCount[string(libovsdbutil.ACLEgress)][string(anpapi.AdminNetworkPolicyRuleActionAllow)] += allow
+		ruleCount[string(libovsdbutil.ACLEgress)][string(anpapi.AdminNetworkPolicyRuleActionDeny)] += deny
+	}
+
+	return ruleCount
+}
+
+func (c *Controller) countRules(rules []*gressRule) (int, int, int) {
+	var passCount, allowCount, denyCount int
+	for _, rule := range rules {
+		switch rule.action {
+		case nbdb.ACLActionAllowRelated:
+			allowCount++
+		case nbdb.ACLActionDrop:
+			denyCount++
+		case nbdb.ACLActionPass:
+			passCount++
+		default:
+			panic(fmt.Sprintf("Failed to count rule type: unknown acl action %s", rule.action))
+		}
+	}
+	return allowCount, passCount, denyCount
+}
+
+// Collect first triggers the fetchANPRuleCountMetric. Then it
+// creates constant metrics for each host on the fly based on the returned data.
+//
+// Note that Collect could be called concurrently, so we depend on
+// fetchANPRuleCountMetric to be concurrency-safe.
+func (c *Controller) Collect(ch chan<- prometheus.Metric) {
+	aRuleCount := c.fetchANPRuleCountMetric(false)
+	for direction, actions := range aRuleCount {
+		for action, count := range actions {
+			ch <- prometheus.MustNewConstMetric(
+				anpRuleCountDesc,
+				prometheus.GaugeValue,
+				float64(count),
+				direction,
+				action,
+			)
+		}
+	}
+	bRuleCount := c.fetchANPRuleCountMetric(true)
+	for direction, actions := range bRuleCount {
+		for action, count := range actions {
+			ch <- prometheus.MustNewConstMetric(
+				banpRuleCountDesc,
+				prometheus.GaugeValue,
+				float64(count),
+				direction,
+				action,
+			)
+		}
+	}
+}


### PR DESCRIPTION
**- What this PR does and why is it needed**

This PR is adding rule count metrics for ANP/BANP
Goal is to be able to count number of rules across all ANP CRDs and BANP CRDs in the cluster.
The approach taken here is to add 2 metrics one for ANP and another for BANP.
Each metric has two labels (direction of the rule with max 2 cardinality and action of the rule with max 3 cardinality)
Each metric is tailored to gather data from a single ANP/BANP, hope is on prometheus we can query the total across all ANP/BANP?

=============================OUTDATED INFO BELOW TO BE IGNORED============================
EDIT: I met with @martinkennelly and @npinaeva and we have a path forward here:

1. Do feature wise generic DB counter metric which is extensible; this will be FeatureObjectsMetric {cardinality1: featureOwnerIndex; cardinality2: EntityinOVNDB}
3. Use a poller and do this every 30seconds so that it doesn't have to be called from the feature code
4. Change eRulesCount and iRulesCount into metric with 3 timeseries (anp,banp being 1st timeseries label) (ingress, egress being 2nd time series label) (pass, deny, allow type rules being the 3rd timeseries label)
5. So far 3 metrics will go into telemetry: the ANPcount, BANPCount, ACL/AS count for ANP/BANP


OUTDATED INFO BELOW:
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This PR adds 3 more metrics to ANP/BANP:

1. Number of (B)ANP Egress && Ingress rules across the cluster
2. Number of ACLs owned by (B)ANP: https://github.com/ovn-org/ovn-kubernetes/pull/4254
3. Number of AddressSets owned by (B)ANP: https://github.com/ovn-org/ovn-kubernetes/pull/4254

these are helpful to (A) know how users are using this feature and how many rules they are creating + (B) how many acls, address-sets this controller generates so that we can quickly determine this number versus that of other features like EFW, Netpol, Multicast etc.

**- Special notes for reviewers**
I probably went overboard with my thinking and put some other ideas in https://github.com/ovn-org/ovn-kubernetes/pull/4252 based on my spike work (https://docs.google.com/document/d/1LQ1IENCehjtiYTvBL8uORXU8GZwFbpNXMnAhVNfqnIM/edit) but I am unsure if we need to do all that. Could use some help in determining if there is value in adding metrics for:

1. number of namespace type egress and ingress peers
2. number of pods type egress and ingress peers
3. number of nodes types egress peers
8. number of networks type egress peers
9. number of namedPorts, portRanges and normal Ports

defined => it will give us a better idea of how users are using this feature as suggested by Chris, but again we have not done something like this before and this would be mean tooo many metrics, I was wondering if there is value here or not. Anyhow its not like we can expose all this via telemetry so there might not be that much value here.

**- How to verify it**
Once we confirm this PR's design, I will test this manually on OCP and attach a screenshot


**- Description for the changelog**
`Add metrics for ANP/BANP`