### PR TITLE
Changes PMTUD tests to use an external docker container

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1084,6 +1084,16 @@ func randStr(n int) string {
 	return string(b)
 }
 
+func isIPv4Supported() bool {
+	val, present := os.LookupEnv("KIND_IPV4_SUPPORT")
+	return present && val == "true"
+}
+
+func isIPv6Supported() bool {
+	val, present := os.LookupEnv("KIND_IPV6_SUPPORT")
+	return present && val == "true"
+}
+
 func isInterconnectEnabled() bool {
 	val, present := os.LookupEnv("OVN_ENABLE_INTERCONNECT")
 	return present && val == "true"


### PR DESCRIPTION
The test previously used a host network pod to act as the external server and test ingress PMTUD with OVN. This changes it to be an external server as a docker container, which sets us up for the future where  pod -> host goes via overlay and wouldn't test PMTUD in the same way.

