### PR TITLE
Fixes flaking node ip migration ETP local check

### DIFF
--- a/test/e2e/node_ip_mac_migration.go
+++ b/test/e2e/node_ip_mac_migration.go
@@ -519,6 +519,11 @@ spec:
 										return true, nil
 									}
 								}
+								// Due to potential k8s bug described here: https://github.com/ovn-org/ovn-kubernetes/issues/4073
+								// We may need to restart kubelet for the backend pod to update its host networked IP address
+								restartCmd := []string{"docker", "exec", workerNode.Name, "systemctl", "restart", "kubelet"}
+								_, restartErr := runCommand(restartCmd...)
+								framework.ExpectNoError(restartErr)
 								return false, nil
 							})
 							framework.ExpectNoError(err)


### PR DESCRIPTION
Adds a restart to kubelet to make sure the host networked "backend" pod IP is updated to the new IP so that the proper flows are programmed.

Fixes #4073

