### PR TITLE
Unskip ETP=local+terminating endpoints

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -127,10 +127,6 @@ if [ "$DUALSTACK_CONVERSION" == true ]; then
   SKIPPED_TESTS=$SKIPPED_TESTS$DUALSTACK_CONVERSION_TESTS
 fi
 
-if [ "$OVN_GATEWAY_MODE" == "local" ]; then
-  SKIPPED_TESTS+="should fallback to local terminating endpoints when there are no ready endpoints with externalTrafficPolicy=Local"
-fi
-
 SKIPPED_TESTS="$(groomTestList "${SKIPPED_TESTS}")"
 
 # if we set PARALLEL=true, skip serial test


### PR DESCRIPTION
UPDATE:
Original fix here went into https://github.com/ovn-org/ovn-kubernetes/pull/4256
I am converting this PR to fix: https://github.com/ovn-org/ovn-kubernetes/pull/4253#discussion_r1551952094

OUTDATED INFO ON OLD PR:
I think we should definitely spend some time fixing https://github.com/ovn-org/ovn-kubernetes/issues/4229

cc @jluhrsen this might be why you saw some lanes not running tests and finishing in 5mins?

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Accidental addition of `|` pipe during skipping makes it `||` which matches empty string which skips all tests :/
Not on all lanes I think shard, local, v6 ones only:

- ovn-ci / e2e (shard-conformance, HA, local, ipv6, snatGW, 1br, ic-disabled) (pull_request)
- ovn-ci / e2e (shard-conformance, noHA, local, dualstack, snatGW, 1br, ic-single-node-zones) 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->