### PR TITLE
Add (B)ANP ACL/AddressSet count metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -67,4 +67,5 @@ This list is to help notify if there are additions, changes or removals to metri
 - Add `ovnkube_master_egress_routing_via_host` (https://github.com/ovn-org/ovn-kubernetes/pull/2833)
 - Add `ovnkube_resource_retry_failures_total` (https://github.com/ovn-org/ovn-kubernetes/pull/3314)
 - Add `ovs_vswitchd_interfaces_total` and `ovs_vswitchd_interface_up_wait_seconds_total` (https://github.com/ovn-org/ovn-kubernetes/pull/3391)
-- Add `ovnkube_controller_admin_network_policy_custom_resource_total` and `ovnkube_controller_baseline_admin_network_policy_custom_resource_total` (https://github.com/ovn-org/ovn-kubernetes/pull/4239)
+- Add `ovnkube_controller_admin_network_policies` and `ovnkube_controller_baseline_admin_network_policies` (https://github.com/ovn-org/ovn-kubernetes/pull/4239)
+- Add `ovnkube_controller_admin_network_policies_db_objects` and `ovnkube_controller_baseline_admin_network_policies_db_objects` (https://github.com/ovn-org/ovn-kubernetes/pull/4254)

--- a/go-controller/pkg/libovsdb/util/metric.go
+++ b/go-controller/pkg/libovsdb/util/metric.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"k8s.io/klog/v2"
+)
+
+// GetACLCount returns the number of ACLs owned by idsType/controllerName
+func GetACLCount(nbClient libovsdbclient.Client, idsType *ops.ObjectIDsType, controllerName string) int {
+	predicateIDs := ops.NewDbObjectIDs(idsType, controllerName, nil)
+	p := ops.GetPredicate[*nbdb.ACL](predicateIDs, nil)
+	ACLs, err := ops.FindACLsWithPredicate(nbClient, p)
+	if err != nil {
+		klog.Warningf("Cannot find ACLs: %v; Resetting metrics...", err)
+		return 0
+	}
+	return len(ACLs)
+}
+
+// GetAddressSetCount returns the number of AddressSets owned by idsType/controllerName
+func GetAddressSetCount(nbClient libovsdbclient.Client, idsType *ops.ObjectIDsType, controllerName string) int {
+	predicateIDs := ops.NewDbObjectIDs(idsType, controllerName, nil)
+	p := ops.GetPredicate[*nbdb.AddressSet](predicateIDs, nil)
+	ASes, err := ops.FindAddressSetsWithPredicate(nbClient, p)
+	if err != nil {
+		klog.Warningf("Cannot find AddressSets: %v; Resetting metrics...", err)
+		return 0
+	}
+	return len(ASes)
+}

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -574,6 +574,8 @@ func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 		}()
 	}
 
+	metrics.RunOVNKubeFeatureDBObjectsMetricsUpdater(oc.nbClient, oc.controllerName, 30*time.Second, oc.stopChan)
+
 	return nil
 }
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
See https://github.com/ovn-org/ovn-kubernetes/pull/4248 and https://docs.google.com/document/d/1LQ1IENCehjtiYTvBL8uORXU8GZwFbpNXMnAhVNfqnIM/edit for more information

We are adding two metrics:

1. ANP(Table_Name) DB Object counter metric
2. BANP(Table_Name) DB Object counter metric
3. We can easily do EFW if we decide this approach is ok. (NetPol needs a sum of many type of ACL IDs so not exploring that in this PR)
4. A poller routine that runs every 30seconds scrapes for the nbdb object counts owned by each configured feature

**- Special notes for reviewers**
The ACL/AS count for ANP/BANP is pretty useful for users, scale, devs to assess how this feature is being used.
We plan to expose this via telemetry.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->