### PR TITLE
Restore some skipped IPv6 testing

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -685,8 +685,12 @@ var _ = ginkgo.Describe("Services", func() {
 			ginkgo.By("Deleting additional IP addresses from nodes")
 			for nodeName, ipFamilies := range nodeIPs {
 				for _, ip := range ipFamilies {
+					subnetMask := "/32"
+					if utilnet.IsIPv6String(ip) {
+						subnetMask = "/128"
+					}
 					_, err := runCommand(containerRuntime, "exec", nodeName, "ip", "addr", "delete",
-						fmt.Sprintf("%s/32", ip), "dev", "breth0")
+						fmt.Sprintf("%s%s", ip, subnetMask), "dev", "breth0")
 					if err != nil && !strings.Contains(err.Error(),
 						"RTNETLINK answers: Cannot assign requested address") {
 						framework.Failf("failed to remove ip address %s from node %s, err: %q", ip, nodeName, err)
@@ -759,7 +763,7 @@ var _ = ginkgo.Describe("Services", func() {
 					nodeIPs[node.Name] = make(map[int]string)
 				}
 				if utilnet.IsIPv6String(e2enode.GetAddresses(&node, v1.NodeInternalIP)[0]) {
-					newIP = "fc00:f853:ccd:e794::" + strconv.Itoa(i)
+					newIP = "fc00:f853:ccd:e793:1111::" + strconv.Itoa(i)
 					nodeIPs[node.Name][6] = newIP
 				} else {
 					newIP = "172.18.1." + strconv.Itoa(i+1)
@@ -831,7 +835,7 @@ var _ = ginkgo.Describe("Services", func() {
 								"hostname")
 							// Expect to receive a valid hostname
 							return nodesHostnames.Has(epHostname)
-						}, "20s", "1s").Should(gomega.BeTrue())
+						}, "40s", "1s").Should(gomega.BeTrue())
 					}
 				}
 			}

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -365,6 +365,10 @@ var _ = ginkgo.Describe("Services", func() {
 				ginkgo.It("queries to the nodePort service shall work for UDP", func() {
 					for _, size := range []string{"small", "large"} {
 						for _, serviceNodeIP := range serviceNodeInternalIPs {
+							flushCmd := "ip route flush cache"
+							if utilnet.IsIPv6String(serviceNodeIP) {
+								flushCmd = "ip -6 route flush cache"
+							}
 							if size == "large" && !hostNetwork {
 								// Flushing the IP route cache will remove any routes in the cache
 								// that are a result of receiving a "need to frag" packet.
@@ -372,7 +376,7 @@ var _ = ginkgo.Describe("Services", func() {
 								_, err := e2epodoutput.RunHostCmdWithRetries(
 									clientPod.Namespace,
 									clientPod.Name,
-									"ip route flush cache",
+									flushCmd,
 									framework.Poll,
 									60*time.Second)
 								framework.ExpectNoError(err, "Flushing the ip route cache failed")
@@ -464,8 +468,11 @@ var _ = ginkgo.Describe("Services", func() {
 								if isInterconnectEnabled() {
 									containerName = "ovnkube-controller"
 								}
-								_, err := e2ekubectl.RunKubectl(ovnNs, "exec", ovnKubeNodePod.Name, "--container", containerName, "--",
-									"ip", "route", "flush", "cache")
+
+								arguments := []string{"exec", ovnKubeNodePod.Name, "--container", containerName, "--"}
+								sepFlush := strings.Split(flushCmd, " ")
+								arguments = append(arguments, sepFlush...)
+								_, err := e2ekubectl.RunKubectl(ovnNs, arguments...)
 								framework.ExpectNoError(err, "Flushing the ip route cache failed")
 							}
 						}

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -39,7 +39,6 @@ test node readiness according to its defaults interface MTU size|\
 egress IP validation|\
 e2e egress firewall policy validation|\
 OVS CPU affinity pinning|\
-should listen on each host addresses|\
 Pod to pod TCP with low MTU|\
 queries to the hostNetworked server pod on another node shall work for TCP|\
 queries to the hostNetworked server pod on another node shall work for UDP|\
@@ -114,7 +113,6 @@ if [ "$OVN_GATEWAY_MODE" == "local" ]; then
     fi
     SKIPPED_TESTS+="Should be allowed to node local host-networked endpoints by nodeport services|\
 Should be allowed by nodeport services|\
-Should be allowed to node local cluster-networked endpoints by nodeport services with externalTrafficPolicy=local|\
 Should successfully create then remove a static pod|\
 Should validate connectivity from a pod to a non-node host address on same node|\
 Should validate connectivity within a namespace of pods on separate nodes|\

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -107,8 +107,7 @@ if [ "$OVN_GATEWAY_MODE" == "local" ]; then
     if [ "$SKIPPED_TESTS" != "" ]; then
         SKIPPED_TESTS+="|"
     fi
-    SKIPPED_TESTS+="Should be allowed to node local host-networked endpoints by nodeport services|\
-Should be allowed by nodeport services|\
+    SKIPPED_TESTS+="Should be allowed by nodeport services|\
 Should successfully create then remove a static pod|\
 Should validate connectivity from a pod to a non-node host address on same node|\
 Should validate connectivity within a namespace of pods on separate nodes|\

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -99,10 +99,6 @@ if [ "$OVN_GATEWAY_MODE" == "shared" ]; then
   fi
   SKIPPED_TESTS+="Should ensure load balancer service|LGW"
   # See https://github.com/ovn-org/ovn-kubernetes/issues/4138 for details
-  if [ "$KIND_IPV6_SUPPORT" == true ]; then
-    SKIPPED_TESTS+="|"
-    SKIPPED_TESTS+="queries to the nodePort service shall work for UDP"
-  fi
 fi
 
 if [ "$OVN_GATEWAY_MODE" == "local" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

This PR fixes some of the ipv6 e2e tests and unskips them from CI 
"Services when a nodePort service targeting a pod with hostNetwork:true is created when tests are run towards the agnhost echo service [It] queries to the nodePort service shall work for UDP on IPV6 Shared gateway"
"Services when a nodePort service targeting a pod with hostNetwork:true is created when tests are run towards the agnhost echo service [It] queries to the nodePort service shall work for UDP on IPV6 Shared gateway"
and the ginkgo step "Services of type NodePort: should listen on each host addresses"
"e2e ingress to host-networked pods traffic validation: Should be allowed to node local host-networked endpoints by nodeport services" in local gateway mode 

the testing was not doing the correct action for ipv6

fixes:
https://github.com/ovn-org/ovn-kubernetes/issues/4135
https://github.com/ovn-org/ovn-kubernetes/issues/4136
https://github.com/ovn-org/ovn-kubernetes/issues/4138



**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->