### PR TITLE
Remove extra || in SKIP formatting && bump k8 test binary to fix e2e issues found

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -125,9 +125,6 @@ if [ "$DUALSTACK_CONVERSION" == true ]; then
 fi
 
 if [ "$OVN_GATEWAY_MODE" == "local" ]; then
-  if [ "$SKIPPED_TESTS" != "" ]; then
-    SKIPPED_TESTS+="|"
-  fi
   SKIPPED_TESTS+="should fallback to local terminating endpoints when there are no ready endpoints with externalTrafficPolicy=Local"
 fi
 

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -45,7 +45,7 @@ install_kind() {
 }
 
 pushd $TMP_DIR
-K8S_VERSION="v1.28.0"
+K8S_VERSION="v1.28.6"
 
 # Install kubectl for K8S_VERSION in use
 # (to get latest stable version: $(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt )


### PR DESCRIPTION
Attempting to fix issue found in e2e tests in PR: https://github.com/ovn-org/ovn-kubernetes/pull/4253

Following tests were failing but should now be resolved:
](https://github.com/ovn-org/ovn-kubernetes/actions/runs/8551587549/job/23431934438?pr=4253)

More details in https://github.com/ovn-org/ovn-kubernetes/pull/4253 regarding the first commit.