### PR TITLE
Refactor NetworkController.Cleanup

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -266,13 +266,13 @@ func (ncc *networkClusterController) newRetryFramework(objectType reflect.Type, 
 }
 
 // Cleanup the subnet annotations from the node for the secondary networks
-func (ncc *networkClusterController) Cleanup(netName string) error {
+func (ncc *networkClusterController) Cleanup() error {
 	if !ncc.IsSecondary() {
 		return fmt.Errorf("default network can't be cleaned up")
 	}
 
 	if ncc.hasNodeAllocation() {
-		err := ncc.nodeAllocator.Cleanup(netName)
+		err := ncc.nodeAllocator.Cleanup()
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -325,7 +325,7 @@ func (na *NodeAllocator) updateNodeNetworkAnnotationsWithRetry(nodeName string, 
 }
 
 // Cleanup the subnet annotations from the node
-func (na *NodeAllocator) Cleanup(netName string) error {
+func (na *NodeAllocator) Cleanup() error {
 	networkName := na.netInfo.GetNetworkName()
 
 	// remove hostsubnet annotation for this network

--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -180,7 +180,7 @@ func (sncm *secondaryNetworkClusterManager) CleanupDeletedNetworks(allController
 
 	for netName, oc := range staleNetworkControllers {
 		klog.Infof("Cleanup subnet annotation for stale network %s", netName)
-		err = oc.Cleanup(netName)
+		err = oc.Cleanup()
 		if err != nil {
 			klog.Errorf("Failed to delete stale subnet annotation for network %s: %v", netName, err)
 		}

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -56,9 +56,9 @@ type NetworkController interface {
 	AddNAD(nadName string)
 	DeleteNAD(nadName string)
 	HasNAD(nadName string) bool
-	// Cleanup cleans up the given network, it could be called to clean up network controllers that are deleted when
-	// ovn-k8s is down; so it's receiver could be a dummy network controller.
-	Cleanup(netName string) error
+	// Cleanup cleans up the NetworkController-owned resources, it could be called to clean up network controllers that are deleted when
+	// ovn-k8s is down; so it's receiver could be a dummy network controller, it just needs to know its network name.
+	Cleanup() error
 }
 
 // NetworkControllerManager manages all network controllers
@@ -549,7 +549,7 @@ func (nadController *NetAttachDefinitionController) deleteNADFromController(netN
 		if len(nni.nadNames) == 0 {
 			klog.V(5).Infof("%s: The last NAD: %s of network %s has been deleted, stopping network controller", nadController.name, nadName, networkName)
 			oc.Stop()
-			err := oc.Cleanup(oc.GetNetworkName())
+			err := oc.Cleanup()
 			// set isStarted to false even stop failed, as the operation could be half-done.
 			// So if a new NAD with the same netconf comes in, it can restart the controller.
 			nni.isStarted = false

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -160,7 +160,7 @@ func (cm *NetworkControllerManager) CleanupDeletedNetworks(allControllers []nad.
 
 	for netName, oc := range staleNetworkControllers {
 		klog.Infof("Cleanup entities for stale network %s", netName)
-		err = oc.Cleanup(netName)
+		err = oc.Cleanup()
 		if err != nil {
 			klog.Errorf("Failed to delete stale OVN logical entities for network %s: %v", netName, err)
 		}

--- a/go-controller/pkg/node/secondary_node_network_controller.go
+++ b/go-controller/pkg/node/secondary_node_network_controller.go
@@ -54,6 +54,6 @@ func (nc *SecondaryNodeNetworkController) Stop() {
 }
 
 // Cleanup cleans up node entities for the given secondary network
-func (nc *SecondaryNodeNetworkController) Cleanup(netName string) error {
+func (nc *SecondaryNodeNetworkController) Cleanup() error {
 	return nil
 }

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -246,7 +246,9 @@ func (oc *BaseSecondaryLayer2NetworkController) stop() {
 
 // cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
-func (oc *BaseSecondaryLayer2NetworkController) cleanup(topotype, netName string) error {
+func (oc *BaseSecondaryLayer2NetworkController) cleanup() error {
+	netName := oc.GetNetworkName()
+	klog.Infof("Delete OVN logical entities for network %s", netName)
 	// delete layer 2 logical switches
 	ops, err := libovsdbops.DeleteLogicalSwitchesWithPredicateOps(oc.nbClient, nil,
 		func(item *nbdb.LogicalSwitch) bool {
@@ -256,8 +258,7 @@ func (oc *BaseSecondaryLayer2NetworkController) cleanup(topotype, netName string
 		return fmt.Errorf("failed to get ops for deleting switches of network %s: %v", netName, err)
 	}
 
-	controllerName := getNetworkControllerName(netName)
-	ops, err = cleanupPolicyLogicalEntities(oc.nbClient, ops, controllerName)
+	ops, err = cleanupPolicyLogicalEntities(oc.nbClient, ops, oc.controllerName)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -108,9 +108,8 @@ func (oc *SecondaryLayer2NetworkController) run(ctx context.Context) error {
 
 // Cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
-func (oc *SecondaryLayer2NetworkController) Cleanup(netName string) error {
-	klog.Infof("Delete OVN logical entities for network %s", netName)
-	return oc.BaseSecondaryLayer2NetworkController.cleanup(types.Layer2Topology, netName)
+func (oc *SecondaryLayer2NetworkController) Cleanup() error {
+	return oc.BaseSecondaryLayer2NetworkController.cleanup()
 }
 
 func (oc *SecondaryLayer2NetworkController) Init() error {

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -364,13 +364,13 @@ func (oc *SecondaryLayer3NetworkController) Stop() {
 
 // Cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
-func (oc *SecondaryLayer3NetworkController) Cleanup(netName string) error {
+func (oc *SecondaryLayer3NetworkController) Cleanup() error {
 	// cleans up related OVN logical entities
 	var ops []ovsdb.Operation
 	var err error
 
 	// Note : Cluster manager removes the subnet annotation for the node.
-
+	netName := oc.GetNetworkName()
 	klog.Infof("Delete OVN logical entities for %s network controller of network %s", types.Layer3Topology, netName)
 	// first delete node logical switches
 	ops, err = libovsdbops.DeleteLogicalSwitchesWithPredicateOps(oc.nbClient, ops,
@@ -390,8 +390,7 @@ func (oc *SecondaryLayer3NetworkController) Cleanup(netName string) error {
 		return fmt.Errorf("failed to get ops for deleting routers of network %s: %v", netName, err)
 	}
 
-	controllerName := getNetworkControllerName(netName)
-	ops, err = cleanupPolicyLogicalEntities(oc.nbClient, ops, controllerName)
+	ops, err = cleanupPolicyLogicalEntities(oc.nbClient, ops, oc.controllerName)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -103,9 +103,8 @@ func (oc *SecondaryLocalnetNetworkController) run(ctx context.Context) error {
 
 // Cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
-func (oc *SecondaryLocalnetNetworkController) Cleanup(netName string) error {
-	klog.Infof("Delete OVN logical entities for network %s", netName)
-	return oc.BaseSecondaryLayer2NetworkController.cleanup(types.LocalnetTopology, netName)
+func (oc *SecondaryLocalnetNetworkController) Cleanup() error {
+	return oc.BaseSecondaryLayer2NetworkController.cleanup()
 }
 
 func (oc *SecondaryLocalnetNetworkController) Init() error {


### PR DESCRIPTION
 Cleanup method doesn't need netName, as it should be already known to the NetworkController.
Was promised as a part of https://github.com/ovn-org/ovn-kubernetes/pull/3579 review