### PR TITLE
remove ovn-{nb|sb}ctl CLI latency metrics and alerts

### DIFF
--- a/dist/templates/ovnkube-alerts.yaml.j2
+++ b/dist/templates/ovnkube-alerts.yaml.j2
@@ -95,38 +95,6 @@ spec:
          The pod creation latency aggregated across all masters for the last 
          15minutes is more than 5 seconds as compared to 15 minutes before last 15 minutes.
 
-    - alert: OvnKubeHighNBCliLatency99thPercentile
-      expr: |
-        histogram_quantile(0.99,
-          sum by (le) (
-            rate(ovnkube_controller_ovn_cli_latency_seconds_bucket{
-              command="ovn-nbctl"}[15m])
-          )
-        ) > 3 
-      for: 10m
-      labels:
-       severity: warning
-      annotations:
-       description: |
-         The ovn-nbctl 99th percentile CLI latency {{ value }} aggregated 
-         across all masters for the last 15minutes is more than 3 seconds.
-
-    - alert: OvnKubeHighSBCliLatency99thPercentile
-      expr: |
-        histogram_quantile(0.99,
-          sum by (le) (
-            rate(ovnkube_controller_ovn_cli_latency_seconds_bucket{
-              command="ovn-sbctl"}[15m])
-          )
-        ) > 3
-      for: 10m
-      labels:
-       severity: warning
-      annotations:
-       description: |
-         The ovn-sbctl 99th percentile CLI latency {{ value }} aggregated
-         across all masters for the last 15minutes is more than 3 seconds.
-
     - alert: OvnKubeHighK8sNetworkPolicyUpdateLatency99thPercentile
       expr: |
         histogram_quantile(0.99,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,6 +17,7 @@ Measurement accuracy can be impacted by other parallel processing that might be 
 ## Change log
 This list is to help notify if there are additions, changes or removals to metrics. Latest changes are at the top of this list.
 
+- Remove ovnkube_controller_ovn_cli_latency_seconds metrics since we have moved most of the OVN DB operations to libovsdb.
 - Effect of OVN IC architecture:
   - Move all the metrics from subsystem "ovnkube-master" to subsystem "ovnkube-controller". The non-IC and IC deployments will each continue to have their ovnkube-master and ovnkube-controller containers running inside the ovnkube-master and ovnkube-controller pods. The metrics scraping should work seemlessly. See https://github.com/ovn-org/ovn-kubernetes/pull/3723 for details
   - Move the following metrics from subsystem "master" to subsystem "clustermanager". Therefore, the follow metrics are renamed.

--- a/go-controller/pkg/metrics/ovnkube_controller.go
+++ b/go-controller/pkg/metrics/ovnkube_controller.go
@@ -61,17 +61,6 @@ var metricPodCreationLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15),
 })
 
-// metricOvnCliLatency is the duration to execute OVN commands using CLI tools ovn-nbctl or ovn-sbctl.
-var metricOvnCliLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: MetricOvnkubeNamespace,
-	Subsystem: MetricOvnkubeSubsystemController,
-	Name:      "ovn_cli_latency_seconds",
-	Help:      "The latency of various OVN commands. Currently, ovn-nbctl and ovn-sbctl",
-	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
-	// labels
-	[]string{"command"},
-)
-
 // MetricResourceUpdateCount is the number of times a particular resource's UpdateFunc has been called.
 var MetricResourceUpdateCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: MetricOvnkubeNamespace,
@@ -388,9 +377,6 @@ func RegisterOVNKubeControllerPerformance(nbClient libovsdbclient.Client) {
 	prometheus.MustRegister(MetricRequeueServiceCount)
 	prometheus.MustRegister(MetricSyncServiceCount)
 	prometheus.MustRegister(MetricSyncServiceLatency)
-	prometheus.MustRegister(metricOvnCliLatency)
-	// This is set to not create circular import between metrics and util package
-	util.MetricOvnCliLatency = metricOvnCliLatency
 	registerWorkqueueMetrics(MetricOvnkubeNamespace, MetricOvnkubeSubsystemController)
 	prometheus.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/afero"
 
 	"k8s.io/klog/v2"
@@ -72,10 +71,6 @@ func PrepareTestConfig() {
 	ovsRunDir = savedOVSRunDir
 	ovnRunDir = savedOVNRunDir
 }
-
-// this metric is set only for the ovnkube in master mode since 99.9% of
-// all the ovn-nbctl/ovn-sbctl calls occur on the master
-var MetricOvnCliLatency *prometheus.HistogramVec
 
 func runningPlatform() (string, error) {
 	if runtime.GOOS == windowsOS {
@@ -424,11 +419,7 @@ func RunOVNNbctlWithTimeout(timeout int, args ...string) (string, string, error)
 // FIXME: Remove when https://github.com/ovn-org/libovsdb/issues/235 is fixed
 func RunOVNNbctlRawOutput(timeout int, args ...string) (string, string, error) {
 	cmdArgs, envVars := getNbctlArgsAndEnv(timeout, args...)
-	start := time.Now()
 	stdout, stderr, err := runOVNretry(runner.nbctlPath, envVars, cmdArgs...)
-	if MetricOvnCliLatency != nil {
-		MetricOvnCliLatency.WithLabelValues("ovn-nbctl").Observe(time.Since(start).Seconds())
-	}
 	return stdout.String(), stderr.String(), err
 }
 
@@ -459,11 +450,7 @@ func RunOVNSbctlWithTimeout(timeout int, args ...string) (string, string,
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--timeout=%d", timeout))
 	cmdArgs = append(cmdArgs, "--no-leader-only")
 	cmdArgs = append(cmdArgs, args...)
-	start := time.Now()
 	stdout, stderr, err := runOVNretry(runner.sbctlPath, nil, cmdArgs...)
-	if MetricOvnCliLatency != nil {
-		MetricOvnCliLatency.WithLabelValues("ovn-sbctl").Observe(time.Since(start).Seconds())
-	}
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 


### PR DESCRIPTION
we have moved away from invoking the CLI to leveraging libovsdb go-module for OVN DB operations, so this metric and its associated alerts are of no use.


@trozet @cathy-zhou @tssurya PTAL