### PR TITLE
incorrect OVN DB version is being scrapped

### DIFF
--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -333,8 +333,8 @@ func getNBDBSockPath() (string, error) {
 }
 
 func getOvnDbVersionInfo() {
-	stdout, _, err := util.RunOVSDBClient("-V")
-	if err == nil && strings.HasPrefix(stdout, "ovsdb-client (Open vSwitch) ") {
+	stdout, _, err := util.RunOVNNBAppCtl("version")
+	if err == nil && strings.HasPrefix(stdout, "ovsdb-server (Open vSwitch) ") {
 		ovnDbVersion = strings.Fields(stdout)[3]
 	}
 	basePath, err := getNBDBSockPath()

--- a/go-controller/pkg/metrics/ovs.go
+++ b/go-controller/pkg/metrics/ovs.go
@@ -285,10 +285,16 @@ var metricOvsUpcallFlowLimitHit = prometheus.NewGauge(prometheus.GaugeOpts{
 type ovsClient func(args ...string) (string, string, error)
 
 func getOvsVersionInfo() {
-	stdout, _, err := util.RunOVSVsctl("--version")
-	if err == nil && strings.HasPrefix(stdout, "ovs-vsctl (Open vSwitch)") {
-		ovsVersion = strings.Fields(stdout)[3]
+	stdout, _, err := util.RunOvsVswitchdAppCtl("version")
+	if err != nil {
+		klog.Errorf("Failed to get version information: %s", err.Error())
+		return
 	}
+	if !strings.HasPrefix(stdout, "ovs-vswitchd (Open vSwitch)") {
+		klog.Errorf("Unexpected ovs-appctl version output: %s", stdout)
+		return
+	}
+	ovsVersion = strings.Fields(stdout)[3]
 }
 
 // ovsDatapathLookupsMetrics obtains the ovs datapath


### PR DESCRIPTION
ovnkube-node pod could be running different container image from OVN DB pod, so we will need to use:

  `ovs-appctl -t /path/to/ovnnb_db.ctl version`

Authored-By: Zhen Wang <zhewang@nvidia.com>

