### PR TITLE
Introduce metrics and alerts to track the logfile size

### DIFF
--- a/dist/templates/ovnkube-alerts.yaml.j2
+++ b/dist/templates/ovnkube-alerts.yaml.j2
@@ -159,6 +159,20 @@ spec:
          The 99th percentile {{ $labels.name }} update latency {{ value }} aggregated
          across all masters for the last 15minutes is more than 1 seconds.
 
+    # The logfile size is in bytes. We first convert it into MiB. Then, we collect last 15 minutes of
+    # the time series data and check if the rate at which the log file is increasing is more than 1MB
+    # over the last 5 minutes.
+    - alert: OvnKubeNodeLogFileSize
+      expr: |
+        rate(ovnkube_node_logfile_size_bytes{namespace="ovn-kubernetes", job="ovnkube-node"}[15m]) * 5 * 60 / 1024 / 1024 > 1
+      for: 10m
+      labels:
+       severity: warning
+      annotations:
+       message: |
+         Pod ovn-kubernetes/ {{ $labels.pod }} {{ $labels.logfile_name }} file size is
+         increasing {{ printf "%.2f" $value }} Mb / 5 minutes for the last 10 minutes
+
     - alert: OvnNBDBStale
       expr: time() - max(ovnkube_controller_nb_e2e_timestamp) > 120
       for: 4m

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,6 +17,7 @@ Measurement accuracy can be impacted by other parallel processing that might be 
 ## Change log
 This list is to help notify if there are additions, changes or removals to metrics. Latest changes are at the top of this list.
 
+- Add metrics to track logfile size for ovnkube processes - ovnkube_node_logfile_size_bytes and ovnkube_controller_logfile_size_bytes
 - Remove ovnkube_controller_ovn_cli_latency_seconds metrics since we have moved most of the OVN DB operations to libovsdb.
 - Effect of OVN IC architecture:
   - Move all the metrics from subsystem "ovnkube-master" to subsystem "ovnkube-controller". The non-IC and IC deployments will each continue to have their ovnkube-master and ovnkube-controller containers running inside the ovnkube-master and ovnkube-controller pods. The metrics scraping should work seemlessly. See https://github.com/ovn-org/ovn-kubernetes/pull/3723 for details

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -527,7 +527,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 			}
 
 			// register ovnkube node specific prometheus metrics exported by the node
-			metrics.RegisterNodeMetrics()
+			metrics.RegisterNodeMetrics(ctx.Done())
 
 			nodeNetworkControllerManager, err := controllerManager.NewNodeNetworkControllerManager(
 				ovnClientset,

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -234,7 +234,7 @@ func (cm *NetworkControllerManager) configureSvcTemplateSupport() {
 
 func (cm *NetworkControllerManager) configureMetrics(stopChan <-chan struct{}) {
 	metrics.RegisterOVNKubeControllerPerformance(cm.nbClient)
-	metrics.RegisterOVNKubeControllerFunctional()
+	metrics.RegisterOVNKubeControllerFunctional(stopChan)
 	metrics.RunTimestamp(stopChan, cm.sbClient, cm.nbClient)
 	metrics.MonitorIPSec(cm.nbClient)
 }


### PR DESCRIPTION
We have found several instances where the size of the log file increased very rapidly and consumed good amount of disk space. With the addition of this metric and alert, it will provide deployers with an ability to know if an ovnkube-node or ovnkube-controller daemon is misbehaving.