### PR TITLE
Add support for EgressIP and ExternalTrafficPolicy=Local to coexist

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-23.09.0-139.fc39
+ARG ovnver=ovn-24.03.1-5.fc39
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/dist/images/Dockerfile.fedora.dev
+++ b/dist/images/Dockerfile.fedora.dev
@@ -15,7 +15,7 @@
 # this image in any production environment.
 #
 
-FROM fedora:38 AS ovnbuilder
+FROM fedora:39 AS ovnbuilder
 
 USER root
 
@@ -64,7 +64,7 @@ RUN rm rpm/rpmbuild/RPMS/x86_64/*docker*
 RUN git log -n 1
 
 # Build the final image
-FROM fedora:37
+FROM fedora:39
 
 # Install needed dependencies.
 RUN INSTALL_PKGS=" \

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -22,7 +22,7 @@ else
 CONTAINER_RUNTIME=docker
 endif
 CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1; echo $$?)
-OVN_SCHEMA_VERSION ?= v23.06.0
+OVN_SCHEMA_VERSION ?= v24.03.1
 ifeq ($(NOROOT),TRUE)
 C_ARGS = -e NOROOT=TRUE
 else

--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -203,6 +203,7 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		nbdb.LoadBalancerTable:  {{Columns: []model.ColumnKey{{Column: "name"}}}},
 		nbdb.LogicalSwitchTable: {{Columns: []model.ColumnKey{{Column: "name"}}}},
 		nbdb.LogicalRouterTable: {{Columns: []model.ColumnKey{{Column: "name"}}}},
+		nbdb.QoSTable:           {{Columns: []model.ColumnKey{{Column: "external_ids", Key: types.PrimaryIDKey}}}},
 	})
 
 	c, err := newClient(cfg, dbModel, stopCh, enableMetricsOption)

--- a/go-controller/pkg/libovsdb/ops/db_object_ids.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_ids.go
@@ -112,13 +112,13 @@ func newObjectIDsType(dbTable dbObjType, ownerObjectType ownerType, keys []Exter
 //	 dbIndex := NewDbObjectIDs(AddressSetEgressFirewallDNS, "DefaultController",
 //			map[ExternalIDKey]string{
 //				ObjectNameKey: "dns.name",
-//				AddressSetIPFamilyKey: "ipv4"
+//				IPFamilyKey:   "ipv4"
 //		})
 //
 //	uses AddressSetEgressFirewallDNS = newObjectIDsType(addressSet, EgressFirewallDNSOwnerType, []ExternalIDKey{
 //			// dnsName
 //			ObjectNameKey,
-//			AddressSetIPFamilyKey,
+//			IPFamilyKey,
 //	 })
 //
 // its dbIndex will be mapped to the following ExternalIDs

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -40,7 +40,7 @@ const (
 	PriorityKey           ExternalIDKey = "priority"
 	PolicyDirectionKey    ExternalIDKey = "direction"
 	GressIdxKey           ExternalIDKey = "gress-index"
-	AddressSetIPFamilyKey ExternalIDKey = "ip-family"
+	IPFamilyKey           ExternalIDKey = "ip-family"
 	TypeKey               ExternalIDKey = "type"
 	IpKey                 ExternalIDKey = "ip"
 	PortPolicyIndexKey    ExternalIDKey = "port-policy-index"
@@ -59,7 +59,7 @@ var AddressSetAdminNetworkPolicy = newObjectIDsType(addressSet, AdminNetworkPoli
 	PolicyDirectionKey,
 	// gress rule's index
 	GressIdxKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var AddressSetBaselineAdminNetworkPolicy = newObjectIDsType(addressSet, BaselineAdminNetworkPolicyOwnerType, []ExternalIDKey{
@@ -69,19 +69,19 @@ var AddressSetBaselineAdminNetworkPolicy = newObjectIDsType(addressSet, Baseline
 	PolicyDirectionKey,
 	// gress rule's index
 	GressIdxKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var AddressSetEgressFirewallDNS = newObjectIDsType(addressSet, EgressFirewallDNSOwnerType, []ExternalIDKey{
 	// dnsName
 	ObjectNameKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var AddressSetHybridNodeRoute = newObjectIDsType(addressSet, HybridNodeRouteOwnerType, []ExternalIDKey{
 	// nodeName
 	ObjectNameKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var AddressSetEgressQoS = newObjectIDsType(addressSet, EgressQoSOwnerType, []ExternalIDKey{
@@ -89,13 +89,13 @@ var AddressSetEgressQoS = newObjectIDsType(addressSet, EgressQoSOwnerType, []Ext
 	ObjectNameKey,
 	// egress qos priority
 	PriorityKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var AddressSetPodSelector = newObjectIDsType(addressSet, PodSelectorOwnerType, []ExternalIDKey{
 	// pod selector string representation
 	ObjectNameKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 // deprecated, should only be used for sync
@@ -106,25 +106,25 @@ var AddressSetNetworkPolicy = newObjectIDsType(addressSet, NetworkPolicyOwnerTyp
 	PolicyDirectionKey,
 	// gress rule index
 	GressIdxKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var AddressSetNamespace = newObjectIDsType(addressSet, NamespaceOwnerType, []ExternalIDKey{
 	// namespace
 	ObjectNameKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var AddressSetEgressIP = newObjectIDsType(addressSet, EgressIPOwnerType, []ExternalIDKey{
 	// cluster-wide address set name
 	ObjectNameKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var AddressSetEgressService = newObjectIDsType(addressSet, EgressServiceOwnerType, []ExternalIDKey{
 	// cluster-wide address set name
 	ObjectNameKey,
-	AddressSetIPFamilyKey,
+	IPFamilyKey,
 })
 
 var ACLAdminNetworkPolicy = newObjectIDsType(acl, AdminNetworkPolicyOwnerType, []ExternalIDKey{

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -7,6 +7,7 @@ const (
 	acl
 	dhcpOptions
 	portGroup
+	logicalRouterPolicy
 )
 
 const (
@@ -280,4 +281,14 @@ var PortGroupCluster = newObjectIDsType(portGroup, ClusterOwnerType, []ExternalI
 	// name of a global port group
 	// currently ClusterPortGroup and ClusterRtrPortGroup are present
 	ObjectNameKey,
+})
+
+var LogicalRouterPolicyEgressIP = newObjectIDsType(logicalRouterPolicy, EgressIPOwnerType, []ExternalIDKey{
+	// the priority of the LRP
+	PriorityKey,
+	// for the reroute policies it should be the "EIPName_Namespace/podName"
+	// for the no-reroute global policies it should be the unique global name
+	ObjectNameKey,
+	// the IP Family for this policy, ip4 or ip6 or ip(dualstack)
+	IPFamilyKey,
 })

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -301,3 +301,12 @@ var QoSEgressQoS = newObjectIDsType(qos, EgressQoSOwnerType, []ExternalIDKey{
 	// namespace
 	ObjectNameKey,
 })
+
+var QoSRuleEgressIP = newObjectIDsType(qos, EgressIPOwnerType, []ExternalIDKey{
+	// the priority of the QoSRule
+	PriorityKey,
+	// should be the unique global name
+	ObjectNameKey,
+	// the IP Family for this policy, ip4 or ip6 or ip(dualstack)
+	IPFamilyKey,
+})

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -8,6 +8,7 @@ const (
 	dhcpOptions
 	portGroup
 	logicalRouterPolicy
+	qos
 )
 
 const (
@@ -291,4 +292,12 @@ var LogicalRouterPolicyEgressIP = newObjectIDsType(logicalRouterPolicy, EgressIP
 	ObjectNameKey,
 	// the IP Family for this policy, ip4 or ip6 or ip(dualstack)
 	IPFamilyKey,
+})
+
+var QoSEgressQoS = newObjectIDsType(qos, EgressQoSOwnerType, []ExternalIDKey{
+	// the priority of the QoSRule (OVN priority is the same as the rule index priority for this feature)
+	// this value will be unique in a given namespace
+	PriorityKey,
+	// namespace
+	ObjectNameKey,
 })

--- a/go-controller/pkg/libovsdb/ops/model.go
+++ b/go-controller/pkg/libovsdb/ops/model.go
@@ -270,6 +270,9 @@ func copyIndexes(model model.Model) model.Model {
 	case *nbdb.QoS:
 		return &nbdb.QoS{
 			UUID: t.UUID,
+			ExternalIDs: map[string]string{
+				types.PrimaryIDKey: t.ExternalIDs[types.PrimaryIDKey],
+			},
 		}
 	case *nbdb.ChassisTemplateVar:
 		return &nbdb.ChassisTemplateVar{

--- a/go-controller/pkg/libovsdb/ops/qos.go
+++ b/go-controller/pkg/libovsdb/ops/qos.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"strings"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
@@ -29,10 +28,7 @@ func CreateOrUpdateQoSesOps(nbClient libovsdbclient.Client, ops []libovsdb.Opera
 		// can't use i in the predicate, for loop replaces it in-memory
 		qos := qoses[i]
 		opModel := operationModel{
-			Model: qos,
-			ModelPredicate: func(q *nbdb.QoS) bool {
-				return strings.Contains(q.Match, qos.Match) && q.Priority == qos.Priority
-			},
+			Model:          qos,
 			OnModelUpdates: []interface{}{}, // update all fields
 			ErrNotFound:    false,
 			BulkOp:         false,
@@ -50,10 +46,7 @@ func UpdateQoSesOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, qo
 		// can't use i in the predicate, for loop replaces it in-memory
 		qos := qoses[i]
 		opModel := operationModel{
-			Model: qos,
-			ModelPredicate: func(q *nbdb.QoS) bool {
-				return strings.Contains(q.Match, qos.Match) && q.Priority == qos.Priority
-			},
+			Model:          qos,
 			OnModelUpdates: []interface{}{}, // update all fields
 			ErrNotFound:    true,
 			BulkOp:         false,

--- a/go-controller/pkg/nbdb/dns.go
+++ b/go-controller/pkg/nbdb/dns.go
@@ -11,6 +11,7 @@ const DNSTable = "DNS"
 type DNS struct {
 	UUID        string            `ovsdb:"_uuid"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	Options     map[string]string `ovsdb:"options"`
 	Records     map[string]string `ovsdb:"records"`
 }
 
@@ -34,6 +35,36 @@ func copyDNSExternalIDs(a map[string]string) map[string]string {
 }
 
 func equalDNSExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *DNS) GetOptions() map[string]string {
+	return a.Options
+}
+
+func copyDNSOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDNSOptions(a, b map[string]string) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}
@@ -81,6 +112,7 @@ func equalDNSRecords(a, b map[string]string) bool {
 func (a *DNS) DeepCopyInto(b *DNS) {
 	*b = *a
 	b.ExternalIDs = copyDNSExternalIDs(a.ExternalIDs)
+	b.Options = copyDNSOptions(a.Options)
 	b.Records = copyDNSRecords(a.Records)
 }
 
@@ -102,6 +134,7 @@ func (a *DNS) CloneModel() model.Model {
 func (a *DNS) Equals(b *DNS) bool {
 	return a.UUID == b.UUID &&
 		equalDNSExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalDNSOptions(a.Options, b.Options) &&
 		equalDNSRecords(a.Records, b.Records)
 }
 

--- a/go-controller/pkg/nbdb/logical_router_policy.go
+++ b/go-controller/pkg/nbdb/logical_router_policy.go
@@ -21,6 +21,7 @@ var (
 type LogicalRouterPolicy struct {
 	UUID        string                    `ovsdb:"_uuid"`
 	Action      LogicalRouterPolicyAction `ovsdb:"action"`
+	BFDSessions []string                  `ovsdb:"bfd_sessions"`
 	ExternalIDs map[string]string         `ovsdb:"external_ids"`
 	Match       string                    `ovsdb:"match"`
 	Nexthop     *string                   `ovsdb:"nexthop"`
@@ -35,6 +36,34 @@ func (a *LogicalRouterPolicy) GetUUID() string {
 
 func (a *LogicalRouterPolicy) GetAction() LogicalRouterPolicyAction {
 	return a.Action
+}
+
+func (a *LogicalRouterPolicy) GetBFDSessions() []string {
+	return a.BFDSessions
+}
+
+func copyLogicalRouterPolicyBFDSessions(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterPolicyBFDSessions(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func (a *LogicalRouterPolicy) GetExternalIDs() map[string]string {
@@ -157,6 +186,7 @@ func (a *LogicalRouterPolicy) GetPriority() int {
 
 func (a *LogicalRouterPolicy) DeepCopyInto(b *LogicalRouterPolicy) {
 	*b = *a
+	b.BFDSessions = copyLogicalRouterPolicyBFDSessions(a.BFDSessions)
 	b.ExternalIDs = copyLogicalRouterPolicyExternalIDs(a.ExternalIDs)
 	b.Nexthop = copyLogicalRouterPolicyNexthop(a.Nexthop)
 	b.Nexthops = copyLogicalRouterPolicyNexthops(a.Nexthops)
@@ -181,6 +211,7 @@ func (a *LogicalRouterPolicy) CloneModel() model.Model {
 func (a *LogicalRouterPolicy) Equals(b *LogicalRouterPolicy) bool {
 	return a.UUID == b.UUID &&
 		a.Action == b.Action &&
+		equalLogicalRouterPolicyBFDSessions(a.BFDSessions, b.BFDSessions) &&
 		equalLogicalRouterPolicyExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
 		a.Match == b.Match &&
 		equalLogicalRouterPolicyNexthop(a.Nexthop, b.Nexthop) &&

--- a/go-controller/pkg/nbdb/logical_router_port.go
+++ b/go-controller/pkg/nbdb/logical_router_port.go
@@ -21,6 +21,7 @@ type LogicalRouterPort struct {
 	Networks       []string          `ovsdb:"networks"`
 	Options        map[string]string `ovsdb:"options"`
 	Peer           *string           `ovsdb:"peer"`
+	Status         map[string]string `ovsdb:"status"`
 }
 
 func (a *LogicalRouterPort) GetUUID() string {
@@ -275,6 +276,36 @@ func equalLogicalRouterPortPeer(a, b *string) bool {
 	return *a == *b
 }
 
+func (a *LogicalRouterPort) GetStatus() map[string]string {
+	return a.Status
+}
+
+func copyLogicalRouterPortStatus(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterPortStatus(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
 func (a *LogicalRouterPort) DeepCopyInto(b *LogicalRouterPort) {
 	*b = *a
 	b.Enabled = copyLogicalRouterPortEnabled(a.Enabled)
@@ -286,6 +317,7 @@ func (a *LogicalRouterPort) DeepCopyInto(b *LogicalRouterPort) {
 	b.Networks = copyLogicalRouterPortNetworks(a.Networks)
 	b.Options = copyLogicalRouterPortOptions(a.Options)
 	b.Peer = copyLogicalRouterPortPeer(a.Peer)
+	b.Status = copyLogicalRouterPortStatus(a.Status)
 }
 
 func (a *LogicalRouterPort) DeepCopy() *LogicalRouterPort {
@@ -315,7 +347,8 @@ func (a *LogicalRouterPort) Equals(b *LogicalRouterPort) bool {
 		a.Name == b.Name &&
 		equalLogicalRouterPortNetworks(a.Networks, b.Networks) &&
 		equalLogicalRouterPortOptions(a.Options, b.Options) &&
-		equalLogicalRouterPortPeer(a.Peer, b.Peer)
+		equalLogicalRouterPortPeer(a.Peer, b.Peer) &&
+		equalLogicalRouterPortStatus(a.Status, b.Status)
 }
 
 func (a *LogicalRouterPort) EqualsModel(b model.Model) bool {

--- a/go-controller/pkg/nbdb/model.go
+++ b/go-controller/pkg/nbdb/model.go
@@ -48,7 +48,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Northbound",
-  "version": "7.0.4",
+  "version": "7.3.0",
   "tables": {
     "ACL": {
       "columns": {
@@ -485,6 +485,18 @@ var schema = `{
     "DNS": {
       "columns": {
         "external_ids": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
+        "options": {
           "type": {
             "key": {
               "type": "string"
@@ -953,6 +965,17 @@ var schema = `{
             }
           }
         },
+        "bfd_sessions": {
+          "type": {
+            "key": {
+              "type": "uuid",
+              "refTable": "BFD",
+              "refType": "weak"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
         "external_ids": {
           "type": {
             "key": {
@@ -1109,6 +1132,18 @@ var schema = `{
             },
             "min": 0,
             "max": 1
+          }
+        },
+        "status": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
           }
         }
       },
@@ -1860,12 +1895,18 @@ var schema = `{
           "type": {
             "key": {
               "type": "string",
-              "enum": "dscp"
+              "enum": [
+                "set",
+                [
+                  "dscp",
+                  "mark"
+                ]
+              ]
             },
             "value": {
               "type": "integer",
               "minInteger": 0,
-              "maxInteger": 63
+              "maxInteger": 4294967295
             },
             "min": 0,
             "max": "unlimited"

--- a/go-controller/pkg/nbdb/qos.go
+++ b/go-controller/pkg/nbdb/qos.go
@@ -15,6 +15,7 @@ type (
 
 var (
 	QoSActionDSCP         QoSAction    = "dscp"
+	QoSActionMark         QoSAction    = "mark"
 	QoSBandwidthRate      QoSBandwidth = "rate"
 	QoSBandwidthBurst     QoSBandwidth = "burst"
 	QoSDirectionFromLport QoSDirection = "from-lport"

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -136,7 +136,7 @@ func (asf *ovnAddressSetFactory) EnsureAddressSet(dbIDs *libovsdbops.DbObjectIDs
 }
 
 func getDbIDsWithIPFamily(dbIDs *libovsdbops.DbObjectIDs, ipFamily string) *libovsdbops.DbObjectIDs {
-	return dbIDs.AddIDs(map[libovsdbops.ExternalIDKey]string{libovsdbops.AddressSetIPFamilyKey: ipFamily})
+	return dbIDs.AddIDs(map[libovsdbops.ExternalIDKey]string{libovsdbops.IPFamilyKey: ipFamily})
 }
 
 // GetAddressSet returns the address-set that matches the given dbIDs
@@ -154,10 +154,10 @@ func (asf *ovnAddressSetFactory) GetAddressSet(dbIDs *libovsdbops.DbObjectIDs) (
 	}
 	for i := range addrSetList {
 		addrSet := addrSetList[i]
-		if addrSet.ExternalIDs[libovsdbops.AddressSetIPFamilyKey.String()] == ipv4InternalID {
+		if addrSet.ExternalIDs[libovsdbops.IPFamilyKey.String()] == ipv4InternalID {
 			v4set = asf.newOvnAddressSet(addrSet)
 		}
-		if addrSet.ExternalIDs[libovsdbops.AddressSetIPFamilyKey.String()] == ipv6InternalID {
+		if addrSet.ExternalIDs[libovsdbops.IPFamilyKey.String()] == ipv6InternalID {
 			v6set = asf.newOvnAddressSet(addrSet)
 		}
 	}
@@ -198,7 +198,7 @@ func (asf *ovnAddressSetFactory) ProcessEachAddressSet(ownerController string, d
 			return fmt.Errorf("failed to get objectIDs for %+v address set from ExternalIDs: %w", as, err)
 		}
 		// remove ipFamily to process address set only once
-		dbIDsWithoutIPFam := dbIDs.RemoveIDs(libovsdbops.AddressSetIPFamilyKey)
+		dbIDsWithoutIPFam := dbIDs.RemoveIDs(libovsdbops.IPFamilyKey)
 		nameWithoutIPFam := getOvnAddressSetsName(dbIDsWithoutIPFam)
 		if processedAddressSets.Has(nameWithoutIPFam) {
 			// We have already processed the address set. In case of dual stack we will have _v4 and _v6
@@ -307,7 +307,7 @@ func (asf *ovnAddressSetFactory) ensureOvnAddressSetOps(addresses []string, dbID
 
 func (asf *ovnAddressSetFactory) validateDbIDs(dbIDs *libovsdbops.DbObjectIDs) error {
 	unsetKeys := dbIDs.GetUnsetKeys()
-	if len(unsetKeys) == 1 && unsetKeys[0] == libovsdbops.AddressSetIPFamilyKey {
+	if len(unsetKeys) == 1 && unsetKeys[0] == libovsdbops.IPFamilyKey {
 		return nil
 	}
 	return fmt.Errorf("wrong set of keys is unset %v", unsetKeys)
@@ -352,8 +352,8 @@ type ovnAddressSet struct {
 // therefore the name should not include ipFamily information. DbObjectIDs without ipFamily is what is used by
 // the AddressSetFactory functions.
 func getOvnAddressSetsName(dbIDs *libovsdbops.DbObjectIDs) string {
-	if dbIDs.GetObjectID(libovsdbops.AddressSetIPFamilyKey) != "" {
-		dbIDs = dbIDs.RemoveIDs(libovsdbops.AddressSetIPFamilyKey)
+	if dbIDs.GetObjectID(libovsdbops.IPFamilyKey) != "" {
+		dbIDs = dbIDs.RemoveIDs(libovsdbops.IPFamilyKey)
 	}
 	return dbIDs.String()
 }

--- a/go-controller/pkg/ovn/controller/admin_network_policy/repair_test.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/repair_test.go
@@ -382,7 +382,7 @@ func accessControlList(name string, gressPrefix libovsdbutil.ACLDirection, prior
 func addressSet(name, gressPrefix string, priority int32, banp bool) *nbdb.AddressSet {
 	objIDs := GetANPPeerAddrSetDbIDs(name, gressPrefix, fmt.Sprintf("%d", priority),
 		"default-network-controller", banp)
-	dbIDsWithIPFam := objIDs.AddIDs(map[libovsdbops.ExternalIDKey]string{libovsdbops.AddressSetIPFamilyKey: "ipv4"})
+	dbIDsWithIPFam := objIDs.AddIDs(map[libovsdbops.ExternalIDKey]string{libovsdbops.IPFamilyKey: "ipv4"})
 	as := &nbdb.AddressSet{
 		UUID:        dbIDsWithIPFam.String() + "-UUID",
 		ExternalIDs: dbIDsWithIPFam.GetExternalIDs(),

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2028,7 +2028,7 @@ func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressS
 		matchV6 = fmt.Sprintf(`(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s`,
 			ipv6EgressIPServedPodsAS, ipv6EgressServiceServedPodsAS, ipv6ClusterNodeIPAS)
 	}
-	options := map[string]string{"pkt_mark": "1008"}
+	options := map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark}
 	// Create global allow policy for node traffic
 	if matchV4 != "" {
 		if err := createLogicalRouterPolicy(nbClient, matchV4, types.DefaultNoRereoutePriority, nil, options); err != nil {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -349,6 +349,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Action:   nbdb.LogicalRouterPolicyActionAllow,
 					UUID:     "default-no-reroute-UUID",
 				},
+				getNoReRouteReplyTrafficPolicy(),
 				&nbdb.LogicalRouterPolicy{
 					Priority: types.DefaultNoRereoutePriority,
 					Match:    fmt.Sprintf("ip4.src == 10.128.0.0/14 && ip4.dst == %s", config.Gateway.V4JoinSubnet),
@@ -394,7 +395,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				&nbdb.LogicalRouter{
 					Name:     types.OVNClusterRouter,
 					UUID:     types.OVNClusterRouter + "-UUID",
-					Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"},
+					Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 				},
 				&nbdb.LogicalRouterPort{
 					UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -539,6 +540,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Action:   nbdb.LogicalRouterPolicyActionAllow,
 					UUID:     "default-no-reroute-UUID",
 				},
+				getNoReRouteReplyTrafficPolicy(),
 				&nbdb.LogicalRouterPolicy{
 					Priority: types.DefaultNoRereoutePriority,
 					Match:    fmt.Sprintf("ip4.src == 10.128.0.0/14 && ip4.dst == %s", config.Gateway.V4JoinSubnet),
@@ -570,7 +572,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				&nbdb.LogicalRouter{
 					Name:     types.OVNClusterRouter,
 					UUID:     types.OVNClusterRouter + "-UUID",
-					Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"},
+					Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 				},
 				&nbdb.LogicalRouterPort{
 					UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -773,6 +775,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
 							UUID:     "default-no-reroute-UUID",
 						},
+						getNoReRouteReplyTrafficPolicy(),
 						&nbdb.LogicalRouterPolicy{
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    fmt.Sprintf("ip4.src == 10.128.0.0/14 && ip4.dst == %s", config.Gateway.V4JoinSubnet),
@@ -823,7 +826,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
 							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"},
+							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						&nbdb.LogicalRouterPort{
 							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID",
@@ -1155,9 +1158,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node3.Name + "-UUID"},
 						},
 						&nbdb.LogicalRouter{
-							Name:     types.OVNClusterRouter,
-							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"},
+							Name: types.OVNClusterRouter,
+							UUID: types.OVNClusterRouter + "-UUID",
+							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID",
+								"no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						&nbdb.LogicalRouterPort{
 							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID",
@@ -1219,6 +1223,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  types.ExternalSwitchPrefix + node3Name,
 							Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -1499,6 +1504,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
 							UUID:     "default-no-reroute-UUID",
 						},
+						getNoReRouteReplyTrafficPolicy(),
 						&nbdb.LogicalRouterPolicy{
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    fmt.Sprintf("ip4.src == 10.128.0.0/14 && ip4.dst == %s", config.Gateway.V4JoinSubnet),
@@ -1531,7 +1537,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
 							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"},
+							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						&nbdb.LogicalRouterPort{
 							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID",
@@ -1863,7 +1869,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
 							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"reroute-UUID", "no-reroute-node-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID"},
+							Policies: []string{"reroute-UUID", "no-reroute-node-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						&nbdb.LogicalRouterPort{
 							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -1925,6 +1931,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  node2.Name,
 							Ports: []string{"k8s-" + node2.Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 					if node1Zone == "remote" {
 						expectedDatabaseState = append(expectedDatabaseState, getReRoutePolicy(egressPod.Status.PodIP, "4", "remote-reroute-UUID", reroutePolicyNextHop, eipExternalID))
@@ -2206,7 +2213,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							getReRoutePolicy(egressPod3Node2.Status.PodIP, "4", "reroute-UUID", egressPod3Node2Reroute, eipExternalID),
 							getReRoutePolicy(egressPod4Node2.Status.PodIP, "4", "reroute-UUID2", egressPod4Node2Reroute, eip2ExternalID))
 					}
-					ovnCRPolicies := []string{"no-reroute-node-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID"}
+					ovnCRPolicies := []string{"no-reroute-node-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "egressip-no-reroute-reply-traffic"}
 					for _, lrp := range lrps {
 						ovnCRPolicies = append(ovnCRPolicies, lrp.UUID)
 					}
@@ -2309,6 +2316,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  node2.Name,
 							Ports: []string{"k8s-" + node2.Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 					if node1Zone != "remote" {
 						expectedDatabaseState[3].(*nbdb.LogicalRouter).Nat = append(expectedDatabaseState[3].(*nbdb.LogicalRouter).Nat, "egressip-nat-UUID", "egressip2-nat-UUID")
@@ -2585,8 +2593,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						&nbdb.LogicalRouter{
 							Name:     types.OVNClusterRouter,
 							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"},
-							//Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"},
+							Policies: []string{"default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						&nbdb.LogicalRouterPort{
 							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -2652,6 +2659,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  node2.Name,
 							Ports: []string{"k8s-" + node2.Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 					if node1Zone != "remote" {
 						expectedDatabaseState = append(expectedDatabaseState, getReRoutePolicy(egressPod.Status.PodIP, "4", "reroute-UUID", nodeLogicalRouterIPv4, eipExternalID))
@@ -2659,7 +2667,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					} else {
 						// if node1 where the pod lives is remote we can't see the EIP setup done since master belongs to local zone
 						expectedDatabaseState[4].(*nbdb.LogicalRouter).Nat = []string{}
-						expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies = []string{"no-reroute-node-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID"}
+						expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies = []string{"no-reroute-node-UUID", "default-no-reroute-UUID",
+							"no-reroute-service-UUID", "egressip-no-reroute-reply-traffic"}
 						expectedDatabaseState = expectedDatabaseState[1:]
 					}
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -2764,6 +2773,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  node2.Name,
 							Ports: []string{"k8s-" + node2.Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 					if node2Zone != "remote" {
 						// either not interconnect or egressNode is in localZone
@@ -2772,7 +2782,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					}
 					// all cases: reroute logical router policy is gone and won't be recreated since node1 is deleted - that is where the pod lives
 					// NOTE: This test is not really a real scenario, it depicts a transient state.
-					expectedDatabaseState[5].(*nbdb.LogicalRouter).Policies = []string{"default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"}
+					expectedDatabaseState[5].(*nbdb.LogicalRouter).Policies = []string{"default-no-reroute-UUID", "no-reroute-service-UUID",
+						"no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"}
 					expectedDatabaseState = expectedDatabaseState[1:]
 
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
@@ -3007,9 +3018,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
 						},
 						&nbdb.LogicalRouter{
-							Name:     types.OVNClusterRouter,
-							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "no-reroute-node-UUID"},
+							Name: types.OVNClusterRouter,
+							UUID: types.OVNClusterRouter + "-UUID",
+							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID",
+								"no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						&nbdb.LogicalRouterPort{
 							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -3071,6 +3083,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  node2.Name,
 							Ports: []string{"k8s-" + node2.Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 
 					if node1Zone == "remote" {
@@ -3900,6 +3913,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "default-no-reroute-UUID",
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    fmt.Sprintf("ip4.src == 10.128.0.0/14 && ip4.dst == %s", config.Gateway.V4JoinSubnet),
@@ -3930,6 +3944,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							"no-reroute-service-UUID",
 							"default-no-reroute-node-UUID",
 							"default-v6-no-reroute-node-UUID",
+							"egressip-no-reroute-reply-traffic",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -5237,9 +5252,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
 						},
 						&nbdb.LogicalRouter{
-							Name:     types.OVNClusterRouter,
-							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+							Name: types.OVNClusterRouter,
+							UUID: types.OVNClusterRouter + "-UUID",
+							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID",
+								"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						&nbdb.LogicalRouterPort{
 							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID",
@@ -5309,6 +5325,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  node2Name,
 							Ports: []string{"k8s-" + node2Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 					if !interconnect || node1Zone != "remote" {
 						expectedDatabaseState[3].(*nbdb.LogicalRouter).Nat = []string{"egressip-nat-1-UUID"}
@@ -5332,7 +5349,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						expectedDatabaseState[0].(*nbdb.LogicalRouterPolicy).Nexthops = []string{"100.64.0.2", "100.88.0.3"}
 					}
 					if node2Zone != node1Zone && node1Zone == "remote" {
-						expectedDatabaseState[5].(*nbdb.LogicalRouter).Policies = []string{"default-no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"}
+						expectedDatabaseState[5].(*nbdb.LogicalRouter).Policies = []string{"default-no-reroute-UUID", "no-reroute-service-UUID",
+							"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"}
 						expectedDatabaseState = expectedDatabaseState[1:] // policy is not visible since podNode is remote
 					}
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -5395,9 +5413,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Ports: []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID"},
 						},
 						&nbdb.LogicalRouter{
-							Name:     types.OVNClusterRouter,
-							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+							Name: types.OVNClusterRouter,
+							UUID: types.OVNClusterRouter + "-UUID",
+							Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID",
+								"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						&nbdb.LogicalRouterPort{
 							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node2.Name + "-UUID",
@@ -5467,6 +5486,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  node2Name,
 							Ports: []string{"k8s-" + node2Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 					if !interconnect || node1Zone != "remote" {
 						expectedDatabaseState[3].(*nbdb.LogicalRouter).Nat = []string{"egressip-nat-1-UUID"}
@@ -5492,7 +5512,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						expectedDatabaseState[0].(*nbdb.LogicalRouterPolicy).Nexthops = []string{"100.64.0.2", "100.88.0.3"}
 					}
 					if node2Zone != node1Zone && node1Zone == "remote" {
-						expectedDatabaseState[5].(*nbdb.LogicalRouter).Policies = []string{"default-no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"}
+						expectedDatabaseState[5].(*nbdb.LogicalRouter).Policies = []string{"default-no-reroute-UUID", "no-reroute-service-UUID",
+							"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"}
 						expectedDatabaseState = expectedDatabaseState[1:] // policy is not visible since podNode is remote
 					}
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -5933,6 +5954,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match: fmt.Sprintf("(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s",
@@ -5942,9 +5964,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -6315,6 +6338,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -6338,9 +6362,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID: "reroute-UUID1",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID1", "default-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID1",
+							"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -6423,6 +6448,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -6438,7 +6464,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -6669,6 +6695,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -6683,9 +6710,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 					podReRoutePolicy,
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID1", "default-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID1",
+							"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					node1GR,
 					&nbdb.LogicalSwitchPort{
@@ -7132,9 +7160,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							UUID:     "no-reroute-service-UUID",
 						},
 						&nbdb.LogicalRouter{
-							Name:     types.OVNClusterRouter,
-							UUID:     types.OVNClusterRouter + "-UUID",
-							Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID1", "default-no-reroute-node-UUID"},
+							Name: types.OVNClusterRouter,
+							UUID: types.OVNClusterRouter + "-UUID",
+							Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID1",
+								"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 						},
 						node1GR, node2GR,
 						node1LSP, node2LSP,
@@ -7171,6 +7200,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  types.ExternalSwitchPrefix + node2Name,
 							Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name + "-UUID"},
 						},
+						getNoReRouteReplyTrafficPolicy(),
 					}
 					podLSP := &nbdb.LogicalSwitchPort{
 						UUID:      util.GetLogicalPortName(egressPod1.Namespace, egressPod1.Name) + "-UUID",
@@ -7190,7 +7220,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					finalDatabaseStatewithPod := append(expectedDatabaseStatewithPod, podLSP)
 					if node1Zone == "remote" {
 						// policy is not visible since podNode is in remote zone
-						finalDatabaseStatewithPod[4].(*nbdb.LogicalRouter).Policies = []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"}
+						finalDatabaseStatewithPod[4].(*nbdb.LogicalRouter).Policies = []string{"no-reroute-UUID", "no-reroute-service-UUID",
+							"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"}
 						finalDatabaseStatewithPod = finalDatabaseStatewithPod[2:]
 						podEIPSNAT.ExternalIP = "192.168.126.12" // EIP SNAT is not visible since podNode is remote, SNAT towards nodeIP is visible.
 						podEIPSNAT.LogicalPort = nil
@@ -7443,7 +7474,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					}
 					if node1Zone == "remote" {
 						// policy is not visible since podNode is in remote zone
-						finalDatabaseStatewithPod[4].(*nbdb.LogicalRouter).Policies = []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"}
+						finalDatabaseStatewithPod[4].(*nbdb.LogicalRouter).Policies = []string{"no-reroute-UUID", "no-reroute-service-UUID",
+							"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"}
 						finalDatabaseStatewithPod = finalDatabaseStatewithPod[2:]
 						podEIPSNAT.ExternalIP = "192.168.126.12" // EIP SNAT is not visible since podNode is remote, SNAT towards nodeIP is visible.
 						podEIPSNAT.LogicalPort = nil
@@ -7593,6 +7625,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match: fmt.Sprintf("(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s",
@@ -7614,9 +7647,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:     "no-reroute-service-UUID",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node.Name,
@@ -7666,6 +7700,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match: fmt.Sprintf("(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s",
@@ -7687,9 +7722,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:     "no-reroute-service-UUID",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node.Name,
@@ -7832,6 +7868,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -7847,7 +7884,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -8011,6 +8048,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -8026,7 +8064,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -8085,6 +8123,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -8098,9 +8137,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:     "no-reroute-service-UUID",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -8315,6 +8355,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "default-no-reroute-UUID",
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    fmt.Sprintf("ip4.src == 10.128.0.0/14 && ip4.dst == %s", config.Gateway.V4JoinSubnet),
@@ -8345,9 +8386,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"reroute-UUID", "default-no-reroute-UUID", "no-reroute-service-UUID",
+							"default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -8547,6 +8589,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						UUID:     "keep-me-UUID",
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -8560,9 +8603,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:     "no-reroute-service-UUID",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"keep-me-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"keep-me-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -8756,6 +8800,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					podEIPSNAT, &nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -8767,9 +8812,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					}, podReRoutePolicy, &nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID", "default-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID", "default-no-reroute-node-UUID",
+							"egressip-no-reroute-reply-traffic"},
 					}, node1GR, node1LSP,
 					&nbdb.LogicalRouterPort{
 						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -8904,6 +8950,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -8919,7 +8966,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -8978,6 +9025,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -8993,7 +9041,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -9062,6 +9110,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -9077,7 +9126,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -9240,6 +9289,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -9255,7 +9305,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -9315,6 +9365,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -9330,7 +9381,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -9416,6 +9467,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -9431,7 +9483,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + node1.Name,
@@ -9636,6 +9688,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -9649,7 +9702,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					}, &nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					}, node1GR, node1LSP,
 					&nbdb.LogicalRouterPort{
 						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -9852,6 +9905,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					podEIPSNAT, &nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -9863,9 +9917,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					}, podReRoutePolicy, &nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID1", "default-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "reroute-UUID1", "default-no-reroute-node-UUID",
+							"egressip-no-reroute-reply-traffic"},
 					}, node1GR, node1LSP,
 					&nbdb.LogicalRouterPort{
 						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -9900,6 +9955,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -9913,7 +9969,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					}, &nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					}, node1GR, node1LSP,
 					&nbdb.LogicalRouterPort{
 						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -10089,6 +10145,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -10104,7 +10161,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
 						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -10183,6 +10240,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -10216,9 +10274,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID: "reroute-UUID2",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "reroute-UUID1", "reroute-UUID2"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "reroute-UUID1",
+							"reroute-UUID2", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -10339,6 +10398,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -10424,9 +10484,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "reroute-UUID1", "reroute-UUID2"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "reroute-UUID1",
+							"reroute-UUID2", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -10503,6 +10564,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match:    "ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14",
@@ -10571,9 +10633,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "reroute-UUID1", "reroute-UUID2"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "reroute-UUID1", "reroute-UUID2",
+							"egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -10667,6 +10730,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Action:   nbdb.LogicalRouterPolicyActionAllow,
 						UUID:     "no-reroute-service-UUID",
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.NAT{
 						UUID:       "egressip-nat-UUID1",
 						LogicalIP:  podV4IP,
@@ -10686,9 +10750,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -10883,6 +10948,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match: fmt.Sprintf("(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s",
@@ -10914,9 +10980,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:     "no-reroute-service-UUID",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -10977,6 +11044,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match: fmt.Sprintf("(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s",
@@ -11009,9 +11077,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:     "no-reroute-service-UUID",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -11087,6 +11156,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:    "default-no-reroute-node-UUID",
 						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
+					getNoReRouteReplyTrafficPolicy(),
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
 						Match: fmt.Sprintf("(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s",
@@ -11118,9 +11188,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID:     "no-reroute-service-UUID",
 					},
 					&nbdb.LogicalRouter{
-						Name:     types.OVNClusterRouter,
-						UUID:     types.OVNClusterRouter + "-UUID",
-						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID", "default-v6-no-reroute-node-UUID"},
+						Name: types.OVNClusterRouter,
+						UUID: types.OVNClusterRouter + "-UUID",
+						Policies: []string{"no-reroute-UUID", "no-reroute-service-UUID", "default-no-reroute-node-UUID",
+							"default-v6-no-reroute-node-UUID", "egressip-no-reroute-reply-traffic"},
 					},
 					&nbdb.LogicalRouter{
 						Name:  types.GWRouterPrefix + node1.Name,
@@ -11189,6 +11260,16 @@ func getEIPSNAT(podIP, egressIP, expectedNatLogicalPort string) *nbdb.NAT {
 		Options: map[string]string{
 			"stateless": "false",
 		},
+	}
+}
+
+func getNoReRouteReplyTrafficPolicy() *nbdb.LogicalRouterPolicy {
+	return &nbdb.LogicalRouterPolicy{
+		Priority:    types.DefaultNoRereoutePriority,
+		Match:       fmt.Sprintf("pkt.mark == %d", types.EgressIPReplyTrafficConnectionMark),
+		Action:      nbdb.LogicalRouterPolicyActionAllow,
+		ExternalIDs: getEgressIPLRPNoReRouteDbIDs(types.DefaultNoRereoutePriority, ReplyTrafficNoReroute, IPFamilyValue).GetExternalIDs(),
+		UUID:        "egressip-no-reroute-reply-traffic",
 	}
 }
 

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -369,7 +369,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Priority: types.DefaultNoRereoutePriority,
 					Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 					Action:   nbdb.LogicalRouterPolicyActionAllow,
-					Options:  map[string]string{"pkt_mark": "1008"},
+					Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					UUID:     "no-reroute-node-UUID",
 				},
 				&nbdb.NAT{
@@ -559,7 +559,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Priority: types.DefaultNoRereoutePriority,
 					Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 					Action:   nbdb.LogicalRouterPolicyActionAllow,
-					Options:  map[string]string{"pkt_mark": "1008"},
+					Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					UUID:     "no-reroute-node-UUID",
 				},
 				&nbdb.LogicalRouter{
@@ -793,7 +793,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
-							Options:  map[string]string{"pkt_mark": "1008"},
+							Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:     "no-reroute-node-UUID",
 						},
 						&nbdb.NAT{
@@ -1122,7 +1122,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
-							Options:  map[string]string{"pkt_mark": "1008"},
+							Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:     "no-reroute-node-UUID",
 						},
 						&nbdb.NAT{
@@ -1509,7 +1509,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
-							Options:  map[string]string{"pkt_mark": "1008"},
+							Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:     "no-reroute-node-UUID",
 						},
 						&nbdb.LogicalRouter{
@@ -1847,7 +1847,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
-							Options:  map[string]string{"pkt_mark": "1008"},
+							Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:     "no-reroute-node-UUID",
 						},
 						&nbdb.LogicalRouter{
@@ -2229,7 +2229,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
-							Options:  map[string]string{"pkt_mark": "1008"},
+							Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:     "no-reroute-node-UUID",
 						},
 						&nbdb.LogicalRouter{
@@ -2555,7 +2555,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
-							Options:  map[string]string{"pkt_mark": "1008"},
+							Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:     "no-reroute-node-UUID",
 						},
 						&nbdb.LogicalRouterPolicy{
@@ -2695,7 +2695,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
-							Options:  map[string]string{"pkt_mark": "1008"},
+							Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:     "no-reroute-node-UUID",
 						},
 						&nbdb.LogicalRouterPolicy{
@@ -2981,7 +2981,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Priority: types.DefaultNoRereoutePriority,
 							Match:    "(ip4.src == $a4548040316634674295 || ip4.src == $a13607449821398607916) && ip4.dst == $a14918748166599097711",
 							Action:   nbdb.LogicalRouterPolicyActionAllow,
-							Options:  map[string]string{"pkt_mark": "1008"},
+							Options:  map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:     "no-reroute-node-UUID",
 						},
 						&nbdb.LogicalRouterPolicy{
@@ -3912,7 +3912,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -3920,7 +3920,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-v6-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.OVNClusterRouter,
@@ -5277,7 +5277,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 							Action:  nbdb.LogicalRouterPolicyActionAllow,
 							UUID:    "default-no-reroute-node-UUID",
-							Options: map[string]string{"pkt_mark": "1008"},
+							Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -5435,7 +5435,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 							Action:  nbdb.LogicalRouterPolicyActionAllow,
 							UUID:    "default-no-reroute-node-UUID",
-							Options: map[string]string{"pkt_mark": "1008"},
+							Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      "k8s-" + node1Name + "-UUID",
@@ -5931,7 +5931,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -5939,7 +5939,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-v6-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
@@ -6313,7 +6313,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -6421,7 +6421,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -6667,7 +6667,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -7159,7 +7159,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 							Action:  nbdb.LogicalRouterPolicyActionAllow,
 							UUID:    "default-no-reroute-node-UUID",
-							Options: map[string]string{"pkt_mark": "1008"},
+							Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 						},
 						&nbdb.LogicalSwitch{
 							UUID:  types.ExternalSwitchPrefix + node1Name + "-UUID",
@@ -7591,7 +7591,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -7599,7 +7599,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-v6-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -7664,7 +7664,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -7672,7 +7672,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-v6-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -7830,7 +7830,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -8009,7 +8009,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -8083,7 +8083,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -8307,7 +8307,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -8545,7 +8545,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						UUID:     "keep-me-UUID",
@@ -8754,7 +8754,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					podEIPSNAT, &nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -8902,7 +8902,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -8976,7 +8976,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9060,7 +9060,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9238,7 +9238,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9313,7 +9313,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9414,7 +9414,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9634,7 +9634,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9850,7 +9850,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					podEIPSNAT, &nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -9898,7 +9898,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10087,7 +10087,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10181,7 +10181,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10337,7 +10337,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10501,7 +10501,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10653,7 +10653,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10881,7 +10881,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10889,7 +10889,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-v6-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPort{
 						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -10975,7 +10975,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -10983,7 +10983,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-v6-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPort{
 						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
@@ -11085,7 +11085,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority: types.DefaultNoRereoutePriority,
@@ -11093,7 +11093,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
 						Action:  nbdb.LogicalRouterPolicyActionAllow,
 						UUID:    "default-v6-no-reroute-node-UUID",
-						Options: map[string]string{"pkt_mark": "1008"},
+						Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					},
 					&nbdb.LogicalRouterPort{
 						UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",

--- a/go-controller/pkg/ovn/egressqos_test.go
+++ b/go-controller/pkg/ovn/egressqos_test.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					Match:       "some-match",
 					Priority:    EgressQoSFlowStartPriority,
 					Action:      map[string]int{nbdb.QoSActionDSCP: 50},
-					ExternalIDs: map[string]string{"EgressQoS": "staleNS"},
+					ExternalIDs: getEgressQoSRuleDbIDs("staleNS", EgressQoSFlowStartPriority).GetExternalIDs(),
 					UUID:        "staleQoS-UUID",
 				}
 				staleAddrSet, _ := addressset.GetTestDbAddrSets(
@@ -148,7 +148,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					Match:       match1,
 					Priority:    EgressQoSFlowStartPriority,
 					Action:      map[string]int{nbdb.QoSActionDSCP: 50},
-					ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+					ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority).GetExternalIDs(),
 					UUID:        "qos1-UUID",
 				}
 				qos2 := &nbdb.QoS{
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					Match:       match2,
 					Priority:    EgressQoSFlowStartPriority - 1,
 					Action:      map[string]int{nbdb.QoSActionDSCP: 60},
-					ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+					ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority-1).GetExternalIDs(),
 					UUID:        "qos2-UUID",
 				}
 				node1Switch.QOSRules = []string{qos1.UUID, qos2.UUID}
@@ -190,7 +190,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					Match:       match1,
 					Priority:    EgressQoSFlowStartPriority,
 					Action:      map[string]int{nbdb.QoSActionDSCP: 40},
-					ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+					ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority).GetExternalIDs(),
 					UUID:        "qos3-UUID",
 				}
 				node1Switch.QOSRules = []string{qos3.UUID}
@@ -255,7 +255,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					Match:       "some-match",
 					Priority:    EgressQoSFlowStartPriority,
 					Action:      map[string]int{nbdb.QoSActionDSCP: 50},
-					ExternalIDs: map[string]string{"EgressQoS": "staleNS"},
+					ExternalIDs: getEgressQoSRuleDbIDs("staleNS", EgressQoSFlowStartPriority).GetExternalIDs(),
 					UUID:        "staleQoS-UUID",
 				}
 				staleAddrSet, _ := addressset.GetTestDbAddrSets(
@@ -342,7 +342,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					Match:       match1,
 					Priority:    EgressQoSFlowStartPriority,
 					Action:      map[string]int{nbdb.QoSActionDSCP: 50},
-					ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+					ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority).GetExternalIDs(),
 					UUID:        "qos1-UUID",
 				}
 				qos2 := &nbdb.QoS{
@@ -350,7 +350,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					Match:       match2,
 					Priority:    EgressQoSFlowStartPriority - 1,
 					Action:      map[string]int{nbdb.QoSActionDSCP: 60},
-					ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+					ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority-1).GetExternalIDs(),
 					UUID:        "qos2-UUID",
 				}
 				node1Switch.QOSRules = []string{qos1.UUID, qos2.UUID}
@@ -389,7 +389,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					Match:       match1,
 					Priority:    EgressQoSFlowStartPriority,
 					Action:      map[string]int{nbdb.QoSActionDSCP: 40},
-					ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+					ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority).GetExternalIDs(),
 					UUID:        "qos3-UUID",
 				}
 				node1Switch.QOSRules = []string{qos3.UUID}
@@ -568,7 +568,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 1.2.3.4/32) && ip4.src == $%s", asv4),
 				Priority:    EgressQoSFlowStartPriority,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 50},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority).GetExternalIDs(),
 				UUID:        "qos1-UUID",
 			}
 			qos2 := &nbdb.QoS{
@@ -576,7 +576,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 5.6.7.8/32) && ip4.src == $%s", asv4),
 				Priority:    EgressQoSFlowStartPriority - 1,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 60},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority-1).GetExternalIDs(),
 				UUID:        "qos2-UUID",
 			}
 			node1Switch.QOSRules = append(node1Switch.QOSRules, qos1.UUID, qos2.UUID)
@@ -694,7 +694,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 1.2.3.4/32) && ip4.src == $%s", asv4),
 				Priority:    EgressQoSFlowStartPriority,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 50},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority).GetExternalIDs(),
 				UUID:        "qos1-UUID",
 			}
 			qos2 := &nbdb.QoS{
@@ -702,7 +702,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 5.6.7.8/32) && ip4.src == $%s", asv4),
 				Priority:    EgressQoSFlowStartPriority - 1,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 60},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority-1).GetExternalIDs(),
 				UUID:        "qos2-UUID",
 			}
 			node1Switch.QOSRules = append(node1Switch.QOSRules, qos1.UUID, qos2.UUID)
@@ -855,7 +855,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 1.2.3.4/32) && ip4.src == $%s", asv4),
 				Priority:    EgressQoSFlowStartPriority,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 40},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority).GetExternalIDs(),
 				UUID:        "qos1-UUID",
 			}
 			qosAS := getEgressQosAddrSetDbIDs(namespaceT.Name, fmt.Sprintf("%d", EgressQoSFlowStartPriority-1), controllerName)
@@ -865,7 +865,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 5.6.7.8/32) && ip4.src == $%s", qosASv4),
 				Priority:    EgressQoSFlowStartPriority - 1,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 50},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority-1).GetExternalIDs(),
 				UUID:        "qos2-UUID",
 			}
 			qosAS = getEgressQosAddrSetDbIDs(namespaceT.Name, fmt.Sprintf("%d", EgressQoSFlowStartPriority-2), controllerName)
@@ -875,7 +875,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 5.6.7.8/32) && ip4.src == $%s", qosASv4),
 				Priority:    EgressQoSFlowStartPriority - 2,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 60},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority-2).GetExternalIDs(),
 				UUID:        "qos3-UUID",
 			}
 			node1Switch.QOSRules = append(node1Switch.QOSRules, qos1.UUID, qos2.UUID, qos3.UUID)
@@ -998,7 +998,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 1.2.3.4/32) && ip4.src == $%s", asv4),
 				Priority:    EgressQoSFlowStartPriority,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 40},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority).GetExternalIDs(),
 				UUID:        "qos1-UUID",
 			}
 			qosAS := getEgressQosAddrSetDbIDs(namespaceT.Name, fmt.Sprintf("%d", EgressQoSFlowStartPriority-1), controllerName)
@@ -1008,7 +1008,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 				Match:       fmt.Sprintf("(ip4.dst == 5.6.7.8/32) && ip4.src == $%s", qosASv4),
 				Priority:    EgressQoSFlowStartPriority - 1,
 				Action:      map[string]int{nbdb.QoSActionDSCP: 50},
-				ExternalIDs: map[string]string{"EgressQoS": namespaceT.Name},
+				ExternalIDs: getEgressQoSRuleDbIDs(namespaceT.Name, EgressQoSFlowStartPriority-1).GetExternalIDs(),
 				UUID:        "qos2-UUID",
 			}
 			nodeSwitch.QOSRules = append(nodeSwitch.QOSRules, qos1.UUID, qos2.UUID)

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -15,6 +15,7 @@ import (
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	egresssvc "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -1614,7 +1615,7 @@ func getDefaultNoReroutePolicies(controllerName string) []*nbdb.LogicalRouterPol
 				egressipPodsV4, egressSvcPodsV4, nodeIPsV4),
 			Action:  nbdb.LogicalRouterPolicyActionAllow,
 			UUID:    "default-no-reroute-node-UUID",
-			Options: map[string]string{"pkt_mark": "1008"},
+			Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 		},
 		&nbdb.LogicalRouterPolicy{
 			Priority: ovntypes.DefaultNoRereoutePriority,
@@ -1622,7 +1623,7 @@ func getDefaultNoReroutePolicies(controllerName string) []*nbdb.LogicalRouterPol
 				egressipPodsV6, egressSvcPodsV6, nodeIPsV6),
 			Action:  nbdb.LogicalRouterPolicyActionAllow,
 			UUID:    "default-v6-no-reroute-node-UUID",
-			Options: map[string]string{"pkt_mark": "1008"},
+			Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 		},
 	)
 

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -1625,6 +1625,7 @@ func getDefaultNoReroutePolicies(controllerName string) []*nbdb.LogicalRouterPol
 			UUID:    "default-v6-no-reroute-node-UUID",
 			Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 		},
+		getNoReRouteReplyTrafficPolicy(),
 	)
 
 	allLRPS = append(allLRPS,

--- a/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync.go
@@ -153,7 +153,7 @@ func (syncer *AddressSetsSyncer) getNamespaceAddrSetDbIDs(namespaceName string) 
 }
 
 func buildNewAddressSet(dbIDs *libovsdbops.DbObjectIDs, ipFamily string) *nbdb.AddressSet {
-	dbIDsWithIPFam := dbIDs.AddIDs(map[libovsdbops.ExternalIDKey]string{libovsdbops.AddressSetIPFamilyKey: ipFamily})
+	dbIDsWithIPFam := dbIDs.AddIDs(map[libovsdbops.ExternalIDKey]string{libovsdbops.IPFamilyKey: ipFamily})
 	externalIDs := dbIDsWithIPFam.GetExternalIDs()
 	name := externalIDs[libovsdbops.PrimaryIDKey.String()]
 	as := &nbdb.AddressSet{

--- a/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync_test.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync_test.go
@@ -563,7 +563,7 @@ var _ = ginkgo.Describe("OVN Address Set Syncer", func() {
 					hashedASName1, hashedASName3, hashedASName2),
 				Action:  nbdb.LogicalRouterPolicyActionAllow,
 				UUID:    "default-no-reroute-node-UUID",
-				Options: map[string]string{"pkt_mark": "1008"},
+				Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 			},
 			&nbdb.LogicalRouter{
 				UUID:     types.OVNClusterRouter + "-UUID",
@@ -710,7 +710,7 @@ var _ = ginkgo.Describe("OVN Address Set Syncer", func() {
 					hashedASName1, hashedASName3, hashedASName2),
 				Action:  nbdb.LogicalRouterPolicyActionAllow,
 				UUID:    "default-no-reroute-node-UUID",
-				Options: map[string]string{"pkt_mark": "1008"},
+				Options: map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 			},
 			&nbdb.LogicalRouter{
 				UUID:     types.OVNClusterRouter + "-UUID",

--- a/go-controller/pkg/sbdb/bfd.go
+++ b/go-controller/pkg/sbdb/bfd.go
@@ -21,6 +21,7 @@ var (
 // BFD defines an object in BFD table
 type BFD struct {
 	UUID        string            `ovsdb:"_uuid"`
+	ChassisName string            `ovsdb:"chassis_name"`
 	DetectMult  int               `ovsdb:"detect_mult"`
 	Disc        int               `ovsdb:"disc"`
 	DstIP       string            `ovsdb:"dst_ip"`
@@ -35,6 +36,10 @@ type BFD struct {
 
 func (a *BFD) GetUUID() string {
 	return a.UUID
+}
+
+func (a *BFD) GetChassisName() string {
+	return a.ChassisName
 }
 
 func (a *BFD) GetDetectMult() int {
@@ -152,6 +157,7 @@ func (a *BFD) CloneModel() model.Model {
 
 func (a *BFD) Equals(b *BFD) bool {
 	return a.UUID == b.UUID &&
+		a.ChassisName == b.ChassisName &&
 		a.DetectMult == b.DetectMult &&
 		a.Disc == b.Disc &&
 		a.DstIP == b.DstIP &&

--- a/go-controller/pkg/sbdb/dhcpv6_options.go
+++ b/go-controller/pkg/sbdb/dhcpv6_options.go
@@ -12,9 +12,10 @@ type (
 )
 
 var (
-	DHCPv6OptionsTypeIpv6 DHCPv6OptionsType = "ipv6"
-	DHCPv6OptionsTypeStr  DHCPv6OptionsType = "str"
-	DHCPv6OptionsTypeMAC  DHCPv6OptionsType = "mac"
+	DHCPv6OptionsTypeIpv6   DHCPv6OptionsType = "ipv6"
+	DHCPv6OptionsTypeStr    DHCPv6OptionsType = "str"
+	DHCPv6OptionsTypeMAC    DHCPv6OptionsType = "mac"
+	DHCPv6OptionsTypeDomain DHCPv6OptionsType = "domain"
 )
 
 // DHCPv6Options defines an object in DHCPv6_Options table

--- a/go-controller/pkg/sbdb/dns.go
+++ b/go-controller/pkg/sbdb/dns.go
@@ -12,6 +12,7 @@ type DNS struct {
 	UUID        string            `ovsdb:"_uuid"`
 	Datapaths   []string          `ovsdb:"datapaths"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	Options     map[string]string `ovsdb:"options"`
 	Records     map[string]string `ovsdb:"records"`
 }
 
@@ -77,6 +78,36 @@ func equalDNSExternalIDs(a, b map[string]string) bool {
 	return true
 }
 
+func (a *DNS) GetOptions() map[string]string {
+	return a.Options
+}
+
+func copyDNSOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDNSOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
 func (a *DNS) GetRecords() map[string]string {
 	return a.Records
 }
@@ -111,6 +142,7 @@ func (a *DNS) DeepCopyInto(b *DNS) {
 	*b = *a
 	b.Datapaths = copyDNSDatapaths(a.Datapaths)
 	b.ExternalIDs = copyDNSExternalIDs(a.ExternalIDs)
+	b.Options = copyDNSOptions(a.Options)
 	b.Records = copyDNSRecords(a.Records)
 }
 
@@ -133,6 +165,7 @@ func (a *DNS) Equals(b *DNS) bool {
 	return a.UUID == b.UUID &&
 		equalDNSDatapaths(a.Datapaths, b.Datapaths) &&
 		equalDNSExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalDNSOptions(a.Options, b.Options) &&
 		equalDNSRecords(a.Records, b.Records)
 }
 

--- a/go-controller/pkg/sbdb/fdb.go
+++ b/go-controller/pkg/sbdb/fdb.go
@@ -9,10 +9,11 @@ const FDBTable = "FDB"
 
 // FDB defines an object in FDB table
 type FDB struct {
-	UUID    string `ovsdb:"_uuid"`
-	DpKey   int    `ovsdb:"dp_key"`
-	MAC     string `ovsdb:"mac"`
-	PortKey int    `ovsdb:"port_key"`
+	UUID      string `ovsdb:"_uuid"`
+	DpKey     int    `ovsdb:"dp_key"`
+	MAC       string `ovsdb:"mac"`
+	PortKey   int    `ovsdb:"port_key"`
+	Timestamp int    `ovsdb:"timestamp"`
 }
 
 func (a *FDB) GetUUID() string {
@@ -29,6 +30,10 @@ func (a *FDB) GetMAC() string {
 
 func (a *FDB) GetPortKey() int {
 	return a.PortKey
+}
+
+func (a *FDB) GetTimestamp() int {
+	return a.Timestamp
 }
 
 func (a *FDB) DeepCopyInto(b *FDB) {
@@ -54,7 +59,8 @@ func (a *FDB) Equals(b *FDB) bool {
 	return a.UUID == b.UUID &&
 		a.DpKey == b.DpKey &&
 		a.MAC == b.MAC &&
-		a.PortKey == b.PortKey
+		a.PortKey == b.PortKey &&
+		a.Timestamp == b.Timestamp
 }
 
 func (a *FDB) EqualsModel(b model.Model) bool {

--- a/go-controller/pkg/sbdb/igmp_group.go
+++ b/go-controller/pkg/sbdb/igmp_group.go
@@ -9,11 +9,12 @@ const IGMPGroupTable = "IGMP_Group"
 
 // IGMPGroup defines an object in IGMP_Group table
 type IGMPGroup struct {
-	UUID     string   `ovsdb:"_uuid"`
-	Address  string   `ovsdb:"address"`
-	Chassis  *string  `ovsdb:"chassis"`
-	Datapath *string  `ovsdb:"datapath"`
-	Ports    []string `ovsdb:"ports"`
+	UUID        string   `ovsdb:"_uuid"`
+	Address     string   `ovsdb:"address"`
+	Chassis     *string  `ovsdb:"chassis"`
+	ChassisName string   `ovsdb:"chassis_name"`
+	Datapath    *string  `ovsdb:"datapath"`
+	Ports       []string `ovsdb:"ports"`
 }
 
 func (a *IGMPGroup) GetUUID() string {
@@ -44,6 +45,10 @@ func equalIGMPGroupChassis(a, b *string) bool {
 		return true
 	}
 	return *a == *b
+}
+
+func (a *IGMPGroup) GetChassisName() string {
+	return a.ChassisName
 }
 
 func (a *IGMPGroup) GetDatapath() *string {
@@ -122,6 +127,7 @@ func (a *IGMPGroup) Equals(b *IGMPGroup) bool {
 	return a.UUID == b.UUID &&
 		a.Address == b.Address &&
 		equalIGMPGroupChassis(a.Chassis, b.Chassis) &&
+		a.ChassisName == b.ChassisName &&
 		equalIGMPGroupDatapath(a.Datapath, b.Datapath) &&
 		equalIGMPGroupPorts(a.Ports, b.Ports)
 }

--- a/go-controller/pkg/sbdb/load_balancer.go
+++ b/go-controller/pkg/sbdb/load_balancer.go
@@ -19,14 +19,16 @@ var (
 
 // LoadBalancer defines an object in Load_Balancer table
 type LoadBalancer struct {
-	UUID          string                `ovsdb:"_uuid"`
-	DatapathGroup *string               `ovsdb:"datapath_group"`
-	Datapaths     []string              `ovsdb:"datapaths"`
-	ExternalIDs   map[string]string     `ovsdb:"external_ids"`
-	Name          string                `ovsdb:"name"`
-	Options       map[string]string     `ovsdb:"options"`
-	Protocol      *LoadBalancerProtocol `ovsdb:"protocol"`
-	Vips          map[string]string     `ovsdb:"vips"`
+	UUID            string                `ovsdb:"_uuid"`
+	DatapathGroup   *string               `ovsdb:"datapath_group"`
+	Datapaths       []string              `ovsdb:"datapaths"`
+	ExternalIDs     map[string]string     `ovsdb:"external_ids"`
+	LrDatapathGroup *string               `ovsdb:"lr_datapath_group"`
+	LsDatapathGroup *string               `ovsdb:"ls_datapath_group"`
+	Name            string                `ovsdb:"name"`
+	Options         map[string]string     `ovsdb:"options"`
+	Protocol        *LoadBalancerProtocol `ovsdb:"protocol"`
+	Vips            map[string]string     `ovsdb:"vips"`
 }
 
 func (a *LoadBalancer) GetUUID() string {
@@ -111,6 +113,50 @@ func equalLoadBalancerExternalIDs(a, b map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func (a *LoadBalancer) GetLrDatapathGroup() *string {
+	return a.LrDatapathGroup
+}
+
+func copyLoadBalancerLrDatapathGroup(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLoadBalancerLrDatapathGroup(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *LoadBalancer) GetLsDatapathGroup() *string {
+	return a.LsDatapathGroup
+}
+
+func copyLoadBalancerLsDatapathGroup(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLoadBalancerLsDatapathGroup(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
 }
 
 func (a *LoadBalancer) GetName() string {
@@ -204,6 +250,8 @@ func (a *LoadBalancer) DeepCopyInto(b *LoadBalancer) {
 	b.DatapathGroup = copyLoadBalancerDatapathGroup(a.DatapathGroup)
 	b.Datapaths = copyLoadBalancerDatapaths(a.Datapaths)
 	b.ExternalIDs = copyLoadBalancerExternalIDs(a.ExternalIDs)
+	b.LrDatapathGroup = copyLoadBalancerLrDatapathGroup(a.LrDatapathGroup)
+	b.LsDatapathGroup = copyLoadBalancerLsDatapathGroup(a.LsDatapathGroup)
 	b.Options = copyLoadBalancerOptions(a.Options)
 	b.Protocol = copyLoadBalancerProtocol(a.Protocol)
 	b.Vips = copyLoadBalancerVips(a.Vips)
@@ -229,6 +277,8 @@ func (a *LoadBalancer) Equals(b *LoadBalancer) bool {
 		equalLoadBalancerDatapathGroup(a.DatapathGroup, b.DatapathGroup) &&
 		equalLoadBalancerDatapaths(a.Datapaths, b.Datapaths) &&
 		equalLoadBalancerExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalLoadBalancerLrDatapathGroup(a.LrDatapathGroup, b.LrDatapathGroup) &&
+		equalLoadBalancerLsDatapathGroup(a.LsDatapathGroup, b.LsDatapathGroup) &&
 		a.Name == b.Name &&
 		equalLoadBalancerOptions(a.Options, b.Options) &&
 		equalLoadBalancerProtocol(a.Protocol, b.Protocol) &&

--- a/go-controller/pkg/sbdb/model.go
+++ b/go-controller/pkg/sbdb/model.go
@@ -52,7 +52,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Southbound",
-  "version": "20.27.2",
+  "version": "20.33.0",
   "tables": {
     "Address_Set": {
       "columns": {
@@ -78,6 +78,9 @@ var schema = `{
     },
     "BFD": {
       "columns": {
+        "chassis_name": {
+          "type": "string"
+        },
         "detect_mult": {
           "type": "integer"
         },
@@ -472,7 +475,8 @@ var schema = `{
                 [
                   "ipv6",
                   "str",
-                  "mac"
+                  "mac",
+                  "domain"
                 ]
               ]
             }
@@ -494,6 +498,18 @@ var schema = `{
           }
         },
         "external_ids": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
+        "options": {
           "type": {
             "key": {
               "type": "string"
@@ -625,6 +641,9 @@ var schema = `{
               "maxInteger": 16777215
             }
           }
+        },
+        "timestamp": {
+          "type": "integer"
         }
       },
       "indexes": [
@@ -790,6 +809,9 @@ var schema = `{
             "max": 1
           }
         },
+        "chassis_name": {
+          "type": "string"
+        },
         "datapath": {
           "type": {
             "key": {
@@ -939,6 +961,26 @@ var schema = `{
             },
             "min": 0,
             "max": "unlimited"
+          }
+        },
+        "lr_datapath_group": {
+          "type": {
+            "key": {
+              "type": "uuid",
+              "refTable": "Logical_DP_Group"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "ls_datapath_group": {
+          "type": {
+            "key": {
+              "type": "uuid",
+              "refTable": "Logical_DP_Group"
+            },
+            "min": 0,
+            "max": 1
           }
         },
         "name": {
@@ -1694,6 +1736,9 @@ var schema = `{
     },
     "Service_Monitor": {
       "columns": {
+        "chassis_name": {
+          "type": "string"
+        },
         "external_ids": {
           "type": {
             "key": {

--- a/go-controller/pkg/sbdb/service_monitor.go
+++ b/go-controller/pkg/sbdb/service_monitor.go
@@ -23,6 +23,7 @@ var (
 // ServiceMonitor defines an object in Service_Monitor table
 type ServiceMonitor struct {
 	UUID        string                  `ovsdb:"_uuid"`
+	ChassisName string                  `ovsdb:"chassis_name"`
 	ExternalIDs map[string]string       `ovsdb:"external_ids"`
 	IP          string                  `ovsdb:"ip"`
 	LogicalPort string                  `ovsdb:"logical_port"`
@@ -36,6 +37,10 @@ type ServiceMonitor struct {
 
 func (a *ServiceMonitor) GetUUID() string {
 	return a.UUID
+}
+
+func (a *ServiceMonitor) GetChassisName() string {
+	return a.ChassisName
 }
 
 func (a *ServiceMonitor) GetExternalIDs() map[string]string {
@@ -187,6 +192,7 @@ func (a *ServiceMonitor) CloneModel() model.Model {
 
 func (a *ServiceMonitor) Equals(b *ServiceMonitor) bool {
 	return a.UUID == b.UUID &&
+		a.ChassisName == b.ChassisName &&
 		equalServiceMonitorExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
 		a.IP == b.IP &&
 		a.LogicalPort == b.LogicalPort &&

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -94,6 +94,7 @@ const (
 	DefaultNoRereoutePriority             = 102
 	EgressSVCReroutePriority              = 101
 	EgressIPReroutePriority               = 100
+	EgressIPRerouteQoSRulePriority        = 103
 	EgressLiveMigrationReroutePiority     = 10
 
 	// Packet marking

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -96,6 +96,9 @@ const (
 	EgressIPReroutePriority               = 100
 	EgressLiveMigrationReroutePiority     = 10
 
+	// Packet marking
+	EgressIPNodeConnectionMark = "1008"
+
 	V6NodeLocalNATSubnet           = "fd99::/64"
 	V6NodeLocalNATSubnetPrefix     = 64
 	V6NodeLocalNATSubnetNextHop    = "fd99::1"

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -97,7 +97,8 @@ const (
 	EgressLiveMigrationReroutePiority     = 10
 
 	// Packet marking
-	EgressIPNodeConnectionMark = "1008"
+	EgressIPNodeConnectionMark         = "1008"
+	EgressIPReplyTrafficConnectionMark = 42
 
 	V6NodeLocalNATSubnet           = "fd99::/64"
 	V6NodeLocalNATSubnetPrefix     = 64

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -176,6 +176,20 @@ func (h *egressNodeAvailabilityHandlerViaHealthCheck) Disable(nodeName string) {
 	h.setMode(nodeName, true, false)
 }
 
+type egressIPStatus struct {
+	Node     string `json:"node"`
+	EgressIP string `json:"egressIP"`
+}
+
+type egressIP struct {
+	Status struct {
+		Items []egressIPStatus `json:"items"`
+	} `json:"status"`
+}
+type egressIPs struct {
+	Items []egressIP `json:"items"`
+}
+
 var _ = ginkgo.Describe("e2e egress IP validation", func() {
 	const (
 		servicePort             int32  = 9999
@@ -297,20 +311,6 @@ var _ = ginkgo.Describe("e2e egress IP validation", func() {
 			}
 			return true, nil
 		}
-	}
-
-	type egressIPStatus struct {
-		Node     string `json:"node"`
-		EgressIP string `json:"egressIP"`
-	}
-
-	type egressIP struct {
-		Status struct {
-			Items []egressIPStatus `json:"items"`
-		} `json:"status"`
-	}
-	type egressIPs struct {
-		Items []egressIP `json:"items"`
 	}
 
 	command := []string{"/agnhost", "netexec", fmt.Sprintf("--http-port=%s", podHTTPPort)}

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -190,6 +190,107 @@ type egressIPs struct {
 	Items []egressIP `json:"items"`
 }
 
+type node struct {
+	name   string
+	nodeIP string
+}
+
+func configNetworkAndGetTarget(subnet string, nodesToAttachNet []string, v6 bool, targetSecondaryNode node) (string, string) {
+	// configure and add additional network to worker containers for EIP multi NIC feature
+	createNetwork(secondaryNetworkName, subnet, v6)
+	if v6 {
+		// HACK: ensure bridges don't talk to each other. For IPv6, docker support for isolated networks is experimental.
+		// Remove when it is no longer experimental. See func description for full details.
+		if err := isolateIPv6Networks(primaryNetworkName, secondaryNetworkName); err != nil {
+			framework.Failf("failed to isolate IPv6 networks: %v", err)
+		}
+	}
+	for _, nodeName := range nodesToAttachNet {
+		attachNetwork(secondaryNetworkName, nodeName)
+	}
+	v4Addr, v6Addr := createClusterExternalContainer(targetSecondaryNode.name, "docker.io/httpd", []string{"--network", secondaryNetworkName, "-P"}, []string{})
+	if v4Addr == "" && !v6 {
+		panic("failed to get v4 address")
+	}
+	if v6Addr == "" && v6 {
+		panic("failed to get v6 address")
+	}
+	return v4Addr, v6Addr
+}
+
+func tearDownNetworkAndTargetForMultiNIC(nodeToDetachNet []string, targetSecondaryNode node) {
+	deleteClusterExternalContainer(targetSecondaryNode.name)
+	for _, nodeName := range nodeToDetachNet {
+		detachNetwork(secondaryNetworkName, nodeName)
+	}
+	deleteNetwork(secondaryNetworkName)
+}
+
+func removeSliceElement(s []string, i int) []string {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
+}
+
+// targetExternalContainerAndTest targets the external test container from
+// our test pods, collects its logs and verifies that the logs have traces
+// of the `verifyIPs` provided. We need to target the external test
+// container multiple times until we verify that all IPs provided by
+// `verifyIPs` have been verified. This is done by passing it a slice of
+// verifyIPs and removing each item when it has been found. This function is
+// wrapped in a `wait.PollImmediate` which results in the fact that it only
+// passes once verifyIPs is of length 0. targetExternalContainerAndTest
+// initiates only a single connection at a time, sequentially, hence: we
+// perform one connection attempt, check that the IP seen is expected,
+// remove it from the list of verifyIPs, see that it's length is not 0 and
+// retry again. We do this until all IPs have been seen. If that never
+// happens (because of a bug) the test fails.
+func targetExternalContainerAndTest(targetNode node, podName, podNamespace string, expectSuccess bool, verifyIPs []string) wait.ConditionFunc {
+	return func() (bool, error) {
+		_, err := e2ekubectl.RunKubectl(podNamespace, "exec", podName, "--", "curl", "--connect-timeout", "2", net.JoinHostPort(targetNode.nodeIP, "80"))
+		if err != nil {
+			if !expectSuccess {
+				// curl should timeout with a string containing this error, and this should be the case if we expect a failure
+				if !strings.Contains(err.Error(), "Connection timed out") {
+					framework.Logf("the test expected netserver container to not be able to connect, but it did with another error, err : %v", err)
+					return false, nil
+				}
+				return true, nil
+			}
+			return false, nil
+		}
+		var targetNodeLogs string
+		if strings.Contains(targetNode.name, "-host-net-pod") {
+			// host-networked-pod
+			targetNodeLogs, err = e2ekubectl.RunKubectl(podNamespace, "logs", targetNode.name)
+		} else {
+			// external container
+			targetNodeLogs, err = runCommand(containerRuntime, "logs", targetNode.name)
+		}
+		if err != nil {
+			framework.Logf("failed to inspect logs in test container: %v", err)
+			return false, nil
+		}
+		targetNodeLogs = strings.TrimSuffix(targetNodeLogs, "\n")
+		logLines := strings.Split(targetNodeLogs, "\n")
+		lastLine := logLines[len(logLines)-1]
+		for i := 0; i < len(verifyIPs); i++ {
+			if strings.Contains(lastLine, verifyIPs[i]) {
+				verifyIPs = removeSliceElement(verifyIPs, i)
+				break
+			}
+		}
+		if len(verifyIPs) != 0 && expectSuccess {
+			framework.Logf("the test external container did not have any trace of the IPs: %v being logged, last logs: %s", verifyIPs, logLines[len(logLines)-1])
+			return false, nil
+		}
+		if !expectSuccess && len(verifyIPs) == 0 {
+			framework.Logf("the test external container did have a trace of the IPs: %v being logged, it should not have, last logs: %s", verifyIPs, logLines[len(logLines)-1])
+			return false, nil
+		}
+		return true, nil
+	}
+}
+
 var _ = ginkgo.Describe("e2e egress IP validation", func() {
 	const (
 		servicePort             int32  = 9999
@@ -207,11 +308,6 @@ var _ = ginkgo.Describe("e2e egress IP validation", func() {
 		ciNetworkName                  = "kind"
 		retryTimeout                   = 3 * retryTimeout // Boost the retryTimeout for EgressIP tests.
 	)
-
-	type node struct {
-		name   string
-		nodeIP string
-	}
 
 	podEgressLabel := map[string]string{
 		"wants": "egress",
@@ -243,71 +339,6 @@ var _ = ginkgo.Describe("e2e egress IP validation", func() {
 					framework.Logf("Error: attempted connection to API server found err:  %v", err)
 					return false, nil
 				}
-			}
-			return true, nil
-		}
-	}
-
-	removeSliceElement := func(s []string, i int) []string {
-		s[i] = s[len(s)-1]
-		return s[:len(s)-1]
-	}
-
-	// targetExternalContainerAndTest targets the external test container from
-	// our test pods, collects its logs and verifies that the logs have traces
-	// of the `verifyIPs` provided. We need to target the external test
-	// container multiple times until we verify that all IPs provided by
-	// `verifyIPs` have been verified. This is done by passing it a slice of
-	// verifyIPs and removing each item when it has been found. This function is
-	// wrapped in a `wait.PollImmediate` which results in the fact that it only
-	// passes once verifyIPs is of length 0. targetExternalContainerAndTest
-	// initiates only a single connection at a time, sequentially, hence: we
-	// perform one connection attempt, check that the IP seen is expected,
-	// remove it from the list of verifyIPs, see that it's length is not 0 and
-	// retry again. We do this until all IPs have been seen. If that never
-	// happens (because of a bug) the test fails.
-	targetExternalContainerAndTest := func(targetNode node, podName, podNamespace string, expectSuccess bool, verifyIPs []string) wait.ConditionFunc {
-		return func() (bool, error) {
-			_, err := e2ekubectl.RunKubectl(podNamespace, "exec", podName, "--", "curl", "--connect-timeout", "2", net.JoinHostPort(targetNode.nodeIP, "80"))
-			if err != nil {
-				if !expectSuccess {
-					// curl should timeout with a string containing this error, and this should be the case if we expect a failure
-					if !strings.Contains(err.Error(), "Connection timed out") {
-						framework.Logf("the test expected netserver container to not be able to connect, but it did with another error, err : %v", err)
-						return false, nil
-					}
-					return true, nil
-				}
-				return false, nil
-			}
-			var targetNodeLogs string
-			if strings.Contains(targetNode.name, "-host-net-pod") {
-				// host-networked-pod
-				targetNodeLogs, err = e2ekubectl.RunKubectl(podNamespace, "logs", targetNode.name)
-			} else {
-				// external container
-				targetNodeLogs, err = runCommand(containerRuntime, "logs", targetNode.name)
-			}
-			if err != nil {
-				framework.Logf("failed to inspect logs in test container: %v", err)
-				return false, nil
-			}
-			targetNodeLogs = strings.TrimSuffix(targetNodeLogs, "\n")
-			logLines := strings.Split(targetNodeLogs, "\n")
-			lastLine := logLines[len(logLines)-1]
-			for i := 0; i < len(verifyIPs); i++ {
-				if strings.Contains(lastLine, verifyIPs[i]) {
-					verifyIPs = removeSliceElement(verifyIPs, i)
-					break
-				}
-			}
-			if len(verifyIPs) != 0 && expectSuccess {
-				framework.Logf("the test external container did not have any trace of the IPs: %v being logged, last logs: %s", verifyIPs, logLines[len(logLines)-1])
-				return false, nil
-			}
-			if !expectSuccess && len(verifyIPs) == 0 {
-				framework.Logf("the test external container did have a trace of the IPs: %v being logged, it should not have, last logs: %s", verifyIPs, logLines[len(logLines)-1])
-				return false, nil
 			}
 			return true, nil
 		}
@@ -451,37 +482,6 @@ var _ = ginkgo.Describe("e2e egress IP validation", func() {
 		return reflect.DeepEqual(eIPsFound, ips)
 	}
 
-	configNetworkAndGetTarget := func(subnet string, nodesToAttachNet []string, v6 bool) (string, string) {
-		// configure and add additional network to worker containers for EIP multi NIC feature
-		createNetwork(secondaryNetworkName, subnet, v6)
-		if v6 {
-			// HACK: ensure bridges don't talk to each other. For IPv6, docker support for isolated networks is experimental.
-			// Remove when it is no longer experimental. See func description for full details.
-			if err := isolateIPv6Networks(primaryNetworkName, secondaryNetworkName); err != nil {
-				framework.Failf("failed to isolate IPv6 networks: %v", err)
-			}
-		}
-		for _, nodeName := range nodesToAttachNet {
-			attachNetwork(secondaryNetworkName, nodeName)
-		}
-		v4Addr, v6Addr := createClusterExternalContainer(targetSecondaryNode.name, "docker.io/httpd", []string{"--network", secondaryNetworkName, "-P"}, []string{})
-		if v4Addr == "" && !v6 {
-			panic("failed to get v4 address")
-		}
-		if v6Addr == "" && v6 {
-			panic("failed to get v6 address")
-		}
-		return v4Addr, v6Addr
-	}
-
-	tearDownNetworkAndTargetForMultiNIC := func(nodeToDetachNet []string) {
-		deleteClusterExternalContainer(targetSecondaryNode.name)
-		for _, nodeName := range nodeToDetachNet {
-			detachNetwork(secondaryNetworkName, nodeName)
-		}
-		deleteNetwork(secondaryNetworkName)
-	}
-
 	getIPVersions := func(ips ...string) (bool, bool) {
 		var v4, v6 bool
 		for _, ip := range ips {
@@ -534,12 +534,12 @@ var _ = ginkgo.Describe("e2e egress IP validation", func() {
 			_, targetNode.nodeIP = createClusterExternalContainer(targetNode.name, "docker.io/httpd", []string{"--network", ciNetworkName, "-P"}, []string{})
 			_, deniedTargetNode.nodeIP = createClusterExternalContainer(deniedTargetNode.name, "docker.io/httpd", []string{"--network", ciNetworkName, "-P"}, []string{})
 			// configure and add additional network to worker containers for EIP multi NIC feature
-			_, targetSecondaryNode.nodeIP = configNetworkAndGetTarget(secondaryIPV6Subnet, []string{egress1Node.name, egress2Node.name}, isV6)
+			_, targetSecondaryNode.nodeIP = configNetworkAndGetTarget(secondaryIPV6Subnet, []string{egress1Node.name, egress2Node.name}, isV6, targetSecondaryNode)
 		} else {
 			targetNode.nodeIP, _ = createClusterExternalContainer(targetNode.name, "docker.io/httpd", []string{"--network", ciNetworkName, "-P"}, []string{})
 			deniedTargetNode.nodeIP, _ = createClusterExternalContainer(deniedTargetNode.name, "docker.io/httpd", []string{"--network", ciNetworkName, "-P"}, []string{})
 			// configure and add additional network to worker containers for EIP multi NIC feature
-			targetSecondaryNode.nodeIP, _ = configNetworkAndGetTarget(secondaryIPV4Subnet, []string{egress1Node.name, egress2Node.name}, isV6)
+			targetSecondaryNode.nodeIP, _ = configNetworkAndGetTarget(secondaryIPV4Subnet, []string{egress1Node.name, egress2Node.name}, isV6, targetSecondaryNode)
 		}
 
 		// ensure all nodes are ready and reachable
@@ -561,7 +561,7 @@ var _ = ginkgo.Describe("e2e egress IP validation", func() {
 		e2ekubectl.RunKubectlOrDie("default", "label", "node", egress2Node.name, "k8s.ovn.org/egress-assignable-")
 		deleteClusterExternalContainer(targetNode.name)
 		deleteClusterExternalContainer(deniedTargetNode.name)
-		tearDownNetworkAndTargetForMultiNIC([]string{egress1Node.name, egress2Node.name})
+		tearDownNetworkAndTargetForMultiNIC([]string{egress1Node.name, egress2Node.name}, targetSecondaryNode)
 		// ensure all nodes are ready and reachable
 		for _, node := range []string{egress1Node.name, egress2Node.name} {
 			setNodeReady(node, true)

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1316,6 +1316,8 @@ metadata:
 			framework.Logf("Re-create the default BGP Advertisement configuration for other tests")
 			e2ekubectl.RunKubectlOrDie("metallb-system", "apply", "-f", bgpEmptyYaml)
 		}()
+		e2ekubectl.RunKubectlOrDie("default", "delete", "eip", "egressip", "--ignore-not-found=true")
+		e2ekubectl.RunKubectlOrDie("default", "label", "node", nonBackendNodeName, "k8s.ovn.org/egress-assignable-")
 	})
 
 	ginkgo.It("Should ensure connectivity works on an external service when mtu changes in intermediate node", func() {
@@ -1709,6 +1711,176 @@ spec:
 		time.Sleep(time.Second * 10) // buffer to ensure all learn flows are created correctly after the previous drop
 
 		// OVN drops the 1st packet so let's be sure to another set of netcat connections at least to check the srcIP
+		output, err = runCommand(cmd...)
+		framework.ExpectNoError(err, "failed to connect to load balancer service")
+		framework.Logf("netcat command output %s", output)
+
+		// Check that sourceIP of the LBService is preserved
+		ginkgo.By("ensure the sourceIP of the external container is preserved!")
+		targetPodLogs, err = e2ekubectl.RunKubectl("default", "logs", "-l", "app=nginx", "--container", "udp-server")
+		framework.ExpectNoError(err, "failed to inspect logs in backend pods")
+		framework.Logf("%v", targetPodLogs)
+		if strings.Count(targetPodLogs, lbClientIPv4) >= 2 {
+			framework.Logf("found the expected srcIP %s!", lbClientIPv4)
+		} else if strings.Count(targetPodLogs, lbClientIPv6) >= 2 {
+			framework.Logf("found the expected srcIP %s!", lbClientIPv6)
+		} else {
+			framework.Failf("could not get expected srcIP!")
+		}
+	})
+	ginkgo.It("Should ensure load balancer service works when ETP=local and backend pods are also egressIP served pods", func() {
+		// TEST LOGIC: This test uses metaLB BGP for advertising routes towards 1 KIND ovnk cluster node
+		// (node where the service backend pods live) as potential candidate to reach the load balancer service (192.168.10.0 service VIP).
+		// There is also a FRR router that sits in front of the KIND cluster through which traffic flows to the service VIP.
+		// External client (name: lbclient container {installation details in kind.sh script}) tries to reach a
+		// load balancer service with VIP: 192.168.10.0 that has 4 backends running on one of the nodes in the cluster through
+		// the FRR router.
+		// -----------------       ------------------      VIP: 192.168.10.0  ---------------------
+		// |               |       |                |                         | ovn-control-plane |
+		// |   lbclient    |------>|   FRR router   |------> KIND cluster --> ---------------------
+		// |               |       |                |                         |    ovn-worker     |   (4 backend CNI pods running
+		// -----------------       ------------------                         ---------------------    on one of the nodes - say on ovn-worker -
+		//                                                                    |    ovn-worker2    |    serving lb service; they are also
+		//                                                                    ---------------------    served by EIP on primary network)
+		//
+		// So as an example here ovn-worker is where pods live and pods are served by EIP which is assigned on ovn-worker2
+		// Now we test ETP=local works as expected without EIP re-routes messing with the reply traffic:
+		// lbclient->FRR router->ovn-worker->br-ex->GR_ovn-worker->join->cluster-router->ovn-worker-switch->pod and response goes back
+		// same way without it getting re-routed to egressNode ovn-worker2
+		err := framework.WaitForServiceEndpointsNum(context.TODO(), f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*120)
+		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an enpoint, err: %v", svcName, err))
+
+		svcLoadBalancerIP, err := getServiceLoadBalancerIP(f.ClientSet, namespaceName, svcName)
+		framework.ExpectNoError(err, fmt.Sprintf("failed to get service lb ip: %s, err: %v", svcName, err))
+
+		ginkgo.By("patching service " + svcName + " to externalTrafficPolicy=local")
+		err = patchServiceStringValue(f.ClientSet, svcName, "default", "/spec/externalTrafficPolicy", "Local")
+		framework.ExpectNoError(err)
+		output := e2ekubectl.RunKubectlOrDie("default", "get", "svc", svcName, "-o=jsonpath='{.spec.externalTrafficPolicy}'")
+		gomega.Expect(output).To(gomega.Equal("'Local'"))
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		ginkgo.By("1 nodeIP route is advertised correctly by metalb BGP routes")
+		// since ETP=local; ensure only this node's IP route is advertised correctly by metalb BGP routes
+		// sample:
+		// 192.168.10.0 nhid 31 via 172.19.0.4 dev eth0 proto bgp metric 20
+		nodeIP, err := getNodeIP(f.ClientSet, backendNodeName)
+		framework.ExpectNoError(err, fmt.Sprintf("failed to get nodes's %s node ip address", backendNodeName))
+		framework.Logf("NodeIP of node %s is %s", backendNodeName, nodeIP)
+		cmd := []string{containerRuntime, "exec", routerContainer}
+
+		ipVer := ""
+		if utilnet.IsIPv6String(svcLoadBalancerIP) {
+			ipVer = " -6"
+		}
+		bgpRouteCommand := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, svcLoadBalancerIP), " ")
+		cmd = append(cmd, bgpRouteCommand...)
+
+		gomega.Eventually(func() bool {
+			routes, err := runCommand(cmd...)
+			framework.ExpectNoError(err, "failed to get BGP routes from intermediary router")
+			framework.Logf("Routes in FRR %s", routes)
+			routeCount := 0
+			matchedRoute := ""
+			for _, route := range strings.Split(routes, "\n") {
+				match := strings.Contains(route, nodeIP)
+				if match {
+					framework.Logf("DEBUG: Matched route %s for pattern %s", route, nodeIP)
+					matchedRoute = route
+				}
+				if strings.Contains(route, "via") {
+					routeCount++
+				}
+			}
+			return routeCount == 1 && strings.Contains(matchedRoute, nodeIP)
+		}, 60*time.Second).Should(gomega.BeTrue())
+
+		ginkgo.By("by sending a UDP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
+		netcatCmd := fmt.Sprintf("echo hostname | nc -uv -w2 %s %d",
+			svcLoadBalancerIP,
+			endpointUDPPort,
+		)
+		cmd = []string{containerRuntime, "exec", clientContainer, "bash", "-x", "-c", netcatCmd}
+		framework.Logf("netcat command %s", cmd)
+		output, err = runCommand(cmd...)
+		framework.ExpectNoError(err, "failed to connect to load balancer service")
+		framework.Logf("netcat command output %s", output)
+
+		ginkgo.By("ensure the sourceIP of the external container is preserved!")
+		// Check that sourceIP of the LBService is preserved
+		targetPodLogs, err := e2ekubectl.RunKubectl("default", "logs", "-l", "app=nginx", "--container", "udp-server")
+		framework.ExpectNoError(err, "failed to inspect logs in backend pods")
+		framework.Logf("%v", targetPodLogs)
+		lbClientIPv4, lbClientIPv6 := getContainerAddressesForNetwork(clientContainer, "clientnet")
+		framework.Logf("%v", lbClientIPv4)
+		if strings.Contains(targetPodLogs, lbClientIPv4) {
+			framework.Logf("found the expected srcIP %s!", lbClientIPv4)
+		} else if strings.Contains(targetPodLogs, lbClientIPv6) {
+			framework.Logf("found the expected srcIP %s!", lbClientIPv6)
+		} else {
+			framework.Failf("could not get expected srcIP!")
+		}
+
+		ginkgo.By("label " + nonBackendNodeName + " as egressIP assignable")
+		e2enode.AddOrUpdateLabelOnNode(f.ClientSet, nonBackendNodeName, "k8s.ovn.org/egress-assignable", "dummy")
+
+		ginkgo.By("Create an EgressIP object with one egress IP defined")
+		// Assign the egress IP without conflicting with any node IP,
+		// the kind subnet is /16 or /64 so the following should be fine.
+		dupIP := func(ip net.IP) net.IP {
+			dup := make(net.IP, len(ip))
+			copy(dup, ip)
+			return dup
+		}
+		sampleNodeIP := net.ParseIP(nodeIP)
+		egressIP1 := dupIP(sampleNodeIP)
+		egressIP1[len(egressIP1)-2]++
+
+		var egressIPConfig = fmt.Sprintf(`apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: ` + "egressip" + `
+spec:
+    egressIPs:
+    - ` + egressIP1.String() + `
+    podSelector:
+        matchLabels:
+            app: nginx
+    namespaceSelector:
+        matchLabels:
+            kubernetes.io/metadata.name: ` + namespaceName + `
+`)
+		if err := os.WriteFile("egressip.yaml", []byte(egressIPConfig), 0644); err != nil {
+			framework.Failf("Unable to write CRD config to disk: %v", err)
+		}
+		defer func() {
+			if err := os.Remove("egressip.yaml"); err != nil {
+				framework.Logf("Unable to remove the CRD config from disk: %v", err)
+			}
+		}()
+
+		framework.Logf("Create the EgressIP configuration")
+		e2ekubectl.RunKubectlOrDie("default", "create", "-f", "egressip.yaml")
+
+		ginkgo.By("4. Check that the status is of length one and that it is assigned to " + nonBackendNodeName)
+		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+			egressIP := egressIPs{}
+			egressIPStdout, err := e2ekubectl.RunKubectl("default", "get", "eip", "-o", "json")
+			if err != nil {
+				framework.Logf("Error: failed to get the EgressIP object, err: %v", err)
+				return false, nil
+			}
+			json.Unmarshal([]byte(egressIPStdout), &egressIP)
+			if len(egressIP.Items) > 1 {
+				framework.Failf("Didn't expect to retrieve more than one egress IP during the execution of this test, saw: %v", len(egressIP.Items))
+			}
+			return egressIP.Items[0].Status.Items[0].Node == nonBackendNodeName, nil
+		})
+		if err != nil {
+			framework.Failf("Error: expected to have 1 egress IP assignment")
+		}
+
+		ginkgo.By("by sending a UDP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 		output, err = runCommand(cmd...)
 		framework.ExpectNoError(err, "failed to connect to load balancer service")
 		framework.Logf("netcat command output %s", output)


### PR DESCRIPTION
**- What this PR does and why is it needed**

This PR fixes the broken interaction between egressIPs and ETP=local features.
Currently if an EIP served pod is on a different node than the egressNode and
it is also a backend to the ETP=local service type, then the reply packet destined
for the ingress service traffic served by the EIP pod get's re-routed to the egressNode
using the reRoute policies we add for EIPs. This breaks the service traffic.

This PR implements the solution we did via https://issues.redhat.com/browse/FDP-42
to ensure these features work together seamlessly.

Solution:

Step1: Add a qos-rule to the node switches:

`from-lport   103 (ip4.src == $a4548040316634674295 && ct.trk && ct.rpl) mark=42`
where `a4548040316634674295` is the address set that contains all EIP pods.

Step2: Add new LRP at 102 to match on mark and simply "allow" thus skipping the re-routes
LRP:

sample:
```
102 pkt.mark == 42 allow
```

**However we must do the mark changes ONLY for local zone pods not for remote zone pods, else it breaks traffic since mark doesn't persist outside the local node.**

**- Special notes for reviewers**

- The logic to add QoS Rules has been added to the syncNamespaces/initClusterPolicies function so that on start all nodes get this rule
- It has also being added to the addNodeEvent handler so that when new node is added we get this rule
- It has not been added to updateNode event since there is nothing to do during node updates
- It has also not been added to the deleteNode event handler since switch goes away and rules will also go away unless it is still being referenced by another switch
- EgressSVC feature has not been added to this mix because there the reply traffic should be going out with SVC VIP so unsure what the expected behaviour for that feature is; but in the future if that is something that needs to be fixed it should be easy to do that the same way
- since its new LRP/QoS add it will take effect on upgrades

**- How to verify it**

1. All changes to existing unit tests already cover the unit testing around this
2. E2E has been added for cross functionality testing between services and egress ips.

The `2024-04-25T14:09:40.7078121Z [0mLoad Balancer Service Tests with MetalLB [0m[1mShould ensure load balancer service works when ETP=local and backend pods are also egressIP served pods[0m` is running on both v4 and v6 lanes for LGW gateway mode and here the egressNode is different from the node where the pod lives

AND `should work on secondary node interfaces for ETP=local and ETP=cluster when backend pods are also served by EgressIP` is running on SGW mode both v4 & v6

**- Description for the changelog**
`Support ETP=local with EIP`

/label ci