### PR TITLE
control file is not same as sock file

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -45,8 +45,8 @@ const (
 )
 
 const (
-	nbdbCtlSock     = "ovnnb_db.ctl"
-	sbdbCtlSock     = "ovnsb_db.ctl"
+	nbdbCtlFileName = "ovnnb_db.ctl"
+	sbdbCtlFileName = "ovnsb_db.ctl"
 	OvnNbdbLocation = "/etc/ovn/ovnnb_db.db"
 	OvnSbdbLocation = "/etc/ovn/ovnsb_db.db"
 	FloodAction     = "FLOOD"
@@ -486,12 +486,12 @@ func RunOVNNBAppCtlWithTimeout(timeout int, args ...string) (string, string, err
 	return RunOVNNBAppCtl(cmdArgs...)
 }
 
-// RunOVNNBAppCtl runs an 'ovn-appctl -t nbdbCtlSockPath command'.
+// RunOVNNBAppCtl runs an 'ovn-appctl -t nbdbCtlFileName command'.
 func RunOVNNBAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
 	cmdArgs = []string{
 		"-t",
-		runner.ovnRunDir + nbdbCtlSock,
+		runner.ovnRunDir + nbdbCtlFileName,
 	}
 	cmdArgs = append(cmdArgs, args...)
 	stdout, stderr, err := runOVNretry(runner.ovnappctlPath, nil, cmdArgs...)
@@ -505,12 +505,12 @@ func RunOVNSBAppCtlWithTimeout(timeout int, args ...string) (string, string, err
 	return RunOVNSBAppCtl(cmdArgs...)
 }
 
-// RunOVNSBAppCtl runs an 'ovn-appctl -t sbdbCtlSockPath command'.
+// RunOVNSBAppCtl runs an 'ovn-appctl -t sbdbCtlFileName command'.
 func RunOVNSBAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
 	cmdArgs = []string{
 		"-t",
-		runner.ovnRunDir + sbdbCtlSock,
+		runner.ovnRunDir + sbdbCtlFileName,
 	}
 	cmdArgs = append(cmdArgs, args...)
 	stdout, stderr, err := runOVNretry(runner.ovnappctlPath, nil, cmdArgs...)

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -1452,13 +1452,13 @@ func TestRunOVNNBAppCtl(t *testing.T) {
 		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
-			desc:                    "negative: run `ovn-appctl -t nbdbCtlSockPath` command",
-			expectedErr:             fmt.Errorf("failed to execute ovn-appctl -t nbdbCtlSockPath command"),
-			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl -t nbdbCtlSockPath command")}},
+			desc:                    "negative: run `ovn-appctl -t nbdbCtlFileName` command",
+			expectedErr:             fmt.Errorf("failed to execute ovn-appctl -t nbdbCtlFileName command"),
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl -t nbdbCtlFileName command")}},
 			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
-			desc:                    "positive: run `ovn-appctl -t nbdbCtlSockPath` command",
+			desc:                    "positive: run `ovn-appctl -t nbdbCtlFileName` command",
 			expectedErr:             nil,
 			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
 			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
@@ -1495,13 +1495,13 @@ func TestRunOVNSBAppCtl(t *testing.T) {
 		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
-			desc:                    "negative: run `ovn-appctl -t sbdbCtlSockPath` command",
-			expectedErr:             fmt.Errorf("failed to execute ovn-appctl -t sbdbCtlSockPath command"),
-			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl -t sbdbCtlSockPath command")}},
+			desc:                    "negative: run `ovn-appctl -t sbdbCtlFileName` command",
+			expectedErr:             fmt.Errorf("failed to execute ovn-appctl -t sbdbCtlFileName command"),
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl -t sbdbCtlFileName command")}},
 			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
-			desc:                    "positive: run `ovn-appctl -t sbdbCtlSockPath` command",
+			desc:                    "positive: run `ovn-appctl -t sbdbCtlFileName` command",
 			expectedErr:             nil,
 			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
 			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},


### PR DESCRIPTION
control file is used to communicate with the running daemon to modify its properties, whereas sock file is AF_UNIX transport to run OVSDB protocol over

@trozet should be an easy one