### PR TITLE
Dockerfile.ubuntu : fix build issue

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -14,11 +14,13 @@ USER root
 
 RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux
 
-RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
 # Install OVS and OVN packages.
-RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host kubectl
+RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host
+
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 RUN mkdir -p /var/run/openvswitch
 


### PR DESCRIPTION
This change stops using the Xenial repo, as it is no longer available.

The failure would look like this:
```
$ cd $(git rev-parse --show-toplevel)/dist/images && make ubuntu

docker build -t ovn-kube-u-amd64 -f Dockerfile.ubuntu . DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon    428MB
Step 1/23 : FROM ubuntu:23.10
 ---> 0adee8f4dd22
Step 2/23 : USER root
 ---> Using cache
 ---> a517bccf401f
Step 3/23 : RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux
 ---> Using cache
 ---> 6994116cf2ef
Step 4/23 : RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
 ---> Using cache
 ---> 932eef1283d2
Step 5/23 : RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 ---> Using cache
 ---> 150a17c05e3b
Step 6/23 : RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host kubectl
 ---> Running in d6bc967663e5
Hit:1 http://archive.ubuntu.com/ubuntu mantic InRelease
Hit:2 http://security.ubuntu.com/ubuntu mantic-security InRelease
Hit:3 http://archive.ubuntu.com/ubuntu mantic-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu mantic-backports InRelease
Get:6 http://archive.ubuntu.com/ubuntu mantic/main amd64 DEP-11 Metadata [665 kB]
Ign:5 https://packages.cloud.google.com/apt kubernetes-xenial InRelease
Get:7 http://archive.ubuntu.com/ubuntu mantic/universe amd64 DEP-11 Metadata [5809 kB]
Get:8 http://security.ubuntu.com/ubuntu mantic-security/main amd64 DEP-11 Metadata [7954 B]
Get:10 http://security.ubuntu.com/ubuntu mantic-security/universe amd64 DEP-11 Metadata [4195 B]
Err:9 https://packages.cloud.google.com/apt kubernetes-xenial Release
  404  Not Found [IP: 142.250.72.110 443]
Get:11 http://archive.ubuntu.com/ubuntu mantic/multiverse amd64 DEP-11 Metadata [38.1 kB]
Get:12 http://archive.ubuntu.com/ubuntu mantic-updates/main amd64 DEP-11 Metadata [7960 B]
Get:13 http://archive.ubuntu.com/ubuntu mantic-updates/universe amd64 DEP-11 Metadata [4197 B]
Reading package lists...
E: The repository 'https://apt.kubernetes.io kubernetes-xenial Release' does not have a Release file.
The command '/bin/sh -c apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host kubectl' returned a non-zero code: 100
make: *** [Makefile:26: ubuntu] Error 100
```