### PR TITLE
set external_ids:ovn-set-local-ip="true" on nodes 

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -308,6 +308,8 @@ func setupOVNNode(node *kapi.Node) error {
 		fmt.Sprintf("external_ids:ovn-monitor-all=%t", config.Default.MonitorAll),
 		fmt.Sprintf("external_ids:ovn-ofctrl-wait-before-clear=%d", config.Default.OfctrlWaitBeforeClear),
 		fmt.Sprintf("external_ids:ovn-enable-lflow-cache=%t", config.Default.LFlowCacheEnable),
+		// when creating tunnel ports set local_ip, helps ensures multiple interfaces and ipv6 will work
+		"external_ids:ovn-set-local-ip=\"true\"",
 	}
 
 	if config.Default.LFlowCacheLimit > 0 {

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -256,7 +256,8 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-is-interconn=false "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
-						"external_ids:ovn-enable-lflow-cache=true",
+						"external_ids:ovn-enable-lflow-cache=true "+
+						"external_ids:ovn-set-local-ip=\"true\"",
 						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -361,6 +362,7 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
 						"external_ids:ovn-enable-lflow-cache=false "+
+						"external_ids:ovn-set-local-ip=\"true\" "+
 						"external_ids:ovn-limit-lflow-cache=1000 "+
 						"external_ids:ovn-memlimit-lflow-cache-kb=100000",
 						nodeIP, interval, ofintval, ofintval, nodeName),
@@ -428,7 +430,8 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-is-interconn=false "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
-						"external_ids:ovn-enable-lflow-cache=true",
+						"external_ids:ovn-enable-lflow-cache=true "+
+						"external_ids:ovn-set-local-ip=\"true\"",
 						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 
@@ -502,7 +505,8 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-is-interconn=false "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
-						"external_ids:ovn-enable-lflow-cache=true",
+						"external_ids:ovn-enable-lflow-cache=true "+
+						"external_ids:ovn-set-local-ip=\"true\"",
 						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 
@@ -576,7 +580,8 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-is-interconn=false "+
 						"external_ids:ovn-monitor-all=true "+
 						"external_ids:ovn-ofctrl-wait-before-clear=0 "+
-						"external_ids:ovn-enable-lflow-cache=true",
+						"external_ids:ovn-enable-lflow-cache=true "+
+						"external_ids:ovn-set-local-ip=\"true\"",
 						nodeIP, interval, ofintval, ofintval, nodeName),
 				})
 

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -39,7 +39,6 @@ test node readiness according to its defaults interface MTU size|\
 egress IP validation|\
 e2e egress firewall policy validation|\
 OVS CPU affinity pinning|\
-should listen on each host addresses|\
 Pod to pod TCP with low MTU|\
 queries to the hostNetworked server pod on another node shall work for TCP|\
 queries to the hostNetworked server pod on another node shall work for UDP|\


### PR DESCRIPTION
When we do not set external_ids:ovn-set-local-ip="true" on OVS we doe not set local_ip parameter when creating tunnel ports and ipv6 does not work with multiple addresses on the same interface 


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->