### PR TITLE
e2e diagnostic fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -496,6 +496,9 @@ jobs:
       # set 3 hours for control-plane tests as these might take a while
       timeout-minutes: ${{ matrix.target == 'control-plane' && 180 || matrix.target == 'external-gateway' && 180 || 120 }}
       run: |
+        # used by e2e diagnostics package
+        export OVN_IMAGE="ovn-daemonset-f:pr"
+        
         if [ "${{ matrix.target }}" == "multi-homing" ]; then
           make -C test control-plane WHAT="Multi Homing"
         elif [ "${{ matrix.target }}" == "node-ip-mac-migration" ]; then

--- a/test/e2e/diagnostics/daemonset.go
+++ b/test/e2e/diagnostics/daemonset.go
@@ -44,10 +44,11 @@ func (d *Diagnostics) composeDiagnosticsDaemonSet(name, cmd, tool string) appsv1
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:    "ovn-kube",
-						Image:   ovnImage,
-						Command: []string{"bash", "-c"},
-						Args:    []string{cmd},
+						Name:            "ovn-kube",
+						Image:           ovnImage,
+						ImagePullPolicy: v1.PullIfNotPresent,
+						Command:         []string{"bash", "-c"},
+						Args:            []string{cmd},
 						SecurityContext: &v1.SecurityContext{
 							Privileged: pointer.Bool(true),
 						},

--- a/test/e2e/diagnostics/tcpdump.go
+++ b/test/e2e/diagnostics/tcpdump.go
@@ -2,6 +2,7 @@ package diagnostics
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,7 +17,7 @@ func (d *Diagnostics) TCPDumpDaemonSet(ifaces []string, expression string) {
 	By("Creating tcpdump daemonsets")
 	daemonSets := []appsv1.DaemonSet{}
 	for _, iface := range ifaces {
-		daemonSetName := "node-tcpdump-" + iface
+		daemonSetName := "node-tcpdump-" + strings.ReplaceAll(iface, "_", "-")
 		cmd := fmt.Sprintf("tcpdump -vvv -nne -i %s %s", iface, expression)
 		daemonSets = append(daemonSets, d.composeDiagnosticsDaemonSet(daemonSetName, cmd, "node-tcpdump"))
 	}


### PR DESCRIPTION
- Fix e2e diagnostics tcpdump daemonset name to avoid invalid character `_`.
- Define OVN_IMAGE for e2e job task. Change pull policy as there is no
image repository backing the test cluster.