### PR TITLE
virt, persistent ips: make the feature configurable

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -904,7 +904,8 @@ create_ovn_kube_manifests() {
     --compact-mode="${OVN_COMPACT_MODE}" \
     --enable-interconnect="${OVN_ENABLE_INTERCONNECT}" \
     --enable-multi-external-gateway=true \
-    --enable-ovnkube-identity="${OVN_ENABLE_OVNKUBE_IDENTITY}"
+    --enable-ovnkube-identity="${OVN_ENABLE_OVNKUBE_IDENTITY}" \
+    --enable-persistent-ips=true
   popd
 }
 

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -90,6 +90,7 @@ OVNKUBE_METRICS_SCALE_ENABLE=
 OVN_STATELESS_NETPOL_ENABLE="false"
 OVN_ENABLE_INTERCONNECT=
 OVN_ENABLE_OVNKUBE_IDENTITY="true"
+OVN_ENABLE_PERSISTENT_IPS=
 # IN_UPGRADE is true only if called by upgrade-ovn.sh during the upgrade test,
 # it will render only the parts in ovn-setup.yaml related to RBAC permissions.
 IN_UPGRADE=
@@ -338,6 +339,9 @@ while [ "$1" != "" ]; do
   --ovn-northd-backoff-interval)
     OVN_NORTHD_BACKOFF_INTERVAL=$VALUE
     ;;
+  --enable-persistent-ips)
+    OVN_ENABLE_PERSISTENT_IPS=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -516,6 +520,9 @@ echo "ovn_enable_ovnkube_identity: ${ovn_enable_ovnkube_identity}"
 
 ovn_northd_backoff_interval=${OVN_NORTHD_BACKOFF_INTERVAL}
 echo "ovn_northd_backoff_interval: ${ovn_northd_backoff_interval}"
+
+ovn_enable_persistent_ips=${OVN_ENABLE_PERSISTENT_IPS}
+echo "ovn_enable_persistent_ips: ${ovn_enable_persistent_ips}"
 
 ovn_image=${ovnkube_image} \
   ovnkube_compact_mode_enable=${ovnkube_compact_mode_enable} \
@@ -700,6 +707,7 @@ ovn_image=${ovnkube_image} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
+  ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   jinjanate ../templates/ovnkube-master.yaml.j2 -o ${output_dir}/ovnkube-master.yaml
 
 ovn_image=${ovnkube_image} \
@@ -738,6 +746,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
   ovn_v4_transit_switch_subnet=${ovn_v4_transit_switch_subnet} \
   ovn_v6_transit_switch_subnet=${ovn_v6_transit_switch_subnet} \
+  ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   jinjanate ../templates/ovnkube-control-plane.yaml.j2 -o ${output_dir}/ovnkube-control-plane.yaml
 
 ovn_image=${image} \
@@ -827,6 +836,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
   ovn_northd_backoff_interval=${ovn_northd_backoff_interval} \
+  ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   jinjanate ../templates/ovnkube-single-node-zone.yaml.j2 -o ${output_dir}/ovnkube-single-node-zone.yaml
 
 ovn_image=${ovnkube_image} \
@@ -884,6 +894,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_multi_external_gateway=${ovn_enable_multi_external_gateway} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
   ovn_northd_backoff_interval=${ovn_enable_backoff_interval} \
+  ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   jinjanate ../templates/ovnkube-zone-controller.yaml.j2 -o ${output_dir}/ovnkube-zone-controller.yaml
 
 ovn_image=${image} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -280,6 +280,8 @@ ovn_enable_interconnect=${OVN_ENABLE_INTERCONNECT:-false}
 ovn_enable_multi_external_gateway=${OVN_ENABLE_MULTI_EXTERNAL_GATEWAY:-false}
 #OVN_ENABLE_OVNKUBE_IDENTITY - enable per node cert
 ovn_enable_ovnkube_identity=${OVN_ENABLE_OVNKUBE_IDENTITY:-true}
+#OVN_ENABLE_PERSISTENT_IPS - enable IPAM for virtualization workloads (KubeVirt persistent IPs)
+ovn_enable_persistent_ips=${OVN_ENABLE_PERSISTENT_IPS:-false}
 
 # OVNKUBE_NODE_MODE - is the mode which ovnkube node operates
 ovnkube_node_mode=${OVNKUBE_NODE_MODE:-"full"}
@@ -1247,6 +1249,12 @@ ovn-master() {
     echo "=============== ovn-master ========== MASTER ONLY"
   fi
 
+  persistent_ips_enabled_flag=
+  if [[ ${ovn_enable_persistent_ips} == "true" ]]; then
+	  persistent_ips_enabled_flag="--enable-persistent-ips"
+  fi
+  echo "persistent_ips_enabled_flag: ${persistent_ips_enabled_flag}"
+
   /usr/bin/ovnkube --init-master ${K8S_NODE} \
     ${anp_enabled_flag} \
     ${disable_forwarding_flag} \
@@ -1273,6 +1281,7 @@ ovn-master() {
     ${ovn_v4_masquerade_subnet_opt} \
     ${ovn_v6_join_subnet_opt} \
     ${ovn_v6_masquerade_subnet_opt} \
+    ${persistent_ips_enabled_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
     --host-network-namespace ${ovn_host_network_namespace} \
@@ -2063,6 +2072,12 @@ ovn-cluster-manager() {
   fi
   echo "multi_network_enabled_flag: ${multi_network_enabled_flag}"
 
+  persistent_ips_enabled_flag=
+  if [[ ${ovn_enable_persistent_ips} == "true" ]]; then
+	  persistent_ips_enabled_flag="--enable-persistent-ips"
+  fi
+  echo "persistent_ips_enabled_flag: ${persistent_ips_enabled_flag}"
+
   ovnkube_cluster_manager_metrics_bind_address="${metrics_endpoint_ip}:9411"
   echo "ovnkube_cluster_manager_metrics_bind_address: ${ovnkube_cluster_manager_metrics_bind_address}"
 
@@ -2105,6 +2120,7 @@ ovn-cluster-manager() {
     ${hybrid_overlay_flags} \
     ${multicast_enabled_flag} \
     ${multi_network_enabled_flag} \
+    ${persistent_ips_enabled_flag} \
     ${ovnkube_enable_interconnect_flag} \
     ${ovnkube_enable_multi_external_gateway_flag} \
     ${ovnkube_metrics_tls_opts} \

--- a/dist/templates/ovnkube-control-plane.yaml.j2
+++ b/dist/templates/ovnkube-control-plane.yaml.j2
@@ -168,6 +168,8 @@ spec:
           value: "{{ ovn_v4_transit_switch_subnet }}"
         - name: OVN_V6_TRANSIT_SWITCH_SUBNET
           value: "{{ ovn_v6_transit_switch_subnet }}"
+        - name: OVN_ENABLE_PERSISTENT_IPS
+          value: "{{ ovn_enable_persistent_ips }}"
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -296,6 +296,8 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: host_network_namespace
+        - name: OVN_ENABLE_PERSISTENT_IPS
+          value: "{{ ovn_enable_persistent_ips }}"
       # end of container
 
       volumes:

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -133,7 +133,8 @@ func (ncc *networkClusterController) hasNodeAllocation() bool {
 }
 
 func (ncc *networkClusterController) allowPersistentIPs() bool {
-	return ncc.NetInfo.AllowsPersistentIPs() &&
+	return config.OVNKubernetesFeature.EnablePersistentIPs &&
+		ncc.NetInfo.AllowsPersistentIPs() &&
 		util.DoesNetworkRequireIPAM(ncc.NetInfo) &&
 		(ncc.NetInfo.TopologyType() == types.Layer2Topology || ncc.NetInfo.TopologyType() == types.LocalnetTopology)
 }

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -165,17 +165,17 @@ func (ncc *networkClusterController) init() error {
 
 		var (
 			podAllocationAnnotator *annotationalloc.PodAnnotationAllocator
-			ipamClaimsReconciler   *persistentips.IPAMClaimReconciler
+			ipamClaimsReconciler   persistentips.PersistentAllocations
 		)
 
 		if ncc.allowPersistentIPs() {
 			ncc.retryIPAMClaims = ncc.newRetryFramework(factory.IPAMClaimsType, true)
-			ipamClaimsReconciler = persistentips.NewIPAMClaimReconciler(
+			ncc.ipamClaimReconciler = persistentips.NewIPAMClaimReconciler(
 				ncc.kube,
 				ncc.NetInfo,
 				ncc.watchFactory.IPAMClaimsInformer().Lister(),
 			)
-			ncc.ipamClaimReconciler = ipamClaimsReconciler
+			ipamClaimsReconciler = ncc.ipamClaimReconciler
 		}
 
 		podAllocationAnnotator = annotationalloc.NewPodAnnotationAllocator(

--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/id"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/ip/subnet"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/persistentips"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -59,7 +60,7 @@ func NewPodAllocator(
 	// this network might not have IPAM, we will just allocate MAC addresses
 	if util.DoesNetworkRequireIPAM(netInfo) {
 		podAllocator.ipAllocator = ipAllocator
-		if netInfo.AllowsPersistentIPs() {
+		if config.OVNKubernetesFeature.EnablePersistentIPs && netInfo.AllowsPersistentIPs() {
 			podAllocator.ipamClaimsReconciler = claimsReconciler
 		}
 	}

--- a/go-controller/pkg/clustermanager/secondary_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/secondary_network_unit_test.go
@@ -326,8 +326,9 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 						gomega.Expect(
 							initConfig(ctx, ovnkconfig.OVNKubernetesFeatureConfig{
-								EnableMultiNetwork: true,
-								EnableInterconnect: true},
+								EnableMultiNetwork:  true,
+								EnableInterconnect:  true,
+								EnablePersistentIPs: true},
 							)).To(gomega.Succeed())
 						var err error
 						f, err = factory.NewClusterManagerWatchFactory(fakeClient)
@@ -371,8 +372,9 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 						gomega.Expect(
 							initConfig(ctx, ovnkconfig.OVNKubernetesFeatureConfig{
-								EnableMultiNetwork: true,
-								EnableInterconnect: true},
+								EnableMultiNetwork:  true,
+								EnableInterconnect:  true,
+								EnablePersistentIPs: true},
 							)).To(gomega.Succeed())
 						var err error
 						f, err = factory.NewClusterManagerWatchFactory(fakeClient)
@@ -417,8 +419,9 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 						gomega.Expect(
 							initConfig(ctx, ovnkconfig.OVNKubernetesFeatureConfig{
-								EnableMultiNetwork: true,
-								EnableInterconnect: true},
+								EnableMultiNetwork:  true,
+								EnableInterconnect:  true,
+								EnablePersistentIPs: true},
 							)).To(gomega.Succeed())
 						var err error
 						f, err = factory.NewClusterManagerWatchFactory(fakeClient)
@@ -483,8 +486,9 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 						gomega.Expect(
 							initConfig(ctx, ovnkconfig.OVNKubernetesFeatureConfig{
-								EnableMultiNetwork: true,
-								EnableInterconnect: true},
+								EnableMultiNetwork:  true,
+								EnableInterconnect:  true,
+								EnablePersistentIPs: true},
 							)).To(gomega.Succeed())
 						var err error
 						f, err = factory.NewClusterManagerWatchFactory(fakeClient)
@@ -552,8 +556,9 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 						gomega.Expect(
 							initConfig(ctx, ovnkconfig.OVNKubernetesFeatureConfig{
-								EnableMultiNetwork: true,
-								EnableInterconnect: true},
+								EnableMultiNetwork:  true,
+								EnableInterconnect:  true,
+								EnablePersistentIPs: true},
 							)).To(gomega.Succeed())
 
 						f, err = factory.NewClusterManagerWatchFactory(fakeClient)

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -403,6 +403,7 @@ type OVNKubernetesFeatureConfig struct {
 	EnableStatelessNetPol           bool `gcfg:"enable-stateless-netpol"`
 	EnableInterconnect              bool `gcfg:"enable-interconnect"`
 	EnableMultiExternalGateway      bool `gcfg:"enable-multi-external-gateway"`
+	EnablePersistentIPs             bool `gcfg:"enable-persistent-ips"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -1040,6 +1041,12 @@ var OVNK8sFeatureFlags = []cli.Flag{
 		Usage:       "Configure to use AdminPolicyBasedExternalRoute CRD feature with ovn-kubernetes.",
 		Destination: &cliConfig.OVNKubernetesFeature.EnableMultiExternalGateway,
 		Value:       OVNKubernetesFeature.EnableMultiExternalGateway,
+	},
+	&cli.BoolFlag{
+		Name:        "enable-persistent-ips",
+		Usage:       "Configure to use the persistent ips feature for virtualization with ovn-kubernetes.",
+		Destination: &cliConfig.OVNKubernetesFeature.EnablePersistentIPs,
+		Value:       OVNKubernetesFeature.EnablePersistentIPs,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -227,6 +227,7 @@ enable-multi-networkpolicy=false
 enable-interconnect=false
 enable-multi-external-gateway=false
 enable-admin-network-policy=false
+enable-persistent-ips=false
 
 [clustermanager]
 v4-transit-switch-subnet=100.89.0.0/16
@@ -336,6 +337,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OVNKubernetesFeature.EnableInterconnect).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EnableMultiExternalGateway).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EnableAdminNetworkPolicy).To(gomega.BeFalse())
+			gomega.Expect(OVNKubernetesFeature.EnablePersistentIPs).To(gomega.BeFalse())
 
 			for _, a := range []OvnAuthConfig{OvnNorth, OvnSouth} {
 				gomega.Expect(a.Scheme).To(gomega.Equal(OvnDBSchemeUnix))
@@ -591,6 +593,7 @@ var _ = Describe("Config Operations", func() {
 			"enable-interconnect=true",
 			"enable-multi-external-gateway=true",
 			"enable-admin-network-policy=true",
+			"enable-persistent-ips=true",
 			"zone=foo",
 		)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -678,6 +681,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OVNKubernetesFeature.EnableInterconnect).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableMultiExternalGateway).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableAdminNetworkPolicy).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EnablePersistentIPs).To(gomega.BeTrue())
 			gomega.Expect(HybridOverlay.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("11.132.0.0/14"), 23},
 			}))
@@ -782,6 +786,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OVNKubernetesFeature.EnableInterconnect).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableMultiExternalGateway).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableAdminNetworkPolicy).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EnablePersistentIPs).To(gomega.BeTrue())
 			gomega.Expect(HybridOverlay.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("11.132.0.0/14"), 23},
 			}))
@@ -853,6 +858,7 @@ var _ = Describe("Config Operations", func() {
 			"-enable-interconnect=true",
 			"-enable-multi-external-gateway=true",
 			"-enable-admin-network-policy=true",
+			"-enable-persistent-ips=true",
 			"-healthz-bind-address=0.0.0.0:4321",
 			"-zone=bar",
 			"-dns-service-namespace=kube-system-2",

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -239,7 +239,9 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 		stopChan:             make(chan struct{}),
 	}
 
-	if config.OVNKubernetesFeature.EnableMultiNetwork && !config.OVNKubernetesFeature.EnableInterconnect {
+	if config.OVNKubernetesFeature.EnableMultiNetwork &&
+		config.OVNKubernetesFeature.EnablePersistentIPs &&
+		!config.OVNKubernetesFeature.EnableInterconnect {
 		wf.ipamClaimsFactory = ipamclaimsfactory.NewSharedInformerFactory(ovnClientset.IPAMClaimsClient, resyncInterval)
 	}
 
@@ -359,7 +361,9 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 		}
 	}
 
-	if config.OVNKubernetesFeature.EnableMultiNetwork && !config.OVNKubernetesFeature.EnableInterconnect {
+	if config.OVNKubernetesFeature.EnableMultiNetwork &&
+		config.OVNKubernetesFeature.EnablePersistentIPs &&
+		!config.OVNKubernetesFeature.EnableInterconnect {
 		wf.informers[IPAMClaimsType], err = newInformer(IPAMClaimsType, wf.ipamClaimsFactory.K8s().V1alpha1().IPAMClaims().Informer())
 		if err != nil {
 			return nil, err
@@ -607,7 +611,9 @@ func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset
 		stopChan:             make(chan struct{}),
 	}
 
-	if config.OVNKubernetesFeature.EnableMultiNetwork && config.OVNKubernetesFeature.EnableInterconnect {
+	if config.OVNKubernetesFeature.EnableMultiNetwork &&
+		config.OVNKubernetesFeature.EnablePersistentIPs &&
+		config.OVNKubernetesFeature.EnableInterconnect {
 		wf.ipamClaimsFactory = ipamclaimsfactory.NewSharedInformerFactory(ovnClientset.IPAMClaimsClient, resyncInterval)
 	}
 
@@ -685,9 +691,12 @@ func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset
 		if err != nil {
 			return nil, err
 		}
-		wf.informers[IPAMClaimsType], err = newInformer(IPAMClaimsType, wf.ipamClaimsFactory.K8s().V1alpha1().IPAMClaims().Informer())
-		if err != nil {
-			return nil, err
+
+		if config.OVNKubernetesFeature.EnablePersistentIPs {
+			wf.informers[IPAMClaimsType], err = newInformer(IPAMClaimsType, wf.ipamClaimsFactory.K8s().V1alpha1().IPAMClaims().Informer())
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -357,6 +357,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		config.OVNKubernetesFeature.EnableEgressService = true
 		config.OVNKubernetesFeature.EnableAdminNetworkPolicy = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnablePersistentIPs = true
 		config.Kubernetes.PlatformType = string(ocpconfigapi.AWSPlatformType)
 
 		fakeClient = &fake.Clientset{}
@@ -876,6 +877,20 @@ var _ = Describe("Watch Factory Operations", func() {
 		It("does not contain Baseline Admin Network Policy informer", func() {
 			config.OVNKubernetesFeature.EnableAdminNetworkPolicy = false
 			testExisting(BaselineAdminNetworkPolicyType)
+		})
+	})
+
+	Context("when Persistent IPs feature is disabled", func() {
+		testExisting := func(objType reflect.Type) {
+			wf, err = NewMasterWatchFactory(ovnClientset)
+			Expect(err).NotTo(HaveOccurred())
+			err = wf.Start()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wf.informers).NotTo(HaveKey(objType))
+		}
+		It("does not contain IPAMClaims informer", func() {
+			config.OVNKubernetesFeature.EnablePersistentIPs = false
+			testExisting(IPAMClaimsType)
 		})
 	})
 

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -13,6 +13,7 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
@@ -674,7 +675,8 @@ func (bsnc *BaseSecondaryNetworkController) WatchIPAMClaims() error {
 }
 
 func (oc *BaseSecondaryNetworkController) allowPersistentIPs() bool {
-	return oc.NetInfo.AllowsPersistentIPs() &&
+	return config.OVNKubernetesFeature.EnablePersistentIPs &&
+		oc.NetInfo.AllowsPersistentIPs() &&
 		util.DoesNetworkRequireIPAM(oc.NetInfo) &&
 		(oc.NetInfo.TopologyType() == types.Layer2Topology || oc.NetInfo.TopologyType() == types.LocalnetTopology)
 }

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -283,7 +283,7 @@ func (oc *BaseSecondaryLayer2NetworkController) run() error {
 
 	// when on IC, it will be the NetworkController that returns the IPAMClaims
 	// IPs back to the pool
-	if oc.allocatesPodAnnotation() && oc.NetInfo.AllowsPersistentIPs() {
+	if oc.allocatesPodAnnotation() && oc.allowPersistentIPs() {
 		// WatchIPAMClaims should be started before WatchPods to prevent OVN-K
 		// master assigning IPs to pods without taking into account the persistent
 		// IPs set aside for the IPAMClaims

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -61,7 +61,7 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 	}
 
 	if oc.allocatesPodAnnotation() {
-		var claimsReconciler *persistentips.IPAMClaimReconciler
+		var claimsReconciler persistentips.PersistentAllocations
 		if oc.allowPersistentIPs() {
 			ipamClaimsReconciler := persistentips.NewIPAMClaimReconciler(
 				oc.kube,

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -56,7 +56,7 @@ func NewSecondaryLocalnetNetworkController(cnci *CommonNetworkControllerInfo, ne
 	}
 
 	if oc.allocatesPodAnnotation() {
-		var claimsReconciler *persistentips.IPAMClaimReconciler
+		var claimsReconciler persistentips.PersistentAllocations
 		if oc.allowPersistentIPs() {
 			ipamClaimsReconciler := persistentips.NewIPAMClaimReconciler(
 				oc.kube,

--- a/helm/ovn-kubernetes/values.yaml
+++ b/helm/ovn-kubernetes/values.yaml
@@ -76,6 +76,8 @@ global:
   enableMultiExternalGateway: true
   # -- Configure to use stateless network policy feature with ovn-kubernetes
   enableStatelessNetworkPolicy: false
+  # -- Configure to use the IPAMClaims CRD feature with ovn-kubernetes, thus granting persistent IPs across restarts / migration for KubeVirt VMs
+  enablePersistentIPs: false
   # -- Enables metrics related to scaling
   enableMetricsScale: ""
   # -- Enables monitoring OVN-Kubernetes master and OVN configuration duration


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Only start the IPAMClaim factory watchers if the persistent IPs feature gate is enabled.

Currently, anytime multi-network is enabled in IC scenarios we assume the IPAMClaims CRD is installed. This might not be always the case - let's add a feature gate then.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->