### PR TITLE
Follow up fix how detect any network following lib change

### DIFF
--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -303,7 +303,7 @@ func LinkRoutesDel(link netlink.Link, subnets []*net.IPNet) error {
 			deleteRoute := false
 
 			if subnet == nil {
-				deleteRoute = IsAnyNetwork(route.Dst)
+				deleteRoute = IsNilOrAnyNetwork(route.Dst)
 			} else if route.Dst != nil {
 				deleteRoute = route.Dst.String() == subnet.String()
 			}
@@ -349,25 +349,13 @@ func LinkRoutesAdd(link netlink.Link, gwIP net.IP, subnets []*net.IPNet, mtu int
 	return nil
 }
 
-// IsAnyNetwork checks if the argument network is an any network for ipv4 or ipv6.
-func IsAnyNetwork(ipNet *net.IPNet) bool {
+// IsNilOrAnyNetwork checks if the argument network is nil or an any network for ipv4 or ipv6.
+func IsNilOrAnyNetwork(ipNet *net.IPNet) bool {
 	if ipNet == nil {
-		return false
+		return true
 	}
-	ones, _ := ipNet.Mask.Size()
-	//v4
-	if ipNet.IP.To4() != nil {
-		v4Any := net.ParseIP("0.0.0.0")
-		if ipNet.IP.Equal(v4Any) && ones == 0 {
-			return true
-		}
-	} else {
-		v6Any := net.ParseIP("::")
-		if ipNet.IP.Equal(v6Any) && ones == 0 {
-			return true
-		}
-	}
-	return false
+
+	return ipNet.IP.IsUnspecified()
 }
 
 // LinkRouteGetFilteredRoute gets a route for the given route filter.

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -143,7 +143,7 @@ func saveRoute(oldLink, newLink netlink.Link, routes []netlink.Route) error {
 		// Handle routes for default gateway later.  This is a special case for
 		// GCE where we have /32 IP addresses and we can't add the default
 		// gateway before the route to the gateway.
-		if IsAnyNetwork(route.Dst) && route.Gw != nil && route.LinkIndex > 0 {
+		if IsNilOrAnyNetwork(route.Dst) && route.Gw != nil && route.LinkIndex > 0 {
 			continue
 		} else if route.Dst != nil && !route.Dst.IP.IsGlobalUnicast() {
 			continue
@@ -158,7 +158,7 @@ func saveRoute(oldLink, newLink netlink.Link, routes []netlink.Route) error {
 	// Now add the default gateway (if any) via this interface.
 	for i := range routes {
 		route := routes[i]
-		if IsAnyNetwork(route.Dst) && route.Gw != nil && route.LinkIndex > 0 {
+		if IsNilOrAnyNetwork(route.Dst) && route.Gw != nil && route.LinkIndex > 0 {
 			// Remove route from 'oldLink' and move it to 'newLink'
 			err := delAddRoute(oldLink, newLink, route)
 			if err != nil {


### PR DESCRIPTION
This change is aimed at making the ANY network check backward compatible with the old netlink library and simplifying the process by utilizing the library function IP.IsUnspecified().

This is a follow up change for https://github.com/ovn-org/ovn-kubernetes/commit/14f5f1841114740307511e586e18079b5368fe47
