### PR TITLE
Move parts of kind.sh into kind-common

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -432,7 +432,7 @@ jobs:
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' }}"
       OVN_HA: "${{ matrix.ha == 'HA' }}"
       OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws == 'noSnatGW' }}"
-      KIND_INSTALL_METALLB: "${{ matrix.target == 'control-plane' }}"
+      KIND_INSTALL_METALLB: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"

--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -1,0 +1,369 @@
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]
+then
+    >&2 echo 'Please source this script, not execute it!'
+    exit 1
+fi
+
+ARCH=""
+case $(uname -m) in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64"   ;;
+esac
+
+function if_error_exit {
+    ###########################################################################
+    # Description:                                                            #
+    # Validate if previous command failed and show an error msg (if provided) #
+    #                                                                         #
+    # Arguments:                                                              #
+    #   $1 - error message if not provided, it will just exit                 #
+    ###########################################################################
+    if [ "$?" != "0" ]; then
+        if [ -n "$1" ]; then
+            RED="\e[31m"
+            ENDCOLOR="\e[0m"
+            echo -e "[ ${RED}FAILED${ENDCOLOR} ] ${1}"
+        fi
+        exit 1
+    fi
+}
+
+run_kubectl() {
+  local retries=0
+  local attempts=10
+  while true; do
+    if kubectl "$@"; then
+      break
+    fi
+
+    ((retries += 1))
+    if [[ "${retries}" -gt ${attempts} ]]; then
+      echo "error: 'kubectl $*' did not succeed, failing"
+      exit 1
+    fi
+    echo "info: waiting for 'kubectl $*' to succeed..."
+    sleep 1
+  done
+}
+
+command_exists() {
+  cmd="$1"
+  command -v ${cmd} >/dev/null 2>&1
+}
+
+detect_apiserver_url() {
+  # Detect API_URL used for in-cluster communication
+  #
+  # Despite OVN run in pod they will only obtain the VIRTUAL apiserver address
+  # and since OVN has to provide the connectivity to service
+  # it can not be bootstrapped
+  #
+  # This is the address of the node with the control-plane
+  API_URL=$(kind get kubeconfig --internal --name "${KIND_CLUSTER_NAME}" | grep server | awk '{ print $2 }')
+}
+
+docker_disable_ipv6() {
+  # Docker disables IPv6 globally inside containers except in the eth0 interface.
+  # Kind enables IPv6 globally the containers ONLY for dual-stack and IPv6 deployments.
+  # Ovnkube-node tries to move all global addresses from the gateway interface to the
+  # bridge interface it creates. This breaks on KIND with IPv4 only deployments, because the new
+  # internal bridge has IPv6 disable and can't move the IPv6 from the eth0 interface.
+  # We can enable IPv6 always in the container, since the docker setup with IPv4 only
+  # is not very common.
+  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
+  for n in $KIND_NODES; do
+    $OCI_BIN exec "$n" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
+    $OCI_BIN exec "$n" sysctl --ignore net.ipv6.conf.all.forwarding=1
+  done
+}
+
+coredns_patch() {
+  dns_server="8.8.8.8"
+  # No need for ipv6 nameserver for dual stack, it will ask for 
+  # A and AAAA records
+  if [ "$IP_FAMILY" == "ipv6" ]; then
+    dns_server="2001:4860:4860::8888"
+  fi
+
+  # Patch CoreDNS to work
+  # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
+  # to work in an offline environment:
+  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
+  # 2. Github CI adds following domains to resolv.conf search field:
+  # .net.
+  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
+  # otherwise pods stops trying to resolve the domain.
+  # Get the current config
+  original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
+  echo "Original CoreDNS config:"
+  echo "${original_coredns}"
+  # Patch it
+  fixed_coredns=$(
+    printf '%s' "${original_coredns}" | sed \
+      -e 's/^.*kubernetes cluster\.local/& net/' \
+      -e '/^.*upstream$/d' \
+      -e '/^.*fallthrough.*$/d' \
+      -e 's/^\(.*forward \.\).*$/\1 '"$dns_server"' {/' \
+      -e '/^.*loop$/d' \
+  )
+  echo "Patched CoreDNS config:"
+  echo "${fixed_coredns}"
+  printf '%s' "${fixed_coredns}" | kubectl apply -f -
+}
+
+install_ingress() {
+  run_kubectl apply -f "${DIR}/ingress/mandatory.yaml"
+  run_kubectl apply -f "${DIR}/ingress/service-nodeport.yaml"
+}
+
+METALLB_DIR="/tmp/metallb"
+install_metallb() {
+  mkdir -p /tmp/metallb
+  local builddir
+  builddir=$(mktemp -d "${METALLB_DIR}/XXXXXX")
+
+  pushd "${builddir}"
+  git clone https://github.com/metallb/metallb.git
+  cd metallb
+  # Use global IP next hops in IPv6
+  if  [ "$KIND_IPV6_SUPPORT" == true ]; then
+    sed -i '/address-family PROTOCOL unicast/a \
+  neighbor NODE0_IP route-map IPV6GLOBAL in\n  neighbor NODE1_IP route-map IPV6GLOBAL in\n  neighbor NODE2_IP route-map IPV6GLOBAL in' dev-env/bgp/frr/bgpd.conf.tmpl
+    printf "route-map IPV6GLOBAL permit 10\n set ipv6 next-hop prefer-global" >> dev-env/bgp/frr/bgpd.conf.tmpl
+  fi
+  pip install -r dev-env/requirements.txt
+
+  local ip_family ipv6_network
+  if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
+    ip_family="dual"
+    ipv6_network="--ipv6 --subnet=${METALLB_CLIENT_NET_SUBNET_IPV6}"
+  elif  [ "$KIND_IPV6_SUPPORT" == true ]; then
+    ip_family="ipv6"
+    ipv6_network="--ipv6 --subnet=${METALLB_CLIENT_NET_SUBNET_IPV6}"
+  else
+    ip_family="ipv4"
+    ipv6_network=""
+  fi
+  # Override GOBIN until https://github.com/metallb/metallb/issues/2218 is fixed.
+  GOBIN="" inv dev-env -n ovn -b frr -p bgp -i "${ip_family}"
+
+  docker network create --subnet="${METALLB_CLIENT_NET_SUBNET_IPV4}" ${ipv6_network} --driver bridge clientnet
+  docker network connect clientnet frr
+  if  [ "$KIND_IPV6_SUPPORT" == true ]; then
+    # Enable IPv6 forwarding in FRR
+    docker exec frr sysctl -w net.ipv6.conf.all.forwarding=1
+  fi
+  docker run  --cap-add NET_ADMIN --user 0  -d --network clientnet  --rm  --name lbclient  quay.io/itssurya/dev-images:metallb-lbservice
+  popd
+  delete_metallb_dir
+
+  # The metallb commit https://github.com/metallb/metallb/commit/1a8e52c393d40efd17f28491616f6f9f7790a522
+  # removes control plane node from acting as a bgp speaker for service routes.
+  # Hence remove node.kubernetes.io/exclude-from-external-load-balancers label from control-plane nodes
+  # so that they are also available for advertising bgp routes which are needed for ovnkube's service
+  # specific e2e tests.
+  MASTER_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}" | sort | head -n "${KIND_NUM_MASTER}")
+  for n in $MASTER_NODES; do
+    kubectl label node "$n" node.kubernetes.io/exclude-from-external-load-balancers-
+  done
+
+  kind_network_v4=$(docker inspect -f '{{index .NetworkSettings.Networks "kind" "IPAddress"}}' frr)
+  echo "FRR kind network IPv4: ${kind_network_v4}"
+  kind_network_v6=$(docker inspect -f '{{index .NetworkSettings.Networks "kind" "GlobalIPv6Address"}}' frr)
+  echo "FRR kind network IPv6: ${kind_network_v6}"
+  local client_network_v4 client_network_v6
+  client_network_v4=$(docker inspect -f '{{index .NetworkSettings.Networks "clientnet" "IPAddress"}}' frr)
+  echo "FRR client network IPv4: ${client_network_v4}"
+  client_network_v6=$(docker inspect -f '{{index .NetworkSettings.Networks "clientnet" "GlobalIPv6Address"}}' frr)
+  echo "FRR client network IPv6: ${client_network_v6}"
+
+  local client_subnets
+  client_subnets=$(docker network inspect clientnet -f '{{range .IPAM.Config}}{{.Subnet}}#{{end}}')
+  echo "${client_subnets}"
+  local client_subnets_v4 client_subnets_v6
+  client_subnets_v4=$(echo "${client_subnets}" | cut -d '#' -f 1)
+  echo "client subnet IPv4: ${client_subnets_v4}"
+  client_subnets_v6=$(echo "${client_subnets}" | cut -d '#' -f 2)
+  echo "client subnet IPv6: ${client_subnets_v6}"
+
+  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
+  for n in ${KIND_NODES}; do
+    if [ "$KIND_IPV4_SUPPORT" == true ]; then
+        docker exec "${n}" ip route add "${client_subnets_v4}" via "${kind_network_v4}"
+    fi
+    if [ "$KIND_IPV6_SUPPORT" == true ]; then
+        docker exec "${n}" ip -6 route add "${client_subnets_v6}" via "${kind_network_v6}"
+    fi
+  done
+
+  # for now, we only run one test with metalLB load balancer for which this
+  # one svcVIP (192.168.10.0/fc00:f853:ccd:e799::) is more than enough since at a time we will only
+  # have one load balancer service
+  if [ "$KIND_IPV4_SUPPORT" == true ]; then
+    docker exec lbclient ip route add 192.168.10.0 via "${client_network_v4}" dev eth0
+  fi
+  if [ "$KIND_IPV6_SUPPORT" == true ]; then
+    docker exec lbclient ip -6 route add fc00:f853:ccd:e799:: via "${client_network_v6}" dev eth0
+  fi
+  sleep 30
+}
+
+install_plugins() {
+  git clone https://github.com/containernetworking/plugins.git
+  pushd plugins
+  CGO_ENABLED=0 ./build_linux.sh
+  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
+  # Opted for not overwritting the existing plugins
+  for node in $KIND_NODES; do
+    for plugin in bandwidth bridge dhcp dummy firewall host-device ipvlan macvlan sbr static tuning vlan vrf; do
+      $OCI_BIN cp ./bin/$plugin $node:/opt/cni/bin/
+    done
+  done
+  popd
+  rm -rf plugins
+}
+
+destroy_metallb() {
+  if docker ps --format '{{.Names}}' | grep -Eq '^lbclient$'; then
+      docker stop lbclient
+  fi
+  if docker ps --format '{{.Names}}' | grep -Eq '^frr$'; then
+      docker stop frr
+  fi
+  if docker network ls --format '{{.Name}}' | grep -q '^clientnet$'; then
+      docker network rm clientnet
+  fi
+  delete_metallb_dir
+}
+
+delete_metallb_dir() {
+  if ! [ -d "${METALLB_DIR}" ]; then
+      return
+  fi
+
+  # The build directory will contain read only directories after building. Files cannot be deleted, even by the owner.
+  # Therefore, set all dirs to u+rwx.
+  find "${METALLB_DIR}" -type d -exec chmod u+rwx "{}" \;
+  rm -rf "${METALLB_DIR}"
+}
+
+# kubectl_wait_pods will set a total timeout of 300s for IPv4 and 480s for IPv6. It will first wait for all
+# DaemonSets to complete with kubectl rollout. This command will block until all pods of the DS are actually up.
+# Next, it iterates over all pods with name=ovnkube-db and ovnkube-master and waits for them to post "Ready".
+# Last, it will do the same with all pods in the kube-system namespace.
+kubectl_wait_pods() {
+  # IPv6 cluster seems to take a little longer to come up, so extend the wait time.
+  OVN_TIMEOUT=300
+  if [ "$KIND_IPV6_SUPPORT" == true ]; then
+    OVN_TIMEOUT=480
+  fi
+
+  # We will make sure that we timeout all commands at current seconds + the desired timeout.
+  endtime=$(( SECONDS + OVN_TIMEOUT ))
+
+  for ds in ovnkube-node ovs-node; do
+    timeout=$(calculate_timeout ${endtime})
+    echo "Waiting for k8s to launch all ${ds} pods (timeout ${timeout})..."
+    kubectl rollout status daemonset -n ovn-kubernetes ${ds} --timeout ${timeout}s
+  done
+
+  pods=""
+  if [ "$OVN_ENABLE_INTERCONNECT" == true ]; then
+    pods="ovnkube-control-plane"
+  else
+    pods="ovnkube-master ovnkube-db"
+  fi
+  for name in ${pods}; do
+    timeout=$(calculate_timeout ${endtime})
+    echo "Waiting for k8s to create ${name} pods (timeout ${timeout})..."
+    kubectl wait pods -n ovn-kubernetes -l name=${name} --for condition=Ready --timeout=${timeout}s
+  done
+
+  timeout=$(calculate_timeout ${endtime})
+  if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=${timeout}s ; then
+    echo "some pods in the system are not running"
+    kubectl get pods -A -o wide || true
+    exit 1
+  fi
+}
+
+# calculate_timeout takes an absolute endtime in seconds (based on bash script runtime, see
+# variable $SECONDS) and calculates a relative timeout value. Should the calculated timeout
+# be <= 0, return one second.
+calculate_timeout() {
+  endtime=$1
+  timeout=$(( endtime - SECONDS ))
+  if [ ${timeout} -le 0 ]; then
+      timeout=1
+  fi
+  echo ${timeout}
+}
+
+sleep_until_pods_settle() {
+  echo "Pods are all up, allowing things settle for 30 seconds..."
+  sleep 30
+}
+
+function is_nested_virt_enabled() {
+    local kvm_nested="unknown"
+    if [ -f "/sys/module/kvm_intel/parameters/nested" ]; then
+        kvm_nested=$( cat /sys/module/kvm_intel/parameters/nested )
+    elif [ -f "/sys/module/kvm_amd/parameters/nested" ]; then
+        kvm_nested=$( cat /sys/module/kvm_amd/parameters/nested )
+    fi
+    [ "$kvm_nested" == "1" ] || [ "$kvm_nested" == "Y" ] || [ "$kvm_nested" == "y" ]
+}
+
+function install_kubevirt() {
+    local kubevirt_version="$(curl -L https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)"
+    for node in $(kubectl get node --no-headers  -o custom-columns=":metadata.name"); do
+        $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_watches=1048576' >> /etc/sysctl.conf"
+        $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_instances=512' >> /etc/sysctl.conf"
+        $OCI_BIN exec -i $node bash -c "sysctl -p /etc/sysctl.conf"
+        if [[ "${node}" =~ worker ]]; then
+            kubectl label nodes $node node-role.kubernetes.io/worker="" --overwrite=true
+        fi
+    done
+    local kubevirt_release_url="https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}"
+
+    echo "Deploy latest nighly build Kubevirt"
+    if [ "$(kubectl get kubevirts -n kubevirt kubevirt -ojsonpath='{.status.phase}')" != "Deployed" ]; then
+      kubectl apply -f "${kubevirt_release_url}/kubevirt-operator.yaml"
+      kubectl apply -f "${kubevirt_release_url}/kubevirt-cr.yaml"
+      if ! is_nested_virt_enabled; then
+        kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
+      fi
+      kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"virtualMachineOptions":{"disableSerialConsoleLog":{}}}}}'
+    fi
+    if ! kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m; then
+        kubectl get pod -n kubevirt -l || true
+        kubectl describe pod -n kubevirt -l || true
+        for p in $(kubectl get pod -n kubevirt -l -o name |sed "s#pod/##"); do
+            kubectl logs -p --all-containers=true -n kubevirt $p || true
+            kubectl logs --all-containers=true -n kubevirt $p || true
+        done
+    fi
+    
+    if [ ! -d "./bin" ]
+    then
+        mkdir -p ./bin
+        if_error_exit "Failed to create bin dir!"
+    fi
+
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        OS_TYPE="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        OS_TYPE="darwin"
+    fi
+
+    pushd ./bin
+       if [ ! -f ./virtctl ]; then
+           cli_name="virtctl-${kubevirt_version}-${OS_TYPE}-${ARCH}"
+           curl -LO "${kubevirt_release_url}/${cli_name}"
+           mv ${cli_name} virtctl
+           if_error_exit "Failed to download virtctl!"
+       fi
+    popd
+
+    chmod +x ./bin/virtctl
+}

--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -14,7 +14,7 @@ case $(uname -m) in
     aarch64) ARCH="arm64"   ;;
 esac
 
-function if_error_exit {
+if_error_exit() {
     ###########################################################################
     # Description:                                                            #
     # Validate if previous command failed and show an error msg (if provided) #
@@ -157,6 +157,7 @@ install_metallb() {
     # Enable IPv6 forwarding in FRR
     docker exec frr sysctl -w net.ipv6.conf.all.forwarding=1
   fi
+  # Note: this image let's us use it also for creating load balancer backends that can send big packets
   docker run  --cap-add NET_ADMIN --user 0  -d --network clientnet  --rm  --name lbclient  quay.io/itssurya/dev-images:metallb-lbservice
   popd
   delete_metallb_dir
@@ -308,7 +309,7 @@ sleep_until_pods_settle() {
   sleep 30
 }
 
-function is_nested_virt_enabled() {
+is_nested_virt_enabled() {
     local kvm_nested="unknown"
     if [ -f "/sys/module/kvm_intel/parameters/nested" ]; then
         kvm_nested=$( cat /sys/module/kvm_intel/parameters/nested )
@@ -318,7 +319,7 @@ function is_nested_virt_enabled() {
     [ "$kvm_nested" == "1" ] || [ "$kvm_nested" == "Y" ] || [ "$kvm_nested" == "y" ]
 }
 
-function install_kubevirt() {
+install_kubevirt() {
     local kubevirt_version="$(curl -L https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)"
     for node in $(kubectl get node --no-headers  -o custom-columns=":metadata.name"); do
         $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_watches=1048576' >> /etc/sysctl.conf"

--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -1,6 +1,10 @@
 if [ "${BASH_SOURCE[0]}" -ef "$0" ]
 then
-    >&2 echo 'Please source this script, not execute it!'
+    >&2 echo 'This file contains bash helper functions that are common to'
+    >&2 echo 'kind.sh and kind-helm.sh scripts and is meant to be sourced'
+    >&2 echo 'by them upon invocation. In other words, it is not useful'
+    >&2 echo 'when executed as a standalone script.'
+    >&2 echo 'Please source this script, do not execute it!'
     exit 1
 fi
 

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -275,6 +275,7 @@ create_ovn_kubernetes() {
         --set ovnkube-master.replicas=${MASTER_REPLICAS} \
         --set global.image.repository=$(get_image) \
         --set global.image.tag=$(get_tag) \
+        --set global.enableAdminNetworkPolicy=true \
         --set global.enableMulticast=$(if [ "${OVN_MULTICAST_ENABLE}" == "true" ]; then echo "true"; else echo "false"; fi) \
         --set global.enableHybridOverlay=$(if [ "${OVN_HYBRID_OVERLAY_ENABLE}" == "true" ]; then echo "true"; else echo "false"; fi) \
         --set global.emptyLbEvents=$(if [ "${OVN_EMPTY_LB_EVENTS}" == "true" ]; then echo "true"; else echo "false"; fi) \

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -2,10 +2,21 @@
 
 set -exo pipefail
 
-export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Returns the full directory name of the script
+export DIR="$( cd -- "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+export OCI_BIN=${KIND_EXPERIMENTAL_PROVIDER:-docker}
+
+# Source the kind-common file from the same directory where this script is located
+source "${DIR}/kind-common"
 
 set_default_params() {
+
   # Set default values
+  export KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS:-false}
+  export KIND_INSTALL_METALLB=${KIND_INSTALL_METALLB:-false}
+  export KIND_INSTALL_PLUGINS=${KIND_INSTALL_PLUGINS:-false}
+  export KIND_INSTALL_KUBEVIRT=${KIND_INSTALL_KUBEVIRT:-false}
   export OVN_HA=${OVN_HA:-false}
   export OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
   export OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
@@ -17,26 +28,62 @@ set_default_params() {
 
   # Setup KUBECONFIG patch based on cluster-name
   export KUBECONFIG=${KUBECONFIG:-${HOME}/${KIND_CLUSTER_NAME}.conf}
+
+  # Input not currently validated. Modify outside script at your own risk.
+  # These are the same values defaulted to in KIND code (kind/default.go).
+  # NOTE: KIND NET_CIDR_IPV6 default use a /64 but OVN have a /64 per host
+  # so it needs to use a larger subnet
+  #  Upstream - NET_CIDR_IPV6=fd00:10:244::/64 SVC_CIDR_IPV6=fd00:10:96::/112
+  export NET_CIDR_IPV4=${NET_CIDR_IPV4:-10.244.0.0/16}
+  export NET_SECOND_CIDR_IPV4=${NET_SECOND_CIDR_IPV4:-172.19.0.0/16}
+  export SVC_CIDR_IPV4=${SVC_CIDR_IPV4:-10.96.0.0/16}
+  export NET_CIDR_IPV6=${NET_CIDR_IPV6:-fd00:10:244::/48}
+  export SVC_CIDR_IPV6=${SVC_CIDR_IPV6:-fd00:10:96::/112}
+  export JOIN_SUBNET_IPV4=${JOIN_SUBNET_IPV4:-100.64.0.0/16}
+  export JOIN_SUBNET_IPV6=${JOIN_SUBNET_IPV6:-fd98::/64}
+  export MASQUERADE_SUBNET_IPV4=${MASQUERADE_SUBNET_IPV4:-169.254.169.0/29}
+  export MASQUERADE_SUBNET_IPV6=${MASQUERADE_SUBNET_IPV6:-fd69::/125}
+  export TRANSIT_SWITCH_SUBNET_IPV4=${TRANSIT_SWITCH_SUBNET_IPV4:-100.88.0.0/16}
+  export TRANSIT_SWITCH_SUBNET_IPV6=${TRANSIT_SWITCH_SUBNET_IPV6:-fd97::/64}
+  export METALLB_CLIENT_NET_SUBNET_IPV4=${METALLB_CLIENT_NET_SUBNET_IPV4:-172.22.0.0/16}
+  export METALLB_CLIENT_NET_SUBNET_IPV6=${METALLB_CLIENT_NET_SUBNET_IPV6:-fc00:f853:ccd:e792::/64}
+
+  export KIND_NUM_MASTER=1
+  if [ "$OVN_HA" == true ]; then
+    KIND_NUM_MASTER=3
+  fi
+
+  # Hard code ipv4 support until IPv6 is implemented
+  export KIND_IPV4_SUPPORT=true
 }
 
 usage() {
     echo "usage: kind-helm.sh [--delete]"
-    echo "       [ -kt | --keep-taint ]"
-    echo "       [ -ha | --ha-enabled ]"
-    echo "       [ -me | --multicast-enabled ]"
-    echo "       [ -ho | --hybrid-enabled ]"
-    echo "       [ -el | --ovn-empty-lb-events ]"
-    echo "       [ -wk | --num-workers <num> ]"
-    echo "       [ -cn | --cluster-name ]"
+    echo "       [ -kt  | --keep-taint ]"
+    echo "       [ -ha  | --ha-enabled ]"
+    echo "       [ -me  | --multicast-enabled ]"
+    echo "       [ -ho  | --hybrid-enabled ]"
+    echo "       [ -el  | --ovn-empty-lb-events ]"
+    echo "       [ -ii  | --install-ingress ]"
+    echo "       [ -mlb | --install-metallb ]"
+    echo "       [ -pl  | --install-cni-plugins ]"
+    echo "       [ -ikv | --install-kubevirt ]"
+    echo "       [ -wk  | --num-workers <num> ]"
+    echo "       [ -cn  | --cluster-name ]"
     echo "       [ -h ]"
     echo ""
     echo "--delete                            Delete current cluster"
     echo "-kt  | --keep-taint                 Do not remove taint components"
     echo "                                    DEFAULT: Remove taint components"
-    echo "-ha  | --ha-enabled                 Enable high availability. DEFAULT: HA Disabled"
     echo "-me  | --multicast-enabled          Enable multicast. DEFAULT: Disabled"
     echo "-ho  | --hybrid-enabled             Enable hybrid overlay. DEFAULT: Disabled"
     echo "-el  | --ovn-empty-lb-events        Enable empty-lb-events generation for LB without backends. DEFAULT: Disabled"
+    echo "-ii  | --install-ingress            Flag to install Ingress Components."
+    echo "                                    DEFAULT: Don't install ingress components."
+    echo "-mlb | --install-metallb            Install metallb to test service type LoadBalancer deployments"
+    echo "-pl  | --install-cni-plugins        Install CNI plugins"
+    echo "-ikv | --install-kubevirt           Install kubevirt"
+    echo "-ha  | --ha-enabled                 Enable high availability. DEFAULT: HA Disabled"
     echo "-wk  | --num-workers                Number of worker nodes. DEFAULT: 2 workers"
     echo "-cn  | --cluster-name               Configure the kind cluster's name"
     echo ""
@@ -49,13 +96,24 @@ parse_args() {
             --delete )                          delete
                                                 exit
                                                 ;;
-            -ha | --ha-enabled )                OVN_HA=true
+            -kt | --keep-taint )                KIND_REMOVE_TAINT=false
                                                 ;;
             -me | --multicast-enabled)          OVN_MULTICAST_ENABLE=true
                                                 ;;
             -ho | --hybrid-enabled )            OVN_HYBRID_OVERLAY_ENABLE=true
                                                 ;;
-            -kt | --keep-taint )                KIND_REMOVE_TAINT=false
+            -el | --ovn-empty-lb-events )       OVN_EMPTY_LB_EVENTS=true
+                                                ;;
+            -ii | --install-ingress )           KIND_INSTALL_INGRESS=true
+                                                ;;
+            -mlb | --install-metallb )          KIND_INSTALL_METALLB=true
+                                                ;;
+            -pl | --install-cni-plugins )       KIND_INSTALL_PLUGINS=true
+                                                ;;
+            -ikv | --install-kubevirt)          KIND_INSTALL_KUBEVIRT=true
+                                                ;;
+            -ha | --ha-enabled )                OVN_HA=true
+                                                KIND_NUM_MASTER=3
                                                 ;;
             -wk | --num-workers )               shift
                                                 if ! [[ "$1" =~ ^[0-9]+$ ]]; then
@@ -70,8 +128,6 @@ parse_args() {
                                                 # Setup KUBECONFIG
                                                 set_default_params
                                                 ;;
-            -el | --ovn-empty-lb-events )       OVN_EMPTY_LB_EVENTS=true
-                                                ;;
             * )                                 usage
                                                 exit 1
         esac
@@ -83,6 +139,10 @@ print_params() {
      echo "Using these parameters to deploy KIND + helm"
      echo ""
      echo "KUBECONFIG = $KUBECONFIG"
+     echo "KIND_INSTALL_INGRESS = $KIND_INSTALL_INGRESS"
+     echo "KIND_INSTALL_METALLB = $KIND_INSTALL_METALLB"
+     echo "KIND_INSTALL_PLUGINS = $KIND_INSTALL_PLUGINS"
+     echo "KIND_INSTALL_KUBEVIRT = $KIND_INSTALL_KUBEVIRT"
      echo "OVN_HA = $OVN_HA"
      echo "OVN_MULTICAST_ENABLE = $OVN_MULTICAST_ENABLE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
@@ -90,17 +150,13 @@ print_params() {
      echo "KIND_CLUSTER_NAME = $KIND_CLUSTER_NAME"
      echo "KIND_REMOVE_TAINT = $KIND_REMOVE_TAINT"
      echo "OVN_IMAGE = $OVN_IMAGE"
+     echo "KIND_NUM_MASTER = $KIND_NUM_MASTER"
      echo "KIND_NUM_WORKER = $KIND_NUM_WORKER"
      echo ""
 }
 
-command_exists() {
-  cmd="$1"
-  command -v ${cmd} >/dev/null 2>&1
-}
-
 check_dependencies() {
-    for cmd in docker kubectl kind helm go ; do \
+    for cmd in $OCI_BIN kubectl kind helm go ; do \
          if ! command_exists $cmd ; then
            2&>1 echo "Dependency not met: $cmd"
            exit 1
@@ -108,8 +164,8 @@ check_dependencies() {
     done
 
     # check for currently unsupported features
-    [ "${KIND_INSTALL_METALLB}" == "true" ] && { &>1 echo "Fatal: KIND_INSTALL_METALLB support not implemented yet"; exit 1; } ||:
     [ "${KIND_IPV6_SUPPORT}" == "true" ] && { &>1 echo "Fatal: KIND_IPV6_SUPPORT support not implemented yet"; exit 1; } ||:
+    [ "${OVN_ENABLE_INTERCONNECT}" == "true" ] && { &>1 echo "Fatal: OVN_ENABLE_INTERCONNECT support not implemented yet"; exit 1; } ||:
 }
 
 helm_prereqs() {
@@ -119,21 +175,6 @@ helm_prereqs() {
     sudo sysctl fs.inotify.max_user_instances=512
 }
 
-docker_disable_ipv6() {
-  # Docker disables IPv6 globally inside containers except in the eth0 interface.
-  # Kind enables IPv6 globally the containers ONLY for dual-stack and IPv6 deployments.
-  # Ovnkube-node tries to move all global addresses from the gateway interface to the
-  # bridge interface it creates. This breaks on KIND with IPv4 only deployments, because the new
-  # internal bridge has IPv6 disable and can't move the IPv6 from the eth0 interface.
-  # We can enable IPv6 always in the container, since the docker setup with IPv4 only
-  # is not very common.
-  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}" | grep -v external-load-balancer)
-  for n in $KIND_NODES; do
-    docker exec "$n" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
-    docker exec "$n" sysctl --ignore net.ipv6.conf.all.forwarding=1
-  done
-}
-
 build_ovn_image() {
     if [ "${SKIP_OVN_IMAGE_REBUILD}" == "true" ]; then
       echo "Explicitly instructed not to rebuild ovn image: ${OVN_IMAGE}"
@@ -141,16 +182,16 @@ build_ovn_image() {
     fi
 
     # Build ovn image
-    pushd ${SCRIPT_DIR}/../go-controller
+    pushd ${DIR}/../go-controller
     make
     popd
 
     # Build ovn kube image
-    pushd ${SCRIPT_DIR}/../dist/images
+    pushd ${DIR}/../dist/images
     # Find all built executables, but ignore the 'windows' directory if it exists
     find ../../go-controller/_output/go/bin/ -maxdepth 1 -type f -exec cp -f {} . \;
     echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
-    docker build -t "${OVN_IMAGE}" -f Dockerfile.fedora .
+    $OCI_BIN build -t "${OVN_IMAGE}" -f Dockerfile.fedora .
     popd
 }
 
@@ -164,40 +205,6 @@ get_tag() {
     local image_and_tag="${1:-$OVN_IMAGE}"  # Use $1 if provided, otherwise use $OVN_IMAGE
     local tag="${image_and_tag##*:}"  # Extract everything after the last colon
     echo "$tag"
-}
-
-coredns_patch() {
-  dns_server="8.8.8.8"
-  # No need for ipv6 nameserver for dual stack, it will ask for
-  # A and AAAA records
-  if [ "$IP_FAMILY" == "ipv6" ]; then
-    dns_server="2001:4860:4860::8888"
-  fi
-
-  # Patch CoreDNS to work
-  # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
-  # to work in an offline environment:
-  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
-  # 2. Github CI adds following domains to resolv.conf search field:
-  # .net.
-  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
-  # otherwise pods stops trying to resolve the domain.
-  # Get the current config
-  original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
-  echo "Original CoreDNS config:"
-  echo "${original_coredns}"
-  # Patch it
-  fixed_coredns=$(
-    printf '%s' "${original_coredns}" | sed \
-      -e 's/^.*kubernetes cluster\.local/& net/' \
-      -e '/^.*upstream$/d' \
-      -e '/^.*fallthrough.*$/d' \
-      -e 's/^\(.*forward \.\).*$/\1 '"$dns_server"' {/' \
-      -e '/^.*loop$/d' \
-  )
-  echo "Patched CoreDNS config:"
-  echo "${fixed_coredns}"
-  printf '%s' "${fixed_coredns}" | kubectl apply -f -
 }
 
 create_kind_cluster() {
@@ -257,12 +264,13 @@ EOT
 }
 
 create_ovn_kubernetes() {
-    cd ${SCRIPT_DIR}/../helm/ovn-kubernetes
+    cd ${DIR}/../helm/ovn-kubernetes
 
     MASTER_REPLICAS=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l)
     helm install ovn-kubernetes . -f values.yaml \
-        --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" \
-	--set serviceNetwork=10.96.0.0/16 \
+        --set k8sAPIServer=${API_URL} \
+        --set podNetwork="${NET_CIDR_IPV4}/24" \
+        --set serviceNetwork=${SVC_CIDR_IPV4} \
         --set ovnkube-identity.replicas=${MASTER_REPLICAS} \
         --set ovnkube-master.replicas=${MASTER_REPLICAS} \
         --set global.image.repository=$(get_image) \
@@ -275,116 +283,17 @@ create_ovn_kubernetes() {
 }
 
 delete() {
+  if [ "$KIND_INSTALL_METALLB" == true ]; then
+    destroy_metallb
+  fi
   helm uninstall ovn-kubernetes && sleep 5 ||:
   kind delete cluster --name "${KIND_CLUSTER_NAME:-ovn}"
-}
-
-coredns_patch() {
-  dns_server="8.8.8.8"
-  # No need for ipv6 nameserver for dual stack, it will ask for 
-  # A and AAAA records
-  if [ "$IP_FAMILY" == "ipv6" ]; then
-    dns_server="2001:4860:4860::8888"
-  fi
-
-  # Patch CoreDNS to work
-  # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
-  # to work in an offline environment:
-  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
-  # 2. Github CI adds following domains to resolv.conf search field:
-  # .net.
-  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
-  # otherwise pods stops trying to resolve the domain.
-  # Get the current config
-  original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
-  echo "Original CoreDNS config:"
-  echo "${original_coredns}"
-  # Patch it
-  fixed_coredns=$(
-    printf '%s' "${original_coredns}" | sed \
-      -e 's/^.*kubernetes cluster\.local/& net/' \
-      -e '/^.*upstream$/d' \
-      -e '/^.*fallthrough.*$/d' \
-      -e 's/^\(.*forward \.\).*$/\1 '"$dns_server"' {/' \
-      -e '/^.*loop$/d' \
-  )
-  echo "Patched CoreDNS config:"
-  echo "${fixed_coredns}"
-  printf '%s' "${fixed_coredns}" | kubectl apply -f -
-}
-
-# kubectl_wait_pods will set a total timeout of 300s for IPv4 and 480s for IPv6. It will first wait for all
-# DaemonSets to complete with kubectl rollout. This command will block until all pods of the DS are actually up.
-# Next, it iterates over all pods in ovn-kubernetes namespace and waits for them to post "Ready".
-# Last, it will do the same with all pods in the kube-system namespace.
-kubectl_wait_pods() {
-  local OVN_TIMEOUT=300
-
-  # We will make sure that we timeout all commands at current seconds + the desired timeout.
-  endtime=$(( SECONDS + OVN_TIMEOUT ))
-
-  dss=$(kubectl -n ovn-kubernetes get daemonset --no-headers --sort-by=.metadata.name -o jsonpath='{.items[*].metadata.name}')
-  for ds in ${dss}; do
-    timeout=$(calculate_timeout ${endtime})
-    echo "Waiting for k8s to launch all ${ds} pods (timeout ${timeout})..."
-    kubectl rollout status daemonset -n ovn-kubernetes ${ds} --timeout ${timeout}s
-  done
-
-  pods=$(kubectl -n ovn-kubernetes get pod --no-headers --sort-by=.metadata.name -o jsonpath='{.items[*].metadata.name}')
-  for pod in ${pods}; do
-    timeout=$(calculate_timeout ${endtime})
-    echo "Waiting for k8s to create pod ${pod} (timeout ${timeout})..."
-    if ! kubectl wait pod ${pod} -n ovn-kubernetes --for condition=Ready --timeout=${timeout}s ; then
-        >&2 echo "pod $pod in the ovn-kubernetes namespace is not ready after time out"
-        kubectl get pods -A -o wide || true
-        exit 1
-    fi
-  done
-
-  timeout=$(calculate_timeout ${endtime})
-  if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=${timeout}s ; then
-    >&2 echo "some pods in the system are not running"
-    kubectl get pods -A -o wide || true
-    exit 1
-  fi
-}
-
-# calculate_timeout takes an absolute endtime in seconds (based on bash script runtime, see
-# variable $SECONDS) and calculates a relative timeout value. Should the calculated timeout
-# be <= 0, return one second.
-calculate_timeout() {
-  endtime=$1
-  timeout=$(( endtime - SECONDS ))
-  if [ ${timeout} -le 0 ]; then
-      timeout=1
-  fi
-  echo ${timeout}
 }
 
 install_online_ovn_kubernetes_crds() {
   # NOTE: When you update vendoring versions for the ANP & BANP APIs, we must update the version of the CRD we pull from in the below URL
   run_kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
   run_kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
-}
-
-# Copied from kind.sh
-# TODO: we should have a common file for common functions without duplicating them
-run_kubectl() {
-  local retries=0
-  local attempts=10
-  while true; do
-    if kubectl "$@"; then
-      break
-    fi
-
-    ((retries += 1))
-    if [[ "${retries}" -gt ${attempts} ]]; then
-      echo "error: 'kubectl $*' did not succeed, failing"
-      exit 1
-    fi
-    echo "info: waiting for 'kubectl $*' to succeed..."
-    sleep 1
-  done
 }
 
 check_dependencies
@@ -394,8 +303,25 @@ parse_args "$@"
 helm_prereqs
 build_ovn_image
 create_kind_cluster
+detect_apiserver_url
 docker_disable_ipv6
 coredns_patch
 create_ovn_kubernetes
+
 install_online_ovn_kubernetes_crds
+if [ "$KIND_INSTALL_INGRESS" == true ]; then
+  install_ingress
+fi
+
 kubectl_wait_pods
+sleep_until_pods_settle
+
+if [ "$KIND_INSTALL_METALLB" == true ]; then
+  install_metallb
+fi
+if [ "$KIND_INSTALL_PLUGINS" == true ]; then
+  install_plugins
+fi
+if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
+  install_kubevirt
+fi

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -2,29 +2,9 @@
 
 # Returns the full directory name of the script
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ARCH=""
-case $(uname -m) in
-    x86_64)  ARCH="amd64" ;;
-    aarch64) ARCH="arm64"   ;;
-esac
 
-function if_error_exit {
-    ###########################################################################
-    # Description:                                                            #
-    # Validate if previous command failed and show an error msg (if provided) #
-    #                                                                         #
-    # Arguments:                                                              #
-    #   $1 - error message if not provided, it will just exit                 #
-    ###########################################################################
-    if [ "$?" != "0" ]; then
-        if [ -n "$1" ]; then
-            RED="\e[31m"
-            ENDCOLOR="\e[0m"
-            echo -e "[ ${RED}FAILED${ENDCOLOR} ] ${1}"
-        fi
-        exit 1
-    fi
-}
+# Source the kind-common file from the same directory where this script is located
+source "${DIR}/kind-common"
 
 function setup_kubectl_bin() {
     ###########################################################################
@@ -55,24 +35,6 @@ function setup_kubectl_bin() {
 
     chmod +x ./bin/kubectl
     export PATH=${PATH}:$(pwd)/bin
-}
-
-run_kubectl() {
-  local retries=0
-  local attempts=10
-  while true; do
-    if kubectl "$@"; then
-      break
-    fi
-
-    ((retries += 1))
-    if [[ "${retries}" -gt ${attempts} ]]; then
-      echo "error: 'kubectl $*' did not succeed, failing"
-      exit 1
-    fi
-    echo "info: waiting for 'kubectl $*' to succeed..."
-    sleep 1
-  done
 }
 
 # Some environments (Fedora32,31 on desktop), have problems when the cluster
@@ -443,11 +405,6 @@ print_params() {
      echo ""
 }
 
-command_exists() {
-  cmd="$1"
-  command -v ${cmd} >/dev/null 2>&1
-}
-
 install_jinjanator_renderer() {
   # ensure jinjanator renderer installed
   pip install wheel --user
@@ -639,17 +596,6 @@ set_default_params() {
   OVN_MTU=${OVN_MTU:-1400}
 }
 
-detect_apiserver_url() {
-  # Detect API_URL used for in-cluster communication
-  #
-  # Despite OVN run in pod they will only obtain the VIRTUAL apiserver address
-  # and since OVN has to provide the connectivity to service
-  # it can not be bootstrapped
-  #
-  # This is the address of the node with the control-plane
-  API_URL=$(kind get kubeconfig --internal --name "${KIND_CLUSTER_NAME}" | grep server | awk '{ print $2 }')
-}
-
 check_ipv6() {
   if [ "$KIND_IPV6_SUPPORT" == true ]; then
     # Collect additional IPv6 data on test environment
@@ -788,57 +734,6 @@ create_kind_cluster() {
   kind create cluster --name "${KIND_CLUSTER_NAME}" --kubeconfig "${KUBECONFIG}" --image "${KIND_IMAGE}":"${K8S_VERSION}" --config=${KIND_CONFIG_LCL} --retain
 
   cat "${KUBECONFIG}"
-}
-
-
-
-docker_disable_ipv6() {
-  # Docker disables IPv6 globally inside containers except in the eth0 interface.
-  # Kind enables IPv6 globally the containers ONLY for dual-stack and IPv6 deployments.
-  # Ovnkube-node tries to move all global addresses from the gateway interface to the
-  # bridge interface it creates. This breaks on KIND with IPv4 only deployments, because the new
-  # internal bridge has IPv6 disable and can't move the IPv6 from the eth0 interface.
-  # We can enable IPv6 always in the container, since the docker setup with IPv4 only
-  # is not very common.
-  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
-  for n in $KIND_NODES; do
-    $OCI_BIN exec "$n" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
-    $OCI_BIN exec "$n" sysctl --ignore net.ipv6.conf.all.forwarding=1
-  done
-}
-
-coredns_patch() {
-  dns_server="8.8.8.8"
-  # No need for ipv6 nameserver for dual stack, it will ask for 
-  # A and AAAA records
-  if [ "$IP_FAMILY" == "ipv6" ]; then
-    dns_server="2001:4860:4860::8888"
-  fi
-
-  # Patch CoreDNS to work
-  # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
-  # to work in an offline environment:
-  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
-  # 2. Github CI adds following domains to resolv.conf search field:
-  # .net.
-  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
-  # otherwise pods stops trying to resolve the domain.
-  # Get the current config
-  original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
-  echo "Original CoreDNS config:"
-  echo "${original_coredns}"
-  # Patch it
-  fixed_coredns=$(
-    printf '%s' "${original_coredns}" | sed \
-      -e 's/^.*kubernetes cluster\.local/& net/' \
-      -e '/^.*upstream$/d' \
-      -e '/^.*fallthrough.*$/d' \
-      -e 's/^\(.*forward \.\).*$/\1 '"$dns_server"' {/' \
-      -e '/^.*loop$/d' \
-  )
-  echo "Patched CoreDNS config:"
-  echo "${fixed_coredns}"
-  printf '%s' "${fixed_coredns}" | kubectl apply -f -
 }
 
 set_ovn_image() {
@@ -1079,142 +974,6 @@ install_ovn() {
   fi
 }
 
-install_ingress() {
-  run_kubectl apply -f "${DIR}/ingress/mandatory.yaml"
-  run_kubectl apply -f "${DIR}/ingress/service-nodeport.yaml"
-}
-
-METALLB_DIR="/tmp/metallb"
-install_metallb() {
-  mkdir -p /tmp/metallb
-  local builddir
-  builddir=$(mktemp -d "${METALLB_DIR}/XXXXXX")
-
-  pushd "${builddir}"
-  git clone https://github.com/metallb/metallb.git
-  cd metallb
-  # Use global IP next hops in IPv6
-  if  [ "$KIND_IPV6_SUPPORT" == true ]; then
-    sed -i '/address-family PROTOCOL unicast/a \
-  neighbor NODE0_IP route-map IPV6GLOBAL in\n  neighbor NODE1_IP route-map IPV6GLOBAL in\n  neighbor NODE2_IP route-map IPV6GLOBAL in' dev-env/bgp/frr/bgpd.conf.tmpl
-    printf "route-map IPV6GLOBAL permit 10\n set ipv6 next-hop prefer-global" >> dev-env/bgp/frr/bgpd.conf.tmpl
-  fi
-  pip install -r dev-env/requirements.txt
-
-  local ip_family ipv6_network
-  if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
-    ip_family="dual"
-    ipv6_network="--ipv6 --subnet=${METALLB_CLIENT_NET_SUBNET_IPV6}"
-  elif  [ "$KIND_IPV6_SUPPORT" == true ]; then
-    ip_family="ipv6"
-    ipv6_network="--ipv6 --subnet=${METALLB_CLIENT_NET_SUBNET_IPV6}"
-  else
-    ip_family="ipv4"
-    ipv6_network=""
-  fi
-  # Override GOBIN until https://github.com/metallb/metallb/issues/2218 is fixed.
-  GOBIN="" inv dev-env -n ovn -b frr -p bgp -i "${ip_family}"
-
-  docker network create --subnet="${METALLB_CLIENT_NET_SUBNET_IPV4}" ${ipv6_network} --driver bridge clientnet
-  docker network connect clientnet frr
-  if  [ "$KIND_IPV6_SUPPORT" == true ]; then
-    # Enable IPv6 forwarding in FRR
-    docker exec frr sysctl -w net.ipv6.conf.all.forwarding=1
-  fi
-  docker run  --cap-add NET_ADMIN --user 0  -d --network clientnet  --rm  --name lbclient  quay.io/itssurya/dev-images:metallb-lbservice
-  popd
-  delete_metallb_dir
-
-  # The metallb commit https://github.com/metallb/metallb/commit/1a8e52c393d40efd17f28491616f6f9f7790a522
-  # removes control plane node from acting as a bgp speaker for service routes.
-  # Hence remove node.kubernetes.io/exclude-from-external-load-balancers label from control-plane nodes
-  # so that they are also available for advertising bgp routes which are needed for ovnkube's service
-  # specific e2e tests.
-  MASTER_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}" | sort | head -n "${KIND_NUM_MASTER}")
-  for n in $MASTER_NODES; do
-    kubectl label node "$n" node.kubernetes.io/exclude-from-external-load-balancers-
-  done
-
-  kind_network_v4=$(docker inspect -f '{{index .NetworkSettings.Networks "kind" "IPAddress"}}' frr)
-  echo "FRR kind network IPv4: ${kind_network_v4}"
-  kind_network_v6=$(docker inspect -f '{{index .NetworkSettings.Networks "kind" "GlobalIPv6Address"}}' frr)
-  echo "FRR kind network IPv6: ${kind_network_v6}"
-  local client_network_v4 client_network_v6
-  client_network_v4=$(docker inspect -f '{{index .NetworkSettings.Networks "clientnet" "IPAddress"}}' frr)
-  echo "FRR client network IPv4: ${client_network_v4}"
-  client_network_v6=$(docker inspect -f '{{index .NetworkSettings.Networks "clientnet" "GlobalIPv6Address"}}' frr)
-  echo "FRR client network IPv6: ${client_network_v6}"
-
-  local client_subnets
-  client_subnets=$(docker network inspect clientnet -f '{{range .IPAM.Config}}{{.Subnet}}#{{end}}')
-  echo "${client_subnets}"
-  local client_subnets_v4 client_subnets_v6
-  client_subnets_v4=$(echo "${client_subnets}" | cut -d '#' -f 1)
-  echo "client subnet IPv4: ${client_subnets_v4}"
-  client_subnets_v6=$(echo "${client_subnets}" | cut -d '#' -f 2)
-  echo "client subnet IPv6: ${client_subnets_v6}"
-
-  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
-  for n in ${KIND_NODES}; do
-    if [ "$KIND_IPV4_SUPPORT" == true ]; then
-        docker exec "${n}" ip route add "${client_subnets_v4}" via "${kind_network_v4}"
-    fi
-    if [ "$KIND_IPV6_SUPPORT" == true ]; then
-        docker exec "${n}" ip -6 route add "${client_subnets_v6}" via "${kind_network_v6}"
-    fi
-  done
-
-  # for now, we only run one test with metalLB load balancer for which this
-  # one svcVIP (192.168.10.0/fc00:f853:ccd:e799::) is more than enough since at a time we will only
-  # have one load balancer service
-  if [ "$KIND_IPV4_SUPPORT" == true ]; then
-    docker exec lbclient ip route add 192.168.10.0 via "${client_network_v4}" dev eth0
-  fi
-  if [ "$KIND_IPV6_SUPPORT" == true ]; then
-    docker exec lbclient ip -6 route add fc00:f853:ccd:e799:: via "${client_network_v6}" dev eth0
-  fi
-  sleep 30
-}
-
-install_plugins() {
-  git clone https://github.com/containernetworking/plugins.git
-  pushd plugins
-  CGO_ENABLED=0 ./build_linux.sh
-  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
-  # Opted for not overwritting the existing plugins
-  for node in $KIND_NODES; do
-    for plugin in bandwidth bridge dhcp dummy firewall host-device ipvlan macvlan sbr static tuning vlan vrf; do
-      $OCI_BIN cp ./bin/$plugin $node:/opt/cni/bin/
-    done
-  done
-  popd
-  rm -rf plugins
-}
-
-destroy_metallb() {
-  if docker ps --format '{{.Names}}' | grep -Eq '^lbclient$'; then
-      docker stop lbclient
-  fi
-  if docker ps --format '{{.Names}}' | grep -Eq '^frr$'; then
-      docker stop frr
-  fi
-  if docker network ls --format '{{.Name}}' | grep -q '^clientnet$'; then
-      docker network rm clientnet
-  fi
-  delete_metallb_dir
-}
-
-delete_metallb_dir() {
-  if ! [ -d "${METALLB_DIR}" ]; then
-      return
-  fi
-
-  # The build directory will contain read only directories after building. Files cannot be deleted, even by the owner.
-  # Therefore, set all dirs to u+rwx.
-  find "${METALLB_DIR}" -type d -exec chmod u+rwx "{}" \;
-  rm -rf "${METALLB_DIR}"
-}
-
 install_multus() {
   echo "Installing multus-cni daemonset ..."
   multus_manifest="https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset.yml"
@@ -1231,58 +990,6 @@ install_ipamclaim_crd() {
   echo "Installing IPAMClaim CRD ..."
   ipamclaims_manifest="https://raw.githubusercontent.com/k8snetworkplumbingwg/ipamclaims/v0.4.0-alpha/artifacts/k8s.cni.cncf.io_ipamclaims.yaml"
   run_kubectl apply -f "$ipamclaims_manifest"
-}
-
-# kubectl_wait_pods will set a total timeout of 300s for IPv4 and 480s for IPv6. It will first wait for all
-# DaemonSets to complete with kubectl rollout. This command will block until all pods of the DS are actually up.
-# Next, it iterates over all pods with name=ovnkube-db and ovnkube-master and waits for them to post "Ready".
-# Last, it will do the same with all pods in the kube-system namespace.
-kubectl_wait_pods() {
-  # IPv6 cluster seems to take a little longer to come up, so extend the wait time.
-  OVN_TIMEOUT=300
-  if [ "$KIND_IPV6_SUPPORT" == true ]; then
-    OVN_TIMEOUT=480
-  fi
-
-  # We will make sure that we timeout all commands at current seconds + the desired timeout.
-  endtime=$(( SECONDS + OVN_TIMEOUT ))
-
-  for ds in ovnkube-node ovs-node; do
-    timeout=$(calculate_timeout ${endtime})
-    echo "Waiting for k8s to launch all ${ds} pods (timeout ${timeout})..."
-    kubectl rollout status daemonset -n ovn-kubernetes ${ds} --timeout ${timeout}s
-  done
-
-  pods=""
-  if [ "$OVN_ENABLE_INTERCONNECT" == true ]; then
-    pods="ovnkube-control-plane"
-  else
-    pods="ovnkube-master ovnkube-db"
-  fi
-  for name in ${pods}; do
-    timeout=$(calculate_timeout ${endtime})
-    echo "Waiting for k8s to create ${name} pods (timeout ${timeout})..."
-    kubectl wait pods -n ovn-kubernetes -l name=${name} --for condition=Ready --timeout=${timeout}s
-  done
-
-  timeout=$(calculate_timeout ${endtime})
-  if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=${timeout}s ; then
-    echo "some pods in the system are not running"
-    kubectl get pods -A -o wide || true
-    exit 1
-  fi
-}
-
-# calculate_timeout takes an absolute endtime in seconds (based on bash script runtime, see
-# variable $SECONDS) and calculates a relative timeout value. Should the calculated timeout
-# be <= 0, return one second.
-calculate_timeout() {
-  endtime=$1
-  timeout=$(( endtime - SECONDS ))
-  if [ ${timeout} -le 0 ]; then
-      timeout=1
-  fi
-  echo ${timeout}
 }
 
 # install_ipsec will apply the IPsec DaemonSet, create a CA that can be used by the IPsec pods. It will then add it to
@@ -1371,11 +1078,6 @@ docker_create_second_disconnected_interface() {
   done
 }
 
-sleep_until_pods_settle() {
-  echo "Pods are all up, allowing things settle for 30 seconds..."
-  sleep 30
-}
-
 # run_script_in_container should be used when kind.sh is run nested in a container
 # and makes sure the control-plane node is rechable by substituting 127.0.0.1
 # with the control-plane container's IP
@@ -1418,70 +1120,6 @@ add_dns_hostnames() {
   for n in $KIND_NODES; do
 	docker exec $n bash -c "echo  $dns >> /etc/hosts"
   done
-}
-
-function is_nested_virt_enabled() {
-    local kvm_nested="unknown"
-    if [ -f "/sys/module/kvm_intel/parameters/nested" ]; then
-        kvm_nested=$( cat /sys/module/kvm_intel/parameters/nested )
-    elif [ -f "/sys/module/kvm_amd/parameters/nested" ]; then
-        kvm_nested=$( cat /sys/module/kvm_amd/parameters/nested )
-    fi
-    [ "$kvm_nested" == "1" ] || [ "$kvm_nested" == "Y" ] || [ "$kvm_nested" == "y" ]
-}
-
-function install_kubevirt() {
-    local kubevirt_version="$(curl -L https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)"
-    for node in $(kubectl get node --no-headers  -o custom-columns=":metadata.name"); do
-        $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_watches=1048576' >> /etc/sysctl.conf"
-        $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_instances=512' >> /etc/sysctl.conf"
-        $OCI_BIN exec -i $node bash -c "sysctl -p /etc/sysctl.conf"
-        if [[ "${node}" =~ worker ]]; then
-            kubectl label nodes $node node-role.kubernetes.io/worker="" --overwrite=true
-        fi
-    done
-    local kubevirt_release_url="https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}"
-
-    echo "Deploy latest nighly build Kubevirt"
-    if [ "$(kubectl get kubevirts -n kubevirt kubevirt -ojsonpath='{.status.phase}')" != "Deployed" ]; then
-      kubectl apply -f "${kubevirt_release_url}/kubevirt-operator.yaml"
-      kubectl apply -f "${kubevirt_release_url}/kubevirt-cr.yaml"
-      if ! is_nested_virt_enabled; then
-        kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
-      fi
-      kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"virtualMachineOptions":{"disableSerialConsoleLog":{}}}}}'
-    fi
-    if ! kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m; then
-        kubectl get pod -n kubevirt -l || true
-        kubectl describe pod -n kubevirt -l || true
-        for p in $(kubectl get pod -n kubevirt -l -o name |sed "s#pod/##"); do
-            kubectl logs -p --all-containers=true -n kubevirt $p || true
-            kubectl logs --all-containers=true -n kubevirt $p || true
-        done
-    fi
-    
-    if [ ! -d "./bin" ]
-    then
-        mkdir -p ./bin
-        if_error_exit "Failed to create bin dir!"
-    fi
-
-    if [[ "$OSTYPE" == "linux-gnu" ]]; then
-        OS_TYPE="linux"
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        OS_TYPE="darwin"
-    fi
-
-    pushd ./bin
-       if [ ! -f ./virtctl ]; then
-           cli_name="virtctl-${kubevirt_version}-${OS_TYPE}-${ARCH}"
-           curl -LO "${kubevirt_release_url}/${cli_name}"
-           mv ${cli_name} virtctl
-           if_error_exit "Failed to download virtctl!"
-       fi
-    popd
-
-    chmod +x ./bin/virtctl
 }
 
 check_dependencies

--- a/helm/ovn-kubernetes/values.yaml
+++ b/helm/ovn-kubernetes/values.yaml
@@ -13,9 +13,9 @@ tags:
 # -- Endpoint of Kubernetes api server
 k8sAPIServer: https://172.25.0.2:6443
 # -- IP range for Kubernetes pods, /14 is the top level range, under which each /23 range will be assigned to a node
-podNetwork: 10.128.0.0/14/23
+podNetwork: 10.244.0.0/16/24
 # -- A comma-separated set of CIDR notation IP ranges from which k8s assigns service cluster IPs. This should be the same as the value provided for kube-apiserver "--service-cluster-ip-range" option
-serviceNetwork: 172.30.0.0/16
+serviceNetwork: 10.96.0.0/16
 # -- MTU of network interface in a Kubernetes pod
 mtu: 1400
 # -- Whether or not call `lookup` Helm function, set it to `true` if you want to run `helm dry-run/template/lint`
@@ -51,7 +51,7 @@ global:
   # -- A comma separated set of IP subnets and the associated hostsubnetlengths (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\") to use with the extended hybrid network
   hybridOverlayNetCidr: ""
   # -- Whether or not to use Admin Network Policy CRD feature with ovn-kubernetes
-  enableAdminNetworkPolicy: true
+  enableAdminNetworkPolicy: false
   # -- Configure to use EgressIP CRD feature with ovn-kubernetes
   enableEgressIp: true
   # -- Configure EgressIP node reachability using gRPC on this TCP port

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -44,9 +44,6 @@ queries to the hostNetworked server pod on another node shall work for TCP|\
 queries to the hostNetworked server pod on another node shall work for UDP|\
 ipv4 pod"
 
-METALLB_SKIPPED_TESTS="EgressService|\
-Load Balancer Service Tests with MetalLB"
-
 SKIPPED_TESTS=""
 
 if [ "$KIND_IPV4_SUPPORT" == true ]; then
@@ -164,14 +161,6 @@ if [ "${WHAT}" != "${KV_LIVE_MIGRATION_TESTS}" ]; then
 	SKIPPED_TESTS+="|"
   fi
   SKIPPED_TESTS+=$KV_LIVE_MIGRATION_TESTS
-fi
-
-# Skip tests that require metal-lb, if such is not being installed
-if [ "${KIND_INSTALL_METALLB}" == "false" ];then
-  if [ "$SKIPPED_TESTS" != "" ]; then
-	SKIPPED_TESTS+="|"
-  fi
-  SKIPPED_TESTS+=$METALLB_SKIPPED_TESTS
 fi
 
 # setting these is required to make RuntimeClass tests work ... :/


### PR DESCRIPTION
- Move common functions into a single file that both kind.sh and kind-helm.sh can use
- Install metal-lb in when deploying via kind-helm, so e2e egress tests are exercised

Partially fixes https://github.com/ovn-org/ovn-kubernetes/issues/4257 
Will address ovn-ic deployment under helm in a separate PR.
