### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @trozet @dcbw @girishmg @jcaamano @tssurya


### PR DESCRIPTION
This file is used to control who gets assigned as a reviewer to a PR. It can be fine grained paths to different files and folders, but we were just matching on any files and adding all committers as reviewers to every PR. Instead of this, we will try out managing reviewers via github team settings.

