### PR TITLE
EQoS: Set force:true for server-side-apply

### DIFF
--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -1108,6 +1108,6 @@ func (oc *DefaultNetworkController) updateEgressQoSZoneStatusCondition(newCondit
 	applyObj := egressqosapply.EgressQoS(name, namespace).
 		WithStatus(egressqosapply.EgressQoSStatus().WithConditions(newCondition))
 	_, err = oc.kube.EgressQoSClient.K8sV1().EgressQoSes(namespace).ApplyStatus(context.TODO(),
-		applyObj, metav1.ApplyOptions{FieldManager: oc.zone})
+		applyObj, metav1.ApplyOptions{FieldManager: oc.zone, Force: true})
 	return err
 }


### PR DESCRIPTION

**- What this PR does and why is it needed**

Force: true was not set on EQoS status updates in ovnkube-controller
causes conflicts when trying to patch

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
`Use force:true when doing server side apply`