### PR TITLE
OCPBUGS-31679: localnet, multi-homing: introduce localnet alias

### DIFF
--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -50,6 +50,14 @@ type NetConf struct {
 	// restart.
 	AllowPersistentIPs bool `json:"allowPersistentIPs,omitempty"`
 
+	// PhysicalNetworkName indicates the name of the physical network to which
+	// the OVN overlay will connect. Only applies to `localnet` topologies.
+	// When omitted, the physical network name of the network will be the value
+	// of the `name` attribute.
+	// This attribute allows multiple overlays to share the same physical
+	// network mapping in the hosts.
+	PhysicalNetworkName string `json:"physicalNetworkName,omitempty"`
+
 	// PciAddrs in case of using sriov or Auxiliry device name in case of SF
 	DeviceID string `json:"deviceID,omitempty"`
 	// LogFile to log all the messages from cni shim binary to

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -284,9 +284,7 @@ func (oc *SecondaryLocalnetNetworkController) Init() error {
 		Name:      oc.GetNetworkScopedName(types.OVNLocalnetPort),
 		Addresses: []string{"unknown"},
 		Type:      "localnet",
-		Options: map[string]string{
-			"network_name": oc.GetNetworkName(),
-		},
+		Options:   oc.localnetPortNetworkNameOptions(),
 	}
 	intVlanID := int(oc.Vlan())
 	if intVlanID != 0 {
@@ -345,4 +343,14 @@ func (oc *SecondaryLocalnetNetworkController) newRetryFramework(
 		oc.watchFactory,
 		resourceHandler,
 	)
+}
+
+func (oc *SecondaryLocalnetNetworkController) localnetPortNetworkNameOptions() map[string]string {
+	localnetLSPOptions := map[string]string{
+		"network_name": oc.GetNetworkName(),
+	}
+	if oc.PhysicalNetworkName() != "" {
+		localnetLSPOptions["network_name"] = oc.PhysicalNetworkName()
+	}
+	return localnetLSPOptions
 }

--- a/test/e2e/localnet-underlay.go
+++ b/test/e2e/localnet-underlay.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -159,4 +161,49 @@ func bridgeMapping(physnet, ovsBridge string) BridgeMapping {
 		physnet:   physnet,
 		ovsBridge: ovsBridge,
 	}
+}
+
+// TODO: make this function idempotent; use golang netlink instead
+func createVLANInterface(deviceName string, vlanID string, ipAddress *string) error {
+	vlan := vlanName(deviceName, vlanID)
+	cmd := exec.Command("sudo", "ip", "link", "add", "link", deviceName, "name", vlan, "type", "vlan", "id", vlanID)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create vlan interface %s: %v", vlan, err)
+	}
+
+	cmd = exec.Command("sudo", "ip", "link", "set", "dev", vlan, "up")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to enable vlan interface %s: %v", vlan, err)
+	}
+
+	if ipAddress != nil {
+		cmd = exec.Command("sudo", "ip", "addr", "add", *ipAddress, "dev", vlan)
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to define the vlan interface %q IP Address %s: %v", vlan, *ipAddress, err)
+		}
+	}
+	return nil
+}
+
+// TODO: make this function idempotent; use golang netlink instead
+func deleteVLANInterface(deviceName string, vlanID string) error {
+	vlan := vlanName(deviceName, vlanID)
+	cmd := exec.Command("sudo", "ip", "link", "del", vlan)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to delete vlan interface %s: %v", vlan, err)
+	}
+	return nil
+}
+
+func vlanName(deviceName string, vlanID string) string {
+	// MAX IFSIZE 16; got to truncate it to add the vlan suffix
+	if len(deviceName)+len(vlanID)+1 > 16 {
+		deviceName = deviceName[:len(deviceName)-len(vlanID)-1]
+	}
+	return fmt.Sprintf("%s.%s", deviceName, vlanID)
 }

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -52,16 +52,17 @@ func getNetCIDRSubnet(netCIDR string) (string, error) {
 }
 
 type networkAttachmentConfigParams struct {
-	cidr               string
-	excludeCIDRs       []string
-	namespace          string
-	name               string
-	topology           string
-	networkName        string
-	vlanID             int
-	allowPersistentIPs bool
-	role               string
-	mtu                int
+	cidr                string
+	excludeCIDRs        []string
+	namespace           string
+	name                string
+	topology            string
+	networkName         string
+	vlanID              int
+	allowPersistentIPs  bool
+	role                string
+	mtu                 int
+	physicalNetworkName string
 }
 
 type networkAttachmentConfig struct {
@@ -100,6 +101,7 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
         "netAttachDefName": %q,
         "vlanID": %d,
         "allowPersistentIPs": %t,
+        "physicalNetworkName": %q,
         "role": %q
 }
 `,
@@ -111,6 +113,7 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
 		namespacedName(config.namespace, config.name),
 		config.vlanID,
 		config.allowPersistentIPs,
+		config.physicalNetworkName,
 		config.role,
 	)
 	return generateNetAttachDef(config.namespace, config.name, nadSpec)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR introduces a network name alias to use when configuring the localnet networks.

By using this alias, the user can create multiple networks - on different vlans - without having to reconfigure the node's OVN bridge mappings. Essentially, the use can provide a **single** mapping and piggy-back multiple physical configurations in it.

Users in OpenShift use kubernetes-nmstate to configure these mappings; this way, they get to skip provisioning multiple policies. 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
In this PR we are adding an alias to the network name attribute in the localnet logical switch port mandatory options.

By doing that, we can create multiple networks pointing at the same OVS bridge without having to provision additional bridge mappings, which provides a leaner and more focuses user workflow since any time the admin wants to define a new VLAN, all they need to do is to create a NetworkAttachmentDefinition (and re-use the existing binding).

This would be the new secondary networks definitions:
```yaml
---
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: tenantblue123
spec:
  config: |2
    {
            "cniVersion": "0.4.0",
            "name": "tenantblue123",
            "type": "ovn-k8s-cni-overlay",
            "topology":"localnet",
            "vlanID": 123,
            "physicalNetworkName": "tenantblue",
            "subnets": "192.100.200.0/24",
            "excludeSubnets": "192.100.200.1/32",
            "netAttachDefName": "default/tenantblue123"
    }
---
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: tenantblue321
spec:
  config: |2
    {
            "cniVersion": "0.4.0",
            "name": "tenantblue321",
            "type": "ovn-k8s-cni-overlay",
            "topology":"localnet",
            "vlanID": 321,
            "physicalNetworkName": "tenantblue",
            "subnets": "192.150.250.0/24",
            "excludeSubnets": "192.150.250.1/32",
            "netAttachDefName": "default/tenantblue321"
    }
```

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

Provision workloads ataching to those networks, and check the OVS databases contents:
```bash
# logical switch ports (localnet)
_uuid               : 014037c2-e34a-4ae1-b798-23133dbba72b
addresses           : [unknown]
dhcpv4_options      : []
dhcpv6_options      : []
dynamic_addresses   : []
enabled             : []
external_ids        : {}
ha_chassis_group    : []
mirror_rules        : []
name                : tenantblue321_ovn_localnet_port
options             : {network_name=tenantblue}
parent_name         : []
port_security       : []
tag                 : 321
tag_request         : 321
type                : localnet
up                  : false


_uuid               : f9092ca2-a876-47c1-9897-1b12be6d573f
addresses           : [unknown]
dhcpv4_options      : []
dhcpv6_options      : []
dynamic_addresses   : []
enabled             : []
external_ids        : {}
ha_chassis_group    : []
mirror_rules        : []
name                : tenantblue123_ovn_localnet_port
options             : {network_name=tenantblue}
parent_name         : []
port_security       : []
tag                 : 123
tag_request         : 123
type                : localnet
up                  : false

# OVS bridges port configuration
kubectl exec ovs-node-m6ch6 -novn-kubernetes -- ovs-vsctl show  
27800d09-e777-4798-86c6-45a5adfc5079
    Bridge breth0
        fail_mode: standalone
        Port patch-tenantblue123_ovn_localnet_port-to-br-int
            Interface patch-tenantblue123_ovn_localnet_port-to-br-int
                type: patch
                options: {peer=patch-br-int-to-tenantblue123_ovn_localnet_port}
        Port breth0
            Interface breth0
                type: internal
        Port patch-breth0_ovn-worker-to-br-int
            Interface patch-breth0_ovn-worker-to-br-int
                type: patch
                options: {peer=patch-br-int-to-breth0_ovn-worker}
        Port patch-tenantblue321_ovn_localnet_port-to-br-int
            Interface patch-tenantblue321_ovn_localnet_port-to-br-int
                type: patch
                options: {peer=patch-br-int-to-tenantblue321_ovn_localnet_port}
        Port eth0
            Interface eth0
    Bridge br-int
        fail_mode: secure
        datapath_type: system
...
        Port patch-br-int-to-breth0_ovn-worker
            Interface patch-br-int-to-breth0_ovn-worker
                type: patch
                options: {peer=patch-breth0_ovn-worker-to-br-int}
        Port patch-br-int-to-tenantblue321_ovn_localnet_port
            Interface patch-br-int-to-tenantblue321_ovn_localnet_port
                type: patch
                options: {peer=patch-tenantblue321_ovn_localnet_port-to-br-int}
        Port patch-br-int-to-tenantblue123_ovn_localnet_port
            Interface patch-br-int-to-tenantblue123_ovn_localnet_port
                type: patch
                options: {peer=patch-tenantblue123_ovn_localnet_port-to-br-int}
        Port "43bd51029b658_3"
            Interface "43bd51029b658_3"
    ovs_version: "3.2.2"

# OVS global configuration - check the external ids
kubectl exec ovs-node-m6ch6 -novn-kubernetes -- ovs-vsctl list open .
_uuid               : 27800d09-e777-4798-86c6-45a5adfc5079
bridges             : [580eae59-db86-4eb8-81f1-da44f4a0a23d, e65ed98f-bc0d-46d3-aef6-bf67aa67e517]
cur_cfg             : 45
datapath_types      : [netdev, system]
datapaths           : {system=a7910ab8-fe2d-4df8-83bd-b889d684fd7d}
db_version          : "8.4.0"
dpdk_initialized    : false
dpdk_version        : "DPDK 22.11.1"
external_ids        : {hostname=ovn-worker, ovn-bridge-mappings="physnet:breth0,tenantblue:breth0", ovn-enable-lflow-cache="true", ovn-encap-ip="10.89.0.5", ovn-encap-type=geneve, ovn-is-interconn="true", ovn-monitor-all="true", ovn-ofctrl-wait-before-clear="0", ovn-openflow-probe-interval="180", ovn-remote="unix:/var/run/ovn/ovnsb_db.sock", ovn-remote-probe-interval="100000", ovn-set-local-ip="true", rundir="/var/run/openvswitch", system-id="02e441c7-2c53-493e-94d1-9c0bc14359b0"}
iface_types         : [afxdp, afxdp-nonpmd, bareudp, erspan, geneve, gre, gtpu, internal, ip6erspan, ip6gre, lisp, patch, srv6, stt, system, tap, vxlan]
manager_options     : []
next_cfg            : 45
other_config        : {bundle-idle-timeout="180", ovn-chassis-idx-02e441c7-2c53-493e-94d1-9c0bc14359b0="", vlan-limit="0"}
ovs_version         : "3.2.2"
ssl                 : []
statistics          : {}
system_type         : fedora
system_version      : "39"
```

We'll still see multiple patch ports (one per network) while using a single mapping - localnet `tenantblue` to bridge `breth0`. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Introduce a localnet network name alias, which allows OVN bridge mapping re-use.