### PR TITLE
Add logic to unfurl Aggregate type error in IsSuppressedError function

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -927,7 +927,11 @@ func (oc *DefaultNetworkController) addIPToHostNetworkNamespaceAddrSet(node *kap
 
 	hostNetworkPolicyIPs, err := oc.getHostNamespaceAddressesForNode(node)
 	if err != nil {
-		return fmt.Errorf("error parsing annotation for node %s: %v", node.Name, err)
+		parsedErr := err
+		if !oc.isLocalZoneNode(node) {
+			parsedErr = types.NewSuppressedError(err)
+		}
+		return fmt.Errorf("error parsing annotation for node %s: %w", node.Name, parsedErr)
 	}
 
 	// add the host network IPs for this node to host network namespace's address set

--- a/go-controller/pkg/types/errors.go
+++ b/go-controller/pkg/types/errors.go
@@ -3,6 +3,8 @@ package types
 import (
 	"errors"
 	"fmt"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type SuppressedError struct {
@@ -25,5 +27,18 @@ func NewSuppressedError(err error) error {
 
 func IsSuppressedError(err error) bool {
 	var suppressedError *SuppressedError
+	// errors.As() is not supported with Aggregate type error. Aggregate.Errors() converts an
+	// Aggregate type error into a slice of builtin error and then errors.As() can be used
+	if agg, ok := err.(kerrors.Aggregate); ok && err != nil {
+		suppress := false
+		for _, err := range agg.Errors() {
+			if errors.As(err, &suppressedError) {
+				suppress = true
+			} else {
+				return false
+			}
+		}
+		return suppress
+	}
 	return errors.As(err, &suppressedError)
 }


### PR DESCRIPTION
errors.As() is not supported[1] with Aggregate type error. This PR is to unfurl Aggregate type error into a slice of builtin error by using Aggregate.Errors() function. errors.As() can then be used with each element of the slice.

This PR also wraps 'annotation not found' errors for remote zone nodes with SuppressedError type to suppress expected logs for remote zone nodes going forward.

Upstream Issue: https://github.com/ovn-org/ovn-kubernetes/issues/4332
[1] - https://pkg.go.dev/k8s.io/apimachinery/pkg/util/errors#Aggregate
closes #4332 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
closes #4332 

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->