### PR TITLE
Generate API reference documentation for all of our CRDs

### DIFF
--- a/crd-docs-config.yaml
+++ b/crd-docs-config.yaml
@@ -1,0 +1,8 @@
+processor:
+  ignoreTypes:
+    - "(EgressIP|EgressQoS|EgressFirewall|EgressService|AdminPolicyBasedExternalRoute)List$"
+  ignoreFields:
+    - "TypeMeta$"
+
+render:
+  kubernetesVersion: 1.28

--- a/docs/developer-guide/admin-epbr-api-spec.md
+++ b/docs/developer-guide/admin-epbr-api-spec.md
@@ -1,0 +1,157 @@
+# API Reference
+
+## Packages
+- [k8s.ovn.org/v1](#k8sovnorgv1)
+
+
+## k8s.ovn.org/v1
+
+Package v1 contains API Schema definitions for the network v1 API group
+
+### Resource Types
+- [AdminPolicyBasedExternalRoute](#adminpolicybasedexternalroute)
+
+
+
+#### AdminPolicyBasedExternalRoute
+
+
+
+AdminPolicyBasedExternalRoute is a CRD allowing the cluster administrators to configure policies for external gateway IPs to be applied to all the pods contained in selected namespaces.
+Egress traffic from the pods that belong to the selected namespaces to outside the cluster is routed through these external gateway IPs.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `k8s.ovn.org/v1` | | |
+| `kind` _string_ | `AdminPolicyBasedExternalRoute` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[AdminPolicyBasedExternalRouteSpec](#adminpolicybasedexternalroutespec)_ |  |  | Required: {} <br /> |
+| `status` _[AdminPolicyBasedRouteStatus](#adminpolicybasedroutestatus)_ |  |  |  |
+
+
+#### AdminPolicyBasedExternalRouteSpec
+
+
+
+AdminPolicyBasedExternalRouteSpec defines the desired state of AdminPolicyBasedExternalRoute
+
+
+
+_Appears in:_
+- [AdminPolicyBasedExternalRoute](#adminpolicybasedexternalroute)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `from` _[ExternalNetworkSource](#externalnetworksource)_ | From defines the selectors that will determine the target namespaces to this CR. |  |  |
+| `nextHops` _[ExternalNextHops](#externalnexthops)_ | NextHops defines two types of hops: Static and Dynamic. Each hop defines at least one external gateway IP. |  | MinProperties: 1 <br /> |
+
+
+#### AdminPolicyBasedRouteStatus
+
+
+
+AdminPolicyBasedRouteStatus contains the observed status of the AdminPolicyBased route types.
+
+
+
+_Appears in:_
+- [AdminPolicyBasedExternalRoute](#adminpolicybasedexternalroute)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | Captures the time when the last change was applied. |  |  |
+| `messages` _string array_ | An array of Human-readable messages indicating details about the status of the object. |  |  |
+| `status` _[StatusType](#statustype)_ | A concise indication of whether the AdminPolicyBasedRoute resource is applied with success |  |  |
+
+
+#### DynamicHop
+
+
+
+DynamicHop defines the configuration for a dynamic external gateway interface.
+These interfaces are wrapped around a pod object that resides inside the cluster.
+The field NetworkAttachmentName captures the name of the multus network name to use when retrieving the gateway IP to use.
+The PodSelector and the NamespaceSelector are mandatory fields.
+
+
+
+_Appears in:_
+- [ExternalNextHops](#externalnexthops)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `podSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | PodSelector defines the selector to filter the pods that are external gateways. |  | Required: {} <br /> |
+| `namespaceSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | NamespaceSelector defines a selector to filter the namespaces where the pod gateways are located. |  | Required: {} <br /> |
+| `networkAttachmentName` _string_ | NetworkAttachmentName determines the multus network name to use when retrieving the pod IPs that will be used as the gateway IP.<br />When this field is empty, the logic assumes that the pod is configured with HostNetwork and is using the node's IP as gateway. |  |  |
+| `bfdEnabled` _boolean_ | BFDEnabled determines if the interface implements the Bidirectional Forward Detection protocol. Defaults to false. | false |  |
+
+
+#### ExternalNetworkSource
+
+
+
+ExternalNetworkSource contains the selectors used to determine the namespaces where the policy will be applied to
+
+
+
+_Appears in:_
+- [AdminPolicyBasedExternalRouteSpec](#adminpolicybasedexternalroutespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `namespaceSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | NamespaceSelector defines a selector to be used to determine which namespaces will be targeted by this CR |  |  |
+
+
+#### ExternalNextHops
+
+
+
+ExternalNextHops contains slices of StaticHops and DynamicHops structures. Minimum is one StaticHop or one DynamicHop.
+
+_Validation:_
+- MinProperties: 1
+
+_Appears in:_
+- [AdminPolicyBasedExternalRouteSpec](#adminpolicybasedexternalroutespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `static` _[StaticHop](#statichop) array_ | StaticHops defines a slice of StaticHop. This field is optional. |  |  |
+| `dynamic` _[DynamicHop](#dynamichop) array_ | DynamicHops defines a slices of DynamicHop. This field is optional. |  |  |
+
+
+#### StaticHop
+
+
+
+StaticHop defines the configuration of a static IP that acts as an external Gateway Interface. IP field is mandatory.
+
+
+
+_Appears in:_
+- [ExternalNextHops](#externalnexthops)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `ip` _string_ | IP defines the static IP to be used for egress traffic. The IP can be either IPv4 or IPv6. |  | Pattern: `^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*` <br />Required: {} <br /> |
+| `bfdEnabled` _boolean_ | BFDEnabled determines if the interface implements the Bidirectional Forward Detection protocol. Defaults to false. | false |  |
+
+
+#### StatusType
+
+_Underlying type:_ _string_
+
+StatusType defines the types of status used in the Status field. The value determines if the
+deployment of the CR was successful or if it failed.
+
+
+
+_Appears in:_
+- [AdminPolicyBasedRouteStatus](#adminpolicybasedroutestatus)
+
+
+

--- a/docs/developer-guide/egress-firewall-api-spec.md
+++ b/docs/developer-guide/egress-firewall-api-spec.md
@@ -1,0 +1,116 @@
+# API Reference
+
+## Packages
+- [k8s.ovn.org/v1](#k8sovnorgv1)
+
+
+## k8s.ovn.org/v1
+
+Package v1 contains API Schema definitions for the network v1 API group
+
+
+
+
+
+#### EgressFirewallDestination
+
+
+
+EgressFirewallDestination is the target that traffic is either allowed or denied to
+
+_Validation:_
+- MaxProperties: 1
+- MinProperties: 1
+
+_Appears in:_
+- [EgressFirewallRule](#egressfirewallrule)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `cidrSelector` _string_ | cidrSelector is the CIDR range to allow/deny traffic to. If this is set, dnsName and nodeSelector must be unset. |  |  |
+| `dnsName` _string_ | dnsName is the domain name to allow/deny traffic to. If this is set, cidrSelector and nodeSelector must be unset. |  | Pattern: `^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$` <br /> |
+| `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | nodeSelector will allow/deny traffic to the Kubernetes node IP of selected nodes. If this is set,<br />cidrSelector and DNSName must be unset. |  |  |
+
+
+#### EgressFirewallPort
+
+
+
+EgressFirewallPort specifies the port to allow or deny traffic to
+
+
+
+_Appears in:_
+- [EgressFirewallRule](#egressfirewallrule)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `protocol` _string_ | protocol (tcp, udp, sctp) that the traffic must match. |  | Pattern: `^TCP|UDP|SCTP$` <br /> |
+| `port` _integer_ | port that the traffic must match |  | Maximum: 65535 <br />Minimum: 1 <br /> |
+
+
+#### EgressFirewallRule
+
+
+
+EgressFirewallRule is a single egressfirewall rule object
+
+
+
+_Appears in:_
+- [EgressFirewallSpec](#egressfirewallspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _[EgressFirewallRuleType](#egressfirewallruletype)_ | type marks this as an "Allow" or "Deny" rule |  | Pattern: `^Allow|Deny$` <br /> |
+| `ports` _[EgressFirewallPort](#egressfirewallport) array_ | ports specify what ports and protocols the rule applies to |  |  |
+| `to` _[EgressFirewallDestination](#egressfirewalldestination)_ | to is the target that traffic is allowed/denied to |  | MaxProperties: 1 <br />MinProperties: 1 <br /> |
+
+
+#### EgressFirewallRuleType
+
+_Underlying type:_ _string_
+
+EgressNetworkFirewallRuleType indicates whether an EgressNetworkFirewallRule allows or denies traffic
+
+_Validation:_
+- Pattern: `^Allow|Deny$`
+
+_Appears in:_
+- [EgressFirewallRule](#egressfirewallrule)
+
+
+
+#### EgressFirewallSpec
+
+
+
+EgressFirewallSpec is a desired state description of EgressFirewall.
+
+
+
+_Appears in:_
+- [EgressFirewall](#egressfirewall)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `egress` _[EgressFirewallRule](#egressfirewallrule) array_ | a collection of egress firewall rule objects |  |  |
+
+
+#### EgressFirewallStatus
+
+
+
+
+
+
+
+_Appears in:_
+- [EgressFirewall](#egressfirewall)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `status` _string_ |  |  |  |
+| `messages` _string array_ |  |  |  |
+
+

--- a/docs/developer-guide/egress-ip-api-spec.md
+++ b/docs/developer-guide/egress-ip-api-spec.md
@@ -1,0 +1,65 @@
+# API Reference
+
+## Packages
+- [k8s.ovn.org/v1](#k8sovnorgv1)
+
+
+## k8s.ovn.org/v1
+
+Package v1 contains API Schema definitions for the network v1 API group
+
+
+
+
+
+#### EgressIPSpec
+
+
+
+EgressIPSpec is a desired state description of EgressIP.
+
+
+
+_Appears in:_
+- [EgressIP](#egressip)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `egressIPs` _string array_ | EgressIPs is the list of egress IP addresses requested. Can be IPv4 and/or IPv6.<br />This field is mandatory. |  |  |
+| `namespaceSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | NamespaceSelector applies the egress IP only to the namespace(s) whose label<br />matches this definition. This field is mandatory. |  |  |
+| `podSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | PodSelector applies the egress IP only to the pods whose label<br />matches this definition. This field is optional, and in case it is not set:<br />results in the egress IP being applied to all pods in the namespace(s)<br />matched by the NamespaceSelector. In case it is set: is intersected with<br />the NamespaceSelector, thus applying the egress IP to the pods<br />(in the namespace(s) already matched by the NamespaceSelector) which<br />match this pod selector. |  |  |
+
+
+#### EgressIPStatus
+
+
+
+
+
+
+
+_Appears in:_
+- [EgressIP](#egressip)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `items` _[EgressIPStatusItem](#egressipstatusitem) array_ | The list of assigned egress IPs and their corresponding node assignment. |  |  |
+
+
+#### EgressIPStatusItem
+
+
+
+The per node status, for those egress IPs who have been assigned.
+
+
+
+_Appears in:_
+- [EgressIPStatus](#egressipstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `node` _string_ | Assigned node name |  |  |
+| `egressIP` _string_ | Assigned egress IP |  |  |
+
+

--- a/docs/developer-guide/egress-qos-api-spec.md
+++ b/docs/developer-guide/egress-qos-api-spec.md
@@ -1,0 +1,89 @@
+# API Reference
+
+## Packages
+- [k8s.ovn.org/v1](#k8sovnorgv1)
+
+
+## k8s.ovn.org/v1
+
+Package v1 contains API Schema definitions for the network v1 API group
+
+### Resource Types
+- [EgressQoS](#egressqos)
+
+
+
+#### EgressQoS
+
+
+
+EgressQoS is a CRD that allows the user to define a DSCP value
+for pods egress traffic on its namespace to specified CIDRs.
+Traffic from these pods will be checked against each EgressQoSRule in
+the namespace's EgressQoS, and if there is a match the traffic is marked
+with the relevant DSCP value.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `k8s.ovn.org/v1` | | |
+| `kind` _string_ | `EgressQoS` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[EgressQoSSpec](#egressqosspec)_ |  |  |  |
+| `status` _[EgressQoSStatus](#egressqosstatus)_ |  |  |  |
+
+
+#### EgressQoSRule
+
+
+
+
+
+
+
+_Appears in:_
+- [EgressQoSSpec](#egressqosspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `dscp` _integer_ | DSCP marking value for matching pods' traffic. |  | Maximum: 63 <br />Minimum: 0 <br /> |
+| `dstCIDR` _string_ | DstCIDR specifies the destination's CIDR. Only traffic heading<br />to this CIDR will be marked with the DSCP value.<br />This field is optional, and in case it is not set the rule is applied<br />to all egress traffic regardless of the destination. |  | Format: cidr <br /> |
+| `podSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | PodSelector applies the QoS rule only to the pods in the namespace whose label<br />matches this definition. This field is optional, and in case it is not set<br />results in the rule being applied to all pods in the namespace. |  |  |
+
+
+#### EgressQoSSpec
+
+
+
+EgressQoSSpec defines the desired state of EgressQoS
+
+
+
+_Appears in:_
+- [EgressQoS](#egressqos)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `egress` _[EgressQoSRule](#egressqosrule) array_ | a collection of Egress QoS rule objects |  |  |
+
+
+#### EgressQoSStatus
+
+
+
+EgressQoSStatus defines the observed state of EgressQoS
+
+
+
+_Appears in:_
+- [EgressQoS](#egressqos)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `status` _string_ | A concise indication of whether the EgressQoS resource is applied with success. |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | An array of condition objects indicating details about status of EgressQoS object. |  |  |
+
+

--- a/docs/developer-guide/egress-service-api-spec.md
+++ b/docs/developer-guide/egress-service-api-spec.md
@@ -1,0 +1,87 @@
+# API Reference
+
+## Packages
+- [k8s.ovn.org/v1](#k8sovnorgv1)
+
+
+## k8s.ovn.org/v1
+
+Package v1 contains API Schema definitions for the network v1 API group
+
+### Resource Types
+- [EgressService](#egressservice)
+
+
+
+#### EgressService
+
+
+
+EgressService is a CRD that allows the user to request that the source
+IP of egress packets originating from all of the pods that are endpoints
+of the corresponding LoadBalancer Service would be its ingress IP.
+In addition, it allows the user to request that egress packets originating from
+all of the pods that are endpoints of the LoadBalancer service would use a different
+network than the main one.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `k8s.ovn.org/v1` | | |
+| `kind` _string_ | `EgressService` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[EgressServiceSpec](#egressservicespec)_ |  |  |  |
+| `status` _[EgressServiceStatus](#egressservicestatus)_ |  |  |  |
+
+
+#### EgressServiceSpec
+
+
+
+EgressServiceSpec defines the desired state of EgressService
+
+
+
+_Appears in:_
+- [EgressService](#egressservice)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `sourceIPBy` _[SourceIPMode](#sourceipmode)_ | Determines the source IP of egress traffic originating from the pods backing the LoadBalancer Service.<br />When `LoadBalancerIP` the source IP is set to its LoadBalancer ingress IP.<br />When `Network` the source IP is set according to the interface of the Network,<br />leveraging the masquerade rules that are already in place.<br />Typically these rules specify SNAT to the IP of the outgoing interface,<br />which means the packet will typically leave with the IP of the node. |  | Enum: [LoadBalancerIP Network] <br /> |
+| `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta)_ | Allows limiting the nodes that can be selected to handle the service's traffic when sourceIPBy=LoadBalancerIP.<br />When present only a node whose labels match the specified selectors can be selected<br />for handling the service's traffic.<br />When it is not specified any node in the cluster can be chosen to manage the service's traffic. |  |  |
+| `network` _string_ | The network which this service should send egress and corresponding ingress replies to.<br />This is typically implemented as VRF mapping, representing a numeric id or string name<br />of a routing table which by omission uses the default host routing. |  |  |
+
+
+#### EgressServiceStatus
+
+
+
+EgressServiceStatus defines the observed state of EgressService
+
+
+
+_Appears in:_
+- [EgressService](#egressservice)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `host` _string_ | The name of the node selected to handle the service's traffic.<br />In case sourceIPBy=Network the field will be set to "ALL". |  |  |
+
+
+#### SourceIPMode
+
+_Underlying type:_ _string_
+
+
+
+_Validation:_
+- Enum: [LoadBalancerIP Network]
+
+_Appears in:_
+- [EgressServiceSpec](#egressservicespec)
+
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
         - EgressService: developer-guide/egress-service-api-spec.md
         - EgressQoS: developer-guide/egress-qos-api-spec.md
         - EgressFirewall: developer-guide/egress-firewall-api-spec.md
+        - AdminPolicyBasedExternalRoutes: developer-guide/admin-epbr-api-spec.md
       - OVN Kubernetes Container Images: developer-guide/image-build.md
       - Documentation Guide: developer-guide/documentation.md
       - Local Testing Guide: developer-guide/testing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,8 @@ nav:
       - Reviewing Guide: governance/REVIEWING.md
       - Coding Guide: developer-guide/developer.md
       - Kubernetes CRD API-Reference Guide: developer-guide/api-spec.md
+      - Kubernetes CRD API-Reference Guide:
+        - EgressFirewall: developer-guide/egress-firewall-api-spec.md
       - OVN Kubernetes Container Images: developer-guide/image-build.md
       - Documentation Guide: developer-guide/documentation.md
       - Local Testing Guide: developer-guide/testing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,8 +91,8 @@ nav:
       - Contributing Guide: governance/CONTRIBUTING.md
       - Reviewing Guide: governance/REVIEWING.md
       - Coding Guide: developer-guide/developer.md
-      - Kubernetes CRD API-Reference Guide: developer-guide/api-spec.md
       - Kubernetes CRD API-Reference Guide:
+        - EgressQoS: developer-guide/egress-qos-api-spec.md
         - EgressFirewall: developer-guide/egress-firewall-api-spec.md
       - OVN Kubernetes Container Images: developer-guide/image-build.md
       - Documentation Guide: developer-guide/documentation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Reviewing Guide: governance/REVIEWING.md
       - Coding Guide: developer-guide/developer.md
       - Kubernetes CRD API-Reference Guide:
+        - EgressIP: developer-guide/egress-ip-api-spec.md
         - EgressService: developer-guide/egress-service-api-spec.md
         - EgressQoS: developer-guide/egress-qos-api-spec.md
         - EgressFirewall: developer-guide/egress-firewall-api-spec.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Reviewing Guide: governance/REVIEWING.md
       - Coding Guide: developer-guide/developer.md
       - Kubernetes CRD API-Reference Guide:
+        - EgressService: developer-guide/egress-service-api-spec.md
         - EgressQoS: developer-guide/egress-qos-api-spec.md
         - EgressFirewall: developer-guide/egress-firewall-api-spec.md
       - OVN Kubernetes Container Images: developer-guide/image-build.md


### PR DESCRIPTION
the API reference documentation was generated by using this project
https://github.com/elastic/crd-ref-docs/. The config that was used to
generate the API is

$ go install github.com/elastic/crd-ref-docs@latest
$ ~/gowork/bin/crd-ref-docs \
  --source-path=~/gowork/src/githubcom/ovn-org/ovn-kubernetes/\
  go-controller/pkg/crd/egressfirewall/ \
  --config=crd-docs-config.yaml --renderer=markdown \
  --output-path=./docs/developer-guide/egress-firewall-api-spec.md
  
  Please check my github landing page:

https://girishmg.github.io/ovn-kubernetes/developer-guide/egress-firewall-api-spec/
https://girishmg.github.io/ovn-kubernetes/developer-guide/egress-qos-api-spec/
https://girishmg.github.io/ovn-kubernetes/developer-guide/egress-service-api-spec/
https://girishmg.github.io/ovn-kubernetes/developer-guide/egress-ip-api-spec/
https://girishmg.github.io/ovn-kubernetes/developer-guide/admin-epbr-api-spec/

@tssurya @trozet 

