### PR TITLE
Fix EIP GARP config overwritten by gateway update

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -823,12 +823,8 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 		if err != nil {
 			return err
 		}
-		// add the GARP configuration for all the new nodes we get
-		// since we use the "exclude-lb-vips-from-garp": "true"
-		// we shouldn't have scale issues
-		// NOTE: Adding GARP needs to be done only during node add
-		// It is a one time operation and doesn't need to be done during
-		// node updates. It needs to be done only for nodes local to this zone
+		// Add routing specific to Egress IP NOTE: GARP configuration that
+		// Egress IP depends on is added from the gateway reconciliation logic
 		return h.oc.addEgressNode(node)
 
 	case factory.EgressFwNodeType:
@@ -1066,10 +1062,6 @@ func (h *defaultNetworkControllerEventHandler) DeleteResource(obj, cachedObj int
 
 	case factory.EgressNodeType:
 		node := obj.(*kapi.Node)
-		// remove the GARP setup for the node
-		if err := h.oc.deleteEgressNode(node); err != nil {
-			return err
-		}
 		// remove the IPs from the destination address-set of the default LRP (102)
 		err := h.oc.ensureDefaultNoRerouteNodePolicies()
 		if err != nil {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1248,26 +1248,6 @@ func (oc *DefaultNetworkController) addEgressNode(node *v1.Node) error {
 	}
 	if oc.isLocalZoneNode(node) {
 		klog.V(5).Infof("Egress node: %s about to be initialized", node.Name)
-		// This option will program OVN to start sending GARPs for all external IPS
-		// that the logical switch port has been configured to use. This is
-		// necessary for egress IP because if an egress IP is moved between two
-		// nodes, the nodes need to actively update the ARP cache of all neighbors
-		// as to notify them the change. If this is not the case: packets will
-		// continue to be routed to the old node which hosted the egress IP before
-		// it was moved, and the connections will fail.
-		portName := types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name
-		lsp := nbdb.LogicalSwitchPort{
-			Name: portName,
-			// Setting nat-addresses to router will send out GARPs for all externalIPs and LB VIPs
-			// hosted on the GR. Setting exclude-lb-vips-from-garp to true will make sure GARPs for
-			// LB VIPs are not sent, thereby preventing GARP overload.
-			Options: map[string]string{"nat-addresses": "router", "exclude-lb-vips-from-garp": "true"},
-		}
-		err := libovsdbops.UpdateLogicalSwitchPortSetOptions(oc.nbClient, &lsp)
-		if err != nil {
-			return fmt.Errorf("unable to configure GARP on external logical switch port for egress node: %s, "+
-				"this will result in packet drops during egress IP re-assignment,  err: %v", node.Name, err)
-		}
 		if config.OVNKubernetesFeature.EnableInterconnect && oc.zone != types.OvnDefaultZone {
 			// NOTE: EgressIP is not supported on multi-nodes-in-same-zone case
 			// NOTE2: We don't want this route for all-nodes-in-same-zone (almost nonIC a.k.a single zone) case because
@@ -1278,31 +1258,6 @@ func (oc *DefaultNetworkController) addEgressNode(node *v1.Node) error {
 			if err := libovsdbutil.CreateDefaultRouteToExternal(oc.nbClient, node.Name); err != nil {
 				return err
 			}
-		}
-	}
-	return nil
-}
-
-func (oc *DefaultNetworkController) deleteEgressNode(node *v1.Node) error {
-	if node == nil {
-		return nil
-	}
-	if oc.isLocalZoneNode(node) {
-		klog.V(5).Infof("Egress node: %s about to be removed", node.Name)
-		// This will remove the option described in addEgressNode from the logical
-		// switch port, since this node will not be used for egress IP assignments
-		// from now on.
-		portName := types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name
-		lsp := nbdb.LogicalSwitchPort{
-			Name:    portName,
-			Options: map[string]string{"nat-addresses": "", "exclude-lb-vips-from-garp": ""},
-		}
-		err := libovsdbops.UpdateLogicalSwitchPortSetOptions(oc.nbClient, &lsp)
-		if errors.Is(err, libovsdbclient.ErrNotFound) {
-			// if the LSP setup is already gone, then don't count it as error.
-			klog.Warningf("Unable to remove GARP configuration on external logical switch port for egress node: %s, err: %v", node.Name, err)
-		} else if err != nil {
-			return fmt.Errorf("unable to remove GARP configuration on external logical switch port for egress node: %s, err: %v", node.Name, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -193,7 +193,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			annotations := map[string]string{
 				"k8s.ovn.org/node-primary-ifaddr":             fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", "", ni.addresses[0]),
 				"k8s.ovn.org/node-subnets":                    fmt.Sprintf("{\"default\":\"%s\"}", nodeSubnets[i]),
-				util.OVNNodeHostCIDRs:                         fmt.Sprintf("%s", hostCIDRs),
+				util.OVNNodeHostCIDRs:                         hostCIDRs,
 				"k8s.ovn.org/node-transit-switch-port-ifaddr": fmt.Sprintf("{\"ipv6\":\"%s\"}", ni.transitPortIP), // used only for ic=true test
 				"k8s.ovn.org/zone-name":                       ni.zone,
 			}
@@ -304,7 +304,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitch{
@@ -482,7 +484,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -687,7 +691,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -695,7 +701,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitch{
@@ -728,11 +736,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					err = fakeOvn.controller.WatchEgressIP()
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-					lsp := &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name}
-					gomega.Expect(fakeOvn.controller.nbClient.Get(context.Background(), lsp)).Should(gomega.Succeed())
-					gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
-					gomega.Eventually(lsp.Options["exclude-lb-vips-from-garp"]).Should(gomega.Equal("true"))
 
 					fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP, node1IPv4OVNNet)
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
@@ -967,7 +970,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -975,7 +980,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -983,7 +990,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -1023,18 +1032,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					err = fakeOvn.controller.WatchEgressIP()
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-					lsp := &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name}
-					err = fakeOvn.controller.nbClient.Get(context.Background(), lsp)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
-					gomega.Eventually(lsp.Options["exclude-lb-vips-from-garp"]).Should(gomega.Equal("true"))
-
-					lsp = &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name}
-					err = fakeOvn.controller.nbClient.Get(context.Background(), lsp)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
-					gomega.Eventually(lsp.Options["exclude-lb-vips-from-garp"]).Should(gomega.Equal("true"))
 
 					fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP, node1IPv4OVNNet)
 
@@ -1182,10 +1179,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-								/* GARP is deleted since node has been deleted */
-								// "nat-addresses":             "router",
-								// "exclude-lb-vips-from-garp": "true",
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -1331,7 +1327,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -1339,7 +1337,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -1347,7 +1347,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node3Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node3Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -1551,10 +1553,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-								/* GARP is deleted since node has been deleted */
-								// "nat-addresses":             "router",
-								// "exclude-lb-vips-from-garp": "true",
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -1724,7 +1725,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -1732,7 +1735,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -1875,7 +1880,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -1883,7 +1890,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -1916,16 +1925,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name:  node2.Name,
 							Ports: []string{"k8s-" + node2.Name + "-UUID"},
 						},
-					}
-					if node2Zone != "remote" {
-						// add GARP config only if node is in local zone
-						expectedDatabaseState[10].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[10].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
-					}
-					if node1Zone == "global" {
-						// GARP is configured only for nodes in local zones, the master of the remote zone will do it for the remote nodes
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 					}
 					if node1Zone == "remote" {
 						expectedDatabaseState = append(expectedDatabaseState, getReRoutePolicy(egressPod.Status.PodIP, "4", "remote-reroute-UUID", reroutePolicyNextHop, eipExternalID))
@@ -2059,7 +2058,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -2067,7 +2068,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -2261,7 +2264,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -2269,7 +2274,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -2304,10 +2311,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					}
 					if node1Zone != "remote" {
-						// GARP is configured only for nodes in local zones, the master of the remote zone will do it for the remote nodes
-
-						expectedDatabaseState[8].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[8].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 						expectedDatabaseState[3].(*nbdb.LogicalRouter).Nat = append(expectedDatabaseState[3].(*nbdb.LogicalRouter).Nat, "egressip-nat-UUID", "egressip2-nat-UUID")
 						expectedDatabaseState = append(expectedDatabaseState, &nbdb.NAT{
 							UUID:       "egressip-nat-UUID",
@@ -2334,11 +2337,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								"stateless": "false",
 							},
 						})
-					}
-					if node2Zone != "remote" {
-						// add GARP config only if node is in local zone
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 					}
 
 					for _, lrp := range lrps {
@@ -2469,7 +2467,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -2477,7 +2477,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitch{
@@ -2526,14 +2528,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP, node1IPv4Net)
-
-					lsp := &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name}
-					fakeOvn.controller.nbClient.Get(context.Background(), lsp)
-					if node1Zone == "global" {
-						// only if node is global we add this
-						gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
-						gomega.Eventually(lsp.Options["exclude-lb-vips-from-garp"]).Should(gomega.Equal("true"))
-					}
 
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 					egressIPs, nodes := getEgressIPStatus(egressIPName)
@@ -2609,7 +2603,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -2617,7 +2613,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitch{
@@ -2655,15 +2653,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Ports: []string{"k8s-" + node2.Name + "-UUID"},
 						},
 					}
-					if node2Zone != "remote" {
-						// add GARP config only if node is in local zone
-						expectedDatabaseState[10].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[10].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
-					}
 					if node1Zone != "remote" {
-						// add GARP config only if node is in local zone
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 						expectedDatabaseState = append(expectedDatabaseState, getReRoutePolicy(egressPod.Status.PodIP, "4", "reroute-UUID", nodeLogicalRouterIPv4, eipExternalID))
 						expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies = append(expectedDatabaseState[6].(*nbdb.LogicalRouter).Policies, "reroute-UUID")
 					} else {
@@ -2740,7 +2730,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitch{
@@ -2777,9 +2769,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						// either not interconnect or egressNode is in localZone
 						expectedDatabaseState = append(expectedDatabaseState, eipSNAT)
 						expectedDatabaseState[4].(*nbdb.LogicalRouter).Nat = []string{"egressip-nat-UUID"} // 4th item is node2's GR
-						// add GARP config only if node is in local zone
-						expectedDatabaseState[7].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[7].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 					}
 					// all cases: reroute logical router policy is gone and won't be recreated since node1 is deleted - that is where the pod lives
 					// NOTE: This test is not really a real scenario, it depicts a transient state.
@@ -2884,7 +2873,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -2892,7 +2883,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -2946,14 +2939,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP, node1IPv4SecondaryHostNet)
-
-					lsp := &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name}
-					fakeOvn.controller.nbClient.Get(context.Background(), lsp)
-					if node1Zone == "global" {
-						// GARP is configured only for nodes in local zones, the master of the remote zone will do it for the remote nodes
-						gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
-						gomega.Eventually(lsp.Options["exclude-lb-vips-from-garp"]).Should(gomega.Equal("true"))
-					}
 
 					err = fakeOvn.controller.WatchEgressIP()
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -3041,7 +3026,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -3049,7 +3036,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -3084,16 +3073,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					}
 
-					if node1Zone == "global" {
-						// GARP is configured only for nodes in local zones, the master of the remote zone will do it for the remote nodes
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
-					}
-					if node2Zone != "remote" {
-						// add GARP config only if node is in local zone
-						expectedDatabaseState[10].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[10].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
-					}
 					if node1Zone == "remote" {
 						podPolicy := getReRoutePolicy(podV4IP, "4", "static-reroute-UUID", []string{node2MgntIP.To4().String()}, eipExternalID)
 						expectedDatabaseState = append(expectedDatabaseState, podPolicy)
@@ -5100,7 +5079,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -5108,7 +5089,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 									Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 									Type: "router",
 									Options: map[string]string{
-										"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+										"nat-addresses":             "router",
+										"exclude-lb-vips-from-garp": "true",
 									},
 								},
 								&nbdb.LogicalSwitchPort{
@@ -5273,7 +5256,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -5281,7 +5266,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalRouterPolicy{
@@ -5324,8 +5311,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					}
 					if !interconnect || node1Zone != "remote" {
-						expectedDatabaseState[8].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[8].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 						expectedDatabaseState[3].(*nbdb.LogicalRouter).Nat = []string{"egressip-nat-1-UUID"}
 						expectedDatabaseState = append(expectedDatabaseState, natEIP1)
 					}
@@ -5334,8 +5319,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						expectedDatabaseState[5].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID"}
 					}
 					if !interconnect || node2Zone != "remote" {
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 						expectedDatabaseState[4].(*nbdb.LogicalRouter).Nat = []string{"egressip-nat-2-UUID"}
 						expectedDatabaseState = append(expectedDatabaseState, natEIP2)
 					}
@@ -5431,7 +5414,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -5439,7 +5424,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalRouterPolicy{
@@ -5482,8 +5469,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					}
 					if !interconnect || node1Zone != "remote" {
-						expectedDatabaseState[8].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[8].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 						expectedDatabaseState[3].(*nbdb.LogicalRouter).Nat = []string{"egressip-nat-1-UUID"}
 						natEIP1.ExternalIP = assignedEgressIP1
 						expectedDatabaseState = append(expectedDatabaseState, natEIP1)
@@ -5493,8 +5478,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						expectedDatabaseState[5].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID"}
 					}
 					if !interconnect || node2Zone != "remote" {
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["nat-addresses"] = "router"
-						expectedDatabaseState[9].(*nbdb.LogicalSwitchPort).Options["exclude-lb-vips-from-garp"] = "true"
 						expectedDatabaseState[4].(*nbdb.LogicalRouter).Nat = []string{"egressip-nat-2-UUID"}
 						natEIP2.ExternalIP = assignedEgressIP2
 						expectedDatabaseState = append(expectedDatabaseState, natEIP2)
@@ -5871,7 +5854,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -5879,7 +5864,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -6066,7 +6053,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + nodeName,
 							Type: "router",
 							Options: map[string]string{
-								"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + nodeName,
+								"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + nodeName,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
 							},
 						},
 						&nbdb.LogicalSwitchPort{
@@ -6155,7 +6144,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + nodeName,
 						Type: "router",
 						Options: map[string]string{
-							"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + nodeName,
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + nodeName,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -6256,7 +6247,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							nodeSwitch,
@@ -6584,7 +6577,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							nodeSwitch,
@@ -6960,7 +6955,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					}
 					node2LSP := &nbdb.LogicalSwitchPort{
@@ -6968,7 +6965,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					}
 
@@ -7110,24 +7109,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						UUID: "reroute-UUID1",
 					}
 					node1GR.Nat = []string{"egressip-nat-UUID1"}
-					node1LSP.Options = map[string]string{
-						"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-						"nat-addresses":             "router",
-						"exclude-lb-vips-from-garp": "true",
-					}
-					if node1Zone != node2Zone && node1Zone == "remote" {
-						// GARP for remote zones are taken care of by remote controller
-						node1LSP.Options = map[string]string{
-							"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-						}
-					}
-					if !interconnect || node2Zone == "global" {
-						node2LSP.Options = map[string]string{
-							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses":             "router",
-							"exclude-lb-vips-from-garp": "true",
-						}
-					}
 					nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, DefaultNetworkControllerName)
 					fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4})
 
@@ -7568,7 +7549,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node.Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node.Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -7791,7 +7774,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -7799,7 +7784,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -7966,7 +7953,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -7974,7 +7963,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -8242,7 +8233,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -8250,7 +8243,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -8504,7 +8499,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -8650,7 +8647,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 					Type: "router",
 					Options: map[string]string{
-						"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+						"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+						"nat-addresses":             "router",
+						"exclude-lb-vips-from-garp": "true",
 					},
 				}
 				fakeOvn.startWithDBSetup(
@@ -8740,11 +8739,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				podEIPSNAT := getEIPSNAT(podV4IP, egressIP, "k8s-node1")
 				podReRoutePolicy := getReRoutePolicy(egressPodIP[0].String(), "4", "reroute-UUID", nodeLogicalRouterIPv4, eipExternalID)
 				node1GR.Nat = []string{"egressip-nat-UUID"}
-				node1LSP.Options = map[string]string{
-					"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-					"nat-addresses":             "router",
-					"exclude-lb-vips-from-garp": "true",
-				}
 
 				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, DefaultNetworkControllerName)
 				fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4})
@@ -8852,7 +8846,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -8860,7 +8856,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -9183,7 +9181,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -9191,7 +9191,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -9546,7 +9548,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 					Type: "router",
 					Options: map[string]string{
-						"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+						"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+						"nat-addresses":             "router",
+						"exclude-lb-vips-from-garp": "true",
 					},
 				}
 				fakeOvn.startWithDBSetup(
@@ -9617,11 +9621,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
 				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
 
-				node1LSP.Options = map[string]string{
-					"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-					"nat-addresses":             "router",
-					"exclude-lb-vips-from-garp": "true",
-				}
 				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, DefaultNetworkControllerName)
 				fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4})
 
@@ -9739,7 +9738,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 					Type: "router",
 					Options: map[string]string{
-						"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+						"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+						"nat-addresses":             "router",
+						"exclude-lb-vips-from-garp": "true",
 					},
 				}
 				fakeOvn.startWithDBSetup(
@@ -9836,11 +9837,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					UUID: "reroute-UUID1",
 				}
 				node1GR.Nat = []string{"egressip-nat-UUID1"}
-				node1LSP.Options = map[string]string{
-					"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-					"nat-addresses":             "router",
-					"exclude-lb-vips-from-garp": "true",
-				}
 				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, DefaultNetworkControllerName)
 				fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4})
 
@@ -10022,7 +10018,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitchPort{
@@ -10030,7 +10028,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -10834,9 +10834,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 								Type: "router",
 								Options: map[string]string{
-									//"nat-addresses":             "router",
-									//"exclude-lb-vips-from-garp": "true",
-									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+									"nat-addresses":             "router",
+									"exclude-lb-vips-from-garp": "true",
 								},
 							},
 							&nbdb.LogicalSwitch{
@@ -10943,7 +10943,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitch{
@@ -11135,7 +11137,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -592,6 +592,20 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 		Type: "router",
 		Options: map[string]string{
 			"router-port": externalRouterPort,
+
+			// This option will program OVN to start sending GARPs for all external IPS
+			// that the logical switch port has been configured to use. This is
+			// necessary for egress IP because if an egress IP is moved between two
+			// nodes, the nodes need to actively update the ARP cache of all neighbors
+			// as to notify them the change. If this is not the case: packets will
+			// continue to be routed to the old node which hosted the egress IP before
+			// it was moved, and the connections will fail.
+			"nat-addresses": "router",
+
+			// Setting nat-addresses to router will send out GARPs for all externalIPs and LB VIPs
+			// hosted on the GR. Setting exclude-lb-vips-from-garp to true will make sure GARPs for
+			// LB VIPs are not sent, thereby preventing GARP overload.
+			"exclude-lb-vips-from-garp": "true",
 		},
 		Addresses: []string{macAddress},
 	}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -31,10 +30,10 @@ func init() {
 	format.MaxLength = 0
 }
 
-func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter,
+func generateGatewayInitExpectedNB(testData []libovsdbtest.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter,
 	expectedNodeSwitch *nbdb.LogicalSwitch, nodeName string, clusterIPSubnets []*net.IPNet, hostSubnets []*net.IPNet,
 	l3GatewayConfig *util.L3GatewayConfig, joinLRPIPs, defLRPIPs []*net.IPNet, skipSnat bool, nodeMgmtPortIP,
-	gatewayMTU string) []libovsdb.TestData {
+	gatewayMTU string) []libovsdbtest.TestData {
 
 	GRName := "GR_" + nodeName
 	gwSwitchPort := types.JoinSwitchToGWRouterPrefix + GRName
@@ -308,7 +307,9 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 			Name: externalSwitchPortToRouter,
 			Type: "router",
 			Options: map[string]string{
-				"router-port": externalRouterPort,
+				"router-port":               externalRouterPort,
+				"nat-addresses":             "router",
+				"exclude-lb-vips-from-garp": "true",
 			},
 			Addresses: []string{l3GatewayConfig.MACAddress.String()},
 		},
@@ -424,7 +425,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := false
 			expectedOVNClusterRouter.StaticRoutes = []string{} // the leftover LGW route should have got deleted
 			// We don't set up the Allow from mgmt port ACL here
@@ -500,7 +501,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := false
 			expectedOVNClusterRouter.StaticRoutes = []string{} // the leftover LGW route should have got deleted
 			// We don't set up the Allow from mgmt port ACL here
@@ -566,7 +567,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := false
 			expectedOVNClusterRouter.StaticRoutes = []string{}
 			// We don't set up the Allow from mgmt port ACL here
@@ -648,7 +649,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := false
 			expectedOVNClusterRouter.StaticRoutes = []string{}
 			// We don't set up the Allow from mgmt port ACL here
@@ -746,7 +747,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := false
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
@@ -816,7 +817,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := false
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
@@ -888,7 +889,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := false
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
@@ -958,7 +959,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := true
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
@@ -1060,7 +1061,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := true
 
 			// remove bad route from expected data
@@ -1163,7 +1164,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := false
 			expectedOVNClusterRouter.StaticRoutes = []string{} // the leftover SGW route should have got deleted
 			// We don't set up the Allow from mgmt port ACL here
@@ -1242,7 +1243,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := true
 
 			// remove bad route from expected data
@@ -1350,7 +1351,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			testData := []libovsdb.TestData{}
+			testData := []libovsdbtest.TestData{}
 			skipSnat := true
 
 			mgmtPortIP := ""


### PR DESCRIPTION
A node update may overwrite the GARP options from the external switch router port.

Handle these options directly from the gateway reconciliation logic and avoid writing to the same DB row from two concurrent threads which might also be racey.

As a curiosity, on my local environment where I reproduced this, ~~I had sysctl rp_filter=2. With that in place, and~~ with no GARP, the external server was sending replies to the old egress node and the old egress node was able to forward them to the new egress node, so no connectivity hiccup but a permanent undesired path. On an OCP environment however, ~~with rp_filter=1,~~ the old egress node can't forward to the new egress node. The connectivity hiccup is there, and without GARP it takes longer for the external server to become aware of the mac for the new egress node.
