### PR TITLE
Node delete should not fail when it can never succeed when `node-subnet` annot isnt assigned

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -963,6 +963,11 @@ func (oc *DefaultNetworkController) delIPFromHostNetworkNamespaceAddrSet(node *k
 
 	hostNetworkPolicyIPs, err := oc.getHostNamespaceAddressesForNode(node)
 	if err != nil {
+		if util.IsAnnotationNotSetError(err) {
+			// if annotation is not set for node subnet or node GW router LRP IP address, we can assume nothing was added to the
+			// host network namespace address set. We depend on both annotations to be set before configuring the address set.
+			return nil
+		}
 		return fmt.Errorf("error parsing annotation for node %s: %v", node.Name, err)
 	}
 


### PR DESCRIPTION
Node delete is failing and retrying until retry limit when it can never succeed when particular annotations arent added in time before the node is deleted.

~/hold~

~Need to add unit test.~

All thanks to @trozet  for his KinD scaler PR to reproduce #4331 !