### PR TITLE
IPAM e2e test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,7 +437,7 @@ jobs:
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
-      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' }}"
+      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' }}"
       KIND_INSTALL_KUBEVIRT: "${{ matrix.target == 'kv-live-migration' }}"
       OVN_COMPACT_MODE: "${{ matrix.target == 'compact-mode' }}"
       OVN_DUMMY_GATEWAY_BRIDGE: "${{ matrix.target == 'compact-mode' }}"

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1449,6 +1449,7 @@ function install_kubevirt() {
       if ! is_nested_virt_enabled; then
         kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
       fi
+      kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"featureGates":["PersistentIPs"]}}}}'
       kubectl -n kubevirt patch kubevirt kubevirt --type=merge --patch '{"spec":{"configuration":{"virtualMachineOptions":{"disableSerialConsoleLog":{}}}}}'
     fi
     if ! kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m; then

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1233,6 +1233,18 @@ install_ipamclaim_crd() {
   run_kubectl apply -f "$ipamclaims_manifest"
 }
 
+install_kubevirt_ipam_claims() {
+  local cert_manager_version="v1.14.4"
+  echo "Installing cert-manager ..."
+  manifest="https://github.com/cert-manager/cert-manager/releases/download/${cert_manager_version}/cert-manager.yaml"
+  run_kubectl apply -f "$manifest"
+
+  echo "Installing KubeVirt IPAM manager ..."
+  manifest="https://raw.githubusercontent.com/maiqueb/kubevirt-ipam-claims/main/dist/install.yaml"
+  run_kubectl apply -f "$manifest"
+  kubectl wait -n kubevirt-ipam-claims-system deployment kubevirt-ipam-claims-controller-manager --for condition=Available --timeout 2m
+}
+
 # kubectl_wait_pods will set a total timeout of 300s for IPv4 and 480s for IPv6. It will first wait for all
 # DaemonSets to complete with kubectl rollout. This command will block until all pods of the DS are actually up.
 # Next, it iterates over all pods with name=ovnkube-db and ovnkube-master and waits for them to post "Ready".
@@ -1556,4 +1568,5 @@ if [ "$KIND_INSTALL_PLUGINS" == true ]; then
 fi
 if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
   install_kubevirt
+  install_kubevirt_ipam_claims
 fi

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -37,6 +37,7 @@ replace (
 
 require (
 	github.com/google/go-cmp v0.6.0
+	github.com/k8snetworkplumbingwg/ipamclaims v0.4.0-alpha
 	github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20230301165931-f1873dc329c6
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/ginkgo/v2 v2.13.0
@@ -87,7 +88,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/glog v1.1.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/cel-go v0.17.7 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -792,8 +792,9 @@ github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
-github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
+github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
+github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -956,6 +957,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/k8snetworkplumbingwg/ipamclaims v0.4.0-alpha h1:ss+EP77GlQmh90hGKpnAG4Q3VVxRlB7GoncemaPtO4g=
+github.com/k8snetworkplumbingwg/ipamclaims v0.4.0-alpha/go.mod h1:qlR+sKxQ2OGfwhFCuXSd7rJ/GgC38vQBeHKQ7f2YnpI=
 github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20230301165931-f1873dc329c6 h1:KliAwTu2G07C1UYX8DoLoIy80Giy436XrhO4MX8FChM=
 github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20230301165931-f1873dc329c6/go.mod h1:kEJ4WM849yNmXekuSXLRwb+LaZ9usC06O8JgoAIq+f4=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -19,10 +19,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,6 +37,10 @@ import (
 
 	butaneconfig "github.com/coreos/butane/config"
 	butanecommon "github.com/coreos/butane/config/common"
+
+	ipamclaimsv1alpha1 "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kvmigrationsv1alpha1 "kubevirt.io/api/migrations/v1alpha1"
@@ -56,6 +60,14 @@ func newControllerRuntimeClient() (crclient.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = ipamclaimsv1alpha1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = nadv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
 	return crclient.New(config, crclient.Options{
 		Scheme: scheme,
 	})
@@ -68,54 +80,12 @@ var _ = Describe("Kubevirt Virtual Machines", func() {
 		crClient           crclient.Client
 		namespace          string
 		tcpServerPort      = int32(9900)
-		isDualStack        = false
 		wg                 sync.WaitGroup
 		selectedNodes      = []corev1.Node{}
 		httpServerTestPods = []*corev1.Pod{}
 		clientSet          kubernetes.Interface
 		// Systemd resolvd prevent resolving kube api service by fqdn, so
 		// we replace it here with NetworkManager
-		butane = fmt.Sprintf(`
-variant: fcos
-version: 1.4.0
-storage:
-  files:
-    - path: /root/test/server.go
-      contents:
-        local: kubevirt/echoserver/main.go
-systemd:
-  units:
-    - name: systemd-resolved.service
-      mask: true
-    - name: replace-resolved.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Replace systemd resolvd with NetworkManager
-        Wants=network-online.target
-        After=network-online.target
-        [Service]
-        ExecStart=rm -f /etc/resolv.conf
-        ExecStart=systemctl restart NetworkManager
-        Type=oneshot
-        [Install]
-        WantedBy=multi-user.target
-    - name: echoserver.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Golang echo server
-        Wants=replace-resolved.service
-        After=replace-resolved.service
-        [Service]
-        ExecStart=podman run --name tcpserver --tls-verify=false --privileged --net=host -v /root/test:/test:z registry.access.redhat.com/ubi9/go-toolset:1.20 go run /test/server.go %d
-        [Install]
-        WantedBy=multi-user.target
-passwd:
-  users:
-  - name: core
-    password_hash: $y$j9T$b7RFf2LW7MUOiF4RyLHKA0$T.Ap/uzmg8zrTcUNXyXvBvT26UgkC6zZUVg3UKXeEp5
-`, tcpServerPort)
 		labelNode = func(nodeName, label string) error {
 			patch := fmt.Sprintf(`{"metadata": {"labels": {"%s": ""}}}`, label)
 			_, err := fr.ClientSet.CoreV1().Nodes().Patch(context.Background(), nodeName, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
@@ -133,81 +103,24 @@ passwd:
 			}
 			return nil
 		}
+		isDualStack = func() bool {
+			nodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).WithOffset(1).ToNot(HaveOccurred())
+			Expect(nodeList.Items).WithOffset(1).ToNot(BeEmpty())
+			hasIPv4Address, hasIPv6Address := false, false
+			for _, addr := range nodeList.Items[0].Status.Addresses {
+				if addr.Type == corev1.NodeInternalIP {
+					if utilnet.IsIPv4String(addr.Address) {
+						hasIPv4Address = true
+					}
+					if utilnet.IsIPv6String(addr.Address) {
+						hasIPv6Address = true
+					}
+				}
+			}
+			return hasIPv4Address && hasIPv6Address
+		}
 	)
-
-	BeforeEach(func() {
-		namespace = fr.Namespace.Name
-		// So we can use it at AfterEach, since fr.ClientSet is nil there
-		clientSet = fr.ClientSet
-
-		var err error
-		crClient, err = newControllerRuntimeClient()
-		Expect(err).ToNot(HaveOccurred())
-
-		workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(workerNodeList.Items).ToNot(BeEmpty())
-		hasIPv4Address, hasIPv6Address := false, false
-		for _, a := range workerNodeList.Items[0].Status.Addresses {
-			if a.Type == corev1.NodeInternalIP {
-				if utilnet.IsIPv4String(a.Address) {
-					hasIPv4Address = true
-				}
-				if utilnet.IsIPv6String(a.Address) {
-					hasIPv6Address = true
-				}
-			}
-		}
-		isDualStack = hasIPv4Address && hasIPv6Address
-
-		nodesByOVNZone := map[string][]corev1.Node{}
-		for _, workerNode := range workerNodeList.Items {
-			ovnZone, ok := workerNode.Labels["k8s.ovn.org/zone-name"]
-			if !ok {
-				ovnZone = "global"
-			}
-			_, ok = nodesByOVNZone[ovnZone]
-			if !ok {
-				nodesByOVNZone[ovnZone] = []corev1.Node{}
-			}
-			nodesByOVNZone[ovnZone] = append(nodesByOVNZone[ovnZone], workerNode)
-		}
-
-		selectedNodes = []corev1.Node{}
-		// If there is one global zone select the first three for the
-		// migration
-		if len(nodesByOVNZone) == 1 {
-			selectedNodes = []corev1.Node{
-				workerNodeList.Items[0],
-				workerNodeList.Items[1],
-				workerNodeList.Items[2],
-			}
-			// Otherwise select a pair of nodes from different OVN zones
-		} else {
-			for _, nodes := range nodesByOVNZone {
-				selectedNodes = append(selectedNodes, nodes[0])
-				if len(selectedNodes) == 3 {
-					break // we want just three of them
-				}
-			}
-		}
-
-		Expect(selectedNodes).To(HaveLen(3), "at least three nodes in different zones are needed for interconnect scenarios")
-
-		// Label the selected nodes with the generated namespaces, so we can
-		// configure VM nodeSelector with it and live migration will take only
-		// them into consideration
-		for _, node := range selectedNodes {
-			Expect(labelNode(node.Name, namespace)).To(Succeed())
-		}
-
-	})
-
-	AfterEach(func() {
-		for _, node := range selectedNodes {
-			unlabelNode(node.Name, namespace)
-		}
-	})
 
 	type liveMigrationTestData struct {
 		mode                kubevirtv1.MigrationMode
@@ -353,6 +266,59 @@ passwd:
 			return fr.ClientSet.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), policy, metav1.CreateOptions{})
 		}
 
+		checkEastWestTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
+			polling := 15 * time.Second
+			timeout := time.Minute
+			for podName, podIPs := range podIPsByName {
+				for _, podIP := range podIPs {
+					output := ""
+					Eventually(func() error {
+						var err error
+						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("curl http://%s", net.JoinHostPort(podIP, "8000")), polling)
+						return err
+					}).
+						WithOffset(1).
+						WithPolling(polling).
+						WithTimeout(timeout).
+						Should(Succeed(), func() string { return stage + ": " + podName + ": " + output })
+				}
+			}
+		}
+
+		httpServerTestPodsDefaultNetworkIPs = func() map[string][]string {
+			ips := map[string][]string{}
+			for _, pod := range httpServerTestPods {
+				for _, podIP := range pod.Status.PodIPs {
+					ips[pod.Name] = append(ips[pod.Name], podIP.IP)
+				}
+			}
+			return ips
+		}
+
+		checkPodHasIPsAtNetwork = func(netName string, expectedNumberOfAddresses int) func(Gomega, *corev1.Pod) {
+			return func(g Gomega, pod *corev1.Pod) {
+				netStatus, err := podNetworkStatus(pod, func(status nadapi.NetworkStatus) bool {
+					return status.Name == netName
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(netStatus).To(HaveLen(1))
+				g.Expect(netStatus[0].IPs).To(HaveLen(expectedNumberOfAddresses))
+			}
+		}
+
+		httpServerTestPodsMultusNetworkIPs = func(netName string) map[string][]string {
+			ips := map[string][]string{}
+			for _, pod := range httpServerTestPods {
+				netStatus, err := podNetworkStatus(pod, func(status nadapi.NetworkStatus) bool {
+					return status.Name == netName
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(netStatus).To(HaveLen(1))
+				ips[pod.Name] = append(ips[pod.Name], netStatus[0].IPs...)
+			}
+			return ips
+		}
+
 		checkConnectivity = func(vmName string, endpoints []*net.TCPConn, stage string) {
 			by(vmName, "Check connectivity "+stage)
 			vmi := &kubevirtv1.VirtualMachineInstance{
@@ -372,20 +338,8 @@ passwd:
 				WithOffset(1).
 				Should(Succeed(), step)
 
-			step = by(vmName, stage+": Check e/w tcp traffic")
-			for _, pod := range httpServerTestPods {
-				for _, podIP := range pod.Status.PodIPs {
-					output := ""
-					Eventually(func() error {
-						output, err = kubevirt.RunCommand(vmi, fmt.Sprintf("curl http://%s", net.JoinHostPort(podIP.IP, "8000")), polling)
-						return err
-					}).
-						WithOffset(1).
-						WithPolling(polling).
-						WithTimeout(timeout).
-						Should(Succeed(), func() string { return step + ": " + pod.Name + ": " + output })
-				}
-			}
+			stage = by(vmName, stage+": Check e/w tcp traffic")
+			checkEastWestTraffic(vmi, httpServerTestPodsDefaultNetworkIPs(), stage)
 
 			step = by(vmName, stage+": Check n/s tcp traffic")
 			output := ""
@@ -490,6 +444,36 @@ passwd:
 			Expect(vmi.Status.MigrationState.Mode).WithOffset(1).To(Equal(migrationMode), "should be the expected migration mode %s", migrationMode)
 		}
 
+		vmiMigrations = func(client crclient.Client) ([]kubevirtv1.VirtualMachineInstanceMigration, error) {
+			unstructuredVMIMigrations := &unstructured.UnstructuredList{}
+			unstructuredVMIMigrations.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   kubevirtv1.GroupVersion.Group,
+				Kind:    "VirtualMachineInstanceMigrationList",
+				Version: kubevirtv1.GroupVersion.Version,
+			})
+
+			if err := client.List(context.Background(), unstructuredVMIMigrations); err != nil {
+				return nil, err
+			}
+			if len(unstructuredVMIMigrations.Items) == 0 {
+				return nil, fmt.Errorf("empty migration list")
+			}
+
+			var migrations []kubevirtv1.VirtualMachineInstanceMigration
+			for i := range unstructuredVMIMigrations.Items {
+				var vmiMigration kubevirtv1.VirtualMachineInstanceMigration
+				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+					unstructuredVMIMigrations.Items[i].Object,
+					&vmiMigration,
+				); err != nil {
+					return nil, err
+				}
+				migrations = append(migrations, vmiMigration)
+			}
+
+			return migrations, nil
+		}
+
 		checkLiveMigrationFailed = func(vmName string) {
 			By("checking the VM live-migrated failed to migrate")
 			vmi := &kubevirtv1.VirtualMachineInstance{
@@ -546,7 +530,104 @@ passwd:
 			}
 
 		}
-		fcosVM = func(idx int, labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
+
+		addressesFromStatus = func(vmi *kubevirtv1.VirtualMachineInstance) func() ([]string, error) {
+			return func() ([]string, error) {
+				err := crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)
+				if err != nil {
+					return nil, err
+				}
+				var addresses []string
+				for _, iface := range vmi.Status.Interfaces {
+					for _, ip := range iface.IPs {
+						addresses = append(addresses, ip)
+					}
+				}
+				return addresses, nil
+			}
+		}
+
+		createVirtualMachine = func(vm *kubevirtv1.VirtualMachine) {
+			By(fmt.Sprintf("Create virtual machine %s", vm.Name))
+			vmCreationRetries := 0
+			Eventually(func() error {
+				if vmCreationRetries > 0 {
+					// retry due to unknown issue where kubevirt webhook gets stuck reading the request body
+					// https://github.com/ovn-org/ovn-kubernetes/issues/3902#issuecomment-1750257559
+					By(fmt.Sprintf("Retrying vm %s creation", vm.Name))
+				}
+				err := crClient.Create(context.Background(), vm)
+				vmCreationRetries++
+				return err
+			}).WithOffset(1).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+		}
+
+		createVirtualMachineInstance = func(vmi *kubevirtv1.VirtualMachineInstance) {
+			By(fmt.Sprintf("Create virtual machine instance %s", vmi.Name))
+			vmiCreationRetries := 0
+			Eventually(func() error {
+				if vmiCreationRetries > 0 {
+					// retry due to unknown issue where kubevirt webhook gets stuck reading the request body
+					// https://github.com/ovn-org/ovn-kubernetes/issues/3902#issuecomment-1750257559
+					By(fmt.Sprintf("Retrying vmi %s creation", vmi.Name))
+				}
+				err := crClient.Create(context.Background(), vmi)
+				vmiCreationRetries++
+				return err
+			}).WithOffset(1).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+		}
+
+		waitVirtualMachineInstanceReadiness = func(vmi *kubevirtv1.VirtualMachineInstance) {
+			By(fmt.Sprintf("Waiting for readiness at virtual machine %s", vmi.Name))
+			Eventually(func() []kubevirtv1.VirtualMachineInstanceCondition {
+				err := crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vmi), vmi)
+				Expect(err).To(SatisfyAny(WithTransform(apierrors.IsNotFound, BeTrue()), Succeed()))
+				return vmi.Status.Conditions
+			}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(ContainElement(SatisfyAll(
+				HaveField("Type", kubevirtv1.VirtualMachineInstanceReady),
+				HaveField("Status", corev1.ConditionTrue),
+			)))
+		}
+
+		waitVirtualMachineAddresses = func(vmi *kubevirtv1.VirtualMachineInstance) []kubevirt.Address {
+			step := by(vmi.Name, "Wait for virtual machine to receive IPv4 address from DHCP")
+			Eventually(addressByFamily(ipv4, vmi)).
+				WithPolling(time.Second).
+				WithTimeout(5*time.Minute).
+				Should(HaveLen(1), step)
+			addresses, err := addressByFamily(ipv4, vmi)()
+			Expect(err).ToNot(HaveOccurred())
+			if isDualStack() {
+				output, err := kubevirt.RunCommand(vmi, `echo '{"interfaces":[{"name":"enp1s0","type":"ethernet","state":"up","ipv4":{"enabled":true,"dhcp":true},"ipv6":{"enabled":true,"dhcp":true,"autoconf":false}}],"routes":{"config":[{"destination":"::/0","next-hop-interface":"enp1s0","next-hop-address":"fe80::1"}]}}' |nmstatectl apply`, 5*time.Second)
+				Expect(err).ToNot(HaveOccurred(), output)
+				step = by(vmi.Name, "Wait for virtual machine to receive IPv6 address from DHCP")
+				Eventually(addressByFamily(ipv6, vmi)).
+					WithPolling(time.Second).
+					WithTimeout(5*time.Minute).
+					Should(HaveLen(2), func() string {
+						output, _ := kubevirt.RunCommand(vmi, "journalctl -u nmstate", 2*time.Second)
+						return step + " -> journal nmstate: " + output
+					})
+				ipv6Addresses, err := addressByFamily(ipv6, vmi)()
+				Expect(err).ToNot(HaveOccurred())
+				addresses = append(addresses, ipv6Addresses...)
+			}
+			return addresses
+		}
+
+		virtualMachineAddressesFromStatus = func(vmi *kubevirtv1.VirtualMachineInstance, expectedNumberOfAddresses int) []string {
+			step := by(vmi.Name, "Wait for virtual machine to report addresses")
+			Eventually(addressesFromStatus(vmi)).
+				WithPolling(time.Second).
+				WithTimeout(10*time.Second).
+				Should(HaveLen(expectedNumberOfAddresses), step)
+
+			addresses, err := addressesFromStatus(vmi)()
+			Expect(err).ToNot(HaveOccurred())
+			return addresses
+		}
+
+		fcosVMI = func(idx int, labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachineInstance, error) {
 			workingDirectory, err := os.Getwd()
 			if err != nil {
 				return nil, err
@@ -556,6 +637,84 @@ passwd:
 					FilesDir: workingDirectory,
 				},
 			})
+			if err != nil {
+				return nil, fmt.Errorf("failed translating butane: %w", err)
+			}
+			return &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   namespace,
+					Name:        fmt.Sprintf("worker%d", idx),
+					Annotations: annotations,
+					Labels:      labels,
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					NodeSelector: nodeSelector,
+					Domain: kubevirtv1.DomainSpec{
+						Resources: kubevirtv1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+						Devices: kubevirtv1.Devices{
+							Disks: []kubevirtv1.Disk{
+								{
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{
+											Bus: kubevirtv1.DiskBusVirtio,
+										},
+									},
+									Name: "containerdisk",
+								},
+								{
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{
+											Bus: kubevirtv1.DiskBusVirtio,
+										},
+									},
+									Name: "cloudinitdisk",
+								},
+							},
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "net1",
+									InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+										Bridge: &kubevirtv1.InterfaceBridge{},
+									},
+								},
+							},
+							Rng: &kubevirtv1.Rng{},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name:          "net1",
+							NetworkSource: networkSource,
+						},
+					},
+					TerminationGracePeriodSeconds: pointer.Int64(5),
+					Volumes: []kubevirtv1.Volume{
+						{
+							Name: "containerdisk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								ContainerDisk: &kubevirtv1.ContainerDiskSource{
+									Image: "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50",
+								},
+							},
+						},
+						{
+							Name: "cloudinitdisk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
+									UserData: string(ignition),
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		}
+		fcosVM = func(idx int, labels map[string]string, annotations map[string]string, nodeSelector map[string]string, networkSource kubevirtv1.NetworkSource, butane string) (*kubevirtv1.VirtualMachine, error) {
+			vmi, err := fcosVMI(idx, labels, annotations, nodeSelector, networkSource, butane)
 			if err != nil {
 				return nil, err
 			}
@@ -568,88 +727,74 @@ passwd:
 					Running: pointer.Bool(true),
 					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{
-								"kubevirt.io/allow-pod-bridge-network-live-migration": "",
-							},
-							Labels: labels,
+							Annotations: annotations,
+							Labels:      labels,
 						},
-						Spec: kubevirtv1.VirtualMachineInstanceSpec{
-							NodeSelector: map[string]string{
-								namespace: "",
-							},
-							Domain: kubevirtv1.DomainSpec{
-								Resources: kubevirtv1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("512Mi"),
-									},
-								},
-								Devices: kubevirtv1.Devices{
-									Disks: []kubevirtv1.Disk{
-										{
-											DiskDevice: kubevirtv1.DiskDevice{
-												Disk: &kubevirtv1.DiskTarget{
-													Bus: kubevirtv1.DiskBusVirtio,
-												},
-											},
-											Name: "containerdisk",
-										},
-										{
-											DiskDevice: kubevirtv1.DiskDevice{
-												Disk: &kubevirtv1.DiskTarget{
-													Bus: kubevirtv1.DiskBusVirtio,
-												},
-											},
-											Name: "cloudinitdisk",
-										},
-									},
-									Interfaces: []kubevirtv1.Interface{
-										{
-											Name: "pod",
-											InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
-												Bridge: &kubevirtv1.InterfaceBridge{},
-											},
-										},
-									},
-									Rng: &kubevirtv1.Rng{},
-								},
-							},
-							Networks: []kubevirtv1.Network{
-								{
-									Name: "pod",
-									NetworkSource: kubevirtv1.NetworkSource{
-										Pod: &kubevirtv1.PodNetwork{},
-									},
-								},
-							},
-							TerminationGracePeriodSeconds: pointer.Int64(5),
-							Volumes: []kubevirtv1.Volume{
-								{
-									Name: "containerdisk",
-									VolumeSource: kubevirtv1.VolumeSource{
-										ContainerDisk: &kubevirtv1.ContainerDiskSource{
-											Image: "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50",
-										},
-									},
-								},
-								{
-									Name: "cloudinitdisk",
-									VolumeSource: kubevirtv1.VolumeSource{
-										CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
-											UserData: string(ignition),
-										},
-									},
-								},
-							},
-						},
+						Spec: vmi.Spec,
 					},
 				},
 			}, nil
 		}
 
-		composeVMs = func(numberOfVMs int, labels map[string]string) ([]*kubevirtv1.VirtualMachine, error) {
+		composeDefaultNetworkLiveMigratableVM = func(idx int, labels map[string]string, butane string) (*kubevirtv1.VirtualMachine, error) {
+			annotations := map[string]string{
+				"kubevirt.io/allow-pod-bridge-network-live-migration": "",
+			}
+			nodeSelector := map[string]string{
+				namespace: "",
+			}
+			networkSource := kubevirtv1.NetworkSource{
+				Pod: &kubevirtv1.PodNetwork{},
+			}
+			return fcosVM(idx, labels, annotations, nodeSelector, networkSource, butane)
+		}
+
+		composeDefaultNetworkLiveMigratableVMs = func(numberOfVMs int, labels map[string]string) ([]*kubevirtv1.VirtualMachine, error) {
+			butane := fmt.Sprintf(`
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+    - path: /root/test/server.go
+      contents:
+        local: kubevirt/echoserver/main.go
+systemd:
+  units:
+    - name: systemd-resolved.service
+      mask: true
+    - name: replace-resolved.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Replace systemd resolvd with NetworkManager
+        Wants=network-online.target
+        After=network-online.target
+        [Service]
+        ExecStart=rm -f /etc/resolv.conf
+        ExecStart=systemctl restart NetworkManager
+        Type=oneshot
+        [Install]
+        WantedBy=multi-user.target
+    - name: echoserver.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Golang echo server
+        Wants=replace-resolved.service
+        After=replace-resolved.service
+        [Service]
+        ExecStart=podman run --name tcpserver --tls-verify=false --privileged --net=host -v /root/test:/test:z registry.access.redhat.com/ubi9/go-toolset:1.20 go run /test/server.go %d
+        [Install]
+        WantedBy=multi-user.target
+passwd:
+  users:
+  - name: core
+    password_hash: $y$j9T$b7RFf2LW7MUOiF4RyLHKA0$T.Ap/uzmg8zrTcUNXyXvBvT26UgkC6zZUVg3UKXeEp5
+`, tcpServerPort)
+
 			vms := []*kubevirtv1.VirtualMachine{}
 			for i := 1; i <= numberOfVMs; i++ {
-				vm, err := fcosVM(i, labels, butane)
+				vm, err := composeDefaultNetworkLiveMigratableVM(i, labels, butane)
 				if err != nil {
 					return nil, err
 				}
@@ -663,7 +808,7 @@ passwd:
 			checkConnectivityAndNetworkPolicies(vmName, endpoints, step)
 		}
 
-		runTest = func(td liveMigrationTestData, vm *kubevirtv1.VirtualMachine) {
+		runLiveMigrationTest = func(td liveMigrationTestData, vm *kubevirtv1.VirtualMachine) {
 			defer GinkgoRecover()
 			defer wg.Done()
 			step := by(vm.Name, "Login to virtual machine")
@@ -677,24 +822,7 @@ passwd:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kubevirt.LoginToFedora(vmi, "core", "fedora")).To(Succeed(), step)
 
-			step = by(vm.Name, "Wait for virtual machine to receive IPv4 address from DHCP")
-			Eventually(addressByFamily(ipv4, vmi)).
-				WithPolling(time.Second).
-				WithTimeout(5*time.Minute).
-				Should(HaveLen(1), step)
-
-			if isDualStack {
-				output, err := kubevirt.RunCommand(vmi, `echo '{"interfaces":[{"name":"enp1s0","type":"ethernet","state":"up","ipv4":{"enabled":true,"dhcp":true},"ipv6":{"enabled":true,"dhcp":true,"autoconf":false}}],"routes":{"config":[{"destination":"::/0","next-hop-interface":"enp1s0","next-hop-address":"fe80::1"}]}}' |nmstatectl apply`, 5*time.Second)
-				Expect(err).ToNot(HaveOccurred(), output)
-				step = by(vm.Name, "Wait for virtual machine to receive IPv6 address from DHCP")
-				Eventually(addressByFamily(ipv6, vmi)).
-					WithPolling(time.Second).
-					WithTimeout(5*time.Minute).
-					Should(HaveLen(2), func() string {
-						output, _ := kubevirt.RunCommand(vmi, "journalctl -u nmstate", 2*time.Second)
-						return step + " -> journal nmstate: " + output
-					})
-			}
+			waitVirtualMachineAddresses(vmi)
 
 			step = by(vm.Name, "Expose tcpServer as a service")
 			svc, err := fr.ClientSet.CoreV1().Services(namespace).Create(context.TODO(), composeService("tcpserver", vm.Name, tcpServerPort), metav1.CreateOptions{})

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -36,13 +36,14 @@ func getNetCIDRSubnet(netCIDR string) (string, error) {
 }
 
 type networkAttachmentConfigParams struct {
-	cidr         string
-	excludeCIDRs []string
-	namespace    string
-	name         string
-	topology     string
-	networkName  string
-	vlanID       int
+	cidr               string
+	excludeCIDRs       []string
+	namespace          string
+	name               string
+	topology           string
+	networkName        string
+	vlanID             int
+	allowPersistentIPs bool
 }
 
 type networkAttachmentConfig struct {
@@ -76,7 +77,8 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
         "excludeSubnets": %q,
         "mtu": 1300,
         "netAttachDefName": %q,
-        "vlanID": %d
+        "vlanID": %d,
+        "allowPersistentIPs": %t
 }
 `,
 		config.networkName,
@@ -85,6 +87,7 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
 		strings.Join(config.excludeCIDRs, ","),
 		namespacedName(config.namespace, config.name),
 		config.vlanID,
+		config.allowPersistentIPs,
 	)
 	return generateNetAttachDef(config.namespace, config.name, nadSpec)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR adds e2e tests for the KubeVirt persistent IPs feature.

Until the feature is integrated in upstream KubeVirt, we can rely on an external controller + webhook that creates the IPAMClaims / requests them on behalf of KubeVirt. 

Requesting the IPAMClaims on behalf of KubeVirt is provided by a mutating webhook that adds the `ipam-claim-reference` attribute to the launcher pod's network selection elements for networks (on launcher pods) that have the persistent IPs knob enabled. It requires `cert-manager`, which is also installed in this PR.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
Once the KubeVirt integration is merged, we can stop installing cert-manager & the `kubevirt-ipam-claims` tool, and start to install the KubeVirt latest built version.

This PR has all the commits of #4191 - except the one where we run a custom built version of KubeVirt. 

It also has an extra commit (which will eventually be dropped) installing cert-manager, and webhook + controller to create / request the IPAMClaims for the KubeVirt VM.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Run the e2e tests, KubeVirt related lane. 

The filter would be:
```bash
ENABLE_MULTI_NET=true make -C test control-plane WHAT="Kubevirt Virtual Machines"
```

**Note:** the above focus also runs the default network KubeVirt migration tests.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->