### PR TITLE
kubevirt, e2e: Check e/w traffic without serial

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -123,15 +123,36 @@ func EnsurePodAnnotationForVM(watchFactory *factory.WatchFactory, kube *kube.Kub
 	return podAnnotation, nil
 }
 
+// AllVMPodsAreCompleted return true if all the vm pods are completed
+func AllVMPodsAreCompleted(client *factory.WatchFactory, pod *corev1.Pod) (bool, error) {
+	if !IsPodLiveMigratable(pod) {
+		return false, nil
+	}
+
+	vmPods, err := findVMRelatedPods(client, pod)
+	if err != nil {
+		return false, fmt.Errorf("failed finding related pods for pod %s/%s when checking if they are completed: %v", pod.Namespace, pod.Name, err)
+	}
+
+	for _, vmPod := range vmPods {
+		if !util.PodCompleted(vmPod) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 // IsMigratedSourcePodStale return false if the pod is live migratable,
 // not completed and is the running VM pod with newest creation timestamp
 func IsMigratedSourcePodStale(client *factory.WatchFactory, pod *corev1.Pod) (bool, error) {
 	if !IsPodLiveMigratable(pod) {
 		return false, nil
 	}
+
 	if util.PodCompleted(pod) {
 		return true, nil
 	}
+
 	vmPods, err := findVMRelatedPods(client, pod)
 	if err != nil {
 		return false, fmt.Errorf("failed finding related pods for pod %s/%s when checking live migration left overs: %v", pod.Namespace, pod.Name, err)
@@ -185,17 +206,17 @@ func ExtractVMNameFromPod(pod *corev1.Pod) *ktypes.NamespacedName {
 }
 
 func CleanUpLiveMigratablePod(nbClient libovsdbclient.Client, watchFactory *factory.WatchFactory, pod *corev1.Pod) error {
-	// This pod is not part of ip migration so we don't need to clean up
 	if !IsPodLiveMigratable(pod) {
 		return nil
 	}
-	isMigratedSourcePodStale, err := IsMigratedSourcePodStale(watchFactory, pod)
+
+	allVMPodsCompleted, err := AllVMPodsAreCompleted(watchFactory, pod)
 	if err != nil {
 		return fmt.Errorf("failed cleaning up VM when checking if pod is leftover: %v", err)
 	}
-	// Everything has already being cleand up since this is an old migration
-	// pod
-	if isMigratedSourcePodStale {
+
+	// Do cleanup only if all the pods related to the VM are completed
+	if !allVMPodsCompleted {
 		return nil
 	}
 

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -142,6 +142,31 @@ func AllVMPodsAreCompleted(client *factory.WatchFactory, pod *corev1.Pod) (bool,
 	return true, nil
 }
 
+// isLiveMigrationInProgress return true if a live migration is still progressing
+func isLiveMigrationInProgress(client *factory.WatchFactory, pod *corev1.Pod) (bool, error) {
+	if !IsPodLiveMigratable(pod) {
+		return false, nil
+	}
+
+	vmPods, err := findVMRelatedPods(client, pod)
+	if err != nil {
+		return false, fmt.Errorf("failed finding related pods for pod %s/%s when checking if they are completed: %v", pod.Namespace, pod.Name, err)
+	}
+
+	vmPods = append(vmPods, pod)
+
+	numberOfRunningPods := 0
+	for _, vmPod := range vmPods {
+		if util.PodRunning(vmPod) {
+			numberOfRunningPods++
+		}
+		if numberOfRunningPods > 1 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // IsMigratedSourcePodStale return false if the pod is live migratable,
 // not completed and is the running VM pod with newest creation timestamp
 func IsMigratedSourcePodStale(client *factory.WatchFactory, pod *corev1.Pod) (bool, error) {

--- a/go-controller/vendor/github.com/j-keck/arping/arp_datagram.go
+++ b/go-controller/vendor/github.com/j-keck/arping/arp_datagram.go
@@ -40,6 +40,23 @@ func newArpRequest(
 		tpa:   dstIP.To4()}
 }
 
+func newArpReply(
+	srcMac net.HardwareAddr,
+	srcIP net.IP,
+	dstMac net.HardwareAddr,
+	dstIP net.IP) arpDatagram {
+	return arpDatagram{
+		htype: uint16(1),
+		ptype: uint16(0x0800),
+		hlen:  uint8(6),
+		plen:  uint8(4),
+		oper:  uint16(responseOper),
+		sha:   srcMac,
+		spa:   srcIP.To4(),
+		tha:   dstMac,
+		tpa:   dstIP.To4()}
+}
+
 func (datagram arpDatagram) Marshal() []byte {
 	buf := new(bytes.Buffer)
 	binary.Write(buf, binary.BigEndian, datagram.htype)

--- a/go-controller/vendor/github.com/j-keck/arping/arping.go
+++ b/go-controller/vendor/github.com/j-keck/arping/arping.go
@@ -2,60 +2,57 @@
 //
 // The currently supported platforms are: Linux and BSD.
 //
-//
 // The library requires raw socket access. So it must run as root, or with appropriate capabilities under linux:
 // `sudo setcap cap_net_raw+ep <BIN>`.
 //
-//
 // Examples:
 //
-//   ping a host:
-//   ------------
-//     package main
-//     import ("fmt"; "github.com/j-keck/arping"; "net")
+//	ping a host:
+//	------------
+//	  package main
+//	  import ("fmt"; "github.com/j-keck/arping"; "net")
 //
-//     func main(){
-//       dstIP := net.ParseIP("192.168.1.1")
-//       if hwAddr, duration, err := arping.Ping(dstIP); err != nil {
-//         fmt.Println(err)
-//       } else {
-//         fmt.Printf("%s (%s) %d usec\n", dstIP, hwAddr, duration/1000)
-//       }
-//     }
-//
-//
-//   resolve mac address:
-//   --------------------
-//     package main
-//     import ("fmt"; "github.com/j-keck/arping"; "net")
-//
-//     func main(){
-//       dstIP := net.ParseIP("192.168.1.1")
-//       if hwAddr, _, err := arping.Ping(dstIP); err != nil {
-//         fmt.Println(err)
-//       } else {
-//         fmt.Printf("%s is at %s\n", dstIP, hwAddr)
-//       }
-//     }
+//	  func main(){
+//	    dstIP := net.ParseIP("192.168.1.1")
+//	    if hwAddr, duration, err := arping.Ping(dstIP); err != nil {
+//	      fmt.Println(err)
+//	    } else {
+//	      fmt.Printf("%s (%s) %d usec\n", dstIP, hwAddr, duration/1000)
+//	    }
+//	  }
 //
 //
-//   check if host is online:
-//   ------------------------
-//     package main
-//     import ("fmt"; "github.com/j-keck/arping"; "net")
+//	resolve mac address:
+//	--------------------
+//	  package main
+//	  import ("fmt"; "github.com/j-keck/arping"; "net")
 //
-//     func main(){
-//       dstIP := net.ParseIP("192.168.1.1")
-//       _, _, err := arping.Ping(dstIP)
-//       if err == arping.ErrTimeout {
-//         fmt.Println("offline")
-//       }else if err != nil {
-//         fmt.Println(err.Error())
-//       }else{
-//         fmt.Println("online")
-//       }
-//     }
+//	  func main(){
+//	    dstIP := net.ParseIP("192.168.1.1")
+//	    if hwAddr, _, err := arping.Ping(dstIP); err != nil {
+//	      fmt.Println(err)
+//	    } else {
+//	      fmt.Printf("%s is at %s\n", dstIP, hwAddr)
+//	    }
+//	  }
 //
+//
+//	check if host is online:
+//	------------------------
+//	  package main
+//	  import ("fmt"; "github.com/j-keck/arping"; "net")
+//
+//	  func main(){
+//	    dstIP := net.ParseIP("192.168.1.1")
+//	    _, _, err := arping.Ping(dstIP)
+//	    if err == arping.ErrTimeout {
+//	      fmt.Println("offline")
+//	    }else if err != nil {
+//	      fmt.Println(err.Error())
+//	    }else{
+//	      fmt.Println("online")
+//	    }
+//	  }
 package arping
 
 import (
@@ -201,7 +198,7 @@ func GratuitousArpOverIface(srcIP net.IP, iface net.Interface) error {
 
 	srcMac := iface.HardwareAddr
 	broadcastMac := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
-	request := newArpRequest(srcMac, srcIP, broadcastMac, srcIP)
+	request := newArpReply(srcMac, srcIP, broadcastMac, srcIP)
 
 	sock, err := initialize(iface)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does and why is it needed
Kubevirt serial console do not survive live migration so we should reduce the use of it. This change test east/west traffic using the agnhost pods as clients so we don't have to login into the VM.
