### PR TITLE
kubevirt: Propertly remove migration leftovers

### DIFF
--- a/go-controller/pkg/ovn/kubevirt_test.go
+++ b/go-controller/pkg/ovn/kubevirt_test.go
@@ -825,10 +825,20 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				}
 
 				if t.podName != "" {
+					pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					pod.Status.Phase = corev1.PodSucceeded
+					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
 					err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Delete(context.TODO(), t.podName, metav1.DeleteOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
 					if t.migrationTarget.nodeName != "" {
+						pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.migrationTarget.podName, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						pod.Status.Phase = corev1.PodSucceeded
+						_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
+						Expect(err).NotTo(HaveOccurred())
 						err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Delete(context.TODO(), t.migrationTarget.podName, metav1.DeleteOptions{})
 						Expect(err).NotTo(HaveOccurred())
 					}


### PR DESCRIPTION
#### What this PR does and why is it needed
After merging https://github.com/ovn-org/ovn-kubernetes/commit/469c4e8202166b9b334c8785fc14e0f3193597e7 the live migration leftovers were not removed since all the VM's pods are at completed state so the cleanup was skip.

This change simplify that logic by removing left overs if all the VM's pods are completed.


```release-note
kubevirt: Propertly remove migration leftovers
```
