### PR TITLE
Dockerfile.ubuntu: Use ubuntu:24.04

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -8,7 +8,7 @@
 #
 # So this file will change over time.
 
-FROM ubuntu:23.10
+FROM ubuntu:24.04
 
 USER root
 


### PR DESCRIPTION
This change updates the OVN DB schema to be compatible with Object type nbdb.LogicalRouterPolicy field BFDSessions.

```
Database OVN_Northbound validation error (2): Mapper Error. Object type nbdb.DNS contains field Options (map[string]string). OVS tag options: Column does not exist in schema. Mapper Error. Object type nbdb.LogicalRouterPolicy contains field BFDSessions ([]string). OVS tag bfd_sessions: Column does not exist in schema.
```