### PR TITLE
Make egress firewall node controller level-driven

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -146,9 +146,6 @@ type egressIPPod struct{}
 type egressIPNamespace struct{}
 type egressNode struct{}
 
-// types for handlers related to egress Firewall
-type egressFwNode struct{}
-
 // types for handlers in use by ovn-k node
 type namespaceExGw struct{}
 type endpointSliceForStaleConntrackRemoval struct{}
@@ -169,7 +166,6 @@ var (
 	EgressIPNamespaceType                 reflect.Type = reflect.TypeOf(&egressIPNamespace{})
 	EgressIPPodType                       reflect.Type = reflect.TypeOf(&egressIPPod{})
 	EgressNodeType                        reflect.Type = reflect.TypeOf(&egressNode{})
-	EgressFwNodeType                      reflect.Type = reflect.TypeOf(&egressFwNode{})
 	CloudPrivateIPConfigType              reflect.Type = reflect.TypeOf(&ocpcloudnetworkapi.CloudPrivateIPConfig{})
 	EgressQoSType                         reflect.Type = reflect.TypeOf(&egressqosapi.EgressQoS{})
 	EgressServiceType                     reflect.Type = reflect.TypeOf(&egressserviceapi.EgressService{})
@@ -898,7 +894,7 @@ type AddHandlerFuncType func(namespace string, sel labels.Selector, funcs cache.
 // This is relevant only for handlers that are sharing the same resources:
 // Pods: shared by PodType (0), EgressIPPodType (1), AddressSetPodSelectorType (2), LocalPodSelectorType (3)
 // Namespaces: shared by NamespaceType (0), EgressIPNamespaceType (1), PeerNamespaceSelectorType (3), AddressSetNamespaceAndPodSelectorType (4)
-// Nodes: shared by NodeType (0), EgressNodeType (1), EgressFwNodeType (1)
+// Nodes: shared by NodeType (0), EgressNodeType (1)
 // By default handlers get the defaultHandlerPriority which is 0 (highest priority). Higher the number, lower the priority to get an event.
 // Example: EgressIPPodType will always get the pod event after PodType and AddressSetPodSelectorType will always get the event after PodType and EgressIPPodType
 // NOTE: If you are touching this function to add a new object type that uses shared objects, please make sure to update `minHandlerPriority` if needed
@@ -917,8 +913,6 @@ func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority int) 
 	case AddressSetNamespaceAndPodSelectorType:
 		return 3
 	case EgressNodeType:
-		return 1
-	case EgressFwNodeType:
 		return 1
 	default:
 		return defaultHandlerPriority
@@ -946,7 +940,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 			return wf.AddMultiNetworkPolicyHandler(funcs, processExisting)
 		}, nil
 
-	case NodeType, EgressNodeType, EgressFwNodeType:
+	case NodeType, EgressNodeType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
 			return wf.AddNodeHandler(funcs, processExisting, priority)

--- a/go-controller/pkg/ovn/base_event_handler.go
+++ b/go-controller/pkg/ovn/base_event_handler.go
@@ -30,7 +30,6 @@ func hasResourceAnUpdateFunc(objType reflect.Type) bool {
 		factory.EgressIPNamespaceType,
 		factory.EgressIPPodType,
 		factory.EgressNodeType,
-		factory.EgressFwNodeType,
 		factory.NamespaceType,
 		factory.MultiNetworkPolicyType,
 		factory.IPAMClaimsType:
@@ -97,21 +96,6 @@ func (h *baseNetworkControllerEventHandler) areResourcesEqual(objType reflect.Ty
 		// force update path for EgressIP resource.
 		return false, nil
 
-	case factory.EgressFwNodeType:
-		oldNode, ok := obj1.(*kapi.Node)
-		if !ok {
-			return false, fmt.Errorf("could not cast obj1 of type %T to *kapi.Node", obj1)
-		}
-		newNode, ok := obj2.(*kapi.Node)
-		if !ok {
-			return false, fmt.Errorf("could not cast obj2 of type %T to *kapi.Node", obj2)
-		}
-		if reflect.DeepEqual(oldNode.Labels, newNode.Labels) &&
-			!util.NodeHostCIDRsAnnotationChanged(oldNode, newNode) {
-			return true, nil
-		}
-		return false, nil
-
 	case factory.NamespaceType:
 		// force update path for Namespace resource.
 		return false, nil
@@ -160,8 +144,7 @@ func (h *baseNetworkControllerEventHandler) getResourceFromInformerCache(objType
 		obj, err = watchFactory.GetNetworkPolicy(namespace, name)
 
 	case factory.NodeType,
-		factory.EgressNodeType,
-		factory.EgressFwNodeType:
+		factory.EgressNodeType:
 		obj, err = watchFactory.GetNode(name)
 
 	case factory.PodType,
@@ -206,7 +189,6 @@ func (h *baseNetworkControllerEventHandler) isResourceScheduled(objType reflect.
 func needsUpdateDuringRetry(objType reflect.Type) bool {
 	switch objType {
 	case factory.EgressNodeType,
-		factory.EgressFwNodeType,
 		factory.EgressIPType,
 		factory.EgressIPPodType,
 		factory.EgressIPNamespaceType,

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -854,7 +854,7 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 
 	case factory.EgressFwNodeType:
 		node := obj.(*kapi.Node)
-		if err = h.oc.updateEgressFirewallForNode(nil, node); err != nil {
+		if err = h.oc.updateEgressFirewallForNode(node.Name); err != nil {
 			klog.Infof("Node add failed during egress firewall eval for node: %s, will try again later: %v",
 				node.Name, err)
 			return err
@@ -1035,9 +1035,8 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		return nil
 
 	case factory.EgressFwNodeType:
-		oldNode := oldObj.(*kapi.Node)
 		newNode := newObj.(*kapi.Node)
-		return h.oc.updateEgressFirewallForNode(oldNode, newNode)
+		return h.oc.updateEgressFirewallForNode(newNode.Name)
 
 	case factory.NamespaceType:
 		oldNs, newNs := oldObj.(*kapi.Namespace), newObj.(*kapi.Namespace)
@@ -1113,7 +1112,7 @@ func (h *defaultNetworkControllerEventHandler) DeleteResource(obj, cachedObj int
 		if !ok {
 			return fmt.Errorf("could not cast obj of type %T to *knet.Node", obj)
 		}
-		return h.oc.updateEgressFirewallForNode(node, nil)
+		return h.oc.updateEgressFirewallForNode(node.Name)
 
 	case factory.NamespaceType:
 		ns := obj.(*kapi.Namespace)

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -341,7 +341,9 @@ func (oc *DefaultNetworkController) Start(ctx context.Context) error {
 
 // Stop gracefully stops the controller
 func (oc *DefaultNetworkController) Stop() {
-	oc.dnsNameResolver.Shutdown()
+	if oc.dnsNameResolver != nil {
+		oc.dnsNameResolver.Shutdown()
+	}
 	close(oc.stopChan)
 	oc.cancelableCtx.Cancel()
 	oc.wg.Wait()

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -34,7 +34,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -1647,7 +1646,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				output: egressFirewallRule{
 					id:     1,
 					access: egressfirewallapi.EgressFirewallRuleAllow,
-					to: destination{nodeAddrs: sets.New[string](), nodeSelector: &metav1.LabelSelector{
+					to: destination{nodeAddrs: map[string][]string{}, nodeSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"no": "match"}}},
 				},
 			},
@@ -1662,7 +1661,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				output: egressFirewallRule{
 					id:     1,
 					access: egressfirewallapi.EgressFirewallRuleAllow,
-					to:     destination{nodeAddrs: sets.New("10.10.10.10", "9.9.9.9"), nodeSelector: &metav1.LabelSelector{}},
+					to:     destination{nodeAddrs: map[string][]string{node1Name: {node1Addr}, node2Name: {node2Addr}}, nodeSelector: &metav1.LabelSelector{}},
 				},
 			},
 			// match one node
@@ -1676,7 +1675,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				output: egressFirewallRule{
 					id:     1,
 					access: egressfirewallapi.EgressFirewallRuleAllow,
-					to:     destination{nodeAddrs: sets.New(node1Addr), nodeSelector: &metav1.LabelSelector{MatchLabels: nodeLabel}},
+					to:     destination{nodeAddrs: map[string][]string{node1Name: {node1Addr}}, nodeSelector: &metav1.LabelSelector{MatchLabels: nodeLabel}},
 				},
 			},
 		}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -329,13 +329,6 @@ func (oc *DefaultNetworkController) WatchEgressNodes() error {
 	return err
 }
 
-// WatchEgressFwNodes starts the watching of nodes for Egress Firewall where
-// firewall rules may match nodes using a node selector
-func (oc *DefaultNetworkController) WatchEgressFwNodes() error {
-	_, err := oc.retryEgressFwNodes.WatchResource()
-	return err
-}
-
 // WatchEgressIP starts the watching of egressip resource and calls back the
 // appropriate handler logic. It also initiates the other dedicated resource
 // handlers for egress IP setup: namespaces, pods.


### PR DESCRIPTION
Beginning of the story is in https://github.com/ovn-org/ovn-kubernetes/pull/4386
Switch to level-driven controller to avoid
dependency between node handler and ef node handler.
If EF handler is ever deadlocked (and it can be as node handler iterates
all egress firewalls, which in turn, depend on dns resolvers), node
handler should not be affected.
See a new test for more idea.