### PR TITLE
Consolidate use of errors

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
+++ b/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 	"github.com/urfave/cli/v2"
-	"k8s.io/apimachinery/pkg/util/errors"
 	kexec "k8s.io/utils/exec"
 )
 
@@ -31,7 +31,7 @@ var NicsToBridgeCommand = cli.Command{
 			}
 		}
 
-		return errors.NewAggregate(errorList)
+		return utilerrors.Join(errorList...)
 	},
 }
 
@@ -57,6 +57,6 @@ var BridgesToNicCommand = cli.Command{
 			}
 		}
 
-		return errors.NewAggregate(errorList)
+		return utilerrors.Join(errorList...)
 	},
 }

--- a/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
+++ b/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
@@ -18,7 +18,6 @@ import (
 
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listers "k8s.io/client-go/listers/core/v1"
@@ -40,6 +39,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/csrapprover"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovnwebhook"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
 )
@@ -176,7 +176,7 @@ func main() {
 
 		runWg.Wait()
 		cancel()
-		return errors.NewAggregate([]error{errWebhook, errApprover})
+		return utilerrors.Join(errWebhook, errApprover)
 	}
 
 	c.Flags = []cli.Flag{

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -31,6 +30,7 @@ import (
 	ovnnode "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kexec "k8s.io/utils/exec"
 )
@@ -572,7 +572,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	wg.Wait()
 	klog.Infof("Stopped ovnkube")
 
-	err = errors.Join(managerErr, controllerErr, nodeErr)
+	err = utilerrors.Join(managerErr, controllerErr, nodeErr)
 	if err != nil {
 		return fmt.Errorf("failed to run ovnkube: %w", err)
 	}

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/openshift/api v0.0.0-20231120222239-b86761094ee3
 	github.com/openshift/client-go v0.0.0-20231121143148-910ca30a1a9a
 	github.com/ovn-org/libovsdb v0.6.1-0.20240125124854-03f787b1a892
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.5.0
 	github.com/safchain/ethtool v0.3.1-0.20231027162144-83e5e0097c91
@@ -101,6 +100,7 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/go-controller/pkg/clustermanager/dnsnameresolver/resolver_info.go
+++ b/go-controller/pkg/clustermanager/dnsnameresolver/resolver_info.go
@@ -6,12 +6,12 @@ import (
 	"hash/fnv"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 
 	ocpnetworkclientset "github.com/openshift/client-go/network/clientset/versioned"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 // resolverInfo maintains consistent information about the DNS names, the
@@ -148,7 +148,7 @@ func (resInfo *resolverInfo) ModifyDNSNamesForNamespace(dnsNames []string, names
 
 	// Return the errors, if any.
 	if len(errorList) != 0 {
-		return errors.NewAggregate(errorList)
+		return utilerrors.Join(errorList...)
 	}
 
 	return nil
@@ -176,7 +176,7 @@ func (resInfo *resolverInfo) DeleteDNSNamesForNamespace(namespace string) error 
 
 	// Return the errors, if any.
 	if len(errorList) != 0 {
-		return errors.NewAggregate(errorList)
+		return utilerrors.Join(errorList...)
 	}
 
 	return nil

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -24,10 +24,10 @@ import (
 	objretry "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -738,7 +738,7 @@ func (eIPC *egressIPClusterController) reconcileSecondaryHostNetworkEIPs(node *v
 		}
 	}
 	if len(errorAggregate) > 0 {
-		return utilerrors.NewAggregate(errorAggregate)
+		return utilerrors.Join(errorAggregate...)
 	}
 	return nil
 }
@@ -771,7 +771,7 @@ func (eIPC *egressIPClusterController) addEgressNode(nodeName string) error {
 	}
 
 	if len(errors) > 0 {
-		return utilerrors.NewAggregate(errors)
+		return utilerrors.Join(errors...)
 	}
 	return nil
 }
@@ -816,7 +816,7 @@ func (eIPC *egressIPClusterController) deleteEgressNode(nodeName string) error {
 		}
 	}
 	if len(errorAggregate) > 0 {
-		return utilerrors.NewAggregate(errorAggregate)
+		return utilerrors.Join(errorAggregate...)
 	}
 	return nil
 }

--- a/go-controller/pkg/clustermanager/egressservice/egressservice_cluster.go
+++ b/go-controller/pkg/clustermanager/egressservice/egressservice_cluster.go
@@ -15,11 +15,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -385,7 +385,7 @@ func (c *Controller) repair() error {
 		}
 	}
 
-	return errors.NewAggregate(errorList)
+	return utilerrors.Join(errorList...)
 }
 
 // onEgressServiceAdd queues the EgressService for processing.

--- a/go-controller/pkg/clustermanager/node/subnet_allocator.go
+++ b/go-controller/pkg/clustermanager/node/subnet_allocator.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"sync"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -231,7 +231,7 @@ func (sna *BaseSubnetAllocator) releaseNetworks(owner string, subnets ...*net.IP
 		}
 	}
 
-	return utilerrors.NewAggregate(errorList)
+	return utilerrors.Join(errorList...)
 }
 
 // releaseAllNetworks attempts to release all subnets of a given owner, even

--- a/go-controller/pkg/kube/healthcheck/healthcheck.go
+++ b/go-controller/pkg/kube/healthcheck/healthcheck.go
@@ -22,12 +22,12 @@ import (
 	"net/http"
 	"sync"
 
-	"k8s.io/klog/v2"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 // Server serves HTTP endpoints for each service name, with results
@@ -174,7 +174,7 @@ func (hcs *server) SyncServices(newServices map[types.NamespacedName]uint16) err
 			klog.V(5).Infof("Healthcheck %q closed", nsn.String())
 		}(nsn, svc)
 	}
-	return apierrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 type hcInstance struct {

--- a/go-controller/pkg/node/base_node_network_controller_dpu.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	kapi "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -17,6 +16,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 // Check if the Pod is ready so that we can add its associated DPU to br-int.
@@ -79,7 +79,7 @@ func (bnnc *BaseNodeNetworkController) delDPUPodForNAD(pod *kapi.Pod, dpuCD *uti
 			errs = append(errs, fmt.Errorf("failed to delete VF representor for %s: %v", podDesc, err))
 		}
 	}
-	return apierrors.NewAggregate(errs)
+	return utilerrors.Join(errs...)
 }
 
 func dpuConnectionDetailChanged(oldDPUCD, newDPUCD *util.DPUConnectionDetails) bool {

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -23,13 +23,13 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -229,7 +229,7 @@ func (c *Controller) Run(stopCh <-chan struct{}, wg *sync.WaitGroup, threads int
 	}
 	syncWg.Wait()
 	if len(syncErrs) != 0 {
-		return kerrors.NewAggregate(syncErrs)
+		return utilerrors.Join(syncErrs...)
 	}
 
 	wg.Add(1)

--- a/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
+++ b/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
@@ -19,12 +19,12 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -313,7 +313,7 @@ func (c *Controller) repair() error {
 		errorList = append(errorList, err)
 	}
 
-	return errors.NewAggregate(errorList)
+	return utilerrors.Join(errorList...)
 }
 
 // Remove stale ip rules, update caches with valid existing ones.
@@ -387,7 +387,7 @@ func (c *Controller) repairIPRules(v4EpsToServices, v6EpsToServices, cipsToServi
 			}
 		}
 
-		return errors.NewAggregate(errorList)
+		return utilerrors.Join(errorList...)
 	}
 
 	errorList := []error{}
@@ -405,7 +405,7 @@ func (c *Controller) repairIPRules(v4EpsToServices, v6EpsToServices, cipsToServi
 		}
 	}
 
-	return errors.NewAggregate(errorList)
+	return utilerrors.Join(errorList...)
 }
 
 // Remove stale iptables rules, update caches with valid existing ones.
@@ -548,7 +548,7 @@ func (c *Controller) repairIPTables(v4EpsToServices, v6EpsToServices map[string]
 			}
 		}
 
-		return errors.NewAggregate(errorList)
+		return utilerrors.Join(errorList...)
 	}
 
 	errorList := []error{}
@@ -587,7 +587,7 @@ func (c *Controller) repairIPTables(v4EpsToServices, v6EpsToServices map[string]
 		}
 	}
 
-	return errors.NewAggregate(errorList)
+	return utilerrors.Join(errorList...)
 }
 
 func (c *Controller) runEgressServiceWorker(wg *sync.WaitGroup) {
@@ -907,7 +907,7 @@ func (c *Controller) clearServiceIPRules(state *svcState) error {
 		state.netEps.Delete(ip)
 	}
 
-	return errors.NewAggregate(errorList)
+	return utilerrors.Join(errorList...)
 }
 
 // Clears all of the iptables rules that relate to the service and removes it from the cache.

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -14,7 +14,6 @@ import (
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -39,6 +38,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/vishvananda/netlink"
@@ -1211,7 +1211,7 @@ func (nc *DefaultNodeNetworkController) reconcileConntrackUponEndpointSliceEvent
 			}
 		}
 	}
-	return apierrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 
 }
 func (nc *DefaultNodeNetworkController) WatchEndpointSlices() error {

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -7,15 +7,16 @@ import (
 	"fmt"
 	"net"
 
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice"
 	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	kapi "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog/v2"
-	utilnet "k8s.io/utils/net"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 const (
@@ -547,7 +548,7 @@ func recreateIPTRules(table, chain string, keepIPTRules []nodeipt.Rule) error {
 	if err = restoreIptRulesFiltered(keepIPTRules, filter); err != nil {
 		errors = append(errors, err)
 	}
-	return apierrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 // getGatewayIPTRules returns ClusterIP, NodePort, ExternalIP and LoadBalancer iptables rules for service.

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	kerrors2 "k8s.io/apimachinery/pkg/util/errors"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -113,7 +113,7 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 			// Services create OpenFlow flows as well, need to update them all
 			if gw.servicesRetryFramework != nil {
 				if errs := gw.addAllServices(); errs != nil {
-					err := kerrors2.NewAggregate(errs)
+					err := utilerrors.Join(errs...)
 					klog.Errorf("Failed to sync all services after node IP change: %v", err)
 				}
 			}

--- a/go-controller/pkg/node/healthcheck_node.go
+++ b/go-controller/pkg/node/healthcheck_node.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/pkg/errors"
 
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"

--- a/go-controller/pkg/node/healthcheck_service.go
+++ b/go-controller/pkg/node/healthcheck_service.go
@@ -7,11 +7,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -79,7 +79,7 @@ func (l *loadBalancerHealthChecker) UpdateService(old, new *kapi.Service) error 
 			errors = append(errors, err)
 		}
 	}
-	return apierrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 func (l *loadBalancerHealthChecker) DeleteService(svc *kapi.Service) error {

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -8,7 +8,6 @@ import (
 	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 )
@@ -94,7 +93,7 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 
 	routeList, err := util.GetNetLinkOps().RouteListFiltered(family, filter, mask)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "failed to get routing table in node")
+		return "", nil, fmt.Errorf("failed to get routing table in node: %w", err)
 	}
 	routes := filterRoutesByIfIndex(routeList, gwIfIdx)
 	// use the first valid default gateway

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -5,10 +5,11 @@ import (
 	"sync"
 	"time"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 
 	"github.com/vishvananda/netlink"
+
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 type ipRule struct {
@@ -164,7 +165,7 @@ func (rm *Controller) reconcile() error {
 	}
 
 	rm.rules = rulesToKeep
-	return utilerrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {

--- a/go-controller/pkg/node/iptables/iptables.go
+++ b/go-controller/pkg/node/iptables/iptables.go
@@ -1,13 +1,15 @@
 package iptables
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
+	"k8s.io/klog/v2"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 // Rule represents an iptables rule.
@@ -22,8 +24,8 @@ type Rule struct {
 // filter is a map[table][chain] of valid tables/chains to use for filtering rules to be added.
 // If no rule exists for the filter, the chain will still be restored as empty.
 func RestoreRulesFiltered(rules []Rule, filter map[string]map[string]struct{}) error {
-	addErrors := errors.New("")
 	var err error
+	var errs []error
 	var ipt util.IPTablesHelper
 
 	// stores the rules we want to program, keyed by protocol, table, chain
@@ -62,8 +64,8 @@ func RestoreRulesFiltered(rules []Rule, filter map[string]map[string]struct{}) e
 	for proto, tableMap := range ruleMap {
 		// get iptables helper
 		if ipt, err = util.GetIPTablesHelper(proto); err != nil {
-			addErrors = errors.Wrapf(addErrors,
-				"Failed to get iptables helper for protocol: %v, error: %v , err", proto, err)
+			err = fmt.Errorf("failed to get iptables helper for protocol %v: %w", proto, err)
+			errs = append(errs, err)
 			continue
 		}
 
@@ -72,22 +74,19 @@ func RestoreRulesFiltered(rules []Rule, filter map[string]map[string]struct{}) e
 			// config map is built for the table, configure everything now
 			err = ipt.Restore(table, chainMap)
 			if err != nil {
-				addErrors = errors.Wrapf(addErrors, "failed to restore iptables group of rules for table: %s,"+
-					"error: %v", table, err)
+				err = fmt.Errorf("failed to restore iptables group of rules for table %s: %w", table, err)
+				errs = append(errs, err)
 			}
 		}
 	}
 
-	if addErrors.Error() == "" {
-		addErrors = nil
-	}
-	return addErrors
+	return utilerrors.Join(errs...)
 }
 
 // AddRules adds the given rules to iptables.
-func AddRules(rules []Rule, append bool) error {
-	addErrors := errors.New("")
+func AddRules(rules []Rule, isAppend bool) error {
 	var err error
+	var errs []error
 	var ipt util.IPTablesHelper
 	var exists bool
 
@@ -100,8 +99,8 @@ func AddRules(rules []Rule, append bool) error {
 
 	for _, r := range rules {
 		if ipt, err = util.GetIPTablesHelper(r.Protocol); err != nil {
-			addErrors = errors.Wrapf(addErrors,
-				"Failed to add iptables %s/%s rule %q: %v", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			err := fmt.Errorf("failed to add iptables %s/%s rule %q: %w", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			errs = append(errs, err)
 			continue
 		}
 		if _, ok := createdChains[r.Protocol][r.Table][r.Chain]; !ok {
@@ -120,46 +119,42 @@ func AddRules(rules []Rule, append bool) error {
 		if !exists && err == nil {
 			klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
 				r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
-			if append {
+			if isAppend {
 				err = ipt.Append(r.Table, r.Chain, r.Args...)
 			} else {
 				err = ipt.Insert(r.Table, r.Chain, 1, r.Args...)
 			}
 		}
 		if err != nil {
-			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
-				r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			err := fmt.Errorf("failed to add iptables %s/%s rule %q: %w", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			errs = append(errs, err)
 		}
 	}
-	if addErrors.Error() == "" {
-		addErrors = nil
-	}
-	return addErrors
+
+	return utilerrors.Join(errs...)
 }
 
 // DelRules deletes the given rules from iptables.
 func DelRules(rules []Rule) error {
-	delErrors := errors.New("")
 	var err error
+	var errs []error
 	var ipt util.IPTablesHelper
 	for _, r := range rules {
 		klog.V(5).Infof("Deleting rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
 			r.Table, r.Chain, strings.Join(r.Args, " "), r.Protocol)
 		if ipt, err = util.GetIPTablesHelper(r.Protocol); err != nil {
-			delErrors = errors.Wrapf(delErrors,
-				"Failed to delete iptables %s/%s rule %q: %v", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			err := fmt.Errorf("failed to delete iptables %s/%s rule %q: %w", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+			errs = append(errs, err)
 			continue
 		}
 		if exists, err := ipt.Exists(r.Table, r.Chain, r.Args...); err == nil && exists {
 			err := ipt.Delete(r.Table, r.Chain, r.Args...)
 			if err != nil {
-				delErrors = errors.Wrapf(delErrors, "failed to delete iptables %s/%s rule %q: %v",
-					r.Table, r.Chain, strings.Join(r.Args, " "), err)
+				err := fmt.Errorf("failed to delete iptables %s/%s rule %q: %w", r.Table, r.Chain, strings.Join(r.Args, " "), err)
+				errs = append(errs, err)
 			}
 		}
 	}
-	if delErrors.Error() == "" {
-		delErrors = nil
-	}
-	return delErrors
+
+	return utilerrors.Join(errs...)
 }

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
 
 	"k8s.io/klog/v2"
 )
@@ -229,7 +228,7 @@ func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
 	// the integration bridge, as a result the ofport number changed for that patch interface
 	curOfportPatch, stderr, err := util.GetOVSOfPort("--if-exists", "get", "Interface", patchIntf, "ofport")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get ofport of %s, stderr: %q", patchIntf, stderr)
+		return fmt.Errorf("failed to get ofport of %s, stderr: %q: %w", patchIntf, stderr, err)
 
 	}
 	if ofPortPatch != curOfportPatch {
@@ -242,7 +241,7 @@ func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
 	// bridge, as a result the ofport number changed for that physical interface
 	curOfportPhys, stderr, err := util.GetOVSOfPort("--if-exists", "get", "interface", physIntf, "ofport")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get ofport of %s, stderr: %q", physIntf, stderr)
+		return fmt.Errorf("failed to get ofport of %s, stderr: %q: %w", physIntf, stderr, err)
 	}
 	if ofPortPhys != curOfportPhys {
 		klog.Errorf("Fatal error: phys port %s ofport changed from %s to %s",
@@ -317,7 +316,7 @@ func bootstrapOVSFlows() error {
 	} else {
 		bridgeMACAddress, err = util.GetOVSPortMACAddress(bridge)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get MAC address for ovs port %s", bridge)
+			return fmt.Errorf("failed to get MAC address for ovs port %s: %w", bridge, err)
 		}
 	}
 

--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -153,7 +153,7 @@ func (p *portClaimWatcher) AddService(svc *kapi.Service) error {
 			errors = append(errors, fmt.Errorf("error claiming port for service: %s/%s: %v", svc.Namespace, svc.Name, err))
 		}
 	}
-	return apierrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 func (p *portClaimWatcher) UpdateService(old, new *kapi.Service) error {
@@ -168,7 +168,7 @@ func (p *portClaimWatcher) UpdateService(old, new *kapi.Service) error {
 			errors = append(errors, fmt.Errorf("error updating port claim for service: %s/%s: %v", old.Namespace, old.Name, err))
 		}
 	}
-	return apierrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 func (p *portClaimWatcher) DeleteService(svc *kapi.Service) error {
@@ -177,7 +177,7 @@ func (p *portClaimWatcher) DeleteService(svc *kapi.Service) error {
 		for _, err := range raw_errors {
 			errors = append(errors, fmt.Errorf("error removing port claim for service: %s/%s: %v", svc.Namespace, svc.Name, err))
 		}
-		return apierrors.NewAggregate(errors)
+		return utilerrors.Join(errors...)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -3,15 +3,13 @@ package addressset
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -182,7 +180,7 @@ func (asf *ovnAddressSetFactory) forEachAddressSet(ownerController string, dbIDs
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to iterate address sets: %v", utilerrors.NewAggregate(errs))
+		return fmt.Errorf("failed to iterate address sets: %v", utilerrors.Join(errs...))
 	}
 
 	return nil
@@ -411,7 +409,7 @@ func (as *ovnAddressSets) SetAddresses(addresses []string) error {
 		err = as.v6.setAddresses(v6addresses)
 	}
 	if as.v4 != nil {
-		err = errors.Wrapf(err, "%v", as.v4.setAddresses(v4addresses))
+		err = utilerrors.Join(err, as.v4.setAddresses(v4addresses))
 	}
 
 	return err

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -14,11 +15,10 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
@@ -145,7 +145,7 @@ func (bnc *BaseNetworkController) aclLoggingUpdateNsInfo(annotation string, nsIn
 		nsInfo.aclLogging.Allow = ""
 	}
 
-	return apierrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 // This function implements the main body of work of syncNamespaces.

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -18,7 +19,6 @@ import (
 	logicalswitchmanager "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -17,11 +17,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kerrorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -747,7 +747,7 @@ func (bnc *BaseNetworkController) handleLocalPodSelectorAddFunc(np *networkPolic
 	}
 
 	if len(errs) > 0 {
-		return kerrorsutil.NewAggregate(errs)
+		return utilerrors.Join(errs...)
 	}
 	return nil
 }
@@ -1335,7 +1335,7 @@ func (bnc *BaseNetworkController) handlePeerNamespaceSelectorAdd(np *networkPoli
 			errors = append(errors, err)
 		}
 	}
-	return kerrorsutil.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 
 }
 

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -21,10 +21,10 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/persistentips"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -263,7 +263,7 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 		}
 	}
 	if len(errs) != 0 {
-		return kerrors.NewAggregate(errs)
+		return utilerrors.Join(errs...)
 	}
 	return nil
 }
@@ -602,7 +602,7 @@ func (bsnc *BaseSecondaryNetworkController) updateNamespaceForSecondaryNetwork(o
 	if err := bsnc.multicastUpdateNamespace(newer, nsInfo); err != nil {
 		errors = append(errors, err)
 	}
-	return kerrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 func (bsnc *BaseSecondaryNetworkController) deleteNamespace4SecondaryNetwork(ns *kapi.Namespace) error {

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -14,9 +14,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -358,7 +358,7 @@ func (oc *BaseSecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *co
 		// process all pods so they are reconfigured as local
 		errs := oc.addAllPodsOnNode(node.Name)
 		if errs != nil {
-			err := kerrors.NewAggregate(errs)
+			err := utilerrors.Join(errs...)
 			return err
 		}
 	}
@@ -378,7 +378,7 @@ func (oc *BaseSecondaryLayer2NetworkController) addUpdateRemoteNodeEvent(node *c
 		// process all pods so they are reconfigured as remote
 		errs := oc.addAllPodsOnNode(node.Name)
 		if errs != nil {
-			err = kerrors.NewAggregate(errs)
+			err = utilerrors.Join(errs...)
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy.go
@@ -1,6 +1,7 @@
 package adminnetworkpolicy
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -14,7 +15,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -84,7 +84,7 @@ func (c *Controller) syncAdminNetworkPolicy(key string) error {
 	if err != nil {
 		// we can ignore the error if status update doesn't succeed; best effort
 		_ = c.updateANPStatusToNotReady(anp.Name, err.Error())
-		if errors.Unwrap(err) != ErrorANPPriorityUnsupported && errors.Unwrap(err) != ErrorANPWithDuplicatePriority {
+		if !errors.Is(err, ErrorANPPriorityUnsupported) && !errors.Is(err, ErrorANPWithDuplicatePriority) {
 			// we don't want to retry for these specific errors since they
 			// need manual intervention from users to update their CRDs
 			return nil

--- a/go-controller/pkg/ovn/controller/admin_network_policy/repair.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/repair.go
@@ -1,6 +1,7 @@
 package adminnetworkpolicy
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -8,7 +9,6 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -611,11 +610,11 @@ func (nb *northBoundClient) delHybridRoutePolicyForPod(podIP net.IP, node string
 func (nb *northBoundClient) extSwitchPrefix(nodeName string) (string, error) {
 	node, err := nb.nodeLister.Get(nodeName)
 	if err != nil {
-		return "", errors.Wrapf(err, "extSwitchPrefix: failed to find node %s", nodeName)
+		return "", fmt.Errorf("extSwitchPrefix failed to find node %s: %w", nodeName, err)
 	}
 	l3GatewayConfig, err := util.ParseNodeL3GatewayAnnotation(node)
 	if err != nil {
-		return "", errors.Wrapf(err, "extSwitchPrefix: failed to parse l3 gateway annotation for node %s", nodeName)
+		return "", fmt.Errorf("extSwitchPrefix failed to parse l3 gateway annotation for node %s: %w", nodeName, err)
 	}
 
 	if l3GatewayConfig.EgressGWInterfaceID != "" {

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -19,11 +19,11 @@ import (
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -563,7 +563,7 @@ func (c *Controller) repair() error {
 		errorList = append(errorList, fmt.Errorf("failed to set pod IPs in the egressservice address set, err: %v", err))
 	}
 
-	return errors.NewAggregate(errorList)
+	return utilerrors.Join(errorList...)
 }
 
 // onEgressServiceAdd queues the EgressService for processing.

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -32,10 +32,10 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -803,7 +803,7 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 			h.oc.syncHostNetAddrSetFailed.Store(node.Name, true)
 			aggregatedErrors = append(aggregatedErrors, err)
 		}
-		return kerrors.NewAggregate(aggregatedErrors)
+		return utilerrors.Join(aggregatedErrors...)
 
 	case factory.EgressFirewallType:
 		egressFirewall := obj.(*egressfirewall.EgressFirewall).DeepCopy()
@@ -986,7 +986,7 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 				h.oc.syncHostNetAddrSetFailed.Delete(newNode.Name)
 			}
 		}
-		return kerrors.NewAggregate(aggregatedErrors)
+		return utilerrors.Join(aggregatedErrors...)
 
 	case factory.EgressIPType:
 		oldEIP := oldObj.(*egressipv1.EgressIP)

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -18,11 +18,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/batching"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -311,7 +311,7 @@ func (oc *DefaultNetworkController) addEgressFirewall(egressFirewall *egressfire
 		ef.egressRules = append(ef.egressRules, efr)
 	}
 	if len(errorList) > 0 {
-		return errors.NewAggregate(errorList)
+		return utilerrors.Join(errorList...)
 	}
 
 	pgName := oc.getNamespacePortGroupName(egressFirewall.Namespace)

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -19,7 +20,6 @@ import (
 	apbroutecontroller "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -909,11 +909,11 @@ func (oc *DefaultNetworkController) cleanUpBFDEntry(gatewayIP, gatewayRouter, pr
 func (oc *DefaultNetworkController) extSwitchPrefix(nodeName string) (string, error) {
 	node, err := oc.watchFactory.GetNode(nodeName)
 	if err != nil {
-		return "", errors.Wrapf(err, "extSwitchPrefix: failed to find node %s", nodeName)
+		return "", fmt.Errorf("extSwitchPrefix failed to find node %s: %w", nodeName, err)
 	}
 	l3GatewayConfig, err := util.ParseNodeL3GatewayAnnotation(node)
 	if err != nil {
-		return "", errors.Wrapf(err, "extSwitchPrefix: failed to parse l3 gateway annotation for node %s", nodeName)
+		return "", fmt.Errorf("extSwitchPrefix failed to parse l3 gateway annotation for node %s: %w", nodeName, err)
 	}
 
 	if l3GatewayConfig.EgressGWInterfaceID != "" {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -25,13 +25,13 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
@@ -1125,7 +1125,7 @@ func (oc *DefaultNetworkController) syncStaleSNATRules(egressIPCache map[string]
 		}
 	}
 	if len(errors) > 0 {
-		return utilerrors.NewAggregate(errors)
+		return utilerrors.Join(errors...)
 	}
 	// The routers length 0 check is needed because some of ovnk master restart unit tests have
 	// router object referring to SNAT's UUID string instead of actual UUID (though it may not

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -1,6 +1,7 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -13,7 +14,6 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
-	"github.com/pkg/errors"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1,30 +1,29 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"time"
 
 	kapi "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
-	"github.com/pkg/errors"
-
-	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
-	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 const (
@@ -734,7 +733,7 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSy
 		}
 	}
 
-	return kerrors.NewAggregate(errs)
+	return utilerrors.Join(errs...)
 }
 
 func (oc *DefaultNetworkController) addUpdateRemoteNodeEvent(node *kapi.Node, syncZoneIC bool) error {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -31,7 +32,6 @@ import (
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -10,9 +10,9 @@ import (
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
@@ -136,7 +136,7 @@ func (oc *DefaultNetworkController) configureNamespace(nsInfo *namespaceInfo, ns
 	if err := oc.configureNamespaceCommon(nsInfo, ns); err != nil {
 		errors = append(errors, err)
 	}
-	return kerrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 func (oc *DefaultNetworkController) updateNamespace(old, newer *kapi.Namespace) error {
@@ -271,7 +271,7 @@ func (oc *DefaultNetworkController) updateNamespace(old, newer *kapi.Namespace) 
 	if err := oc.multicastUpdateNamespace(newer, nsInfo); err != nil {
 		errors = append(errors, err)
 	}
-	return kerrors.NewAggregate(errors)
+	return utilerrors.Join(errors...)
 }
 
 func (oc *DefaultNetworkController) deleteNamespace(ns *kapi.Namespace) error {

--- a/go-controller/pkg/ovn/pod_selector_address_set.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set.go
@@ -17,12 +17,12 @@ import (
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	kerrorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
@@ -626,7 +626,7 @@ func (bnc *BaseNetworkController) handleNamespaceDel(podHandlerInfo *PodSelector
 			errs = append(errs, err)
 		}
 	}
-	return kerrorsutil.NewAggregate(errs)
+	return utilerrors.Join(errs...)
 }
 
 func getPodSelectorAddrSetDbIDs(psasKey, controller string) *libovsdbops.DbObjectIDs {

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -21,9 +21,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	kapi "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
@@ -506,7 +506,7 @@ func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *kapi.N
 		}
 	}
 
-	err = kerrors.NewAggregate(errs)
+	err = utilerrors.Join(errs...)
 	if err != nil {
 		oc.recordNodeErrorEvent(node, err)
 	}

--- a/go-controller/pkg/util/errors/join.go
+++ b/go-controller/pkg/util/errors/join.go
@@ -1,0 +1,84 @@
+package errors
+
+import "strings"
+
+// Join returns an error that wraps the given errors. Any nil error values are
+// discarded. Join returns nil if every value in errs is nil. Copied from the
+// golang standard library at
+// https://github.com/golang/go/blob/a5339da341b8f37c87b77c2fc1318d6ecd2331ff/src/errors/join.go#L19
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// The difference with the above implementation resides in how this error
+// formats. The former uses new lines to concatenate errors which is an
+// inconvenience. This implementation formats as the concatenation of the
+// strings obtained by calling the Error method of each element of errs,
+// recursively unwrapping them if necessary, separated by commas and surrounded
+// by brackets.
+//
+// This is similar as to how the k8s.io apimachinery aggregate error format.
+// However this error is simpler and supports the full wrapping semantics, while
+// k8s.io apimachinery aggregate error doesn't support the 'errors.As'.
+func Join(errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	e := &joinError{
+		errs: make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, err)
+		}
+	}
+	return e
+}
+
+type joinError struct {
+	errs []error
+}
+
+func (e *joinError) Error() string {
+	// Since Join returns nil if every value in errs is nil,
+	// e.errs cannot be empty.
+	if len(e.errs) == 1 {
+		return e.errs[0].Error()
+	}
+
+	var sb strings.Builder
+	sb.WriteByte('[')
+	for _, err := range e.errs {
+		expand(err, &sb)
+	}
+	sb.WriteByte(']')
+
+	return sb.String()
+}
+
+func expand(err error, sb *strings.Builder) {
+	if err == nil {
+		return
+	}
+	switch e := err.(type) {
+	case interface{ Unwrap() []error }:
+		errors := e.Unwrap()
+		for _, err := range errors {
+			expand(err, sb)
+		}
+	default:
+		// we use '1' here because we start with the opening bracket "["
+		if sb.Len() > 1 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(err.Error())
+	}
+}
+
+func (e *joinError) Unwrap() []error {
+	return e.errs
+}

--- a/go-controller/pkg/util/errors/join_test.go
+++ b/go-controller/pkg/util/errors/join_test.go
@@ -1,0 +1,102 @@
+package errors
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// Copied from
+// https://github.com/golang/go/blob/a5339da341b8f37c87b77c2fc1318d6ecd2331ff/src/errors/join_test.go#L13
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+func TestJoinReturnsNil(t *testing.T) {
+	if err := Join(); err != nil {
+		t.Errorf("errors.Join() = %v, want nil", err)
+	}
+	if err := Join(nil); err != nil {
+		t.Errorf("errors.Join(nil) = %v, want nil", err)
+	}
+	if err := Join(nil, nil); err != nil {
+		t.Errorf("errors.Join(nil, nil) = %v, want nil", err)
+	}
+}
+
+// Copied from
+// https://github.com/golang/go/blob/a5339da341b8f37c87b77c2fc1318d6ecd2331ff/src/errors/join_test.go#L25
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+func TestJoin(t *testing.T) {
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+	for _, test := range []struct {
+		errs []error
+		want []error
+	}{{
+		errs: []error{err1},
+		want: []error{err1},
+	}, {
+		errs: []error{err1, err2},
+		want: []error{err1, err2},
+	}, {
+		errs: []error{err1, nil, err2},
+		want: []error{err1, err2},
+	}} {
+		got := Join(test.errs...).(interface{ Unwrap() []error }).Unwrap()
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Join(%v) = %v; want %v", test.errs, got, test.want)
+		}
+		if len(got) != cap(got) {
+			t.Errorf("Join(%v) returns errors with len=%v, cap=%v; want len==cap", test.errs, len(got), cap(got))
+		}
+	}
+}
+
+// Copied from
+// https://github.com/golang/go/blob/a5339da341b8f37c87b77c2fc1318d6ecd2331ff/src/errors/join_test.go#L51
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+func TestJoinErrorMethod(t *testing.T) {
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+	for _, test := range []struct {
+		errs []error
+		want string
+	}{{
+		errs: []error{err1},
+		want: "err1",
+	}, {
+		errs: []error{err1, err2},
+		want: "[err1, err2]",
+	}, {
+		errs: []error{err1, nil, err2},
+		want: "[err1, err2]",
+	}} {
+		got := Join(test.errs...).Error()
+		if got != test.want {
+			t.Errorf("Join(%v).Error() = %q; want %q", test.errs, got, test.want)
+		}
+	}
+}
+
+func TestJoinErrorMethodRecursive(t *testing.T) {
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+	err3 := errors.New("err3")
+	err4 := errors.New("err4")
+	for _, test := range []struct {
+		errs []error
+		want string
+	}{{
+		errs: []error{err1, Join(err2), err3},
+		want: "[err1, err2, err3]",
+	}, {
+		errs: []error{err1, Join(err2, err3), err4},
+		want: "[err1, err2, err3, err4]",
+	}, {
+		errs: []error{err1, Join(err2, nil, err3), err4},
+		want: "[err1, err2, err3, err4]",
+	}} {
+		got := Join(test.errs...).Error()
+		if got != test.want {
+			t.Errorf("Join(%v).Error() = %q; want %q", test.errs, got, test.want)
+		}
+	}
+}

--- a/go-controller/pkg/util/external_gw_conntrack.go
+++ b/go-controller/pkg/util/external_gw_conntrack.go
@@ -4,6 +4,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -11,14 +12,14 @@ import (
 	"time"
 
 	"github.com/mdlayher/ndp"
-	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 
 	kapi "k8s.io/api/core/v1"
-	utilapierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 // inspired by arping timeout
@@ -324,5 +325,5 @@ func SyncConntrackForExternalGateways(gwIPsToKeep sets.Set[string], isPodInLocal
 		}
 	}
 
-	return utilapierrors.NewAggregate(errs)
+	return utilerrors.Join(errs...)
 }


### PR DESCRIPTION
As follows:

* Replaced all equivalent uses of github.com/pkg/errors for standard library errors
* Replaced the uses of github.com/pkg/errors Wrapf for fmt.Errorf. The need for the stack trace that Wrapf brings seems arbitrary
* Replaced the uses of the standard library errors Join, as well as k8s aggregate errors, with our own implementation which works similarly to standard library's but formats the concatenation as the k8s aggregate errors separating with commas rather than new lines which is an inconvenience. When compared to k8s aggregate errors, our implementation is simpler catering to our needs and complies fully with current wrapping mechanism whereas the former does not support 'errors.As'
