### PR TITLE
Add github actions for stale issues

### DIFF
--- a/.github/workflows/stale-action.yml
+++ b/.github/workflows/stale-action.yml
@@ -1,0 +1,30 @@
+name: 'Close stale Issues and Warn stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issue related configurations go here
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          exempt-all-issue-milestones: true
+          exempt-issue-labels: 'kind/ci-flake'
+          stale-issue-label: 'lifecycle/stale'
+          days-before-issue-stale: 60
+          days-before-issue-close: 5
+          # PR related configurations go here
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or reach out to maintainers for code reviews or consider closing this if you do not plan to work on it.'
+          exempt-all-pr-milestones: true
+          stale-pr-label: 'lifecycle/stale'
+          days-before-pr-stale: 90
+          # we never close a PR
+          days-before-pr-close: -1


### PR DESCRIPTION

#### What this PR does and why is it needed
 For maintainers it is hard to keep the repo clean manually.
There are 270+ issues on this project and its not possible
for any human to go through them and clean them
This list will only keep growing if we don't have a
system in place to close stale issues.

#### Which issue(s) this PR fixes
Fixes #

#### Special notes for reviewers
PR uses https://github.com/marketplace/actions/close-stale-issues#usage so more details
and further fine tuning can be found there.

#### How to verify it
NO IDEA :)
But its a cron job that runs every 1.5 hours so we'll know soon? :D

#### Details to documentation updates
Yea I will perhaps add a section later on to the docs.


#### Description for the changelog
`Add cronjob to cleanup stale issues and PRs but we NEVER CLOSE PRs`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
NONE
```
