### PR TITLE
Change area labels on issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/e2e-testing.yaml
+++ b/.github/ISSUE_TEMPLATE/e2e-testing.yaml
@@ -1,6 +1,6 @@
 name: Enhancing E2E Test Coverage
 description: Provide supporting details for enhancements to our existing e2e test coverage
-labels: e2e-testing
+labels: area/e2e-testing
 body:
   - type: textarea
     id: e2e-testing

--- a/.github/ISSUE_TEMPLATE/unit-testing.yaml
+++ b/.github/ISSUE_TEMPLATE/unit-testing.yaml
@@ -1,6 +1,6 @@
 name: Enhancing Unit Test Coverage
 description: Provide supporting details for enhancements to our existing unit test coverage
-labels: unit-testing
+labels: area/unit-testing
 body:
   - type: textarea
     id: unit-testing


### PR DESCRIPTION
I am sorting labels based on types "Area", "Kind", "Feature", "Lifecycle" etc. This is part of that.
Would be nice to get these in so that new issues don't start getting opened against the wrong labels.