### PR TITLE
Support OVS-DOCA

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -202,9 +202,9 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 			// Find the hostInterface name
 			condString := []string{"external-ids:sandbox=" + pr.SandboxID}
 			if pr.netName != types.DefaultNetworkName {
-				condString = append(condString, fmt.Sprintf(" external_ids:%s=%s", types.NADExternalID, pr.nadName))
+				condString = append(condString, fmt.Sprintf("external_ids:%s=%s", types.NADExternalID, pr.nadName))
 			} else {
-				condString = append(condString, fmt.Sprintf(" external_ids:%s{=}[]", types.NADExternalID))
+				condString = append(condString, fmt.Sprintf("external_ids:%s{=}[]", types.NADExternalID))
 			}
 			ovsIfNames, err := ovsFind("Interface", "name", condString...)
 			if err != nil || len(ovsIfNames) != 1 {

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -1445,6 +1445,9 @@ func TestConfigureOVS(t *testing.T) {
 			assert.Nil(t, err)
 
 			tc.execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: genOVSGetCmd("bridge", "br-int", "datapath_type", ""),
+			})
+			tc.execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSFindCmd("30", "Interface", "name",
 					"external-ids:iface-id=ns-foo_pod-bar"),
 			})
@@ -1582,6 +1585,9 @@ func TestConfigureOVS_getPfEncapIpWithError(t *testing.T) {
 			pfEncapIp: "",
 			execMockCommands: []*ovntest.ExpectedCmd{
 				{
+					Cmd: genOVSGetCmd("bridge", "br-int", "datapath_type", ""),
+				},
+				{
 					Cmd: genOVSFindCmd("30", "Interface", "name",
 						"external-ids:iface-id=ns-foo_pod-bar"),
 				},
@@ -1612,6 +1618,9 @@ func TestConfigureOVS_getPfEncapIpWithError(t *testing.T) {
 			errMatch:  fmt.Errorf("bad ovn-pf-encap-ip-mapping config"),
 			pfEncapIp: "",
 			execMockCommands: []*ovntest.ExpectedCmd{
+				{
+					Cmd: genOVSGetCmd("bridge", "br-int", "datapath_type", ""),
+				},
 				{
 					Cmd: genOVSFindCmd("30", "Interface", "name",
 						"external-ids:iface-id=ns-foo_pod-bar"),

--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -89,6 +89,14 @@ func ovsSet(table, record string, values ...string) error {
 	return err
 }
 
+func getDatapathType(bridge string) (string, error) {
+	br_type, err := ovsGet("bridge", bridge, "datapath_type", "")
+	if err != nil {
+		return "", err
+	}
+	return br_type, nil
+}
+
 func ovsGet(table, record, column, key string) (string, error) {
 	args := []string{"--if-exists", "get", table, record}
 	if key != "" {

--- a/go-controller/pkg/node/base_node_network_controller_dpu_test.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu_test.go
@@ -196,6 +196,10 @@ var _ = Describe("Node DPU tests", func() {
 			sriovnetOpsMock.On("GetVfRepresentorDPU", "0", "9").Return(vfRep, nil)
 			sriovnetOpsMock.On("GetPCIFromDeviceName", vfRep).Return(vfPciAddress, nil)
 
+			sriovnetOpsMock.On("GetPciFromNetDevice", vfRep).Return("0000:03:00.8", nil)
+			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: genOVSGetCmd("bridge", "br-int", "datapath_type", ""),
+			})
 			// set ovs CMD output
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSFindCmd("30", "Interface", "name",
@@ -225,6 +229,10 @@ var _ = Describe("Node DPU tests", func() {
 		It("Fails if configure OVS fails but OVS interface is added", func() {
 			sriovnetOpsMock.On("GetVfRepresentorDPU", "0", "9").Return(vfRep, nil)
 			sriovnetOpsMock.On("GetPCIFromDeviceName", vfRep).Return(vfPciAddress, nil)
+			sriovnetOpsMock.On("GetPciFromNetDevice", vfRep).Return("0000:03:00.8", nil)
+			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: genOVSGetCmd("bridge", "br-int", "datapath_type", ""),
+			})
 			// set ovs CMD output
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSFindCmd("30", "Interface", "name",
@@ -259,6 +267,9 @@ var _ = Describe("Node DPU tests", func() {
 			BeforeEach(func() {
 				sriovnetOpsMock.On("GetVfRepresentorDPU", "0", "9").Return(vfRep, nil)
 				sriovnetOpsMock.On("GetPCIFromDeviceName", vfRep).Return(vfPciAddress, nil)
+				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: genOVSGetCmd("bridge", "br-int", "datapath_type", ""),
+				})
 				// set ovs CMD output so cni.ConfigureOVS passes without error
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: genOVSFindCmd("30", "Interface", "name",

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -323,6 +323,11 @@ func testManagementPortDPU(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.
 	)
 
 	// OVS cmd setup
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get bridge br-int datapath_type",
+		Output: "",
+	})
+
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgtPort,
 		fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s "+

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -25,6 +25,9 @@ const (
 	LocalBridgeName            = "br-local"
 	LocalnetGatewayNextHopPort = "ovn-k8s-gw0"
 
+	// OVS Bridge Datapath types
+	DatapathUserspace = "netdev"
+
 	// types.OVNClusterRouter is the name of the distributed router
 	OVNClusterRouter = "ovn_cluster_router"
 	OVNJoinSwitch    = "join"

--- a/go-controller/pkg/util/mocks/SriovnetOps.go
+++ b/go-controller/pkg/util/mocks/SriovnetOps.go
@@ -15,6 +15,48 @@ type SriovnetOps struct {
 	mock.Mock
 }
 
+// GetPciFromNetDevice provides a mock function with given fields: name
+func (_m *SriovnetOps) GetPciFromNetDevice(name string) (string, error) {
+	ret := _m.Called(name)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetPortIndexFromRepresentor provides a mock function with given fields: name
+func (_m *SriovnetOps) GetPortIndexFromRepresentor(name string) (int, error) {
+	ret := _m.Called(name)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNetDevicesFromAux provides a mock function with given fields: auxDev
 func (_m *SriovnetOps) GetNetDevicesFromAux(auxDev string) ([]string, error) {
 	ret := _m.Called(auxDev)

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -328,6 +328,31 @@ func GetOVSOfPort(args ...string) (string, string, error) {
 	return stdout, stderr, err
 }
 
+func GetDatapathType(bridge string) (string, error) {
+	br_type, err := getOvsEntry("bridge", bridge, "datapath_type", "")
+	if err != nil {
+		return "", err
+	}
+	return br_type, nil
+}
+
+// getOvsEntry queries the OVS-DB using ovs-vsctl and returns
+// the requested entries.
+func getOvsEntry(table, record, column, key string) (string, error) {
+	args := []string{"--if-exists", "get", table, record}
+	if key != "" {
+		args = append(args, fmt.Sprintf("%s:%s", column, key))
+	} else {
+		args = append(args, column)
+	}
+	stdout, stderr, err := RunOVSVsctl(args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to run 'ovs-vsctl %s': %v: %q",
+			strings.Join(args, " "), err, stderr)
+	}
+	return stdout, err
+}
+
 // RunOVSAppctlWithTimeout runs a command via ovs-appctl.
 func RunOVSAppctlWithTimeout(timeout int, args ...string) (string, string, error) {
 	cmdArgs := []string{fmt.Sprintf("--timeout=%d", timeout)}

--- a/go-controller/pkg/util/sriovnet_linux.go
+++ b/go-controller/pkg/util/sriovnet_linux.go
@@ -23,6 +23,7 @@ const (
 type SriovnetOps interface {
 	GetNetDevicesFromPci(pciAddress string) ([]string, error)
 	GetNetDevicesFromAux(auxDev string) ([]string, error)
+	GetPciFromNetDevice(name string) (string, error)
 	GetUplinkRepresentor(vfPciAddress string) (string, error)
 	GetUplinkRepresentorFromAux(auxDev string) (string, error)
 	GetVfIndexByPciAddress(vfPciAddress string) (int, error)
@@ -37,6 +38,7 @@ type SriovnetOps interface {
 	GetRepresentorPeerMacAddress(netdev string) (net.HardwareAddr, error)
 	GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error)
 	GetPCIFromDeviceName(netdevName string) (string, error)
+	GetPortIndexFromRepresentor(name string) (int, error)
 }
 
 type defaultSriovnetOps struct {
@@ -60,6 +62,10 @@ func (defaultSriovnetOps) GetNetDevicesFromPci(pciAddress string) ([]string, err
 
 func (defaultSriovnetOps) GetNetDevicesFromAux(auxDev string) ([]string, error) {
 	return sriovnet.GetNetDevicesFromAux(auxDev)
+}
+
+func (defaultSriovnetOps) GetPciFromNetDevice(name string) (string, error) {
+	return sriovnet.GetPciFromNetDevice(name)
 }
 
 func (defaultSriovnetOps) GetUplinkRepresentor(vfPciAddress string) (string, error) {
@@ -108,6 +114,10 @@ func (defaultSriovnetOps) GetRepresentorPeerMacAddress(netdev string) (net.Hardw
 
 func (defaultSriovnetOps) GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error) {
 	return sriovnet.GetRepresentorPortFlavour(netdev)
+}
+
+func (defaultSriovnetOps) GetPortIndexFromRepresentor(name string) (int, error) {
+	return sriovnet.GetPortIndexFromRepresentor(name)
 }
 
 // GetFunctionRepresentorName returns representor name for passed device ID. Supported devices are Virtual Function


### PR DESCRIPTION
Offer the possibility to use ovs-doca based userland datapath in OVS with OVN-kubernetes.

ovs-doca uses DOCA Flow library which enables use of the embedded eswitch and other hardware based offload mechanisms in capable hardware.

The ovn bridge will be created with the 'netdev' datapath type. ovnkube will query the datapath type of this bridge and modify OVS requests as necessary. In particular, CNI requests resulting in ovs configuration will add ports of type dpdk if on a 'netdev' bridge. Same with management port as well.

For using ovs-doca with ovn-kubernetes, in addition to initializing ovs-doca correctly, the following ovs configuration needs to be set

`ovs-vsctl set open . external-ids:ovn-bridge-datapath-type=netdev`

Documentation PR: #4408 

#### Special notes for reviewers
<!--
What exactly did you change ?
- Add support for OVS-DOCA DPIF
-->


#### Details to documentation updates
PR #4408 

#### Description for the changelog
<!--
Support for OVS-DOCA DPIF in ovn-kubernetes
-->


```release-note
Allows using OVS-DOCA DPIF.
```
