### PR TITLE
CNI: Add VFIO support for SR-IOV enabled systems

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -112,9 +112,11 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Resp
 	if pr.CNIConf.DeviceID != "" {
 		var err error
 
-		netdevName, err = util.GetNetdevNameFromDeviceId(pr.CNIConf.DeviceID, pr.deviceInfo)
-		if err != nil {
-			return nil, fmt.Errorf("failed in cmdAdd while getting Netdevice name: %v", err)
+		if !pr.IsVFIO {
+			netdevName, err = util.GetNetdevNameFromDeviceId(pr.CNIConf.DeviceID, pr.deviceInfo)
+			if err != nil {
+				return nil, fmt.Errorf("failed in cmdAdd while getting Netdevice name: %w", err)
+			}
 		}
 		if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
 			// Add DPU connection-details annotation so ovnkube-node running on DPU

--- a/go-controller/pkg/cni/cni_dpu_test.go
+++ b/go-controller/pkg/cni/cni_dpu_test.go
@@ -41,6 +41,7 @@ var _ = Describe("cni_dpu tests", func() {
 				DeviceID: "",
 			},
 			timestamp: time.Time{},
+			IsVFIO:    false,
 			netName:   ovntypes.DefaultNetworkName,
 			nadName:   ovntypes.DefaultNetworkName,
 		}

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -180,6 +180,7 @@ func cniRequestToPodRequest(cr *Request) (*PodRequest, error) {
 	if conf.DeviceID != "" {
 		if util.IsPCIDeviceName(conf.DeviceID) {
 			// DeviceID is a PCI address
+			req.IsVFIO = util.GetSriovnetOps().IsVfPciVfioBound(conf.DeviceID)
 		} else if util.IsAuxDeviceName(conf.DeviceID) {
 			// DeviceID is an Auxiliary device name - <driver_name>.<kind_of_a_type>.<id>
 			chunks := strings.Split(conf.DeviceID, ".")

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -1187,7 +1187,7 @@ func TestSetupSriovInterface(t *testing.T) {
 			ovsExec()
 
 			netNsDoError = nil
-			hostIface, contIface, err := setupSriovInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo, tc.inpPCIAddrs)
+			hostIface, contIface, err := setupSriovInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo, tc.inpPCIAddrs, false)
 			t.Log(hostIface, contIface, err)
 			if err == nil {
 				err = netNsDoError

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -152,6 +152,8 @@ type PodRequest struct {
 	ctx context.Context
 	// cancel should be called to cancel this request
 	cancel context.CancelFunc
+	// if CNIConf.DeviceID is present, then captures if the VF is of type VFIO or not
+	IsVFIO bool
 
 	// network name, for default network, this will be types.DefaultNetworkName
 	netName string

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -297,6 +297,20 @@ func (_m *NetLinkOps) LinkSetUp(link netlink.Link) error {
 	return r0
 }
 
+// LinkSetVfHardwareAddr provides a mock function with given fields: pfLink, vfIndex, hwaddr
+func (_m *NetLinkOps) LinkSetVfHardwareAddr(pfLink netlink.Link, vfIndex int, hwaddr net.HardwareAddr) error {
+	ret := _m.Called(pfLink, vfIndex, hwaddr)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(netlink.Link, int, net.HardwareAddr) error); ok {
+		r0 = rf(pfLink, vfIndex, hwaddr)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NeighAdd provides a mock function with given fields: neigh
 func (_m *NetLinkOps) NeighAdd(neigh *netlink.Neigh) error {
 	ret := _m.Called(neigh)

--- a/go-controller/pkg/util/mocks/SriovnetOps.go
+++ b/go-controller/pkg/util/mocks/SriovnetOps.go
@@ -357,6 +357,20 @@ func (_m *SriovnetOps) GetVfRepresentorDPU(pfID string, vfIndex string) (string,
 	return r0, r1
 }
 
+// IsVfPciVfioBound provides a mock function with given fields: pciAddr
+func (_m *SriovnetOps) IsVfPciVfioBound(pciAddr string) bool {
+	ret := _m.Called(pciAddr)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(pciAddr)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewSriovnetOps interface {
 	mock.TestingT
 	Cleanup(func())

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -47,6 +47,7 @@ type NetLinkOps interface {
 	NeighDel(neigh *netlink.Neigh) error
 	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
 	ConntrackDeleteFilter(table netlink.ConntrackTableType, family netlink.InetFamily, filter netlink.CustomConntrackFilter) (uint, error)
+	LinkSetVfHardwareAddr(pfLink netlink.Link, vfIndex int, hwaddr net.HardwareAddr) error
 }
 
 type defaultNetLinkOps struct {
@@ -675,4 +676,8 @@ func GetIPFamily(v6 bool) int {
 		return netlink.FAMILY_V6
 	}
 	return netlink.FAMILY_V4
+}
+
+func (defaultNetLinkOps) LinkSetVfHardwareAddr(pfLink netlink.Link, vfIndex int, hwaddr net.HardwareAddr) error {
+	return netlink.LinkSetVfHardwareAddr(pfLink, vfIndex, hwaddr)
 }


### PR DESCRIPTION
This commit introduces VFIO (Virtual Function I/O) support for Virtual Functions (VFs) on systems with SR-IOV capabilities. KubeVirt virtual machines can now use VFs that are bound to the vfio_pci driver as pass-through PCIe devices.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed

This PR add support for VFIO support  which can use
be used by kubevirt VM which support VFIO pass though

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
Use kubevirt VM with secondary NAD with VFIO as resources.
Tested in my 3 nodes cluster,  one kvm node for control plane
two BM nodes with CX6 with switchdev offloading enabled.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
