### PR TITLE
SDN-4909: rm e2e-periodic and run e2e in full twice daily

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches: [ master ]
   schedule:
     - cron: '0 */12 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -378,7 +379,6 @@ jobs:
 
   e2e:
     name: e2e
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     # 30 mins for kind, 180 mins for control-plane tests, 10 minutes for all other steps
     timeout-minutes: 220
@@ -660,84 +660,3 @@ jobs:
       with:
         name: kind-ovndbs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/ovndbs
-
-  e2e-periodic:
-    name: e2e-periodic
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ["shard-conformance"]
-        ha: ["HA"]
-        gateway-mode: ["local"]
-        ipfamily: ["ipv4", "ipv6", "dualstack"]
-    needs: [ build-pr ]
-    env:
-      JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}"
-      OVN_HA: "${{ matrix.ha == 'HA' }}"
-      KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
-      KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
-      OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target == 'control-plane' }}"
-      OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
-    steps:
-
-      - name: Free up disk space
-        run: |
-          sudo apt-get update
-          sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: "**/*.sum"
-        id: go
-
-      - name: Set up environment
-        run: |
-          export GOPATH=$(go env GOPATH)
-          echo "GOPATH=$GOPATH" >> $GITHUB_ENV
-          echo "$GOPATH/bin" >> $GITHUB_PATH
-      - name: Disable ufw
-        # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
-        # Not needed for KIND deployments, so just disable all the time.
-        run: |
-          sudo ufw disable
-      - uses: actions/download-artifact@v4
-        with:
-          name: test-image-pr
-      - name: Load docker image
-        run: |
-          docker load --input ${CI_IMAGE_PR_TAR} && rm -rf ${CI_IMAGE_PR_TAR}
-      - name: kind setup
-        run: |
-          export OVN_IMAGE="ovn-daemonset-f:pr"
-          make -C test install-kind
-
-      - name: Runner Diagnostics
-        uses: ./.github/actions/diagnostics
-
-      - name: Run Tests
-        run: |
-          make -C test ${{ matrix.target }}
-
-      - name: Runner Diagnostics
-        uses: ./.github/actions/diagnostics
-
-      - name: Export logs
-        if: always()
-        run: |
-          mkdir -p /tmp/kind/logs
-          kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
-      - name: Upload logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
-          path: /tmp/kind/logs
-

--- a/docs/ci/ci.md
+++ b/docs/ci/ci.md
@@ -9,16 +9,22 @@ local workflow that controls the test run is located in
 [ovn-kubernetes/.github/workflows/test.yml](https://github.com/ovn-org/ovn-kubernetes/blob/master/.github/workflows/test.yml).
 
 The following tasks are performed:
+
 - Build OVN-Kubernetes
 - Check out the Kubernetes source tree and compiles some dependencies
 - Install KIND
 - Run a matrix of End-To-End Tests using KIND
 
-The following sections should help you understand (and if needed modify) the set of tests that run and how to run these tests locally.
+The full matrix of e2e tests found [here](https://github.com/ovn-org/ovn-kubernetes/blob/master/.github/workflows/test.yml)
+are also run periodically (twice daily) using an OVN-Kubernetes build based on the currently merged code base.
+
+The following sections should help you understand (and if needed modify) the set of tests that run and how to run these
+tests locally.
 
 ## Understanding the CI Test Suite
 
-The tests are broken into 2 categories, `shard` tests which execute tests from the Kubernetes E2E test suite and the `control-plane` tests which run locally defined tests.
+The tests are broken into 2 categories, `shard` tests which execute tests from the Kubernetes E2E test suite and the
+`control-plane` tests which run locally defined tests.
 
 ### Shard tests
 
@@ -26,6 +32,7 @@ The shard tests are broken into a set of shards, which is just a grouping of tes
 and each shard is run in a separate job in parallel. Shards execute the `shard-%` target in 
 [ovn-kubernetes/test/Makefile](https://github.com/ovn-org/ovn-kubernetes/blob/master/test/Makefile).
 The set of shards may change in the future. Below is an example of the shards at time of this writing:
+
 - shard-network
   - All E2E tests that match `[sig-network]`
 - shard-conformance
@@ -35,7 +42,8 @@ The set of shards may change in the future. Below is an example of the shards at
   - When selecting the `shard-test` target, you focus on a specific test by appending `WHAT=<test name>` to the make command.
   - See bottom of this document for an example.
 
-Shards use the [E2E framework](https://kubernetes.io/blog/2019/03/22/kubernetes-end-to-end-testing-for-everyone/). By selecting a specific shard, you modify ginkgo's `--focus` parameter.
+Shards use the [E2E framework](https://kubernetes.io/blog/2019/03/22/kubernetes-end-to-end-testing-for-everyone/). By
+selecting a specific shard, you modify ginkgo's `--focus` parameter.
 
 The regex expression for determining which E2E test is run in which shard, as
 well as the list of skipped tests is defined in
@@ -46,6 +54,7 @@ well as the list of skipped tests is defined in
 In addition to the `shard-%` tests, there is also a `control-plane` target in 
 [ovn-kubernetes/test/Makefile](https://github.com/ovn-org/ovn-kubernetes/blob/master/test/Makefile).
 Below is a description of this target:
+
 - control-plane
   - All locally defined tests by default.
   - You can focus on a specific test by appending `WHAT=<test name>` to the make command.
@@ -106,7 +115,8 @@ $ PATH=/home/$USER/src/golang/go1-12-1/go/bin:$GOPATH/src/k8s.io/kubernetes/_out
 
 Determine which version of Kubernetes is currently used in CI (See
 [ovn-kubernetes/.github/workflows/test.yml](https://github.com/ovn-org/ovn-kubernetes/blob/master/.github/workflows/test.yml))
-and set the environmental variable `K8S_VERSION` to the same value. Also make sure to export a GOPATH which points to your go directory with `export GOPATH=(...)`.
+and set the environmental variable `K8S_VERSION` to the same value. Also make sure to export a GOPATH which points to
+your go directory with `export GOPATH=(...)`.
 
 ```
 K8S_VERSION=v1.28.0
@@ -201,7 +211,8 @@ tests look for the kube config file in a special location, so make a copy:
 cp ~/ovn.conf ~/.kube/kind-config-kind
 ```
 
-To run the desired shard, first make sure that the necessary environment variables are exported (see section above). Then, go to the location of your local copy of the `ovn-kubernetes` repository:
+To run the desired shard, first make sure that the necessary environment variables are exported (see section above).
+Then, go to the location of your local copy of the `ovn-kubernetes` repository:
 ```
 $ REPO=$GOPATH/src/github.com/ovn-org/ovn-kubernetes
 $ cd $REPO
@@ -291,7 +302,8 @@ Test Suite Passed
 
 #### Running a control-plane test
 
-All local tests are defined as `control-plane` tests. To run a single `control-plane` test, target the `control-plane` action and append the `WHAT=<test name>` parameter, as follows:
+All local tests are defined as `control-plane` tests. To run a single `control-plane` test, target the `control-plane`
+action and append the `WHAT=<test name>` parameter, as follows:
 
 ```
 $ cd $REPO
@@ -300,7 +312,9 @@ $ make control-plane WHAT="should be able to send multicast UDP traffic between 
 $ popd
 ```
 
-The value of `WHAT=` will be used to modify the `-ginkgo.focus` parameter. Individual tests can be retrieved from this repository under [test/e2e](https://github.com/ovn-org/ovn-kubernetes/tree/master/test/e2e). To see a list of individual tests, one could run:
+The value of `WHAT=` will be used to modify the `-ginkgo.focus` parameter. Individual tests can be retrieved from this
+repository under [test/e2e](https://github.com/ovn-org/ovn-kubernetes/tree/master/test/e2e). To see a list of individual
+tests, one could run:
 ~~~
 grep -R ginkgo.It test/
 ~~~


### PR DESCRIPTION
this is to help track down and find the most common flakes we need to fix. It removes the condition on the e2e job to not run on a schedule so the cron will pick it up (twice daily). the e2e job should still run pull_requests for [ master ] branch.

this also adds the "workflow_dispatch" trigger so we can manually trigger the workflow from the github UI.