### PR TITLE
ingress: update image to registry.k8s.io/ingress-nginx/controller:v1.10.1

### DIFF
--- a/contrib/ingress/mandatory.yaml
+++ b/contrib/ingress/mandatory.yaml
@@ -217,7 +217,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0
+          image: registry.k8s.io/ingress-nginx/controller:v1.10.1
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/nginx-configuration


### PR DESCRIPTION
Before this change, the image used was quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0, which has not been updated for ~4 years:

[https://quay.io/repository/kubernetes-ingress-controller/nginx-ingress-controller?tab=tags](https://quay.io/repository/kubernetes-ingress-controller/nginx-ingress-controller?tab=tags)

Stop using v1beta1.Ingress to avoid the following issue when starting the ingress controller:

```
I0605 20:53:28.807814      13 nginx.go:263] Starting NGINX Ingress controller
I0605 20:53:28.810783      13 event.go:281] Event(v1.ObjectReference{Kind:"ConfigMap", Namespace:"ingress-nginx", Name:"nginx-configuration", UID:"90cd2ad0-5769-47a1-a4a5-90b84e9ba609", APIVersion:"v1", ResourceVersion:"649", FieldPath:""}): type: 'Normal' reason: 'CREATE' ConfigMap ingress-nginx/nginx-configuration
I0605 20:53:28.812001      13 event.go:281] Event(v1.ObjectReference{Kind:"ConfigMap", Namespace:"ingress-nginx", Name:"tcp-services", UID:"1fa714b9-79d9-45ac-b135-7f9ffadc0d00", APIVersion:"v1", ResourceVersion:"650", FieldPath:""}): type: 'Normal' reason: 'CREATE' ConfigMap ingress-nginx/tcp-services
I0605 20:53:28.812013      13 event.go:281] Event(v1.ObjectReference{Kind:"ConfigMap", Namespace:"ingress-nginx", Name:"udp-services", UID:"97c2eb93-b8e5-4a59-9d27-47089629ab20", APIVersion:"v1", ResourceVersion:"651", FieldPath:""}): type: 'Normal' reason: 'CREATE' ConfigMap ingress-nginx/udp-services
E0605 20:53:29.910346      13 reflector.go:153] k8s.io/ingress-nginx/internal/ingress/controller/store/store.go:181: Failed to list *v1beta1.Ingress: the server could not find the requested resource
E0605 20:53:30.912852      13 reflector.go:153] k8s.io/ingress-nginx/internal/ingress/controller/store/store.go:181: Failed to list *v1beta1.Ingress: the server could not find the requested resource
```
