### PR TITLE
kubevirt, kind: Add a flag to install ipamclaims

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -374,13 +374,13 @@ install_kubevirt() {
 }
 
 install_kubevirt_ipam_claims() {
+  local kubevirt_ipclaims_manifest=$1
   local cert_manager_version="v1.14.4"
   echo "Installing cert-manager ..."
   manifest="https://github.com/cert-manager/cert-manager/releases/download/${cert_manager_version}/cert-manager.yaml"
   run_kubectl apply -f "$manifest"
 
   echo "Installing KubeVirt IPAM manager ..."
-  manifest="https://raw.githubusercontent.com/maiqueb/kubevirt-ipam-claims/main/dist/install.yaml"
-  run_kubectl apply -f "$manifest"
+  run_kubectl apply -f "${kubevirt_ipclaims_manifest}"
   kubectl wait -n kubevirt-ipam-claims-system deployment kubevirt-ipam-claims-controller-manager --for condition=Available --timeout 2m
 }

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -495,6 +495,7 @@ set_default_params() {
   KIND_INSTALL_METALLB=${KIND_INSTALL_METALLB:-false}
   KIND_INSTALL_PLUGINS=${KIND_INSTALL_PLUGINS:-false}
   KIND_INSTALL_KUBEVIRT=${KIND_INSTALL_KUBEVIRT:-false}
+  KIND_KUBEVIRT_IPAMCLAIMS_MANIFEST=${KIND_KUBEVIRT_IPAMCLAIMS_MANIFEST:-https://raw.githubusercontent.com/maiqueb/kubevirt-ipam-claims/main/dist/install.yaml}
   OVN_HA=${OVN_HA:-false}
   KIND_LOCAL_REGISTRY=${KIND_LOCAL_REGISTRY:-false}
   KIND_LOCAL_REGISTRY_NAME=${KIND_LOCAL_REGISTRY_NAME:-kind-registry}
@@ -1193,5 +1194,5 @@ if [ "$KIND_INSTALL_PLUGINS" == true ]; then
 fi
 if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
   install_kubevirt
-  install_kubevirt_ipam_claims
+  install_kubevirt_ipam_claims ${KIND_KUBEVIRT_IPAMCLAIMS_MANIFEST}
 fi


### PR DESCRIPTION
#### What this PR does and why is it needed
Using kind.sh to deploy a cluster with ovn-k + kubevirt at the ipamclaim controller project, we should skip installing the controller itself so it can be installed from the repo version. This change add a new knob to install the kubevirt ipamclaims controller and remove the installation done at the kubevirt flag.

#### Description for the changelog
Add `--install-kv-ipamclaims` flag to kind.sh

-->
```release-note
Add --install-kv-ipamclaims flag to kind.sh
```
