### PR TITLE
network-segmentation: Handle namespace active-network annotation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -424,6 +424,7 @@ jobs:
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled", "num-workers": "3"}
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3"}
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
+          - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}"
@@ -437,7 +438,8 @@ jobs:
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
-      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' }}"
+      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || matrix.target == 'network-segmentation' }}"
+      ENABLE_NETWORK_SEGMENTATION: "${{ matrix.target == 'network-segmentation' }}"
       KIND_INSTALL_KUBEVIRT: "${{ matrix.target == 'kv-live-migration' }}"
       OVN_COMPACT_MODE: "${{ matrix.target == 'compact-mode' }}"
       OVN_DUMMY_GATEWAY_BRIDGE: "${{ matrix.target == 'compact-mode' }}"
@@ -525,6 +527,8 @@ jobs:
           make -C test control-plane WHAT="Kubevirt Virtual Machines"
         elif [ "${{ matrix.target }}" == "control-plane-helm" ]; then
           make -C test control-plane
+        elif [ "${{ matrix.target }}" == "network-segmentation" ]; then
+          make -C test control-plane WHAT="Network Segmentation"
         else
           make -C test ${{ matrix.target }}
           if [ "${{ matrix.ipfamily }}" != "ipv6" ]; then

--- a/dist/templates/rbac-ovnkube-cluster-manager.yaml.j2
+++ b/dist/templates/rbac-ovnkube-cluster-manager.yaml.j2
@@ -100,3 +100,7 @@ rules:
           - adminnetworkpolicies/status
           - baselineadminnetworkpolicies/status
       verbs: [ "patch" ]
+    - apiGroups: [""]
+      resources:
+          - namespaces/status
+      verbs: [ "patch" ]

--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -57,7 +57,7 @@ func newSecondaryNetworkClusterManager(ovnClient *util.OVNClusterManagerClientse
 		return nil, err
 	}
 	if util.IsNetworkSegmentationSupportEnabled() {
-		sncm.nadController.AddManager("network segmentation", nad.NewNetworkSegmentationManager(ovnClient.KubeClient, wf))
+		sncm.nadController.AddManager("network segmentation", nad.NewNetworkSegmentationManager(ovnClient.KubeClient, wf, ovnClient.NetworkAttchDefClient))
 	}
 	return sncm, nil
 }

--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -56,6 +56,9 @@ func newSecondaryNetworkClusterManager(ovnClient *util.OVNClusterManagerClientse
 	if err != nil {
 		return nil, err
 	}
+	if util.IsNetworkSegmentationSupportEnabled() {
+		sncm.nadController.AddManager("network segmentation", nad.NewNetworkSegmentationManager(ovnClient.KubeClient, wf))
+	}
 	return sncm, nil
 }
 

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -764,6 +764,13 @@ func NewClusterManagerWatchFactory(ovnClientset *util.OVNClusterManagerClientset
 				return nil, err
 			}
 		}
+
+		if util.IsNetworkSegmentationSupportEnabled() {
+			wf.informers[NamespaceType], err = newInformer(NamespaceType, wf.iFactory.Core().V1().Namespaces().Informer())
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if config.OVNKubernetesFeature.EnableMultiExternalGateway {

--- a/go-controller/pkg/network-attach-def-controller/network_segmentation_manager.go
+++ b/go-controller/pkg/network-attach-def-controller/network_segmentation_manager.go
@@ -1,14 +1,20 @@
 package networkAttachDefController
 
 import (
+	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nadclientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 )
 
 var _ NetAttachDefinitionManager = &NetworkSegmentationManager{}
@@ -16,12 +22,14 @@ var _ NetAttachDefinitionManager = &NetworkSegmentationManager{}
 type NetworkSegmentationManager struct {
 	kube         kubernetes.Interface
 	watchFactory *factory.WatchFactory
+	nadClient    nadclientset.Interface
 }
 
-func NewNetworkSegmentationManager(kube kubernetes.Interface, watchFactory *factory.WatchFactory) *NetworkSegmentationManager {
+func NewNetworkSegmentationManager(kube kubernetes.Interface, watchFactory *factory.WatchFactory, nadClient nadclientset.Interface) *NetworkSegmentationManager {
 	return &NetworkSegmentationManager{
 		kube:         kube,
 		watchFactory: watchFactory,
+		nadClient:    nadClient,
 	}
 }
 
@@ -30,7 +38,56 @@ func (m *NetworkSegmentationManager) OnAddNetAttachDef(nad *nettypes.NetworkAtta
 }
 
 func (m *NetworkSegmentationManager) OnDelNetAttachDef(nadName, netName string) error {
-	//TODO
+	namespace, _, err := cache.SplitMetaNamespaceKey(nadName)
+	if err != nil {
+		return err
+	}
+	nadList, err := m.nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed listing network attachment definitions after nad '%s' deletion: %w", nadName, err)
+	}
+
+	if len(nadList.Items) == 0 {
+		pods, err := m.watchFactory.GetPods(namespace)
+		if err != nil {
+			return fmt.Errorf("failed ensuring namespace '%s' active network when listing pods: %w", namespace, err)
+		}
+		networkNamespace, err := m.watchFactory.GetNamespace(namespace)
+		if err != nil {
+			return fmt.Errorf("failed looking for network namespace '%s': %w", namespace, err)
+		}
+		if len(pods) == 0 {
+			if err := util.UpdateNamespaceActiveNetwork(m.kube, networkNamespace, types.DefaultNetworkName); err != nil {
+				return fmt.Errorf("failed annotating namespace with active-network=%s: %w", types.DefaultNetworkName, err)
+			}
+			return nil
+		} else {
+			currentActiveNetwork, ok := networkNamespace.Annotations[util.ActiveNetworkAnnotation]
+			if !ok {
+				return fmt.Errorf("missing active-network annotation at namespace %s", namespace)
+			}
+			if currentActiveNetwork != types.DefaultNetworkName {
+				//TODO: Event
+				klog.Warningf("Active primary network %s deleted from namespace '%s' with pods, marking namespace active network to unknown", currentActiveNetwork, networkNamespace.Name)
+				if err := util.UpdateNamespaceActiveNetwork(m.kube, networkNamespace, types.UnknownNetworkName); err != nil {
+					return fmt.Errorf("failed annotating namespace with active-network=unknown when a primary network was already configured: %w", err)
+				}
+				return nil
+			}
+
+		}
+	}
+
+	for _, nad := range nadList.Items {
+		network, err := util.ParseNADInfo(&nad)
+		if err != nil {
+			return fmt.Errorf("failed parsing nads after nad '%s' deletion: %w", nadName, err)
+		}
+		if err := m.ensureNamespaceActiveNetwork(namespace, network); err != nil {
+			return fmt.Errorf("failed ensuring namespace active network after nad '%s' deletion: %w", nadName, err)
+		}
+	}
+
 	return nil
 }
 
@@ -56,7 +113,7 @@ func (m *NetworkSegmentationManager) ensureNamespaceActiveNetwork(namespace stri
 		return nil
 	}
 
-	if currentActiveNetwork != types.DefaultNetworkName {
+	if currentActiveNetwork != types.DefaultNetworkName && currentActiveNetwork != types.UnknownNetworkName {
 		//TODO: Event
 		klog.Warningf("Active primary network %s already configured at namespace %s, marking namespace active network to unknown", currentActiveNetwork, networkNamespace.Name)
 		if err := util.UpdateNamespaceActiveNetwork(m.kube, networkNamespace, types.UnknownNetworkName); err != nil {

--- a/go-controller/pkg/network-attach-def-controller/network_segmentation_manager.go
+++ b/go-controller/pkg/network-attach-def-controller/network_segmentation_manager.go
@@ -1,0 +1,88 @@
+package networkAttachDefController
+
+import (
+	"fmt"
+
+	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+var _ NetAttachDefinitionManager = &NetworkSegmentationManager{}
+
+type NetworkSegmentationManager struct {
+	kube         kubernetes.Interface
+	watchFactory *factory.WatchFactory
+}
+
+func NewNetworkSegmentationManager(kube kubernetes.Interface, watchFactory *factory.WatchFactory) *NetworkSegmentationManager {
+	return &NetworkSegmentationManager{
+		kube:         kube,
+		watchFactory: watchFactory,
+	}
+}
+
+func (m *NetworkSegmentationManager) OnAddNetAttachDef(nad *nettypes.NetworkAttachmentDefinition, network util.NetInfo) error {
+	return m.ensureNamespaceActiveNetwork(nad.Namespace, network)
+}
+
+func (m *NetworkSegmentationManager) OnDelNetAttachDef(nadName, netName string) error {
+	//TODO
+	return nil
+}
+
+func (m *NetworkSegmentationManager) ensureNamespaceActiveNetwork(namespace string, network util.NetInfo) error {
+	if m.watchFactory == nil || m.kube == nil {
+		return nil
+	}
+	if !network.IsPrimaryNetwork() {
+		return nil
+	}
+
+	networkNamespace, err := m.watchFactory.GetNamespace(namespace)
+	if err != nil {
+		return fmt.Errorf("failed looking for network namespace '%s': %w", namespace, err)
+	}
+
+	currentActiveNetwork, ok := networkNamespace.Annotations[util.ActiveNetworkAnnotation]
+	if !ok {
+		return fmt.Errorf("missing active-network annotation at namespace %s", namespace)
+	}
+
+	if currentActiveNetwork == network.GetNetworkName() {
+		return nil
+	}
+
+	if currentActiveNetwork != types.DefaultNetworkName {
+		//TODO: Event
+		klog.Warningf("Active primary network %s already configured at namespace %s, marking namespace active network to unknown", currentActiveNetwork, networkNamespace.Name)
+		if err := util.UpdateNamespaceActiveNetwork(m.kube, networkNamespace, types.UnknownNetworkName); err != nil {
+			return fmt.Errorf("failed annotating namespace with active-network=unknown when a primary network was already configured: %w", err)
+		}
+		return nil
+	}
+
+	pods, err := m.watchFactory.GetPods(networkNamespace.Name)
+	if err != nil {
+		return fmt.Errorf("failed ensuring namespace '%s' active network when listing pods: %w", networkNamespace.Name, err)
+	}
+
+	// At this point all those pods exist before configuring the primary network,
+	// so we should mark the namespace and send and event
+	if len(pods) > 0 {
+		//TODO: Event
+		klog.Warningf("Pods present at namesapace %s before configuring primary network, marking namespace active network to unknown", networkNamespace.Name)
+		if err := util.UpdateNamespaceActiveNetwork(m.kube, networkNamespace, types.UnknownNetworkName); err != nil {
+			return fmt.Errorf("failed annotating namespace with active-network=unknown when namespace contains pods before configuring a primary network: %w", err)
+		}
+		return nil
+	}
+
+	if err := util.UpdateNamespaceActiveNetwork(m.kube, networkNamespace, network.GetNetworkName()); err != nil {
+		return fmt.Errorf("failed annotating namespace with active-network=%s: %w", network.GetNetworkName(), err)
+	}
+	return nil
+}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -100,6 +100,15 @@ func (oc *DefaultNetworkController) AddNamespace(ns *kapi.Namespace) error {
 	klog.Infof("[%s] adding namespace", ns.Name)
 	// Keep track of how long syncs take.
 	start := time.Now()
+
+	if util.IsNetworkSegmentationSupportEnabled() {
+		if _, ok := ns.Annotations[util.ActiveNetworkAnnotation]; !ok {
+			if err := util.UpdateNamespaceActiveNetwork(oc.kube.KClient, ns, types.DefaultNetworkName); err != nil {
+				return fmt.Errorf("failed annotating namesspace with active-network=default: %w", err)
+			}
+		}
+	}
+
 	defer func() {
 		klog.Infof("[%s] adding namespace took %v", ns.Name, time.Since(start))
 	}()

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -5,6 +5,7 @@ import "time"
 const (
 	// Default network name
 	DefaultNetworkName    = "default"
+	UnknownNetworkName    = "unknown"
 	K8sPrefix             = "k8s-"
 	HybridOverlayPrefix   = "int-"
 	HybridOverlayGRSubfix = "-gr"

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -44,6 +44,7 @@ type networkAttachmentConfigParams struct {
 	networkName        string
 	vlanID             int
 	allowPersistentIPs bool
+	primaryNetwork     bool
 }
 
 type networkAttachmentConfig struct {
@@ -78,7 +79,8 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
         "mtu": 1300,
         "netAttachDefName": %q,
         "vlanID": %d,
-        "allowPersistentIPs": %t
+        "allowPersistentIPs": %t,
+        "primaryNetwork": %t
 }
 `,
 		config.networkName,
@@ -88,6 +90,7 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
 		namespacedName(config.namespace, config.name),
 		config.vlanID,
 		config.allowPersistentIPs,
+		config.primaryNetwork,
 	)
 	return generateNetAttachDef(config.namespace, config.name, nadSpec)
 }
@@ -126,6 +129,9 @@ func generatePodSpec(config podConfiguration) *v1.Pod {
 }
 
 func networkSelectionElements(elements ...nadapi.NetworkSelectionElement) map[string]string {
+	if len(elements) == 0 {
+		return map[string]string{}
+	}
 	marshalledElements, err := json.Marshal(elements)
 	if err != nil {
 		panic(fmt.Errorf("programmer error: you've provided wrong input to the test data: %v", err))

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -1,0 +1,160 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+)
+
+var _ = Describe("Network Segmentation", func() {
+	const (
+		activeNetworkAnnotation = "k8s.ovn.org/active-network"
+	)
+
+	f := wrappedTestFramework("network-segmentation")
+
+	type activeNetworkTest struct {
+		nads                  []networkAttachmentConfigParams
+		podsBeforeNADs        []podConfiguration
+		expectedActiveNetwork string
+	}
+	DescribeTable("should annotate namespace with proper active-network", func(td activeNetworkTest) {
+		nadClient, err := nadclient.NewForConfig(f.ClientConfig())
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Create pods before network attachment definition")
+		podsBeforeNADs := []*corev1.Pod{}
+		for _, pod := range td.podsBeforeNADs {
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(
+				context.Background(),
+				generatePodSpec(pod),
+				metav1.CreateOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			podsBeforeNADs = append(podsBeforeNADs, pod)
+		}
+
+		By("Create network attachment definitions")
+		for _, nad := range td.nads {
+			netConfig := newNetworkAttachmentConfig(nad)
+			netConfig.namespace = f.Namespace.Name
+
+			_, err = nadClient.NetworkAttachmentDefinitions(netConfig.namespace).Create(
+				context.Background(),
+				generateNAD(netConfig),
+				metav1.CreateOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("Wait for active-network annotation")
+		Eventually(thisNamespace(f.ClientSet, f.Namespace)).
+			WithPolling(time.Second / 2).
+			WithTimeout(5 * time.Second).
+			Should(WithTransform(getAnnotations,
+				HaveKeyWithValue(activeNetworkAnnotation, td.expectedActiveNetwork)))
+
+	},
+		Entry("without primary network nads to 'default'", activeNetworkTest{
+			nads:                  []networkAttachmentConfigParams{},
+			expectedActiveNetwork: "default",
+		}),
+		Entry("with one primaryNetwork nad on layer2 to network name", activeNetworkTest{
+			nads: []networkAttachmentConfigParams{{
+				name:           "tenant-blue-l2",
+				networkName:    "net-l2",
+				cidr:           "10.128.0.0/24",
+				topology:       "layer2",
+				primaryNetwork: true,
+			}},
+			expectedActiveNetwork: "net-l2",
+		}),
+		Entry("with one primaryNetwork nad on layer3 to network name", activeNetworkTest{
+			nads: []networkAttachmentConfigParams{{
+				name:           "tenant-blue-l3",
+				networkName:    "net-l3",
+				cidr:           "10.128.0.0/16/24",
+				topology:       "layer3",
+				primaryNetwork: true,
+			}},
+			expectedActiveNetwork: "net-l3",
+		}),
+		Entry("with two primaryNetwork nads on layer3 and same network with network name", activeNetworkTest{
+			nads: []networkAttachmentConfigParams{
+				{
+					name:           "tenant-blue-l3",
+					networkName:    "net-l3",
+					cidr:           "10.128.0.0/16/24",
+					topology:       "layer3",
+					primaryNetwork: true,
+				},
+				{
+					name:           "tenant-red-l3",
+					networkName:    "net-l3",
+					cidr:           "10.128.0.0/16/24",
+					topology:       "layer3",
+					primaryNetwork: true,
+				},
+			},
+			expectedActiveNetwork: "net-l3",
+		}),
+		Entry("with two primaryNetwork nads on layer2 and same network with network name", activeNetworkTest{
+			nads: []networkAttachmentConfigParams{
+				{
+					name:           "tenant-blue-l2",
+					networkName:    "net-l2",
+					cidr:           "10.128.0.0/24",
+					topology:       "layer2",
+					primaryNetwork: true,
+				},
+				{
+					name:           "tenant-red-l2",
+					networkName:    "net-l2",
+					cidr:           "10.128.0.0/24",
+					topology:       "layer2",
+					primaryNetwork: true,
+				},
+			},
+			expectedActiveNetwork: "net-l2",
+		}),
+		Entry("with two primaryNetwork nads and different network with 'unknown'", activeNetworkTest{
+			nads: []networkAttachmentConfigParams{
+				{
+					name:           "tenant-blue-l3",
+					networkName:    "net-l3",
+					cidr:           "10.128.0.0/16/24",
+					topology:       "layer3",
+					primaryNetwork: true,
+				},
+				{
+					name:           "tenant-blue-l2",
+					networkName:    "net-l2",
+					cidr:           "10.128.0.0/24",
+					topology:       "layer2",
+					primaryNetwork: true,
+				},
+			},
+			expectedActiveNetwork: "unknown",
+		}),
+		Entry("with one primaryNetwork nad pods at the namespace with 'unknown'", activeNetworkTest{
+			podsBeforeNADs: []podConfiguration{{
+				name: "pod1",
+			}},
+			nads: []networkAttachmentConfigParams{{
+				name:           "tenant-blue-l2",
+				networkName:    "net-l2",
+				cidr:           "10.128.0.0/24",
+				topology:       "layer2",
+				primaryNetwork: true,
+			}},
+			expectedActiveNetwork: "unknown",
+		}),
+	)
+})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -32,6 +32,7 @@ import (
 	testutils "k8s.io/kubernetes/test/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
 	utilnet "k8s.io/utils/net"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -1239,4 +1240,14 @@ func getGatewayMTUSupport(node *v1.Node) bool {
 		return true
 	}
 	return false
+}
+
+func thisNamespace(cli kubernetes.Interface, namespace *v1.Namespace) func() (*v1.Namespace, error) {
+	return func() (*v1.Namespace, error) {
+		return cli.CoreV1().Namespaces().Get(context.Background(), namespace.Name, metav1.GetOptions{})
+	}
+}
+
+func getAnnotations(obj client.Object) map[string]string {
+	return obj.GetAnnotations()
 }

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -161,6 +161,15 @@ if [ "${WHAT}" != "${KV_LIVE_MIGRATION_TESTS}" ]; then
   SKIPPED_TESTS+=$KV_LIVE_MIGRATION_TESTS
 fi
 
+# Only run network segmentation tests if they are explicitly requested
+KV_NETWORK_SEGMENTATION_TESTS="Network Segmentation"
+if [ "${WHAT}" != "${KV_NETWORK_SEGMENTATION_TESTS}" ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+	SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+=$KV_NETWORK_SEGMENTATION_TESTS
+fi
+
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
#### What this PR does and why is it needed
This change annotate a namespace with `k8s.ovn.org/active-network` selecting the network used for the pod primary interface, by default all the namespaces will contain `k8s.ovn.org/active-network=default` and if a primary network is configured at a namespace using a network attachment definition the annotation will be `k8s.ovn.org/active-network=[network]`.

#### Special notes for reviewers
Stuff that will be done at follow up PRs:
- [ ] Handle pod deletion to remove "unknown" active-network
- [ ] Add localnet negative test.
- [ ] Add the events
- [ ] Docs


#### How to verify it
The PR included e2e test to cover the success scenarios and some "unknown" and nad delete scenarios.

#### Details to documentation updates
Documentation will be done at follow up PRs.


#### Description for the changelog
Annotate namespaces with `k8s.ovn.org/active-network`

#### Does this PR introduce a user-facing change?
NONE

```release-note
Annotate namespaces with `k8s.ovn.org/active-network`
```
