### PR TITLE
User Defined Network Segmentation Feature Gate

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -310,6 +310,8 @@ parse_args() {
                                                 ;;
             -mne | --multi-network-enable )     ENABLE_MULTI_NET=true
                                                 ;;
+            -nse | --network-segmentation-enable) ENABLE_NETWORK_SEGMENTATION=true
+                                                  ;;
             -ic | --enable-interconnect )       OVN_ENABLE_INTERCONNECT=true
                                                 ;;
             --disable-ovnkube-identity)         OVN_ENABLE_OVNKUBE_IDENTITY=false
@@ -391,6 +393,7 @@ print_params() {
      echo "OVN_METRICS_SCALE_ENABLE = $OVN_METRICS_SCALE_ENABLE"
      echo "OVN_ISOLATED = $OVN_ISOLATED"
      echo "ENABLE_MULTI_NET = $ENABLE_MULTI_NET"
+     echo "ENABLE_NETWORK_SEGMENTATION= $ENABLE_NETWORK_SEGMENTATION"
      echo "OVN_ENABLE_INTERCONNECT = $OVN_ENABLE_INTERCONNECT"
      if [ "$OVN_ENABLE_INTERCONNECT" == true ]; then
        echo "KIND_NUM_NODES_PER_ZONE = $KIND_NUM_NODES_PER_ZONE"
@@ -589,6 +592,7 @@ set_default_params() {
     OVN_GATEWAY_OPTS="--allow-no-uplink --gateway-interface=br-ex"
   fi
   ENABLE_MULTI_NET=${ENABLE_MULTI_NET:-false}
+  ENABLE_NETWORK_SEGMENTATION=${ENABLE_NETWORK_SEGMENTATION:-false}
   OVN_COMPACT_MODE=${OVN_COMPACT_MODE:-false}
   if [ "$OVN_COMPACT_MODE" == true ]; then
     KIND_NUM_WORKER=0
@@ -829,6 +833,7 @@ create_ovn_kube_manifests() {
     --v6-transit-switch-subnet="${TRANSIT_SWITCH_SUBNET_IPV6}" \
     --ex-gw-network-interface="${OVN_EX_GW_NETWORK_INTERFACE}" \
     --multi-network-enable="${ENABLE_MULTI_NET}" \
+    --network-segmentation-enable="${ENABLE_NETWORK_SEGMENTATION}" \
     --ovnkube-metrics-scale-enable="${OVN_METRICS_SCALE_ENABLE}" \
     --compact-mode="${OVN_COMPACT_MODE}" \
     --enable-interconnect="${OVN_ENABLE_INTERCONNECT}" \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -70,6 +70,7 @@ OVN_EGRESSQOS_ENABLE=
 OVN_EGRESSSERVICE_ENABLE=
 OVN_DISABLE_OVN_IFACE_ID_VER="false"
 OVN_MULTI_NETWORK_ENABLE=
+OVN_NETWORK_SEGMENTATION_ENABLE=
 OVN_V4_JOIN_SUBNET=""
 OVN_V6_JOIN_SUBNET=""
 OVN_V4_MASQUERADE_SUBNET=""
@@ -262,6 +263,9 @@ while [ "$1" != "" ]; do
   --multi-network-enable)
     OVN_MULTI_NETWORK_ENABLE=$VALUE
     ;;
+  --network-segmentation-enable)
+    OVN_NETWORK_SEGMENTATION_ENABLE=$VALUE
+    ;;
   --egress-service-enable)
     OVN_EGRESSSERVICE_ENABLE=$VALUE
     ;;
@@ -434,6 +438,8 @@ ovn_disable_ovn_iface_id_ver=${OVN_DISABLE_OVN_IFACE_ID_VER}
 echo "ovn_disable_ovn_iface_id_ver: ${ovn_disable_ovn_iface_id_ver}"
 ovn_multi_network_enable=${OVN_MULTI_NETWORK_ENABLE}
 echo "ovn_multi_network_enable: ${ovn_multi_network_enable}"
+ovn_network_segmentation_enable=${OVN_NETWORK_SEGMENTATION_ENABLE}
+echo "ovn_network_segmentation_enable: ${ovn_network_segmentation_enable}"
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
 echo "ovn_hybrid_overlay_net_cidr: ${ovn_hybrid_overlay_net_cidr}"
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS}
@@ -558,6 +564,7 @@ ovn_image=${ovnkube_image} \
   ovn_egress_ip_enable=${ovn_egress_ip_enable} \
   ovn_egress_ip_healthcheck_port=${ovn_egress_ip_healthcheck_port} \
   ovn_multi_network_enable=${ovn_multi_network_enable} \
+  ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
   ovn_egress_service_enable=${ovn_egress_service_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_remote_probe_interval=${ovn_remote_probe_interval} \
@@ -608,6 +615,7 @@ ovn_image=${ovnkube_image} \
   ovn_egress_ip_enable=${ovn_egress_ip_enable} \
   ovn_egress_ip_healthcheck_port=${ovn_egress_ip_healthcheck_port} \
   ovn_multi_network_enable=${ovn_multi_network_enable} \
+  ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
   ovn_egress_service_enable=${ovn_egress_service_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_remote_probe_interval=${ovn_remote_probe_interval} \
@@ -702,6 +710,7 @@ ovn_image=${ovnkube_image} \
   ovn_egress_firewall_enable=${ovn_egress_firewall_enable} \
   ovn_egress_qos_enable=${ovn_egress_qos_enable} \
   ovn_multi_network_enable=${ovn_multi_network_enable} \
+  ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
   ovn_egress_service_enable=${ovn_egress_service_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
@@ -744,6 +753,7 @@ ovn_image=${ovnkube_image} \
   ovn_egress_firewall_enable=${ovn_egress_firewall_enable} \
   ovn_egress_qos_enable=${ovn_egress_qos_enable} \
   ovn_multi_network_enable=${ovn_multi_network_enable} \
+  ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
   ovn_egress_service_enable=${ovn_egress_service_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
@@ -817,6 +827,7 @@ ovn_image=${ovnkube_image} \
   ovn_egress_firewall_enable=${ovn_egress_firewall_enable} \
   ovn_egress_qos_enable=${ovn_egress_qos_enable} \
   ovn_multi_network_enable=${ovn_multi_network_enable} \
+  ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
   ovn_egress_service_enable=${ovn_egress_service_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_remote_probe_interval=${ovn_remote_probe_interval} \
@@ -877,6 +888,7 @@ ovn_image=${ovnkube_image} \
   ovn_egress_firewall_enable=${ovn_egress_firewall_enable} \
   ovn_egress_qos_enable=${ovn_egress_qos_enable} \
   ovn_multi_network_enable=${ovn_multi_network_enable} \
+  ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_remote_probe_interval=${ovn_remote_probe_interval} \
   ovn_monitor_all=${ovn_monitor_all} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -265,6 +265,8 @@ ovn_egressservice_enable=${OVN_EGRESSSERVICE_ENABLE:-false}
 ovn_disable_ovn_iface_id_ver=${OVN_DISABLE_OVN_IFACE_ID_VER:-false}
 #OVN_MULTI_NETWORK_ENABLE - enable multiple network support for ovn-kubernetes
 ovn_multi_network_enable=${OVN_MULTI_NETWORK_ENABLE:-false}
+#OVN_NETWORK_SEGMENTATION_ENABLE - enable user defined primary networks for ovn-kubernetes
+ovn_network_segmentation_enable=${OVN_NETWORK_SEGMENTATION_ENABLE:=false}
 ovn_acl_logging_rate_limit=${OVN_ACL_LOGGING_RATE_LIMIT:-"20"}
 ovn_netflow_targets=${OVN_NETFLOW_TARGETS:-}
 ovn_sflow_targets=${OVN_SFLOW_TARGETS:-}
@@ -1202,6 +1204,12 @@ ovn-master() {
   fi
   echo "multi_network_enabled_flag=${multi_network_enabled_flag}"
 
+  network_segmentation_enabled_flag=
+  if [[ ${ovn_network_segmentation_enable} == "true" ]]; then
+	  network_segmentation_enabled_flag="--enable-multi-network --enable-network-segmentation"
+  fi
+  echo "network_segmentation_enabled_flag=${network_segmentation_enabled_flag}"
+
   egressservice_enabled_flag=
   if [[ ${ovn_egressservice_enable} == "true" ]]; then
 	  egressservice_enabled_flag="--enable-egress-service"
@@ -1278,6 +1286,7 @@ ovn-master() {
     ${libovsdb_client_logfile_flag} \
     ${multicast_enabled_flag} \
     ${multi_network_enabled_flag} \
+    ${network_segmentation_enabled_flag} \
     ${ovn_acl_logging_rate_limit_flag} \
     ${ovn_enable_svc_template_support_flag} \
     ${ovnkube_config_duration_enable_flag} \
@@ -1456,6 +1465,12 @@ ovnkube-controller() {
   fi
   echo "multi_network_enabled_flag=${multi_network_enabled_flag}"
 
+  network_segmentation_enabled_flag=
+  if [[ ${ovn_network_segmentation_enable} == "true" ]]; then
+	  network_segmentation_enabled_flag="--enable-multi-network --enable-network-segmentation"
+  fi
+  echo "network_segmentation_enabled_flag=${network_segmentation_enabled_flag}"
+
   egressservice_enabled_flag=
   if [[ ${ovn_egressservice_enable} == "true" ]]; then
 	  egressservice_enabled_flag="--enable-egress-service"
@@ -1544,6 +1559,7 @@ ovnkube-controller() {
     ${libovsdb_client_logfile_flag} \
     ${multicast_enabled_flag} \
     ${multi_network_enabled_flag} \
+    ${network_segmentation_enabled_flag} \
     ${ovn_acl_logging_rate_limit_flag} \
     ${ovn_dbs} \
     ${ovn_enable_svc_template_support_flag} \
@@ -1717,6 +1733,12 @@ ovnkube-controller-with-node() {
 	  multi_network_enabled_flag="--enable-multi-network --enable-multi-networkpolicy"
   fi
   echo "multi_network_enabled_flag=${multi_network_enabled_flag}"
+
+  network_segmentation_enabled_flag=
+  if [[ ${ovn_network_segmentation_enable} == "true" ]]; then
+	  network_segmentation_enabled_flag="--enable-multi-network --enable-network-segmentation"
+  fi
+  echo "network_segmentation_enabled_flag=${network_segmentation_enabled_flag}"
 
   egressservice_enabled_flag=
   if [[ ${ovn_egressservice_enable} == "true" ]]; then
@@ -1939,6 +1961,7 @@ ovnkube-controller-with-node() {
     ${monitor_all} \
     ${multicast_enabled_flag} \
     ${multi_network_enabled_flag} \
+    ${network_segmentation_enabled_flag} \
     ${netflow_targets} \
     ${ofctrl_wait_before_clear} \
     ${ovn_acl_logging_rate_limit_flag} \
@@ -2095,6 +2118,12 @@ ovn-cluster-manager() {
   fi
   echo "multi_network_enabled_flag: ${multi_network_enabled_flag}"
 
+  network_segmentation_enabled_flag=
+  if [[ ${ovn_network_segmentation_enable} == "true" ]]; then
+	  network_segmentation_enabled_flag="--enable-multi-network --enable-network-segmentation"
+  fi
+  echo "network_segmentation_enabled_flag=${network_segmentation_enabled_flag}"
+
   persistent_ips_enabled_flag=
   if [[ ${ovn_enable_persistent_ips} == "true" ]]; then
 	  persistent_ips_enabled_flag="--enable-persistent-ips"
@@ -2143,6 +2172,7 @@ ovn-cluster-manager() {
     ${hybrid_overlay_flags} \
     ${multicast_enabled_flag} \
     ${multi_network_enabled_flag} \
+    ${network_segmentation_enabled_flag} \
     ${persistent_ips_enabled_flag} \
     ${ovnkube_enable_interconnect_flag} \
     ${ovnkube_enable_multi_external_gateway_flag} \
@@ -2302,6 +2332,11 @@ ovn-node() {
   multi_network_enabled_flag=
   if [[ ${ovn_multi_network_enable} == "true" ]]; then
 	  multi_network_enabled_flag="--enable-multi-network --enable-multi-networkpolicy"
+  fi
+
+  network_segmentation_enabled_flag=
+  if [[ ${ovn_network_segmentation_enable} == "true" ]]; then
+	  network_segmentation_enabled_flag="--enable-multi-network --enable-network-segmentation"
   fi
 
   netflow_targets=
@@ -2482,6 +2517,7 @@ ovn-node() {
         ${monitor_all} \
         ${multicast_enabled_flag} \
         ${multi_network_enabled_flag} \
+        ${network_segmentation_enabled_flag} \
         ${netflow_targets} \
         ${ofctrl_wait_before_clear} \
         ${ovn_dbs} \

--- a/dist/templates/ovnkube-control-plane.yaml.j2
+++ b/dist/templates/ovnkube-control-plane.yaml.j2
@@ -137,6 +137,8 @@ spec:
           value: "{{ ovn_egress_qos_enable }}"
         - name: OVN_MULTI_NETWORK_ENABLE
           value: "{{ ovn_multi_network_enable }}"
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: "{{ ovn_network_segmentation_enable }}"
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -257,6 +257,8 @@ spec:
           value: "{{ ovn_egress_qos_enable }}"
         - name: OVN_MULTI_NETWORK_ENABLE
           value: "{{ ovn_multi_network_enable }}"
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: "{{ ovn_network_segmentation_enable }}"
         - name: OVN_EGRESSSERVICE_ENABLE
           value: "{{ ovn_egress_service_enable }}"
         - name: OVN_HYBRID_OVERLAY_NET_CIDR

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -228,6 +228,8 @@ spec:
           value: "{{ ovn_lflow_cache_limit_kb }}"
         - name: OVN_MULTI_NETWORK_ENABLE
           value: "{{ ovn_multi_network_enable }}"
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: "{{ ovn_network_segmentation_enable }}"
         - name: OVN_ENABLE_INTERCONNECT
           value: "{{ ovn_enable_interconnect }}"
         - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -422,6 +422,8 @@ spec:
           value: "{{ ovn_lflow_cache_limit_kb }}"
         - name: OVN_MULTI_NETWORK_ENABLE
           value: "{{ ovn_multi_network_enable }}"
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: "{{ ovn_network_segmentation_enable }}"
         - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
           value: "{{ ovnkube_node_mgmt_port_netdev }}"
         - name: OVN_EMPTY_LB_EVENTS

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -342,6 +342,8 @@ spec:
           value: "{{ ovn_egress_qos_enable }}"
         - name: OVN_MULTI_NETWORK_ENABLE
           value: "{{ ovn_multi_network_enable }}"
+        - name: OVN_NETWORK_SEGMENTATION_ENABLE
+          value: "{{ ovn_network_segmentation_enable }}"
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -60,6 +60,28 @@ Additionally following iptables rules are added at FORWARD chain to forward clus
 
 ## OVN-Kubernetes Feature Config
 
+### Enable Multiple Networks
+
+Users can create pods with multiple interfaces such that each interface is hooked to
+a separate network thereby enabling multiple networks for a given pod;
+a.k.a multi-homing. All networks that are created as additions to the primary
+default Kubernetes network are fondly called `secondary networks`. This feature
+can be enabled by using the `--enable-multi-network` flag on OVN-Kubernetes clusters.
+
+
+### Enable Network Segmentation
+
+Users can enable the network-segmentation feature using `--enable-network-segmentation`
+flag on a KIND cluster. This allows users to be able to design native isolation between
+their tenant namespaces by coupling all namespaces that belong to the same
+tenant under the same secondary network and then making this network the primary network
+for the pod. Each network is isolated and cannot talk to other user
+defined network. Check out the feature docs for more information on how to segment your
+cluster on a network level.
+
+NOTE: This feature only works if `--enable-multi-network` is
+also enabled since it leverages the secondary networks feature.
+
 ## HA Config
 
 ## OVN Auth Config

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -9,7 +9,10 @@ import (
 // NetConf is CNI NetConf with DeviceID
 type NetConf struct {
 	types.NetConf
-
+	// PrimaryNetwork is valid on only L3 / L2 topologies. Not on localnet.
+	// It allows for using this secondary network as the primary network
+	// for the pod in order to achieve native network segmentation
+	PrimaryNetwork bool `json:"primaryNetwork,omitempty"`
 	// specifies the OVN topology for this network configuration
 	// when not specified, by default it is Layer3AttachDefTopoType
 	Topology string `json:"topology,omitempty"`

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -399,6 +399,7 @@ type OVNKubernetesFeatureConfig struct {
 	EnableEgressService             bool `gcfg:"enable-egress-service"`
 	EgressIPNodeHealthCheckPort     int  `gcfg:"egressip-node-healthcheck-port"`
 	EnableMultiNetwork              bool `gcfg:"enable-multi-network"`
+	EnableNetworkSegmentation       bool `gcfg:"enable-network-segmentation"`
 	EnableMultiNetworkPolicy        bool `gcfg:"enable-multi-networkpolicy"`
 	EnableStatelessNetPol           bool `gcfg:"enable-stateless-netpol"`
 	EnableInterconnect              bool `gcfg:"enable-interconnect"`
@@ -1019,6 +1020,12 @@ var OVNK8sFeatureFlags = []cli.Flag{
 		Usage:       "Configure to use MultiNetworkPolicy CRD feature with ovn-kubernetes.",
 		Destination: &cliConfig.OVNKubernetesFeature.EnableMultiNetworkPolicy,
 		Value:       OVNKubernetesFeature.EnableMultiNetworkPolicy,
+	},
+	&cli.BoolFlag{
+		Name:        "enable-network-segmentation",
+		Usage:       "Configure to use network segmentation feature with ovn-kubernetes.",
+		Destination: &cliConfig.OVNKubernetesFeature.EnableNetworkSegmentation,
+		Value:       OVNKubernetesFeature.EnableNetworkSegmentation,
 	},
 	&cli.BoolFlag{
 		Name:        "enable-stateless-netpol",

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -224,6 +224,7 @@ egressip-reachability-total-timeout=3
 egressip-node-healthcheck-port=1234
 enable-multi-network=false
 enable-multi-networkpolicy=false
+enable-network-segmentation=false
 enable-interconnect=false
 enable-multi-external-gateway=false
 enable-admin-network-policy=false
@@ -333,6 +334,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(1))
 			gomega.Expect(OVNKubernetesFeature.EgressIPNodeHealthCheckPort).To(gomega.Equal(0))
 			gomega.Expect(OVNKubernetesFeature.EnableMultiNetwork).To(gomega.BeFalse())
+			gomega.Expect(OVNKubernetesFeature.EnableNetworkSegmentation).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EnableMultiNetworkPolicy).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EnableInterconnect).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EnableMultiExternalGateway).To(gomega.BeFalse())
@@ -590,6 +592,7 @@ var _ = Describe("Config Operations", func() {
 			"cert-dir="+certDir,
 			"enable-multi-network=true",
 			"enable-multi-networkpolicy=true",
+			"enable-network-segmentation=true",
 			"enable-interconnect=true",
 			"enable-multi-external-gateway=true",
 			"enable-admin-network-policy=true",
@@ -678,6 +681,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(3))
 			gomega.Expect(OVNKubernetesFeature.EgressIPNodeHealthCheckPort).To(gomega.Equal(1234))
 			gomega.Expect(OVNKubernetesFeature.EnableMultiNetwork).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EnableNetworkSegmentation).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableInterconnect).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableMultiExternalGateway).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableAdminNetworkPolicy).To(gomega.BeTrue())
@@ -782,6 +786,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(5))
 			gomega.Expect(OVNKubernetesFeature.EgressIPNodeHealthCheckPort).To(gomega.Equal(4321))
 			gomega.Expect(OVNKubernetesFeature.EnableMultiNetwork).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EnableNetworkSegmentation).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableMultiNetworkPolicy).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableInterconnect).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableMultiExternalGateway).To(gomega.BeTrue())
@@ -855,6 +860,7 @@ var _ = Describe("Config Operations", func() {
 			"-egressip-node-healthcheck-port=4321",
 			"-enable-multi-network=true",
 			"-enable-multi-networkpolicy=true",
+			"-enable-network-segmentation=true",
 			"-enable-interconnect=true",
 			"-enable-multi-external-gateway=true",
 			"-enable-admin-network-policy=true",

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -28,6 +28,7 @@ var (
 type BasicNetInfo interface {
 	// basic network information
 	GetNetworkName() string
+	IsPrimaryNetwork() bool
 	IsSecondary() bool
 	TopologyType() string
 	MTU() int
@@ -57,6 +58,15 @@ type DefaultNetInfo struct{}
 // GetNetworkName returns the network name
 func (nInfo *DefaultNetInfo) GetNetworkName() string {
 	return types.DefaultNetworkName
+}
+
+// IsPrimaryNetwork always returns false for default network.
+// The boolean indicates if this secondary network is
+// meant to be the primary network for the pod. Since default
+// network is never a secondary network this is always false.
+// This cannot be true if IsSecondary() is not true.
+func (nInfo *DefaultNetInfo) IsPrimaryNetwork() bool {
+	return false
 }
 
 // IsSecondary returns if this network is secondary
@@ -135,7 +145,10 @@ func (nInfo *DefaultNetInfo) AllowsPersistentIPs() bool {
 
 // SecondaryNetInfo holds the network name information for secondary network if non-nil
 type secondaryNetInfo struct {
-	netName            string
+	netName string
+	// Should this secondary network be used
+	// as the pod's primary network?
+	primaryNetwork     bool
 	topology           string
 	mtu                int
 	vlan               uint
@@ -153,6 +166,13 @@ type secondaryNetInfo struct {
 // GetNetworkName returns the network name
 func (nInfo *secondaryNetInfo) GetNetworkName() string {
 	return nInfo.netName
+}
+
+// IsPrimaryNetwork returns if this secondary network
+// should be used as the primaryNetwork for the pod
+// to achieve native network segmentation
+func (nInfo *secondaryNetInfo) IsPrimaryNetwork() bool {
+	return nInfo.primaryNetwork
 }
 
 // IsSecondary returns if this network is secondary
@@ -247,6 +267,9 @@ func (nInfo *secondaryNetInfo) CompareNetInfo(other BasicNetInfo) bool {
 	if nInfo.allowPersistentIPs != other.AllowsPersistentIPs() {
 		return false
 	}
+	if nInfo.primaryNetwork != other.IsPrimaryNetwork() {
+		return false
+	}
 
 	lessCIDRNetworkEntry := func(a, b config.CIDRNetworkEntry) bool { return a.String() < b.String() }
 	if !cmp.Equal(nInfo.subnets, other.Subnets(), cmpopts.SortSlices(lessCIDRNetworkEntry)) {
@@ -264,10 +287,11 @@ func newLayer3NetConfInfo(netconf *ovncnitypes.NetConf) (NetInfo, error) {
 	}
 
 	ni := &secondaryNetInfo{
-		netName:  netconf.Name,
-		topology: types.Layer3Topology,
-		subnets:  subnets,
-		mtu:      netconf.MTU,
+		netName:        netconf.Name,
+		primaryNetwork: netconf.PrimaryNetwork,
+		topology:       types.Layer3Topology,
+		subnets:        subnets,
+		mtu:            netconf.MTU,
 	}
 	ni.ipv4mode, ni.ipv6mode = getIPMode(subnets)
 	return ni, nil
@@ -281,6 +305,7 @@ func newLayer2NetConfInfo(netconf *ovncnitypes.NetConf) (NetInfo, error) {
 
 	ni := &secondaryNetInfo{
 		netName:            netconf.Name,
+		primaryNetwork:     netconf.PrimaryNetwork,
 		topology:           types.Layer2Topology,
 		subnets:            subnets,
 		excludeSubnets:     excludes,
@@ -437,6 +462,10 @@ func ParseNetConf(netattachdef *nettypes.NetworkAttachmentDefinition) (*ovncnity
 
 	if netconf.AllowPersistentIPs && netconf.Topology == types.Layer3Topology {
 		return nil, fmt.Errorf("layer3 topology does not allow persistent IPs")
+	}
+
+	if netconf.PrimaryNetwork && netconf.Topology == types.LocalnetTopology {
+		return nil, fmt.Errorf("localnet topology does not allow primaryNetwork:true")
 	}
 
 	if netconf.IPAM.Type != "" {

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -531,6 +531,10 @@ func IsMultiNetworkPoliciesSupportEnabled() bool {
 	return config.OVNKubernetesFeature.EnableMultiNetwork && config.OVNKubernetesFeature.EnableMultiNetworkPolicy
 }
 
+func IsNetworkSegmentationSupportEnabled() bool {
+	return config.OVNKubernetesFeature.EnableMultiNetwork && config.OVNKubernetesFeature.EnableNetworkSegmentation
+}
+
 func DoesNetworkRequireIPAM(netInfo NetInfo) bool {
 	return !((netInfo.TopologyType() == types.Layer2Topology || netInfo.TopologyType() == types.LocalnetTopology) && len(netInfo.Subnets()) == 0)
 }


### PR DESCRIPTION


#### What this PR does and why is it needed

- [x] Adds notion of "primary network" for secondary networks on the NAD
- [x] Adds `enable-network-segmentation` feature gate for this feature


#### Special notes for reviewers

This will be leveraged in future commits

#### How to verify it

UTs are added

#### Details to documentation updates

New config flag docs done!


#### Description for the changelog

`Add feature gate for user-defined-networks-feature`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
Allows users to enable user-defined-networks via feature gate
```
