### PR TITLE
avoid reusing stopped network controllers

### DIFF
--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -48,6 +48,7 @@ type BaseNetworkController interface {
 	Start(ctx context.Context) error
 	Stop()
 	GetNetworkName() string
+	TopologyType() string
 }
 
 type NetworkController interface {


### PR DESCRIPTION
network controllers might not support being stopped and then started again as that was never part of their contract so avoid doing that. Also, for safety, ensure Cleanup for a network runs to completion before attempting to create a new controller for the same network.
