### PR TITLE
e2e: Fix secondaryIPV6Subnet mask

### DIFF
--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -34,7 +34,7 @@ const (
 	OVN_EGRESSIP_LEGACY_HEALTHCHECK_PORT       = "9" // the actual port used by legacy health check
 	primaryNetworkName                         = "kind"
 	secondaryIPV4Subnet                        = "10.10.10.0/24"
-	secondaryIPV6Subnet                        = "2001:db8:abcd:1234:c000::/64"
+	secondaryIPV6Subnet                        = "2001:db8:abcd:1234::/64"
 	secondaryNetworkName                       = "secondary-network"
 )
 


### PR DESCRIPTION
The previous mask was invalid and docker was failing with: invalid subnet `2001:db8:abcd:1234:c000::/64`: it should be `2001:db8:abcd:1234::/64`

/cc @tssurya 