### PR TITLE
Bump OVN to ovn-24.03.2-19 to fix multicast bug

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-24.03.2-5.fc39
+ARG ovnver=ovn-24.03.2-19.fc39
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/test/e2e/multicast.go
+++ b/test/e2e/multicast.go
@@ -23,6 +23,7 @@ const (
 	mcastSource  = "pod-client"
 	mcastServer1 = "pod-server1"
 	mcastServer2 = "pod-server2"
+	mcastServer3 = "pod-server3"
 )
 
 var _ = ginkgo.Describe("Multicast", func() {
@@ -119,6 +120,18 @@ var _ = ginkgo.Describe("Multicast", func() {
 		mcastServerPod2.Spec.NodeName = serverNodeInfo.name
 		e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod2)
 
+		// Start a multicast listener on the same groups and verify it received the traffic (iperf server is the multicast listener)
+		// join multicast group (-B 224.3.3.3), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
+		ginkgo.By("creating first multicast listener pod in node " + clientNodeInfo.name)
+		iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroup)
+		if IsIPv6Cluster(cs) {
+			iperf = iperf + " -V"
+		}
+		cmd = []string{"/bin/sh", "-c", iperf}
+		mcastServerPod3 := newAgnhostPod(fr.Namespace.Name, mcastServer3, cmd...)
+		mcastServerPod3.Spec.NodeName = clientNodeInfo.name
+		e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod3)
+
 		ginkgo.By("checking if pod server1 received multicast traffic")
 		gomega.Eventually(func() (string, error) {
 			return e2epod.GetPodLogs(context.TODO(), cs, ns, mcastServer1, mcastServer1)
@@ -130,6 +143,13 @@ var _ = ginkgo.Describe("Multicast", func() {
 			return e2epod.GetPodLogs(context.TODO(), cs, ns, mcastServer2, mcastServer2)
 		},
 			30*time.Second, 1*time.Second).ShouldNot(gomega.ContainSubstring("connected"))
+
+		ginkgo.By("checking if pod server3 received multicast traffic")
+		gomega.Eventually(func() (string, error) {
+			return e2epod.GetPodLogs(context.TODO(), cs, ns, mcastServer3, mcastServer3)
+		},
+			30*time.Second, 1*time.Second).Should(gomega.ContainSubstring("connected"))
+
 	})
 
 })


### PR DESCRIPTION
Bumps OVN to 24.03.2-19, which reverts multicast-related commits that introduced a regression.
Extends the unit test to cover the scenario that was broken: add an additional receiver to the same node where the sender is.
https://issues.redhat.com/browse/OCPBUGS-34778
https://issues.redhat.com/browse/FDP-656