### PR TITLE
Add missing places when renaming ovn-kubernetes packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: ovn-ci
 on:
   merge_group:
   pull_request:
-    branches: [ master ]
+    branches: [ release-1.0 ]
   schedule:
     - cron: '0 */12 * * *'
 
@@ -26,7 +26,7 @@ env:
 
   # This must be a directory
   CI_IMAGE_CACHE: tmp/image_cache/
-  CI_IMAGE_MASTER_TAR: image-master.tar
+  CI_IMAGE_RELEASE_1_0_TAR: image-release-1-0.tar
   CI_IMAGE_PR_TAR: image-pr.tar
   CI_DIST_IMAGES_OUTPUT: dist/images/_output/
 
@@ -54,57 +54,57 @@ jobs:
         working-directory: go-controller
         args: --modules-download-mode=vendor --timeout=15m0s --verbose
 
-  build-master:
-    name: Build-master
+  build-release-1_0:
+    name: Build-release-1.0
     runs-on: ubuntu-latest
     steps:
-    # Create a cache for the built master image
-    - name: Restore master image cache
-      id: image_cache_master
+    # Create a cache for the built release-1.0 image
+    - name: Restore release-1.0 image cache
+      id: image_cache_release_1_0
       uses: actions/cache@v4
       with:
         path: |
           ${{ env.CI_IMAGE_CACHE }}
-        key: ${{ github.run_id }}-image-cache-master
-    # if CI_IMAGE_MASTER_TAR isn't in cache, try pulling it and saving to the cache rather
+        key: ${{ github.run_id }}-image-cache-release-1-0
+    # if CI_IMAGE_RELEASE_1_0_TAR isn't in cache, try pulling it and saving to the cache rather
     # than building, resort back to building if the cache isn't populated and
     # pulling the image fails.
-    - name: Check if master image build is needed
-      id: is_master_image_build_needed
+    - name: Check if release-1.0 image build is needed
+      id: is_release_1_0_image_build_needed
       continue-on-error: false
       run: |
         set -x
-        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz ]; then
-            cp ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ${CI_IMAGE_MASTER_TAR}.gz
-            gunzip ${CI_IMAGE_MASTER_TAR}.gz
-            echo "MASTER_IMAGE_RESTORED_FROM_CACHE=true" >> "$GITHUB_OUTPUT"
-            echo "MASTER_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
+        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_RELEASE_1_0_TAR}.gz ]; then
+            cp ${CI_IMAGE_CACHE}/${CI_IMAGE_RELEASE_1_0_TAR}.gz ${CI_IMAGE_RELEASE_1_0_TAR}.gz
+            gunzip ${CI_IMAGE_RELEASE_1_0_TAR}.gz
+            echo "RELEASE_1_0_IMAGE_RESTORED_FROM_CACHE=true" >> "$GITHUB_OUTPUT"
+            echo "RELEASE_1_0_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
             exit 0
         fi
 
-        if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master; then
-            docker tag ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master ovn-daemonset-fedora:dev
+        if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:release-1.0; then
+            docker tag ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:release-1.0 ovn-daemonset-fedora:dev
 
-            echo "MASTER_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
+            echo "RELEASE_1_0_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
             exit 0
         fi
-    # only run the following steps if the master image was not found in the cache
-    - name: Check out code into the Go module directory - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+    # only run the following steps if the release-1.0 image was not found in the cache
+    - name: Check out code into the Go module directory - from release-1.0 branch
+      if: steps.is_release_1_0_image_build_needed.outputs.RELEASE_1_0_IMAGE_RESTORED != 'true' && success()
       uses: actions/checkout@v4
       with:
-        ref: master
+        ref: release-1.0
 
     - name: Set up Go
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+      if: steps.is_release_1_0_image_build_needed.outputs.RELEASE_1_0_IMAGE_RESTORED != 'true' && success()
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
         cache-dependency-path: "**/*.sum"
       id: go
 
-    - name: Build - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+    - name: Build - from release-1.0 branch
+      if: steps.is_release_1_0_image_build_needed.outputs.RELEASE_1_0_IMAGE_RESTORED != 'true' && success()
       run: |
         set -x
         pushd go-controller
@@ -112,8 +112,8 @@ jobs:
            make windows
         popd
 
-    - name: Build docker image - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+    - name: Build docker image - from release-1.0 branch
+      if: steps.is_release_1_0_image_build_needed.outputs.RELEASE_1_0_IMAGE_RESTORED != 'true' && success()
       run: |
         pushd dist/images
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .
@@ -122,27 +122,27 @@ jobs:
           docker build -t ovn-daemonset-fedora:dev -f Dockerfile.fedora .
         popd
 
-    - name: Cache master image
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
+    - name: Cache release-1.0 image
+      if: steps.is_release_1_0_image_build_needed.outputs.RELEASE_1_0_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
       continue-on-error: false
       run: |
         set -x
-        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR} ]; then
-            rm -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
+        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_RELEASE_1_0_TAR} ]; then
+            rm -f ${CI_IMAGE_CACHE}${CI_IMAGE_RELEASE_1_0_TAR}
         fi
-        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz ]; then
-            rm -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz
+        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_RELEASE_1_0_TAR}.gz ]; then
+            rm -f ${CI_IMAGE_CACHE}${CI_IMAGE_RELEASE_1_0_TAR}.gz
         fi
-        docker save ovn-daemonset-fedora:dev -o ${CI_IMAGE_MASTER_TAR}
+        docker save ovn-daemonset-fedora:dev -o ${CI_IMAGE_RELEASE_1_0_TAR}
         mkdir -p ${CI_IMAGE_CACHE}
-        cp ${CI_IMAGE_MASTER_TAR} ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
-        gzip ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
+        cp ${CI_IMAGE_RELEASE_1_0_TAR} ${CI_IMAGE_CACHE}${CI_IMAGE_RELEASE_1_0_TAR}
+        gzip ${CI_IMAGE_CACHE}${CI_IMAGE_RELEASE_1_0_TAR}
 
     # run the following always if none of the steps before failed
     - uses: actions/upload-artifact@v4
       with:
-        name: test-image-master
-        path: ${{ env.CI_IMAGE_MASTER_TAR }}
+        name: test-image-release_1_0
+        path: ${{ env.CI_IMAGE_RELEASE_1_0_TAR }}
 
   build-pr:
     name: Build-PR
@@ -246,12 +246,12 @@ jobs:
         path: ${{ env.CI_DIST_IMAGES_OUTPUT }}/${{ env.CI_IMAGE_PR_TAR }}
 
   ovn-upgrade-e2e:
-    name: Upgrade OVN from Master to PR branch based image
+    name: Upgrade OVN from Release-1.0 to PR branch based image
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     needs:
-      - build-master
+      - build-release-1_0
       - build-pr
     strategy:
       fail-fast: false
@@ -266,10 +266,10 @@ jobs:
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_MULTICAST_ENABLE:  "false"
     steps:
-    - name: Check out code into the Go module directory - from Master branch
+    - name: Check out code into the Go module directory - from Release-1.0 branch
       uses: actions/checkout@v4
       with:
-          ref: master
+          ref: release-1.0
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -295,10 +295,10 @@ jobs:
           msbuild mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*
 
-    - name: Download test-image-master
+    - name: Download test-image-release_1_0
       uses: actions/download-artifact@v4
       with:
-        name: test-image-master
+        name: test-image-release_1_0
 
     - name: Disable ufw
       # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
@@ -308,7 +308,7 @@ jobs:
 
     - name: Load docker image
       run: |
-        docker load --input ${CI_IMAGE_MASTER_TAR} && rm -rf ${CI_IMAGE_MASTER_TAR}
+        docker load --input ${CI_IMAGE_RELEASE_1_0_TAR} && rm -rf ${CI_IMAGE_RELEASE_1_0_TAR}
 
     - name: kind setup
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,8 @@ jobs:
             exit 0
         fi
 
-        if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master; then
-            docker tag ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master ovn-daemonset-f:dev
+        if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master; then
+            docker tag ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master ovn-daemonset-fedora:dev
 
             echo "MASTER_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -119,7 +119,7 @@ jobs:
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .
           sudo cp -f ../../go-controller/_output/go/bin/hybrid-overlay-node .
           echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
-          docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
+          docker build -t ovn-daemonset-fedora:dev -f Dockerfile.fedora .
         popd
 
     - name: Cache master image
@@ -133,7 +133,7 @@ jobs:
         if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz ]; then
             rm -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz
         fi
-        docker save ovn-daemonset-f:dev -o ${CI_IMAGE_MASTER_TAR}
+        docker save ovn-daemonset-fedora:dev -o ${CI_IMAGE_MASTER_TAR}
         mkdir -p ${CI_IMAGE_CACHE}
         cp ${CI_IMAGE_MASTER_TAR} ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
         gzip ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
@@ -201,9 +201,9 @@ jobs:
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .
           sudo cp -f ../../go-controller/_output/go/bin/hybrid-overlay-node .
           echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
-          docker build -t ovn-daemonset-f:pr -f Dockerfile.fedora .
+          docker build -t ovn-daemonset-fedora:pr -f Dockerfile.fedora .
           mkdir _output
-          docker save ovn-daemonset-f:pr > _output/${CI_IMAGE_PR_TAR}
+          docker save ovn-daemonset-fedora:pr > _output/${CI_IMAGE_PR_TAR}
         popd
 
     - name: Submit code coverage to Coveralls
@@ -312,7 +312,7 @@ jobs:
 
     - name: kind setup
       run: |
-        export OVN_IMAGE="ovn-daemonset-f:dev"
+        export OVN_IMAGE="ovn-daemonset-fedora:dev"
         make -C test install-kind
 
     - name: Export kind logs
@@ -350,7 +350,7 @@ jobs:
 
     - name: ovn upgrade
       run: |
-        export OVN_IMAGE="ovn-daemonset-f:pr"
+        export OVN_IMAGE="ovn-daemonset-fedora:pr"
         make -C test upgrade-ovn
 
     - name: Runner Diagnostics
@@ -497,7 +497,7 @@ jobs:
     - name: kind setup
       timeout-minutes: 30
       run: |
-        export OVN_IMAGE="ovn-daemonset-f:pr"
+        export OVN_IMAGE="ovn-daemonset-fedora:pr"
         make -C test install-kind
 
     - name: Runner Diagnostics
@@ -509,7 +509,7 @@ jobs:
       timeout-minutes: ${{ matrix.target == 'control-plane' && 180 || matrix.target == 'external-gateway' && 180 || 120 }}
       run: |
         # used by e2e diagnostics package
-        export OVN_IMAGE="ovn-daemonset-f:pr"
+        export OVN_IMAGE="ovn-daemonset-fedora:pr"
         
         if [ "${{ matrix.target }}" == "multi-homing" ]; then
           make -C test control-plane WHAT="Multi Homing"
@@ -607,7 +607,7 @@ jobs:
 
     - name: kind IPv4 setup
       run: |
-        export OVN_IMAGE="ovn-daemonset-f:pr"
+        export OVN_IMAGE="ovn-daemonset-fedora:pr"
         make -C test install-kind
 
     - name: Convert IPv4 cluster to Dual Stack

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -24,7 +24,7 @@ set_default_params() {
   export KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
   export KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
   export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
-  export OVN_IMAGE=${OVN_IMAGE:-'ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:helm'}
+  export OVN_IMAGE=${OVN_IMAGE:-'ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:helm'}
 
   # Setup KUBECONFIG patch based on cluster-name
   export KUBECONFIG=${KUBECONFIG:-${HOME}/${KIND_CLUSTER_NAME}.conf}

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -739,9 +739,9 @@ create_kind_cluster() {
 set_ovn_image() {
   # if we're using the local registry and still need to build, push to local registry
   if [ "$KIND_LOCAL_REGISTRY" == true ];then
-    OVN_IMAGE="localhost:5000/ovn-daemonset-f:latest"
+    OVN_IMAGE="localhost:5000/ovn-daemonset-fedora:latest"
   else
-    OVN_IMAGE="localhost/ovn-daemonset-f:dev"
+    OVN_IMAGE="localhost/ovn-daemonset-fedora:dev"
   fi
 }
 
@@ -846,9 +846,9 @@ install_ovn_image() {
   else
     if [ "$OCI_BIN" == "podman" ]; then
       # podman: cf https://github.com/kubernetes-sigs/kind/issues/2027
-      rm -f /tmp/ovn-kube-f.tar
-      podman save -o /tmp/ovn-kube-f.tar "${OVN_IMAGE}"
-      kind load image-archive /tmp/ovn-kube-f.tar --name "${KIND_CLUSTER_NAME}"
+      rm -f /tmp/ovn-kube-fedora.tar
+      podman save -o /tmp/ovn-kube-fedora.tar "${OVN_IMAGE}"
+      kind load image-archive /tmp/ovn-kube-fedora.tar --name "${KIND_CLUSTER_NAME}"
     else
       kind load docker-image "${OVN_IMAGE}" --name "${KIND_CLUSTER_NAME}"
     fi

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
 #
-# The standard name for this image is ovn-kube-u
+# The standard name for this image is ovn-kube-ubuntu
 
 # Notes:
 # This is for a development build where the ovn-kubernetes utilities

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -21,32 +21,32 @@ OVS_BRANCH ?= master
 OVN_BRANCH ?= main
 OCI_BIN ?= docker
 
-# The image of ovnkube/ovn-daemonset-u should be multi-arched before using it on arm64
+# The image of ovnkube/ovn-daemonset-ubuntu should be multi-arched before using it on arm64
 ubuntu: bld
-	${OCI_BIN} build -t ovn-kube-u$(IMAGE_ARCH) -f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
+	${OCI_BIN} build -t ovn-kube-ubuntu$(IMAGE_ARCH) -f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
 ifeq ($(ARCH),amd64)
-	${OCI_BIN} tag "ovn-kube-u$(IMAGE_ARCH):latest" \
-              "ovn-kube-u:latest"
+	${OCI_BIN} tag "ovn-kube-ubuntu$(IMAGE_ARCH):latest" \
+              "ovn-kube-ubuntu:latest"
 endif
 	# This is the default in the ovnkube*.yaml files
 	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube
-	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-u:latest
-	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-u:latest
+	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-ubuntu:latest
+	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-ubuntu:latest
 
 fedora: bld
-	${OCI_BIN} build -t ovn-kube-f -f Dockerfile.fedora .
+	${OCI_BIN} build -t ovn-kube-fedora -f Dockerfile.fedora .
 	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube
-	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-f:latest
-	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest
+	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-fedora:latest
+	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-fedora:latest
 
 fedora-dev: bld
 	${OCI_BIN} build \
 		     --build-arg OVS_BRANCH=$(OVS_BRANCH) \
 		     --build-arg OVN_BRANCH=$(OVN_BRANCH) \
-		     -t ovn-kube-f-dev -f Dockerfile.fedora.dev .
+		     -t ovn-kube-fedora-dev -f Dockerfile.fedora.dev .
 	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube
-	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-f:latest
-	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest \
+	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-fedora:latest
+	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-fedora:latest \
                     --net-cidr=10.244.0.0/16 \
                     --svc-cidr=10.96.0.0/12 \
                     --gateway-mode="local" \
@@ -63,7 +63,7 @@ DOCKER_IMAGE_TAG = latest
 
 # Multi-arch the ubuntu based image with fat-manifest
 ubuntu-image-multi-arch:
-	./push_manifest.sh ovn-daemonset-u $(DOCKER_IMAGE_TAG)
+	./push_manifest.sh ovn-daemonset-ubuntu $(DOCKER_IMAGE_TAG)
 
 # This target expands the daemonset yaml templates into final form
 # Use CLI flags or environment variables to customize its behavior.

--- a/dist/images/push_manifest.sh
+++ b/dist/images/push_manifest.sh
@@ -8,7 +8,7 @@ do
     PLATFORMS=$PLATFORMS,linux/${LINUX_ARCH[$i]}
 done
 
-IMAGES_OVN=${1:-ovn-daemonset-u}
+IMAGES_OVN=${1:-ovn-daemonset-ubuntu}
 BRANCH_TAG=${2:-latest}
 DOCKER_REPOSITORY=${3:-docker.io/ovnkube}
 MANITOOL_VERSION=${4:-v1.0.0}

--- a/docs/developer-guide/image-build.md
+++ b/docs/developer-guide/image-build.md
@@ -1,0 +1,30 @@
+# OVN-Kubernetes Container Images
+
+This file covers the container images available for OVN-Kubernetes and how to build them.
+
+## Images / Packages
+
+There are Ubuntu and Fedora-based images available in [GitHub's Registry](https://github.com/orgs/ovn-org/packages?repo_name=ovn-kubernetes). They are automatically generated upon merges via [a workflow](https://github.com/ovn-org/ovn-kubernetes/blob/9f1f3f2866fc566ffbe582ae9adf77d60d838484/.github/workflows/docker.yml#L5).
+Prior to release-1.0, they were called ovn-kube-f (for the Fedora-based image) and ovnkube-u (for the Ubuntu-based image). From release 1.0 and beyond, these have been renamed to ovn-kube-fedora and ovn-kube-ubuntu, respectively.
+
+Therefore, use the following images and tags to obtain these images:
+
+- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master
+- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:release-1.0
+
+- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+- ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:release-1.0
+
+## Building Images
+
+To build images locally, use the following [Makefile](https://github.com/ovn-org/ovn-kubernetes/blob/master/dist/images/Makefile) and their respective Dockerfiles from the [dist/images](https://github.com/ovn-org/ovn-kubernetes/tree/master/dist/images) folder in this repository.
+
+```bash
+$ cd dist/images
+$ make fedora
+$ make ubuntu
+```
+
+The build will create an image called ovn-kube-fedora:latest or ovn-kube-ubuntu:latest, which can be re-tagged.
+For example: `${OCI_BIN} tag ovn-kube-fedora:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-fedora:master`
+

--- a/docs/developer-guide/release.md
+++ b/docs/developer-guide/release.md
@@ -15,7 +15,7 @@ Each new release of OVN-Kubernetes is defined with a "version" that represents t
   * `ovnkube-identity`: is the executable that is invoked to run ovn-kubernetes identity manager, which includes the admission webhook and the CertificateSigningRequest approver
 * `ovnkube` API configuration 
 * scripts used to deploy OVN-Kubernetes including helm charts
-* Images for [fedora](https://github.com/ovn-org/ovn-kubernetes/pkgs/container/ovn-kubernetes%2Fovn-kube-f) and [ubuntu](https://github.com/ovn-org/ovn-kubernetes/pkgs/container/ovn-kubernetes%2Fovn-kube-u)
+* Images for [fedora](https://github.com/ovn-org/ovn-kubernetes/pkgs/container/ovn-kubernetes%2Fovn-kube-fedora) and [ubuntu](https://github.com/ovn-org/ovn-kubernetes/pkgs/container/ovn-kubernetes%2Fovn-kube-ubuntu)
 
 ## Release Planning
 

--- a/docs/developer-guide/release.md
+++ b/docs/developer-guide/release.md
@@ -6,13 +6,13 @@ Each new release of OVN-Kubernetes is defined with a "version" that represents t
 
 * Source Code
 * Binaries
-  * `ovnkube`: which is our main single all-in-one binary executable used to launch the ovnkube control plane and data plane pods in a kubernetes deployment
-  * `ovn-k8s-cni-overlay`: is the cni executable to be placed in /opt/cni/bin (or another directory in which kubernetes will look for the plugin) so that it can be invoked for each pod event by kubernetes
-  * `hybrid-overlay-node`
-  * `ovn-kube-util`: contains the Utils for ovn-kubernetes
-  * `ovndbchecker`
-  * `ovnkube-trace`: is the binary that contains ovnkube-trace which is an abstraction used to invoke OVN/OVS packet tracing utils
-  * `ovnkube-identity`: is the executable that is invoked to run ovn-kubernetes identity manager, which includes the admission webhook and the CertificateSigningRequest approver
+    * `ovnkube`: which is our main single all-in-one binary executable used to launch the ovnkube control plane and data plane pods in a kubernetes deployment
+    * `ovn-k8s-cni-overlay`: is the cni executable to be placed in /opt/cni/bin (or another directory in which kubernetes will look for the plugin) so that it can be invoked for each pod event by kubernetes
+    * `hybrid-overlay-node`
+    * `ovn-kube-util`: contains the Utils for ovn-kubernetes
+    * `ovndbchecker`
+    * `ovnkube-trace`: is the binary that contains ovnkube-trace which is an abstraction used to invoke OVN/OVS packet tracing utils
+    * `ovnkube-identity`: is the executable that is invoked to run ovn-kubernetes identity manager, which includes the admission webhook and the CertificateSigningRequest approver
 * `ovnkube` API configuration 
 * scripts used to deploy OVN-Kubernetes including helm charts
 * Images for [fedora](https://github.com/ovn-org/ovn-kubernetes/pkgs/container/ovn-kubernetes%2Fovn-kube-fedora) and [ubuntu](https://github.com/ovn-org/ovn-kubernetes/pkgs/container/ovn-kubernetes%2Fovn-kube-ubuntu)

--- a/docs/installation/INSTALL.KUBEADM.md
+++ b/docs/installation/INSTALL.KUBEADM.md
@@ -448,14 +448,14 @@ echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse 
 
 Now, build and push the image with:
 ~~~
-OVN_IMAGE=192.168.123.254:5000/ovn-daemonset-f:latest
+OVN_IMAGE=192.168.123.254:5000/ovn-daemonset-fedora:latest
 buildah bud -t $OVN_IMAGE -f Dockerfile.fedora .
 podman push $OVN_IMAGE
 ~~~
 
 Next, run:
 ~~~
-OVN_IMAGE=192.168.123.254:5000/ovn-daemonset-f:latest
+OVN_IMAGE=192.168.123.254:5000/ovn-daemonset-fedora:latest
 MASTER_IP=192.168.123.1
 NET_CIDR="172.16.0.0/16/24"
 SVC_CIDR="172.17.0.0/16"

--- a/docs/installation/launching-ovn-kubernetes-with-helm.md
+++ b/docs/installation/launching-ovn-kubernetes-with-helm.md
@@ -70,14 +70,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-u:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:
@@ -389,7 +389,7 @@ true
 			<td>global.image.repository</td>
 			<td>string</td>
 			<td><pre lang="json">
-"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u"
+"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu"
 </pre>
 </td>
 			<td>Image repository for ovn-kubernetes components</td>

--- a/helm/basic-deploy.sh
+++ b/helm/basic-deploy.sh
@@ -44,7 +44,7 @@ sudo sysctl fs.inotify.max_user_instances=512
 # build image
 cd ../dist/images
 make ubuntu
-docker tag ovn-kube-u:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
 # create a cluster, with 1 controller and 1 worker node
 kind_cluster_name=ovn-helm
 cat <<EOT > /tmp/kind.yaml
@@ -59,9 +59,9 @@ networking:
 EOT
 kind delete clusters $kind_cluster_name
 kind create cluster --name $kind_cluster_name --config /tmp/kind.yaml
-kind load docker-image --name $kind_cluster_name ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+kind load docker-image --name $kind_cluster_name ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
 cd ../../helm/ovn-kubernetes
 helm install ovn-kubernetes . -f values.yaml \
     --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" \
     --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) \
-    --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u --set global.image.tag=master
+    --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -81,14 +81,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-u:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:
@@ -400,7 +400,7 @@ true
 			<td>global.image.repository</td>
 			<td>string</td>
 			<td><pre lang="json">
-"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u"
+"ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu"
 </pre>
 </td>
 			<td>Image repository for ovn-kubernetes components</td>

--- a/helm/ovn-kubernetes/README.md.gotmpl
+++ b/helm/ovn-kubernetes/README.md.gotmpl
@@ -79,14 +79,14 @@ networking:
 ```
 # cd dist/images
 # make ubuntu
-# docker tag ovn-kube-u:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
-# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master
+# docker tag ovn-kube-ubuntu:latest ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
+# kind load docker-image ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu:master
 ```
 
 - Run `helm install` with propery `k8sAPIServer`, `ovnkube-identity.replicas`, image repo and tag
 ```
 # cd helm/ovn-kubernetes
-# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u --set global.image.tag=master
+# helm install ovn-kubernetes . -f values.yaml --set k8sAPIServer="https://$(kubectl get pods -n kube-system -l component=kube-apiserver -o jsonpath='{.items[0].status.hostIP}'):6443" --set ovnkube-identity.replicas=$(kubectl get node -l node-role.kubernetes.io/control-plane --no-headers | wc -l) --set global.image.repository=ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu --set global.image.tag=master
 ```
 
 ## Notes:

--- a/helm/ovn-kubernetes/values.yaml
+++ b/helm/ovn-kubernetes/values.yaml
@@ -138,7 +138,7 @@ global:
   libovsdbClientLogFile: ""
   image:
     # -- Image repository for ovn-kubernetes components
-    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u
+    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu
     # -- Specify image tag to run
     tag: master
     # -- Image pull policy

--- a/test/e2e/diagnostics/daemonset.go
+++ b/test/e2e/diagnostics/daemonset.go
@@ -20,7 +20,7 @@ func composePeriodicCmd(cmd string, interval uint32) string {
 func (d *Diagnostics) composeDiagnosticsDaemonSet(name, cmd, tool string) appsv1.DaemonSet {
 	ovnImage := os.Getenv("OVN_IMAGE")
 	if ovnImage == "" {
-		ovnImage = "localhost/ovn-daemonset-f:dev"
+		ovnImage = "localhost/ovn-daemonset-fedora:dev"
 	}
 	return appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/scripts/test-ovnkube-trace.sh
+++ b/test/scripts/test-ovnkube-trace.sh
@@ -12,7 +12,7 @@ set -e
 if [ "${KUBECONFIG}" == "" ]; then
   export KUBECONFIG=${HOME}/ovn.conf
 fi
-export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-f:pr}
+export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-fedora:pr}
 
 DIR=$(dirname "${BASH_SOURCE[0]}")
 

--- a/test/scripts/upgrade-ovn.sh
+++ b/test/scripts/upgrade-ovn.sh
@@ -4,7 +4,7 @@
 set -ex
 
 export KUBECONFIG=${KUBECONFIG:-${HOME}/ovn.conf}
-export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-f:pr}
+export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-fedora:pr}
 
 kubectl_wait_pods() {
   # Check that everything is fine and running. IPv6 cluster seems to take a little
@@ -260,7 +260,7 @@ set_cluster_cidr_ip_families() {
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn} # Set default values
 
 # setup env needed for regenerating ovn resources from the checked-out branch
-# this will use the new OVN image as well: ovn-daemonset-f:pr
+# this will use the new OVN image as well: ovn-daemonset-fedora:pr
 set_default_ovn_manifest_params
 print_ovn_manifest_params
 


### PR DESCRIPTION
Backport of https://github.com/ovn-org/ovn-kubernetes/pull/4452 to the release-1.0 branch.

This backport includes an additional commit, where the workflow for GitHub changes from the master to the release-1.0 branch. This is needed in order to have CI enabled for PRs on this branch.

