### PR TITLE
Reformatted AdminNetworkPolicy to align with new feature format

### DIFF
--- a/docs/features/network-security-controls/baseline-admin-network-policy.md
+++ b/docs/features/network-security-controls/baseline-admin-network-policy.md
@@ -1,0 +1,109 @@
+## BaselineAdminNetworkPolicy
+
+## Introduction
+
+## Motivation
+
+## How to enable this feature on an OVN-Kubernetes cluster
+
+## Workflow Description
+
+## Implementation Details
+
+## Troubleshooting
+
+## Future Items
+
+Kubernetes AdminNetworkPolicy API reference: https://github.com/kubernetes-sigs/network-policy-api/blob/429a9e6ae89d411f89d5a16aba38a5d920c969ee/apis/v1alpha1/baseline_adminnetworkpolicy_types.go
+
+Since we can delegate decisions from administrators to namespace owners, what if namespace owners don't have policies in place for the same set of subjects? Admins in such cases might want to keep a default set of guardrails in the cluster. Thus we allow one BANP to be created in the cluster with the name `default`. The rules in `default` BANP are created in Tier3.
+
+Sample API:
+
+```
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: BaselineAdminNetworkPolicy
+metadata:
+  name: default
+spec:
+  subject:
+    namespaces:
+      matchLabels:
+          conformance-house: gryffindor
+  ingress:
+  - name: "deny-all-ingress-from-slytherin"
+    action: "Deny"
+    from:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
+  egress:
+  - name: "deny-all-egress-to-slytherin"
+    action: "Deny"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            conformance-house: slytherin
+```
+
+* BANP doesn't have any priority field, since we can have only one in the cluster
+* We keep nbdb.ACL's priority range 1750 - 1649 range reserved for BANP rules in the cluster.
+* Rest of the implementation details for ANP is applicable to BANP as well.
+
+Corresponding ACLs:
+
+```
+_uuid               : 436b5a0f-9616-42b5-865d-489ec1d42666
+action              : drop
+direction           : to-lport
+external_ids        : {direction=BANPIngress, "k8s.ovn.org/id"="admin-network-policy-controller:BaselineAdminNetworkPolicy:default:BANPIngress:1750", "k8s.ovn.org/name"=default, "k8s.ovn.org/owner-controller"=admin-network-policy-controller, "k8s.ovn.org/owner-type"=BaselineAdminNetworkPolicy, priority="1750"}
+label               : 0
+log                 : false
+match               : "((ip4.src == $a2535546904205657311)) && (outport == @a16982411286042166782)"
+meter               : acl-logging
+name                : default_BANPIngress_1750
+options             : {}
+priority            : 1750
+severity            : debug
+tier                : 3
+===
+_uuid               : d42cb240-fac1-4429-a1bc-02efddda69cf
+action              : drop
+direction           : from-lport
+external_ids        : {direction=BANPEgress, "k8s.ovn.org/id"="admin-network-policy-controller:BaselineAdminNetworkPolicy:default:BANPEgress:1750", "k8s.ovn.org/name"=default, "k8s.ovn.org/owner-controller"=admin-network-policy-controller, "k8s.ovn.org/owner-type"=BaselineAdminNetworkPolicy, priority="1750"}
+label               : 0
+log                 : false
+match               : "((ip4.dst == $a6430502402203365)) && (inport == @a16982411286042166782)"
+meter               : acl-logging
+name                : default_BANPEgress_1750
+options             : {apply-after-lb="true"}
+priority            : 1750
+severity            : debug
+tier                : 3
+```
+
+The Address-Set for the above BaselineAdminNetworkPolicy is:
+
+```
+_uuid               : a3ac7d6b-9185-4099-84f8-92d28460b4c3
+addresses           : ["10.244.0.5", "10.244.1.6"]
+external_ids        : {direction=BANPIngress, ip-family=v4, "k8s.ovn.org/id"="admin-network-policy-controller:BaselineAdminNetworkPolicy:default:BANPIngress:1750:v4", "k8s.ovn.org/name"=default, "k8s.ovn.org/owner-controller"=admin-network-policy-controller, "k8s.ovn.org/owner-type"=BaselineAdminNetworkPolicy, priority="1750"}
+name                : a2535546904205657311
+===
+_uuid               : b3e08332-e6bb-4f4e-bbc4-c36f717f149a
+addresses           : ["10.244.0.5", "10.244.1.6"]
+external_ids        : {direction=BANPEgress, ip-family=v4, "k8s.ovn.org/id"="admin-network-policy-controller:BaselineAdminNetworkPolicy:default:BANPEgress:1750:v4", "k8s.ovn.org/name"=default, "k8s.ovn.org/owner-controller"=admin-network-policy-controller, "k8s.ovn.org/owner-type"=BaselineAdminNetworkPolicy, priority="1750"}
+name                : a6430502402203365
+```
+
+The PortGroup for the above AdminNetworkPolicy is:
+
+```
+_uuid               : 9ec16567-6f51-49fb-aedb-40c477ad470d
+acls                : [436b5a0f-9616-42b5-865d-489ec1d42666, d42cb240-fac1-4429-a1bc-02efddda69cf]
+external_ids        : {BaselineAdminNetworkPolicy=default}
+name                : a16982411286042166782
+ports               : [a22a4c3a-bb65-4b22-8bc1-13e1e8899a7b, c7e4ffe3-73df-4db5-a3bc-a9649394d549]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
     - NetworkSecurityControls:
       - NetworkPolicy: features/network-security-controls/network-policy.md
       - AdminNetworkPolicy: features/network-security-controls/admin-network-policy.md
+      - BaselineAdminNetworkPolicy: features/network-security-controls/baseline-admin-network-policy.md
       - EgressFirewall: features/network-security-controls/egress-firewall.md
     - InfrastructureSecurityControls:
       - NodeIdentity: features/infrastructure-security-controls/node-identity.md


### PR DESCRIPTION
…d added additional examples to AdminNetworkPolicy moved baseline admin network policy to seperate section.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This PR enhances the documentation for AdminNetworkPolicy, bringing it in-line with the new feature documentation template. It also separates out AdminNetworkPolicy and BaselineAdminNetworkPolicy, as I believe they are separate features that can be documented separately.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->

Added many more examples and user facing documentation in AdminNetworkPolicy, bringing it in line with the new feature documentation template. Clarified the motivation and introduction behind the feature as well as moving around some of the developer focused documentation. Broke up the AdminNetworkPolicy and BaselineAdminNetworkPolicy sections into two separate pieces of documentation, BaselineAdminNetworkPolicy will be reformatted in another pull request.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
