### PR TITLE
UDN: Use synthetic network selection element

### DIFF
--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -201,7 +201,12 @@ func (a *PodAllocator) reconcile(old, new *corev1.Pod, releaseFromAllocator bool
 		return nil
 	}
 
-	onNetwork, networkMap, err := util.GetPodNADToNetworkMapping(pod, a.netInfo)
+	activeNetwork, err := a.getActiveNetworkForNamespace(pod.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed looking for an active network: %w", err)
+	}
+
+	onNetwork, networkMap, err := util.GetPodNADToNetworkMappingWithActiveNetwork(pod, a.netInfo, activeNetwork)
 	if err != nil {
 		return fmt.Errorf("failed to get NAD to network mapping: %w", err)
 	}

--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -100,7 +100,7 @@ func (a *PodAllocator) Init() error {
 
 // getActiveNetworkForNamespace returns the active network for the given namespace
 // and is a wrapper around util.GetActiveNetworkForNamespace
-func (a *PodAllocator) getActiveNetworkForNamespace(namespace string) (string, error) {
+func (a *PodAllocator) getActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
 	return util.GetActiveNetworkForNamespace(namespace, a.nadLister)
 }
 
@@ -139,16 +139,11 @@ func (a *PodAllocator) GetNetworkRole(pod *corev1.Pod) (string, error) {
 	}
 	activeNetwork, err := a.getActiveNetworkForNamespace(pod.Namespace)
 	if err != nil {
+		// FIXME(tssurya) emit event here if util.IsUnknownActiveNetworkError; add support for
+		// recorder in the NCM controller
 		return "", err
 	}
-	if activeNetwork == types.UnknownNetworkName {
-		// FIXME(tssurya) emit event here; add support for
-		// recorder in the NCM controller
-		return "", fmt.Errorf("unable to determine what is the"+
-			"primary network for this pod %s; please remove multiple primary network"+
-			"NADs from namespace %s", pod.Name, pod.Namespace)
-	}
-	if activeNetwork == a.netInfo.GetNetworkName() {
+	if activeNetwork.GetNetworkName() == a.netInfo.GetNetworkName() {
 		return types.NetworkRolePrimary, nil
 	}
 	if a.netInfo.IsDefault() {

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -1,8 +1,12 @@
 package cni
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"time"
+
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -10,6 +14,8 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
+	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/udn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kubevirt"
@@ -131,8 +137,9 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Resp
 	}
 	// Get the IP address and MAC address of the pod
 	// for DPU, ensure connection-details is present
-	pod, annotations, podNADAnnotation, err := GetPodWithAnnotations(pr.ctx, clientset, namespace, podName,
-		pr.nadName, annotCondFn)
+
+	primaryUDN := udn.NewPrimaryNetwork(clientset.nadLister)
+	pod, annotations, podNADAnnotation, err := GetPodWithAnnotations(pr.ctx, clientset, namespace, podName, pr.nadName, primaryUDN.WaitForPrimaryAnnotationFn(namespace, annotCondFn))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod annotation: %v", err)
 	}
@@ -140,8 +147,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Resp
 		return nil, err
 	}
 
-	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, podNADAnnotation, pr.PodUID, netdevName,
-		pr.nadName, pr.netName, pr.CNIConf.MTU)
+	podInterfaceInfo, err := pr.buildPodInterfaceInfo(annotations, podNADAnnotation, netdevName)
 	if err != nil {
 		return nil, err
 	}
@@ -150,9 +156,21 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Resp
 
 	response := &Response{KubeAuth: kubeAuth}
 	if !config.UnprivilegedMode {
+		//TODO: There is nothing technical to run this at unprivileged mode but
+		//      we will tackle that later on.
 		response.Result, err = pr.getCNIResult(clientset, podInterfaceInfo)
 		if err != nil {
 			return nil, err
+		}
+		if primaryUDN.Found() {
+			primaryUDNPodRequest := pr.buildPrimaryUDNPodRequest(pod, primaryUDN)
+			primaryUDNPodInfo, err := primaryUDNPodRequest.buildPodInterfaceInfo(annotations, primaryUDN.Annotation(), primaryUDN.NetworkDevice())
+			if err != nil {
+				return nil, err
+			}
+			if _, err := primaryUDNPodRequest.getCNIResult(clientset, primaryUDNPodInfo); err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		response.PodIFInfo = podInterfaceInfo
@@ -328,4 +346,43 @@ func (pr *PodRequest) getCNIResult(getter PodInfoGetter, podInterfaceInfo *PodIn
 		Interfaces: interfacesArray,
 		IPs:        ips,
 	}, nil
+}
+
+func (pr *PodRequest) buildPrimaryUDNPodRequest(
+	pod *kapi.Pod,
+	primaryUDN *udn.UserDefinedPrimaryNetwork,
+) *PodRequest {
+	req := &PodRequest{
+		Command:      pr.Command,
+		PodNamespace: pod.Namespace,
+		PodName:      pod.Name,
+		PodUID:       string(pod.UID),
+		SandboxID:    pr.SandboxID,
+		Netns:        pr.Netns,
+		IfName:       primaryUDN.InterfaceName(),
+		CNIConf: &ovncnitypes.NetConf{
+			// primary UDN MTU will be taken from config.Default.MTU
+			// if not specified at the NAD
+			MTU: primaryUDN.MTU(),
+		},
+		timestamp:  time.Now(),
+		IsVFIO:     pr.IsVFIO,
+		netName:    primaryUDN.NetworkName(),
+		nadName:    primaryUDN.NADName(),
+		deviceInfo: v1.DeviceInfo{},
+	}
+	req.ctx, req.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+	return req
+}
+
+func (pr *PodRequest) buildPodInterfaceInfo(annotations map[string]string, podAnnotation *util.PodAnnotation, netDevice string) (*PodInterfaceInfo, error) {
+	return PodAnnotation2PodInfo(
+		annotations,
+		podAnnotation,
+		pr.PodUID,
+		netDevice,
+		pr.nadName,
+		pr.netName,
+		pr.CNIConf.MTU,
+	)
 }

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -71,6 +71,10 @@ func NewCNIServer(factory factory.NodeWatchFactory, kclient kubernetes.Interface
 		handlePodRequestFunc: HandlePodRequest,
 	}
 
+	if util.IsNetworkSegmentationSupportEnabled() {
+		s.clientSet.nadLister = factory.NADInformer().Lister()
+	}
+
 	if len(config.Kubernetes.CAData) > 0 {
 		s.kubeAuth.KubeCAData = base64.StdEncoding.EncodeToString(config.Kubernetes.CAData)
 	}

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -192,7 +192,7 @@ func setupNetwork(link netlink.Link, ifInfo *PodInterfaceInfo) error {
 	}
 	for _, gw := range ifInfo.Gateways {
 		if err := cniPluginLibOps.AddRoute(nil, gw, link, ifInfo.RoutableMTU); err != nil {
-			return fmt.Errorf("failed to add gateway route: %v", err)
+			return fmt.Errorf("failed to add gateway route to link '%s': %v", link.Attrs().Name, err)
 		}
 	}
 	for _, route := range ifInfo.Routes {
@@ -438,8 +438,8 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 		return fmt.Errorf("failed to get datapath type for bridge br-int : %v", err)
 	}
 
-	klog.Infof("ConfigureOVS: namespace: %s, podName: %s, network: %s, NAD %s, SandboxID: %q, PCI device ID: %s, UID: %q, MAC: %s, IPs: %v",
-		namespace, podName, ifInfo.NetName, ifInfo.NADName, sandboxID, deviceID, initialPodUID, ifInfo.MAC, ipStrs)
+	klog.Infof("ConfigureOVS: namespace: %s, podName: %s, hostIfaceName: %s, network: %s, NAD %s, SandboxID: %q, PCI device ID: %s, UID: %q, MAC: %s, IPs: %v",
+		namespace, podName, hostIfaceName, ifInfo.NetName, ifInfo.NADName, sandboxID, deviceID, initialPodUID, ifInfo.MAC, ipStrs)
 
 	// Find and remove any existing OVS port with this iface-id. Pods can
 	// have multiple sandboxes if some are waiting for garbage collection,

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -319,7 +319,7 @@ func TestSetupNetwork(t *testing.T) {
 				{OnCallMethodName: "AddRoute", OnCallMethodArgType: []string{"*net.IPNet", "net.IP", "*mocks.Link", "int"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			linkMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}, CallTimes: 2},
 			},
 		},
 		{
@@ -1128,7 +1128,7 @@ func TestSetupSriovInterface(t *testing.T) {
 				{OnCallMethodName: "AddRoute", OnCallMethodArgType: []string{"*net.IPNet", "net.IP", "*mocks.Link", "int"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			linkMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Flags: net.FlagUp}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Flags: net.FlagUp}}, CallTimes: 2},
 			},
 			nsMockHelper: []ovntest.TestifyMockHelper{},
 		},

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
+
 	kapi "k8s.io/api/core/v1"
 )
 
@@ -177,6 +179,7 @@ type ClientSet struct {
 	PodInfoGetter
 	kclient   kubernetes.Interface
 	podLister corev1listers.PodLister
+	nadLister nadlister.NetworkAttachmentDefinitionLister
 }
 
 func NewClientSet(kclient kubernetes.Interface, podLister corev1listers.PodLister) *ClientSet {

--- a/go-controller/pkg/cni/udn/primary_network.go
+++ b/go-controller/pkg/cni/udn/primary_network.go
@@ -1,0 +1,132 @@
+package udn
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// wait on a certain pod annotation related condition
+type podAnnotWaitCond = func(map[string]string, string) (*util.PodAnnotation, bool)
+
+type UserDefinedPrimaryNetwork struct {
+	nadLister     nadlister.NetworkAttachmentDefinitionLister
+	annotation    *util.PodAnnotation
+	activeNetwork util.NetInfo
+}
+
+func NewPrimaryNetwork(nadLister nadlister.NetworkAttachmentDefinitionLister) *UserDefinedPrimaryNetwork {
+	return &UserDefinedPrimaryNetwork{
+		nadLister: nadLister,
+	}
+}
+
+func (p *UserDefinedPrimaryNetwork) InterfaceName() string {
+	return "ovn-udn1"
+}
+
+func (p *UserDefinedPrimaryNetwork) NetworkDevice() string {
+	// TODO: Support for non VFIO devices like SRIOV have to be implemented
+	return ""
+}
+
+func (p *UserDefinedPrimaryNetwork) Annotation() *util.PodAnnotation {
+	return p.annotation
+}
+
+func (p *UserDefinedPrimaryNetwork) NetworkName() string {
+	if p.activeNetwork == nil {
+		return ""
+	}
+	return p.activeNetwork.GetNetworkName()
+}
+
+func (p *UserDefinedPrimaryNetwork) NADName() string {
+	if p.activeNetwork == nil || p.activeNetwork.IsDefault() {
+		return ""
+	}
+	nads := p.activeNetwork.GetNADs()
+	if len(nads) < 1 {
+		return ""
+	}
+	return nads[0]
+}
+
+func (p *UserDefinedPrimaryNetwork) MTU() int {
+	if p.activeNetwork == nil {
+		return 0
+	}
+	return p.activeNetwork.MTU()
+}
+
+func (p *UserDefinedPrimaryNetwork) Found() bool {
+	return p.annotation != nil && p.activeNetwork != nil
+}
+
+func (p *UserDefinedPrimaryNetwork) WaitForPrimaryAnnotationFn(namespace string, annotCondFn podAnnotWaitCond) podAnnotWaitCond {
+	return func(annotations map[string]string, nadName string) (*util.PodAnnotation, bool) {
+		annotation, isReady := annotCondFn(annotations, nadName)
+		if annotation == nil {
+			return nil, false
+		}
+		if nadName != types.DefaultNetworkName || annotation.Role == types.NetworkRolePrimary {
+			return annotation, isReady
+		}
+
+		if err := p.ensureAnnotation(annotations); err != nil {
+			//TODO: Event ?
+			klog.Warningf("Failed looking for primary network annotation: %v", err)
+			return nil, false
+		}
+		if err := p.ensureActiveNetwork(namespace); err != nil {
+			//TODO: Event ?
+			klog.Warningf("Failed looking for primary network name: %v", err)
+			return nil, false
+		}
+		return annotation, isReady
+	}
+}
+
+func (p *UserDefinedPrimaryNetwork) ensureActiveNetwork(namespace string) error {
+	if p.activeNetwork != nil {
+		return nil
+	}
+	activeNetwork, err := util.GetActiveNetworkForNamespace(namespace, p.nadLister)
+	if err != nil {
+		return err
+	}
+	if activeNetwork.IsDefault() {
+		return fmt.Errorf("missing primary user defined network NAD")
+	}
+	p.activeNetwork = activeNetwork
+	return nil
+}
+
+func (p *UserDefinedPrimaryNetwork) ensureAnnotation(annotations map[string]string) error {
+	if p.annotation != nil {
+		return nil
+	}
+	podNetworks, err := util.UnmarshalPodAnnotationAllNetworks(annotations)
+	if err != nil {
+		return err
+	}
+	for nadName, podNetwork := range podNetworks {
+		if podNetwork.Role != types.NetworkRolePrimary {
+			continue
+		}
+		p.annotation, err = util.UnmarshalPodAnnotation(annotations, nadName)
+		if err != nil {
+			return err
+		}
+		break
+	}
+	if p.annotation == nil {
+		return fmt.Errorf("missing network annotation with primary role '%+v'", annotations)
+	}
+	return nil
+}

--- a/go-controller/pkg/cni/udn/primary_network_test.go
+++ b/go-controller/pkg/cni/udn/primary_network_test.go
@@ -1,0 +1,188 @@
+package udn
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/labels"
+
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	v1nadmocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
+	types "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func TestWaitForPrimaryAnnotationFn(t *testing.T) {
+
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+	tests := []struct {
+		description           string
+		namespace             string
+		nadName               string
+		annotationFromFn      *util.PodAnnotation
+		isReadyFromFn         bool
+		annotations           map[string]string
+		nads                  []*nadapi.NetworkAttachmentDefinition
+		getActiveNetworkError error
+		expectedIsReady       bool
+		expectedFound         bool
+		expectedAnnotation    *util.PodAnnotation
+		expectedNADName       string
+		expectedNetworkName   string
+		expectedMTU           int
+	}{
+		{
+			description: "With non default nad should be ready",
+			nadName:     "red",
+			annotationFromFn: &util.PodAnnotation{
+				Role: types.NetworkRoleSecondary,
+			},
+			isReadyFromFn:   true,
+			expectedIsReady: true,
+			expectedAnnotation: &util.PodAnnotation{
+				Role: types.NetworkRoleSecondary,
+			},
+		},
+		{
+			description:        "With no ovn annotation should force return not ready",
+			nadName:            types.DefaultNetworkName,
+			annotationFromFn:   nil,
+			isReadyFromFn:      true,
+			expectedAnnotation: nil,
+			expectedIsReady:    false,
+		},
+		{
+			description: "With primary default should be ready",
+			nadName:     types.DefaultNetworkName,
+			annotationFromFn: &util.PodAnnotation{
+				Role: types.NetworkRolePrimary,
+			},
+			isReadyFromFn: true,
+			expectedAnnotation: &util.PodAnnotation{
+				Role: types.NetworkRolePrimary,
+			},
+			expectedIsReady: true,
+		},
+		{
+			description: "With missing primary annotation and active network should return not ready",
+			nadName:     types.DefaultNetworkName,
+			annotationFromFn: &util.PodAnnotation{
+				Role: types.NetworkRoleInfrastructure,
+			},
+			isReadyFromFn:   true,
+			expectedIsReady: false,
+		},
+		{
+			description: "With primary network annotation and missing active network should return not ready",
+			namespace:   "ns1",
+			nadName:     types.DefaultNetworkName,
+			annotationFromFn: &util.PodAnnotation{
+				Role: types.NetworkRoleInfrastructure,
+			},
+			isReadyFromFn: true,
+			annotations: map[string]string{
+				"k8s.ovn.org/pod-networks": `{"ns1/nad1": {
+					"role": "primary",
+			        "mac_address": "0a:58:fd:98:00:01"
+				}}`,
+			},
+			expectedIsReady: false,
+		},
+		{
+			description: "With missing primary network annotation and active network should return not ready",
+			nadName:     types.DefaultNetworkName,
+			annotationFromFn: &util.PodAnnotation{
+				Role: types.NetworkRoleInfrastructure,
+			},
+			isReadyFromFn: true,
+			nads: []*nadapi.NetworkAttachmentDefinition{
+				ovntest.GenerateNAD("blue", "nad1", "ns1",
+					types.Layer2Topology, "10.100.200.0/24", types.NetworkRolePrimary),
+			},
+			expectedIsReady: false,
+		},
+		{
+			description: "With primary network annotation and active network should return ready",
+			namespace:   "ns1",
+			nadName:     types.DefaultNetworkName,
+			annotationFromFn: &util.PodAnnotation{
+				Role: types.NetworkRoleInfrastructure,
+			},
+			isReadyFromFn: true,
+			annotations: map[string]string{
+				"k8s.ovn.org/pod-networks": `{"ns1/nad1": {
+					"role": "primary",
+			        "mac_address": "0a:58:fd:98:00:01"
+				}}`,
+			},
+			nads: []*nadapi.NetworkAttachmentDefinition{
+				ovntest.GenerateNAD("blue", "nad1", "ns1",
+					types.Layer2Topology, "10.100.200.0/24", types.NetworkRolePrimary),
+			},
+			expectedIsReady:     true,
+			expectedFound:       true,
+			expectedNetworkName: "blue",
+			expectedNADName:     "ns1/nad1",
+			expectedAnnotation: &util.PodAnnotation{
+				Role: types.NetworkRoleInfrastructure,
+			},
+			expectedMTU: 1300,
+		},
+		{
+			description: "With primary network annotation and active network and no MTU should return ready with default MTU",
+			namespace:   "ns1",
+			nadName:     types.DefaultNetworkName,
+			annotationFromFn: &util.PodAnnotation{
+				Role: types.NetworkRoleInfrastructure,
+			},
+			isReadyFromFn: true,
+			annotations: map[string]string{
+				"k8s.ovn.org/pod-networks": `{"ns1/nad1": {
+					"role": "primary",
+			        "mac_address": "0a:58:fd:98:00:01"
+				}}`,
+			},
+			nads: []*nadapi.NetworkAttachmentDefinition{
+				ovntest.GenerateNADWithoutMTU("blue", "nad1", "ns1",
+					types.Layer2Topology, "10.100.200.0/24", types.NetworkRolePrimary),
+			},
+			expectedIsReady:     true,
+			expectedFound:       true,
+			expectedNetworkName: "blue",
+			expectedNADName:     "ns1/nad1",
+			expectedAnnotation: &util.PodAnnotation{
+				Role: types.NetworkRoleInfrastructure,
+			},
+			expectedMTU: 1400,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			g := NewWithT(t)
+			nadLister := v1nadmocks.NetworkAttachmentDefinitionLister{}
+			nadNamespaceLister := v1nadmocks.NetworkAttachmentDefinitionNamespaceLister{}
+			nadLister.On("NetworkAttachmentDefinitions", tt.namespace).Return(&nadNamespaceLister)
+			nadNamespaceLister.On("List", labels.Everything()).Return(tt.nads, nil)
+			waitCond := func(map[string]string, string) (*util.PodAnnotation, bool) {
+				return tt.annotationFromFn, tt.isReadyFromFn
+			}
+			userDefinedPrimaryNetwork := NewPrimaryNetwork(&nadLister)
+			obtainedAnnotation, obtainedIsReady := userDefinedPrimaryNetwork.WaitForPrimaryAnnotationFn(tt.namespace, waitCond)(tt.annotations, tt.nadName)
+			obtainedFound := userDefinedPrimaryNetwork.Found()
+			obtainedNetworkName := userDefinedPrimaryNetwork.NetworkName()
+			obtainedNADName := userDefinedPrimaryNetwork.NADName()
+			obtainedMTU := userDefinedPrimaryNetwork.MTU()
+			g.Expect(obtainedIsReady).To(Equal(tt.expectedIsReady), "should return expected readiness")
+			g.Expect(obtainedFound).To(Equal(tt.expectedFound), "should return expected found flag")
+			g.Expect(obtainedNetworkName).To(Equal(tt.expectedNetworkName), "should return expected network name")
+			g.Expect(obtainedNADName).To(Equal(tt.expectedNADName), "should return expected nad name")
+			g.Expect(obtainedAnnotation).To(Equal(tt.expectedAnnotation), "should return expected ovn pod annotation")
+			g.Expect(obtainedMTU).To(Equal(tt.expectedMTU), "should return expected MTU")
+		})
+	}
+}

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -16,7 +16,7 @@ import (
 )
 
 // wait on a certain pod annotation related condition
-type podAnnotWaitCond func(map[string]string, string) (*util.PodAnnotation, bool)
+type podAnnotWaitCond = func(map[string]string, string) (*util.PodAnnotation, bool)
 
 // isOvnReady is a wait condition for OVN master to set pod-networks annotation
 func isOvnReady(podAnnotation map[string]string, nadName string) (*util.PodAnnotation, bool) {

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -36,6 +36,8 @@ import (
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+
+	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 )
 
 // CommonNetworkControllerInfo structure is place holder for all fields shared among controllers.
@@ -770,7 +772,11 @@ func (bnc *BaseNetworkController) isLocalZoneNode(node *kapi.Node) bool {
 // getActiveNetworkForNamespace returns the active network for the given namespace
 // and is a wrapper around util.GetActiveNetworkForNamespace
 func (bnc *BaseNetworkController) getActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
-	return util.GetActiveNetworkForNamespace(namespace, bnc.watchFactory.NADInformer().Lister())
+	var nadLister nadlister.NetworkAttachmentDefinitionLister
+	if util.IsNetworkSegmentationSupportEnabled() {
+		nadLister = bnc.watchFactory.NADInformer().Lister()
+	}
+	return util.GetActiveNetworkForNamespace(namespace, nadLister)
 }
 
 // GetNetworkRole returns the role of this controller's

--- a/go-controller/pkg/testing/util.go
+++ b/go-controller/pkg/testing/util.go
@@ -8,7 +8,7 @@ import (
 )
 
 func GenerateNAD(networkName, name, namespace, topology, cidr, role string) *nadapi.NetworkAttachmentDefinition {
-	nadSpec := fmt.Sprintf(
+	return GenerateNADWithConfig(name, namespace, fmt.Sprintf(
 		`
 {
         "cniVersion": "0.4.0",
@@ -26,8 +26,27 @@ func GenerateNAD(networkName, name, namespace, topology, cidr, role string) *nad
 		cidr,
 		fmt.Sprintf("%s/%s", namespace, name),
 		role,
-	)
-	return GenerateNADWithConfig(name, namespace, nadSpec)
+	))
+}
+func GenerateNADWithoutMTU(networkName, name, namespace, topology, cidr, role string) *nadapi.NetworkAttachmentDefinition {
+	return GenerateNADWithConfig(name, namespace, fmt.Sprintf(
+		`
+{
+        "cniVersion": "0.4.0",
+        "name": %q,
+        "type": "ovn-k8s-cni-overlay",
+        "topology":%q,
+        "subnets": %q,
+        "netAttachDefName": %q,
+        "role": %q
+}
+`,
+		networkName,
+		topology,
+		cidr,
+		fmt.Sprintf("%s/%s", namespace, name),
+		role,
+	))
 }
 
 func GenerateNADWithConfig(name, namespace, config string) *nadapi.NetworkAttachmentDefinition {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -5,7 +5,6 @@ import "time"
 const (
 	// Default network name
 	DefaultNetworkName    = "default"
-	UnknownNetworkName    = "unknown"
 	K8sPrefix             = "k8s-"
 	HybridOverlayPrefix   = "int-"
 	HybridOverlayGRSubfix = "-gr"

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -118,7 +118,9 @@ type podConfiguration struct {
 
 func generatePodSpec(config podConfiguration) *v1.Pod {
 	podSpec := e2epod.NewAgnhostPod(config.namespace, config.name, nil, nil, nil, config.containerCmd...)
-	podSpec.Annotations = networkSelectionElements(config.attachments...)
+	if len(config.attachments) > 0 {
+		podSpec.Annotations = networkSelectionElements(config.attachments...)
+	}
 	podSpec.Spec.NodeSelector = config.nodeSelector
 	podSpec.Labels = config.labels
 	if config.isPrivileged {

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	iputils "github.com/containernetworking/plugins/pkg/ip"
-	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -110,12 +110,10 @@ var _ = Describe("Network Segmentation", func() {
 				},
 				*podConfig(
 					"client-pod",
-					nadName,
 					withNodeSelector(map[string]string{nodeHostnameKey: workerOneNodeName}),
 				),
 				*podConfig(
 					"server-pod",
-					nadName,
 					withCommand(func() []string {
 						return httpServerContainerCmd(port)
 					}),
@@ -132,12 +130,10 @@ var _ = Describe("Network Segmentation", func() {
 				},
 				*podConfig(
 					"client-pod",
-					nadName,
 					withNodeSelector(map[string]string{nodeHostnameKey: workerOneNodeName}),
 				),
 				*podConfig(
 					"server-pod",
-					nadName,
 					withCommand(func() []string {
 						return httpServerContainerCmd(port)
 					}),
@@ -334,7 +330,6 @@ var _ = Describe("Network Segmentation", func() {
 				},
 				*podConfig(
 					"udn-pod",
-					nadName,
 					withCommand(func() []string {
 						return httpServerContainerCmd(port)
 					}),
@@ -351,7 +346,6 @@ var _ = Describe("Network Segmentation", func() {
 				},
 				*podConfig(
 					"udn-pod",
-					nadName,
 					withCommand(func() []string {
 						return httpServerContainerCmd(port)
 					}),
@@ -364,10 +358,9 @@ var _ = Describe("Network Segmentation", func() {
 
 type podOption func(*podConfiguration)
 
-func podConfig(podName, nadName string, opts ...podOption) *podConfiguration {
+func podConfig(podName string, opts ...podOption) *podConfiguration {
 	pod := &podConfiguration{
-		attachments: []nadapi.NetworkSelectionElement{{Name: nadName}},
-		name:        podName,
+		name: podName,
 	}
 	for _, opt := range opts {
 		opt(pod)


### PR DESCRIPTION
#### What this PR does and why is it needed
Add logic at secondary network controller to trigger the creation of network selection element (but not annotate the pod) with the found active network, it also plumbs the primary network at the pod network namespace

It also introduce "Pending" egress test to activate it when topology for egress is in place.

Superceeds:
- https://github.com/ovn-org/ovn-kubernetes/pull/4459

#### How to verify it
It contains some unit test and the already present east/west traffic e2e

#### Details to documentation updates
NONE

#### Does this PR introduce a user-facing change?
NONE

-->
```release-note
Wired up primary network lsp and network namespace config by creating a network selection element.
```
