### PR TITLE
Add support for DNSNameResolver in KIND cluster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -398,19 +398,20 @@ jobs:
         # num-workers : "<integer value>"
         # num-nodes-per-zone : "<integer value>"
         # forwarding : ["", "disable-forwarding"]
+        # dns-name-resolver : ["", "enable-dns-name-resolver"]
         include:
           - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
-          - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
+          - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-disabled",          "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "control-plane-helm", "ha": "HA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "control-plane-helm", "ha": "HA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "dns-name-resolver": "enable-dns-name-resolver"}
+          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
-          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
+          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "multi-homing-helm", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
@@ -452,6 +453,7 @@ jobs:
       KIND_NUM_NODES_PER_ZONE: "${{ matrix.num-nodes-per-zone }}"
       OVN_DISABLE_FORWARDING: "${{ matrix.forwarding == 'disable-forwarding' }}"
       USE_HELM: "${{ matrix.target == 'control-plane-helm' || matrix.target == 'multi-homing-helm' }}"
+      OVN_ENABLE_DNSNAMERESOLVER: "${{ matrix.dns-name-resolver == 'enable-dns-name-resolver' }}"
     steps:
 
     - name: Free up disk space

--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -438,3 +438,141 @@ enable_multi_net() {
 kind_get_nodes() {
   kind get nodes --name "${KIND_CLUSTER_NAME}" | grep -v external-load-balancer
 }
+
+set_dnsnameresolver_images() {
+  if [ "$KIND_LOCAL_REGISTRY" == true ];then
+    COREDNS_WITH_OCP_DNSNAMERESOLVER="localhost:5000/coredns-with-ocp-dnsnameresolver:latest"
+    DNSNAMERESOLVER_OPERATOR="localhost:5000/dnsnameresolver-operator:latest"
+  else
+    COREDNS_WITH_OCP_DNSNAMERESOLVER="localhost/coredns-with-ocp-dnsnameresolver:dev"
+    DNSNAMERESOLVER_OPERATOR="localhost/dnsnameresolver-operator:dev"
+  fi
+}
+
+# build_image accepts three arguments. The first argument is the absolute path to the directory
+# which contains the Dockerfile. The second argument is the image name along with the tag. The
+# third argument is the name of the Dockerfile to use for building the image. 
+build_image() {
+  pushd ${1}
+  $OCI_BIN build -t "${2}" -f ${3} .
+
+  # store in local registry
+  if [ "$KIND_LOCAL_REGISTRY" == true ];then
+    echo "Pushing built image (${2}) to local $OCI_BIN registry"
+    $OCI_BIN push "${2}"
+  fi
+  popd
+}
+
+build_dnsnameresolver_images() {
+  set_dnsnameresolver_images
+  rm -rf /tmp/coredns-ocp-dnsnameresolver
+  git clone https://github.com/openshift/coredns-ocp-dnsnameresolver.git /tmp/coredns-ocp-dnsnameresolver
+  pushd /tmp/coredns-ocp-dnsnameresolver
+  git checkout 850cb5757982d368195744d3565c1565a7f0d43a
+  popd
+ 
+  build_image /tmp/coredns-ocp-dnsnameresolver ${COREDNS_WITH_OCP_DNSNAMERESOLVER} Dockerfile.upstream
+
+  build_image /tmp/coredns-ocp-dnsnameresolver/operator ${DNSNAMERESOLVER_OPERATOR} Dockerfile
+}
+
+# install_image accepts the image name along with the tag as an argument and installs it.
+install_image() {
+  # If local registry is being used push image there for consumption by kind cluster
+  if [ "$KIND_LOCAL_REGISTRY" == true ]; then
+    echo "${1} should already be avaliable in local registry, not loading"
+  else
+    if [ "$OCI_BIN" == "podman" ]; then
+      # podman: cf https://github.com/kubernetes-sigs/kind/issues/2027
+      rm -f /tmp/image.tar
+      podman save -o /tmp/image.tar "${1}"
+      kind load image-archive /tmp/image.tar --name "${KIND_CLUSTER_NAME}"
+    else
+      kind load docker-image "${1}" --name "${KIND_CLUSTER_NAME}"
+    fi
+  fi
+}
+
+install_dnsnameresolver_images() {
+  install_image ${COREDNS_WITH_OCP_DNSNAMERESOLVER}
+  install_image ${DNSNAMERESOLVER_OPERATOR}
+}
+
+install_dnsnameresolver_operator() {
+  pushd /tmp/coredns-ocp-dnsnameresolver/operator
+  
+  # Before installing DNSNameResolver operator, update the args so that the operator
+  # is configured with the correct values.
+  sed -i -e 's/^\(.*--coredns-namespace=\).*/\1kube-system/' \
+    -e 's/^\(.*--coredns-service-name=\).*/\1kube-dns/' \
+    -e 's/^\(.*--dns-name-resolver-namespace=\).*/\1ovn-kubernetes/' \
+    -e 's/^\(.*--coredns-port=\).*/\153/' config/default/manager_auth_proxy_patch.yaml
+
+  make install
+  make deploy IMG=${DNSNAMERESOLVER_OPERATOR}
+  popd
+}
+
+update_clusterrole_coredns() {
+  original_clusterrole=$(kubectl get clusterrole system:coredns -oyaml)
+  echo "Original CoreDNS clusterrole:"
+  echo "${original_clusterrole}"
+  additional_permissions=$(printf '%s' '
+- apiGroups:
+  - network.openshift.io
+  resources:
+  - dnsnameresolvers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - network.openshift.io
+  resources:
+  - dnsnameresolvers/status
+  verbs:
+  - update
+  - get
+  - patch
+')
+  updated_clusterrole="${original_clusterrole}${additional_permissions}"
+  echo "Patched CoreDNS clusterrole:"
+  echo "${updated_clusterrole}"
+  printf '%s' "${updated_clusterrole}" | kubectl apply -f -
+}
+
+add_ocp_dnsnameresolver_to_coredns_config() {
+  original_corefile=$(kubectl get -n=kube-system configmap/coredns -o=jsonpath="{.data['Corefile']}")
+  if ! grep -wq "ocp_dnsnameresolver" <<< ${original_corefile}; then
+    echo "Original CoreDNS Corefile:"
+    echo "${original_corefile}"
+    updated_corefile=$(
+      printf '%s' "${original_corefile}" | sed -e 's/^\(.*\)\(forward.*\)/\1ocp_dnsnameresolver {\n\1   namespaces ovn-kubernetes\n\1}\n\1\2/'
+    )
+    echo "Patched CoreDNS Corefile:"
+    echo "${updated_corefile}"
+    printf '%s' "${updated_corefile}" > /tmp/Corefile.json
+    updated_coredns=$(kubectl create configmap coredns -n=kube-system --from-file=Corefile=/tmp/Corefile.json -oyaml --dry-run=client)
+    echo "Patched CoreDNS config:"
+    echo "${updated_coredns}"
+    printf '%s' "${updated_coredns}" | kubectl apply -f -
+  fi
+}
+
+update_coredns_deployment_image() {
+  kubectl -n=kube-system set image deploy/coredns coredns=${COREDNS_WITH_OCP_DNSNAMERESOLVER}
+}
+
+# kubectl_wait_dnsnameresolver_pods will set a total timeout of 60s and wait for the pods
+# related to the dns name resolver feature to become "Ready".
+kubectl_wait_dnsnameresolver_pods() {
+  TIMEOUT=60
+
+  # We will make sure that we timeout all commands at current seconds + the desired timeout.
+  endtime=$(( SECONDS + TIMEOUT ))
+
+  timeout=$(calculate_timeout ${endtime})
+  echo "Waiting for pods in dnsnameresolver-operator namespace to become ready (timeout ${timeout})..."
+  kubectl wait -n dnsnameresolver-operator --for=condition=ready pods --all --timeout=${timeout}s
+}

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -93,6 +93,7 @@ OVN_ENABLE_INTERCONNECT=
 OVN_ENABLE_OVNKUBE_IDENTITY="true"
 OVN_ENABLE_PERSISTENT_IPS=
 OVN_ENABLE_SVC_TEMPLATE_SUPPORT="true"
+OVN_ENABLE_DNSNAMERESOLVER="false"
 # IN_UPGRADE is true only if called by upgrade-ovn.sh during the upgrade test,
 # it will render only the parts in ovn-setup.yaml related to RBAC permissions.
 IN_UPGRADE=
@@ -350,6 +351,9 @@ while [ "$1" != "" ]; do
   --enable-svc-template-support)
     OVN_ENABLE_SVC_TEMPLATE_SUPPORT=$VALUE
     ;;
+  --enable-dnsnameresolver)
+    OVN_ENABLE_DNSNAMERESOLVER=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -536,6 +540,9 @@ echo "ovn_enable_persistent_ips: ${ovn_enable_persistent_ips}"
 
 ovn_enable_svc_template_support=${OVN_ENABLE_SVC_TEMPLATE_SUPPORT}
 echo "ovn_enable_svc_template_support: ${ovn_enable_svc_template_support}"
+
+ovn_enable_dnsnameresolver=${OVN_ENABLE_DNSNAMERESOLVER}
+echo "ovn_enable_dnsnameresolver: ${ovn_enable_dnsnameresolver}"
 
 ovn_image=${ovnkube_image} \
   ovnkube_compact_mode_enable=${ovnkube_compact_mode_enable} \
@@ -725,6 +732,7 @@ ovn_image=${ovnkube_image} \
   ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_svc_template_support=${ovn_enable_svc_template_support} \
+  ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
   jinjanate ../templates/ovnkube-master.yaml.j2 -o ${output_dir}/ovnkube-master.yaml
 
 ovn_image=${ovnkube_image} \
@@ -765,6 +773,7 @@ ovn_image=${ovnkube_image} \
   ovn_v4_transit_switch_subnet=${ovn_v4_transit_switch_subnet} \
   ovn_v6_transit_switch_subnet=${ovn_v6_transit_switch_subnet} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
+  ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
   jinjanate ../templates/ovnkube-control-plane.yaml.j2 -o ${output_dir}/ovnkube-control-plane.yaml
 
 ovn_image=${image} \
@@ -857,6 +866,7 @@ ovn_image=${ovnkube_image} \
   ovn_northd_backoff_interval=${ovn_northd_backoff_interval} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_svc_template_support=${ovn_enable_svc_template_support} \
+  ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
   jinjanate ../templates/ovnkube-single-node-zone.yaml.j2 -o ${output_dir}/ovnkube-single-node-zone.yaml
 
 ovn_image=${ovnkube_image} \
@@ -917,6 +927,7 @@ ovn_image=${ovnkube_image} \
   ovn_northd_backoff_interval=${ovn_enable_backoff_interval} \
   ovn_enable_persistent_ips=${ovn_enable_persistent_ips} \
   ovn_enable_svc_template_support=${ovn_enable_svc_template_support} \
+  ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
   jinjanate ../templates/ovnkube-zone-controller.yaml.j2 -o ${output_dir}/ovnkube-zone-controller.yaml
 
 ovn_image=${image} \
@@ -976,12 +987,15 @@ net_cidr=${net_cidr} svc_cidr=${svc_cidr} \
 
 ovn_enable_interconnect=${ovn_enable_interconnect} \
 ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
+ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
   jinjanate ../templates/rbac-ovnkube-node.yaml.j2 -o ${output_dir}/rbac-ovnkube-node.yaml
 
 ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
+ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
   jinjanate ../templates/rbac-ovnkube-cluster-manager.yaml.j2 -o ${output_dir}/rbac-ovnkube-cluster-manager.yaml
 
 ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
+ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
   jinjanate ../templates/rbac-ovnkube-master.yaml.j2 -o ${output_dir}/rbac-ovnkube-master.yaml
 
 cp ../templates/rbac-ovnkube-identity.yaml.j2 ${output_dir}/rbac-ovnkube-identity.yaml

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -95,6 +95,7 @@ fi
 # OVN_KUBERNETES_CONNTRACK_ZONE - Conntrack zone number used for openflow rules (default 64000)
 # OVN_NORTHD_BACKOFF_INTERVAL - ovn northd backoff interval in ms (default 300)
 # OVN_ENABLE_SVC_TEMPLATE_SUPPORT - enable svc template support
+# OVN_ENABLE_DNSNAMERESOLVER - enable dns name resolver support
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -307,6 +308,8 @@ ovnkube_compact_mode_enable=${OVNKUBE_COMPACT_MODE_ENABLE:-false}
 ovn_northd_backoff_interval=${OVN_NORTHD_BACKOFF_INTERVAL:-"300"}
 # OVN_ENABLE_SVC_TEMPLATE_SUPPORT - enable svc template support
 ovn_enable_svc_template_support=${OVN_ENABLE_SVC_TEMPLATE_SUPPORT:-true}
+# OVN_ENABLE_DNSNAMERESOLVER - enable dns name resolver support
+ovn_enable_dnsnameresolver=${OVN_ENABLE_DNSNAMERESOLVER:-false}
 
 # Determine the ovn rundir.
 if [[ -f /usr/bin/ovn-appctl ]]; then
@@ -1271,6 +1274,12 @@ ovn-master() {
   fi
   echo "persistent_ips_enabled_flag: ${persistent_ips_enabled_flag}"
 
+  ovn_enable_dnsnameresolver_flag=
+  if [[ ${ovn_enable_dnsnameresolver} == "true" ]]; then
+	  ovn_enable_dnsnameresolver_flag="--enable-dns-name-resolver"
+  fi
+  echo "ovn_enable_dnsnameresolver_flag=${ovn_enable_dnsnameresolver_flag}"
+
   /usr/bin/ovnkube --init-master ${K8S_NODE} \
     ${anp_enabled_flag} \
     ${disable_forwarding_flag} \
@@ -1300,6 +1309,7 @@ ovn-master() {
     ${ovn_v6_join_subnet_opt} \
     ${ovn_v6_masquerade_subnet_opt} \
     ${persistent_ips_enabled_flag} \
+    ${ovn_enable_dnsnameresolver_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
     --host-network-namespace ${ovn_host_network_namespace} \
@@ -1545,6 +1555,12 @@ ovnkube-controller() {
   fi
   echo "ovn_enable_svc_template_support_flag=${ovn_enable_svc_template_support_flag}"
 
+  ovn_enable_dnsnameresolver_flag=
+  if [[ ${ovn_enable_dnsnameresolver} == "true" ]]; then
+	  ovn_enable_dnsnameresolver_flag="--enable-dns-name-resolver"
+  fi
+  echo "ovn_enable_dnsnameresolver_flag=${ovn_enable_dnsnameresolver_flag}"
+
   echo "=============== ovnkube-controller ========== MASTER ONLY"
   /usr/bin/ovnkube --init-ovnkube-controller ${K8S_NODE} \
     ${anp_enabled_flag} \
@@ -1575,6 +1591,7 @@ ovnkube-controller() {
     ${ovn_v4_masquerade_subnet_opt} \
     ${ovn_v6_join_subnet_opt} \
     ${ovn_v6_masquerade_subnet_opt} \
+    ${ovn_enable_dnsnameresolver_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --gateway-mode=${ovn_gateway_mode} \
     --host-network-namespace ${ovn_host_network_namespace} \
@@ -1937,6 +1954,12 @@ ovnkube-controller-with-node() {
   fi
   echo "ovn_enable_svc_template_support_flag=${ovn_enable_svc_template_support_flag}"
 
+  ovn_enable_dnsnameresolver_flag=
+  if [[ ${ovn_enable_dnsnameresolver} == "true" ]]; then
+	  ovn_enable_dnsnameresolver_flag="--enable-dns-name-resolver"
+  fi
+  echo "ovn_enable_dnsnameresolver_flag=${ovn_enable_dnsnameresolver_flag}"
+
   echo "=============== ovnkube-controller-with-node --init-ovnkube-controller-with-node=========="
   /usr/bin/ovnkube --init-ovnkube-controller ${K8S_NODE} --init-node ${K8S_NODE} \
     ${anp_enabled_flag} \
@@ -1985,6 +2008,7 @@ ovnkube-controller-with-node() {
     ${routable_mtu_flag} \
     ${sflow_targets} \
     ${ssl_opts} \
+    ${ovn_enable_dnsnameresolver_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --export-ovs-metrics \
     --gateway-mode=${ovn_gateway_mode} \
@@ -2160,6 +2184,12 @@ ovn-cluster-manager() {
   fi
   echo "empty_lb_events_flag=${empty_lb_events_flag}"
 
+  ovn_enable_dnsnameresolver_flag=
+  if [[ ${ovn_enable_dnsnameresolver} == "true" ]]; then
+	  ovn_enable_dnsnameresolver_flag="--enable-dns-name-resolver"
+  fi
+  echo "ovn_enable_dnsnameresolver_flag=${ovn_enable_dnsnameresolver_flag}"
+
   echo "=============== ovn-cluster-manager ========== MASTER ONLY"
   /usr/bin/ovnkube --init-cluster-manager ${K8S_NODE} \
     ${anp_enabled_flag} \
@@ -2184,6 +2214,7 @@ ovn-cluster-manager() {
     ${ovn_v6_masquerade_subnet_opt} \
     ${ovn_v4_transit_switch_subnet_opt} \
     ${ovn_v6_transit_switch_subnet_opt} \
+    ${ovn_enable_dnsnameresolver_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --host-network-namespace ${ovn_host_network_namespace} \
     --logfile-maxage=${ovnkube_logfile_maxage} \

--- a/dist/templates/ovnkube-control-plane.yaml.j2
+++ b/dist/templates/ovnkube-control-plane.yaml.j2
@@ -172,6 +172,8 @@ spec:
           value: "{{ ovn_v6_transit_switch_subnet }}"
         - name: OVN_ENABLE_PERSISTENT_IPS
           value: "{{ ovn_enable_persistent_ips }}"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "{{ ovn_enable_dnsnameresolver }}"
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -302,6 +302,8 @@ spec:
               key: host_network_namespace
         - name: OVN_ENABLE_PERSISTENT_IPS
           value: "{{ ovn_enable_persistent_ips }}"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "{{ ovn_enable_dnsnameresolver }}"
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -448,6 +448,8 @@ spec:
           value: "{{ ovn_enable_ovnkube_identity }}"
         - name: OVN_ENABLE_SVC_TEMPLATE_SUPPORT
           value: "{{ ovn_enable_svc_template_support }}"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "{{ ovn_enable_dnsnameresolver }}"
 
         readinessProbe:
           exec:

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -380,6 +380,8 @@ spec:
           value: "local"
         - name: OVN_SOUTH
           value: "local"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "{{ ovn_enable_dnsnameresolver }}"
       # end of container
 
       volumes:

--- a/dist/templates/rbac-ovnkube-cluster-manager.yaml.j2
+++ b/dist/templates/rbac-ovnkube-cluster-manager.yaml.j2
@@ -107,3 +107,9 @@ rules:
           - endpointslices
       verbs: [ "create", "update", "delete", "deletecollection" ]
     {%- endif %}
+    {% if ovn_enable_dnsnameresolver == "true" -%}
+    - apiGroups: ["network.openshift.io"]
+      resources:
+          - dnsnameresolvers
+      verbs: [ "create", "delete", "list", "patch", "update", "watch" ]
+    {%- endif %}

--- a/dist/templates/rbac-ovnkube-master.yaml.j2
+++ b/dist/templates/rbac-ovnkube-master.yaml.j2
@@ -125,6 +125,12 @@ rules:
       verbs: [ "create", "update", "delete", "deletecollection" ]
     {%- endif %}
 
+    {% if ovn_enable_dnsnameresolver == "true" -%}
+    - apiGroups: ["network.openshift.io"]
+      resources:
+          - dnsnameresolvers
+      verbs: [ "create", "delete", "list", "patch", "update", "watch" ]
+    {%- endif %}
 
 
 # https://github.com/ovn-org/ovn-kubernetes/blob/e1e7d40f9a6c6038b52696c1b8f8915a4d73160e/go-controller/pkg/ovn/topology_version.go#L28

--- a/dist/templates/rbac-ovnkube-node.yaml.j2
+++ b/dist/templates/rbac-ovnkube-node.yaml.j2
@@ -204,6 +204,12 @@ rules:
           - pods/status # In IC ovnkube-controller, and ovnkube-node in DPU mode updates pod annotations for local pods
           - nodes/status
       verbs: [ "patch", "update" ]
+    {% if ovn_enable_dnsnameresolver == "true" -%}
+    - apiGroups: ["network.openshift.io"]
+      resources:
+          - dnsnameresolvers
+      verbs: [ "get", "list", "watch" ]
+    {%- endif %}
 
 # Without IC endpoints are read by ovnkube-node on startup
 # With IC endpoints are created by ovnkube-zone-controller/sb-ovsdb startup script in multinode-zone for IC

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -151,6 +151,8 @@ spec:
           value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
         - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
           value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
       # end of container
       volumes:
       # TODO: Need to check why we need this?

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
@@ -83,3 +83,9 @@ rules:
         - adminpolicybasedexternalroutes/status
         - egressfirewalls/status
       verbs: [ "patch", "update" ]
+    {{- if eq (hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false) true }}
+    - apiGroups: ["network.openshift.io"]
+      resources:
+          - dnsnameresolvers
+      verbs: [ "create", "delete", "list", "patch", "update", "watch" ]
+    {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -275,6 +275,8 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: host_network_namespace
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
       # end of container
       volumes:
       # TODO: Need to check why we need this?

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/rbac-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/rbac-ovnkube-master.yaml
@@ -113,6 +113,12 @@ rules:
           - pods/status
           - services/status
       verbs: [ "patch", "update" ]
+    {{- if eq (hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false) true }}
+    - apiGroups: ["network.openshift.io"]
+      resources:
+          - dnsnameresolvers
+      verbs: [ "create", "delete", "list", "patch", "update", "watch" ]
+    {{- end }}
 
 
 # https://github.com/ovn-org/ovn-kubernetes/blob/e1e7d40f9a6c6038b52696c1b8f8915a4d73160e/go-controller/pkg/ovn/topology_version.go#L28

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -427,6 +427,8 @@ spec:
           value: {{ hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true | quote }}
         - name: OVN_ENABLE_SVC_TEMPLATE_SUPPORT
           value: {{ hasKey .Values.global "enableSvcTemplate" | ternary .Values.global.enableSvcTemplate true | quote }
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -346,6 +346,8 @@ spec:
           value: "local"
         - name: OVN_SOUTH
           value: "local"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
       # end of container
       volumes:
       # Common volumes

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
@@ -198,6 +198,12 @@ rules:
           - pods/status # In IC ovnkube-controller, and ovnkube-node in DPU mode updates pod annotations for local pods
           - nodes/status
       verbs: [ "patch", "update" ]
+    {{- if eq (hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false) true }}
+    - apiGroups: ["network.openshift.io"]
+      resources:
+          - dnsnameresolvers
+      verbs: [ "get", "list", "watch" ]
+    {{- end }}
 
 # Without IC endpoints are read by ovnkube-node on startup
 # With IC endpoints are created by ovnkube-zone-controller/sb-ovsdb startup script in multinode-zone for IC

--- a/helm/ovn-kubernetes/values.yaml
+++ b/helm/ovn-kubernetes/values.yaml
@@ -87,6 +87,8 @@ global:
   # -- Indicates if ovn-controller should enable/disable the logical flow in-memory cache when processing Southbound database logical flow changes
   # @default -- true
   enableLFlowCache: true
+  # -- Configure to use DNSNameResolver feature with ovn-kubernetes
+  enableDNSNameResolver: false
   # -- Maximum number of logical flow cache entries ovn-controller may create when the logical flow cache is enabled
   # @default -- unlimited
   lFlowCacheLimit: ""


### PR DESCRIPTION
This PR adds support for DNSNameResolver in KIND cluster.

A new flag, `[-dns | --enable-dnsnameresolver]`, is now supported by `contrib/kind.sh`. When a KIND cluster is installed using this flag, the cluster will be using DNSNameResolver for resolving DNS names used in EgressFirewall rules. Wildcard DNS names will also supported in EgressFirewall DNS rules.