### PR TITLE
UDN: Prerequisite: Make OVN topology network aware.

### DIFF
--- a/go-controller/pkg/kubevirt/router.go
+++ b/go-controller/pkg/kubevirt/router.go
@@ -94,7 +94,7 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 	if config.OVNKubernetesFeature.EnableInterconnect {
 		// NOTE: EIP & ESVC use same route and if this is already present thanks to those features,
 		// this will be a no-op
-		if err := libovsdbutil.CreateDefaultRouteToExternal(nbClient, types.OVNClusterRouter, pod.Spec.NodeName); err != nil {
+		if err := libovsdbutil.CreateDefaultRouteToExternal(nbClient, types.OVNClusterRouter, types.GWRouterPrefix+pod.Spec.NodeName); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/kubevirt/router.go
+++ b/go-controller/pkg/kubevirt/router.go
@@ -94,7 +94,7 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 	if config.OVNKubernetesFeature.EnableInterconnect {
 		// NOTE: EIP & ESVC use same route and if this is already present thanks to those features,
 		// this will be a no-op
-		if err := libovsdbutil.CreateDefaultRouteToExternal(nbClient, pod.Spec.NodeName); err != nil {
+		if err := libovsdbutil.CreateDefaultRouteToExternal(nbClient, types.OVNClusterRouter, pod.Spec.NodeName); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/libovsdb/util/router.go
+++ b/go-controller/pkg/libovsdb/util/router.go
@@ -29,7 +29,7 @@ import (
 // (TODO: FIXME): With this route, we are officially breaking support for IC with zones that have multiple-nodes
 // NOTE: This route is exactly the same as what is added by pod-live-migration feature and we keep the route exactly
 // same across the 3 features so that if the route already exists on the node, this is just a no-op
-func CreateDefaultRouteToExternal(nbClient libovsdbclient.Client, nodeName string) error {
+func CreateDefaultRouteToExternal(nbClient libovsdbclient.Client, clusterRouter, nodeName string) error {
 	gatewayIPs, err := GetLRPAddrs(nbClient, types.GWRouterToJoinSwitchPrefix+types.GWRouterPrefix+nodeName)
 	if err != nil {
 		return fmt.Errorf("attempt at finding node gateway router %s network information failed, err: %w", nodeName, err)
@@ -54,7 +54,7 @@ func CreateDefaultRouteToExternal(nbClient libovsdbclient.Client, nodeName strin
 				lrsr.Nexthop == gatewayIP.IP.String() &&
 				lrsr.Policy != nil && *lrsr.Policy == nbdb.LogicalRouterStaticRoutePolicySrcIP
 		}
-		if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient, types.OVNClusterRouter, &lrsr, p); err != nil {
+		if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient, clusterRouter, &lrsr, p); err != nil {
 			return fmt.Errorf("unable to create pod to external catch-all reroute for node %s, err: %v", nodeName, err)
 		}
 	}

--- a/go-controller/pkg/libovsdb/util/router.go
+++ b/go-controller/pkg/libovsdb/util/router.go
@@ -29,16 +29,16 @@ import (
 // (TODO: FIXME): With this route, we are officially breaking support for IC with zones that have multiple-nodes
 // NOTE: This route is exactly the same as what is added by pod-live-migration feature and we keep the route exactly
 // same across the 3 features so that if the route already exists on the node, this is just a no-op
-func CreateDefaultRouteToExternal(nbClient libovsdbclient.Client, clusterRouter, nodeName string) error {
-	gatewayIPs, err := GetLRPAddrs(nbClient, types.GWRouterToJoinSwitchPrefix+types.GWRouterPrefix+nodeName)
+func CreateDefaultRouteToExternal(nbClient libovsdbclient.Client, clusterRouter, gwRouterName string) error {
+	gatewayIPs, err := GetLRPAddrs(nbClient, types.GWRouterToJoinSwitchPrefix+gwRouterName)
 	if err != nil {
-		return fmt.Errorf("attempt at finding node gateway router %s network information failed, err: %w", nodeName, err)
+		return fmt.Errorf("attempt at finding node gateway router %s network information failed, err: %w", gwRouterName, err)
 	}
 	clusterSubnets := util.GetAllClusterSubnets()
 	for _, subnet := range clusterSubnets {
 		gatewayIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6String(subnet.IP.String()), gatewayIPs)
 		if err != nil {
-			return fmt.Errorf("could not find gateway IP for node %s with family %v: %v", nodeName, false, err)
+			return fmt.Errorf("could not find gateway IP for gateway router %s with family %v: %v", gwRouterName, false, err)
 		}
 		lrsr := nbdb.LogicalRouterStaticRoute{
 			IPPrefix: subnet.String(),
@@ -55,7 +55,7 @@ func CreateDefaultRouteToExternal(nbClient libovsdbclient.Client, clusterRouter,
 				lrsr.Policy != nil && *lrsr.Policy == nbdb.LogicalRouterStaticRoutePolicySrcIP
 		}
 		if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient, clusterRouter, &lrsr, p); err != nil {
-			return fmt.Errorf("unable to create pod to external catch-all reroute for node %s, err: %v", nodeName, err)
+			return fmt.Errorf("unable to create pod to external catch-all reroute for gateway router %s, err: %v", gwRouterName, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/libovsdb/util/switch.go
+++ b/go-controller/pkg/libovsdb/util/switch.go
@@ -23,7 +23,7 @@ var updateNodeSwitchLock sync.Mutex
 // is added to the logical switch's exclude_ips. This prevents ovn-northd log
 // spam about duplicate IP addresses.
 // See https://github.com/ovn-org/ovn-kubernetes/pull/779
-func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, mgmtIfName, nodeName string, subnet *net.IPNet) error {
+func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, mgmtIfName, switchName, nodeName string, subnet *net.IPNet) error {
 	if utilnet.IsIPv6CIDR(subnet) {
 		// We don't exclude any IPs in IPv6
 		return nil
@@ -77,7 +77,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, mgmtIfName, node
 	}
 
 	sw := nbdb.LogicalSwitch{
-		Name:        nodeName,
+		Name:        switchName,
 		OtherConfig: map[string]string{"exclude_ips": excludeIPs},
 	}
 	err = libovsdbops.UpdateLogicalSwitchSetOtherConfig(nbClient, &sw)

--- a/go-controller/pkg/libovsdb/util/switch.go
+++ b/go-controller/pkg/libovsdb/util/switch.go
@@ -23,7 +23,7 @@ var updateNodeSwitchLock sync.Mutex
 // is added to the logical switch's exclude_ips. This prevents ovn-northd log
 // spam about duplicate IP addresses.
 // See https://github.com/ovn-org/ovn-kubernetes/pull/779
-func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string, subnet *net.IPNet) error {
+func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, mgmtIfName, nodeName string, subnet *net.IPNet) error {
 	if utilnet.IsIPv6CIDR(subnet) {
 		// We don't exclude any IPs in IPv6
 		return nil
@@ -34,7 +34,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 
 	// Only query the cache for mp0 and HO LSPs
 	haveManagementPort := true
-	managmentPort := &nbdb.LogicalSwitchPort{Name: types.K8sPrefix + nodeName}
+	managmentPort := &nbdb.LogicalSwitchPort{Name: mgmtIfName}
 	_, err := libovsdbops.GetLogicalSwitchPort(nbClient, managmentPort)
 	if errors.Is(err, libovsdbclient.ErrNotFound) {
 		klog.V(5).Infof("Management port does not exist for node %s", nodeName)

--- a/go-controller/pkg/libovsdb/util/switch_test.go
+++ b/go-controller/pkg/libovsdb/util/switch_test.go
@@ -268,12 +268,12 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			var e error
 			if tc.setCfgHybridOvlyEnabled {
 				config.HybridOverlay.Enabled = true
-				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, ipnet); e != nil {
+				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, nodeName, ipnet); e != nil {
 					t.Fatal(fmt.Errorf("failed to update NodeSwitchExcludeIPs with Hybrid Overlay enabled err: %v", e))
 				}
 				config.HybridOverlay.Enabled = false
 			} else {
-				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, ipnet); e != nil {
+				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, nodeName, ipnet); e != nil {
 					t.Fatal(fmt.Errorf("failed to update NodeSwitchExcludeIPs with Hybrid Overlay disabled err: %v", e))
 				}
 

--- a/go-controller/pkg/libovsdb/util/switch_test.go
+++ b/go-controller/pkg/libovsdb/util/switch_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	ovnutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
@@ -267,12 +268,12 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			var e error
 			if tc.setCfgHybridOvlyEnabled {
 				config.HybridOverlay.Enabled = true
-				if e = UpdateNodeSwitchExcludeIPs(nbClient, nodeName, ipnet); e != nil {
+				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, ipnet); e != nil {
 					t.Fatal(fmt.Errorf("failed to update NodeSwitchExcludeIPs with Hybrid Overlay enabled err: %v", e))
 				}
 				config.HybridOverlay.Enabled = false
 			} else {
-				if e = UpdateNodeSwitchExcludeIPs(nbClient, nodeName, ipnet); e != nil {
+				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, ipnet); e != nil {
 					t.Fatal(fmt.Errorf("failed to update NodeSwitchExcludeIPs with Hybrid Overlay disabled err: %v", e))
 				}
 

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -223,7 +223,7 @@ func (bnc *BaseNetworkController) createOvnClusterRouter() (*nbdb.LogicalRouter,
 	}
 
 	// Create a single common distributed router for the cluster.
-	logicalRouterName := bnc.GetNetworkScopedName(types.OVNClusterRouter)
+	logicalRouterName := bnc.GetNetworkScopedClusterRouterName()
 	logicalRouter := nbdb.LogicalRouter{
 		Name: logicalRouterName,
 		ExternalIDs: map[string]string{
@@ -284,7 +284,7 @@ func (bnc *BaseNetworkController) syncNodeClusterRouterPort(node *kapi.Node, hos
 	}
 
 	switchName := bnc.GetNetworkScopedName(node.Name)
-	logicalRouterName := bnc.GetNetworkScopedName(types.OVNClusterRouter)
+	logicalRouterName := bnc.GetNetworkScopedClusterRouterName()
 	lrpName := types.RouterToSwitchPrefix + switchName
 	lrpNetworks := []string{}
 	for _, hostSubnet := range hostSubnets {
@@ -432,7 +432,7 @@ func (bnc *BaseNetworkController) deleteNodeLogicalNetwork(nodeName string) erro
 		return fmt.Errorf("failed to delete logical switch %s: %v", switchName, err)
 	}
 
-	logicalRouterName := bnc.GetNetworkScopedName(types.OVNClusterRouter)
+	logicalRouterName := bnc.GetNetworkScopedClusterRouterName()
 	logicalRouter := nbdb.LogicalRouter{Name: logicalRouterName}
 	logicalRouterPort := nbdb.LogicalRouterPort{
 		Name: types.RouterToSwitchPrefix + switchName,

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -317,7 +317,7 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 	clusterLoadBalancerGroupUUID, switchLoadBalancerGroupUUID string) error {
 	// logical router port MAC is based on IPv4 subnet if there is one, else IPv6
 	var nodeLRPMAC net.HardwareAddr
-	switchName := bnc.GetNetworkScopedName(nodeName)
+	switchName := bnc.GetNetworkScopedSwitchName(nodeName)
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := util.GetNodeGatewayIfAddr(hostSubnet)
 		nodeLRPMAC = util.IPAddrToHWAddr(gwIfAddr.IP)

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -112,16 +112,16 @@ func (bnc *BaseNetworkController) deleteStaleLogicalSwitchPorts(expectedLogicalP
 		switchNames = make([]string, 0, len(nodes))
 		for _, n := range nodes {
 			// skip nodes that are not running ovnk (inferred from host subnets)
-			switchName := bnc.GetNetworkScopedName(n.Name)
+			switchName := bnc.GetNetworkScopedSwitchName(n.Name)
 			if bnc.lsManager.IsNonHostSubnetSwitch(switchName) {
 				continue
 			}
 			switchNames = append(switchNames, switchName)
 		}
 	} else if topoType == ovntypes.Layer2Topology {
-		switchNames = []string{bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch)}
+		switchNames = []string{bnc.GetNetworkScopedSwitchName(ovntypes.OVNLayer2Switch)}
 	} else if topoType == ovntypes.LocalnetTopology {
-		switchNames = []string{bnc.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch)}
+		switchNames = []string{bnc.GetNetworkScopedSwitchName(ovntypes.OVNLocalnetSwitch)}
 	} else {
 		return fmt.Errorf("topology type %s not supported", topoType)
 	}
@@ -405,11 +405,11 @@ func (bnc *BaseNetworkController) getExpectedSwitchName(pod *kapi.Pod) (string, 
 		topoType := bnc.TopologyType()
 		switch topoType {
 		case ovntypes.Layer3Topology:
-			switchName = bnc.GetNetworkScopedName(pod.Spec.NodeName)
+			switchName = bnc.GetNetworkScopedSwitchName(pod.Spec.NodeName)
 		case ovntypes.Layer2Topology:
-			switchName = bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch)
+			switchName = bnc.GetNetworkScopedSwitchName(ovntypes.OVNLayer2Switch)
 		case ovntypes.LocalnetTopology:
-			switchName = bnc.GetNetworkScopedName(ovntypes.OVNLocalnetSwitch)
+			switchName = bnc.GetNetworkScopedSwitchName(ovntypes.OVNLocalnetSwitch)
 		default:
 			return "", fmt.Errorf("topology type %s not supported", topoType)
 		}

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -22,6 +22,7 @@ import (
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 // Admin Policy Based Route services
@@ -182,7 +183,7 @@ func (c *ExternalGatewayMasterController) DelAllLegacyHybridRoutePolicies() erro
 
 // DeletePodSNAT exposes the function deletePodSNAT
 func (c *ExternalGatewayMasterController) DeletePodSNAT(nodeName string, extIPs, podIPNets []*net.IPNet) error {
-	return c.nbClient.deletePodSNAT(nodeName, extIPs, podIPNets)
+	return c.nbClient.deletePodSNAT(nodeName, util.GetGatewayRouterFromNode(nodeName), extIPs, podIPNets)
 }
 
 func (c *ExternalGatewayMasterController) GetAPBRoutePolicyStatus(policyName string) (*adminpolicybasedrouteapi.AdminPolicyBasedRouteStatus, error) {

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -219,7 +219,7 @@ func (nb *northBoundClient) deletePodSNAT(nodeName string, extIPs, podIPNets []*
 		return err
 	}
 	logicalRouter := nbdb.LogicalRouter{
-		Name: types.GWRouterPrefix + nodeName,
+		Name: util.GetGatewayRouterFromNode(nodeName),
 	}
 	err = libovsdbops.DeleteNATs(nb.nbClient, &logicalRouter, nats...)
 	if err != nil {

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -194,18 +194,18 @@ func (nb *northBoundClient) addGatewayIPs(pod *v1.Pod, egress *gateway_info.Gate
 	if config.Gateway.DisableSNATMultipleGWs {
 		// delete all perPodSNATs (if this pod was controlled by egressIP controller, it will stop working since
 		// a pod cannot be used for multiple-external-gateways and egressIPs at the same time)
-		if err := nb.deletePodSNAT(pod.Spec.NodeName, []*net.IPNet{}, podIPs); err != nil {
+		if err := nb.deletePodSNAT(pod.Spec.NodeName, util.GetGatewayRouterFromNode(pod.Spec.NodeName), []*net.IPNet{}, podIPs); err != nil {
 			klog.Error(err.Error())
 		}
 	}
 	podNsName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
-	return true, nb.addGWRoutesForPod(egress.Elems(), podIPs, podNsName, pod.Spec.NodeName)
+	return true, nb.addGWRoutesForPod(egress.Elems(), podIPs, podNsName, pod.Spec.NodeName, util.GetGatewayRouterFromNode(pod.Spec.NodeName))
 }
 
 // deletePodSNAT removes per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
 // if allSNATs flag is set, then all the SNATs (including against egressIPs if any) for that pod will be deleted
 // used when disableSNATMultipleGWs=true
-func (nb *northBoundClient) deletePodSNAT(nodeName string, extIPs, podIPNets []*net.IPNet) error {
+func (nb *northBoundClient) deletePodSNAT(nodeName, gwRouterName string, extIPs, podIPNets []*net.IPNet) error {
 	node, err := nb.nodeLister.Get(nodeName)
 	if err != nil {
 		return err
@@ -219,7 +219,7 @@ func (nb *northBoundClient) deletePodSNAT(nodeName string, extIPs, podIPNets []*
 		return err
 	}
 	logicalRouter := nbdb.LogicalRouter{
-		Name: util.GetGatewayRouterFromNode(nodeName),
+		Name: gwRouterName,
 	}
 	err = libovsdbops.DeleteNATs(nb.nbClient, &logicalRouter, nats...)
 	if err != nil {
@@ -229,7 +229,7 @@ func (nb *northBoundClient) deletePodSNAT(nodeName string, extIPs, podIPNets []*
 }
 
 // addEgressGwRoutesForPod handles adding all routes to gateways for a pod on a specific GR
-func (nb *northBoundClient) addGWRoutesForPod(gateways []*gateway_info.GatewayInfo, podIfAddrs []*net.IPNet, podNsName ktypes.NamespacedName, node string) error {
+func (nb *northBoundClient) addGWRoutesForPod(gateways []*gateway_info.GatewayInfo, podIfAddrs []*net.IPNet, podNsName ktypes.NamespacedName, node, gr string) error {
 	pod, err := nb.podLister.Pods(podNsName.Namespace).Get(podNsName.Name)
 	if err != nil {
 		return err
@@ -242,8 +242,6 @@ func (nb *northBoundClient) addGWRoutesForPod(gateways []*gateway_info.GatewayIn
 		klog.V(4).Infof("APB will not add exgw routes for pod %s not in the local zone %s", podNsName, nb.zone)
 		return nil
 	}
-
-	gr := util.GetGatewayRouterFromNode(node)
 
 	routesAdded := 0
 	portPrefix, err := nb.extSwitchPrefix(node)
@@ -416,9 +414,7 @@ func (nb *northBoundClient) createOrUpdateBFDStaticRoute(bfdEnabled bool, gw str
 	return nil
 }
 
-func (nb *northBoundClient) updateExternalGWInfoCacheForPodIPWithGatewayIP(podIP, gwIP, nodeName string, bfdEnabled bool, namespacedName ktypes.NamespacedName) error {
-	gr := util.GetGatewayRouterFromNode(nodeName)
-
+func (nb *northBoundClient) updateExternalGWInfoCacheForPodIPWithGatewayIP(podIP, gwIP, nodeName, gr string, bfdEnabled bool, namespacedName ktypes.NamespacedName) error {
 	return nb.externalGatewayRouteInfo.CreateOrLoad(namespacedName, func(routeInfo *RouteInfo) error {
 		// if route was already programmed, skip it
 		if foundGR, ok := routeInfo.PodExternalRoutes[podIP][gwIP]; ok && foundGR == gr {

--- a/go-controller/pkg/ovn/controller/apbroute/repair.go
+++ b/go-controller/pkg/ovn/controller/apbroute/repair.go
@@ -269,7 +269,8 @@ func (c *ExternalGatewayMasterController) processOVNRoute(ovnRoute *ovnRoute, gw
 				if noDbChanges {
 					return true
 				}
-				err := c.nbClient.updateExternalGWInfoCacheForPodIPWithGatewayIP(podIP, ovnRoute.nextHop, managedIPGWInfo.nodeName, gwInfo.BFDEnabled, managedIPGWInfo.namespacedName)
+				err := c.nbClient.updateExternalGWInfoCacheForPodIPWithGatewayIP(podIP, ovnRoute.nextHop, managedIPGWInfo.nodeName,
+					util.GetGatewayRouterFromNode(managedIPGWInfo.nodeName), gwInfo.BFDEnabled, managedIPGWInfo.namespacedName)
 				if err == nil {
 					return true
 				}

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -52,6 +52,9 @@ type DeleteLegacyDefaultNoRerouteNodePoliciesFunc func(libovsdbclient.Client, st
 type CreateDefaultRouteToExternalFunc func(nbClient libovsdbclient.Client, nodeName string) error
 
 type Controller struct {
+	// network information
+	util.NetInfo
+
 	controllerName string
 	client         kubernetes.Interface
 	nbClient       libovsdbclient.Client
@@ -112,6 +115,7 @@ type nodeState struct {
 }
 
 func NewController(
+	netInfo util.NetInfo,
 	controllerName string,
 	client kubernetes.Interface,
 	nbClient libovsdbclient.Client,
@@ -129,6 +133,7 @@ func NewController(
 	klog.Info("Setting up event handlers for Egress Services")
 
 	c := &Controller{
+		NetInfo:                                  netInfo,
 		controllerName:                           controllerName,
 		client:                                   client,
 		nbClient:                                 nbClient,

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -461,10 +461,10 @@ func (c *Controller) repair() error {
 
 	errorList := []error{}
 	ops := []libovsdb.Operation{}
-	ops, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, ops, ovntypes.OVNClusterRouter, lrpPredicate)
+	ops, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, ops, c.GetNetworkScopedClusterRouterName(), lrpPredicate)
 	if err != nil {
 		errorList = append(errorList,
-			fmt.Errorf("failed to create ops for deleting stale logical router policies from router %s: %v", ovntypes.OVNClusterRouter, err))
+			fmt.Errorf("failed to create ops for deleting stale logical router policies from router %s: %v", c.GetNetworkScopedClusterRouterName(), err))
 	}
 
 	if config.OVNKubernetesFeature.EnableInterconnect {
@@ -532,10 +532,10 @@ func (c *Controller) repair() error {
 			svcKeyToRemoteConfiguredV6Endpoints[svcKey] = append(svcKeyToLocalConfiguredV6Endpoints[svcKey], logicalIP)
 			return false
 		}
-		ops, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, ops, ovntypes.OVNClusterRouter, lrpICPredicate)
+		ops, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, ops, c.GetNetworkScopedClusterRouterName(), lrpICPredicate)
 		if err != nil {
 			errorList = append(errorList,
-				fmt.Errorf("failed to create ops for deleting stale logical router policies from router %s: %v", ovntypes.OVNClusterRouter, err))
+				fmt.Errorf("failed to create ops for deleting stale logical router policies from router %s: %v", c.GetNetworkScopedClusterRouterName(), err))
 		}
 	}
 
@@ -886,7 +886,7 @@ func (c *Controller) clearServiceResourcesAndRequeue(key string, svcState *svcSt
 	}
 
 	deleteOps := []libovsdb.Operation{}
-	deleteOps, err := libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, deleteOps, ovntypes.OVNClusterRouter, p)
+	deleteOps, err := libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, deleteOps, c.GetNetworkScopedClusterRouterName(), p)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -49,7 +49,7 @@ type InitClusterEgressPoliciesFunc func(client libovsdbclient.Client, addressSet
 type EnsureNoRerouteNodePoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
 	controllerName string, nodeLister corelisters.NodeLister) error
 type DeleteLegacyDefaultNoRerouteNodePoliciesFunc func(libovsdbclient.Client, string) error
-type CreateDefaultRouteToExternalFunc func(nbClient libovsdbclient.Client, nodeName string) error
+type CreateDefaultRouteToExternalFunc func(nbClient libovsdbclient.Client, clusterRouter, nodeName string) error
 
 type Controller struct {
 	// network information

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -49,7 +49,7 @@ type InitClusterEgressPoliciesFunc func(client libovsdbclient.Client, addressSet
 type EnsureNoRerouteNodePoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
 	controllerName, clusterRouter string, nodeLister corelisters.NodeLister) error
 type DeleteLegacyDefaultNoRerouteNodePoliciesFunc func(nbClient libovsdbclient.Client, clusterRouter, nodeName string) error
-type CreateDefaultRouteToExternalFunc func(nbClient libovsdbclient.Client, clusterRouter, nodeName string) error
+type CreateDefaultRouteToExternalFunc func(nbClient libovsdbclient.Client, clusterRouter, gwRouterName string) error
 
 type Controller struct {
 	// network information

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -45,10 +45,10 @@ const (
 )
 
 type InitClusterEgressPoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-	controllerName string) error
+	controllerName, clusterRouter string) error
 type EnsureNoRerouteNodePoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-	controllerName string, nodeLister corelisters.NodeLister) error
-type DeleteLegacyDefaultNoRerouteNodePoliciesFunc func(libovsdbclient.Client, string) error
+	controllerName, clusterRouter string, nodeLister corelisters.NodeLister) error
+type DeleteLegacyDefaultNoRerouteNodePoliciesFunc func(nbClient libovsdbclient.Client, clusterRouter, nodeName string) error
 type CreateDefaultRouteToExternalFunc func(nbClient libovsdbclient.Client, clusterRouter, nodeName string) error
 
 type Controller struct {
@@ -231,7 +231,7 @@ func (c *Controller) Run(wg *sync.WaitGroup, threadiness int) error {
 		klog.Errorf("Failed to repair Egress Services entries: %v", err)
 	}
 
-	err = c.initClusterEgressPolicies(c.nbClient, c.addressSetFactory, c.controllerName)
+	err = c.initClusterEgressPolicies(c.nbClient, c.addressSetFactory, c.controllerName, c.GetNetworkScopedClusterRouterName())
 	if err != nil {
 		klog.Errorf("Failed to init Egress Services cluster policies: %v", err)
 	}

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_node.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_node.go
@@ -156,7 +156,7 @@ func (c *Controller) syncNode(key string) error {
 
 	// At this point the node exists and is ready
 	if config.OVNKubernetesFeature.EnableInterconnect && c.zone != types.OvnDefaultZone && c.isNodeInLocalZone(n) {
-		if err := c.createDefaultRouteToExternalForIC(c.nbClient, nodeName); err != nil {
+		if err := c.createDefaultRouteToExternalForIC(c.nbClient, c.GetNetworkScopedClusterRouterName(), nodeName); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_node.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_node.go
@@ -123,13 +123,13 @@ func (c *Controller) syncNode(key string) error {
 		delete(c.nodesZoneState, nodeName)
 	}
 
-	if err := c.deleteLegacyDefaultNoRerouteNodePolicies(c.nbClient, nodeName); err != nil {
+	if err := c.deleteLegacyDefaultNoRerouteNodePolicies(c.nbClient, c.GetNetworkScopedClusterRouterName(), nodeName); err != nil {
 		return err
 	}
 
 	// We ensure node no re-route policies contemplating possible node IP
 	// address changes regardless of allocated services.
-	err = c.ensureNoRerouteNodePolicies(c.nbClient, c.addressSetFactory, c.controllerName, c.nodeLister)
+	err = c.ensureNoRerouteNodePolicies(c.nbClient, c.addressSetFactory, c.controllerName, c.GetNetworkScopedClusterRouterName(), c.nodeLister)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_node.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_node.go
@@ -156,7 +156,7 @@ func (c *Controller) syncNode(key string) error {
 
 	// At this point the node exists and is ready
 	if config.OVNKubernetesFeature.EnableInterconnect && c.zone != types.OvnDefaultZone && c.isNodeInLocalZone(n) {
-		if err := c.createDefaultRouteToExternalForIC(c.nbClient, c.GetNetworkScopedClusterRouterName(), nodeName); err != nil {
+		if err := c.createDefaultRouteToExternalForIC(c.nbClient, c.GetNetworkScopedClusterRouterName(), c.GetNetworkScopedGWRouterName(nodeName)); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_service.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_service.go
@@ -250,7 +250,7 @@ func (c *Controller) createOrUpdateLogicalRouterPoliciesOps(key, v4MgmtIP, v6Mgm
 			return item.Match == lrp.Match && item.Priority == lrp.Priority && item.ExternalIDs[svcExternalIDKey] == key
 		}
 
-		allOps, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(c.nbClient, allOps, ovntypes.OVNClusterRouter, lrp, p)
+		allOps, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(c.nbClient, allOps, c.GetNetworkScopedClusterRouterName(), lrp, p)
 		if err != nil {
 			return nil, err
 		}
@@ -270,7 +270,7 @@ func (c *Controller) createOrUpdateLogicalRouterPoliciesOps(key, v4MgmtIP, v6Mgm
 			return item.Match == lrp.Match && item.Priority == lrp.Priority && item.ExternalIDs[svcExternalIDKey] == key
 		}
 
-		allOps, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(c.nbClient, allOps, ovntypes.OVNClusterRouter, lrp, p)
+		allOps, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(c.nbClient, allOps, c.GetNetworkScopedClusterRouterName(), lrp, p)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +291,7 @@ func (c *Controller) deleteLogicalRouterPoliciesOps(key string, v4Endpoints, v6E
 			return item.Match == match && item.Priority == ovntypes.EgressSVCReroutePriority && item.ExternalIDs[svcExternalIDKey] == key
 		}
 
-		allOps, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, allOps, ovntypes.OVNClusterRouter, p)
+		allOps, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, allOps, c.GetNetworkScopedClusterRouterName(), p)
 		if err != nil {
 			return nil, err
 		}
@@ -303,7 +303,7 @@ func (c *Controller) deleteLogicalRouterPoliciesOps(key string, v4Endpoints, v6E
 			return item.Match == match && item.Priority == ovntypes.EgressSVCReroutePriority && item.ExternalIDs[svcExternalIDKey] == key
 		}
 
-		allOps, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, allOps, ovntypes.OVNClusterRouter, p)
+		allOps, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, allOps, c.GetNetworkScopedClusterRouterName(), p)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -211,6 +211,7 @@ func newDefaultNetworkControllerCommon(cnci *CommonNetworkControllerInfo,
 		},
 		externalGatewayRouteInfo: apbExternalRouteController.ExternalGWRouteInfoCache,
 		eIPC: egressIPZoneController{
+			NetInfo:            &util.DefaultNetInfo{},
 			nodeUpdateMutex:    &sync.Mutex{},
 			podAssignmentMutex: &sync.Mutex{},
 			podAssignment:      make(map[string]*podAssignmentState),

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -189,9 +189,9 @@ func (oc *DefaultNetworkController) deleteStaleACLs() error {
 	p := func(item *nbdb.LogicalRouterPolicy) bool {
 		return item.Priority <= types.EgressFirewallStartPriority && item.Priority >= types.MinimumReservedEgressFirewallPriority
 	}
-	err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, types.OVNClusterRouter, p)
+	err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), p)
 	if err != nil {
-		return fmt.Errorf("error deleting egress firewall policies on router %s: %v", types.OVNClusterRouter, err)
+		return fmt.Errorf("error deleting egress firewall policies on router %s: %v", oc.GetNetworkScopedClusterRouterName(), err)
 	}
 
 	// delete acls from all switches, they reside on the port group now

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -744,10 +744,10 @@ func (oc *DefaultNetworkController) addHybridRoutePolicyForPod(podIP net.IP, nod
 		p := func(item *nbdb.LogicalRouterPolicy) bool {
 			return item.Priority == logicalRouterPolicy.Priority && strings.Contains(item.Match, matchSrcAS)
 		}
-		err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(oc.nbClient, types.OVNClusterRouter,
+		err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(),
 			&logicalRouterPolicy, p, &logicalRouterPolicy.Nexthops, &logicalRouterPolicy.Match, &logicalRouterPolicy.Action)
 		if err != nil {
-			return fmt.Errorf("failed to add policy route %+v to %s: %v", logicalRouterPolicy, types.OVNClusterRouter, err)
+			return fmt.Errorf("failed to add policy route %+v to %s: %v", logicalRouterPolicy, oc.GetNetworkScopedClusterRouterName(), err)
 		}
 	}
 	return nil
@@ -809,9 +809,9 @@ func (oc *DefaultNetworkController) delHybridRoutePolicyForPod(podIP net.IP, nod
 			p := func(item *nbdb.LogicalRouterPolicy) bool {
 				return item.Priority == types.HybridOverlayReroutePriority && item.Match == matchStr
 			}
-			err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, types.OVNClusterRouter, p)
+			err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), p)
 			if err != nil {
-				return fmt.Errorf("error deleting policy %s on router %s: %v", matchStr, types.OVNClusterRouter, err)
+				return fmt.Errorf("error deleting policy %s on router %s: %v", matchStr, oc.GetNetworkScopedClusterRouterName(), err)
 			}
 		}
 		if len(ipv4PodIPs) == 0 && len(ipv6PodIPs) == 0 {
@@ -834,9 +834,9 @@ func (oc *DefaultNetworkController) delAllHybridRoutePolicies() error {
 	policyPred := func(item *nbdb.LogicalRouterPolicy) bool {
 		return item.Priority == types.HybridOverlayReroutePriority
 	}
-	err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, types.OVNClusterRouter, policyPred)
+	err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), policyPred)
 	if err != nil {
-		return fmt.Errorf("error deleting hybrid route policies on %s: %v", types.OVNClusterRouter, err)
+		return fmt.Errorf("error deleting hybrid route policies on %s: %v", oc.GetNetworkScopedClusterRouterName(), err)
 	}
 
 	// nuke all the address-sets.
@@ -865,9 +865,9 @@ func (oc *DefaultNetworkController) delAllLegacyHybridRoutePolicies() error {
 		}
 		return true
 	}
-	err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, types.OVNClusterRouter, p)
+	err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), p)
 	if err != nil {
-		return fmt.Errorf("error deleting legacy hybrid route policies on %s: %v", types.OVNClusterRouter, err)
+		return fmt.Errorf("error deleting legacy hybrid route policies on %s: %v", oc.GetNetworkScopedClusterRouterName(), err)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -580,14 +580,14 @@ func (oc *DefaultNetworkController) deletePodSNAT(nodeName string, extIPs, podIP
 		klog.V(4).Infof("Node %s is not in the local zone %s", nodeName, oc.zone)
 		return nil
 	}
-	ops, err := deletePodSNATOps(oc.nbClient, nil, nodeName, extIPs, podIPNets)
+	ops, err := deletePodSNATOps(oc.nbClient, nil, oc.GetNetworkScopedGWRouterName(nodeName), extIPs, podIPNets)
 	if err != nil {
 		return err
 	}
 
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
 	if err != nil {
-		return fmt.Errorf("failed to delete SNAT rule for pod on gateway router %s: %w", types.GWRouterPrefix+nodeName, err)
+		return fmt.Errorf("failed to delete SNAT rule for pod on gateway router %s: %w", oc.GetNetworkScopedGWRouterName(nodeName), err)
 	}
 	return nil
 }
@@ -630,13 +630,13 @@ func getExternalIPsGR(watchFactory *factory.WatchFactory, nodeName string) ([]*n
 
 // deletePodSNATOps creates ovsdb operation that removes per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
 // used when disableSNATMultipleGWs=true
-func deletePodSNATOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, nodeName string, extIPs, podIPNets []*net.IPNet) ([]ovsdb.Operation, error) {
+func deletePodSNATOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, gwRouterName string, extIPs, podIPNets []*net.IPNet) ([]ovsdb.Operation, error) {
 	nats, err := buildPodSNAT(extIPs, podIPNets)
 	if err != nil {
 		return nil, err
 	}
 	logicalRouter := nbdb.LogicalRouter{
-		Name: types.GWRouterPrefix + nodeName,
+		Name: gwRouterName,
 	}
 	ops, err = libovsdbops.DeleteNATsOps(nbClient, ops, &logicalRouter, nats...)
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
@@ -647,13 +647,13 @@ func deletePodSNATOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, nod
 
 // addOrUpdatePodSNAT adds or updates per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
 // used when disableSNATMultipleGWs=true
-func addOrUpdatePodSNAT(nbClient libovsdbclient.Client, nodeName string, extIPs, podIfAddrs []*net.IPNet) error {
+func addOrUpdatePodSNAT(nbClient libovsdbclient.Client, gwRouterName string, extIPs, podIfAddrs []*net.IPNet) error {
 	nats, err := buildPodSNAT(extIPs, podIfAddrs)
 	if err != nil {
 		return err
 	}
 	logicalRouter := nbdb.LogicalRouter{
-		Name: types.GWRouterPrefix + nodeName,
+		Name: gwRouterName,
 	}
 	if err := libovsdbops.CreateOrUpdateNATs(nbClient, &logicalRouter, nats...); err != nil {
 		return fmt.Errorf("failed to update SNAT for pods of router %s: %v", logicalRouter.Name, err)
@@ -664,15 +664,14 @@ func addOrUpdatePodSNAT(nbClient libovsdbclient.Client, nodeName string, extIPs,
 // addOrUpdatePodSNATOps returns the operation that adds or updates per pod SNAT rules towards the nodeIP that are
 // applied to the GR where the pod resides
 // used when disableSNATMultipleGWs=true
-func addOrUpdatePodSNATOps(nbClient libovsdbclient.Client, nodeName string, extIPs, podIfAddrs []*net.IPNet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
-	gr := types.GWRouterPrefix + nodeName
-	router := &nbdb.LogicalRouter{Name: gr}
+func addOrUpdatePodSNATOps(nbClient libovsdbclient.Client, gwRouterName string, extIPs, podIfAddrs []*net.IPNet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+	router := &nbdb.LogicalRouter{Name: gwRouterName}
 	nats, err := buildPodSNAT(extIPs, podIfAddrs)
 	if err != nil {
 		return nil, err
 	}
 	if ops, err = libovsdbops.CreateOrUpdateNATsOps(nbClient, ops, router, nats...); err != nil {
-		return nil, fmt.Errorf("failed to update SNAT for pods of router: %s, error: %v", gr, err)
+		return nil, fmt.Errorf("failed to update SNAT for pods of router: %s, error: %v", gwRouterName, err)
 	}
 	return ops, nil
 }
@@ -708,7 +707,7 @@ func (oc *DefaultNetworkController) addHybridRoutePolicyForPod(podIP net.IP, nod
 		}
 
 		// get the GR to join switch ip address
-		grJoinIfAddrs, err := libovsdbutil.GetLRPAddrs(oc.nbClient, types.GWRouterToJoinSwitchPrefix+types.GWRouterPrefix+node)
+		grJoinIfAddrs, err := libovsdbutil.GetLRPAddrs(oc.nbClient, types.GWRouterToJoinSwitchPrefix+oc.GetNetworkScopedGWRouterName(node))
 		if err != nil {
 			return fmt.Errorf("unable to find IP address for node: %s, %s port, err: %v", node, types.GWRouterToJoinSwitchPrefix, err)
 		}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -498,7 +498,7 @@ func (oc *DefaultNetworkController) addGWRoutesForPod(gateways []*gatewayInfo, p
 		return nil
 	}
 
-	gr := util.GetGatewayRouterFromNode(node)
+	gr := oc.GetNetworkScopedGWRouterName(node)
 
 	routesAdded := 0
 	portPrefix, err := oc.extSwitchPrefix(node)

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -3072,7 +3072,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 				_, fullMaskPodNet, _ := net.ParseCIDR("10.128.1.3/32")
 				gomega.Expect(
-					addOrUpdatePodSNAT(fakeOvn.controller.nbClient, pod[0].Spec.NodeName, extIPs, []*net.IPNet{fullMaskPodNet}),
+					addOrUpdatePodSNAT(fakeOvn.controller.nbClient, util.GetGatewayRouterFromNode(pod[0].Spec.NodeName), extIPs, []*net.IPNet{fullMaskPodNet}),
 				).To(gomega.Succeed())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1659,7 +1659,7 @@ func (e *egressIPZoneController) addExternalGWPodSNATOps(ops []ovsdb.Operation, 
 			if err != nil {
 				return nil, err
 			}
-			ops, err = addOrUpdatePodSNATOps(e.nbClient, pod.Spec.NodeName, extIPs, podIPs, ops)
+			ops, err = addOrUpdatePodSNATOps(e.nbClient, e.GetNetworkScopedGWRouterName(pod.Spec.NodeName), extIPs, podIPs, ops)
 			if err != nil {
 				return nil, err
 			}
@@ -1678,7 +1678,7 @@ func (e *egressIPZoneController) deleteExternalGWPodSNATOps(ops []ovsdb.Operatio
 		if err != nil {
 			return nil, err
 		}
-		ops, err = deletePodSNATOps(e.nbClient, ops, pod.Spec.NodeName, extIPs, podIPs)
+		ops, err = deletePodSNATOps(e.nbClient, ops, e.GetNetworkScopedGWRouterName(pod.Spec.NodeName), extIPs, podIPs)
 		if err != nil {
 			return nil, err
 		}
@@ -1690,7 +1690,7 @@ func (e *egressIPZoneController) deleteExternalGWPodSNATOps(ops []ovsdb.Operatio
 }
 
 func (e *egressIPZoneController) getGatewayRouterJoinIP(node string, wantsIPv6 bool) (net.IP, error) {
-	gatewayIPs, err := libovsdbutil.GetLRPAddrs(e.nbClient, types.GWRouterToJoinSwitchPrefix+types.GWRouterPrefix+node)
+	gatewayIPs, err := libovsdbutil.GetLRPAddrs(e.nbClient, types.GWRouterToJoinSwitchPrefix+e.GetNetworkScopedGWRouterName(node))
 	if err != nil {
 		return nil, fmt.Errorf("attempt at finding node gateway router network information failed, err: %w", err)
 	}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1285,7 +1285,7 @@ func (oc *DefaultNetworkController) addEgressNode(node *v1.Node) error {
 			// NOTE3: When the node gets deleted we do not remove this route intentionally because
 			// on IC if the node is gone, then the ovn_cluster_router is also gone along with all
 			// the routes on it.
-			if err := libovsdbutil.CreateDefaultRouteToExternal(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), node.Name); err != nil {
+			if err := libovsdbutil.CreateDefaultRouteToExternal(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), oc.GetNetworkScopedGWRouterName(node.Name)); err != nil {
 				return err
 			}
 		}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2096,12 +2096,13 @@ func (oc *DefaultNetworkController) ensureDefaultNoRerouteQoSRules(nodeName stri
 		}
 	}
 	if len(existingQoSes) > 0 {
+		nodeSwitchName := oc.GetNetworkScopedSwitchName(nodeName)
 		if qosExists {
 			// check if these rules were already added to the existing switch or not
 			addQoSToSwitch := false
-			nodeSwitch, err := libovsdbops.GetLogicalSwitch(oc.nbClient, &nbdb.LogicalSwitch{Name: nodeName})
+			nodeSwitch, err := libovsdbops.GetLogicalSwitch(oc.nbClient, &nbdb.LogicalSwitch{Name: nodeSwitchName})
 			if err != nil {
-				return fmt.Errorf("cannot fetch switch for node %s: %v", nodeName, err)
+				return fmt.Errorf("cannot fetch switch for node %s: %v", nodeSwitchName, err)
 			}
 			for _, qos := range existingQoSes {
 				if slices.Contains(nodeSwitch.QOSRules, qos.UUID) {
@@ -2115,7 +2116,7 @@ func (oc *DefaultNetworkController) ensureDefaultNoRerouteQoSRules(nodeName stri
 				return nil
 			}
 		}
-		ops, err = libovsdbops.AddQoSesToLogicalSwitchOps(oc.nbClient, ops, nodeName, existingQoSes...)
+		ops, err = libovsdbops.AddQoSesToLogicalSwitchOps(oc.nbClient, ops, nodeSwitchName, existingQoSes...)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1917,7 +1917,7 @@ func (e *egressIPZoneController) deleteEgressIPStatusSetup(name string, status e
 
 	var nats []*nbdb.NAT
 	if loadedEgressNode && isLocalZoneEgressNode {
-		routerName := util.GetGatewayRouterFromNode(status.Node)
+		routerName := e.GetNetworkScopedGWRouterName(status.Node)
 		natPred := func(nat *nbdb.NAT) bool {
 			// We should delete NATs only from the status.Node that was passed into this function
 			return nat.ExternalIDs["name"] == name && nat.ExternalIP == status.EgressIP && nat.LogicalPort != nil && *nat.LogicalPort == e.GetNetworkScopedK8sMgmtIntfName(status.Node)
@@ -2266,7 +2266,7 @@ func (e *egressIPZoneController) createNATRuleOps(ops []ovsdb.Operation, podIPs 
 		}
 	}
 	router := &nbdb.LogicalRouter{
-		Name: util.GetGatewayRouterFromNode(status.Node),
+		Name: e.GetNetworkScopedGWRouterName(status.Node),
 	}
 	ops, err = libovsdbops.CreateOrUpdateNATsOps(e.nbClient, ops, router, nats...)
 	if err != nil {
@@ -2289,7 +2289,7 @@ func (e *egressIPZoneController) deleteNATRuleOps(ops []ovsdb.Operation, podIPs 
 		}
 	}
 	router := &nbdb.LogicalRouter{
-		Name: util.GetGatewayRouterFromNode(status.Node),
+		Name: e.GetNetworkScopedGWRouterName(status.Node),
 	}
 	ops, err = libovsdbops.DeleteNATsOps(e.nbClient, ops, router, nats...)
 	if err != nil {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1285,7 +1285,7 @@ func (oc *DefaultNetworkController) addEgressNode(node *v1.Node) error {
 			// NOTE3: When the node gets deleted we do not remove this route intentionally because
 			// on IC if the node is gone, then the ovn_cluster_router is also gone along with all
 			// the routes on it.
-			if err := libovsdbutil.CreateDefaultRouteToExternal(oc.nbClient, node.Name); err != nil {
+			if err := libovsdbutil.CreateDefaultRouteToExternal(oc.nbClient, types.OVNClusterRouter, node.Name); err != nil {
 				return err
 			}
 		}

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -660,7 +660,7 @@ func (oc *DefaultNetworkController) egressQoSSwitches() ([]string, error) {
 	// Find all node switches
 	p := func(item *nbdb.LogicalSwitch) bool {
 		// Ignore external and Join switches(both legacy and current)
-		return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == types.OVNJoinSwitch || item.Name == types.TransitSwitch || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
+		return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || oc.RemoveNetworkScopeFromName(item.Name) == types.OVNJoinSwitch || item.Name == types.TransitSwitch || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
 	}
 
 	nodeLocalSwitches, err := libovsdbops.FindLogicalSwitchesWithPredicate(oc.nbClient, p)

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -1020,7 +1020,7 @@ func (oc *DefaultNetworkController) syncEgressQoSNode(key string) error {
 	klog.V(5).Infof("EgressQoS %s node retrieved from lister: %v", n.Name, n)
 
 	nodeSw := &nbdb.LogicalSwitch{
-		Name: n.Name,
+		Name: oc.GetNetworkScopedSwitchName(n.Name),
 	}
 	nodeSw, err = libovsdbops.GetLogicalSwitch(oc.nbClient, nodeSw)
 	if err != nil {

--- a/go-controller/pkg/ovn/external_gateway_apb_test.go
+++ b/go-controller/pkg/ovn/external_gateway_apb_test.go
@@ -3097,7 +3097,7 @@ var _ = ginkgo.Describe("OVN for APB External Route Operations", func() {
 
 				_, fullMaskPodNet, _ := net.ParseCIDR("10.128.1.3/32")
 				gomega.Expect(
-					addOrUpdatePodSNAT(fakeOvn.controller.nbClient, pod[0].Spec.NodeName, extIPs, []*net.IPNet{fullMaskPodNet}),
+					addOrUpdatePodSNAT(fakeOvn.controller.nbClient, util.GetGatewayRouterFromNode(pod[0].Spec.NodeName), extIPs, []*net.IPNet{fullMaskPodNet}),
 				).To(gomega.Succeed())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{

--- a/go-controller/pkg/ovn/gateway/gateway.go
+++ b/go-controller/pkg/ovn/gateway/gateway.go
@@ -63,9 +63,8 @@ func GetGatewayPhysicalIPs(nbClient libovsdbclient.Client, gatewayRouter string)
 
 // CreateDummyGWMacBindings creates mac bindings (ipv4 and ipv6) for a fake next hops
 // used by host->service traffic
-func CreateDummyGWMacBindings(nbClient libovsdbclient.Client, nodeName string) error {
-	nodeGWRouter := util.GetGatewayRouterFromNode(nodeName)
-	logicalPort := ovntypes.GWRouterToExtSwitchPrefix + nodeGWRouter
+func CreateDummyGWMacBindings(nbClient libovsdbclient.Client, gwRouterName string) error {
+	logicalPort := ovntypes.GWRouterToExtSwitchPrefix + gwRouterName
 	dummyNextHopIPs := node.DummyNextHopIPs()
 	smbs := make([]*nbdb.StaticMACBinding, len(dummyNextHopIPs))
 	for i := range dummyNextHopIPs {
@@ -81,7 +80,7 @@ func CreateDummyGWMacBindings(nbClient libovsdbclient.Client, nodeName string) e
 	if err := libovsdbops.CreateOrUpdateStaticMacBinding(nbClient, smbs...); err != nil {
 		return fmt.Errorf(
 			"failed to create MAC Binding for dummy nexthop %s: %v",
-			nodeName,
+			gwRouterName,
 			err)
 	}
 
@@ -90,9 +89,8 @@ func CreateDummyGWMacBindings(nbClient libovsdbclient.Client, nodeName string) e
 
 // DeleteDummyGWMacBindings removes mac bindings (ipv4 and ipv6) for a fake next hops
 // used by host->service traffic
-func DeleteDummyGWMacBindings(nbClient libovsdbclient.Client, nodeName string) error {
-	nodeGWRouter := util.GetGatewayRouterFromNode(nodeName)
-	logicalPort := ovntypes.GWRouterToExtSwitchPrefix + nodeGWRouter
+func DeleteDummyGWMacBindings(nbClient libovsdbclient.Client, gwRouterName string) error {
+	logicalPort := ovntypes.GWRouterToExtSwitchPrefix + gwRouterName
 	dummyNextHopIPs := node.DummyNextHopIPs()
 	smbs := make([]*nbdb.StaticMACBinding, len(dummyNextHopIPs))
 	for i := range dummyNextHopIPs {

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -21,7 +21,7 @@ import (
 
 // gatewayCleanup removes all the NB DB objects created for a node's gateway
 func (oc *DefaultNetworkController) gatewayCleanup(nodeName string) error {
-	gatewayRouter := types.GWRouterPrefix + nodeName
+	gatewayRouter := oc.GetNetworkScopedGWRouterName(nodeName)
 
 	// Get the gateway router port's IP address (connected to join switch)
 	var nextHops []net.IP

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -69,13 +69,13 @@ func (oc *DefaultNetworkController) gatewayCleanup(nodeName string) error {
 	}
 
 	// Remove external switch
-	externalSwitch := types.ExternalSwitchPrefix + nodeName
+	externalSwitch := oc.GetNetworkScopedExtSwitchName(nodeName)
 	err = libovsdbops.DeleteLogicalSwitch(oc.nbClient, externalSwitch)
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return fmt.Errorf("failed to delete external switch %s: %w", externalSwitch, err)
 	}
 
-	exGWexternalSwitch := types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeName
+	exGWexternalSwitch := types.EgressGWSwitchPrefix + externalSwitch
 	err = libovsdbops.DeleteLogicalSwitch(oc.nbClient, exGWexternalSwitch)
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return fmt.Errorf("failed to delete external switch %s: %w", exGWexternalSwitch, err)

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -57,7 +57,7 @@ func (oc *DefaultNetworkController) gatewayCleanup(nodeName string) error {
 	}
 
 	// Remove the static mac bindings of the gateway router
-	err = gateway.DeleteDummyGWMacBindings(oc.nbClient, nodeName)
+	err = gateway.DeleteDummyGWMacBindings(oc.nbClient, gatewayRouter)
 	if err != nil {
 		return fmt.Errorf("failed to delete GR dummy mac bindings for node %s: %w", nodeName, err)
 	}

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -40,10 +40,10 @@ func (oc *DefaultNetworkController) gatewayCleanup(nodeName string) error {
 	// Remove the patch port that connects join switch to gateway router
 	portName := types.JoinSwitchToGWRouterPrefix + gatewayRouter
 	lsp := nbdb.LogicalSwitchPort{Name: portName}
-	sw := nbdb.LogicalSwitch{Name: types.OVNJoinSwitch}
+	sw := nbdb.LogicalSwitch{Name: oc.GetNetworkScopedJoinSwitchName()}
 	err = libovsdbops.DeleteLogicalSwitchPorts(oc.nbClient, &sw, &lsp)
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
-		return fmt.Errorf("failed to delete logical switch port %s from switch %s: %w", portName, types.OVNJoinSwitch, err)
+		return fmt.Errorf("failed to delete logical switch port %s from switch %s: %w", portName, sw.Name, err)
 	}
 
 	// Remove the logical router port on the gateway router that connects to the join switch

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -90,7 +90,7 @@ func (oc *DefaultNetworkController) delPbrAndNatRules(nodeName string, lrpTypes 
 	// delete the dnat_and_snat entry that we added for the management port IP
 	// Note: we don't need to delete any MAC bindings that are dynamically learned from OVN SB DB
 	// because there will be none since this NAT is only for outbound traffic and not for inbound
-	mgmtPortName := types.K8sPrefix + nodeName
+	mgmtPortName := oc.GetNetworkScopedK8sMgmtIntfName(nodeName)
 	nat := libovsdbops.BuildDNATAndSNAT(nil, nil, mgmtPortName, "", nil)
 	logicalRouter := nbdb.LogicalRouter{
 		Name: types.OVNClusterRouter,

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -93,7 +93,7 @@ func (oc *DefaultNetworkController) delPbrAndNatRules(nodeName string, lrpTypes 
 	mgmtPortName := oc.GetNetworkScopedK8sMgmtIntfName(nodeName)
 	nat := libovsdbops.BuildDNATAndSNAT(nil, nil, mgmtPortName, "", nil)
 	logicalRouter := nbdb.LogicalRouter{
-		Name: types.OVNClusterRouter,
+		Name: oc.GetNetworkScopedClusterRouterName(),
 	}
 	err := libovsdbops.DeleteNATs(oc.nbClient, &logicalRouter, nat)
 	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -575,7 +575,7 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 	// and add external interface as a logical port to external_switch.
 	// This is a learning switch port with "unknown" address. The external
 	// world is accessed via this port.
-	externalSwitch := externalSwitchName(prefix, nodeName)
+	externalSwitch := prefix + oc.GetNetworkScopedExtSwitchName(nodeName)
 	externalLogicalSwitchPort := nbdb.LogicalSwitchPort{
 		Addresses: []string{"unknown"},
 		Type:      "localnet",
@@ -780,8 +780,4 @@ func (oc *DefaultNetworkController) deletePolicyBasedRoutes(policyID, priority s
 	}
 
 	return nil
-}
-
-func externalSwitchName(prefix string, nodeName string) string {
-	return fmt.Sprintf("%s%s%s", prefix, types.ExternalSwitchPrefix, nodeName)
 }

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -49,11 +49,11 @@ func (oc *DefaultNetworkController) cleanupStalePodSNATs(nodeName string, nodeIP
 			nodeName, err)
 	}
 	gatewayRouter := nbdb.LogicalRouter{
-		Name: types.GWRouterPrefix + nodeName,
+		Name: oc.GetNetworkScopedGWRouterName(nodeName),
 	}
 	routerNats, err := libovsdbops.GetRouterNATs(oc.nbClient, &gatewayRouter)
 	if err != nil && errors.Is(err, libovsdbclient.ErrNotFound) {
-		return fmt.Errorf("unable to get NAT entries for router on node %s: %w", nodeName, err)
+		return fmt.Errorf("unable to get NAT entries for router %s on node %s: %w", gatewayRouter.Name, nodeName, err)
 	}
 	podIPsOnNode := sets.NewString() // collects all podIPs on node
 	for _, pod := range pods {
@@ -120,7 +120,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 	}
 
 	// Create a gateway router.
-	gatewayRouter := types.GWRouterPrefix + nodeName
+	gatewayRouter := oc.GetNetworkScopedGWRouterName(nodeName)
 	physicalIPs := make([]string, len(l3GatewayConfig.IPAddresses))
 	for i, ip := range l3GatewayConfig.IPAddresses {
 		physicalIPs[i] = ip.IP.String()

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -290,7 +290,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 
 	nextHops := l3GatewayConfig.NextHops
 
-	if err := gateway.CreateDummyGWMacBindings(oc.nbClient, nodeName); err != nil {
+	if err := gateway.CreateDummyGWMacBindings(oc.nbClient, gatewayRouter); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -194,10 +194,10 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 			"router-port": gwRouterPort,
 		},
 	}
-	sw := nbdb.LogicalSwitch{Name: types.OVNJoinSwitch}
+	sw := nbdb.LogicalSwitch{Name: oc.GetNetworkScopedJoinSwitchName()}
 	err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(oc.nbClient, &sw, &logicalSwitchPort)
 	if err != nil {
-		return fmt.Errorf("failed to create port %v on logical switch %q: %v", gwSwitchPort, types.OVNJoinSwitch, err)
+		return fmt.Errorf("failed to create port %v on logical switch %q: %v", gwSwitchPort, sw.Name, err)
 	}
 
 	gwLRPMAC := util.IPAddrToHWAddr(gwLRPIPs[0])

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -357,9 +357,9 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 				libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 		}
 		err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
-			types.OVNClusterRouter, &lrsr, p, &lrsr.Nexthop)
+			oc.GetNetworkScopedClusterRouterName(), &lrsr, p, &lrsr.Nexthop)
 		if err != nil {
-			return fmt.Errorf("error creating static route %+v in %s: %v", lrsr, types.OVNClusterRouter, err)
+			return fmt.Errorf("error creating static route %+v in %s: %v", lrsr, oc.GetNetworkScopedClusterRouterName(), err)
 		}
 	}
 
@@ -370,7 +370,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 		if err != nil {
 			return fmt.Errorf("failed to add source IP address based "+
 				"routes in distributed router %s: %v",
-				types.OVNClusterRouter, err)
+				oc.GetNetworkScopedClusterRouterName(), err)
 		}
 
 		lrsr := nbdb.LogicalRouterStaticRoute{
@@ -389,10 +389,10 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 			mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
 			oc.staticRouteCleanup([]net.IP{mgmtIfAddr.IP})
 
-			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, types.OVNClusterRouter,
+			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(),
 				&lrsr, p, &lrsr.Nexthop)
 			if err != nil {
-				return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, types.OVNClusterRouter, err)
+				return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, oc.GetNetworkScopedClusterRouterName(), err)
 			}
 		} else if config.Gateway.Mode == config.GatewayModeLocal {
 			// If migrating from shared to local gateway, let's remove the static routes towards
@@ -403,9 +403,9 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 				return item.IPPrefix == lrsr.IPPrefix && item.Policy != nil && *item.Policy == *lrsr.Policy &&
 					config.ContainsJoinIP(net.ParseIP(item.Nexthop))
 			}
-			err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter, p)
+			err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), p)
 			if err != nil {
-				return fmt.Errorf("error deleting static route %+v in GR %s: %v", lrsr, types.OVNClusterRouter, err)
+				return fmt.Errorf("error deleting static route %+v in GR %s: %v", lrsr, oc.GetNetworkScopedClusterRouterName(), err)
 			}
 		}
 	}
@@ -702,7 +702,7 @@ func (oc *DefaultNetworkController) syncPolicyBasedRoutes(nodeName string, match
 				if policy.Nexthops[0] != nexthop {
 					if err := oc.deletePolicyBasedRoutes(policy.UUID, priority); err != nil {
 						return fmt.Errorf("failed to delete policy route '%s' for host %q on %s "+
-							"error: %v", policy.UUID, nodeName, types.OVNClusterRouter, err)
+							"error: %v", policy.UUID, nodeName, oc.GetNetworkScopedClusterRouterName(), err)
 					}
 					continue
 				}
@@ -717,7 +717,7 @@ func (oc *DefaultNetworkController) syncPolicyBasedRoutes(nodeName string, match
 				if !desiredMatchFound {
 					if err := oc.deletePolicyBasedRoutes(policy.UUID, priority); err != nil {
 						return fmt.Errorf("failed to delete policy route '%s' for host %q on %s "+
-							"error: %v", policy.UUID, nodeName, types.OVNClusterRouter, err)
+							"error: %v", policy.UUID, nodeName, oc.GetNetworkScopedClusterRouterName(), err)
 					}
 					continue
 				}
@@ -731,7 +731,7 @@ func (oc *DefaultNetworkController) syncPolicyBasedRoutes(nodeName string, match
 	for match := range matchTracker {
 		if err := oc.createPolicyBasedRoutes(match, priority, nexthop); err != nil {
 			return fmt.Errorf("failed to add policy route '%s' for host %q on %s "+
-				"error: %v", match, nodeName, types.OVNClusterRouter, err)
+				"error: %v", match, nodeName, oc.GetNetworkScopedClusterRouterName(), err)
 		}
 	}
 	return nil
@@ -763,10 +763,10 @@ func (oc *DefaultNetworkController) createPolicyBasedRoutes(match, priority, nex
 		return item.Priority == lrp.Priority && item.Match == lrp.Match
 	}
 
-	err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(oc.nbClient, types.OVNClusterRouter, &lrp, p,
+	err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), &lrp, p,
 		&lrp.Nexthops, &lrp.Action)
 	if err != nil {
-		return fmt.Errorf("error creating policy %+v on router %s: %v", lrp, types.OVNClusterRouter, err)
+		return fmt.Errorf("error creating policy %+v on router %s: %v", lrp, oc.GetNetworkScopedClusterRouterName(), err)
 	}
 
 	return nil
@@ -774,7 +774,7 @@ func (oc *DefaultNetworkController) createPolicyBasedRoutes(match, priority, nex
 
 func (oc *DefaultNetworkController) deletePolicyBasedRoutes(policyID, priority string) error {
 	lrp := nbdb.LogicalRouterPolicy{UUID: policyID}
-	err := libovsdbops.DeleteLogicalRouterPolicies(oc.nbClient, types.OVNClusterRouter, &lrp)
+	err := libovsdbops.DeleteLogicalRouterPolicies(oc.nbClient, oc.GetNetworkScopedClusterRouterName(), &lrp)
 	if err != nil {
 		return fmt.Errorf("error deleting policy %s: %v", policyID, err)
 	}

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -120,7 +120,7 @@ func (oc *DefaultNetworkController) handleHybridOverlayPort(node *kapi.Node, ann
 			return fmt.Errorf("failed to add hybrid overlay port %+v for node %s: %w", lsp, node.Name, err)
 		}
 		for _, subnet := range subnets {
-			if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, node.Name, subnet); err != nil {
+			if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, oc.GetNetworkScopedK8sMgmtIntfName(node.Name), node.Name, subnet); err != nil {
 				return err
 			}
 		}

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -113,14 +113,14 @@ func (oc *DefaultNetworkController) handleHybridOverlayPort(node *kapi.Node, ann
 			Name:      portName,
 			Addresses: []string{portMAC.String()},
 		}
-		sw := nbdb.LogicalSwitch{Name: node.Name}
+		sw := nbdb.LogicalSwitch{Name: oc.GetNetworkScopedSwitchName(node.Name)}
 
 		err := libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(oc.nbClient, &sw, &lsp)
 		if err != nil {
 			return fmt.Errorf("failed to add hybrid overlay port %+v for node %s: %w", lsp, node.Name, err)
 		}
 		for _, subnet := range subnets {
-			if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, oc.GetNetworkScopedK8sMgmtIntfName(node.Name), node.Name, subnet); err != nil {
+			if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, oc.GetNetworkScopedK8sMgmtIntfName(node.Name), oc.GetNetworkScopedSwitchName(node.Name), node.Name, subnet); err != nil {
 				return err
 			}
 		}
@@ -140,7 +140,7 @@ func (oc *DefaultNetworkController) deleteHybridOverlayPort(node *kapi.Node) err
 	klog.Infof("Removing node %s hybrid overlay port", node.Name)
 	portName := util.GetHybridOverlayPortName(node.Name)
 	lsp := nbdb.LogicalSwitchPort{Name: portName}
-	sw := nbdb.LogicalSwitch{Name: node.Name}
+	sw := nbdb.LogicalSwitch{Name: oc.GetNetworkScopedSwitchName(node.Name)}
 	if err := libovsdbops.DeleteLogicalSwitchPorts(oc.nbClient, &sw, &lsp); err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -227,7 +227,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 			}
 
 			// Logic route policy to steer packet from external to nodePort service backed by non-ovnkube pods to hybrid overlay nodes
-			gwLRPIfAddrs, err := libovsdbutil.GetLRPAddrs(oc.nbClient, ovntypes.GWRouterToJoinSwitchPrefix+ovntypes.GWRouterPrefix+nodeName)
+			gwLRPIfAddrs, err := libovsdbutil.GetLRPAddrs(oc.nbClient, ovntypes.GWRouterToJoinSwitchPrefix+oc.GetNetworkScopedGWRouterName(nodeName))
 			if err != nil {
 				return err
 			}
@@ -273,7 +273,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				}, &clusterRouterStaticRoutes.Nexthop); err != nil {
 				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %w",
 					clusterRouterStaticRoutes.IPPrefix, clusterRouterStaticRoutes.Nexthop,
-					ovntypes.GWRouterPrefix+nodeName, err)
+					oc.GetNetworkScopedGWRouterName(nodeName), err)
 			}
 			klog.Infof("Created hybrid overlay logical route static route at cluster router for node %s", nodeName)
 
@@ -294,7 +294,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				},
 			}
 			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
-				ovntypes.GWRouterPrefix+nodeName, &nodeGWRouterStaticRoutes,
+				oc.GetNetworkScopedGWRouterName(nodeName), &nodeGWRouterStaticRoutes,
 				func(item *nbdb.LogicalRouterStaticRoute) bool {
 					return item.IPPrefix == nodeGWRouterStaticRoutes.IPPrefix &&
 						item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"] &&
@@ -302,7 +302,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				}, &nodeGWRouterStaticRoutes.Nexthop); err != nil {
 				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %w",
 					nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop,
-					ovntypes.GWRouterPrefix+nodeName, err)
+					oc.GetNetworkScopedGWRouterName(nodeName), err)
 			}
 			klog.Infof("Created hybrid overlay logical route static route at gateway router for node %s", nodeName)
 		}
@@ -323,10 +323,10 @@ func (oc *DefaultNetworkController) removeHybridLRPolicySharedGW(node *kapi.Node
 	// order is important here to not incur referential integrity violation
 	// first remove GR routes with a specific predicate, then remove the
 	// remaining ones from cluster router with a generic predicate
-	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.GWRouterPrefix+nodeName, func(item *nbdb.LogicalRouterStaticRoute) bool {
+	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, oc.GetNetworkScopedGWRouterName(nodeName), func(item *nbdb.LogicalRouterStaticRoute) bool {
 		return item.ExternalIDs["name"] == name+ovntypes.HybridOverlayGRSubfix
 	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
-		return fmt.Errorf("failed to delete static route %s from %s, error: %w", name+"gr", ovntypes.GWRouterPrefix+nodeName, err)
+		return fmt.Errorf("failed to delete static route %s from %s, error: %w", name+"gr", oc.GetNetworkScopedGWRouterName(nodeName), err)
 	}
 	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterStaticRoute) bool {
 		return strings.Contains(item.ExternalIDs["name"], name)
@@ -411,13 +411,13 @@ func (oc *DefaultNetworkController) removeRoutesToHONodeSubnet(nodeSubnet *net.I
 	for _, node := range nodes {
 		node := *node
 		// Check existence of Gateway Router before removing the static route from it.
-		if _, err := libovsdbops.GetLogicalRouter(oc.nbClient, &nbdb.LogicalRouter{Name: ovntypes.GWRouterPrefix + node.Name}); err != nil {
+		if _, err := libovsdbops.GetLogicalRouter(oc.nbClient, &nbdb.LogicalRouter{Name: oc.GetNetworkScopedGWRouterName(node.Name)}); err != nil {
 			if err == libovsdbclient.ErrNotFound {
 				continue
 			}
-			return fmt.Errorf("failed to get logical router %s, error: %w", ovntypes.GWRouterPrefix+node.Name, err)
+			return fmt.Errorf("failed to get logical router %s, error: %w", oc.GetNetworkScopedGWRouterName(node.Name), err)
 		}
-		if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.GWRouterPrefix+node.Name, func(item *nbdb.LogicalRouterStaticRoute) bool {
+		if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, oc.GetNetworkScopedGWRouterName(node.Name), func(item *nbdb.LogicalRouterStaticRoute) bool {
 			name, ok := item.ExternalIDs["name"]
 			if !ok {
 				return false
@@ -427,7 +427,7 @@ func (oc *DefaultNetworkController) removeRoutesToHONodeSubnet(nodeSubnet *net.I
 			}
 			return item.IPPrefix == nodeSubnet.String() && item.Policy == nil
 		}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
-			return fmt.Errorf("failed to delete static route to %s from %s, error: %w", nodeSubnet, ovntypes.GWRouterPrefix+node.Name, err)
+			return fmt.Errorf("failed to delete static route to %s from %s, error: %w", nodeSubnet, oc.GetNetworkScopedGWRouterName(node.Name), err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -216,7 +216,7 @@ func (oc *DefaultNetworkController) syncNodeManagementPort(node *kapi.Node, host
 	}
 
 	if v4Subnet != nil {
-		if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, node.Name, v4Subnet); err != nil {
+		if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, oc.GetNetworkScopedK8sMgmtIntfName(node.Name), node.Name, v4Subnet); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -203,7 +203,7 @@ func (oc *DefaultNetworkController) syncNodeManagementPort(node *kapi.Node, host
 		Name:      oc.GetNetworkScopedK8sMgmtIntfName(node.Name),
 		Addresses: []string{addresses},
 	}
-	sw := nbdb.LogicalSwitch{Name: node.Name}
+	sw := nbdb.LogicalSwitch{Name: oc.GetNetworkScopedSwitchName(node.Name)}
 	err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(oc.nbClient, &sw, &logicalSwitchPort)
 	if err != nil {
 		return err

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -190,10 +190,10 @@ func (oc *DefaultNetworkController) syncNodeManagementPort(node *kapi.Node, host
 			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
 				return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 			}
-			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, types.OVNClusterRouter,
+			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, oc.GetNetworkScopedClusterRouterName(),
 				&lrsr, p, &lrsr.Nexthop)
 			if err != nil {
-				return fmt.Errorf("error creating static route %+v on router %s: %v", lrsr, types.OVNClusterRouter, err)
+				return fmt.Errorf("error creating static route %+v on router %s: %v", lrsr, oc.GetNetworkScopedClusterRouterName(), err)
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -200,7 +200,7 @@ func (oc *DefaultNetworkController) syncNodeManagementPort(node *kapi.Node, host
 
 	// Create this node's management logical port on the node switch
 	logicalSwitchPort := nbdb.LogicalSwitchPort{
-		Name:      types.K8sPrefix + node.Name,
+		Name:      oc.GetNetworkScopedK8sMgmtIntfName(node.Name),
 		Addresses: []string{addresses},
 	}
 	sw := nbdb.LogicalSwitch{Name: node.Name}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -107,7 +107,7 @@ func (oc *DefaultNetworkController) SetupMaster(existingNodeNames []string) erro
 
 	// Create OVNJoinSwitch that will be used to connect gateway routers to the distributed router.
 	logicalSwitch := nbdb.LogicalSwitch{
-		Name: types.OVNJoinSwitch,
+		Name: oc.GetNetworkScopedJoinSwitchName(),
 	}
 	// nothing is updated here, so no reason to pass fields
 	err = libovsdbops.CreateOrUpdateLogicalSwitch(oc.nbClient, &logicalSwitch)
@@ -146,10 +146,10 @@ func (oc *DefaultNetworkController) SetupMaster(existingNodeNames []string) erro
 		},
 		Addresses: []string{"router"},
 	}
-	sw := nbdb.LogicalSwitch{Name: types.OVNJoinSwitch}
+	sw := nbdb.LogicalSwitch{Name: oc.GetNetworkScopedJoinSwitchName()}
 	err = libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(oc.nbClient, &sw, &logicalSwitchPort)
 	if err != nil {
-		return fmt.Errorf("failed to create logical switch port %+v and switch %s: %v", logicalSwitchPort, types.OVNJoinSwitch, err)
+		return fmt.Errorf("failed to create logical switch port %+v and switch %s: %v", logicalSwitchPort, sw.Name, err)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -162,7 +162,7 @@ func (oc *DefaultNetworkController) syncNodeManagementPort(node *kapi.Node, host
 	}
 
 	if hostSubnets == nil {
-		hostSubnets, err = util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName)
+		hostSubnets, err = util.ParseNodeHostSubnetAnnotation(node, oc.GetNetworkName())
 		if err != nil {
 			return err
 		}
@@ -267,7 +267,7 @@ func (oc *DefaultNetworkController) addNode(node *kapi.Node) ([]*net.IPNet, erro
 	// Node subnet for the default network is allocated by cluster manager.
 	// Make sure that the node is allocated with the subnet before proceeding
 	// to create OVN Northbound resources.
-	hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName)
+	hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, oc.GetNetworkName())
 	if err != nil {
 		return nil, err
 	}
@@ -862,7 +862,7 @@ func (oc *DefaultNetworkController) getOVNClusterRouterPortToJoinSwitchIfAddrs()
 
 // addUpdateHoNodeEvent reconsile ovn nodes when a hybrid overlay node is added.
 func (oc *DefaultNetworkController) addUpdateHoNodeEvent(node *kapi.Node) error {
-	if subnets, _ := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName); len(subnets) > 0 {
+	if subnets, _ := util.ParseNodeHostSubnetAnnotation(node, oc.GetNetworkName()); len(subnets) > 0 {
 		klog.Infof("Node %q is used to be a OVN-K managed node, deleting it from OVN topology", node.Name)
 		if err := oc.deleteOVNNodeEvent(node); err != nil {
 			return err

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -216,7 +216,7 @@ func (oc *DefaultNetworkController) syncNodeManagementPort(node *kapi.Node, host
 	}
 
 	if v4Subnet != nil {
-		if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, oc.GetNetworkScopedK8sMgmtIntfName(node.Name), node.Name, v4Subnet); err != nil {
+		if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, oc.GetNetworkScopedK8sMgmtIntfName(node.Name), oc.GetNetworkScopedSwitchName(node.Name), node.Name, v4Subnet); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -243,7 +243,7 @@ func (oc *DefaultNetworkController) updateNamespace(old, newer *kapi.Namespace) 
 				} else {
 					if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 						errors = append(errors, err)
-					} else if err = addOrUpdatePodSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, podAnnotation.IPs); err != nil {
+					} else if err = addOrUpdatePodSNAT(oc.nbClient, oc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), extIPs, podAnnotation.IPs); err != nil {
 						errors = append(errors, err)
 					}
 				}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -464,11 +464,11 @@ func (oc *DefaultNetworkController) StartServiceController(wg *sync.WaitGroup, r
 func (oc *DefaultNetworkController) InitEgressServiceZoneController() (*egresssvc_zone.Controller, error) {
 	// If the EgressIP controller is enabled it will take care of creating the
 	// "no reroute" policies - we can pass "noop" functions to the egress service controller.
-	initClusterEgressPolicies := func(libovsdbclient.Client, addressset.AddressSetFactory, string) error { return nil }
-	ensureNodeNoReroutePolicies := func(libovsdbclient.Client, addressset.AddressSetFactory, string, listers.NodeLister) error {
+	initClusterEgressPolicies := func(libovsdbclient.Client, addressset.AddressSetFactory, string, string) error { return nil }
+	ensureNodeNoReroutePolicies := func(libovsdbclient.Client, addressset.AddressSetFactory, string, string, listers.NodeLister) error {
 		return nil
 	}
-	deleteLegacyDefaultNoRerouteNodePolicies := func(libovsdbclient.Client, string) error { return nil }
+	deleteLegacyDefaultNoRerouteNodePolicies := func(libovsdbclient.Client, string, string) error { return nil }
 	// used only when IC=true
 	createDefaultNodeRouteToExternal := func(libovsdbclient.Client, string, string) error { return nil }
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -470,7 +470,7 @@ func (oc *DefaultNetworkController) InitEgressServiceZoneController() (*egresssv
 	}
 	deleteLegacyDefaultNoRerouteNodePolicies := func(libovsdbclient.Client, string) error { return nil }
 	// used only when IC=true
-	createDefaultNodeRouteToExternal := func(libovsdbclient.Client, string) error { return nil }
+	createDefaultNodeRouteToExternal := func(libovsdbclient.Client, string, string) error { return nil }
 
 	if !config.OVNKubernetesFeature.EnableEgressIP {
 		initClusterEgressPolicies = InitClusterEgressPolicies

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -479,7 +479,7 @@ func (oc *DefaultNetworkController) InitEgressServiceZoneController() (*egresssv
 		createDefaultNodeRouteToExternal = libovsdbutil.CreateDefaultRouteToExternal
 	}
 
-	return egresssvc_zone.NewController(DefaultNetworkControllerName, oc.client, oc.nbClient, oc.addressSetFactory,
+	return egresssvc_zone.NewController(oc.NetInfo, DefaultNetworkControllerName, oc.client, oc.nbClient, oc.addressSetFactory,
 		initClusterEgressPolicies, ensureNodeNoReroutePolicies, deleteLegacyDefaultNoRerouteNodePolicies,
 		createDefaultNodeRouteToExternal,
 		oc.stopChan, oc.watchFactory.EgressServiceInformer(), oc.watchFactory.ServiceCoreInformer(),

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -315,7 +315,7 @@ func (oc *DefaultNetworkController) allocateSyncPodsIPs(pod *kapi.Pod) (string, 
 	if err != nil {
 		return "", nil, nil
 	}
-	expectedLogicalPortName, err := oc.allocatePodIPsOnSwitch(pod, annotations, ovntypes.DefaultNetworkName, pod.Spec.NodeName)
+	expectedLogicalPortName, err := oc.allocatePodIPsOnSwitch(pod, annotations, oc.GetNetworkName(), oc.GetNetworkScopedSwitchName(pod.Spec.NodeName))
 	if err != nil {
 		return "", nil, err
 	}
@@ -326,7 +326,7 @@ func (oc *DefaultNetworkController) allocateSyncMigratablePodIPsOnZone(vms map[k
 	allocatePodIPsOnSwitchWrapFn := func(liveMigratablePod *kapi.Pod, liveMigratablePodAnnotation *util.PodAnnotation, switchName, nadName string) (string, error) {
 		return oc.allocatePodIPsOnSwitch(liveMigratablePod, liveMigratablePodAnnotation, switchName, nadName)
 	}
-	vmKey, expectedLogicalPortName, podAnnotation, err := kubevirt.AllocateSyncMigratablePodIPsOnZone(oc.watchFactory, oc.lsManager, ovntypes.DefaultNetworkName, pod, allocatePodIPsOnSwitchWrapFn)
+	vmKey, expectedLogicalPortName, podAnnotation, err := kubevirt.AllocateSyncMigratablePodIPsOnZone(oc.watchFactory, oc.lsManager, oc.GetNetworkName(), pod, allocatePodIPsOnSwitchWrapFn)
 	if err != nil {
 		return nil, "", nil, err
 	}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -263,7 +263,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 		// namespace annotations to go through external egress router
 		if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 			return err
-		} else if ops, err = addOrUpdatePodSNATOps(oc.nbClient, pod.Spec.NodeName, extIPs, podAnnotation.IPs, ops); err != nil {
+		} else if ops, err = addOrUpdatePodSNATOps(oc.nbClient, oc.GetNetworkScopedGWRouterName(pod.Spec.NodeName), extIPs, podAnnotation.IPs, ops); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -113,7 +113,7 @@ func (oc *SecondaryLayer2NetworkController) Cleanup() error {
 }
 
 func (oc *SecondaryLayer2NetworkController) Init() error {
-	switchName := oc.GetNetworkScopedName(types.OVNLayer2Switch)
+	switchName := oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch)
 
 	_, err := oc.initializeLogicalSwitch(switchName, oc.Subnets(), oc.ExcludeSubnets())
 	return err

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -108,7 +108,7 @@ func (oc *SecondaryLocalnetNetworkController) Cleanup() error {
 }
 
 func (oc *SecondaryLocalnetNetworkController) Init() error {
-	switchName := oc.GetNetworkScopedName(types.OVNLocalnetSwitch)
+	switchName := oc.GetNetworkScopedSwitchName(types.OVNLocalnetSwitch)
 
 	logicalSwitch, err := oc.initializeLogicalSwitch(switchName, oc.Subnets(), oc.ExcludeSubnets())
 	if err != nil {

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -48,6 +48,7 @@ type BasicNetInfo interface {
 	GetNetworkScopedClusterRouterName() string
 	GetNetworkScopedGWRouterName(nodeName string) string
 	GetNetworkScopedSwitchName(nodeName string) string
+	GetNetworkScopedJoinSwitchName() string
 }
 
 // NetInfo correlates which NADs refer to a network in addition to the basic
@@ -113,6 +114,10 @@ func (nInfo *DefaultNetInfo) GetNetworkScopedGWRouterName(nodeName string) strin
 
 func (nInfo *DefaultNetInfo) GetNetworkScopedSwitchName(nodeName string) string {
 	return nInfo.GetNetworkScopedName(nodeName)
+}
+
+func (nInfo *DefaultNetInfo) GetNetworkScopedJoinSwitchName() string {
+	return nInfo.GetNetworkScopedName(types.OVNJoinSwitch)
 }
 
 // GetNADs returns the NADs associated with the network, no op for default
@@ -254,6 +259,10 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedGWRouterName(nodeName string) str
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedSwitchName(nodeName string) string {
 	return nInfo.GetNetworkScopedName(nodeName)
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedJoinSwitchName() string {
+	return nInfo.GetNetworkScopedName(types.OVNJoinSwitch)
 }
 
 // getPrefix returns if the logical entities prefix for this network

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -44,6 +44,7 @@ type BasicNetInfo interface {
 	Equals(BasicNetInfo) bool
 	GetNetworkScopedName(name string) string
 	RemoveNetworkScopeFromName(name string) string
+	GetNetworkScopedK8sMgmtIntfName(nodeName string) string
 }
 
 // NetInfo correlates which NADs refer to a network in addition to the basic
@@ -93,6 +94,10 @@ func (nInfo *DefaultNetInfo) GetNetworkScopedName(name string) string {
 func (nInfo *DefaultNetInfo) RemoveNetworkScopeFromName(name string) string {
 	// for the default network, names are not scoped
 	return name
+}
+
+func (nInfo *DefaultNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) string {
+	return GetK8sMgmtIntfName(nInfo.GetNetworkScopedName(nodeName))
 }
 
 // GetNADs returns the NADs associated with the network, no op for default
@@ -218,6 +223,10 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedName(name string) string {
 func (nInfo *secondaryNetInfo) RemoveNetworkScopeFromName(name string) string {
 	// for the default network, names are not scoped
 	return strings.Trim(name, nInfo.getPrefix())
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) string {
+	return GetK8sMgmtIntfName(nInfo.GetNetworkScopedName(nodeName))
 }
 
 // getPrefix returns if the logical entities prefix for this network

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -45,6 +45,7 @@ type BasicNetInfo interface {
 	GetNetworkScopedName(name string) string
 	RemoveNetworkScopeFromName(name string) string
 	GetNetworkScopedK8sMgmtIntfName(nodeName string) string
+	GetNetworkScopedClusterRouterName() string
 }
 
 // NetInfo correlates which NADs refer to a network in addition to the basic
@@ -98,6 +99,10 @@ func (nInfo *DefaultNetInfo) RemoveNetworkScopeFromName(name string) string {
 
 func (nInfo *DefaultNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) string {
 	return GetK8sMgmtIntfName(nInfo.GetNetworkScopedName(nodeName))
+}
+
+func (nInfo *DefaultNetInfo) GetNetworkScopedClusterRouterName() string {
+	return nInfo.GetNetworkScopedName(types.OVNClusterRouter)
 }
 
 // GetNADs returns the NADs associated with the network, no op for default
@@ -227,6 +232,10 @@ func (nInfo *secondaryNetInfo) RemoveNetworkScopeFromName(name string) string {
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) string {
 	return GetK8sMgmtIntfName(nInfo.GetNetworkScopedName(nodeName))
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedClusterRouterName() string {
+	return nInfo.GetNetworkScopedName(types.OVNClusterRouter)
 }
 
 // getPrefix returns if the logical entities prefix for this network

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -47,6 +47,7 @@ type BasicNetInfo interface {
 	GetNetworkScopedK8sMgmtIntfName(nodeName string) string
 	GetNetworkScopedClusterRouterName() string
 	GetNetworkScopedGWRouterName(nodeName string) string
+	GetNetworkScopedSwitchName(nodeName string) string
 }
 
 // NetInfo correlates which NADs refer to a network in addition to the basic
@@ -108,6 +109,10 @@ func (nInfo *DefaultNetInfo) GetNetworkScopedClusterRouterName() string {
 
 func (nInfo *DefaultNetInfo) GetNetworkScopedGWRouterName(nodeName string) string {
 	return GetGatewayRouterFromNode(nInfo.GetNetworkScopedName(nodeName))
+}
+
+func (nInfo *DefaultNetInfo) GetNetworkScopedSwitchName(nodeName string) string {
+	return nInfo.GetNetworkScopedName(nodeName)
 }
 
 // GetNADs returns the NADs associated with the network, no op for default
@@ -245,6 +250,10 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedClusterRouterName() string {
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedGWRouterName(nodeName string) string {
 	return GetGatewayRouterFromNode(nInfo.GetNetworkScopedName(nodeName))
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedSwitchName(nodeName string) string {
+	return nInfo.GetNetworkScopedName(nodeName)
 }
 
 // getPrefix returns if the logical entities prefix for this network

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -49,6 +49,7 @@ type BasicNetInfo interface {
 	GetNetworkScopedGWRouterName(nodeName string) string
 	GetNetworkScopedSwitchName(nodeName string) string
 	GetNetworkScopedJoinSwitchName() string
+	GetNetworkScopedExtSwitchName(nodeName string) string
 }
 
 // NetInfo correlates which NADs refer to a network in addition to the basic
@@ -118,6 +119,10 @@ func (nInfo *DefaultNetInfo) GetNetworkScopedSwitchName(nodeName string) string 
 
 func (nInfo *DefaultNetInfo) GetNetworkScopedJoinSwitchName() string {
 	return nInfo.GetNetworkScopedName(types.OVNJoinSwitch)
+}
+
+func (nInfo *DefaultNetInfo) GetNetworkScopedExtSwitchName(nodeName string) string {
+	return GetExtSwitchFromNode(nInfo.GetNetworkScopedName(nodeName))
 }
 
 // GetNADs returns the NADs associated with the network, no op for default
@@ -263,6 +268,10 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedSwitchName(nodeName string) strin
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedJoinSwitchName() string {
 	return nInfo.GetNetworkScopedName(types.OVNJoinSwitch)
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedExtSwitchName(nodeName string) string {
+	return GetExtSwitchFromNode(nInfo.GetNetworkScopedName(nodeName))
 }
 
 // getPrefix returns if the logical entities prefix for this network

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -46,6 +46,7 @@ type BasicNetInfo interface {
 	RemoveNetworkScopeFromName(name string) string
 	GetNetworkScopedK8sMgmtIntfName(nodeName string) string
 	GetNetworkScopedClusterRouterName() string
+	GetNetworkScopedGWRouterName(nodeName string) string
 }
 
 // NetInfo correlates which NADs refer to a network in addition to the basic
@@ -103,6 +104,10 @@ func (nInfo *DefaultNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) st
 
 func (nInfo *DefaultNetInfo) GetNetworkScopedClusterRouterName() string {
 	return nInfo.GetNetworkScopedName(types.OVNClusterRouter)
+}
+
+func (nInfo *DefaultNetInfo) GetNetworkScopedGWRouterName(nodeName string) string {
+	return GetGatewayRouterFromNode(nInfo.GetNetworkScopedName(nodeName))
 }
 
 // GetNADs returns the NADs associated with the network, no op for default
@@ -236,6 +241,10 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedK8sMgmtIntfName(nodeName string) 
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedClusterRouterName() string {
 	return nInfo.GetNetworkScopedName(types.OVNClusterRouter)
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedGWRouterName(nodeName string) string {
+	return GetGatewayRouterFromNode(nInfo.GetNetworkScopedName(nodeName))
 }
 
 // getPrefix returns if the logical entities prefix for this network

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -121,6 +121,11 @@ func GetGatewayRouterFromNode(node string) string {
 	return types.GWRouterPrefix + node
 }
 
+// GetGatewayRouterFromNode determines a node's corresponding gateway router name
+func GetExtSwitchFromNode(node string) string {
+	return types.ExternalSwitchPrefix + node
+}
+
 // GetNodeInternalAddrs returns the first IPv4 and/or IPv6 InternalIP defined
 // for the node. On certain cloud providers (AWS) the egress IP will be added to
 // the list of node IPs as an InternalIP address, we don't want to create the

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -98,12 +98,17 @@ func GetIPFullMask(ip net.IP) net.IPMask {
 	return net.CIDRMask(32, 32)
 }
 
+// GetK8sMgmtIntfName returns the management port name for a given node.
+func GetK8sMgmtIntfName(nodeName string) string {
+	return types.K8sPrefix + nodeName
+}
+
 // GetLegacyK8sMgmtIntfName returns legacy management ovs-port name
 func GetLegacyK8sMgmtIntfName(nodeName string) string {
 	if len(nodeName) > 11 {
 		return types.K8sPrefix + (nodeName[:11])
 	}
-	return types.K8sPrefix + nodeName
+	return GetK8sMgmtIntfName(nodeName)
 }
 
 // GetWorkerFromGatewayRouter determines a node's corresponding worker switch name from a gateway router name


### PR DESCRIPTION
#### What this PR does and why is it needed
This PR is a prerequisite for adding support for L2/L3 user defined network support.

It adds helpers to avoid hardcoding OVN topology names (cluster router, node switches, managament ports, external switches, GW routers).

It changes (most of) the code base to use the new wrappers.  There are still some places where names are built in an ad-hoc manner, e.g., some parts of the hybrid overlay implementation and the kubevirt package.  The latter doesn't use a network controller derived from BaseNetworkController so making it network aware is left as a follow up task.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
There are quite a few commits in this PR but the rationale is to make the transition to the new helpers in chunks, per functionality to allow for a simpler review process.

#### How to verify it
This doesn't change functionality so existing unit and e2e tests must pass as-is.

#### Details to documentation updates
No doc changes needed.

#### Description for the changelog
Don't hardcode OVN topology names.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
