### PR TITLE
ef e2e: make sure external containers are running and ready to serve

### DIFF
--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -125,14 +125,14 @@ var _ = ginkgo.Describe("e2e egress firewall policy validation", func() {
 			if shouldSucceed {
 				gomega.Eventually(func() bool {
 					_, err := e2ekubectl.RunKubectl(f.Namespace.Name, "exec", srcPodName, testContainerFlag, "--",
-						"nc", "-vz", "-w", fmt.Sprint(testTimeout), dstIP, fmt.Sprint(dstPort))
+						"curl", "-s", "--connect-timeout", fmt.Sprint(testTimeout), net.JoinHostPort(dstIP, fmt.Sprint(dstPort)))
 					return err == nil
 				}, time.Duration(2*testTimeout)*time.Second).Should(gomega.BeTrue(),
 					fmt.Sprintf("expected connection from %s to [%s]:%d to suceed", srcPodName, dstIP, dstPort))
 			} else {
 				gomega.Consistently(func() bool {
 					_, err := e2ekubectl.RunKubectl(f.Namespace.Name, "exec", srcPodName, testContainerFlag, "--",
-						"nc", "-vz", "-w", fmt.Sprint(testTimeout), dstIP, fmt.Sprint(dstPort))
+						"curl", "-s", "--connect-timeout", fmt.Sprint(testTimeout), net.JoinHostPort(dstIP, fmt.Sprint(dstPort)))
 					return err != nil
 				}, time.Duration(2*testTimeout)*time.Second).Should(gomega.BeTrue(),
 					fmt.Sprintf("expected connection from %s to [%s]:%d to fail", srcPodName, dstIP, dstPort))
@@ -140,7 +140,8 @@ var _ = ginkgo.Describe("e2e egress firewall policy validation", func() {
 		}
 
 		checkExternalContainerConnectivity := func(containerName, dstIP string, dstPort int) {
-			cmd := []string{"docker", "exec", containerName, "nc", "-vz", "-w", fmt.Sprint(testTimeout), dstIP, fmt.Sprint(dstPort)}
+			cmd := []string{"docker", "exec", containerName,
+				"curl", "-s", "--connect-timeout", fmt.Sprint(testTimeout), net.JoinHostPort(dstIP, fmt.Sprint(dstPort))}
 			framework.Logf("Running command %v", cmd)
 			_, err := runCommand(cmd...)
 			if err != nil {
@@ -167,14 +168,16 @@ var _ = ginkgo.Describe("e2e egress firewall policy validation", func() {
 			}
 
 			gomega.Eventually(func() bool {
-				cmd := []string{"docker", "exec", externalContainerName1, "nc", "-vz", "-w", fmt.Sprint(testTimeout), externalContainer2IP, fmt.Sprint(externalContainerPort2)}
+				cmd := []string{"docker", "exec", externalContainerName1,
+					"curl", "-s", "--connect-timeout", fmt.Sprint(testTimeout), net.JoinHostPort(externalContainer2IP, fmt.Sprint(externalContainerPort2))}
 				framework.Logf("Running command %v", cmd)
 				_, err := runCommand(cmd...)
 				if err != nil {
 					framework.Logf("Failed: %v", err)
 					return false
 				}
-				cmd = []string{"docker", "exec", externalContainerName2, "nc", "-vz", "-w", fmt.Sprint(testTimeout), externalContainer1IP, fmt.Sprint(externalContainerPort1)}
+				cmd = []string{"docker", "exec", externalContainerName2,
+					"curl", "-s", "--connect-timeout", fmt.Sprint(testTimeout), net.JoinHostPort(externalContainer1IP, fmt.Sprint(externalContainerPort1))}
 				framework.Logf("Running command %v", cmd)
 				_, err = runCommand(cmd...)
 				if err != nil {


### PR DESCRIPTION
before starting the test.

#### What this PR does and why is it needed
An attempt to fix https://github.com/ovn-org/ovn-kubernetes/issues/4480
Based on the reported failures, it seems like a problem with the external container connectivity, as some failures happen even before the egress firewall is created.

Can't guarantee that it will fix it though, couldn't reproduce the problem locally.
WIP: trying to get a couple of successful e2e runs (no egress firewall failures), will update when this is done.
1st green run: https://github.com/ovn-org/ovn-kubernetes/actions/runs/9744630959/job/26893660029?pr=4484
2nd green run: https://github.com/ovn-org/ovn-kubernetes/actions/runs/9747524153/job/26901588241?pr=4484
3rd: https://github.com/ovn-org/ovn-kubernetes/actions/runs/9749486954/job/26907766095?pr=4484
4th: https://github.com/ovn-org/ovn-kubernetes/actions/runs/9757083984/job/26929893035?pr=4484
5th: https://github.com/ovn-org/ovn-kubernetes/actions/runs/9759344723/job/26936886909?pr=4484