### PR TITLE
helm: Add conditional image pull secrets to Helm charts

### DIFF
--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
@@ -25,6 +25,10 @@ spec:
         openshift.io/component: network
         kubernetes.io/os: "linux"
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -31,6 +31,10 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       priorityClassName: "system-cluster-critical"
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.

--- a/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
         kubernetes.io/os: "linux"
         ovn-db-pod: "true"
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       priorityClassName: "system-cluster-critical"
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -32,6 +32,10 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       priorityClassName: "system-cluster-critical"
       serviceAccountName: ovnkube-identity
       hostNetwork: true

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -31,6 +31,10 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       priorityClassName: "system-cluster-critical"
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -26,6 +26,10 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       priorityClassName: "system-cluster-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -26,6 +26,10 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       priorityClassName: "system-cluster-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -26,6 +26,10 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       priorityClassName: "system-cluster-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -28,6 +28,10 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -28,6 +28,10 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.
       serviceAccountName: ovnkube-node

--- a/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
@@ -27,6 +27,10 @@ spec:
         kubernetes.io/os: "linux"
       annotations:
     spec:
+      {{- if hasKey .Values.global "imagePullSecretName" }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       priorityClassName: "system-cluster-critical"
       hostNetwork: true
       dnsPolicy: Default


### PR DESCRIPTION
This patch introduces a conditional inclusion of image pull secrets across various daemonsets and deployments within our Helm charts. Users can now specify the
'imagePullSecretName' in the 'global' values to include this secret. This flexibility allows for secure pulling of images from private repositories when required.

Example usage in values.yaml:
```yaml
global:
  imagePullSecretName: my-registry-secret
```

Documentation reference on using `imagePullSecrets`: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


