### PR TITLE
UDN: L2/L3 - add OVN management port

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -250,13 +250,13 @@ func getAllowFromNodeACLDbIDs(nodeName, mgmtPortIP, controller string) *libovsdb
 // There is no delete function for this ACL type, because the ACL is applied on a node switch.
 // When the node is deleted, switch will be deleted by the node sync, and the dependent ACLs will be
 // garbage-collected.
-func (bnc *BaseNetworkController) addAllowACLFromNode(nodeName string, mgmtPortIP net.IP) error {
+func (bnc *BaseNetworkController) addAllowACLFromNode(switchName string, mgmtPortIP net.IP) error {
 	ipFamily := "ip4"
 	if utilnet.IsIPv6(mgmtPortIP) {
 		ipFamily = "ip6"
 	}
 	match := fmt.Sprintf("%s.src==%s", ipFamily, mgmtPortIP.String())
-	dbIDs := getAllowFromNodeACLDbIDs(nodeName, mgmtPortIP.String(), bnc.controllerName)
+	dbIDs := getAllowFromNodeACLDbIDs(switchName, mgmtPortIP.String(), bnc.controllerName)
 	nodeACL := libovsdbutil.BuildACL(dbIDs, types.DefaultAllowPriority, match,
 		nbdb.ACLActionAllowRelated, nil, libovsdbutil.LportIngress)
 
@@ -265,9 +265,9 @@ func (bnc *BaseNetworkController) addAllowACLFromNode(nodeName string, mgmtPortI
 		return fmt.Errorf("failed to create or update ACL %v: %v", nodeACL, err)
 	}
 
-	ops, err = libovsdbops.AddACLsToLogicalSwitchOps(bnc.nbClient, ops, nodeName, nodeACL)
+	ops, err = libovsdbops.AddACLsToLogicalSwitchOps(bnc.nbClient, ops, switchName, nodeACL)
 	if err != nil {
-		return fmt.Errorf("failed to add ACL %v to switch %s: %v", nodeACL, nodeName, err)
+		return fmt.Errorf("failed to add ACL %v to switch %s: %v", nodeACL, switchName, err)
 	}
 
 	_, err = libovsdbops.TransactAndCheck(bnc.nbClient, ops)

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -3,17 +3,11 @@ package ovn
 import (
 	"fmt"
 	"net"
-	"reflect"
 
-	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,201 +17,10 @@ import (
 
 // method/structure shared by all layer 2 network controller, including localnet and layer2 network controllres.
 
-type baseSecondaryLayer2NetworkControllerEventHandler struct {
-	baseHandler  baseNetworkControllerEventHandler
-	watchFactory *factory.WatchFactory
-	objType      reflect.Type
-	oc           *BaseSecondaryLayer2NetworkController
-	syncFunc     func([]interface{}) error
-}
-
-// AreResourcesEqual returns true if, given two objects of a known resource type, the update logic for this resource
-// type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
-// equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update
-// function or with a delete on the old obj followed by an add on the new obj).
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
-	return h.baseHandler.areResourcesEqual(h.objType, obj1, obj2)
-}
-
-// GetInternalCacheEntry returns the internal cache entry for this object, given an object and its type.
-// This is now used only for pods, which will get their the logical port cache entry.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
-	return h.oc.GetInternalCacheEntryForSecondaryNetwork(h.objType, obj)
-}
-
-// GetResourceFromInformerCache returns the latest state of the object, given an object key and its type.
-// from the informers cache.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
-	return h.baseHandler.getResourceFromInformerCache(h.objType, h.watchFactory, key)
-}
-
-// RecordAddEvent records the add event on this given object.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) RecordAddEvent(obj interface{}) {
-	switch h.objType {
-	case factory.MultiNetworkPolicyType:
-		mnp := obj.(*mnpapi.MultiNetworkPolicy)
-		klog.V(5).Infof("Recording add event on multinetwork policy %s/%s", mnp.Namespace, mnp.Name)
-		metrics.GetConfigDurationRecorder().Start("multinetworkpolicy", mnp.Namespace, mnp.Name)
-	}
-}
-
-// RecordUpdateEvent records the udpate event on this given object.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) RecordUpdateEvent(obj interface{}) {
-	h.baseHandler.recordAddEvent(h.objType, obj)
-}
-
-// RecordDeleteEvent records the delete event on this given object.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) RecordDeleteEvent(obj interface{}) {
-	h.baseHandler.recordAddEvent(h.objType, obj)
-}
-
-// RecordSuccessEvent records the success event on this given object.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) RecordSuccessEvent(obj interface{}) {
-	h.baseHandler.recordAddEvent(h.objType, obj)
-}
-
-// RecordErrorEvent records the error event on this given object.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) RecordErrorEvent(obj interface{}, reason string, err error) {
-}
-
-// IsResourceScheduled returns true if the given object has been scheduled.
-// Only applied to pods for now. Returns true for all other types.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
-	return h.baseHandler.isResourceScheduled(h.objType, obj)
-}
-
-// AddResource adds the specified object to the cluster according to its type and returns the error,
-// if any, yielded during object creation.
-// Given an object to add and a boolean specifying if the function was executed from iterateRetryResources
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
-	switch h.objType {
-	case factory.NodeType:
-		node, ok := obj.(*corev1.Node)
-		if !ok {
-			return fmt.Errorf("could not cast %T object to Node", obj)
-		}
-		return h.oc.addUpdateNodeEvent(node)
-	default:
-		return h.oc.AddSecondaryNetworkResourceCommon(h.objType, obj)
-	}
-}
-
-// UpdateResource updates the specified object in the cluster to its version in newObj according to its
-// type and returns the error, if any, yielded during the object update.
-// Given an old and a new object; The inRetryCache boolean argument is to indicate if the given resource
-// is in the retryCache or not.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
-	switch h.objType {
-	case factory.NodeType:
-		node, ok := newObj.(*corev1.Node)
-		if !ok {
-			return fmt.Errorf("could not cast %T object to Node", newObj)
-		}
-		return h.oc.addUpdateNodeEvent(node)
-	default:
-		return h.oc.UpdateSecondaryNetworkResourceCommon(h.objType, oldObj, newObj, inRetryCache)
-	}
-}
-
-// DeleteResource deletes the object from the cluster according to the delete logic of its resource type.
-// Given an object and optionally a cachedObj; cachedObj is the internal cache entry for this object,
-// used for now for pods and network policies.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
-	switch h.objType {
-	case factory.NodeType:
-		node, ok := obj.(*corev1.Node)
-		if !ok {
-			return fmt.Errorf("could not cast %T object to Node", obj)
-		}
-		return h.oc.deleteNodeEvent(node)
-	default:
-		return h.oc.DeleteSecondaryNetworkResourceCommon(h.objType, obj, cachedObj)
-	}
-}
-
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) SyncFunc(objs []interface{}) error {
-	var syncFunc func([]interface{}) error
-
-	if h.syncFunc != nil {
-		// syncFunc was provided explicitly
-		syncFunc = h.syncFunc
-	} else {
-		switch h.objType {
-		case factory.NodeType:
-			syncFunc = h.oc.syncNodes
-
-		case factory.PodType:
-			syncFunc = h.oc.syncPodsForSecondaryNetwork
-
-		case factory.NamespaceType:
-			syncFunc = h.oc.syncNamespaces
-
-		case factory.MultiNetworkPolicyType:
-			syncFunc = h.oc.syncMultiNetworkPolicies
-
-		case factory.IPAMClaimsType:
-			syncFunc = h.oc.syncIPAMClaims
-
-		default:
-			return fmt.Errorf("no sync function for object type %s", h.objType)
-		}
-	}
-	if syncFunc == nil {
-		return nil
-	}
-	return syncFunc(objs)
-}
-
-// IsObjectInTerminalState returns true if the given object is a in terminal state.
-// This is used now for pods that are either in a PodSucceeded or in a PodFailed state.
-func (h *baseSecondaryLayer2NetworkControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
-	return h.baseHandler.isObjectInTerminalState(h.objType, obj)
-}
-
 // BaseSecondaryLayer2NetworkController structure holds per-network fields and network specific
 // configuration for secondary layer2/localnet network controller
 type BaseSecondaryLayer2NetworkController struct {
 	BaseSecondaryNetworkController
-}
-
-func (oc *BaseSecondaryLayer2NetworkController) initRetryFramework() {
-	oc.retryNodes = oc.newRetryFramework(factory.NodeType)
-	oc.retryPods = oc.newRetryFramework(factory.PodType)
-	if oc.allocatesPodAnnotation() && oc.NetInfo.AllowsPersistentIPs() {
-		oc.retryIPAMClaims = oc.newRetryFramework(factory.IPAMClaimsType)
-	}
-
-	// For secondary networks, we don't have to watch namespace events if
-	// multi-network policy support is not enabled. We don't support
-	// multi-network policy for IPAM-less secondary networks either.
-	if util.IsMultiNetworkPoliciesSupportEnabled() {
-		oc.retryNamespaces = oc.newRetryFramework(factory.NamespaceType)
-		oc.retryNetworkPolicies = oc.newRetryFramework(factory.MultiNetworkPolicyType)
-	}
-}
-
-// newRetryFramework builds and returns a retry framework for the input resource type;
-func (oc *BaseSecondaryLayer2NetworkController) newRetryFramework(
-	objectType reflect.Type) *retry.RetryFramework {
-	eventHandler := &baseSecondaryLayer2NetworkControllerEventHandler{
-		baseHandler:  baseNetworkControllerEventHandler{},
-		objType:      objectType,
-		watchFactory: oc.watchFactory,
-		oc:           oc,
-		syncFunc:     nil,
-	}
-	resourceHandler := &retry.ResourceHandler{
-		HasUpdateFunc:          hasResourceAnUpdateFunc(objectType),
-		NeedsUpdateDuringRetry: needsUpdateDuringRetry(objectType),
-		ObjType:                objectType,
-		EventHandler:           eventHandler,
-	}
-	return retry.NewRetryFramework(
-		oc.stopChan,
-		oc.wg,
-		oc.watchFactory,
-		resourceHandler,
-	)
 }
 
 // stop gracefully stops the controller, and delete all logical entities for this network if requested

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1151,7 +1151,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			ginkgo.By("Syncing node with OVNK")
 			node, err := oc.kube.GetNode(testNode.Name)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = oc.syncNodeManagementPort(node, []*net.IPNet{subnet})
+			err = oc.syncNodeManagementPortDefault(node, node.Name, []*net.IPNet{subnet})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = oc.syncGatewayLogicalNetwork(node, l3GatewayConfig, []*net.IPNet{subnet}, []string{node1.NodeIP})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -2,26 +2,224 @@ package ovn
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"reflect"
 	"sync"
 	"time"
 
+	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	zoneinterconnect "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/persistentips"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
+	corev1 "k8s.io/api/core/v1"
+	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
+
+// method/structure shared by all layer 2 network controller, including localnet and layer2 network controllres.
+
+type secondaryLayer2NetworkControllerEventHandler struct {
+	baseHandler  baseNetworkControllerEventHandler
+	watchFactory *factory.WatchFactory
+	objType      reflect.Type
+	oc           *SecondaryLayer2NetworkController
+	syncFunc     func([]interface{}) error
+}
+
+// AreResourcesEqual returns true if, given two objects of a known resource type, the update logic for this resource
+// type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
+// equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update
+// function or with a delete on the old obj followed by an add on the new obj).
+func (h *secondaryLayer2NetworkControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
+	return h.baseHandler.areResourcesEqual(h.objType, obj1, obj2)
+}
+
+// GetInternalCacheEntry returns the internal cache entry for this object, given an object and its type.
+// This is now used only for pods, which will get their the logical port cache entry.
+func (h *secondaryLayer2NetworkControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
+	return h.oc.GetInternalCacheEntryForSecondaryNetwork(h.objType, obj)
+}
+
+// GetResourceFromInformerCache returns the latest state of the object, given an object key and its type.
+// from the informers cache.
+func (h *secondaryLayer2NetworkControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
+	return h.baseHandler.getResourceFromInformerCache(h.objType, h.watchFactory, key)
+}
+
+// RecordAddEvent records the add event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordAddEvent(obj interface{}) {
+	switch h.objType {
+	case factory.MultiNetworkPolicyType:
+		mnp := obj.(*mnpapi.MultiNetworkPolicy)
+		klog.V(5).Infof("Recording add event on multinetwork policy %s/%s", mnp.Namespace, mnp.Name)
+		metrics.GetConfigDurationRecorder().Start("multinetworkpolicy", mnp.Namespace, mnp.Name)
+	}
+}
+
+// RecordUpdateEvent records the udpate event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordUpdateEvent(obj interface{}) {
+	h.baseHandler.recordAddEvent(h.objType, obj)
+}
+
+// RecordDeleteEvent records the delete event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordDeleteEvent(obj interface{}) {
+	h.baseHandler.recordAddEvent(h.objType, obj)
+}
+
+// RecordSuccessEvent records the success event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordSuccessEvent(obj interface{}) {
+	h.baseHandler.recordAddEvent(h.objType, obj)
+}
+
+// RecordErrorEvent records the error event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordErrorEvent(obj interface{}, reason string, err error) {
+}
+
+// IsResourceScheduled returns true if the given object has been scheduled.
+// Only applied to pods for now. Returns true for all other types.
+func (h *secondaryLayer2NetworkControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
+	return h.baseHandler.isResourceScheduled(h.objType, obj)
+}
+
+// AddResource adds the specified object to the cluster according to its type and returns the error,
+// if any, yielded during object creation.
+// Given an object to add and a boolean specifying if the function was executed from iterateRetryResources
+func (h *secondaryLayer2NetworkControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
+	switch h.objType {
+	case factory.NodeType:
+		node, ok := obj.(*corev1.Node)
+		if !ok {
+			return fmt.Errorf("could not cast %T object to Node", obj)
+		}
+		if h.oc.isLocalZoneNode(node) {
+			var nodeParams *nodeSyncs
+			if fromRetryLoop {
+				_, syncMgmtPort := h.oc.mgmtPortFailed.Load(node.Name)
+				nodeParams = &nodeSyncs{syncMgmtPort: syncMgmtPort}
+			} else {
+				nodeParams = &nodeSyncs{syncMgmtPort: true}
+			}
+			return h.oc.addUpdateLocalNodeEvent(node, nodeParams)
+		}
+		return h.oc.addUpdateRemoteNodeEvent(node)
+	default:
+		return h.oc.AddSecondaryNetworkResourceCommon(h.objType, obj)
+	}
+}
+
+// DeleteResource deletes the object from the cluster according to the delete logic of its resource type.
+// Given an object and optionally a cachedObj; cachedObj is the internal cache entry for this object,
+// used for now for pods and network policies.
+func (h *secondaryLayer2NetworkControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
+	switch h.objType {
+	case factory.NodeType:
+		node, ok := obj.(*corev1.Node)
+		if !ok {
+			return fmt.Errorf("could not cast %T object to Node", obj)
+		}
+		return h.oc.deleteNodeEvent(node)
+	default:
+		return h.oc.DeleteSecondaryNetworkResourceCommon(h.objType, obj, cachedObj)
+	}
+}
+
+// UpdateResource updates the specified object in the cluster to its version in newObj according to its
+// type and returns the error, if any, yielded during the object update.
+// Given an old and a new object; The inRetryCache boolean argument is to indicate if the given resource
+// is in the retryCache or not.
+func (h *secondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
+	switch h.objType {
+	case factory.NodeType:
+		newNode, ok := newObj.(*corev1.Node)
+		if !ok {
+			return fmt.Errorf("could not cast %T object to Node", newObj)
+		}
+		oldNode, ok := oldObj.(*kapi.Node)
+		if !ok {
+			return fmt.Errorf("could not cast oldObj of type %T to *kapi.Node", oldObj)
+		}
+		newNodeIsLocalZoneNode := h.oc.isLocalZoneNode(newNode)
+		nodeSubnetChanged := nodeSubnetChanged(oldNode, newNode)
+		if newNodeIsLocalZoneNode {
+			var nodeSyncsParam *nodeSyncs
+			if h.oc.isLocalZoneNode(oldNode) {
+				// determine what actually changed in this update
+				syncMgmtPort := macAddressChanged(oldNode, newNode) || nodeSubnetChanged
+				nodeSyncsParam = &nodeSyncs{syncMgmtPort: syncMgmtPort}
+			} else {
+				klog.Infof("Node %s moved from the remote zone %s to local zone %s.",
+					newNode.Name, util.GetNodeZone(oldNode), util.GetNodeZone(newNode))
+				// The node is now a local zone node. Trigger a full node sync.
+				nodeSyncsParam = &nodeSyncs{syncMgmtPort: true}
+			}
+
+			return h.oc.addUpdateLocalNodeEvent(newNode, nodeSyncsParam)
+		} else {
+			return h.oc.addUpdateRemoteNodeEvent(newNode)
+		}
+	default:
+		return h.oc.UpdateSecondaryNetworkResourceCommon(h.objType, oldObj, newObj, inRetryCache)
+	}
+}
+
+func (h *secondaryLayer2NetworkControllerEventHandler) SyncFunc(objs []interface{}) error {
+	var syncFunc func([]interface{}) error
+
+	if h.syncFunc != nil {
+		// syncFunc was provided explicitly
+		syncFunc = h.syncFunc
+	} else {
+		switch h.objType {
+		case factory.NodeType:
+			syncFunc = h.oc.syncNodes
+
+		case factory.PodType:
+			syncFunc = h.oc.syncPodsForSecondaryNetwork
+
+		case factory.NamespaceType:
+			syncFunc = h.oc.syncNamespaces
+
+		case factory.MultiNetworkPolicyType:
+			syncFunc = h.oc.syncMultiNetworkPolicies
+
+		case factory.IPAMClaimsType:
+			syncFunc = h.oc.syncIPAMClaims
+
+		default:
+			return fmt.Errorf("no sync function for object type %s", h.objType)
+		}
+	}
+	if syncFunc == nil {
+		return nil
+	}
+	return syncFunc(objs)
+}
+
+// IsObjectInTerminalState returns true if the given object is a in terminal state.
+// This is used now for pods that are either in a PodSucceeded or in a PodFailed state.
+func (h *secondaryLayer2NetworkControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
+	return h.baseHandler.isObjectInTerminalState(h.objType, obj)
+}
 
 // SecondaryLayer2NetworkController is created for logical network infrastructure and policy
 // for a secondary layer2 network
 type SecondaryLayer2NetworkController struct {
 	BaseSecondaryLayer2NetworkController
+
+	// Node-specific syncMaps used by node event handler
+	mgmtPortFailed sync.Map
 }
 
 // NewSecondaryLayer2NetworkController create a new OVN controller for the given secondary layer2 nad
@@ -33,7 +231,8 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 	addressSetFactory := addressset.NewOvnAddressSetFactory(cnci.nbClient, ipv4Mode, ipv6Mode)
 
 	oc := &SecondaryLayer2NetworkController{
-		BaseSecondaryLayer2NetworkController{
+		BaseSecondaryLayer2NetworkController: BaseSecondaryLayer2NetworkController{
+
 			BaseSecondaryNetworkController: BaseSecondaryNetworkController{
 				BaseNetworkController: BaseNetworkController{
 					CommonNetworkControllerInfo: *cnci,
@@ -54,6 +253,7 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 				},
 			},
 		},
+		mgmtPortFailed: sync.Map{},
 	}
 
 	if config.OVNKubernetesFeature.EnableInterconnect {
@@ -113,9 +313,7 @@ func (oc *SecondaryLayer2NetworkController) Cleanup() error {
 }
 
 func (oc *SecondaryLayer2NetworkController) Init() error {
-	switchName := oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch)
-
-	_, err := oc.initializeLogicalSwitch(switchName, oc.Subnets(), oc.ExcludeSubnets())
+	_, err := oc.initializeLogicalSwitch(oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), oc.Subnets(), oc.ExcludeSubnets())
 	return err
 }
 
@@ -125,5 +323,78 @@ func (oc *SecondaryLayer2NetworkController) Stop() {
 }
 
 func (oc *SecondaryLayer2NetworkController) initRetryFramework() {
-	oc.BaseSecondaryLayer2NetworkController.initRetryFramework()
+	oc.retryNodes = oc.newRetryFramework(factory.NodeType)
+	oc.retryPods = oc.newRetryFramework(factory.PodType)
+	if oc.allocatesPodAnnotation() && oc.NetInfo.AllowsPersistentIPs() {
+		oc.retryIPAMClaims = oc.newRetryFramework(factory.IPAMClaimsType)
+	}
+
+	// For secondary networks, we don't have to watch namespace events if
+	// multi-network policy support is not enabled. We don't support
+	// multi-network policy for IPAM-less secondary networks either.
+	if util.IsMultiNetworkPoliciesSupportEnabled() {
+		oc.retryNamespaces = oc.newRetryFramework(factory.NamespaceType)
+		oc.retryNetworkPolicies = oc.newRetryFramework(factory.MultiNetworkPolicyType)
+	}
+}
+
+// newRetryFramework builds and returns a retry framework for the input resource type;
+func (oc *SecondaryLayer2NetworkController) newRetryFramework(
+	objectType reflect.Type) *retry.RetryFramework {
+	eventHandler := &secondaryLayer2NetworkControllerEventHandler{
+		baseHandler:  baseNetworkControllerEventHandler{},
+		objType:      objectType,
+		watchFactory: oc.watchFactory,
+		oc:           oc,
+		syncFunc:     nil,
+	}
+	resourceHandler := &retry.ResourceHandler{
+		HasUpdateFunc:          hasResourceAnUpdateFunc(objectType),
+		NeedsUpdateDuringRetry: needsUpdateDuringRetry(objectType),
+		ObjType:                objectType,
+		EventHandler:           eventHandler,
+	}
+	return retry.NewRetryFramework(
+		oc.stopChan,
+		oc.wg,
+		oc.watchFactory,
+		resourceHandler,
+	)
+}
+
+func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1.Node, nSyncs *nodeSyncs) error {
+	var errs []error
+
+	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
+		if nSyncs.syncMgmtPort {
+			// Layer 2 networks have a single, large subnet, that's the one
+			// associated to the controller.  Take the management port IP from
+			// there.
+			subnets := oc.Subnets()
+			hostSubnets := make([]*net.IPNet, 0, len(subnets))
+			for _, subnet := range oc.Subnets() {
+				hostSubnets = append(hostSubnets, subnet.CIDR)
+			}
+			if _, err := oc.syncNodeManagementPortNoRouteHostSubnets(node, oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), hostSubnets); err != nil {
+				errs = append(errs, err)
+				oc.mgmtPortFailed.Store(node.Name, true)
+			} else {
+				oc.mgmtPortFailed.Delete(node.Name)
+			}
+		}
+	}
+
+	errs = append(errs, oc.BaseSecondaryLayer2NetworkController.addUpdateLocalNodeEvent(node))
+
+	err := utilerrors.Join(errs...)
+	if err != nil {
+		oc.recordNodeErrorEvent(node, err)
+	}
+	return err
+}
+
+func (oc *SecondaryLayer2NetworkController) deleteNodeEvent(node *corev1.Node) error {
+	oc.localZoneNodes.Delete(node.Name)
+	oc.mgmtPortFailed.Delete(node.Name)
+	return nil
 }

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -2,21 +2,179 @@ package ovn
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
+	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/persistentips"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
+
+type secondaryLocalnetNetworkControllerEventHandler struct {
+	baseHandler  baseNetworkControllerEventHandler
+	watchFactory *factory.WatchFactory
+	objType      reflect.Type
+	oc           *SecondaryLocalnetNetworkController
+	syncFunc     func([]interface{}) error
+}
+
+// AreResourcesEqual returns true if, given two objects of a known resource type, the update logic for this resource
+// type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
+// equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update
+// function or with a delete on the old obj followed by an add on the new obj).
+func (h *secondaryLocalnetNetworkControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
+	return h.baseHandler.areResourcesEqual(h.objType, obj1, obj2)
+}
+
+// GetInternalCacheEntry returns the internal cache entry for this object, given an object and its type.
+// This is now used only for pods, which will get their the logical port cache entry.
+func (h *secondaryLocalnetNetworkControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
+	return h.oc.GetInternalCacheEntryForSecondaryNetwork(h.objType, obj)
+}
+
+// GetResourceFromInformerCache returns the latest state of the object, given an object key and its type.
+// from the informers cache.
+func (h *secondaryLocalnetNetworkControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
+	return h.baseHandler.getResourceFromInformerCache(h.objType, h.watchFactory, key)
+}
+
+// RecordAddEvent records the add event on this given object.
+func (h *secondaryLocalnetNetworkControllerEventHandler) RecordAddEvent(obj interface{}) {
+	switch h.objType {
+	case factory.MultiNetworkPolicyType:
+		mnp := obj.(*mnpapi.MultiNetworkPolicy)
+		klog.V(5).Infof("Recording add event on multinetwork policy %s/%s", mnp.Namespace, mnp.Name)
+		metrics.GetConfigDurationRecorder().Start("multinetworkpolicy", mnp.Namespace, mnp.Name)
+	}
+}
+
+// RecordUpdateEvent records the udpate event on this given object.
+func (h *secondaryLocalnetNetworkControllerEventHandler) RecordUpdateEvent(obj interface{}) {
+	h.baseHandler.recordAddEvent(h.objType, obj)
+}
+
+// RecordDeleteEvent records the delete event on this given object.
+func (h *secondaryLocalnetNetworkControllerEventHandler) RecordDeleteEvent(obj interface{}) {
+	h.baseHandler.recordAddEvent(h.objType, obj)
+}
+
+// RecordSuccessEvent records the success event on this given object.
+func (h *secondaryLocalnetNetworkControllerEventHandler) RecordSuccessEvent(obj interface{}) {
+	h.baseHandler.recordAddEvent(h.objType, obj)
+}
+
+// RecordErrorEvent records the error event on this given object.
+func (h *secondaryLocalnetNetworkControllerEventHandler) RecordErrorEvent(obj interface{}, reason string, err error) {
+}
+
+// IsResourceScheduled returns true if the given object has been scheduled.
+// Only applied to pods for now. Returns true for all other types.
+func (h *secondaryLocalnetNetworkControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
+	return h.baseHandler.isResourceScheduled(h.objType, obj)
+}
+
+// AddResource adds the specified object to the cluster according to its type and returns the error,
+// if any, yielded during object creation.
+// Given an object to add and a boolean specifying if the function was executed from iterateRetryResources
+func (h *secondaryLocalnetNetworkControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
+	switch h.objType {
+	case factory.NodeType:
+		node, ok := obj.(*corev1.Node)
+		if !ok {
+			return fmt.Errorf("could not cast %T object to Node", obj)
+		}
+		return h.oc.addUpdateNodeEvent(node)
+	default:
+		return h.oc.AddSecondaryNetworkResourceCommon(h.objType, obj)
+	}
+}
+
+// UpdateResource updates the specified object in the cluster to its version in newObj according to its
+// type and returns the error, if any, yielded during the object update.
+// Given an old and a new object; The inRetryCache boolean argument is to indicate if the given resource
+// is in the retryCache or not.
+func (h *secondaryLocalnetNetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
+	switch h.objType {
+	case factory.NodeType:
+		node, ok := newObj.(*corev1.Node)
+		if !ok {
+			return fmt.Errorf("could not cast %T object to Node", newObj)
+		}
+		return h.oc.addUpdateNodeEvent(node)
+	default:
+		return h.oc.UpdateSecondaryNetworkResourceCommon(h.objType, oldObj, newObj, inRetryCache)
+	}
+}
+
+// DeleteResource deletes the object from the cluster according to the delete logic of its resource type.
+// Given an object and optionally a cachedObj; cachedObj is the internal cache entry for this object,
+// used for now for pods and network policies.
+func (h *secondaryLocalnetNetworkControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
+	switch h.objType {
+	case factory.NodeType:
+		node, ok := obj.(*corev1.Node)
+		if !ok {
+			return fmt.Errorf("could not cast %T object to Node", obj)
+		}
+		return h.oc.deleteNodeEvent(node)
+	default:
+		return h.oc.DeleteSecondaryNetworkResourceCommon(h.objType, obj, cachedObj)
+	}
+}
+
+func (h *secondaryLocalnetNetworkControllerEventHandler) SyncFunc(objs []interface{}) error {
+	var syncFunc func([]interface{}) error
+
+	if h.syncFunc != nil {
+		// syncFunc was provided explicitly
+		syncFunc = h.syncFunc
+	} else {
+		switch h.objType {
+		case factory.NodeType:
+			syncFunc = h.oc.syncNodes
+
+		case factory.PodType:
+			syncFunc = h.oc.syncPodsForSecondaryNetwork
+
+		case factory.NamespaceType:
+			syncFunc = h.oc.syncNamespaces
+
+		case factory.MultiNetworkPolicyType:
+			syncFunc = h.oc.syncMultiNetworkPolicies
+
+		case factory.IPAMClaimsType:
+			syncFunc = h.oc.syncIPAMClaims
+
+		default:
+			return fmt.Errorf("no sync function for object type %s", h.objType)
+		}
+	}
+	if syncFunc == nil {
+		return nil
+	}
+	return syncFunc(objs)
+}
+
+// IsObjectInTerminalState returns true if the given object is a in terminal state.
+// This is used now for pods that are either in a PodSucceeded or in a PodFailed state.
+func (h *secondaryLocalnetNetworkControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
+	return h.baseHandler.isObjectInTerminalState(h.objType, obj)
+}
 
 // SecondaryLocalnetNetworkController is created for logical network infrastructure and policy
 // for a secondary localnet network
@@ -77,7 +235,7 @@ func NewSecondaryLocalnetNetworkController(cnci *CommonNetworkControllerInfo, ne
 	// TBD: changes needs to be made to support multicast in secondary networks
 	oc.multicastSupport = false
 
-	oc.BaseSecondaryLayer2NetworkController.initRetryFramework()
+	oc.initRetryFramework()
 	return oc
 }
 
@@ -143,4 +301,44 @@ func (oc *SecondaryLocalnetNetworkController) Init() error {
 func (oc *SecondaryLocalnetNetworkController) Stop() {
 	klog.Infof("Stoping controller for secondary network %s", oc.GetNetworkName())
 	oc.BaseSecondaryLayer2NetworkController.stop()
+}
+
+func (oc *SecondaryLocalnetNetworkController) initRetryFramework() {
+	oc.retryNodes = oc.newRetryFramework(factory.NodeType)
+	oc.retryPods = oc.newRetryFramework(factory.PodType)
+	if oc.allocatesPodAnnotation() && oc.NetInfo.AllowsPersistentIPs() {
+		oc.retryIPAMClaims = oc.newRetryFramework(factory.IPAMClaimsType)
+	}
+
+	// For secondary networks, we don't have to watch namespace events if
+	// multi-network policy support is not enabled. We don't support
+	// multi-network policy for IPAM-less secondary networks either.
+	if util.IsMultiNetworkPoliciesSupportEnabled() {
+		oc.retryNamespaces = oc.newRetryFramework(factory.NamespaceType)
+		oc.retryNetworkPolicies = oc.newRetryFramework(factory.MultiNetworkPolicyType)
+	}
+}
+
+// newRetryFramework builds and returns a retry framework for the input resource type;
+func (oc *SecondaryLocalnetNetworkController) newRetryFramework(
+	objectType reflect.Type) *retry.RetryFramework {
+	eventHandler := &secondaryLocalnetNetworkControllerEventHandler{
+		baseHandler:  baseNetworkControllerEventHandler{},
+		objType:      objectType,
+		watchFactory: oc.watchFactory,
+		oc:           oc,
+		syncFunc:     nil,
+	}
+	resourceHandler := &retry.ResourceHandler{
+		HasUpdateFunc:          hasResourceAnUpdateFunc(objectType),
+		NeedsUpdateDuringRetry: needsUpdateDuringRetry(objectType),
+		ObjType:                objectType,
+		EventHandler:           eventHandler,
+	}
+	return retry.NewRetryFramework(
+		oc.stopChan,
+		oc.wg,
+		oc.watchFactory,
+		resourceHandler,
+	)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This creates the OVN management port for user defined networks.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
This refactors the magament port creation code and moves it to the base network controller.  It also makes it receive the host subnets as argument.  In L2 networks there's a single large subnet pods get their IPs from.

There's one TODO left here and that is that the management port should be added to the per-network "cluster port group".  However, today, that doesn't exist so we keep adding it to the single, large, cluster-wide port group.  This should be addressed when network policy support is added to user defined networks.

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Existing UTs and e2es must pass.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->
NONE

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adds the OVN management port to L2 and L3 user defined networks.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
NONE
```
