### PR TITLE
Refactor NAD controller: Do not attach to default network

### DIFF
--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -239,6 +239,11 @@ func (nadController *NetAttachDefinitionController) syncNAD(key string, nad *net
 		return err
 	}
 
+	if ensureNetwork.IsDefault() {
+		klog.V(5).Infof("%s: NAD add for default network (key %s), skip it", nadController.name, key)
+		return nil
+	}
+
 	// ensure the network associated with the NAD
 	ensureNetwork.AddNADs(key)
 	nadController.nads[key] = ensureNetwork.GetNetworkName()

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller_test.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller_test.go
@@ -105,6 +105,15 @@ func TestNetAttachDefinitionController(t *testing.T) {
 		MTU: 1400,
 	}
 
+	network_Default := &ovncnitypes.NetConf{
+		Topology: types.Layer3Topology,
+		NetConf: cnitypes.NetConf{
+			Name: "default",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		MTU: 1400,
+	}
+
 	type args struct {
 		nad     string
 		network *ovncnitypes.NetConf
@@ -119,6 +128,16 @@ func TestNetAttachDefinitionController(t *testing.T) {
 		args     []args
 		expected []expected
 	}{
+		{
+			name: "NAD on default network should be skipped",
+			args: []args{
+				{
+					nad:     "test/nad_1",
+					network: network_Default,
+				},
+			},
+			expected: []expected{},
+		},
 		{
 			name: "NAD added",
 			args: []args{


### PR DESCRIPTION
Default network does add NADs.
This is a follow up from PR https://github.com/ovn-org/ovn-kubernetes/pull/4461.

This change addresses the following panic:

```
Image built from ovn-kubernetes ref: refs/heads/master  commit: 0a6853062c6f3da40d07b3bc51bfbc61b058f84d

I0703 14:17:52.721946      52 shared_informer.go:311] Waiting for caches to sync for [cluster-manager NAD controller]
I0703 14:17:52.721970      52 shared_informer.go:318] Caches are synced for [cluster-manager NAD controller]
panic: unexpected call for default network

goroutine 89 [running]:
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util.(*DefaultNetInfo).AddNADs(0x205a120?, {0xc0005d6d50?, 0x23f9ce2?, 0x7?})
    /builds/nithyar/ovn_upstream_validation/ovn-kubernetes/go-controller/pkg/util/multi_network.go:148 +0x25

github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller.(*NetAttachDefinitionController).syncNAD(0xc0004c1630, {0xc000e3ae40, 0x13}, 0x43e02e?)
    /builds/nithyar/ovn_upstream_validation/ovn-kubernetes/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go:243 +0x67b

github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller.(*NetAttachDefinitionController).syncAll(0xc0004c1630)
    /builds/nithyar/ovn_upstream_validation/ovn-kubernetes/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go:139 +0x2ba

github.com/ovn-org/ovn-kubernetes/go-controller/pkg/controller.StartWithInitialSync(0xc000e03e08, {0xc00050bdf8, 0x1, 0x0?})
    /builds/nithyar/ovn_upstream_validation/ovn-kubernetes/go-controller/pkg/controller/controller.go:293 +0x18e

github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller.(*NetAttachDefinitionController).Start(0xc0004c1630)
    /builds/nithyar/ovn_upstream_validation/ovn-kubernetes/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go:100 +0x85

github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager.(*secondaryNetworkClusterManager).Start(0xc0005d69f0)
    /builds/nithyar/ovn_upstream_validation/ovn-kubernetes/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go:69 +0x7d

github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager.(*ClusterManager).Start(0xc0000f5180, {0x27d4730, 0xc0004c0c80})
    /builds/nithyar/ovn_upstream_validation/ovn-kubernetes/go-controller/pkg/clustermanager/clustermanager.go:139 +0x125
main.runOvnKube.func2()
    /builds/nithyar/ovn_upstream_validation/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:460 +0x377
```
