### PR TITLE
ci: Add lane to test ovnkube-trace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -425,6 +425,7 @@ jobs:
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3"}
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}"
@@ -438,8 +439,8 @@ jobs:
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
-      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || matrix.target == 'network-segmentation' }}"
-      ENABLE_NETWORK_SEGMENTATION: "${{ matrix.target == 'network-segmentation' }}"
+      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || matrix.target == 'network-segmentation' || matrix.target == 'tools'}}"
+      ENABLE_NETWORK_SEGMENTATION: "${{ matrix.target == 'network-segmentation' || matrix.target == 'tools'}}"
       KIND_INSTALL_KUBEVIRT: "${{ matrix.target == 'kv-live-migration' }}"
       OVN_COMPACT_MODE: "${{ matrix.target == 'compact-mode' }}"
       OVN_DUMMY_GATEWAY_BRIDGE: "${{ matrix.target == 'compact-mode' }}"
@@ -529,6 +530,9 @@ jobs:
           make -C test control-plane
         elif [ "${{ matrix.target }}" == "network-segmentation" ]; then
           make -C test control-plane WHAT="Network Segmentation"
+        elif [ "${{ matrix.target }}" == "tools" ]; then
+          make -C go-controller build
+          make -C test tools
         else
           make -C test ${{ matrix.target }}
           if [ "${{ matrix.ipfamily }}" != "ipv6" ]; then

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -10,8 +10,11 @@ const (
 	HybridOverlayPrefix   = "int-"
 	HybridOverlayGRSubfix = "-gr"
 
+	// K8sMgmtIntfNamePrefix name to be used as an OVS internal port on the node as prefix for networs
+	K8sMgmtIntfNamePrefix = "ovn-k8s-mp"
+
 	// K8sMgmtIntfName name to be used as an OVS internal port on the node
-	K8sMgmtIntfName = "ovn-k8s-mp0"
+	K8sMgmtIntfName = K8sMgmtIntfNamePrefix + "0"
 
 	// PhysicalNetworkName is the name that maps to an OVS bridge that provides
 	// access to physical/external network

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -111,6 +111,18 @@ func GetLegacyK8sMgmtIntfName(nodeName string) string {
 	return GetK8sMgmtIntfName(nodeName)
 }
 
+// GetNetworkScopedK8sMgmtHostIntfName returns the management port host interface name for a network id
+// NOTE: network id is used instead of name so we don't reach the linux device name limit of 15 chars
+func GetNetworkScopedK8sMgmtHostIntfName(networkID uint) string {
+	intfName := types.K8sMgmtIntfNamePrefix + fmt.Sprintf("%d", networkID)
+	// We are over linux 15 chars limit for network devices, let's trim it
+	// for the prefix so we keep networkID as much as possible
+	if len(intfName) > 15 {
+		return intfName[:15]
+	}
+	return intfName
+}
+
 // GetWorkerFromGatewayRouter determines a node's corresponding worker switch name from a gateway router name
 func GetWorkerFromGatewayRouter(gr string) string {
 	return strings.TrimPrefix(gr, types.GWRouterPrefix)

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -335,3 +335,8 @@ func TestGenerateId(t *testing.T) {
 	matchesPattern, _ := regexp.MatchString("([a-zA-Z0-9-]*)", id)
 	assert.True(t, matchesPattern)
 }
+
+func TestGetNetworkScopedK8sMgmtHostIntfName(t *testing.T) {
+	intfName := GetNetworkScopedK8sMgmtHostIntfName(1245678)
+	assert.Equal(t, "ovn-k8s-mp12456", intfName)
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -41,3 +41,7 @@ conformance:
 	E2E_REPORT_DIR=$(E2E_REPORT_DIR) \
 	E2E_REPORT_PREFIX=$(JOB_NAME)_ \
 	./scripts/conformance.sh
+
+.PHONY: tools
+tools:
+	./scripts/test-ovnkube-trace.sh

--- a/test/scripts/test-ovnkube-trace.sh
+++ b/test/scripts/test-ovnkube-trace.sh
@@ -497,6 +497,9 @@ if ovnkube_trace ${src_pods[0]} ${dst_svc[0]} -udp; then
   exit 1
 fi
 
+echo "Run ovnkube-trace to dump UDN VRF table IDs"
+ovnkube_trace --dump-udn-vrf-table-ids
+
 if [ ${POST_CLEANUP} == true ]; then
   cleanup
 fi


### PR DESCRIPTION
#### What this PR does and why is it needed
The project contains an script to exercise ovnkube-trace but that script is not run by any CI lane, this change add a lane named "tools" to run that script.


#### Description for the changelog
Add "tools" ci lane

-->
```release-note
NONE
```
