### PR TITLE
Bump OVSDBTimeout and make it configurable.

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -146,7 +146,7 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout*2)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout*2)
 	go func() {
 		<-stopCh
 		cancel()
@@ -211,7 +211,7 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout*2)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout*2)
 	go func() {
 		<-stopCh
 		cancel()

--- a/go-controller/pkg/libovsdb/ops/acl.go
+++ b/go-controller/pkg/libovsdb/ops/acl.go
@@ -7,8 +7,8 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 // GetACLName returns the ACL name if it has one otherwise returns
@@ -29,7 +29,7 @@ type aclPredicate func(*nbdb.ACL) bool
 
 // FindACLsWithPredicate looks up ACLs from the cache based on a given predicate
 func FindACLsWithPredicate(nbClient libovsdbclient.Client, p aclPredicate) ([]*nbdb.ACL, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	acls := []*nbdb.ACL{}
 	err := nbClient.WhereCache(p).List(ctx, &acls)

--- a/go-controller/pkg/libovsdb/ops/address_set.go
+++ b/go-controller/pkg/libovsdb/ops/address_set.go
@@ -6,8 +6,8 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 type addressSetPredicate func(*nbdb.AddressSet) bool
@@ -33,7 +33,7 @@ func getNonZeroAddressSetMutableFields(as *nbdb.AddressSet) []interface{} {
 // FindAddressSetsWithPredicate looks up address sets from the cache based on a
 // given predicate
 func FindAddressSetsWithPredicate(nbClient libovsdbclient.Client, p addressSetPredicate) ([]*nbdb.AddressSet, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	found := []*nbdb.AddressSet{}
 	err := nbClient.WhereCache(p).List(ctx, &found)

--- a/go-controller/pkg/libovsdb/ops/chassis.go
+++ b/go-controller/pkg/libovsdb/ops/chassis.go
@@ -6,13 +6,13 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 // ListChassis looks up all chassis from the cache
 func ListChassis(sbClient libovsdbclient.Client) ([]*sbdb.Chassis, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	searchedChassis := []*sbdb.Chassis{}
 	err := sbClient.List(ctx, &searchedChassis)
@@ -21,7 +21,7 @@ func ListChassis(sbClient libovsdbclient.Client) ([]*sbdb.Chassis, error) {
 
 // ListChassisPrivate looks up all chassis private models from the cache
 func ListChassisPrivate(sbClient libovsdbclient.Client) ([]*sbdb.ChassisPrivate, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	found := []*sbdb.ChassisPrivate{}
 	err := sbClient.List(ctx, &found)

--- a/go-controller/pkg/libovsdb/ops/lbgroup.go
+++ b/go-controller/pkg/libovsdb/ops/lbgroup.go
@@ -6,8 +6,8 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 // CreateOrUpdateLoadBalancerGroup creates or updates the provided load balancer
@@ -76,7 +76,7 @@ type loadBalancerGroupPredicate func(*nbdb.LoadBalancerGroup) bool
 // FindLoadBalancerGroupsWithPredicate looks up load balancer groups from the
 // cache based on a given predicate
 func FindLoadBalancerGroupsWithPredicate(nbClient libovsdbclient.Client, p loadBalancerGroupPredicate) ([]*nbdb.LoadBalancerGroup, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	groups := []*nbdb.LoadBalancerGroup{}
 	err := nbClient.WhereCache(p).List(ctx, &groups)

--- a/go-controller/pkg/libovsdb/ops/loadbalancer.go
+++ b/go-controller/pkg/libovsdb/ops/loadbalancer.go
@@ -3,11 +3,10 @@ package ops
 import (
 	"context"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 )
 
@@ -133,7 +132,7 @@ func DeleteLoadBalancers(nbClient libovsdbclient.Client, lbs []*nbdb.LoadBalance
 // ListLoadBalancers looks up all load balancers from the cache
 func ListLoadBalancers(nbClient libovsdbclient.Client) ([]*nbdb.LoadBalancer, error) {
 	lbs := []*nbdb.LoadBalancer{}
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	err := nbClient.List(ctx, &lbs)
 	return lbs, err

--- a/go-controller/pkg/libovsdb/ops/model_client.go
+++ b/go-controller/pkg/libovsdb/ops/model_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	"github.com/ovn-org/libovsdb/client"
@@ -464,7 +465,7 @@ func (m *modelClient) where(opModel *operationModel) error {
 		// no indexes available
 		return errNoIndexes
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	var err error
 	if err = m.client.Where(copyModel).List(ctx, opModel.ExistingResult); err != nil {
@@ -484,7 +485,7 @@ func (m *modelClient) where(opModel *operationModel) error {
 }
 
 func (m *modelClient) whereCache(opModel *operationModel) error {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	var err error
 	if err = m.client.WhereCache(opModel.ModelPredicate).List(ctx, opModel.ExistingResult); err != nil {

--- a/go-controller/pkg/libovsdb/ops/portgroup.go
+++ b/go-controller/pkg/libovsdb/ops/portgroup.go
@@ -5,8 +5,8 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 type portGroupPredicate func(group *nbdb.PortGroup) bool
@@ -14,7 +14,7 @@ type portGroupPredicate func(group *nbdb.PortGroup) bool
 // FindPortGroupsWithPredicate looks up port groups from the cache based on a
 // given predicate
 func FindPortGroupsWithPredicate(nbClient libovsdbclient.Client, p portGroupPredicate) ([]*nbdb.PortGroup, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	found := []*nbdb.PortGroup{}
 	err := nbClient.WhereCache(p).List(ctx, &found)

--- a/go-controller/pkg/libovsdb/ops/qos.go
+++ b/go-controller/pkg/libovsdb/ops/qos.go
@@ -5,8 +5,8 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 type QoSPredicate func(*nbdb.QoS) bool
@@ -14,7 +14,7 @@ type QoSPredicate func(*nbdb.QoS) bool
 // FindQoSesWithPredicate looks up QoSes from the cache based on a
 // given predicate
 func FindQoSesWithPredicate(nbClient libovsdbclient.Client, p QoSPredicate) ([]*nbdb.QoS, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	found := []*nbdb.QoS{}
 	err := nbClient.WhereCache(p).List(ctx, &found)

--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -8,8 +8,8 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -39,7 +39,7 @@ func GetLogicalRouter(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter
 // FindLogicalRoutersWithPredicate looks up logical routers from the cache based on a
 // given predicate
 func FindLogicalRoutersWithPredicate(nbClient libovsdbclient.Client, p logicalRouterPredicate) ([]*nbdb.LogicalRouter, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	found := []*nbdb.LogicalRouter{}
 	err := nbClient.WhereCache(p).List(ctx, &found)
@@ -142,7 +142,7 @@ type logicalRouterPortPredicate func(*nbdb.LogicalRouterPort) bool
 // FindLogicalRouterPortWithPredicate looks up logical router port from
 // the cache based on a given predicate
 func FindLogicalRouterPortWithPredicate(nbClient libovsdbclient.Client, p logicalRouterPortPredicate) ([]*nbdb.LogicalRouterPort, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	found := []*nbdb.LogicalRouterPort{}
 	err := nbClient.WhereCache(p).List(ctx, &found)
@@ -249,7 +249,7 @@ type logicalRouterPolicyPredicate func(*nbdb.LogicalRouterPolicy) bool
 // FindLogicalRouterPoliciesWithPredicate looks up logical router policies from
 // the cache based on a given predicate
 func FindLogicalRouterPoliciesWithPredicate(nbClient libovsdbclient.Client, p logicalRouterPolicyPredicate) ([]*nbdb.LogicalRouterPolicy, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	found := []*nbdb.LogicalRouterPolicy{}
 	err := nbClient.WhereCache(p).List(ctx, &found)
@@ -557,7 +557,7 @@ type logicalRouterStaticRoutePredicate func(*nbdb.LogicalRouterStaticRoute) bool
 // FindLogicalRouterStaticRoutesWithPredicate looks up logical router static
 // routes from the cache based on a given predicate
 func FindLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client, p logicalRouterStaticRoutePredicate) ([]*nbdb.LogicalRouterStaticRoute, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	found := []*nbdb.LogicalRouterStaticRoute{}
 	err := nbClient.WhereCache(p).List(ctx, &found)
@@ -1001,7 +1001,7 @@ func GetNAT(nbClient libovsdbclient.Client, nat *nbdb.NAT) (*nbdb.NAT, error) {
 // FindNATsWithPredicate looks up NATs from the cache based on a given predicate
 func FindNATsWithPredicate(nbClient libovsdbclient.Client, predicate natPredicate) ([]*nbdb.NAT, error) {
 	nats := []*nbdb.NAT{}
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	err := nbClient.WhereCache(predicate).List(ctx, &nats)
 	return nats, err

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -8,8 +8,8 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 // LOGICAL_SWITCH OPs
@@ -20,7 +20,7 @@ type switchPredicate func(*nbdb.LogicalSwitch) bool
 // based on a given predicate
 func FindLogicalSwitchesWithPredicate(nbClient libovsdbclient.Client, p switchPredicate) ([]*nbdb.LogicalSwitch, error) {
 	found := []*nbdb.LogicalSwitch{}
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	err := nbClient.WhereCache(p).List(ctx, &found)
 	return found, err

--- a/go-controller/pkg/libovsdb/ops/template_var.go
+++ b/go-controller/pkg/libovsdb/ops/template_var.go
@@ -5,15 +5,15 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 type chassisTemplateVarPredicate func(*nbdb.ChassisTemplateVar) bool
 
 // ListTemplateVar looks up all chassis template variables.
 func ListTemplateVar(nbClient libovsdbclient.Client) ([]*nbdb.ChassisTemplateVar, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 
 	templatesList := []*nbdb.ChassisTemplateVar{}

--- a/go-controller/pkg/libovsdb/ops/transact.go
+++ b/go-controller/pkg/libovsdb/ops/transact.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 )
 
 // TransactWithRetry will attempt a transaction several times if it receives an error indicating that the client
@@ -41,7 +41,7 @@ func TransactAndCheck(c client.Client, ops []ovsdb.Operation) ([]ovsdb.Operation
 
 	klog.V(5).Infof("Configuring OVN: %+v", ops)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.TODO(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 
 	results, err := TransactWithRetry(ctx, c, ops)

--- a/go-controller/pkg/ovn/controller/unidling/unidle.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle.go
@@ -9,8 +9,8 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
-	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	kapi "k8s.io/api/core/v1"
@@ -62,7 +62,7 @@ func NewController(recorder record.EventRecorder, serviceInformer cache.SharedIn
 	klog.Info("Populating Initial ContollerEvent events")
 
 	var controllerEvents []sbdb.ControllerEvent
-	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	err := sbClient.List(ctx, &controllerEvents)
 	if err != nil {
@@ -178,7 +178,7 @@ func (uc *unidlingController) handleLbEmptyBackendsEvent(event sbdb.ControllerEv
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 	defer cancel()
 	result, err := uc.sbClient.Transact(ctx, op...)
 	if err != nil {

--- a/go-controller/pkg/ovn/controller/unidling/unidle_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"golang.org/x/net/context"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,7 +99,7 @@ var _ = Describe("Unidling Controller", func() {
 		// Controller_Event is deleted
 		Eventually(
 			func() int {
-				ctx, _ := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+				ctx, _ := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 				var events []sbdb.ControllerEvent
 				err = sbClient.List(ctx, &events)
 				Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -948,7 +948,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					// sleep long enough for TransactWithRetry to fail, causing egress firewall Add to fail
-					time.Sleep(t.OVSDBTimeout + time.Second)
+					time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 					// check to see if the retry cache has an entry for this egress firewall
 					key := getEgressFirewallNamespacedName(egressFirewall)
 					ginkgo.By("retry entry: old obj should not be nil, new obj should be nil")
@@ -959,7 +959,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						gomega.BeNil(),             // newObj should be nil
 					)
 
-					connCtx, cancel := context.WithTimeout(context.Background(), t.OVSDBTimeout)
+					connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 					defer cancel()
 					resetNBClient(connCtx, fakeOVN.controller.nbClient)
 					retry.SetRetryObjWithNoBackoff(key, fakeOVN.controller.retryEgressFirewalls)
@@ -1014,7 +1014,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall1.Namespace).Update(context.TODO(), egressFirewall1, metav1.UpdateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					// sleep long enough for TransactWithRetry to fail, causing egress firewall Add to fail
-					time.Sleep(t.OVSDBTimeout + time.Second)
+					time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 					// check to see if the retry cache has an entry for this egress firewall
 					key, err := retry.GetResourceKey(egressFirewall)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1027,7 +1027,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						gomega.Not(gomega.BeNil()), // newObj should not be nil
 					)
 
-					connCtx, cancel := context.WithTimeout(context.Background(), t.OVSDBTimeout)
+					connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 					defer cancel()
 					ginkgo.By("bringing up NBDB and requesting retry of entry")
 					resetNBClient(connCtx, fakeOVN.controller.nbClient)

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -1131,7 +1131,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					// sleep long enough for TransactWithRetry to fail, causing egressnode operations to fail
 					// there is a chance that both egressnode events(node1 removal and node2 update) will end up in the same event queue
 					// sleep for double the time to allow for two consecutive TransactWithRetry timeouts
-					time.Sleep(2 * (types.OVSDBTimeout + time.Second))
+					time.Sleep(2 * (config.Default.OVSDBTxnTimeout + time.Second))
 					// check to see if the retry cache has an entry
 					key1 := node1.Name
 					ginkgo.By("retry entry: old obj should not be nil, new obj should be nil")
@@ -1152,7 +1152,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					//	gomega.Not(gomega.BeNil()), // config should not be nil
 					//)
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP, "")
-					connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+					connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 					defer cancel()
 					resetNBClient(connCtx, fakeOvn.controller.nbClient)
 					retry.SetRetryObjWithNoBackoff(key1, fakeOvn.controller.retryEgressNodes)
@@ -1541,7 +1541,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					// sleep long enough for TransactWithRetry to fail, causing egressnode operations to fail
 					// there is a chance that both egressnode events(node1 removal and node2 update) will end up in the same event queue
 					// sleep for double the time to allow for two consecutive TransactWithRetry timeouts
-					time.Sleep(2 * (types.OVSDBTimeout + time.Second))
+					time.Sleep(2 * (config.Default.OVSDBTxnTimeout + time.Second))
 					// check to see if the retry cache has an entry
 					key1 := node1.Name
 					ginkgo.By("retry entry: old obj should not be nil, new obj should be nil")
@@ -1561,7 +1561,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					//	gomega.Not(gomega.BeNil()), // newObj should not be nil
 					//	gomega.Not(gomega.BeNil()), // config should not be nil
 					//)
-					connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+					connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 					defer cancel()
 					resetNBClient(connCtx, fakeOvn.controller.nbClient)
 					retry.SetRetryObjWithNoBackoff(key1, fakeOvn.controller.retryEgressNodes)
@@ -3757,7 +3757,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					}).Should(gomega.BeFalse())
 					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(egressPod.Namespace).Update(context.TODO(), podUpdate, metav1.UpdateOptions{})
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-					time.Sleep(types.OVSDBTimeout + time.Second)
+					time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 					// check to see if the retry cache has an entry
 					var key string
 					key, err = retry.GetResourceKey(podUpdate)
@@ -3772,7 +3772,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						gomega.Not(gomega.BeNil()), // config should not be nil
 					)
 
-					connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+					connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 					defer cancel()
 					resetNBClient(connCtx, fakeOvn.controller.nbClient)
 
@@ -4738,13 +4738,13 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP.String(), "::/64")
 
 					// sleep long enough for TransactWithRetry to fail, causing egressnode operations to fail
-					time.Sleep(types.OVSDBTimeout + time.Second)
+					time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 					// check to see if the retry cache has an entry
 					key, err := retry.GetResourceKey(&eIP)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					retry.CheckRetryObjectEventually(key, true, fakeOvn.controller.retryEgressIPs)
 
-					connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+					connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 					defer cancel()
 					resetNBClient(connCtx, fakeOvn.controller.nbClient)
 					retry.SetRetryObjWithNoBackoff(key, fakeOvn.controller.retryEgressIPs)
@@ -6289,7 +6289,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				// sleep long enough for TransactWithRetry to fail, causing egressnode operations to fail
 				// there is a chance that both egressnode events(node1 removal and node2 update) will end up in the same event queue
 				// sleep for double the time to allow for two consecutive TransactWithRetry timeouts
-				time.Sleep(2 * (types.OVSDBTimeout + time.Second))
+				time.Sleep(2 * (config.Default.OVSDBTxnTimeout + time.Second))
 				// check to see if the retry cache has an entry
 				key, err := retry.GetResourceKey(&node)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -6305,7 +6305,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node.Labels = map[string]string{}
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+				connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
 				retry.SetRetryObjWithNoBackoff(key, fakeOvn.controller.retryEgressNodes)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1365,7 +1365,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				gomega.BeNil(),             // oldObj should be nil
 				gomega.Not(gomega.BeNil()), // newObj should not be nil
 			)
-			connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+			connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 			defer cancel()
 			ginkgo.By("bring up NBDB")
 			resetNBClient(connCtx, oc.nbClient)
@@ -1420,7 +1420,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// sleep long enough for TransactWithRetry to fail, causing LS (and other rows related to node) delete to fail
-			time.Sleep(types.OVSDBTimeout + time.Second)
+			time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 
 			// check the retry entry for this node
 			ginkgo.By("retry entry: old obj should not be nil, new obj should be nil")
@@ -1432,7 +1432,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			)
 
 			// reconnect nbdb
-			connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+			connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 			defer cancel()
 			resetNBClient(connCtx, oc.nbClient)
 

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -502,7 +502,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					},
 				)
 
-				ctext, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				ctext, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 				defer cancel()
 				lsl := []nbdb.LogicalSwitch{}
 				err := fakeOvn.controller.nbClient.WhereCache(
@@ -1058,11 +1058,11 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// sleep long enough for TransactWithRetry to fail, causing pod add to fail
-				time.Sleep(ovntypes.OVSDBTimeout + time.Second)
+				time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 
 				// check to see if the pod retry cache has an entry for this policy
 				retry.CheckRetryObjectEventually(key, true, fakeOvn.controller.retryPods)
-				connCtx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
@@ -1138,11 +1138,11 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// sleep long enough for TransactWithRetry to fail, causing pod delete to fail
-				time.Sleep(ovntypes.OVSDBTimeout + time.Second)
+				time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 
 				// check to see if the pod retry cache has an entry for this pod
 				retry.CheckRetryObjectEventually(key, true, fakeOvn.controller.retryPods)
-				connCtx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
@@ -1214,7 +1214,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				err = fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// sleep long enough for TransactWithRetry to fail, causing pod add to fail
-				time.Sleep(ovntypes.OVSDBTimeout + time.Second)
+				time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 
 				// wait until retry entry appears
 
@@ -1248,7 +1248,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				// restore nbdb, trigger a retry and verify that the retry entry gets deleted
 				// because it reached retry.MaxFailedAttempts and the corresponding pod has NOT been added to OVN
-				connCtx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
 
@@ -1332,7 +1332,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// sleep long enough for TransactWithRetry to fail, causing pod delete to fail
-				time.Sleep(ovntypes.OVSDBTimeout + time.Second)
+				time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 
 				// wait until retry entry appears and check that it is marked for deletion
 				retry.CheckRetryObjectMultipleFieldsEventually(
@@ -1361,7 +1361,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				// restore nbdb and verify that the retry entry gets deleted because it reached
 				// retry.MaxFailedAttempts and the corresponding pod has NOT been deleted from OVN
-				connCtx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1121,13 +1121,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					Create(context.TODO(), networkPolicy2, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
-				time.Sleep(types.OVSDBTimeout + time.Second)
+				time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 				// check to see if the retry cache has an entry for this policy
 				key, err := retry.GetResourceKey(networkPolicy2)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				retry.CheckRetryObjectEventually(key, true, fakeOvn.controller.retryNetworkPolicies)
 
-				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+				connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
 				retry.SetRetryObjWithNoBackoff(key, fakeOvn.controller.retryPods)
@@ -1180,7 +1180,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
-				time.Sleep(types.OVSDBTimeout + time.Second)
+				time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 				// create second networkpolicy with the same name, but different tcp port
 				networkPolicy2 := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum+1)
 				// check retry entry for this policy
@@ -1193,7 +1193,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					gomega.Not(gomega.BeNil()), // oldObj should not be nil
 					gomega.BeNil(),             // newObj should be nil
 				)
-				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+				connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
 
@@ -1515,13 +1515,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
-				time.Sleep(types.OVSDBTimeout + time.Second)
+				time.Sleep(config.Default.OVSDBTxnTimeout + time.Second)
 
 				// check to see if the retry cache has an entry for this policy
 				key, err := retry.GetResourceKey(networkPolicy)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				retry.CheckRetryObjectEventually(key, true, fakeOvn.controller.retryNetworkPolicies)
-				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+				connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
 				retry.SetRetryObjWithNoBackoff(key, fakeOvn.controller.retryPods)


### PR DESCRIPTION
Make OVSDBTimeout for transactions a part of config.Global instead of const. A reasonable value for this timeout depends on the size of the cluster and making it configurable may help solve crashloop problems. It also speeds up testing as timeout may be set to lower value for unit tests.
`types.OVSDBTimeout` is still used in `libovsdb.newClient` for inactivity and reconnectTimeouts.
How much time a transaction takes depends on the size of this transaction, one of the most complicated examples is address set dbIDs sync, which needs to update address set name and all its references (i.e. acls, lrps, qoses matches). I have set batch size for transaction to 50 https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync.go#L76 considering this is small enough, but a customer hit that timeout. 
Then I considered doing something similar to port group code https://github.com/ovn-org/ovn-kubernetes/blob/425a328cd1729d0dc9ce0a52936d47dee1702b4e/go-controller/pkg/ovn/external_ids_syncer/port_group/port_group_sync.go#L42-L76, but it is way too complicated for address sets with 3 different referencing object types, and looks like an overkill just to avoid a valid transaction timing out.
I am not aware of any reasoning for the existing db timeout = 10s, so I am trying to figure out which value makes sense by default. Considering the timeout is only there to avoid rpc call hanging, which should almost never happen, a couple of minutes sounds like a reasonable upper threshold.
Now getting back to 50 address set batch size (as there is not better reference for what should be supported) I measured locally that updating 50 address sets, each referencing 5000 ACLs takes 41s, with 10000 ACLs it takes 80s.
As I have seen clusters using thousands of ACLs, and namespace selector is quite popular (which is converted to the address sets reference in the ACL.match), I assume it is a good enough example to try to support.
That is how I ended up with default value of 100s, to make sure mentioned transactions succeed, but if the rpc call hangs, we can still recover.