### PR TITLE
udn, egress, e2e: assert a pod can reach a service outside the cluster

### DIFF
--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -363,6 +363,84 @@ var _ = Describe("Network Segmentation", func() {
 				),
 			),
 		)
+
+		Context("an HTTP service which is deployed outside the Kubernetes cluster", func() {
+			const (
+				externalContainerName = "ovn-k-egress-test-helper"
+			)
+			var externalIpv4 string
+			BeforeEach(func() {
+				externalIpv4, _ = createClusterExternalContainer(
+					externalContainerName,
+					"registry.k8s.io/e2e-test-images/agnhost:2.45",
+					runExternalContainerCmd(),
+					httpServerContainerCmd(port),
+				)
+
+				DeferCleanup(func() {
+					deleteClusterExternalContainer(externalContainerName)
+				})
+			})
+
+			XDescribeTable(
+				"can be accessed to from the pods running in the Kubernetes cluster",
+				func(netConfigParams networkAttachmentConfigParams, clientPodConfig podConfiguration) {
+					netConfig := newNetworkAttachmentConfig(netConfigParams)
+
+					netConfig.namespace = f.Namespace.Name
+					clientPodConfig.namespace = f.Namespace.Name
+
+					By("creating the attachment configuration")
+					_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
+						context.Background(),
+						generateNAD(netConfig),
+						metav1.CreateOptions{},
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("instantiating the client pod")
+					clientPod, err := cs.CoreV1().Pods(clientPodConfig.namespace).Create(
+						context.Background(),
+						generatePodSpec(clientPodConfig),
+						metav1.CreateOptions{},
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(clientPod).NotTo(BeNil())
+
+					By("asserting the client pod reaches the `Ready` state")
+					Eventually(func() v1.PodPhase {
+						updatedPod, err := cs.CoreV1().Pods(f.Namespace.Name).Get(context.Background(), clientPod.GetName(), metav1.GetOptions{})
+						if err != nil {
+							return v1.PodFailed
+						}
+						return updatedPod.Status.Phase
+					}, 2*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
+
+					By("asserting the *client* pod can contact the server located outside the cluster")
+					Eventually(func() error {
+						return connectToServer(clientPodConfig, externalIpv4, port)
+					}, 2*time.Minute, 6*time.Second).Should(Succeed())
+				},
+				Entry("by one pod with a single IPv4 address over a layer2 network",
+					networkAttachmentConfigParams{
+						name:     userDefinedNetworkName,
+						topology: "layer2",
+						cidr:     userDefinedNetworkIPv4Subnet,
+						role:     "primary",
+					},
+					*podConfig("client-pod"),
+				),
+				Entry("by one pod with a single IPv4 address over a layer3 network",
+					networkAttachmentConfigParams{
+						name:     userDefinedNetworkName,
+						topology: "layer3",
+						cidr:     userDefinedNetworkIPv4Subnet,
+						role:     "primary",
+					},
+					*podConfig("client-pod"),
+				),
+			)
+		})
 	})
 })
 
@@ -452,4 +530,8 @@ func runUDNPod(cs clientset.Interface, namespace string, serverPodConfig podConf
 		return updatedPod.Status.Phase
 	}, 2*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
 	return updatedPod
+}
+
+func runExternalContainerCmd() []string {
+	return []string{"--network", "kind"}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR adds an e2e test to assert a pod can reach an HTTP service running outside the kubernetes cluster.

To prove it, we run a containerized http server in the kind network, and access it from a pod started in the Kubernetes cluster.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
