### PR TITLE
Cleanup EgressIP multi NIC changes when disabling GatewayModeLocal

### DIFF
--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -28,13 +28,17 @@ type Controller struct {
 
 // NewController creates a new linux IP rule manager
 func NewController(v4, v6 bool) *Controller {
-	return &Controller{
+	nc := &Controller{
 		mu:            &sync.Mutex{},
 		rules:         make([]ipRule, 0),
 		ownPriorities: make(map[int]bool, 0),
 		v4:            v4,
 		v6:            v6,
 	}
+	if err := nc.loadHostRules(); err != nil {
+		klog.Warningf("Could not load ip rules from host, err: %q", err)
+	}
+	return nc
 }
 
 // Run starts manages linux IP rules
@@ -61,13 +65,11 @@ func (rm *Controller) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {
 func (rm *Controller) Add(rule netlink.Rule) error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
-	// check if we are already managing this route and if so, no-op
-	for _, existingRule := range rm.rules {
-		if areNetlinkRulesEqual(existingRule.rule, &rule) {
-			return nil
-		}
+	// rm.add == false -> rule was not added -> return from Add().
+	if !rm.add(rule) {
+		return nil
 	}
-	rm.rules = append(rm.rules, ipRule{rule: &rule})
+	// rm.add == true -> rule was added -> trigger reconcilitation.
 	return rm.reconcile()
 }
 
@@ -102,16 +104,8 @@ func (rm *Controller) reconcile() error {
 	defer func() {
 		klog.V(5).Infof("Reconciling IP rules took %v", time.Since(start))
 	}()
-	var family int
-	if rm.v4 && rm.v6 {
-		family = netlink.FAMILY_ALL
-	} else if rm.v4 {
-		family = netlink.FAMILY_V4
-	} else if rm.v6 {
-		family = netlink.FAMILY_V6
-	}
 
-	rulesFound, err := netlink.RuleList(family)
+	rulesFound, err := rm.getNetlinkRules()
 	if err != nil {
 		return err
 	}
@@ -168,8 +162,10 @@ func (rm *Controller) reconcile() error {
 	return utilerrors.Join(errors...)
 }
 
+// areNetlinkRulesEqual returns true if the provided rules are equal (they have the same IP address family and their
+// string representations are equal).
 func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {
-	return r1.String() == r2.String()
+	return r1.Family == r2.Family && r1.String() == r2.String()
 }
 
 func isNetlinkRuleInSlice(rules []netlink.Rule, candidate *netlink.Rule) (bool, *netlink.Rule) {
@@ -183,4 +179,47 @@ func isNetlinkRuleInSlice(rules []netlink.Rule, candidate *netlink.Rule) (bool, 
 		}
 	}
 	return false, netlink.NewRule()
+}
+
+// add adds an IP rule to the in memory list of rules. Returns true if the rule was appended,
+// false if the rule was not added because it already exists.
+func (rm *Controller) add(rule netlink.Rule) bool {
+	// check if we are already managing this route and if so, no-op
+	for _, existingRule := range rm.rules {
+		if areNetlinkRulesEqual(existingRule.rule, &rule) {
+			return false
+		}
+	}
+	rm.rules = append(rm.rules, ipRule{rule: &rule})
+	return true
+}
+
+// getNetlinkRules retrieves all ip rules via netlink for this manager's IP address families.
+func (rm *Controller) getNetlinkRules() ([]netlink.Rule, error) {
+	var family int
+	if rm.v4 && rm.v6 {
+		family = netlink.FAMILY_ALL
+	} else if rm.v4 {
+		family = netlink.FAMILY_V4
+	} else if rm.v6 {
+		family = netlink.FAMILY_V6
+	}
+
+	return netlink.RuleList(family)
+}
+
+// loadHostRules retrieves all ip rules via netlink for this manager's IP address families and adds them to the in
+// memory list of rules.
+func (rm *Controller) loadHostRules() error {
+	rules, err := rm.getNetlinkRules()
+	if err != nil {
+		return err
+	}
+
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	for _, rule := range rules {
+		_ = rm.add(rule)
+	}
+	return nil
 }


### PR DESCRIPTION
a) When transitioning from GatewayModeLocal to GatewayModeShared, make sure
to revert / clean up any changes that are only for local gateway mode.

b) Add missing unit tests for that static EgressIP IP rules, iptables rules, sysctl.

c) The ip rule manager must be synchronized with rules from netlink on
startup, otherwise the Delete action will not work for existing rules.
