### PR TITLE
Auto exclude gw mgmtport ips layer2 udn for non-IC deployments

### DIFF
--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -17,7 +17,8 @@ type LogicalSwitchManager struct {
 	reserveIPs bool
 }
 
-// Initializes a new logical switch manager for L3 networks
+// NewLogicalSwitchManager initializes a new logical switch manager for L3
+// networks.
 func NewLogicalSwitchManager() *LogicalSwitchManager {
 	return &LogicalSwitchManager{
 		allocator:  subnet.NewAllocator(),
@@ -25,12 +26,24 @@ func NewLogicalSwitchManager() *LogicalSwitchManager {
 	}
 }
 
+// NewL2SwitchManager initializes a new logical switch manager for L2 secondary
+// networks.
+// In L2, we do not auto-reserve the GW and mp0 IPs on the subnet - the reasons
+// are different depending on the topology though:
+//   - localnet: it is the user's responsibility to know which IPs to exclude
+//     from the physical network
+//   - layer2: this is a disconnected network, thus it doesn't have a GW, nor a
+//     management port
 func NewL2SwitchManager() *LogicalSwitchManager {
 	return &LogicalSwitchManager{
 		allocator: subnet.NewAllocator(),
 	}
 }
 
+// NewL2SwitchManagerForUserDefinedPrimaryNetwork initializes a new logical
+// switch manager for L2 primary networks.
+// A user defined primary network auto-reserves the .1 and .2 IP addresses,
+// which are required for egressing the cluster over this user defined network.
 func NewL2SwitchManagerForUserDefinedPrimaryNetwork() *LogicalSwitchManager {
 	return NewLogicalSwitchManager()
 }

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -31,6 +31,10 @@ func NewL2SwitchManager() *LogicalSwitchManager {
 	}
 }
 
+func NewL2SwitchManagerForUserDefinedPrimaryNetwork() *LogicalSwitchManager {
+	return NewLogicalSwitchManager()
+}
+
 // AddOrUpdateSwitch adds/updates a switch to the logical switch manager for subnet
 // and IPAM management.
 func (manager *LogicalSwitchManager) AddOrUpdateSwitch(switchName string, hostSubnets []*net.IPNet, excludeSubnets ...*net.IPNet) error {

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -230,6 +230,10 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 	ipv4Mode, ipv6Mode := netInfo.IPMode()
 	addressSetFactory := addressset.NewOvnAddressSetFactory(cnci.nbClient, ipv4Mode, ipv6Mode)
 
+	lsManagerFactoryFn := lsm.NewL2SwitchManager
+	if netInfo.IsPrimaryNetwork() {
+		lsManagerFactoryFn = lsm.NewL2SwitchManagerForUserDefinedPrimaryNetwork
+	}
 	oc := &SecondaryLayer2NetworkController{
 		BaseSecondaryLayer2NetworkController: BaseSecondaryLayer2NetworkController{
 
@@ -238,7 +242,7 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 					CommonNetworkControllerInfo: *cnci,
 					controllerName:              getNetworkControllerName(netInfo.GetNetworkName()),
 					NetInfo:                     netInfo,
-					lsManager:                   lsm.NewL2SwitchManager(),
+					lsManager:                   lsManagerFactoryFn(),
 					logicalPortCache:            newPortCache(stopChan),
 					namespaces:                  make(map[string]*namespaceInfo),
 					namespacesMutex:             sync.Mutex{},

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 	"time"
 
-	iputils "github.com/containernetworking/plugins/pkg/ip"
-	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	iputils "github.com/containernetworking/plugins/pkg/ip"
+
+	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR is the non-IC deployment counter-part of #4514 ; it auto-excludes the GW and mgmt port IPs for layer2 primary networks when IP addresses are assigned on the ovnkube-controller (by the logical switch manager).

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
This code only makes sense **if** we want to support non-IC for user defined networks. 

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Run the associated unit tests.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Auto exclude gw mgmtport ips layer2 udn for non-IC deployments

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
NONE
```
