### PR TITLE
udn: Skip non ovn nads

### DIFF
--- a/go-controller/pkg/testing/util.go
+++ b/go-controller/pkg/testing/util.go
@@ -27,11 +27,15 @@ func GenerateNAD(networkName, name, namespace, topology, cidr, role string) *nad
 		fmt.Sprintf("%s/%s", namespace, name),
 		role,
 	)
+	return GenerateNADWithConfig(name, namespace, nadSpec)
+}
+
+func GenerateNADWithConfig(name, namespace, config string) *nadapi.NetworkAttachmentDefinition {
 	return &nadapi.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: nadapi.NetworkAttachmentDefinitionSpec{Config: nadSpec},
+		Spec: nadapi.NetworkAttachmentDefinitionSpec{Config: config},
 	}
 }

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -362,7 +362,8 @@ func GetActiveNetworkForNamespace(namespace string, nadLister nadlister.NetworkA
 	for _, nad := range namespaceNADs {
 		nadInfo, err := ParseNADInfo(nad)
 		if err != nil {
-			return activeNetwork, err
+			klog.Warningf("Skipping nad '%s/%s' as active network after failing parsing it with %v", nad.Namespace, nad.Name, err)
+			continue
 		}
 		if nadInfo.IsPrimaryNetwork() {
 			activeNetwork = nadInfo.GetNetworkName()

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -282,8 +282,15 @@ func TestGetActiveNetworkForNamespace(t *testing.T) {
 			nads: []*nadapi.NetworkAttachmentDefinition{
 				ovntest.GenerateNAD("surya", "quique", "ns1",
 					types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary),
-				ovntest.GenerateNAD("surya", "quique", "ns2",
+				ovntest.GenerateNAD("surya", "quique1", "ns1",
 					types.Layer2Topology, "10.100.200.0/24", types.NetworkRoleSecondary),
+				ovntest.GenerateNADWithConfig("quique2", "ns1", `
+{
+        "cniVersion": "whocares",
+        "nme": bad,
+        "typ": bad,
+}
+`),
 			},
 			expectedErr:           nil,
 			namespace:             "ns1",


### PR DESCRIPTION
#### What this PR does and why is it needed
When looking for the active network ovn-k should skip the non OVN nads instead of failing with the well known error.

#### How to verify it
It has a unit test

For more information on release notes see: TBD
-->
```release-note
NONE
```
