### PR TITLE
Helm image secrets (continuation)

### DIFF
--- a/helm/ovn-kubernetes/Chart.yaml
+++ b/helm/ovn-kubernetes/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart to deploy ovn-kubernetes cni
 type: application
 version: 1.0.0
 appVersion: "1.0.0"
-home: https://www.ovn.org/
+home: https://ovn-kubernetes.io/
 icon: https://www.ovn.org/images/ovn-logo.png
 sources:
   - https://github.com/ovn-org/ovn-kubernetes

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -154,10 +154,23 @@ false
 			<td>Whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws</td>
 		</tr>
 		<tr>
-			<td>global.egressIpHealthCheckPort</td>
-			<td>string</td>
+			<td>global.dockerConfigSecret</td>
+			<td>object</td>
 			<td><pre lang="json">
-""
+{
+  "auth": "blah_blah_blah",
+  "create": false,
+  "registry": "ghcr.io"
+}
+</pre>
+</td>
+			<td>The secret used for pulling image. Use only if needed. Set create to have have secret created by helm</td>
+		</tr>
+		<tr>
+			<td>global.egressIpHealthCheckPort</td>
+			<td>int</td>
+			<td><pre lang="json">
+9107
 </pre>
 </td>
 			<td>Configure EgressIP node reachability using gRPC on this TCP port</td>
@@ -173,9 +186,9 @@ false
 		</tr>
 		<tr>
 			<td>global.enableAdminNetworkPolicy</td>
-			<td>string</td>
+			<td>bool</td>
 			<td><pre lang="json">
-""
+false
 </pre>
 </td>
 			<td>Whether or not to use Admin Network Policy CRD feature with ovn-kubernetes</td>
@@ -200,36 +213,36 @@ false
 		</tr>
 		<tr>
 			<td>global.enableEgressFirewall</td>
-			<td>string</td>
+			<td>bool</td>
 			<td><pre lang="json">
-""
+true
 </pre>
 </td>
 			<td>Configure to use EgressFirewall CRD feature with ovn-kubernetes</td>
 		</tr>
 		<tr>
 			<td>global.enableEgressIp</td>
-			<td>string</td>
+			<td>bool</td>
 			<td><pre lang="json">
-""
+true
 </pre>
 </td>
 			<td>Configure to use EgressIP CRD feature with ovn-kubernetes</td>
 		</tr>
 		<tr>
 			<td>global.enableEgressQos</td>
-			<td>string</td>
+			<td>bool</td>
 			<td><pre lang="json">
-""
+true
 </pre>
 </td>
 			<td>Configure to use EgressQoS CRD feature with ovn-kubernetes</td>
 		</tr>
 		<tr>
 			<td>global.enableEgressService</td>
-			<td>string</td>
+			<td>bool</td>
 			<td><pre lang="json">
-""
+true
 </pre>
 </td>
 			<td>Configure to use EgressService CRD feature with ovn-kubernetes</td>
@@ -283,7 +296,7 @@ true
 			<td>global.enableMultiExternalGateway</td>
 			<td>bool</td>
 			<td><pre lang="json">
-false
+true
 </pre>
 </td>
 			<td>Configure to use AdminPolicyBasedExternalRoute CRD feature with ovn-kubernetes</td>
@@ -314,6 +327,15 @@ true
 </pre>
 </td>
 			<td>Whether or not enable ovnkube identity webhook</td>
+		</tr>
+		<tr>
+			<td>global.enablePersistentIPs</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Configure to use the IPAMClaims CRD feature with ovn-kubernetes, thus granting persistent IPs across restarts / migration for KubeVirt VMs</td>
 		</tr>
 		<tr>
 			<td>global.enableSsl</td>
@@ -413,6 +435,15 @@ true
 </pre>
 </td>
 			<td>Specify image tag to run</td>
+		</tr>
+		<tr>
+			<td>global.imagePullSecretName</td>
+			<td>string</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>The name of secret used for pulling image. Use only if needed</td>
 		</tr>
 		<tr>
 			<td>global.ipfixCacheActiveTimeout</td>
@@ -604,6 +635,30 @@ false
 			<td>Endpoint of Kubernetes api server</td>
 		</tr>
 		<tr>
+			<td>monitoring</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "commonServiceMonitorSelectorLabels": {
+    "release": "kube-prometheus-stack"
+  }
+}
+</pre>
+</td>
+			<td>prometheus monitoring related fields</td>
+		</tr>
+		<tr>
+			<td>monitoring.commonServiceMonitorSelectorLabels</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "release": "kube-prometheus-stack"
+}
+</pre>
+</td>
+			<td>specify the labels for serviceMonitors to be selected for target discovery. Prometheus operator defines what namespaces and what servicemonitors within these namespaces must be selected for target discovery. The fields defined below helps in defining that.</td>
+		</tr>
+		<tr>
 			<td>mtu</td>
 			<td>int</td>
 			<td><pre lang="json">
@@ -625,7 +680,7 @@ false
 			<td>podNetwork</td>
 			<td>string</td>
 			<td><pre lang="json">
-"10.128.0.0/14/23"
+"10.244.0.0/16/24"
 </pre>
 </td>
 			<td>IP range for Kubernetes pods, /14 is the top level range, under which each /23 range will be assigned to a node</td>
@@ -634,7 +689,7 @@ false
 			<td>serviceNetwork</td>
 			<td>string</td>
 			<td><pre lang="json">
-"172.30.0.0/16"
+"10.96.0.0/16"
 </pre>
 </td>
 			<td>A comma-separated set of CIDR notation IP ranges from which k8s assigns service cluster IPs. This should be the same as the value provided for kube-apiserver "--service-cluster-ip-range" option</td>

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
         openshift.io/component: network
         kubernetes.io/os: "linux"
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -31,7 +31,7 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-db/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         kubernetes.io/os: "linux"
         ovn-db-pod: "true"
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/ovnkube-identity.yaml
@@ -32,7 +32,7 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -31,7 +31,7 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -26,7 +26,7 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -26,7 +26,7 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -26,7 +26,7 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
@@ -27,7 +27,7 @@ spec:
         kubernetes.io/os: "linux"
       annotations:
     spec:
-      {{- if hasKey .Values.global "imagePullSecretName" }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}

--- a/helm/ovn-kubernetes/templates/_helpers.tpl
+++ b/helm/ovn-kubernetes/templates/_helpers.tpl
@@ -57,3 +57,10 @@ Output "yes" if unprivilegedMode is true, otherwise "no"
   {{- print "no" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create dockerconfigjson to access container registry
+*/}}
+{{- define "dockerconfigjson" -}}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .registry .auth }}
+{{- end }}

--- a/helm/ovn-kubernetes/templates/ovn-setup.yaml
+++ b/helm/ovn-kubernetes/templates/ovn-setup.yaml
@@ -63,3 +63,15 @@ kind: Namespace
 metadata:
   name: {{ $hostNetworkNamespace }}
 {{- end }}
+
+{{- if (and .Values.global.dockerConfigSecret .Values.global.dockerConfigSecret.create) }}
+---
+apiVersion: v1
+type: kubernetes.io/dockerconfigjson
+kind: Secret
+metadata:
+  namespace: {{ .Values.global.namespace }}
+  name: {{ .Values.global.imagePullSecretName }}
+data:
+  .dockerconfigjson: {{ include "dockerconfigjson" .Values.global.dockerConfigSecret | b64enc }}
+{{- end }}

--- a/helm/ovn-kubernetes/values.yaml
+++ b/helm/ovn-kubernetes/values.yaml
@@ -143,6 +143,13 @@ global:
     tag: master
     # -- Image pull policy
     pullPolicy: IfNotPresent
+  # -- The name of secret used for pulling image. Use only if needed
+  imagePullSecretName: ""
+  # -- The secret used for pulling image. Use only if needed. Set create to have have secret created by helm
+  dockerConfigSecret:
+    registry: ghcr.io
+    auth: blah_blah_blah
+    create: false
 
 ovnkube-identity:
     # -- number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes


### PR DESCRIPTION
**Note**: This is a continuation of https://github.com/ovn-org/ovn-kubernetes/pull/4494 
It is needed to account for cases where image pull secret itself may need to be created.
This PR allows for secure pulling of images from private repositories when required.

Example usage in values.yaml:

```
global:
    imagePullSecretName: my-registry-secret
    dockerConfigSecret:
      registry: ghcr.io
      auth: blah_blah_blah
      create: true
```

Documentation reference on using imagePullSecrets: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/