### PR TITLE
udn: Add events to primary role network related problems

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -56,7 +56,7 @@ type ClusterManager struct {
 func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.WatchFactory,
 	identity string, wg *sync.WaitGroup, recorder record.EventRecorder) (*ClusterManager, error) {
 
-	defaultNetClusterController := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, ovnClient, wf)
+	defaultNetClusterController := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, ovnClient, wf, recorder)
 
 	zoneClusterController, err := newZoneClusterController(ovnClient, wf)
 	if err != nil {
@@ -74,7 +74,7 @@ func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.W
 	}
 
 	if config.OVNKubernetesFeature.EnableMultiNetwork {
-		cm.secondaryNetClusterManager, err = newSecondaryNetworkClusterManager(ovnClient, wf)
+		cm.secondaryNetClusterManager, err = newSecondaryNetworkClusterManager(ovnClient, wf, recorder)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/clustermanager/network_cluster_controller_test.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -23,6 +24,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 	var (
 		app      *cli.App
 		f        *factory.WatchFactory
+		recorder record.EventRecorder
 		stopChan chan struct{}
 		wg       *sync.WaitGroup
 	)
@@ -36,6 +38,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 		app.Flags = config.Flags
 		stopChan = make(chan struct{})
 		wg = &sync.WaitGroup{}
+		recorder = record.NewFakeRecorder(10)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -76,7 +79,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 				err = f.Start()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f)
+				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f, recorder)
 				ncc.Start(ctx.Context)
 				defer ncc.Stop()
 
@@ -127,7 +130,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 				err = f.Start()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f)
+				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f, recorder)
 				ncc.Start(ctx.Context)
 				defer ncc.Stop()
 
@@ -179,7 +182,7 @@ var _ = ginkgo.Describe("Network Cluster Controller", func() {
 				err = f.Start()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f)
+				ncc := newDefaultNetworkClusterController(&util.DefaultNetInfo{}, fakeClient, f, recorder)
 				ncc.Start(ctx.Context)
 				defer ncc.Stop()
 

--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -7,6 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -40,6 +43,9 @@ type PodAllocator struct {
 
 	nadLister nadlister.NetworkAttachmentDefinitionLister
 
+	// event recorder used to post events to k8s
+	recorder record.EventRecorder
+
 	// track pods that have been released but not deleted yet so that we don't
 	// release more than once
 	releasedPods      map[string]sets.Set[string]
@@ -53,6 +59,7 @@ func NewPodAllocator(
 	ipAllocator subnet.Allocator,
 	claimsReconciler persistentips.PersistentAllocations,
 	nadLister nadlister.NetworkAttachmentDefinitionLister,
+	recorder record.EventRecorder,
 ) *PodAllocator {
 	podAllocator := &PodAllocator{
 		netInfo:                netInfo,
@@ -60,6 +67,7 @@ func NewPodAllocator(
 		releasedPodsMutex:      sync.Mutex{},
 		podAnnotationAllocator: podAnnotationAllocator,
 		nadLister:              nadLister,
+		recorder:               recorder,
 	}
 
 	// this network might not have IPAM, we will just allocate MAC addresses
@@ -98,10 +106,18 @@ func (a *PodAllocator) Init() error {
 	return nil
 }
 
-// getActiveNetworkForNamespace returns the active network for the given namespace
+// getActiveNetworkForNamespace returns the active network for the given pod's namespace
 // and is a wrapper around util.GetActiveNetworkForNamespace
-func (a *PodAllocator) getActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
-	return util.GetActiveNetworkForNamespace(namespace, a.nadLister)
+func (a *PodAllocator) getActiveNetworkForPod(pod *corev1.Pod) (util.NetInfo, error) {
+	activeNetwork, err := util.GetActiveNetworkForNamespace(pod.Namespace, a.nadLister)
+	if err != nil {
+		if util.IsUnknownActiveNetworkError(err) {
+			a.recordPodErrorEvent(pod, err)
+		}
+		return nil, err
+	}
+	return activeNetwork, nil
+
 }
 
 // GetNetworkRole returns the role of this controller's
@@ -137,10 +153,8 @@ func (a *PodAllocator) GetNetworkRole(pod *corev1.Pod) (string, error) {
 		}
 		return types.NetworkRoleSecondary, nil
 	}
-	activeNetwork, err := a.getActiveNetworkForNamespace(pod.Namespace)
+	activeNetwork, err := a.getActiveNetworkForPod(pod)
 	if err != nil {
-		// FIXME(tssurya) emit event here if util.IsUnknownActiveNetworkError; add support for
-		// recorder in the NCM controller
 		return "", err
 	}
 	if activeNetwork.GetNetworkName() == a.netInfo.GetNetworkName() {
@@ -201,7 +215,7 @@ func (a *PodAllocator) reconcile(old, new *corev1.Pod, releaseFromAllocator bool
 		return nil
 	}
 
-	activeNetwork, err := a.getActiveNetworkForNamespace(pod.Namespace)
+	activeNetwork, err := a.getActiveNetworkForPod(pod)
 	if err != nil {
 		return fmt.Errorf("failed looking for an active network: %w", err)
 	}
@@ -399,6 +413,17 @@ func (a *PodAllocator) isPodReleased(nad, uid string) bool {
 		return releasedPods.Has(uid)
 	}
 	return false
+}
+
+func (a *PodAllocator) recordPodErrorEvent(pod *corev1.Pod, podErr error) {
+	podRef, err := ref.GetReference(scheme.Scheme, pod)
+	if err != nil {
+		klog.Errorf("Couldn't get a reference to pod %s/%s to post an event: '%v'",
+			pod.Namespace, pod.Name, err)
+	} else {
+		klog.V(5).Infof("Posting a %s event for Pod %s/%s", corev1.EventTypeWarning, pod.Namespace, pod.Name)
+		a.recorder.Eventf(podRef, corev1.EventTypeWarning, "ErrorAllocatingPod", podErr.Error())
+	}
 }
 
 func podIdAllocationName(nad, uid string) string {

--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -222,6 +222,7 @@ func (a *PodAllocator) reconcile(old, new *corev1.Pod, releaseFromAllocator bool
 
 	onNetwork, networkMap, err := util.GetPodNADToNetworkMappingWithActiveNetwork(pod, a.netInfo, activeNetwork)
 	if err != nil {
+		a.recordPodErrorEvent(pod, err)
 		return fmt.Errorf("failed to get NAD to network mapping: %w", err)
 	}
 

--- a/go-controller/pkg/cni/udn/primary_network.go
+++ b/go-controller/pkg/cni/udn/primary_network.go
@@ -91,13 +91,11 @@ func (p *UserDefinedPrimaryNetwork) WaitForPrimaryAnnotationFn(namespace string,
 		}
 
 		if err := p.ensureAnnotation(annotations); err != nil {
-			//TODO: Event ?
-			klog.Warningf("Failed looking for primary network annotation: %v", err)
+			klog.Errorf("Failed looking for primary network annotation: %v", err)
 			return nil, false
 		}
 		if err := p.ensureActiveNetwork(namespace); err != nil {
-			//TODO: Event ?
-			klog.Warningf("Failed looking for primary network name: %v", err)
+			klog.Errorf("Failed looking for primary network name: %v", err)
 			return nil, false
 		}
 		return annotation, isReady

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -243,6 +243,7 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 
 	on, networkMap, err := util.GetPodNADToNetworkMappingWithActiveNetwork(pod, bsnc.NetInfo, activeNetwork)
 	if err != nil {
+		bsnc.recordPodErrorEvent(pod, err)
 		// configuration error, no need to retry, do not return error
 		klog.Errorf("Error getting network-attachment for pod %s/%s network %s: %v",
 			pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
@@ -428,6 +429,7 @@ func (bsnc *BaseSecondaryNetworkController) removePodForSecondaryNetwork(pod *ka
 
 		_, networkMap, err := util.GetPodNADToNetworkMappingWithActiveNetwork(pod, bsnc.NetInfo, activeNetwork)
 		if err != nil {
+			bsnc.recordPodErrorEvent(pod, err)
 			return err
 		}
 
@@ -508,7 +510,8 @@ func (bsnc *BaseSecondaryNetworkController) syncPodsForSecondaryNetwork(pods []i
 		on, networkMap, err := util.GetPodNADToNetworkMappingWithActiveNetwork(pod, bsnc.NetInfo, activeNetwork)
 		if err != nil || !on {
 			if err != nil {
-				klog.Warningf("Failed to determine if pod %s/%s needs to be plumb interface on network %s: %v",
+				bsnc.recordPodErrorEvent(pod, err)
+				klog.Errorf("Failed to determine if pod %s/%s needs to be plumb interface on network %s: %v",
 					pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
 			}
 			continue

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -347,14 +347,15 @@ type UnknownActiveNetworkError struct {
 	namespace string
 }
 
-func (m UnknownActiveNetworkError) Error() string {
+func (m *UnknownActiveNetworkError) Error() string {
 	return fmt.Sprintf("unable to determine what is the "+
 		"primary role network for namespace '%s'; please remove multiple primary role network"+
 		"NADs from it", m.namespace)
 }
 
 func IsUnknownActiveNetworkError(err error) bool {
-	return errors.As(err, &UnknownActiveNetworkError{})
+	var unknownActiveNetworkError *UnknownActiveNetworkError
+	return errors.As(err, &unknownActiveNetworkError)
 }
 
 // GetActiveNetworkForNamespace returns the NetInfo struct of the active network


### PR DESCRIPTION
#### What this PR does and why is it needed
We should show proper error events on defects related to UDN so users can react properly:

The events that got recorded at the PR will look like the following
Unknown active network
```
ormal   Scheduled               16m                default-scheduler  Successfully assigned default/client-pod to ovn-worker
  Warning  ErrorUpdatingResource   16m (x3 over 16m)  controlplane       addLogicalPort failed for default/client-pod: unable to determine what is the primary role network for namespace 'default'; please remove multiple primary role networkNADs from it
  Warning  ErrorAllocatingPod      16m (x2 over 16m)  controlplane       unable to determine what is the primary role network for namespace 'default'; please remove multiple primary role networkNADs from it
 Warning  ErrorReconcilingPod  69s (x17 over 16m)  controlplane  unable to determine what is the primary role network for namespace 'default'; please remove multiple primary role networkNADs from it
```
Unexpected primary network NSE
```
Events:
  Type     Reason               Age                From               Message
  ----     ------               ----               ----               -------
  Normal   Scheduled            13s                default-scheduler  Successfully assigned default/client-pod to ovn-worker
  Warning  ErrorReconcilingPod  13s (x2 over 13s)  controlplane       unexpected primary network "dvbqf_gryffindor" specified with a NetworkSelectionElement &{Name:gryffindor Namespace:default IPRequest:[] MacRequest: InfinibandGUIDRequest: InterfaceRequest: PortMappingsRequest:[] BandwidthRequest:<nil> CNIArgs:<nil> GatewayRequest:[] IPAMClaimReference:}
  Warning  ErrorReconcilingPod  13s (x2 over 13s)  controlplane       unexpected primary network "dvbqf_gryffindor" specified with a NetworkSelectionElement &{Name:gryffindor Namespace:default IPRequest:[] MacRequest: InfinibandGUIDRequest: InterfaceRequest: PortMappingsRequest:[] BandwidthRequest:<nil> CNIArgs:<nil> GatewayRequest:[] IPAMClaimReference:}
  Warning  ErrorReconcilingPod  13s (x2 over 13s)  controlplane       unexpected primary network "dvbqf_gryffindor" specified with a NetworkSelectionElement &{Name:gryffindor Namespace:default IPRequest:[] MacRequest: InfinibandGUIDRequest: InterfaceRequest: PortMappingsRequest:[] BandwidthRequest:<nil> CNIArgs:<nil> GatewayRequest:[] IPAMClaimReference:}
  Warning  ErrorAllocatingPod   13s (x2 over 13s)  controlplane       unexpected primary network "dvbqf_gryffindor" specified with a NetworkSelectionElement &{Name:gryffindor Namespace:default IPRequest:[] MacRequest: InfinibandGUIDRequest: InterfaceRequest: PortMappingsRequest:[] BandwidthRequest:<nil> CNIArgs:<nil> GatewayRequest:[] IPAMClaimReference:}
  Normal   AddedInterface       12s                multus             Add eth0 [10.244.1.11/24] from ovn-kubernetes

```

#### How to verify it
Unit tests included for events

#### Details to documentation updates
Do we have to document events ? 

#### Description for the changelog
Send events on unknown active network and log errors at CNI

```release-note
Properly log and send events on primary UDN problems
```
