### PR TITLE
Fix stale network cleanup

### DIFF
--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -132,10 +132,10 @@ func (sncm *secondaryNetworkClusterManager) isTopologyManaged(nInfo util.NetInfo
 
 // CleanupDeletedNetworks implements the networkAttachDefController.NetworkControllerManager
 // interface function.
-func (sncm *secondaryNetworkClusterManager) CleanupDeletedNetworks(allControllers []nad.NetworkController) error {
+func (sncm *secondaryNetworkClusterManager) CleanupDeletedNetworks(validNetworks ...util.BasicNetInfo) error {
 	existingNetworksMap := map[string]struct{}{}
-	for _, oc := range allControllers {
-		existingNetworksMap[oc.GetNetworkName()] = struct{}{}
+	for _, network := range validNetworks {
+		existingNetworksMap[network.GetNetworkName()] = struct{}{}
 	}
 
 	staleNetworkControllers := map[string]nad.NetworkController{}

--- a/go-controller/pkg/clustermanager/secondary_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/secondary_network_unit_test.go
@@ -316,8 +316,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				err = oc.init()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				nadControllers := []nad.NetworkController{oc}
-				err = sncm.CleanupDeletedNetworks(nadControllers)
+				err = sncm.CleanupDeletedNetworks(oc)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Clean up the red network
@@ -329,7 +328,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 
 				// Now call CleanupDeletedNetworks() with empty nad controllers.
 				// Blue network should also be cleared.
-				err = sncm.CleanupDeletedNetworks([]nad.NetworkController{})
+				err = sncm.CleanupDeletedNetworks()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectBlueCleanup = true

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -39,7 +39,7 @@ type NetworkController interface {
 // NetworkControllerManager manages all network controllers
 type NetworkControllerManager interface {
 	NewNetworkController(netInfo util.NetInfo) (NetworkController, error)
-	CleanupDeletedNetworks(allControllers []NetworkController) error
+	CleanupDeletedNetworks(validNetworks ...util.BasicNetInfo) error
 }
 
 type watchFactory interface {
@@ -97,6 +97,9 @@ func NewNetAttachDefinitionController(
 }
 
 func (nadController *NetAttachDefinitionController) Start() error {
+	// initial sync here will ensure networks in network manager
+	// network manager will use this initial set of ensured networks to consider
+	// any other network stale on its own sync
 	err := controller.StartWithInitialSync(
 		nadController.syncAll,
 		nadController.controller,

--- a/go-controller/pkg/network-attach-def-controller/network_manager.go
+++ b/go-controller/pkg/network-attach-def-controller/network_manager.go
@@ -153,9 +153,11 @@ func (nm *networkManagerImpl) sync(network string) error {
 }
 
 func (nm *networkManagerImpl) syncAll() error {
-	networkControllers := make([]NetworkController, 0, len(nm.networkControllers))
-	for _, networkControllerState := range nm.networkControllers {
-		networkControllers = append(networkControllers, networkControllerState.controller)
+	// as we sync upon start, consider networks that have not been ensured as
+	// stale and clean them up
+	validNetworks := make([]util.BasicNetInfo, 0, len(nm.networks))
+	for _, network := range nm.networks {
+		validNetworks = append(validNetworks, network)
 	}
-	return nm.ncm.CleanupDeletedNetworks(networkControllers)
+	return nm.ncm.CleanupDeletedNetworks(validNetworks...)
 }

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -114,10 +114,10 @@ func findAllSecondaryNetworkLogicalEntities(nbClient libovsdbclient.Client) ([]*
 	return nodeSwitches, clusterRouters, nil
 }
 
-func (cm *NetworkControllerManager) CleanupDeletedNetworks(allControllers []nad.NetworkController) error {
+func (cm *NetworkControllerManager) CleanupDeletedNetworks(validNetworks ...util.BasicNetInfo) error {
 	existingNetworksMap := map[string]string{}
-	for _, oc := range allControllers {
-		existingNetworksMap[oc.GetNetworkName()] = oc.TopologyType()
+	for _, network := range validNetworks {
+		existingNetworksMap[network.GetNetworkName()] = network.TopologyType()
 	}
 
 	// Get all the existing secondary networks and its logical entities

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -48,7 +48,7 @@ func (ncm *nodeNetworkControllerManager) NewNetworkController(nInfo util.NetInfo
 }
 
 // CleanupDeletedNetworks cleans up all stale entities giving list of all existing secondary network controllers
-func (ncm *nodeNetworkControllerManager) CleanupDeletedNetworks(allControllers []nad.NetworkController) error {
+func (ncm *nodeNetworkControllerManager) CleanupDeletedNetworks(validNetworks ...util.BasicNetInfo) error {
 	return nil
 }
 


### PR DESCRIPTION
The NAD controller was attempting to clean up stale networks from references to network controllers that had not been created yet as the controller itself had not been started. Use the BasicNetInfo of networks that are about to be created instead.
