### PR TITLE
udn, controllers: Add getNetworkID helper

### DIFF
--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -1,0 +1,71 @@
+package node
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = Describe("SecondaryNodeNetworkController", func() {
+	var (
+		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
+	)
+	It("should return networkID from one of the nodes in the cluster", func() {
+		fakeClient := &util.OVNNodeClientset{
+			KubeClient: fake.NewSimpleClientset(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/network-ids": `{"bluenet": "3"}`,
+					},
+				},
+			}),
+		}
+		controller := SecondaryNodeNetworkController{}
+		var err error
+		controller.watchFactory, err = factory.NewNodeWatchFactory(fakeClient, "worker1")
+		Expect(controller.watchFactory.Start()).To(Succeed())
+
+		Expect(err).NotTo(HaveOccurred())
+		controller.NetInfo, err = util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+
+		networkID, err := controller.getNetworkID()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(networkID).To(Equal(3))
+	})
+
+	It("should return invalid networkID if network not found", func() {
+		fakeClient := &util.OVNNodeClientset{
+			KubeClient: fake.NewSimpleClientset(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/network-ids": `{"othernet": "3"}`,
+					},
+				},
+			}),
+		}
+		controller := SecondaryNodeNetworkController{}
+		var err error
+		controller.watchFactory, err = factory.NewNodeWatchFactory(fakeClient, "worker1")
+		Expect(controller.watchFactory.Start()).To(Succeed())
+
+		Expect(err).NotTo(HaveOccurred())
+		controller.NetInfo, err = util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+
+		networkID, err := controller.getNetworkID()
+		Expect(err).To(HaveOccurred())
+		Expect(networkID).To(Equal(util.InvalidNetworkID))
+	})
+})

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -172,6 +172,9 @@ type BaseNetworkController struct {
 // configuration for secondary network controller
 type BaseSecondaryNetworkController struct {
 	BaseNetworkController
+
+	networkID *int
+
 	// multi-network policy events factory handler
 	policyHandler *factory.Handler
 }

--- a/go-controller/pkg/ovn/base_network_controller_secondary_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary_test.go
@@ -1,0 +1,57 @@
+package ovn
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = Describe("BaseSecondaryNetworkController", func() {
+	var (
+		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
+	)
+	It("should return networkID from one of the nodes node", func() {
+		fakeOVN := NewFakeOVN(false)
+		fakeOVN.start(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker1",
+				Annotations: map[string]string{
+					"k8s.ovn.org/network-ids": `{"bluenet": "3"}`,
+				},
+			},
+		})
+		Expect(fakeOVN.NewSecondaryNetworkController(nad)).To(Succeed())
+		controller, ok := fakeOVN.secondaryControllers["bluenet"]
+		Expect(ok).To(BeTrue())
+
+		networkID, err := controller.bnc.getNetworkID()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(networkID).To(Equal(3))
+	})
+	It("should return invalid networkID if network is not found", func() {
+		fakeOVN := NewFakeOVN(false)
+		fakeOVN.start(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker1",
+				Annotations: map[string]string{
+					"k8s.ovn.org/network-ids": `{"other": "3"}`,
+				},
+			},
+		})
+		Expect(fakeOVN.NewSecondaryNetworkController(nad)).To(Succeed())
+		controller, ok := fakeOVN.secondaryControllers["bluenet"]
+		Expect(ok).To(BeTrue())
+
+		networkID, err := controller.bnc.getNetworkID()
+		Expect(err).To(HaveOccurred())
+		Expect(networkID).To(Equal(util.InvalidNetworkID))
+	})
+
+})

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -1252,3 +1252,23 @@ func filterIPVersion(cidrs []netip.Prefix, v6 bool) []netip.Prefix {
 	}
 	return validCIDRs
 }
+
+// GetNetworkID will retrieve the network id for the specified network from the
+// first node that contains that network at the network id annotations, it will
+// return at the first ocurrence, rest of nodes will not be parsed.
+func GetNetworkID(nodes []*corev1.Node, nInfo NetInfo) (int, error) {
+	for _, node := range nodes {
+		var err error
+		networkID, err := ParseNetworkIDAnnotation(node, nInfo.GetNetworkName())
+		if err != nil {
+			if IsAnnotationNotSetError(err) {
+				continue
+			}
+			return InvalidNetworkID, err
+		}
+		if networkID != InvalidNetworkID {
+			return networkID, nil
+		}
+	}
+	return InvalidNetworkID, fmt.Errorf("missing network id for network '%s'", nInfo.GetNetworkName())
+}


### PR DESCRIPTION
#### What this PR does and why is it needed
Find and store the networkID at different at the following UDN controllers:
- layer3
- layer2
- udn node

#### Special notes for reviewers
The `EnsureNetworkID` helper is not created under `pkg/util` to be able to use use factory.NodeWatchFactory, not doing so creates a dependencies cycle since "factory" is already using "pkg/util".

#### How to verify it
Future primary UDN egress e2e tests will use this.


#### Description for the changelog
Store networkID at udn controllers

#### Does this PR introduce a user-facing change?
NONE

```release-note
Store networkID at udn controllers
```
