### PR TITLE
udn, cni: Gate primary role networks

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -139,7 +139,10 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Resp
 	// for DPU, ensure connection-details is present
 
 	primaryUDN := udn.NewPrimaryNetwork(clientset.nadLister)
-	pod, annotations, podNADAnnotation, err := GetPodWithAnnotations(pr.ctx, clientset, namespace, podName, pr.nadName, primaryUDN.WaitForPrimaryAnnotationFn(namespace, annotCondFn))
+	if util.IsNetworkSegmentationSupportEnabled() {
+		annotCondFn = primaryUDN.WaitForPrimaryAnnotationFn(namespace, annotCondFn)
+	}
+	pod, annotations, podNADAnnotation, err := GetPodWithAnnotations(pr.ctx, clientset, namespace, podName, pr.nadName, annotCondFn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod annotation: %v", err)
 	}

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -106,6 +106,9 @@ func (pr *PodRequest) checkOrUpdatePodUID(pod *kapi.Pod) error {
 }
 
 func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Response, error) {
+	return pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientset, getCNIResult)
+}
+func (pr *PodRequest) cmdAddWithGetCNIResultFunc(kubeAuth *KubeAPIAuth, clientset *ClientSet, getCNIResultFn getCNIResultFunc) (*Response, error) {
 	namespace := pr.PodNamespace
 	podName := pr.PodName
 	if namespace == "" || podName == "" {
@@ -161,7 +164,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Resp
 	if !config.UnprivilegedMode {
 		//TODO: There is nothing technical to run this at unprivileged mode but
 		//      we will tackle that later on.
-		response.Result, err = pr.getCNIResult(clientset, podInterfaceInfo)
+		response.Result, err = getCNIResultFn(pr, clientset, podInterfaceInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +174,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Resp
 			if err != nil {
 				return nil, err
 			}
-			if _, err := primaryUDNPodRequest.getCNIResult(clientset, primaryUDNPodInfo); err != nil {
+			if _, err := getCNIResultFn(primaryUDNPodRequest, clientset, primaryUDNPodInfo); err != nil {
 				return nil, err
 			}
 		}
@@ -313,7 +316,7 @@ func HandlePodRequest(request *PodRequest, clientset *ClientSet, kubeAuth *KubeA
 // PodInfoGetter is used to check if sandbox is still valid for the current
 // instance of the pod in the apiserver, see checkCancelSandbox for more info.
 // If kube api is not available from the CNI, pass nil to skip this check.
-func (pr *PodRequest) getCNIResult(getter PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
+func getCNIResult(pr *PodRequest, getter PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
 	interfacesArray, err := pr.ConfigureInterface(getter, podInterfaceInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure pod interface: %v", err)

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -1,0 +1,128 @@
+package cni
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
+	v1nadmocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	v1mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+)
+
+var _ = Describe("Network Segmentation", func() {
+	var (
+		fakeClientset            *fake.Clientset
+		pr                       PodRequest
+		pod                      *v1.Pod
+		podLister                v1mocks.PodLister
+		podNamespaceLister       v1mocks.PodNamespaceLister
+		nadLister                v1nadmocks.NetworkAttachmentDefinitionLister
+		clientSet                *ClientSet
+		kubeAuth                 *KubeAPIAuth
+		obtainedPodIterfaceInfos []*PodInterfaceInfo
+		getCNIResultStub         = func(request *PodRequest, getter PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
+			obtainedPodIterfaceInfos = append(obtainedPodIterfaceInfos, podInterfaceInfo)
+			return nil, nil
+		}
+		enableMultiNetwork, enableNetworkSegmentation bool
+	)
+
+	BeforeEach(func() {
+
+		enableMultiNetwork = config.OVNKubernetesFeature.EnableMultiNetwork
+		enableNetworkSegmentation = config.OVNKubernetesFeature.EnableNetworkSegmentation
+
+		fakeClientset = fake.NewSimpleClientset()
+		pr = PodRequest{
+			Command:      CNIAdd,
+			PodNamespace: "foo-ns",
+			PodName:      "bar-pod",
+			SandboxID:    "824bceff24af3",
+			Netns:        "ns",
+			IfName:       "eth0",
+			CNIConf: &types.NetConf{
+				NetConf:  cnitypes.NetConf{},
+				DeviceID: "",
+			},
+			timestamp: time.Time{},
+			IsVFIO:    false,
+			netName:   ovntypes.DefaultNetworkName,
+			nadName:   ovntypes.DefaultNetworkName,
+		}
+		pr.ctx, pr.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+
+		podNamespaceLister = v1mocks.PodNamespaceLister{}
+		podLister = v1mocks.PodLister{}
+		nadLister = v1nadmocks.NetworkAttachmentDefinitionLister{}
+		clientSet = &ClientSet{
+			podLister: &podLister,
+			nadLister: &nadLister,
+			kclient:   fakeClientset,
+		}
+		kubeAuth = &KubeAPIAuth{
+			Kubeconfig:       config.Kubernetes.Kubeconfig,
+			KubeAPIServer:    config.Kubernetes.APIServer,
+			KubeAPIToken:     config.Kubernetes.Token,
+			KubeAPITokenFile: config.Kubernetes.TokenFile,
+		}
+		podLister.On("Pods", pr.PodNamespace).Return(&podNamespaceLister)
+	})
+	AfterEach(func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = enableMultiNetwork
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = enableNetworkSegmentation
+	})
+
+	Context("with network segmentation fg disabled and annotation without role field", func() {
+		BeforeEach(func() {
+			config.OVNKubernetesFeature.EnableMultiNetwork = false
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = false
+			pod = &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pr.PodName,
+					Namespace: pr.PodNamespace,
+					Annotations: map[string]string{
+						"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"100.10.10.3/24","mac_address":"0a:58:fd:98:00:01"}}`,
+					},
+				},
+			}
+		})
+		It("should not fail at cmdAdd", func() {
+			podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+			Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub)).NotTo(BeNil())
+			Expect(obtainedPodIterfaceInfos).ToNot(BeEmpty())
+		})
+	})
+	Context("with network segmentation fg enabled and annotation with role field", func() {
+		BeforeEach(func() {
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			pod = &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pr.PodName,
+					Namespace: pr.PodNamespace,
+					Annotations: map[string]string{
+						"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"100.10.10.3/24","mac_address":"0a:58:fd:98:00:01", "role":"primary"}}`,
+					},
+				},
+			}
+		})
+		It("should not fail at cmdAdd", func() {
+			podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+			Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub)).NotTo(BeNil())
+			Expect(obtainedPodIterfaceInfos).ToNot(BeEmpty())
+		})
+	})
+
+})

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -255,7 +255,7 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 
 		// In the case where ovnkube-node is running in Unprivileged mode, all the work
-		result, err = pr.getCNIResult(clientset, response.PodIFInfo)
+		result, err = getCNIResult(pr, clientset, response.PodIFInfo)
 		if err != nil {
 			err = fmt.Errorf("failed to get CNI Result from pod interface info %v: %v", response.PodIFInfo, err)
 			klog.Error(err.Error())

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -170,6 +170,7 @@ type PodRequest struct {
 }
 
 type podRequestFunc func(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error)
+type getCNIResultFunc func(request *PodRequest, getter PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error)
 
 type PodInfoGetter interface {
 	getPod(namespace, name string) (*kapi.Pod, error)


### PR DESCRIPTION
#### What this PR does and why is it needed
Don't look for primry UDN networks at CNI if the network segmentation feature gate is not activated.



#### Which issue(s) this PR fixes
Upgrade issues from pre primary UDN networks pods with network segmentation not enabled.

#### How to verify it
Upgrade with pod's from pre primary UDN changes and network segmentation gate not enabled.

#### Description for the changelog
udn, cni: Gate primary role networks

For more information on release notes see: TBD
-->
```release-note
udn, cni: Gate primary role networks
```
