### PR TITLE
UDN: Create/Delete management port interface on the host side

### DIFF
--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -57,6 +57,14 @@ func (ncm *nodeNetworkControllerManager) newCommonNetworkControllerInfo() *node.
 	return node.NewCommonNodeNetworkControllerInfo(ncm.ovnNodeClient.KubeClient, ncm.ovnNodeClient.AdminPolicyRouteClient, ncm.watchFactory, ncm.recorder, ncm.name)
 }
 
+// NAD controller should be started on the node side under the following conditions:
+// (1) dpu mode is enabled when secondary networks feature is enabled
+// (2) primary user defined networks is enabled (all modes)
+func isNodeNADControllerRequired() bool {
+	return ((config.OVNKubernetesFeature.EnableMultiNetwork && config.OvnKubeNode.Mode == ovntypes.NodeModeDPU) ||
+		util.IsNetworkSegmentationSupportEnabled())
+}
+
 // NewNodeNetworkControllerManager creates a new OVN controller manager to manage all the controller for all networks
 func NewNodeNetworkControllerManager(ovnClient *util.OVNClientset, wf factory.NodeWatchFactory, name string,
 	eventRecorder record.EventRecorder) (*nodeNetworkControllerManager, error) {
@@ -70,8 +78,9 @@ func NewNodeNetworkControllerManager(ovnClient *util.OVNClientset, wf factory.No
 	}
 
 	// need to configure OVS interfaces for Pods on secondary networks in the DPU mode
+	// need to start NAD controller on node side for programming gateway pieces for UDNs
 	var err error
-	if config.OVNKubernetesFeature.EnableMultiNetwork && config.OvnKubeNode.Mode == ovntypes.NodeModeDPU {
+	if isNodeNADControllerRequired() {
 		ncm.nadController, err = nad.NewNetAttachDefinitionController("node-network-controller-manager", ncm, wf)
 	}
 	if err != nil {

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -1,0 +1,149 @@
+package node
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// UserDefinedNetworkGateway contains information
+// required to program a UDN at each node's
+// gateway.
+// NOTE: Currently invoked only for primary networks.
+type UserDefinedNetworkGateway struct {
+	// network information
+	util.NetInfo
+	// stores the networkID of this network
+	networkID int
+	// node that its programming things on
+	node *v1.Node
+}
+
+func NewUserDefinedNetworkGateway(netInfo util.NetInfo, networkID int, node *v1.Node) *UserDefinedNetworkGateway {
+	return &UserDefinedNetworkGateway{
+		NetInfo:   netInfo,
+		networkID: networkID,
+		node:      node,
+	}
+}
+
+// AddNetwork will be responsible to create all plumbings
+// required by this UDN on the gateway side
+func (udng *UserDefinedNetworkGateway) AddNetwork() error {
+	return udng.addUDNManagementPort()
+}
+
+// DelNetwork will be responsible to remove all plumbings
+// used by this UDN on the gateway side
+func (udng *UserDefinedNetworkGateway) DelNetwork() error {
+	return udng.deleteUDNManagementPort()
+}
+
+// addUDNManagementPort does the following:
+// STEP1: creates the (netdevice) OVS interface on br-int for the UDN's management port
+// STEP2: It saves the MAC address generated on the 1st go as an option on the OVS interface
+// so that it persists on reboots
+// STEP3: sets up the management port link on the host
+// STEP4: adds the management port IP .2 to the mplink
+func (udng *UserDefinedNetworkGateway) addUDNManagementPort() error {
+	var err error
+	interfaceName := util.GetNetworkScopedK8sMgmtHostIntfName(uint(udng.networkID))
+	var networkLocalSubnets []*net.IPNet
+	if udng.TopologyType() == types.Layer3Topology {
+		networkLocalSubnets, err = util.ParseNodeHostSubnetAnnotation(udng.node, udng.GetNetworkName())
+		if err != nil {
+			return fmt.Errorf("waiting for node %s to start, no annotation found on node for network %s: %w",
+				udng.node.Name, udng.GetNetworkName(), err)
+		}
+	} else if udng.TopologyType() == types.Layer2Topology {
+		// NOTE: We don't support L2 networks without subnets as primary UDNs
+		globalFlatL2Networks := udng.Subnets()
+		for _, globalFlatL2Network := range globalFlatL2Networks {
+			networkLocalSubnets = append(networkLocalSubnets, globalFlatL2Network.CIDR)
+		}
+	}
+
+	// STEP1
+	stdout, stderr, err := util.RunOVSVsctl(
+		"--", "--may-exist", "add-port", "br-int", interfaceName,
+		"--", "set", "interface", interfaceName,
+		"type=internal", "mtu_request="+fmt.Sprintf("%d", udng.NetInfo.MTU()),
+		"external-ids:iface-id="+udng.GetNetworkScopedK8sMgmtIntfName(udng.node.Name),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add port to br-int for network %s, stdout: %q, stderr: %q, error: %w",
+			udng.GetNetworkName(), stdout, stderr, err)
+	}
+	klog.V(3).Infof("Added OVS management port interface %s for network %s", interfaceName, udng.GetNetworkName())
+
+	// STEP2
+	macAddress, err := util.GetOVSPortMACAddress(interfaceName)
+	if err != nil {
+		return fmt.Errorf("failed to get management port MAC address for network %s: %v", udng.GetNetworkName(), err)
+	}
+	// persist the MAC address so that upon node reboot we get back the same mac address.
+	_, stderr, err = util.RunOVSVsctl("set", "interface", interfaceName,
+		fmt.Sprintf("mac=%s", strings.ReplaceAll(macAddress.String(), ":", "\\:")))
+	if err != nil {
+		return fmt.Errorf("failed to persist MAC address %q for %q while plumbing network %s: stderr:%s (%v)",
+			macAddress.String(), interfaceName, udng.GetNetworkName(), stderr, err)
+	}
+
+	// STEP3
+	mplink, err := util.LinkSetUp(interfaceName)
+	if err != nil {
+		return fmt.Errorf("failed to set the link up for interface %s while plumbing network %s, err: %v",
+			interfaceName, udng.GetNetworkName(), err)
+	}
+	klog.V(3).Infof("Setup management port link %s for network %s succeeded", interfaceName, udng.GetNetworkName())
+
+	// STEP4
+	for _, subnet := range networkLocalSubnets {
+		if config.IPv6Mode && utilnet.IsIPv6CIDR(subnet) || config.IPv4Mode && utilnet.IsIPv4CIDR(subnet) {
+			ip := util.GetNodeManagementIfAddr(subnet)
+			var err error
+			var exists bool
+			if exists, err = util.LinkAddrExist(mplink, ip); err == nil && !exists {
+				err = util.LinkAddrAdd(mplink, ip, 0, 0, 0)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to add management port IP from subnet %s to netdevice %s for network %s, err: %v",
+					subnet, interfaceName, udng.GetNetworkName(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// deleteUDNManagementPort does the following:
+// STEP1: deletes the management port link on the host.
+// STEP2: deletes the OVS interface on br-int for the UDN's management port interface
+func (udng *UserDefinedNetworkGateway) deleteUDNManagementPort() error {
+	var err error
+	interfaceName := util.GetNetworkScopedK8sMgmtHostIntfName(uint(udng.networkID))
+
+	// STEP1 (note: doing step2 also guarantees step1; doing it for posterity)
+	if err := util.LinkDelete(interfaceName); err != nil {
+		return fmt.Errorf("failed to delete link %s for network %s: %v", interfaceName, udng.GetNetworkName(), err)
+	}
+	klog.V(3).Infof("Removed management port link %s for network %s", interfaceName, udng.GetNetworkName())
+
+	// STEP2
+	stdout, stderr, err := util.RunOVSVsctl(
+		"--", "--if-exists", "del-port", "br-int", interfaceName,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete port from br-int for network %s, stdout: %q, stderr: %q, error: %v",
+			udng.GetNetworkName(), stdout, stderr, err)
+	}
+	klog.V(3).Infof("Removed OVS management port interface %s for network %s", interfaceName, udng.GetNetworkName())
+	return nil
+}

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1,0 +1,194 @@
+package node
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func getCreationFakeOVSCommands(fexec *ovntest.FakeExec, mgtPort, mgtPortMAC, netName, nodeName string, mtu int) {
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-vsctl --timeout=15" +
+			" -- --may-exist add-port br-int " + mgtPort +
+			" -- set interface " + mgtPort +
+			" type=internal mtu_request=" + fmt.Sprintf("%d", mtu) +
+			" external-ids:iface-id=" + types.K8sPrefix + netName + "_" + nodeName,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + mgtPort + " mac_in_use",
+		Output: mgtPortMAC,
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-vsctl --timeout=15 set interface " + mgtPort + " " + fmt.Sprintf("mac=%s", strings.ReplaceAll(mgtPortMAC, ":", "\\:")),
+	})
+}
+
+func getDeletionFakeOVSCommands(fexec *ovntest.FakeExec, mgtPort string) {
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-vsctl --timeout=15 -- --if-exists del-port br-int " + mgtPort,
+	})
+}
+
+var _ = Describe("UserDefinedNetworkGateway", func() {
+	var (
+		netName             = "bluenet"
+		netID               = "3"
+		nodeName     string = "worker1"
+		mgtPortMAC   string = "00:00:00:55:66:77" // dummy MAC used for fake commands
+		fexec        *ovntest.FakeExec
+		testNS       ns.NetNS
+		v4NodeSubnet = "100.128.0.0/24"
+		v6NodeSubnet = "ae70::66/112"
+		mgtPort      = fmt.Sprintf("%s%s", types.K8sMgmtIntfNamePrefix, netID)
+	)
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.PrepareTestConfig()
+		// Set up a fake vsctl command mock interface
+		fexec = ovntest.NewFakeExec()
+		Expect(util.SetExec(fexec)).To(Succeed())
+		// Set up a fake k8sMgmt interface
+		var err error
+		testNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			// given the netdevice is created using add-port command in OVS
+			// we need to mock create a dummy link for things to work in unit tests
+			ovntest.AddLink(mgtPort)
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+	AfterEach(func() {
+		Expect(testNS.Close()).To(Succeed())
+		Expect(testutils.UnmountNS(testNS)).To(Succeed())
+	})
+	ovntest.OnSupportedPlatformsIt("should create management port for a L3 user defined network", func() {
+		config.IPv6Mode = true
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/network-ids":  fmt.Sprintf("{\"%s\": \"%s\"}", netName, netID),
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"%s\":[\"%s\", \"%s\"]}", netName, v4NodeSubnet, v6NodeSubnet),
+				},
+			},
+		}
+		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16/24,ae70::66/60", types.NetworkRolePrimary)
+		netInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		udnGateway := NewUserDefinedNetworkGateway(netInfo, 3, node)
+		getCreationFakeOVSCommands(fexec, mgtPort, mgtPortMAC, netName, nodeName, netInfo.MTU())
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			Expect(udnGateway.addUDNManagementPort()).To(Succeed())
+			mpLink, err := netlink.LinkByName(mgtPort)
+			Expect(err).NotTo(HaveOccurred())
+			exists, err := util.LinkAddrExist(mpLink, ovntest.MustParseIPNet("100.128.0.2/24"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			exists, err = util.LinkAddrExist(mpLink, ovntest.MustParseIPNet("ae70::2/112"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+	ovntest.OnSupportedPlatformsIt("should delete management port for a L3 user defined network", func() {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/network-ids":  fmt.Sprintf("{\"%s\": \"%s\"}", netName, netID),
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"%s\":[\"%s\", \"%s\"]}", netName, v4NodeSubnet, v6NodeSubnet),
+				},
+			},
+		}
+		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16/24,ae70::66/60", types.NetworkRolePrimary)
+		netInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		udnGateway := NewUserDefinedNetworkGateway(netInfo, 3, node)
+		Expect(err).NotTo(HaveOccurred())
+		getDeletionFakeOVSCommands(fexec, mgtPort)
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			Expect(udnGateway.deleteUDNManagementPort()).To(Succeed())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+	ovntest.OnSupportedPlatformsIt("should create management port for a L2 user defined network", func() {
+		config.IPv6Mode = true
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/network-ids": fmt.Sprintf("{\"%s\": \"%s\"}", netName, netID),
+				},
+			},
+		}
+		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+			types.Layer2Topology, "100.128.0.0/16,ae70::66/60", types.NetworkRolePrimary)
+		netInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		udnGateway := NewUserDefinedNetworkGateway(netInfo, 3, node)
+		Expect(err).NotTo(HaveOccurred())
+		getCreationFakeOVSCommands(fexec, mgtPort, mgtPortMAC, netName, nodeName, netInfo.MTU())
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			Expect(udnGateway.addUDNManagementPort()).To(Succeed())
+			mpLink, err := netlink.LinkByName(mgtPort)
+			Expect(err).NotTo(HaveOccurred())
+			exists, err := util.LinkAddrExist(mpLink, ovntest.MustParseIPNet("100.128.0.2/16"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			exists, err = util.LinkAddrExist(mpLink, ovntest.MustParseIPNet("ae70::2/60"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+	ovntest.OnSupportedPlatformsIt("should delete management port for a L2 user defined network", func() {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/network-ids": fmt.Sprintf("{\"%s\": \"%s\"}", netName, netID),
+				},
+			},
+		}
+		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+			types.Layer2Topology, "100.128.0.0/16,ae70::66/60", types.NetworkRolePrimary)
+		netInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		udnGateway := NewUserDefinedNetworkGateway(netInfo, 3, node)
+		Expect(err).NotTo(HaveOccurred())
+		getDeletionFakeOVSCommands(fexec, mgtPort)
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			Expect(udnGateway.deleteUDNManagementPort()).To(Succeed())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+})

--- a/go-controller/pkg/node/secondary_node_network_controller.go
+++ b/go-controller/pkg/node/secondary_node_network_controller.go
@@ -2,9 +2,12 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"k8s.io/klog/v2"
@@ -17,8 +20,10 @@ type SecondaryNodeNetworkController struct {
 	BaseNodeNetworkController
 	// pod events factory handler
 	podHandler *factory.Handler
-
+	// stores the networkID of this network
 	networkID *int
+	// responsible for programing gateway elements for this network
+	gateway *UserDefinedNetworkGateway
 }
 
 // NewSecondaryNodeNetworkController creates a new OVN controller for creating logical network
@@ -38,11 +43,29 @@ func NewSecondaryNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, n
 func (nc *SecondaryNodeNetworkController) Start(ctx context.Context) error {
 	klog.Infof("Start secondary node network controller of network %s", nc.GetNetworkName())
 
-	handler, err := nc.watchPodsDPU()
-	if err != nil {
-		return err
+	// enable adding ovs ports for dpu pods in both primary and secondary user defined networks
+	if (config.OVNKubernetesFeature.EnableMultiNetwork || util.IsNetworkSegmentationSupportEnabled()) && config.OvnKubeNode.Mode == types.NodeModeDPU {
+		handler, err := nc.watchPodsDPU()
+		if err != nil {
+			return err
+		}
+		nc.podHandler = handler
 	}
-	nc.podHandler = handler
+	if util.IsNetworkSegmentationSupportEnabled() && nc.IsPrimaryNetwork() {
+		node, err := nc.watchFactory.GetNode(nc.name)
+		if err != nil {
+			return err
+		}
+		networkID, err := nc.getNetworkID()
+		if err != nil {
+			return err
+		}
+		nc.gateway = NewUserDefinedNetworkGateway(nc.NetInfo, networkID, node)
+		if err := nc.gateway.AddNetwork(); err != nil {
+			return fmt.Errorf("failed to add network to node gateway for network %s at node %s: %w",
+				nc.GetNetworkName(), nc.name, err)
+		}
+	}
 	return nil
 }
 
@@ -59,6 +82,9 @@ func (nc *SecondaryNodeNetworkController) Stop() {
 
 // Cleanup cleans up node entities for the given secondary network
 func (nc *SecondaryNodeNetworkController) Cleanup() error {
+	if nc.gateway != nil {
+		return nc.gateway.DelNetwork()
+	}
 	return nil
 }
 

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -8,7 +10,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	factoryMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory/mocks"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -33,9 +37,9 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		controller := SecondaryNodeNetworkController{}
 		var err error
 		controller.watchFactory, err = factory.NewNodeWatchFactory(fakeClient, "worker1")
+		Expect(err).NotTo(HaveOccurred())
 		Expect(controller.watchFactory.Start()).To(Succeed())
 
-		Expect(err).NotTo(HaveOccurred())
 		controller.NetInfo, err = util.ParseNADInfo(nad)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -58,14 +62,89 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		controller := SecondaryNodeNetworkController{}
 		var err error
 		controller.watchFactory, err = factory.NewNodeWatchFactory(fakeClient, "worker1")
+		Expect(err).NotTo(HaveOccurred())
 		Expect(controller.watchFactory.Start()).To(Succeed())
 
-		Expect(err).NotTo(HaveOccurred())
 		controller.NetInfo, err = util.ParseNADInfo(nad)
 		Expect(err).NotTo(HaveOccurred())
 
 		networkID, err := controller.getNetworkID()
 		Expect(err).To(HaveOccurred())
 		Expect(networkID).To(Equal(util.InvalidNetworkID))
+	})
+	It("ensure UDNGateway is not invoked when feature gate is OFF", func() {
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = false
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		factoryMock := factoryMocks.NodeWatchFactory{}
+		nodeList := []*corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/network-ids": `{"bluenet": "3"}`,
+					},
+				},
+			},
+		}
+		cnnci := CommonNodeNetworkControllerInfo{name: "worker1", watchFactory: &factoryMock}
+		factoryMock.On("GetNode", "worker1").Return(nodeList[0], nil)
+		factoryMock.On("GetNodes").Return(nodeList, nil)
+		NetInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		controller := NewSecondaryNodeNetworkController(&cnnci, NetInfo)
+		err = controller.Start(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(controller.gateway).To(BeNil())
+	})
+	It("ensure UDNGateway is invoked for Primary UDNs when feature gate is ON", func() {
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		factoryMock := factoryMocks.NodeWatchFactory{}
+		nodeList := []*corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/network-ids": `{"bluenet": "3"}`,
+					},
+				},
+			},
+		}
+		cnnci := CommonNodeNetworkControllerInfo{name: "worker1", watchFactory: &factoryMock}
+		factoryMock.On("GetNode", "worker1").Return(nodeList[0], nil)
+		factoryMock.On("GetNodes").Return(nodeList, nil)
+		NetInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		controller := NewSecondaryNodeNetworkController(&cnnci, NetInfo)
+		err = controller.Start(context.Background())
+		Expect(err).To(HaveOccurred()) // we don't have the gateway pieces setup so its expected to fail here
+		Expect(err.Error()).To(ContainSubstring("no annotation found"))
+		Expect(controller.gateway).To(Not(BeNil()))
+	})
+	It("ensure UDNGateway is not invoked for Primary UDNs when feature gate is ON but network is not Primary", func() {
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		factoryMock := factoryMocks.NodeWatchFactory{}
+		nodeList := []*corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/network-ids": `{"bluenet": "3"}`,
+					},
+				},
+			},
+		}
+		cnnci := CommonNodeNetworkControllerInfo{name: "worker1", watchFactory: &factoryMock}
+		factoryMock.On("GetNode", "worker1").Return(nodeList[0], nil)
+		factoryMock.On("GetNodes").Return(nodeList, nil)
+		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16", types.NetworkRoleSecondary)
+		NetInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		controller := NewSecondaryNodeNetworkController(&cnnci, NetInfo)
+		err = controller.Start(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(controller.gateway).To(BeNil())
 	})
 })


### PR DESCRIPTION
Depends-On: https://github.com/ovn-org/ovn-kubernetes/pull/4529

#### What this PR does and why is it needed

- [x] This PR starts invoking node side SecondaryNodeNetworkController to start up for UDNs. Previously it was only done in multi-homing+dpu mode.
- [x] It creates `AddNetwork` and `DelNetwork` functions which will serve as entry points for rest of gateway plumbing
- [x] It also creates `SecondaryNetworkGateway` which in the future will embed `gateway` struct to get openflow manager
- [x] It creates and deletes the management netdevice on the host side when networks are created and deleted - note that naming scheme is `ovn-k8s-mp<networkID>` so maximum we can have only upto 9999 networks but that's fine for now
- [x] It also creates and removes the OVS interface for the management port
- [x] MTU for the port is honored from NAD if provided and if not we take the default cluster MTU


#### Special notes for reviewers

- We have intentionally kept it separate from default network's syncManagementPort which is way more static
- We also don't have periodic reconcile loops etc at the moment, these can be future enhancements when we have a basic functionally done.

#### How to verify it
```
k8s.ovn.org/network-ids: {"default":"0","l2-network":"5","l3-network":"4"}                                                                               
k8s.ovn.org/node-chassis-id: fe7f50c6-7321-43c3-9329-0435ea0bc33c                                                                                        
k8s.ovn.org/node-gateway-router-lrp-ifaddr: {"ipv4":"100.64.0.3/16","ipv6":"fd98::3/64"}                                                                 
k8s.ovn.org/node-id: 3  
```
and on ovn-worker2
```
13: ovn-k8s-mp4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1300 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 56:b0:ff:89:ce:a0 brd ff:ff:ff:ff:ff:ff
    inet 10.128.2.2/24 brd 10.128.2.255 scope global ovn-k8s-mp4
       valid_lft forever preferred_lft forever
    inet6 2010:100:200:2::2/64 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::54b0:ffff:fe89:cea0/64 scope link 
       valid_lft forever preferred_lft forever
14: ovn-k8s-mp5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1300 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 3a:dc:e6:d3:29:80 brd ff:ff:ff:ff:ff:ff
    inet 10.100.200.2/24 brd 10.100.200.255 scope global ovn-k8s-mp5
       valid_lft forever preferred_lft forever
    inet6 2010:100:200::2/60 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::38dc:e6ff:fed3:2980/64 scope link 
       valid_lft forever preferred_lft forever
```
where mp4 is L3 and mp5 is L2
and on ovn-worker:
```
10: ovn-k8s-mp4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1300 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 1e:ac:90:ac:a4:82 brd ff:ff:ff:ff:ff:ff
    inet 10.128.1.2/24 brd 10.128.1.255 scope global ovn-k8s-mp4
       valid_lft forever preferred_lft forever
    inet6 2010:100:200:1::2/64 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::1cac:90ff:feac:a482/64 scope link 
       valid_lft forever preferred_lft forever
11: ovn-k8s-mp5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1300 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 2a:45:a9:95:b4:94 brd ff:ff:ff:ff:ff:ff
    inet 10.100.200.2/24 brd 10.100.200.255 scope global ovn-k8s-mp5
       valid_lft forever preferred_lft forever
    inet6 2010:100:200::2/60 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::2845:a9ff:fe95:b494/64 scope link 
       valid_lft forever preferred_lft forever
```
where mp4 is L3 and mp5 is L2
