### PR TITLE
enable interconnect in helm chart

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -407,14 +407,14 @@ jobs:
         # forwarding : ["", "disable-forwarding"]
         # dns-name-resolver : ["", "enable-dns-name-resolver"]
         include:
-          - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-disabled",          "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "control-plane-helm", "ha": "HA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "dns-name-resolver": "enable-dns-name-resolver"}
+          - {"target": "control-plane-helm","ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "dns-name-resolver": "enable-dns-name-resolver"}
+          - {"target": "control-plane-helm","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -2011,7 +2011,7 @@ ovnkube-controller-with-node() {
     ${ovn_enable_dnsnameresolver_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --export-ovs-metrics \
-    --gateway-mode=${ovn_gateway_mode} \
+    --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
     --gateway-router-subnet=${ovn_gateway_router_subnet} \
     --host-network-namespace ${ovn_host_network_namespace} \
     --inactivity-probe=${ovn_remote_probe_interval} \

--- a/docs/installation/launching-ovn-kubernetes-with-helm.md
+++ b/docs/installation/launching-ovn-kubernetes-with-helm.md
@@ -233,7 +233,7 @@ false
 			<td>Whether or not to enable hybrid overlay functionality</td>
 		</tr>
 		<tr>
-			<td>global.enableInterConnect</td>
+			<td>global.enableInterconnect</td>
 			<td>bool</td>
 			<td><pre lang="json">
 false

--- a/helm/ovn-kubernetes/README.md
+++ b/helm/ovn-kubernetes/README.md
@@ -56,7 +56,16 @@ some of these subcharts are installed to provide the aforementioned OVN K8s
 CNI features, this can be done by editing `tags` section in values.yaml file.
 
 ## Quickstart:
-Run script `helm/basic-deploy.sh` to set up a basic OVN/Kubernetes cluster.
+- Install Kind, see https://kind.sigs.k8s.io
+- Run script `contrib/kind-helm.sh` to set up a basic OVN/Kubernetes cluster.
+- Run following command to set up a OVN/Kubernetes cluster with single-node-zone interconnect enabled.
+  ```
+  contrib/kind-helm.sh -ic
+  ```
+- Add `-npz` (node-per-zone) to set up cluster with multi-node-zone interconnect
+  ```
+  contrib/kind-helm.sh -ic -wk 3 -npz 2
+  ```
 
 ## Manual steps:
 - Disable IPv6 of `kind` docker network, otherwise ovnkube-node will fail to start
@@ -212,6 +221,15 @@ false
 			<td>Enables monitoring OVN-Kubernetes master and OVN configuration duration</td>
 		</tr>
 		<tr>
+			<td>global.enableDNSNameResolver</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Configure to use DNSNameResolver feature with ovn-kubernetes</td>
+		</tr>
+		<tr>
 			<td>global.enableEgressFirewall</td>
 			<td>bool</td>
 			<td><pre lang="json">
@@ -257,7 +275,7 @@ true
 			<td>Whether or not to enable hybrid overlay functionality</td>
 		</tr>
 		<tr>
-			<td>global.enableInterConnect</td>
+			<td>global.enableInterconnect</td>
 			<td>bool</td>
 			<td><pre lang="json">
 false
@@ -602,7 +620,7 @@ false
 			<td>global.v4MasqueradeSubnet</td>
 			<td>string</td>
 			<td><pre lang="json">
-""
+"169.254.0.0/17"
 </pre>
 </td>
 			<td>The v4 masquerade subnet used for assigning masquerade IPv4 addresses</td>
@@ -620,7 +638,7 @@ false
 			<td>global.v6MasqueradeSubnet</td>
 			<td>string</td>
 			<td><pre lang="json">
-""
+"fd69::/112"
 </pre>
 </td>
 			<td>The v6 masquerade subnet used for assigning masquerade IPv6 addresses</td>
@@ -675,6 +693,15 @@ false
 </pre>
 </td>
 			<td>number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes</td>
+		</tr>
+		<tr>
+			<td>ovnkube-master.replicas</td>
+			<td>int</td>
+			<td><pre lang="json">
+1
+</pre>
+</td>
+			<td>number of ovnkube-master pods</td>
 		</tr>
 		<tr>
 			<td>podNetwork</td>

--- a/helm/ovn-kubernetes/README.md.gotmpl
+++ b/helm/ovn-kubernetes/README.md.gotmpl
@@ -54,7 +54,16 @@ some of these subcharts are installed to provide the aforementioned OVN K8s
 CNI features, this can be done by editing `tags` section in values.yaml file.
 
 ## Quickstart:
-Run script `helm/basic-deploy.sh` to set up a basic OVN/Kubernetes cluster.
+- Install Kind, see https://kind.sigs.k8s.io
+- Run script `contrib/kind-helm.sh` to set up a basic OVN/Kubernetes cluster.
+- Run following command to set up a OVN/Kubernetes cluster with single-node-zone interconnect enabled.
+  ```
+  contrib/kind-helm.sh -ic
+  ```
+- Add `-npz` (node-per-zone) to set up cluster with multi-node-zone interconnect 
+  ```
+  contrib/kind-helm.sh -ic -wk 3 -npz 2
+  ```
 
 ## Manual steps:
 - Disable IPv6 of `kind` docker network, otherwise ovnkube-node will fail to start

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -127,7 +127,7 @@ spec:
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
-          value: {{ default "" .Values.disableSnatMultipleGws | quote }}
+          value: {{ default "" .Values.global.disableSnatMultipleGws | quote }}
         - name: OVN_EMPTY_LB_EVENTS
           value: {{ default "" .Values.global.emptyLbEvents | quote }}
         - name: OVN_V4_JOIN_SUBNET
@@ -151,6 +151,12 @@ spec:
           value: {{ hasKey .Values.global "enableInterconnect" | ternary .Values.global.enableInterconnect false | quote }}
         - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
           value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
+        - name: OVN_V4_TRANSIT_SWITCH_SUBNET
+          value: {{ default "" .Values.global.v4TransitSwitchSubnet | quote }}
+        - name: OVN_V6_TRANSIT_SWITCH_SUBNET
+          value: {{ default "" .Values.global.v6TransitSwitchSubnet | quote }}
+        - name: OVN_ENABLE_PERSISTENT_IPS
+          value: {{ hasKey .Values.global "enablePersistentIPs" | ternary .Values.global.enablePersistentIPs false | quote }}
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
       # end of container

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
@@ -53,20 +53,34 @@ rules:
       verbs: [ "get", "list", "watch" ]
     - apiGroups: ["k8s.cni.cncf.io"]
       resources:
+          - ipamclaims
           - network-attachment-definitions
           - multi-networkpolicies
       verbs: ["list", "get", "watch"]
+    - apiGroups: [ "k8s.cni.cncf.io" ]
+      resources:
+      - ipamclaims/status
+      - network-attachment-definitions
+      verbs: [ "patch", "update" ]
+    - apiGroups: [ "k8s.cni.cncf.io" ]
+      resources:
+      - network-attachment-definitions
+      verbs: [ "create", "delete" ]
     - apiGroups: ["k8s.ovn.org"]
       resources:
           - egressips
           - egressservices
           - adminpolicybasedexternalroutes
           - egressfirewalls
+          - egressqoses
+          - userdefinednetworks
       verbs: [ "get", "list", "watch" ]
     - apiGroups: ["k8s.ovn.org"]
       resources:
           - egressips
           - egressservices/status
+          - userdefinednetworks
+          - userdefinednetworks/status
       verbs: [ "patch", "update" ]
     - apiGroups: [""]
       resources:
@@ -82,7 +96,25 @@ rules:
       resources:
         - adminpolicybasedexternalroutes/status
         - egressfirewalls/status
+        - egressqoses/status
       verbs: [ "patch", "update" ]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies
+          - baselineadminnetworkpolicies
+      verbs: [ "list" ]
+    - apiGroups: ["policy.networking.k8s.io"]
+      resources:
+          - adminnetworkpolicies/status
+          - baselineadminnetworkpolicies/status
+      verbs: [ "patch" ]
+
+    {{- if eq (hasKey .Values.global "enableNetworkSegmentation" | ternary .Values.global.enableNetworkSegmentation false) true }}
+    - apiGroups: ["discovery.k8s.io"]
+      resources:
+          - endpointslices
+      verbs: [ "create", "update", "delete", "deletecollection" ]
+    {{- end }}
     {{- if eq (hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false) true }}
     - apiGroups: ["network.openshift.io"]
       resources:

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/values.yaml
@@ -18,12 +18,3 @@ affinity:
               operator: In
               values:
                 - "linux"
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-    - labelSelector:
-        matchExpressions:
-        - key: name
-          operator: In
-          values:
-          - ovnkube-identity
-      topologyKey: kubernetes.io/hostname

--- a/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-master/templates/deployment-ovnkube-master.yaml
@@ -239,7 +239,7 @@ spec:
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
-          value: {{ default "" .Values.disableSnatMultipleGws | quote }}
+          value: {{ default "" .Values.global.disableSnatMultipleGws | quote }}
         - name: OVN_DISABLE_FORWARDING
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
@@ -275,6 +275,8 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: host_network_namespace
+        - name: OVN_ENABLE_PERSISTENT_IPS
+          value: {{ hasKey .Values.global "enablePersistentIPs" | ternary .Values.global.enablePersistentIPs false | quote }}
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
       # end of container

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -197,7 +197,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "1.0.0s"
+          value: "1.0.0"
         - name: OVN_LOGLEVEL_NORTHD
           value: {{ default "-vconsole:info -vfile:info" .Values.northdLogLevel | quote }}
         - name: K8S_APISERVER
@@ -357,7 +357,7 @@ spec:
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
-          value: {{ default "" .Values.disableSnatMultipleGws | quote }}
+          value: {{ default "" .Values.global.disableSnatMultipleGws | quote }}
         - name: OVN_DISABLE_FORWARDING
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
@@ -380,6 +380,10 @@ spec:
           value: {{ default "" .Values.global.v4JoinSubnet | quote }}
         - name: OVN_V6_JOIN_SUBNET
           value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v4MasqueradeSubnet | quote }}
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v6MasqueradeSubnet | quote }}
         - name: OVN_MULTICAST_ENABLE
           value: {{ default "" .Values.global.enableMulticast | quote }}
         - name: OVN_UNPRIVILEGED_MODE
@@ -426,7 +430,7 @@ spec:
         - name: OVN_ENABLE_OVNKUBE_IDENTITY
           value: {{ hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true | quote }}
         - name: OVN_ENABLE_SVC_TEMPLATE_SUPPORT
-          value: {{ hasKey .Values.global "enableSvcTemplate" | ternary .Values.global.enableSvcTemplate true | quote }
+          value: {{ hasKey .Values.global "enableSvcTemplate" | ternary .Values.global.enableSvcTemplate true | quote }}
         - name: OVN_ENABLE_DNSNAMERESOLVER
           value: {{ hasKey .Values.global "enableDNSNameResolver" | ternary .Values.global.enableDNSNameResolver false | quote }}
         readinessProbe:

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -314,7 +314,7 @@ spec:
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: {{ default "" .Values.global.hybridOverlayNetCidr | quote }}
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
-          value: {{ default "" .Values.disableSnatMultipleGws | quote }}
+          value: {{ default "" .Values.global.disableSnatMultipleGws | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
         - name: OVN_EMPTY_LB_EVENTS
@@ -323,6 +323,10 @@ spec:
           value: {{ default "" .Values.global.v4JoinSubnet | quote }}
         - name: OVN_V6_JOIN_SUBNET
           value: {{ default "" .Values.global.v6JoinSubnet | quote }}
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v4MasqueradeSubnet | quote }}
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: {{ default "" .Values.global.v6MasqueradeSubnet | quote }}
         - name: OVN_SSL_ENABLE
           value: {{ include "isSslEnabled" . | quote }}
         - name: OVN_GATEWAY_MODE
@@ -336,7 +340,7 @@ spec:
         - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
           value: {{ hasKey .Values.global "enableMultiExternalGateway" | ternary .Values.global.enableMultiExternalGateway false | quote }}
         - name: OVN_ENABLE_SVC_TEMPLATE_SUPPORT
-          value: {{ hasKey .Values.global "enableSvcTemplate" | ternary .Values.global.enableSvcTemplate true | quote }
+          value: {{ hasKey .Values.global "enableSvcTemplate" | ternary .Values.global.enableSvcTemplate true | quote }}
         - name: OVN_HOST_NETWORK_NAMESPACE
           valueFrom:
             configMapKeyRef:

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/values.yaml
@@ -9,24 +9,16 @@ libovsdbClientLogFile: ""
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-## Required to be scheduled on a linux node and only one instance of ovnkube-zone-controller pod per node
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: node-role.kubernetes.io/control-plane
-              operator: Exists
+            - key: node-role.kubernetes.io/zone-controller
+              operator: In
+              values:
+              - ""
             - key: kubernetes.io/os
               operator: In
               values:
-                - "linux"
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-    - labelSelector:
-        matchExpressions:
-        - key: name
-          operator: In
-          values:
-          - ovnkube-zone-controller
-      topologyKey: kubernetes.io/hostname
+              - "linux"

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
@@ -150,12 +150,18 @@ rules:
       verbs: [ "get", "list", "watch" ]
     - apiGroups: ["k8s.cni.cncf.io"]
       resources:
+          - ipamclaims
           - multi-networkpolicies
       verbs: ["list", "get", "watch"]
+    - apiGroups: [ "k8s.cni.cncf.io" ]
+      resources:
+          - ipamclaims/status
+      verbs: [ "patch", "update" ]
     - apiGroups: ["k8s.ovn.org"]
       resources:
           - egressfirewalls/status
           - adminpolicybasedexternalroutes/status
+          - egressqoses/status
       verbs: [ "patch", "update" ]
     - apiGroups: ["policy.networking.k8s.io"]
       resources:

--- a/helm/ovn-kubernetes/values-multi-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-multi-node-zone.yaml
@@ -1,0 +1,166 @@
+# Values for ovn-kubernetes with multi-node zone interconnect
+# Requires: ovnkube-control-plane, ovnkube-zone-controller, ovnkube-node
+# enableOvnKubeIdentity need to be false 
+
+# -- list of dependent subcharts that need to be installed for the given deployment mode, these subcharts haven't been tested yet.
+tags:
+  ovn-ipsec: false
+  ovnkube-db: false
+  ovnkube-db-raft: false
+  ovnkube-master: false
+  ovnkube-node-dpu: false
+  ovnkube-node-dpu-host: false
+  ovnkube-single-node-zone: false
+
+# -- Endpoint of Kubernetes api server
+k8sAPIServer: https://172.25.0.2:6443
+# -- IP range for Kubernetes pods, /14 is the top level range, under which each /23 range will be assigned to a node
+podNetwork: 10.244.0.0/16/24
+# -- A comma-separated set of CIDR notation IP ranges from which k8s assigns service cluster IPs. This should be the same as the value provided for kube-apiserver "--service-cluster-ip-range" option
+serviceNetwork: 10.96.0.0/16
+# -- MTU of network interface in a Kubernetes pod
+mtu: 1400
+# -- Whether or not call `lookup` Helm function, set it to `true` if you want to run `helm dry-run/template/lint`
+skipCallToK8s: false
+
+global:
+  # -- The net device to be used for management port, will be renamed to ovn-k8s-mp0 and used to allow host network services and pods to access k8s pod and service networks
+  nodeMgmtPortNetdev: ""
+  # -- The interface on nodes that will be used for external gateway network traffic
+  extGatewayNetworkInterface: ""
+  # -- GENEVE UDP port (default 6081)
+  encapPort: 6081
+  # -- The gateway mode (shared or local), if not given, gateway functionality is disabled
+  gatewayMode: shared
+  # -- Optional extra gateway options
+  gatewayOpts: ""
+  # -- This allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
+  unprivilegedMode: false
+  # -- The v4 join subnet used for assigning join switch IPv4 addresses
+  v4JoinSubnet: "100.64.0.0/16"
+  # -- The v4 masquerade subnet used for assigning masquerade IPv4 addresses
+  v4MasqueradeSubnet: "169.254.0.0/17"
+  # -- The v4 subnet for transit switch
+  v4TransitSwitchSubnet: "100.88.0.0/16"
+  # -- The v6 join subnet used for assigning join switch IPv6 addresses
+  v6JoinSubnet: "fd98::/64"
+  # -- The v6 masquerade subnet used for assigning masquerade IPv6 addresses
+  v6MasqueradeSubnet: "fd69::/112"
+  # -- The v6 subnet for transit switch
+  v6TransitSwitchSubnet: "fd97::/64"
+  # -- Whether or not enable ovnkube identity webhook
+  enableOvnKubeIdentity: false
+  # -- Indicate if ovnkube run master and node in one process
+  enableCompactMode: false
+  # -- Whether or not to enable hybrid overlay functionality
+  enableHybridOverlay: ""
+  # -- A comma separated set of IP subnets and the associated hostsubnetlengths (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\") to use with the extended hybrid network
+  hybridOverlayNetCidr: ""
+  # -- Whether or not to use Admin Network Policy CRD feature with ovn-kubernetes
+  enableAdminNetworkPolicy: false
+  # -- Configure to use EgressIP CRD feature with ovn-kubernetes
+  enableEgressIp: true
+  # -- Configure EgressIP node reachability using gRPC on this TCP port
+  egressIpHealthCheckPort: 9107
+  # -- Configure to use EgressService CRD feature with ovn-kubernetes
+  enableEgressService: true
+  # -- Configure to use EgressFirewall CRD feature with ovn-kubernetes
+  enableEgressFirewall: true
+  # -- Configure to use EgressQoS CRD feature with ovn-kubernetes
+  enableEgressQos: true
+  # -- Enables multicast support between the pods within the same namespace
+  enableMulticast: ""
+  # -- Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes
+  enableMultiNetwork: false
+  # -- Configure to enable IPsec
+  enableIpsec: false
+  # -- Use SSL transport to NB/SB db and northd
+  enableSsl: false
+  # -- Configure to enable interconnecting multiple zones
+  enableInterconnect: true
+  # -- Configure to use AdminPolicyBasedExternalRoute CRD feature with ovn-kubernetes
+  enableMultiExternalGateway: true
+  # -- Configure to use stateless network policy feature with ovn-kubernetes
+  enableStatelessNetworkPolicy: false
+  # -- Configure to use the IPAMClaims CRD feature with ovn-kubernetes, thus granting persistent IPs across restarts / migration for KubeVirt VMs
+  enablePersistentIPs: true
+  # -- Configure to use service template feature with ovn-kubernetes
+  enableSvcTemplate: true
+  # -- Enables metrics related to scaling
+  enableMetricsScale: ""
+  # -- Enables monitoring OVN-Kubernetes master and OVN configuration duration
+  enableConfigDuration: ""
+  # -- Indicates if ovn-controller should enable/disable the logical flow in-memory cache when processing Southbound database logical flow changes
+  # @default -- true
+  enableLFlowCache: true
+  # -- Maximum number of logical flow cache entries ovn-controller may create when the logical flow cache is enabled
+  # @default -- unlimited
+  lFlowCacheLimit: ""
+  # -- Maximum size of the logical flow cache (in KB) ovn-controller may create when the logical flow cache is enabled
+  lFlowCacheLimitKb: ""
+  # -- Configure to use DNSNameResolver feature with ovn-kubernetes
+  enableDNSNameResolver: false
+  # -- Whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
+  disableSnatMultipleGws: ""
+  # -- Controls if forwarding is allowed on OVNK controlled interfaces
+  # @default -- false
+  disableForwarding: ""
+  # -- Disables adding openflow flows to check packets too large to be delivered to OVN due to pod MTU being lower than NIC MTU
+  disablePacketMtuCheck: ""
+  # -- Deprecated: iface-id-ver is always enabled
+  disableIfaceIdVer: false
+  # -- The largest number of messages per second that gets logged before drop
+  # @default 20
+  aclLoggingRateLimit: 20
+  # -- If set, then load balancers do not get deleted when all backends are removed
+  emptyLbEvents: ""
+  # -- Port of north bound ovsdb
+  nbPort: 6641
+  # -- Port of south bound ovsdb
+  sbPort: 6642
+  # -- A comma separated set of NetFlow collectors to export flow data
+  netFlowTargets: ""
+  # -- A comma separated set of SFlow collectors to export flow data
+  sflowTargets: ""
+  # -- A comma separated set of IPFIX collectors to export flow data
+  ipfixTargets: ""
+  # -- Rate at which packets should be sampled and sent to each target collector
+  # @default 400
+  ipfixSampling: ""
+  # -- Maximum number of IPFIX flow records that can be cached at a time
+  # @default 0, meaning disabled
+  ipfixCacheMaxFlows: ""
+  # -- Maximum period in seconds for which an IPFIX flow record is cached and aggregated before being sent
+  # @default 60
+  ipfixCacheActiveTimeout: ""
+  # -- OVN remote probe interval in ms 
+  # @default 100000
+  remoteProbeInterval: 100000
+  # -- Enable monitoring all data from SB DB instead of conditionally monitoring the data relevant to this node only
+  # @default true
+  monitorAll: ""
+  # -- ovn-controller wait time in ms before clearing OpenFlow rules during start up
+  # @default 0
+  ofctrlWaitBeforeClear: ""
+  # -- Separate log file for libovsdb client 
+  libovsdbClientLogFile: ""
+  image:
+    # -- Image repository for ovn-kubernetes components
+    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu
+    # -- Specify image tag to run
+    tag: master
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+
+ovnkube-identity:
+    # -- number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes
+    replicas: 1
+
+# -- prometheus monitoring related fields
+monitoring:
+  # -- specify the labels for serviceMonitors to be selected for target discovery.
+  # Prometheus operator defines what namespaces and what servicemonitors within these
+  # namespaces must be selected for target discovery. The fields defined below helps
+  # in defining that.
+  commonServiceMonitorSelectorLabels:
+    release: kube-prometheus-stack

--- a/helm/ovn-kubernetes/values-no-ic.yaml
+++ b/helm/ovn-kubernetes/values-no-ic.yaml
@@ -1,0 +1,171 @@
+# Values for ovn-kubernetes.
+
+# -- list of dependent subcharts that need to be installed for the given deployment mode, these subcharts haven't been tested yet.
+tags:
+  ovn-ipsec: false
+  ovnkube-control-plane: false
+  ovnkube-db-raft: false
+  ovnkube-node-dpu: false
+  ovnkube-node-dpu-host: false
+  ovnkube-single-node-zone: false
+  ovnkube-zone-controller: false
+
+# -- Endpoint of Kubernetes api server
+k8sAPIServer: https://172.25.0.2:6443
+# -- IP range for Kubernetes pods, /14 is the top level range, under which each /23 range will be assigned to a node
+podNetwork: 10.244.0.0/16/24
+# -- A comma-separated set of CIDR notation IP ranges from which k8s assigns service cluster IPs. This should be the same as the value provided for kube-apiserver "--service-cluster-ip-range" option
+serviceNetwork: 10.96.0.0/16
+# -- MTU of network interface in a Kubernetes pod
+mtu: 1400
+# -- Whether or not call `lookup` Helm function, set it to `true` if you want to run `helm dry-run/template/lint`
+skipCallToK8s: false
+
+global:
+  # -- The net device to be used for management port, will be renamed to ovn-k8s-mp0 and used to allow host network services and pods to access k8s pod and service networks
+  nodeMgmtPortNetdev: ""
+  # -- The interface on nodes that will be used for external gateway network traffic
+  extGatewayNetworkInterface: ""
+  # -- GENEVE UDP port (default 6081)
+  encapPort: 6081
+  # -- The gateway mode (shared or local), if not given, gateway functionality is disabled
+  gatewayMode: shared
+  # -- Optional extra gateway options
+  gatewayOpts: ""
+  # -- This allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
+  unprivilegedMode: false
+  # -- The v4 join subnet used for assigning join switch IPv4 addresses
+  v4JoinSubnet: ""
+  # -- The v4 masquerade subnet used for assigning masquerade IPv4 addresses
+  v4MasqueradeSubnet: "169.254.0.0/17"
+  # -- The v6 join subnet used for assigning join switch IPv6 addresses
+  v6JoinSubnet: ""
+  # -- The v6 masquerade subnet used for assigning masquerade IPv6 addresses
+  v6MasqueradeSubnet: "fd69::/112"
+  # -- Whether or not enable ovnkube identity webhook
+  enableOvnKubeIdentity: true
+  # -- Indicate if ovnkube run master and node in one process
+  enableCompactMode: false
+  # -- Whether or not to enable hybrid overlay functionality
+  enableHybridOverlay: ""
+  # -- A comma separated set of IP subnets and the associated hostsubnetlengths (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\") to use with the extended hybrid network
+  hybridOverlayNetCidr: ""
+  # -- Whether or not to use Admin Network Policy CRD feature with ovn-kubernetes
+  enableAdminNetworkPolicy: false
+  # -- Configure to use EgressIP CRD feature with ovn-kubernetes
+  enableEgressIp: true
+  # -- Configure EgressIP node reachability using gRPC on this TCP port
+  egressIpHealthCheckPort: 9107
+  # -- Configure to use EgressService CRD feature with ovn-kubernetes
+  enableEgressService: true
+  # -- Configure to use EgressFirewall CRD feature with ovn-kubernetes
+  enableEgressFirewall: true
+  # -- Configure to use EgressQoS CRD feature with ovn-kubernetes
+  enableEgressQos: true
+  # -- Enables multicast support between the pods within the same namespace
+  enableMulticast: ""
+  # -- Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes
+  enableMultiNetwork: false
+  # -- Configure to enable IPsec
+  enableIpsec: false
+  # -- Use SSL transport to NB/SB db and northd
+  enableSsl: false
+  # -- Configure to enable interconnecting multiple zones
+  enableInterconnect: false
+  # -- Configure to use AdminPolicyBasedExternalRoute CRD feature with ovn-kubernetes
+  enableMultiExternalGateway: true
+  # -- Configure to use stateless network policy feature with ovn-kubernetes
+  enableStatelessNetworkPolicy: false
+  # -- Configure to use the IPAMClaims CRD feature with ovn-kubernetes, thus granting persistent IPs across restarts / migration for KubeVirt VMs
+  enablePersistentIPs: false
+  # -- Configure to use service template feature with ovn-kubernetes
+  enableSvcTemplate: true
+  # -- Enables metrics related to scaling
+  enableMetricsScale: ""
+  # -- Enables monitoring OVN-Kubernetes master and OVN configuration duration
+  enableConfigDuration: ""
+  # -- Indicates if ovn-controller should enable/disable the logical flow in-memory cache when processing Southbound database logical flow changes
+  # @default -- true
+  enableLFlowCache: true
+  # -- Configure to use DNSNameResolver feature with ovn-kubernetes
+  enableDNSNameResolver: false
+  # -- Maximum number of logical flow cache entries ovn-controller may create when the logical flow cache is enabled
+  # @default -- unlimited
+  lFlowCacheLimit: ""
+  # -- Maximum size of the logical flow cache (in KB) ovn-controller may create when the logical flow cache is enabled
+  lFlowCacheLimitKb: ""
+  # -- Whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
+  disableSnatMultipleGws: ""
+  # -- Controls if forwarding is allowed on OVNK controlled interfaces
+  # @default -- false
+  disableForwarding: ""
+  # -- Disables adding openflow flows to check packets too large to be delivered to OVN due to pod MTU being lower than NIC MTU
+  disablePacketMtuCheck: ""
+  # -- Deprecated: iface-id-ver is always enabled
+  disableIfaceIdVer: false
+  # -- The largest number of messages per second that gets logged before drop
+  # @default 20
+  aclLoggingRateLimit: 20
+  # -- If set, then load balancers do not get deleted when all backends are removed
+  emptyLbEvents: ""
+  # -- Port of north bound ovsdb
+  nbPort: 6641
+  # -- Port of south bound ovsdb
+  sbPort: 6642
+  # -- A comma separated set of NetFlow collectors to export flow data
+  netFlowTargets: ""
+  # -- A comma separated set of SFlow collectors to export flow data
+  sflowTargets: ""
+  # -- A comma separated set of IPFIX collectors to export flow data
+  ipfixTargets: ""
+  # -- Rate at which packets should be sampled and sent to each target collector
+  # @default 400
+  ipfixSampling: ""
+  # -- Maximum number of IPFIX flow records that can be cached at a time
+  # @default 0, meaning disabled
+  ipfixCacheMaxFlows: ""
+  # -- Maximum period in seconds for which an IPFIX flow record is cached and aggregated before being sent
+  # @default 60
+  ipfixCacheActiveTimeout: ""
+  # -- OVN remote probe interval in ms 
+  # @default 100000
+  remoteProbeInterval: 100000
+  # -- Enable monitoring all data from SB DB instead of conditionally monitoring the data relevant to this node only
+  # @default true
+  monitorAll: ""
+  # -- ovn-controller wait time in ms before clearing OpenFlow rules during start up
+  # @default 0
+  ofctrlWaitBeforeClear: ""
+  # -- Separate log file for libovsdb client 
+  libovsdbClientLogFile: ""
+  image:
+    # -- Image repository for ovn-kubernetes components
+    repository: ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-ubuntu
+    # -- Specify image tag to run
+    tag: master
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+  # -- The name of secret used for pulling image. Use only if needed
+  imagePullSecretName: ""
+  # -- The secret used for pulling image. Use only if needed. Set create to have have secret created by helm
+  dockerConfigSecret:
+    registry: ghcr.io
+    auth: blah_blah_blah
+    create: false
+
+ovnkube-identity:
+    # -- number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes
+    replicas: 1
+
+ovnkube-master:
+    # -- number of ovnkube-master pods
+    replicas: 1
+
+# -- prometheus monitoring related fields
+monitoring:
+  # -- specify the labels for serviceMonitors to be selected for target discovery.
+  # Prometheus operator defines what namespaces and what servicemonitors within these
+  # namespaces must be selected for target discovery. The fields defined below helps
+  # in defining that.
+  commonServiceMonitorSelectorLabels:
+    release: kube-prometheus-stack

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -1,13 +1,15 @@
-# Values for ovn-kubernetes.
+# Values for ovn-kubernetes with single-node zone interconnect
+# Requires: ovnkube-single-node-zone, ovnkube-control-plane
 
 # -- list of dependent subcharts that need to be installed for the given deployment mode, these subcharts haven't been tested yet.
 tags:
   ovn-ipsec: false
-  ovnkube-control-plane: false
+  ovnkube-db: false
   ovnkube-db-raft: false
+  ovnkube-master: false
+  ovnkube-node: false
   ovnkube-node-dpu: false
   ovnkube-node-dpu-host: false
-  ovnkube-single-node-zone: false
   ovnkube-zone-controller: false
 
 # -- Endpoint of Kubernetes api server
@@ -35,13 +37,17 @@ global:
   # -- This allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
   unprivilegedMode: false
   # -- The v4 join subnet used for assigning join switch IPv4 addresses
-  v4JoinSubnet: ""
+  v4JoinSubnet: "100.64.0.0/16"
   # -- The v4 masquerade subnet used for assigning masquerade IPv4 addresses
-  v4MasqueradeSubnet: ""
+  v4MasqueradeSubnet: "169.254.0.0/17"
+  # -- The v4 subnet for transit switch
+  v4TransitSwitchSubnet: "100.88.0.0/16"
   # -- The v6 join subnet used for assigning join switch IPv6 addresses
-  v6JoinSubnet: ""
+  v6JoinSubnet: "fd98::/64"
   # -- The v6 masquerade subnet used for assigning masquerade IPv6 addresses
-  v6MasqueradeSubnet: ""
+  v6MasqueradeSubnet: "fd69::/112"
+  # -- The v6 subnet for transit switch
+  v6TransitSwitchSubnet: "fd97::/64"
   # -- Whether or not enable ovnkube identity webhook
   enableOvnKubeIdentity: true
   # -- Indicate if ovnkube run master and node in one process
@@ -71,13 +77,13 @@ global:
   # -- Use SSL transport to NB/SB db and northd
   enableSsl: false
   # -- Configure to enable interconnecting multiple zones
-  enableInterConnect: false
+  enableInterconnect: true
   # -- Configure to use AdminPolicyBasedExternalRoute CRD feature with ovn-kubernetes
   enableMultiExternalGateway: true
   # -- Configure to use stateless network policy feature with ovn-kubernetes
   enableStatelessNetworkPolicy: false
   # -- Configure to use the IPAMClaims CRD feature with ovn-kubernetes, thus granting persistent IPs across restarts / migration for KubeVirt VMs
-  enablePersistentIPs: false
+  enablePersistentIPs: true
   # -- Configure to use service template feature with ovn-kubernetes
   enableSvcTemplate: true
   # -- Enables metrics related to scaling
@@ -87,13 +93,16 @@ global:
   # -- Indicates if ovn-controller should enable/disable the logical flow in-memory cache when processing Southbound database logical flow changes
   # @default -- true
   enableLFlowCache: true
-  # -- Configure to use DNSNameResolver feature with ovn-kubernetes
-  enableDNSNameResolver: false
   # -- Maximum number of logical flow cache entries ovn-controller may create when the logical flow cache is enabled
   # @default -- unlimited
   lFlowCacheLimit: ""
   # -- Maximum size of the logical flow cache (in KB) ovn-controller may create when the logical flow cache is enabled
   lFlowCacheLimitKb: ""
+  # -- Configure to use the IPAMClaims CRD feature with ovn-kubernetes, thus granting persistent IPs across restarts / migration for KubeVirt VMs
+  # @default -- true
+  enablePersistentIPs: true
+  # -- Configure to use DNSNameResolver feature with ovn-kubernetes
+  enableDNSNameResolver: false
   # -- Whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
   disableSnatMultipleGws: ""
   # -- Controls if forwarding is allowed on OVNK controlled interfaces
@@ -145,13 +154,6 @@ global:
     tag: master
     # -- Image pull policy
     pullPolicy: IfNotPresent
-  # -- The name of secret used for pulling image. Use only if needed
-  imagePullSecretName: ""
-  # -- The secret used for pulling image. Use only if needed. Set create to have have secret created by helm
-  dockerConfigSecret:
-    registry: ghcr.io
-    auth: blah_blah_blah
-    create: false
 
 ovnkube-identity:
     # -- number of ovnube-identity pods, co-located with kube-apiserver process, so need to be the same number of control plane nodes


### PR DESCRIPTION
 add `-ic` option to `kind-helm.sh` to enable interconnect
    - if npz is not specified, create single-node zone interconnect
    - if npz is greater than 1, create multi-node zone interconnect

#### What this PR does and why is it needed
support interconnect in Helm chart

#### Which issue(s) this PR fixes
#4371

#### Special notes for reviewers
N/A

#### How to verify it
contrib/kind-helm.sh -ic, should create ovn-k8s with single-node zone interconnect
contrib/kind-helm.sh -ic -wk3 -npz 2, should create ovn-k8s with multi-node zone interconnect
`contrib/kind-helm.sh` only, i.e. without `-ic` option, should create ovn-k8s with interconnect disabled.

#### Details to documentation updates
N/A


#### Description for the changelog
N/A

#### Does this PR introduce a user-facing change?
N/A
