### PR TITLE
udn: Wire up multicast for primary networks.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,7 +433,7 @@ jobs:
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
       OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' }}"
-      OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' }}"
+      OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || matrix.target == 'network-segmentation' }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' }}"
       OVN_HA: "${{ matrix.ha == 'HA' }}"
       OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws == 'noSnatGW' }}"

--- a/go-controller/pkg/ovn/base_network_controller_multicast.go
+++ b/go-controller/pkg/ovn/base_network_controller_multicast.go
@@ -367,3 +367,28 @@ func (bnc *BaseNetworkController) setupClusterPortGroups() error {
 	}
 	return nil
 }
+
+func (bnc *BaseNetworkController) syncDefaultMulticastPolicies() error {
+	// If supported, enable IGMP relay on the router to forward multicast
+	// traffic between nodes.
+	if bnc.multicastSupport {
+		// Drop IP multicast globally. Multicast is allowed only if explicitly
+		// enabled in a namespace.
+		if err := bnc.createDefaultDenyMulticastPolicy(); err != nil {
+			klog.Errorf("Failed to create default deny multicast policy, error: %v", err)
+			return err
+		}
+
+		// Allow IP multicast from node switch to cluster router and from
+		// cluster router to node switch.
+		if err := bnc.createDefaultAllowMulticastPolicy(); err != nil {
+			klog.Errorf("Failed to create default deny multicast policy, error: %v", err)
+			return err
+		}
+	} else {
+		if err := bnc.disableMulticast(); err != nil {
+			return fmt.Errorf("failed to delete default multicast policy, error: %v", err)
+		}
+	}
+	return nil
+}

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -328,10 +328,13 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 			return err
 		}
 	}
-
-	if bsnc.doesNetworkRequireIPAM() && util.IsMultiNetworkPoliciesSupportEnabled() {
+	if bsnc.doesNetworkRequireIPAM() && (util.IsMultiNetworkPoliciesSupportEnabled() || bsnc.multicastSupport) {
 		// Ensure the namespace/nsInfo exists
-		addOps, err := bsnc.addPodToNamespaceForSecondaryNetwork(pod.Namespace, podAnnotation.IPs)
+		portUUID := ""
+		if lsp != nil {
+			portUUID = lsp.UUID
+		}
+		addOps, err := bsnc.addPodToNamespaceForSecondaryNetwork(pod.Namespace, podAnnotation.IPs, portUUID)
 		if err != nil {
 			return err
 		}
@@ -559,7 +562,7 @@ func (bsnc *BaseSecondaryNetworkController) syncPodsForSecondaryNetwork(pods []i
 }
 
 // addPodToNamespaceForSecondaryNetwork returns the ops needed to add pod's IP to the namespace's address set.
-func (bsnc *BaseSecondaryNetworkController) addPodToNamespaceForSecondaryNetwork(ns string, ips []*net.IPNet) ([]ovsdb.Operation, error) {
+func (bsnc *BaseSecondaryNetworkController) addPodToNamespaceForSecondaryNetwork(ns string, ips []*net.IPNet, portUUID string) ([]ovsdb.Operation, error) {
 	var ops []ovsdb.Operation
 	var err error
 	nsInfo, nsUnlock, err := bsnc.ensureNamespaceLockedForSecondaryNetwork(ns, true, nil)
@@ -571,6 +574,12 @@ func (bsnc *BaseSecondaryNetworkController) addPodToNamespaceForSecondaryNetwork
 
 	if ops, err = nsInfo.addressSet.AddAddressesReturnOps(util.IPNetsIPToStringSlice(ips)); err != nil {
 		return nil, err
+	}
+
+	if portUUID != "" && nsInfo.portGroupName != "" {
+		if ops, err = libovsdbops.AddPortsToPortGroupOps(bsnc.nbClient, ops, nsInfo.portGroupName, portUUID); err != nil {
+			return nil, err
+		}
 	}
 
 	return ops, nil

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -289,7 +289,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				config.Gateway.Mode = gwMode
 				app.Action = func(ctx *cli.Context) error {
 					// owned by non-existing namespace
-					fakeController := getFakeController(DefaultNetworkControllerName)
+					fakeController := getFakeController()
 					purgeIDs := fakeController.getEgressFirewallACLDbIDs("none", 0)
 					purgeACL := libovsdbops.BuildACL(
 						"purgeACL1",
@@ -489,7 +489,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				config.Gateway.Mode = gwMode
 				app.Action = func(ctx *cli.Context) error {
 
-					fakeController := getFakeController(DefaultNetworkControllerName)
+					fakeController := getFakeController()
 					fakeOVN.controller = fakeController
 
 					namespace1 := *newNamespace("namespace1")
@@ -522,7 +522,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					namespace1 := *newNamespace("namespace1")
 					dnsName := util.LowerCaseFQDN("www.example.com")
 
-					fakeController := getFakeController(DefaultNetworkControllerName)
+					fakeController := getFakeController()
 					fakeOVN.controller = fakeController
 
 					// add dns address set along with the acl and pg to the initial db.

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
-	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -43,44 +42,8 @@ func (oc *DefaultNetworkController) SetupMaster(existingNodeNames []string) erro
 	}
 	oc.defaultCOPPUUID = *(logicalRouter.Copp)
 
-	pgIDs := oc.getClusterPortGroupDbIDs(types.ClusterPortGroupNameBase)
-	pg := &nbdb.PortGroup{
-		Name: libovsdbutil.GetPortGroupName(pgIDs),
-	}
-	pg, err = libovsdbops.GetPortGroup(oc.nbClient, pg)
-	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+	if err := oc.setupClusterPortGroups(); err != nil {
 		return err
-	}
-	if pg == nil {
-		// we didn't find an existing clusterPG, let's create a new empty PG (fresh cluster install)
-		// Create a cluster-wide port group that all logical switch ports are part of
-		pg := libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
-		err = libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, pg)
-		if err != nil {
-			klog.Errorf("Failed to create cluster port group: %v", err)
-			return err
-		}
-	}
-
-	pgIDs = oc.getClusterPortGroupDbIDs(types.ClusterRtrPortGroupNameBase)
-	pg = &nbdb.PortGroup{
-		Name: libovsdbutil.GetPortGroupName(pgIDs),
-	}
-	pg, err = libovsdbops.GetPortGroup(oc.nbClient, pg)
-	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
-		return err
-	}
-	if pg == nil {
-		// we didn't find an existing clusterRtrPG, let's create a new empty PG (fresh cluster install)
-		// Create a cluster-wide port group with all node-to-cluster router
-		// logical switch ports. Currently the only user is multicast but it might
-		// be used for other features in the future.
-		pg = libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
-		err = libovsdbops.CreateOrUpdatePortGroups(oc.nbClient, pg)
-		if err != nil {
-			klog.Errorf("Failed to create cluster port group: %v", err)
-			return err
-		}
 	}
 
 	// If supported, enable IGMP relay on the router to forward multicast

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -46,26 +46,8 @@ func (oc *DefaultNetworkController) SetupMaster(existingNodeNames []string) erro
 		return err
 	}
 
-	// If supported, enable IGMP relay on the router to forward multicast
-	// traffic between nodes.
-	if oc.multicastSupport {
-		// Drop IP multicast globally. Multicast is allowed only if explicitly
-		// enabled in a namespace.
-		if err := oc.createDefaultDenyMulticastPolicy(); err != nil {
-			klog.Errorf("Failed to create default deny multicast policy, error: %v", err)
-			return err
-		}
-
-		// Allow IP multicast from node switch to cluster router and from
-		// cluster router to node switch.
-		if err := oc.createDefaultAllowMulticastPolicy(); err != nil {
-			klog.Errorf("Failed to create default deny multicast policy, error: %v", err)
-			return err
-		}
-	} else {
-		if err = oc.disableMulticast(); err != nil {
-			return fmt.Errorf("failed to delete default multicast policy, error: %v", err)
-		}
+	if err := oc.syncDefaultMulticastPolicies(); err != nil {
+		return err
 	}
 
 	// Create OVNJoinSwitch that will be used to connect gateway routers to the distributed router.

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1834,7 +1834,11 @@ func newClusterJoinSwitch() *nbdb.LogicalSwitch {
 }
 
 func newClusterPortGroup() *nbdb.PortGroup {
-	fakeController := getFakeController(DefaultNetworkControllerName)
+	return newClusterPortGroupForNetwork(&util.DefaultNetInfo{})
+}
+
+func newClusterPortGroupForNetwork(netInfo util.NetInfo) *nbdb.PortGroup {
+	fakeController := getFakeControllerForNetwork(netInfo)
 	pgIDs := fakeController.getClusterPortGroupDbIDs(types.ClusterPortGroupNameBase)
 	pg := libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
 	pg.UUID = pgIDs.String()
@@ -1842,7 +1846,11 @@ func newClusterPortGroup() *nbdb.PortGroup {
 }
 
 func newRouterPortGroup() *nbdb.PortGroup {
-	fakeController := getFakeController(DefaultNetworkControllerName)
+	return newRouterPortGroupForNetwork(&util.DefaultNetInfo{})
+}
+
+func newRouterPortGroupForNetwork(netInfo util.NetInfo) *nbdb.PortGroup {
+	fakeController := getFakeControllerForNetwork(netInfo)
 	pgIDs := fakeController.getClusterPortGroupDbIDs(types.ClusterRtrPortGroupNameBase)
 	pg := libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
 	pg.UUID = pgIDs.String()

--- a/go-controller/pkg/ovn/network_segmentation_multicast_test.go
+++ b/go-controller/pkg/ovn/network_segmentation_multicast_test.go
@@ -1,0 +1,460 @@
+package ovn
+
+import (
+	"github.com/urfave/cli/v2"
+	v1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/format"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func getDefaultPortGroupsForNetwork(netInfo util.NetInfo) (clusterPortGroup, clusterRtrPortGroup *nbdb.PortGroup) {
+	clusterPortGroup = newClusterPortGroupForNetwork(netInfo)
+	clusterRtrPortGroup = newRouterPortGroupForNetwork(netInfo)
+	return
+}
+
+var _ = Describe("[Network Segmentation] OVN Multicast with IP Address Family", func() {
+	const (
+		namespaceName1 = "namespace1"
+		nodeName       = "node1"
+	)
+	var (
+		app                   *cli.App
+		fakeOvn               *FakeOVN
+		gomegaFormatMaxLength int
+		nad                   = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
+		netInfo util.NetInfo
+	)
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.PrepareTestConfig()
+		config.IPv4Mode = true
+		config.IPv6Mode = false
+		config.EnableMulticast = true
+
+		app = cli.NewApp()
+		app.Name = "test"
+		// flags are written to config.EnableMulticast
+		// if there is no --enable-multicast flag, it will set to false.
+		// alternative approach is to give this flag to app.Run, but that require more changes.
+		//app.Flags = config.Flags
+
+		fakeOvn = NewFakeOVN(true)
+		gomegaFormatMaxLength = format.MaxLength
+		format.MaxLength = 0
+
+		var err error
+		netInfo, err = util.ParseNADInfo(nad)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+		format.MaxLength = gomegaFormatMaxLength
+	})
+
+	Context("on startup", func() {
+		It("creates default Multicast ACLs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				clusterPortGroup, clusterRtrPortGroup := getDefaultPortGroupsForNetwork(netInfo)
+				fakeOvn.startWithDBSetup(libovsdb.TestSetup{
+					NBData: []libovsdb.TestData{
+						clusterPortGroup,
+						clusterRtrPortGroup,
+					},
+				})
+
+				Expect(fakeOvn.NewSecondaryNetworkController(nad)).To(Succeed())
+				controller, ok := fakeOvn.secondaryControllers[netInfo.GetNetworkName()]
+				Expect(ok).To(BeTrue())
+
+				Expect(controller.bnc.createDefaultDenyMulticastPolicy()).To(Succeed())
+				Expect(controller.bnc.createDefaultAllowMulticastPolicy()).To(Succeed())
+
+				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(
+					getMulticastDefaultExpectedDataForNetwork(netInfo, clusterPortGroup, clusterRtrPortGroup)))
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("updates stale default Multicast ACLs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				// start with stale ACLs
+				clusterPortGroup, clusterRtrPortGroup := getDefaultPortGroupsForNetwork(netInfo)
+				fakeOvn.startWithDBSetup(libovsdb.TestSetup{
+					NBData: getMulticastDefaultStaleDataForNetwork(netInfo, clusterPortGroup, clusterRtrPortGroup),
+				})
+
+				Expect(fakeOvn.NewSecondaryNetworkController(nad)).To(Succeed())
+				controller, ok := fakeOvn.secondaryControllers[netInfo.GetNetworkName()]
+				Expect(ok).To(BeTrue())
+
+				Expect(controller.bnc.createDefaultDenyMulticastPolicy()).To(Succeed())
+				Expect(controller.bnc.createDefaultAllowMulticastPolicy()).To(Succeed())
+
+				// check acls are updated
+				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(
+					getMulticastDefaultExpectedDataForNetwork(netInfo, clusterPortGroup, clusterRtrPortGroup)))
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("cleans up Multicast resources when multicast is disabled", func() {
+			app.Action = func(ctx *cli.Context) error {
+				clusterPortGroup, clusterRtrPortGroup := getDefaultPortGroupsForNetwork(netInfo)
+				initialData := getMulticastDefaultExpectedDataForNetwork(netInfo, clusterPortGroup, clusterRtrPortGroup)
+
+				nsData := getMulticastPolicyExpectedDataForNetwork(netInfo, namespaceName1, nil)
+				initialData = append(initialData, nsData...)
+				// namespace is still present, but multicast support is disabled
+				namespace1 := *newNamespace(namespaceName1)
+				fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: initialData},
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespace1,
+						},
+					},
+				)
+
+				Expect(fakeOvn.NewSecondaryNetworkController(nad)).To(Succeed())
+				controller, ok := fakeOvn.secondaryControllers[netInfo.GetNetworkName()]
+				Expect(ok).To(BeTrue())
+
+				// this "if !oc.multicastSupport" part of SetupMaster
+				err := controller.bnc.disableMulticast()
+				Expect(err).NotTo(HaveOccurred())
+
+				// check acls are deleted when multicast is disabled
+				clusterPortGroup, clusterRtrPortGroup = getDefaultPortGroupsForNetwork(netInfo)
+				namespacePortGroup := getNamespacePG(namespaceName1, controller.bnc.controllerName)
+				expectedData := []libovsdb.TestData{
+					clusterPortGroup,
+					clusterRtrPortGroup,
+					namespacePortGroup,
+				}
+
+				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData))
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("creates namespace Multicast ACLs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				clusterPortGroup, clusterRtrPortGroup := getDefaultPortGroupsForNetwork(netInfo)
+				expectedData := getMulticastDefaultExpectedDataForNetwork(netInfo, clusterPortGroup, clusterRtrPortGroup)
+				// namespace exists, but multicast acls do not
+				namespace1 := *newNamespace(namespaceName1)
+				namespace1.Annotations[util.NsMulticastAnnotation] = "true"
+				fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: expectedData},
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespace1,
+						},
+					},
+				)
+
+				Expect(fakeOvn.NewSecondaryNetworkController(nad)).To(Succeed())
+				controller, ok := fakeOvn.secondaryControllers[netInfo.GetNetworkName()]
+				Expect(ok).To(BeTrue())
+
+				err := controller.bnc.WatchNamespaces()
+				Expect(err).NotTo(HaveOccurred())
+				expectedData = append(expectedData, getMulticastPolicyExpectedDataForNetwork(netInfo, namespaceName1, nil)...)
+				Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData))
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		/*
+			It("updates stale namespace Multicast ACLs", func() {
+				app.Action = func(ctx *cli.Context) error {
+					// start with stale ACLs for existing namespace
+					clusterPortGroup, clusterRtrPortGroup := getDefaultPortGroups()
+					expectedData := getMulticastDefaultExpectedData(clusterPortGroup, clusterRtrPortGroup)
+					expectedData = append(expectedData, getMulticastPolicyStaleData(namespaceName1, nil)...)
+					namespace1 := *newNamespace(namespaceName1)
+					namespace1.Annotations[util.NsMulticastAnnotation] = "true"
+					fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: expectedData},
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						},
+					)
+
+					err := fakeOvn.controller.WatchNamespaces()
+					Expect(err).NotTo(HaveOccurred())
+
+					expectedData = getMulticastDefaultExpectedData(clusterPortGroup, clusterRtrPortGroup)
+					expectedData = append(expectedData, getMulticastPolicyExpectedData(namespaceName1, nil)...)
+					Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData))
+					return nil
+				}
+
+				err := app.Run([]string{app.Name})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("cleans up namespace Multicast ACLs when multicast is disabled for namespace", func() {
+				app.Action = func(ctx *cli.Context) error {
+					// start with stale ACLs
+					clusterPortGroup, clusterRtrPortGroup := getDefaultPortGroups()
+					defaultMulticastData := getMulticastDefaultExpectedData(clusterPortGroup, clusterRtrPortGroup)
+					namespaceMulticastData := getMulticastPolicyExpectedData(namespaceName1, nil)
+					namespace1 := *newNamespace(namespaceName1)
+
+					fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: append(defaultMulticastData, namespaceMulticastData...)},
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						},
+					)
+
+					err := fakeOvn.controller.WatchNamespaces()
+					Expect(err).NotTo(HaveOccurred())
+					// only namespaced acls should be dereferenced, default acls will stay
+					namespacePortGroup := getNamespacePG(namespaceName1, fakeOvn.controller.controllerName)
+					expectedData := append(defaultMulticastData, namespacePortGroup)
+					Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData))
+					return nil
+				}
+				err := app.Run([]string{app.Name})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		*/
+	})
+
+	/*
+		Context("during execution", func() {
+			for _, m := range getIpModes() {
+				m := m
+				It("tests enabling/disabling multicast in a namespace "+ipModeStr(m), func() {
+					app.Action = func(ctx *cli.Context) error {
+						namespace1 := *newNamespace(namespaceName1)
+
+						fakeOvn.startWithDBSetup(libovsdb.TestSetup{},
+							&v1.NamespaceList{
+								Items: []v1.Namespace{
+									namespace1,
+								},
+							},
+						)
+						setIpMode(m)
+
+						err := fakeOvn.controller.WatchNamespaces()
+						Expect(err).NotTo(HaveOccurred())
+						ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace1.Name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(ns).NotTo(BeNil())
+
+						// Multicast is denied by default.
+						_, ok := ns.Annotations[util.NsMulticastAnnotation]
+						Expect(ok).To(BeFalse())
+
+						// Enable multicast in the namespace.
+						updateMulticast(fakeOvn, ns, true)
+						expectedData := getMulticastPolicyExpectedData(namespace1.Name, nil)
+						Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+						// Disable multicast in the namespace.
+						updateMulticast(fakeOvn, ns, false)
+
+						namespacePortGroup := getNamespacePG(namespaceName1, fakeOvn.controller.controllerName)
+						Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(namespacePortGroup))
+						return nil
+					}
+
+					err := app.Run([]string{app.Name})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("tests enabling multicast in a namespace with a pod "+ipModeStr(m), func() {
+					app.Action = func(ctx *cli.Context) error {
+						namespace1 := *newNamespace(namespaceName1)
+						pods, tPods, tPodIPs := createTestPods(nodeName, namespaceName1, m)
+
+						fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: getNodeSwitch(nodeName)},
+							&v1.NamespaceList{
+								Items: []v1.Namespace{
+									namespace1,
+								},
+							},
+							&v1.NodeList{
+								Items: []v1.Node{
+									*newNode("node1", "192.168.126.202/24"),
+								},
+							},
+							&v1.PodList{
+								Items: pods,
+							},
+						)
+						setIpMode(m)
+
+						for _, tPod := range tPods {
+							tPod.populateLogicalSwitchCache(fakeOvn)
+						}
+
+						err := fakeOvn.controller.WatchNamespaces()
+						Expect(err).NotTo(HaveOccurred())
+						err = fakeOvn.controller.WatchPods()
+						Expect(err).NotTo(HaveOccurred())
+						ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace1.Name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(ns).NotTo(BeNil())
+
+						// Enable multicast in the namespace
+						updateMulticast(fakeOvn, ns, true)
+						// calculate expected data
+						ports := []string{}
+						for _, tPod := range tPods {
+							ports = append(ports, tPod.portUUID)
+						}
+						expectedData := getMulticastPolicyExpectedData(namespace1.Name, ports)
+						expectedData = append(expectedData, getExpectedDataPodsAndSwitches(tPods, []string{nodeName})...)
+						Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+						fakeOvn.asf.ExpectAddressSetWithAddresses(namespace1.Name, tPodIPs)
+						return nil
+					}
+
+					err := app.Run([]string{app.Name})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("tests enabling multicast in multiple namespaces with a long name > 42 characters "+ipModeStr(m), func() {
+					app.Action = func(ctx *cli.Context) error {
+						longNameSpace1Name := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk" // create with 63 characters
+						namespace1 := *newNamespace(longNameSpace1Name)
+						longNameSpace2Name := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijl" // create with 63 characters
+						namespace2 := *newNamespace(longNameSpace2Name)
+
+						fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: getNodeSwitch(nodeName)},
+							&v1.NamespaceList{
+								Items: []v1.Namespace{
+									namespace1,
+									namespace2,
+								},
+							},
+						)
+						setIpMode(m)
+
+						err := fakeOvn.controller.WatchNamespaces()
+						Expect(err).NotTo(HaveOccurred())
+						fakeOvn.controller.WatchPods()
+						ns1, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace1.Name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(ns1).NotTo(BeNil())
+						ns2, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace2.Name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(ns2).NotTo(BeNil())
+
+						portsns1 := []string{}
+						expectedData := getMulticastPolicyExpectedData(longNameSpace1Name, portsns1)
+						acl := expectedData[0].(*nbdb.ACL)
+						// Post ACL indexing work, multicast ACL's don't have names
+						// We use externalIDs instead; so we can check if the expected IDs exist for the long namespace so that
+						// isEquivalent logic will be correct
+						Expect(acl.Name).To(BeNil())
+						Expect(acl.ExternalIDs[libovsdbops.ObjectNameKey.String()]).To(Equal(longNameSpace1Name))
+						expectedData = append(expectedData, getMulticastPolicyExpectedData(longNameSpace2Name, nil)...)
+						acl = expectedData[3].(*nbdb.ACL)
+						Expect(acl.Name).To(BeNil())
+						Expect(acl.ExternalIDs[libovsdbops.ObjectNameKey.String()]).To(Equal(longNameSpace2Name))
+						expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{}, []string{"node1"})...)
+						// Enable multicast in the namespace.
+						updateMulticast(fakeOvn, ns1, true)
+						updateMulticast(fakeOvn, ns2, true)
+						Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+						return nil
+					}
+
+					err := app.Run([]string{app.Name})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("tests adding a pod to a multicast enabled namespace "+ipModeStr(m), func() {
+					app.Action = func(ctx *cli.Context) error {
+						namespace1 := *newNamespace(namespaceName1)
+						_, tPods, tPodIPs := createTestPods(nodeName, namespaceName1, m)
+
+						ports := []string{}
+						for _, pod := range tPods {
+							ports = append(ports, pod.portUUID)
+						}
+
+						fakeOvn.startWithDBSetup(libovsdb.TestSetup{NBData: getNodeSwitch(nodeName)},
+							&v1.NamespaceList{
+								Items: []v1.Namespace{
+									namespace1,
+								},
+							},
+							&v1.NodeList{
+								Items: []v1.Node{
+									*newNode("node1", "192.168.126.202/24"),
+								},
+							},
+						)
+						setIpMode(m)
+
+						err := fakeOvn.controller.WatchNamespaces()
+						Expect(err).NotTo(HaveOccurred())
+						err = fakeOvn.controller.WatchPods()
+						Expect(err).NotTo(HaveOccurred())
+						ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace1.Name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(ns).NotTo(BeNil())
+
+						// Enable multicast in the namespace.
+						updateMulticast(fakeOvn, ns, true)
+						// Check expected data without pods
+						expectedDataWithoutPods := getMulticastPolicyExpectedData(namespace1.Name, nil)
+						expectedDataWithoutPods = append(expectedDataWithoutPods, getNodeSwitch(nodeName)...)
+						Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDataWithoutPods))
+
+						// Create pods
+						for _, tPod := range tPods {
+							tPod.populateLogicalSwitchCache(fakeOvn)
+							_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(tPod.namespace).Create(context.TODO(), newPod(
+								tPod.namespace, tPod.podName, tPod.nodeName, tPod.podIP), metav1.CreateOptions{})
+							Expect(err).NotTo(HaveOccurred())
+						}
+						// Check pods were added
+						fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(namespace1.Name, tPodIPs)
+						expectedDataWithPods := getMulticastPolicyExpectedData(namespace1.Name, ports)
+						expectedDataWithPods = append(expectedDataWithPods, getExpectedDataPodsAndSwitches(tPods, []string{nodeName})...)
+						Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDataWithPods...))
+
+						// Delete the pod from the namespace.
+						for _, tPod := range tPods {
+							err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(tPod.namespace).Delete(context.TODO(),
+								tPod.podName, *metav1.NewDeleteOptions(0))
+							Expect(err).NotTo(HaveOccurred())
+						}
+						fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(namespace1.Name)
+						Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDataWithoutPods))
+
+						return nil
+					}
+
+					err := app.Run([]string{app.Name})
+					Expect(err).NotTo(HaveOccurred())
+				})
+			}
+		})
+	*/
+})

--- a/go-controller/pkg/ovn/policy_stale_test.go
+++ b/go-controller/pkg/ovn/policy_stale_test.go
@@ -315,7 +315,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 				"egress", "0", DefaultNetworkControllerName)
 			localASName, _ := addressset.GetHashNamesForAS(staleAddrSetIDs)
 			peerASName, _ := getNsAddrSetHashNames(namespace2.Name)
-			fakeController := getFakeController(DefaultNetworkControllerName)
+			fakeController := getFakeController()
 			pgName := fakeController.getNetworkPolicyPGName(networkPolicy.Namespace, networkPolicy.Name)
 			initialData := getPolicyData(newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name))
 			staleACL := initialData[0].(*nbdb.ACL)

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -35,14 +35,18 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-func getFakeController(controllerName string) *DefaultNetworkController {
+func getFakeControllerForNetwork(netInfo util.NetInfo) *DefaultNetworkController {
 	controller := &DefaultNetworkController{
 		BaseNetworkController: BaseNetworkController{
-			controllerName: controllerName,
-			NetInfo:        &util.DefaultNetInfo{},
+			controllerName: getNetworkControllerName(netInfo.GetNetworkName()),
+			NetInfo:        netInfo,
 		},
 	}
 	return controller
+}
+
+func getFakeController() *DefaultNetworkController {
+	return getFakeControllerForNetwork(&util.DefaultNetInfo{})
 }
 
 func newNetworkPolicy(name, namespace string, podSelector metav1.LabelSelector, ingress []knet.NetworkPolicyIngressRule,
@@ -452,7 +456,7 @@ func getNamespaceWithMultiplePoliciesExpectedData(networkPolicies []*knet.Networ
 
 func getHairpinningACLsV4AndPortGroup() []libovsdbtest.TestData {
 	clusterPortGroup := newClusterPortGroup()
-	fakeController := getFakeController(DefaultNetworkControllerName)
+	fakeController := getFakeController()
 	egressIDs := fakeController.getNetpolDefaultACLDbIDs("Egress")
 	egressACL := libovsdbops.BuildACL(
 		"",
@@ -2134,7 +2138,7 @@ var _ = ginkgo.Describe("OVN AllowFromNode ACL low-level operations", func() {
 	)
 
 	getFakeController := func(nbClient libovsdbclient.Client) *DefaultNetworkController {
-		controller := getFakeController(DefaultNetworkControllerName)
+		controller := getFakeController()
 		controller.nbClient = nbClient
 		return controller
 	}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -282,9 +282,9 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 			claimsReconciler)
 	}
 
-	// disable multicast support for secondary networks
-	// TBD: changes needs to be made to support multicast in secondary networks
-	oc.multicastSupport = false
+	// enable multicast suppor at UDN only for primaries + multicast enabled
+	// TBD: changes needs to be made to support multicast beyond primary UDN
+	oc.multicastSupport = util.IsNetworkSegmentationSupportEnabled() && config.EnableMulticast
 
 	oc.initRetryFramework()
 	return oc

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -317,8 +317,17 @@ func (oc *SecondaryLayer2NetworkController) Cleanup() error {
 }
 
 func (oc *SecondaryLayer2NetworkController) Init() error {
-	_, err := oc.initializeLogicalSwitch(oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), oc.Subnets(), oc.ExcludeSubnets())
-	return err
+	if _, err := oc.initializeLogicalSwitch(oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), oc.Subnets(), oc.ExcludeSubnets()); err != nil {
+		return err
+	}
+
+	if oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() && oc.multicastSupport {
+		if err := oc.setupClusterPortGroups(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (oc *SecondaryLayer2NetworkController) Stop() {

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -321,8 +321,15 @@ func (oc *SecondaryLayer2NetworkController) Init() error {
 		return err
 	}
 
-	if oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() && oc.multicastSupport {
+	// Note we don't check multicast support on purpose, the cluster port
+	// group can go beyond multicast and tye sync defualt multicast policies
+	// also remove then if multicast support is disabled
+	if oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() {
 		if err := oc.setupClusterPortGroups(); err != nil {
+			return err
+		}
+
+		if err := oc.syncDefaultMulticastPolicies(); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -291,9 +291,9 @@ func NewSecondaryLayer3NetworkController(cnci *CommonNetworkControllerInfo, netI
 		oc.podAnnotationAllocator = podAnnotationAllocator
 	}
 
-	// disable multicast support for secondary networks
-	// TBD: changes needs to be made to support multicast in secondary networks
-	oc.multicastSupport = false
+	// enable multicast suppor at UDN only for primaries + multicast enabled
+	// TBD: changes needs to be made to support multicast beyond primary UDN
+	oc.multicastSupport = util.IsNetworkSegmentationSupportEnabled() && config.EnableMulticast
 
 	oc.initRetryFramework()
 	return oc

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -461,8 +461,15 @@ func (oc *SecondaryLayer3NetworkController) Init(ctx context.Context) error {
 		return err
 	}
 
-	if oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() && oc.multicastSupport {
+	// Note we don't check multicast support on purpose, the cluster port
+	// group can go beyond multicast and tye sync defualt multicast policies
+	// also remove then if multicast support is disabled
+	if oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() {
 		if err := oc.setupClusterPortGroups(); err != nil {
+			return err
+		}
+
+		if err := oc.syncDefaultMulticastPolicies(); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -303,10 +303,13 @@ func (oc *SecondaryLayer3NetworkController) initRetryFramework() {
 	oc.retryPods = oc.newRetryFramework(factory.PodType)
 	oc.retryNodes = oc.newRetryFramework(factory.NodeType)
 
-	// For secondary networks, we don't have to watch namespace events if
-	// multi-network policy support is not enabled.
-	if util.IsMultiNetworkPoliciesSupportEnabled() {
+	// For secondary networks, we have to watch namespace only either:
+	// - multi-network policy support is enabled
+	// - primary UDN is supported and multicast per namespace can be configured
+	if util.IsMultiNetworkPoliciesSupportEnabled() || (util.IsNetworkSegmentationSupportEnabled() && config.EnableMulticast) {
 		oc.retryNamespaces = oc.newRetryFramework(factory.NamespaceType)
+	}
+	if util.IsMultiNetworkPoliciesSupportEnabled() {
 		oc.retryNetworkPolicies = oc.newRetryFramework(factory.MultiNetworkPolicyType)
 	}
 }

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -457,8 +457,17 @@ func (oc *SecondaryLayer3NetworkController) WatchNodes() error {
 }
 
 func (oc *SecondaryLayer3NetworkController) Init(ctx context.Context) error {
-	_, err := oc.createOvnClusterRouter()
-	return err
+	if _, err := oc.createOvnClusterRouter(); err != nil {
+		return err
+	}
+
+	if oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() && oc.multicastSupport {
+		if err := oc.setupClusterPortGroups(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) error {

--- a/test/e2e/multicast.go
+++ b/test/e2e/multicast.go
@@ -11,7 +11,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -19,33 +18,20 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-const (
-	mcastSource  = "pod-client"
-	mcastServer1 = "pod-server1"
-	mcastServer2 = "pod-server2"
-	mcastServer3 = "pod-server3"
-)
+type nodeInfo struct {
+	name   string
+	nodeIP string
+}
 
 var _ = ginkgo.Describe("Multicast", func() {
 
 	fr := wrappedTestFramework("multicast")
 
-	type nodeInfo struct {
-		name   string
-		nodeIP string
-	}
-
 	var (
-		cs                             clientset.Interface
-		ns                             string
 		clientNodeInfo, serverNodeInfo nodeInfo
 	)
-
 	ginkgo.BeforeEach(func() {
-		cs = fr.ClientSet
-		ns = fr.Namespace.Name
-
-		nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), cs, 2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), fr.ClientSet, 2)
 		framework.ExpectNoError(err)
 		if len(nodes.Items) < 2 {
 			e2eskipper.Skipf(
@@ -64,103 +50,114 @@ var _ = ginkgo.Describe("Multicast", func() {
 			name:   nodes.Items[1].Name,
 			nodeIP: ips[1],
 		}
-
-		// annotate namespace to enable multicast
-		namespace, err := fr.ClientSet.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
-		framework.ExpectNoError(err, "Error getting Namespace %v: %v", fr.Namespace.Name, err)
-		if namespace.ObjectMeta.Annotations == nil {
-			namespace.ObjectMeta.Annotations = map[string]string{}
-		}
-		namespace.ObjectMeta.Annotations["k8s.ovn.org/multicast-enabled"] = "true"
-		_, err = fr.ClientSet.CoreV1().Namespaces().Update(context.Background(), namespace, metav1.UpdateOptions{})
-		framework.ExpectNoError(err, "Error updating Namespace %v: %v", ns, err)
 	})
+	ginkgo.Context("when multicast enabled at namespace", func() {
+		ginkgo.BeforeEach(func() {
+			enableMulticastForNamespace(fr)
+		})
 
-	ginkgo.It("should be able to send multicast UDP traffic between nodes", func() {
-		mcastGroup := "224.3.3.3"
-		mcastGroupBad := "224.5.5.5"
-		if IsIPv6Cluster(cs) {
-			mcastGroup = "ff3e::4321:1234"
-			mcastGroupBad = "ff3e::4321:1235"
-		}
-
-		// Start the multicast source (iperf client is the sender in multicast)
-		ginkgo.By("creating a pod as a multicast source in node " + clientNodeInfo.name)
-		// multicast group (-c 224.3.3.3), UDP (-u), TTL (-T 3), during (-t 3000) seconds, report every (-i 5) seconds
-		iperf := fmt.Sprintf("iperf -c %s -u -T 3 -t 3000 -i 5", mcastGroup)
-		if IsIPv6Cluster(cs) {
-			iperf = iperf + " -V"
-		}
-		cmd := []string{"/bin/sh", "-c", iperf}
-		clientPod := newAgnhostPod(fr.Namespace.Name, mcastSource, cmd...)
-		clientPod.Spec.NodeName = clientNodeInfo.name
-		e2epod.NewPodClient(fr).CreateSync(context.TODO(), clientPod)
-
-		// Start a multicast listener on the same groups and verify it received the traffic (iperf server is the multicast listener)
-		// join multicast group (-B 224.3.3.3), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
-		ginkgo.By("creating first multicast listener pod in node " + serverNodeInfo.name)
-		iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroup)
-		if IsIPv6Cluster(cs) {
-			iperf = iperf + " -V"
-		}
-		cmd = []string{"/bin/sh", "-c", iperf}
-		mcastServerPod1 := newAgnhostPod(fr.Namespace.Name, mcastServer1, cmd...)
-		mcastServerPod1.Spec.NodeName = serverNodeInfo.name
-		e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod1)
-
-		// Start a multicast listener on on other group and verify it does not receive the traffic (iperf server is the multicast listener)
-		// join multicast group (-B 224.4.4.4), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
-		ginkgo.By("creating second multicast listener pod in node " + serverNodeInfo.name)
-		iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroupBad)
-		if IsIPv6Cluster(cs) {
-			iperf = iperf + " -V"
-		}
-		cmd = []string{"/bin/sh", "-c", iperf}
-		mcastServerPod2 := newAgnhostPod(fr.Namespace.Name, mcastServer2, cmd...)
-		mcastServerPod2.Spec.NodeName = serverNodeInfo.name
-		e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod2)
-
-		// Start a multicast listener on the same groups and verify it received the traffic (iperf server is the multicast listener)
-		// join multicast group (-B 224.3.3.3), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
-		ginkgo.By("creating first multicast listener pod in node " + clientNodeInfo.name)
-		iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroup)
-		if IsIPv6Cluster(cs) {
-			iperf = iperf + " -V"
-		}
-		cmd = []string{"/bin/sh", "-c", iperf}
-		mcastServerPod3 := newAgnhostPod(fr.Namespace.Name, mcastServer3, cmd...)
-		mcastServerPod3.Spec.NodeName = clientNodeInfo.name
-		e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod3)
-
-		ginkgo.By("checking if pod server1 received multicast traffic")
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(context.TODO(), cs, ns, mcastServer1, mcastServer1)
-		},
-			30*time.Second, 1*time.Second).Should(gomega.ContainSubstring("connected"))
-
-		ginkgo.By("checking if pod server2 does not received multicast traffic")
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(context.TODO(), cs, ns, mcastServer2, mcastServer2)
-		},
-			30*time.Second, 1*time.Second).ShouldNot(gomega.ContainSubstring("connected"))
-
-		ginkgo.By("checking if pod server3 received multicast traffic")
-		gomega.Eventually(func() (string, error) {
-			return e2epod.GetPodLogs(context.TODO(), cs, ns, mcastServer3, mcastServer3)
-		},
-			30*time.Second, 1*time.Second).Should(gomega.ContainSubstring("connected"))
-
+		ginkgo.It("should be able to send multicast UDP traffic between nodes", func() {
+			testMulticastUDPTraffic(fr, clientNodeInfo, serverNodeInfo)
+		})
+		ginkgo.It("should be able to retrieve multicast IGMP query", func() {
+			testMulticastIGMPQuery(fr, clientNodeInfo, serverNodeInfo)
+		})
 	})
-
 })
 
-var _ = ginkgo.Describe("e2e IGMP validation", func() {
+func testMulticastUDPTraffic(fr *framework.Framework, clientNodeInfo, serverNodeInfo nodeInfo) {
+	ginkgo.GinkgoHelper()
 	const (
-		svcname              string = "igmp-test"
-		ovnNs                string = "ovn-kubernetes"
-		port                 string = "8080"
-		ovnWorkerNode        string = "ovn-worker"
-		ovnWorkerNode2       string = "ovn-worker2"
+		mcastSource  = "pod-client"
+		mcastServer1 = "pod-server1"
+		mcastServer2 = "pod-server2"
+		mcastServer3 = "pod-server3"
+	)
+	var (
+		mcastGroupIPv4    = "224.3.3.3"
+		mcastGroupIPv4Bad = "224.5.5.5"
+		mcastGroupIPv6    = "ff3e::4321:1234"
+		mcastGroupIPv6Bad = "ff3e::4321:1235"
+	)
+
+	mcastGroup := mcastGroupIPv4
+	mcastGroupBad := mcastGroupIPv4Bad
+	if IsIPv6Cluster(fr.ClientSet) {
+		mcastGroup = mcastGroupIPv6
+		mcastGroupBad = mcastGroupIPv6Bad
+	}
+	ns := fr.Namespace.Name
+	// Start the multicast source (iperf client is the sender in multicast)
+	ginkgo.By("creating a pod as a multicast source in node " + clientNodeInfo.name)
+	// multicast group (-c 224.3.3.3), UDP (-u), TTL (-T 3), during (-t 3000) seconds, report every (-i 5) seconds
+	iperf := fmt.Sprintf("iperf -c %s -u -T 3 -t 3000 -i 5", mcastGroup)
+	if IsIPv6Cluster(fr.ClientSet) {
+		iperf = iperf + " -V"
+	}
+	cmd := []string{"/bin/sh", "-c", iperf}
+	clientPod := newAgnhostPod(fr.Namespace.Name, mcastSource, cmd...)
+	clientPod.Spec.NodeName = clientNodeInfo.name
+	e2epod.NewPodClient(fr).CreateSync(context.TODO(), clientPod)
+
+	// Start a multicast listener on the same groups and verify it received the traffic (iperf server is the multicast listener)
+	// join multicast group (-B 224.3.3.3), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
+	ginkgo.By("creating first multicast listener pod in node " + serverNodeInfo.name)
+	iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroup)
+	if IsIPv6Cluster(fr.ClientSet) {
+		iperf = iperf + " -V"
+	}
+	cmd = []string{"/bin/sh", "-c", iperf}
+	mcastServerPod1 := newAgnhostPod(fr.Namespace.Name, mcastServer1, cmd...)
+	mcastServerPod1.Spec.NodeName = serverNodeInfo.name
+	e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod1)
+
+	// Start a multicast listener on on other group and verify it does not receive the traffic (iperf server is the multicast listener)
+	// join multicast group (-B 224.4.4.4), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
+	ginkgo.By("creating second multicast listener pod in node " + serverNodeInfo.name)
+	iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroupBad)
+	if IsIPv6Cluster(fr.ClientSet) {
+		iperf = iperf + " -V"
+	}
+	cmd = []string{"/bin/sh", "-c", iperf}
+	mcastServerPod2 := newAgnhostPod(fr.Namespace.Name, mcastServer2, cmd...)
+	mcastServerPod2.Spec.NodeName = serverNodeInfo.name
+	e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod2)
+
+	// Start a multicast listener on the same groups and verify it received the traffic (iperf server is the multicast listener)
+	// join multicast group (-B 224.3.3.3), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
+	ginkgo.By("creating first multicast listener pod in node " + clientNodeInfo.name)
+	iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroup)
+	if IsIPv6Cluster(fr.ClientSet) {
+		iperf = iperf + " -V"
+	}
+	cmd = []string{"/bin/sh", "-c", iperf}
+	mcastServerPod3 := newAgnhostPod(fr.Namespace.Name, mcastServer3, cmd...)
+	mcastServerPod3.Spec.NodeName = clientNodeInfo.name
+	e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod3)
+
+	ginkgo.By("checking if pod server1 received multicast traffic")
+	gomega.Eventually(func() (string, error) {
+		return e2epod.GetPodLogs(context.TODO(), fr.ClientSet, ns, mcastServer1, mcastServer1)
+	},
+		30*time.Second, 1*time.Second).Should(gomega.ContainSubstring("connected"))
+
+	ginkgo.By("checking if pod server2 does not received multicast traffic")
+	gomega.Eventually(func() (string, error) {
+		return e2epod.GetPodLogs(context.TODO(), fr.ClientSet, ns, mcastServer2, mcastServer2)
+	},
+		30*time.Second, 1*time.Second).ShouldNot(gomega.ContainSubstring("connected"))
+
+	ginkgo.By("checking if pod server3 received multicast traffic")
+	gomega.Eventually(func() (string, error) {
+		return e2epod.GetPodLogs(context.TODO(), fr.ClientSet, ns, mcastServer3, mcastServer3)
+	},
+		30*time.Second, 1*time.Second).Should(gomega.ContainSubstring("connected"))
+
+}
+
+func testMulticastIGMPQuery(f *framework.Framework, clientNodeInfo, serverNodeInfo nodeInfo) {
+	ginkgo.GinkgoHelper()
+	const (
 		mcastGroup           string = "224.1.1.1"
 		mcastV6Group         string = "ff3e::4321:1234"
 		multicastListenerPod string = "multicast-listener-test-pod"
@@ -175,61 +172,61 @@ var _ = ginkgo.Describe("e2e IGMP validation", func() {
 		multicastSourceCommand = []string{"bash", "-c",
 			fmt.Sprintf("iperf -c %s -u -T 2 -t 3000 -i 5", mcastGroup)}
 	)
-	f := wrappedTestFramework(svcname)
-	ginkgo.It("can retrieve multicast IGMP query", func() {
-		// Enable multicast of the test namespace annotation
-		ginkgo.By(fmt.Sprintf("annotating namespace: %s to enable multicast", f.Namespace.Name))
-		annotateArgs := []string{
-			"annotate",
-			"namespace",
-			f.Namespace.Name,
-			fmt.Sprintf("k8s.ovn.org/multicast-enabled=%s", "true"),
-		}
-		e2ekubectl.RunKubectlOrDie(f.Namespace.Name, annotateArgs...)
 
-		// Create a multicast source pod
-		if IsIPv6Cluster(f.ClientSet) {
-			// Multicast group (-c ff3e::4321:1234), UDP (-u), TTL (-T 2), during (-t 3000) seconds, report every (-i 5) seconds, -V (Set the domain to IPv6)
-			multicastSourceCommand = []string{"bash", "-c",
-				fmt.Sprintf("iperf -c %s -u -T 2 -t 3000 -i 5 -V", mcastV6Group)}
-		}
-		ginkgo.By("creating a multicast source pod in node " + ovnWorkerNode)
-		createGenericPod(f, multicastSourcePod, ovnWorkerNode, f.Namespace.Name, multicastSourceCommand)
+	// Create a multicast source pod
+	if IsIPv6Cluster(f.ClientSet) {
+		// Multicast group (-c ff3e::4321:1234), UDP (-u), TTL (-T 2), during (-t 3000) seconds, report every (-i 5) seconds, -V (Set the domain to IPv6)
+		multicastSourceCommand = []string{"bash", "-c",
+			fmt.Sprintf("iperf -c %s -u -T 2 -t 3000 -i 5 -V", mcastV6Group)}
+	}
+	ginkgo.By("creating a multicast source pod in node " + clientNodeInfo.name)
+	createGenericPod(f, multicastSourcePod, clientNodeInfo.name, f.Namespace.Name, multicastSourceCommand)
 
-		// Create a multicast listener pod
-		ginkgo.By("creating a multicast listener pod in node " + ovnWorkerNode2)
-		createGenericPod(f, multicastListenerPod, ovnWorkerNode2, f.Namespace.Name, tcpDumpCommand)
+	// Create a multicast listener pod
+	ginkgo.By("creating a multicast listener pod in node " + serverNodeInfo.name)
+	createGenericPod(f, multicastListenerPod, serverNodeInfo.name, f.Namespace.Name, tcpDumpCommand)
 
-		// Wait for tcpdump on listener pod to be ready
-		err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-			kubectlOut, err := e2ekubectl.RunKubectl(f.Namespace.Name, "exec", multicastListenerPod, "--", "/bin/bash", "-c", "ls")
-			if err != nil {
-				time.Sleep(5 * time.Hour)
-				framework.Failf("failed to retrieve multicast IGMP query: " + err.Error())
-			}
-			if !strings.Contains(kubectlOut, tcpdumpFileName) {
-				return false, nil
-			}
-			return true, nil
-		})
+	// Wait for tcpdump on listener pod to be ready
+	err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+		kubectlOut, err := e2ekubectl.RunKubectl(f.Namespace.Name, "exec", multicastListenerPod, "--", "/bin/bash", "-c", "ls")
 		if err != nil {
+			time.Sleep(5 * time.Hour)
 			framework.Failf("failed to retrieve multicast IGMP query: " + err.Error())
 		}
-
-		// The multicast listener pod join multicast group (-B 224.1.1.1), UDP (-u), during (-t 30) seconds, report every (-i 5) seconds
-		ginkgo.By("multicast listener pod join multicast group")
-		e2ekubectl.RunKubectl(f.Namespace.Name, "exec", multicastListenerPod, "--", "/bin/bash", "-c", fmt.Sprintf("iperf -s -B %s -u -t 30 -i 5", mcastGroup))
-
-		ginkgo.By(fmt.Sprintf("verifying that the IGMP query has been received"))
-		kubectlOut, err := e2ekubectl.RunKubectl(f.Namespace.Name, "exec", multicastListenerPod, "--", "/bin/bash", "-c", fmt.Sprintf("cat %s | grep igmp", tcpdumpFileName))
-		if err != nil {
-			framework.Failf("failed to retrieve multicast IGMP query: " + err.Error())
+		if !strings.Contains(kubectlOut, tcpdumpFileName) {
+			return false, nil
 		}
-		framework.Logf("output:")
-		framework.Logf(kubectlOut)
-		if kubectlOut == "" {
-			framework.Failf("failed to retrieve multicast IGMP query: igmp messages on the tcpdump logfile not found")
-		}
+		return true, nil
 	})
+	if err != nil {
+		framework.Failf("failed to retrieve multicast IGMP query: " + err.Error())
+	}
 
-})
+	// The multicast listener pod join multicast group (-B 224.1.1.1), UDP (-u), during (-t 30) seconds, report every (-i 5) seconds
+	ginkgo.By("multicast listener pod join multicast group")
+	e2ekubectl.RunKubectl(f.Namespace.Name, "exec", multicastListenerPod, "--", "/bin/bash", "-c", fmt.Sprintf("iperf -s -B %s -u -t 30 -i 5", mcastGroup))
+
+	ginkgo.By(fmt.Sprintf("verifying that the IGMP query has been received"))
+	kubectlOut, err := e2ekubectl.RunKubectl(f.Namespace.Name, "exec", multicastListenerPod, "--", "/bin/bash", "-c", fmt.Sprintf("cat %s | grep igmp", tcpdumpFileName))
+	if err != nil {
+		framework.Failf("failed to retrieve multicast IGMP query: " + err.Error())
+	}
+	framework.Logf("output:")
+	framework.Logf(kubectlOut)
+	if kubectlOut == "" {
+		framework.Failf("failed to retrieve multicast IGMP query: igmp messages on the tcpdump logfile not found")
+	}
+}
+
+func enableMulticastForNamespace(fr *framework.Framework) {
+	ginkgo.GinkgoHelper()
+	// annotate namespace to enable multicast
+	namespace, err := fr.ClientSet.CoreV1().Namespaces().Get(context.Background(), fr.Namespace.Name, metav1.GetOptions{})
+	framework.ExpectNoError(err, "Error getting Namespace %v: %v", fr.Namespace.Name, err)
+	if namespace.ObjectMeta.Annotations == nil {
+		namespace.ObjectMeta.Annotations = map[string]string{}
+	}
+	namespace.ObjectMeta.Annotations["k8s.ovn.org/multicast-enabled"] = "true"
+	_, err = fr.ClientSet.CoreV1().Namespaces().Update(context.Background(), namespace, metav1.UpdateOptions{})
+	framework.ExpectNoError(err, "Error updating Namespace %v: %v", fr.Namespace.Name, err)
+}

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -419,6 +419,31 @@ var _ = Describe("Network Segmentation", func() {
 					role:     "primary",
 				}),
 			)
+			DescribeTable("should be able to query multicast IGMP", func(netConfigParams networkAttachmentConfigParams) {
+				ginkgo.By("creating the attachment configuration")
+				netConfigParams.namespace = f.Namespace.Name
+				netConfig := newNetworkAttachmentConfig(netConfigParams)
+				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
+					context.Background(),
+					generateNAD(netConfig),
+					metav1.CreateOptions{},
+				)
+				framework.ExpectNoError(err)
+				testMulticastIGMPQuery(f, clientNodeInfo, serverNodeInfo)
+			},
+				ginkgo.Entry("with primary layer3 UDN", networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer3",
+					cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					role:     "primary",
+				}),
+				ginkgo.Entry("with primary layer2 UDN", networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer2",
+					cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					role:     "primary",
+				}),
+			)
 		})
 	})
 })


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
TODO:
- [ ] The e2e IGMP test depends on installing tcpdump, but we don't have egress yet to do so
- [ ] Unit test, reuse stuff under `pkg/ovn/mutlicast_test.go`

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
