### PR TITLE
UDN: Add IPRules Manager

### DIFF
--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -221,6 +221,12 @@ func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) 
 			defer ncm.wg.Done()
 			ncm.ruleManager.Run(ncm.stopChan, 5*time.Minute)
 		}()
+		// Tell rule manager that we want to fully own all rules at a particular priority.
+		// Any rules created with this priority that we do not recognize it, will be
+		// removed by relevant manager.
+		if err := ncm.ruleManager.OwnPriority(node.UDNMasqueradeIPRulePriority); err != nil {
+			return fmt.Errorf("failed to own priority %d for IP rules: %v", node.UDNMasqueradeIPRulePriority, err)
+		}
 	}
 	return nil
 }

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -44,6 +45,8 @@ type nodeNetworkControllerManager struct {
 	vrfManager *vrfmanager.Controller
 	// route manager that creates and manages routes
 	routeManager *routemanager.Controller
+	// iprule manager that creates and manages iprules for all UDNs
+	ruleManager *iprulemanager.Controller
 }
 
 // NewNetworkController create secondary node network controllers for the given NetInfo
@@ -55,7 +58,8 @@ func (ncm *nodeNetworkControllerManager) NewNetworkController(nInfo util.NetInfo
 		if !ok {
 			return nil, fmt.Errorf("unable to deference default node network controller object")
 		}
-		return node.NewSecondaryNodeNetworkController(ncm.newCommonNetworkControllerInfo(), nInfo, ncm.vrfManager, dnnc.Gateway)
+		return node.NewSecondaryNodeNetworkController(ncm.newCommonNetworkControllerInfo(),
+			nInfo, ncm.vrfManager, ncm.ruleManager, dnnc.Gateway)
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
 }
@@ -127,6 +131,7 @@ func NewNodeNetworkControllerManager(ovnClient *util.OVNClientset, wf factory.No
 	}
 	if util.IsNetworkSegmentationSupportEnabled() {
 		ncm.vrfManager = vrfmanager.NewController(ncm.routeManager)
+		ncm.ruleManager = iprulemanager.NewController(config.IPv4Mode, config.IPv6Mode)
 	}
 	if err != nil {
 		return nil, err
@@ -209,6 +214,14 @@ func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) 
 		}
 	}
 
+	if ncm.ruleManager != nil {
+		// Let's create rule manager that will manage rules on the vrfs for all UDNs
+		ncm.wg.Add(1)
+		go func() {
+			defer ncm.wg.Done()
+			ncm.ruleManager.Run(ncm.stopChan, 5*time.Minute)
+		}()
+	}
 	return nil
 }
 

--- a/go-controller/pkg/node/secondary_node_network_controller.go
+++ b/go-controller/pkg/node/secondary_node_network_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -31,7 +32,7 @@ type SecondaryNodeNetworkController struct {
 // infrastructure and policy for the given secondary network. It supports layer3, layer2 and
 // localnet topology types.
 func NewSecondaryNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, netInfo util.NetInfo,
-	vrfManager *vrfmanager.Controller, defaultNetworkGateway Gateway) (*SecondaryNodeNetworkController, error) {
+	vrfManager *vrfmanager.Controller, ruleManager *iprulemanager.Controller, defaultNetworkGateway Gateway) (*SecondaryNodeNetworkController, error) {
 	snnc := &SecondaryNodeNetworkController{
 		BaseNodeNetworkController: BaseNodeNetworkController{
 			CommonNodeNetworkControllerInfo: *cnnci,
@@ -51,7 +52,8 @@ func NewSecondaryNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, n
 			return nil, fmt.Errorf("error retrieving network id for network %s: %v", netInfo.GetNetworkName(), err)
 		}
 
-		snnc.gateway, err = NewUserDefinedNetworkGateway(snnc.NetInfo, networkID, node, snnc.watchFactory.NodeCoreInformer().Lister(), snnc.Kube, vrfManager, defaultNetworkGateway)
+		snnc.gateway, err = NewUserDefinedNetworkGateway(snnc.NetInfo, networkID, node,
+			snnc.watchFactory.NodeCoreInformer().Lister(), snnc.Kube, vrfManager, ruleManager, defaultNetworkGateway)
 		if err != nil {
 			return nil, fmt.Errorf("error creating UDN gateway for network %s: %v", netInfo.GetNetworkName(), err)
 		}


### PR DESCRIPTION
Depends-On: https://github.com/ovn-org/ovn-kubernetes/pull/4549

#### What this PR does and why is it needed

- [x] Adds iprules manager to NCM which is common for all UDNs
- [x] Programs iprules for each UDN for reply traffic to correctly go into OVN
- [ ] TODO: Understand why VRF TableIDs are leaking post deletion of network

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
```
2000:   from all to 169.254.0.12 lookup 1007
2000:   from all to 169.254.0.14 lookup 1009
```
adds iprules for reply traffic to go back into OVN