### PR TITLE
UDN: Add RPFilter Loose Mode for management port

### DIFF
--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -58,6 +58,13 @@ func getVRFCreationFakeOVSCommands(fexec *ovntest.FakeExec) {
 	})
 }
 
+func getRPFilterLooseModeFakeCommands(fexec *ovntest.FakeExec) {
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp3.rp_filter=2",
+		Output: "net.ipv4.conf.ovn-k8s-mp3.rp_filter = 2",
+	})
+}
+
 func getDeletionFakeOVSCommands(fexec *ovntest.FakeExec, mgtPort string) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovs-vsctl --timeout=15 -- --if-exists del-port br-int " + mgtPort,
@@ -421,6 +428,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		setUpGatewayFakeOVSCommands(fexec)
 		getCreationFakeOVSCommands(fexec, mgtPort, mgtPortMAC, netName, nodeName, netInfo.MTU())
 		getVRFCreationFakeOVSCommands(fexec)
+		getRPFilterLooseModeFakeCommands(fexec)
 		setUpUDNOpenflowManagerFakeOVSCommands(fexec)
 		getDeletionFakeOVSCommands(fexec, mgtPort)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
@@ -587,6 +595,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		setUpGatewayFakeOVSCommands(fexec)
 		getCreationFakeOVSCommands(fexec, mgtPort, mgtPortMAC, netName, nodeName, netInfo.MTU())
 		getVRFCreationFakeOVSCommands(fexec)
+		getRPFilterLooseModeFakeCommands(fexec)
 		setUpUDNOpenflowManagerFakeOVSCommands(fexec)
 		getDeletionFakeOVSCommands(fexec, mgtPort)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
@@ -816,6 +825,17 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*routes[3].Dst).To(Equal(*cidr))
 			Expect(routes[3].LinkIndex).To(Equal(mplink.Attrs().Index))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+	ovntest.OnSupportedPlatformsIt("should set rp filer to loose mode for management port interface", func() {
+		getRPFilterLooseModeFakeCommands(fexec)
+		err := testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err := addRPFilterLooseModeForManagementPort(mgtPort)
+			Expect(err).NotTo(HaveOccurred())
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -302,6 +302,7 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 			defer GinkgoRecover()
 			getCreationFakeOVSCommands(fexec, mgtPort, mgtPortMAC, netName, nodeName, NetInfo.MTU())
 			getVRFCreationFakeOVSCommands(fexec)
+			getRPFilterLooseModeFakeCommands(fexec)
 			getDeletionFakeOVSCommands(fexec, mgtPort)
 
 			By("starting secondary network controller for user defined primary network")


### PR DESCRIPTION
Depends-On: https://github.com/ovn-org/ovn-kubernetes/pull/4552

#### What this PR does and why is it needed

Same as default mp0; needed for traffic coming from OVN
with masqueradeIP to go out.

```
0xffff9a698897b000      9 [<empty>(2468110)] kfree_skb_reason(SKB_DROP_REASON_IP_RPFILTER) 169.254.169.12:0->8.8.8.8:0(icmp)
```

#### How to verify it
```
net.ipv4.conf.ovn-k8s-mp1.rp_filter = 2
net.ipv4.conf.ovn-k8s-mp2.rp_filter = 2
```