### PR TITLE
UDN L3/L2 Add Masquerade SNAT

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -22,7 +22,8 @@ else
 CONTAINER_RUNTIME=docker
 endif
 CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1; echo $$?)
-OVN_SCHEMA_VERSION ?= v24.03.1
+# FIXME(tssurya): In one week when OVN 24.09 is released change the schema version
+OVN_SCHEMA_VERSION ?= 8efac26f6637fc
 ifeq ($(NOROOT),TRUE)
 C_ARGS = -e NOROOT=TRUE
 else

--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -886,6 +886,7 @@ func buildNAT(
 	logicalPort string,
 	externalMac string,
 	externalIDs map[string]string,
+	match string,
 ) *nbdb.NAT {
 	nat := &nbdb.NAT{
 		Type:        natType,
@@ -893,6 +894,7 @@ func buildNAT(
 		LogicalIP:   logicalIP,
 		Options:     map[string]string{"stateless": "false"},
 		ExternalIDs: externalIDs,
+		Match:       match,
 	}
 
 	if logicalPort != "" {
@@ -913,6 +915,16 @@ func BuildSNAT(
 	logicalPort string,
 	externalIDs map[string]string,
 ) *nbdb.NAT {
+	return BuildSNATWithMatch(externalIP, logicalIP, logicalPort, externalIDs, "")
+}
+
+func BuildSNATWithMatch(
+	externalIP *net.IP,
+	logicalIP *net.IPNet,
+	logicalPort string,
+	externalIDs map[string]string,
+	match string,
+) *nbdb.NAT {
 	externalIPStr := ""
 	if externalIP != nil {
 		externalIPStr = externalIP.String()
@@ -923,7 +935,7 @@ func BuildSNAT(
 	if logicalIPMask != 32 && logicalIPMask != 128 {
 		logicalIPStr = logicalIP.String()
 	}
-	return buildNAT(nbdb.NATTypeSNAT, externalIPStr, logicalIPStr, logicalPort, "", externalIDs)
+	return buildNAT(nbdb.NATTypeSNAT, externalIPStr, logicalIPStr, logicalPort, "", externalIDs, match)
 }
 
 // BuildDNATAndSNAT builds a logical router DNAT/SNAT
@@ -933,6 +945,17 @@ func BuildDNATAndSNAT(
 	logicalPort string,
 	externalMac string,
 	externalIDs map[string]string,
+) *nbdb.NAT {
+	return BuildDNATAndSNATWithMatch(externalIP, logicalIP, logicalPort, externalMac, externalIDs, "")
+}
+
+func BuildDNATAndSNATWithMatch(
+	externalIP *net.IP,
+	logicalIP *net.IPNet,
+	logicalPort string,
+	externalMac string,
+	externalIDs map[string]string,
+	match string,
 ) *nbdb.NAT {
 	externalIPStr := ""
 	if externalIP != nil {
@@ -948,7 +971,8 @@ func BuildDNATAndSNAT(
 		logicalIPStr,
 		logicalPort,
 		externalMac,
-		externalIDs)
+		externalIDs,
+		match)
 }
 
 // isEquivalentNAT if it has same uuid. Otherwise, check if types match.

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -307,6 +307,38 @@ func (bnc *BaseNetworkController) syncNodeClusterRouterPort(node *kapi.Node, hos
 		return err
 	}
 
+	if util.IsNetworkSegmentationSupportEnabled() &&
+		bnc.IsPrimaryNetwork() && !config.OVNKubernetesFeature.EnableInterconnect &&
+		bnc.TopologyType() == types.Layer3Topology {
+		// since in nonIC the ovn_cluster_router is distributed, we must specify the gatewayPort for the
+		// conditional SNATs to signal OVN which gatewayport should be chosen if there are mutiple distributed
+		// gateway ports. Now that the LRP is created, let's update the NATs to reflect that.
+		lrp := nbdb.LogicalRouterPort{
+			Name: lrpName,
+		}
+		logicalRouterPort, err := libovsdbops.GetLogicalRouterPort(bnc.nbClient, &lrp)
+		if err != nil {
+			return fmt.Errorf("failed to fetch gatewayport %s for network %q on node %q, err: %w",
+				lrpName, bnc.GetNetworkName(), node.Name, err)
+		}
+		gatewayPort := logicalRouterPort.UUID
+		p := func(item *nbdb.NAT) bool {
+			return item.ExternalIDs[types.NetworkExternalID] == bnc.GetNetworkName() &&
+				item.LogicalPort != nil && *item.LogicalPort == lrpName && item.Match != ""
+		}
+		nonICConditonalSNATs, err := libovsdbops.FindNATsWithPredicate(bnc.nbClient, p)
+		if err != nil {
+			return fmt.Errorf("failed to fetch conditional NATs %s for network %q on node %q, err: %w",
+				lrpName, bnc.GetNetworkName(), node.Name, err)
+		}
+		for _, nat := range nonICConditonalSNATs {
+			nat.GatewayPort = &gatewayPort
+		}
+		if err := libovsdbops.CreateOrUpdateNATs(bnc.nbClient, &logicalRouter, nonICConditonalSNATs...); err != nil {
+			return fmt.Errorf("failed to fetch conditional NATs %s for network %q on node %q, err: %w",
+				lrpName, bnc.GetNetworkName(), node.Name, err)
+		}
+	}
 	return nil
 }
 

--- a/go-controller/pkg/ovn/base_network_controller_secondary_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary_test.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -17,6 +18,10 @@ var _ = Describe("BaseSecondaryNetworkController", func() {
 		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
 	)
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		Expect(config.PrepareTestConfig()).To(Succeed())
+	})
 	It("should return networkID from one of the nodes node", func() {
 		fakeOVN := NewFakeOVN(false)
 		fakeOVN.start(&corev1.Node{

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -13,7 +13,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/generator/udn"
+	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	zoneinterconnect "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
@@ -456,7 +458,14 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 					errs = append(errs, err)
 					oc.gatewaysFailed.Store(node.Name, true)
 				} else {
-					oc.gatewaysFailed.Delete(node.Name)
+					if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
+						if err := oc.addUDNClusterSubnetEgressSNAT(gwConfig.hostSubnets, gwManager.gwRouterName, node); err != nil {
+							errs = append(errs, err)
+							oc.gatewaysFailed.Store(node.Name, true)
+						} else {
+							oc.gatewaysFailed.Delete(node.Name)
+						}
+					}
 				}
 			}
 		}
@@ -478,6 +487,35 @@ func (oc *SecondaryLayer2NetworkController) deleteNodeEvent(node *corev1.Node) e
 	oc.gatewayManagers.Delete(node.Name)
 	oc.localZoneNodes.Delete(node.Name)
 	oc.mgmtPortFailed.Delete(node.Name)
+	return nil
+}
+
+// addUDNClusterSubnetEgressSNAT adds the SNAT on each node's GR in L2 networks
+// snat eth.dst == d6:cf:fd:2c:a6:44 169.254.0.12 10.128.0.0/14
+// snat eth.dst == d6:cf:fd:2c:a6:44 169.254.0.12 2010:100:200::/64
+// these SNATs are required for pod2Egress traffic in LGW mode and pod2SameNode traffic in SGW mode to function properly on UDNs
+// SNAT Breakdown:
+// match = "eth.dst == d6:cf:fd:2c:a6:44"; the MAC here is the mpX interface MAC address for this UDN
+// logicalIP = "10.128.0.0/14"; which is the clustersubnet for this L2 UDN
+// externalIP = "169.254.0.12"; which is the masqueradeIP for this L2 UDN
+// so all in all we want to condionally SNAT all packets that are coming from pods hosted on this node,
+// which are leaving via UDN's mpX interface to the UDN's masqueradeIP.
+func (oc *SecondaryLayer2NetworkController) addUDNClusterSubnetEgressSNAT(localPodSubnets []*net.IPNet, routerName string, node *kapi.Node) error {
+	outputPort := types.GWRouterToJoinSwitchPrefix + routerName
+	nats, err := oc.buildUDNEgressSNAT(localPodSubnets, outputPort, node)
+	if err != nil {
+		return err
+	}
+	if len(nats) == 0 {
+		return nil // nothing to do
+	}
+	router := &nbdb.LogicalRouter{
+		Name: routerName,
+	}
+	if err := libovsdbops.CreateOrUpdateNATs(oc.nbClient, router, nats...); err != nil {
+		return fmt.Errorf("failed to update SNAT for cluster on router: %q for network %q, error: %w",
+			routerName, oc.GetNetworkName(), err)
+	}
 	return nil
 }
 

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -319,10 +319,10 @@ func (oc *SecondaryLayer2NetworkController) Start(ctx context.Context) error {
 		return err
 	}
 
-	return oc.run(ctx)
+	return oc.run()
 }
 
-func (oc *SecondaryLayer2NetworkController) run(ctx context.Context) error {
+func (oc *SecondaryLayer2NetworkController) run() error {
 	return oc.BaseSecondaryLayer2NetworkController.run()
 }
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -700,6 +700,9 @@ func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	masqSNAT := newNATEntry(masqSNATUUID1, "169.254.169.14", nodeSubnet.String(), standardNonDefaultNetworkExtIDs(netInfo))
 	masqSNAT.Match = getMasqueradeManagementIPSNATMatch(dummyMACAddr)
 	masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("rtos-%s_%s", netInfo.GetNetworkName(), nodeName))
+	if !config.OVNKubernetesFeature.EnableInterconnect {
+		masqSNAT.GatewayPort = ptr.To(fmt.Sprintf("rtos-%s_%s", netInfo.GetNetworkName(), nodeName) + "-UUID")
+	}
 
 	gatewayChassisUUID := fmt.Sprintf("%s-%s-UUID", rtosLRPName, gwConfig.ChassisID)
 	expectedEntities := []libovsdbtest.TestData{

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -787,6 +787,13 @@ func udnGWSNATAddress() *net.IPNet {
 	}
 }
 
+func newMasqueradeManagementNATEntry(uuid string, externalIP string, logicalIP string, netInfo util.NetInfo) *nbdb.NAT {
+	masqSNAT := newNATEntry(uuid, "169.254.169.14", layer2Subnet().String(), standardNonDefaultNetworkExtIDs(netInfo))
+	masqSNAT.Match = fmt.Sprintf("eth.dst == %s", dummyMACAddr)
+	masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("rtoj-GR_%s_%s", netInfo.GetNetworkName(), nodeName))
+	return masqSNAT
+}
+
 func newNATEntry(uuid string, externalIP string, logicalIP string, extIDs map[string]string) *nbdb.NAT {
 	return &nbdb.NAT{
 		UUID:        uuid,

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -697,8 +697,8 @@ var _ = Describe("Network Segmentation", func() {
 				DescribeTable(
 					"can be accessed to from the pods running in the Kubernetes cluster",
 					func(netConfigParams networkAttachmentConfigParams, clientPodConfig podConfiguration) {
-						if isLocalGWModeEnabled() {
-							const upstreamIssue = "https://github.com/ovn-org/ovn-kubernetes/pull/4554"
+						if netConfigParams.topology == "layer2" && IsGatewayModeLocal() {
+							const upstreamIssue = "https://github.com/ovn-org/ovn-kubernetes/issues/4686"
 							e2eskipper.Skipf(
 								"These tests are known to fail on Local Gateway deployments. Upstream issue: %s", upstreamIssue,
 							)


### PR DESCRIPTION
Depends-On: https://github.com/ovn-org/ovn-kubernetes/pull/4553
Depends-On: https://github.com/ovn-org/ovn-kubernetes/pull/4718

#### What this PR does and why is it needed

- [x] Adds conditional SNATs on OVN router for UDN pod subnets when destination is management port interface
- [x] When network goes away the router should get deleted so no need to handle explicit NAT deletion
- [x] When the node get's deleted, the entire DB/router should go away, so no need to delete the NAT explicitly although maybe in IC-Disabled this is not the case anymore
- [ ] ~northd readiness fails need to fix that and find out what change in OVN is doing this. It's happening only on this PR with the conditional SNATs. Perhaps there is something fishy somewhere.~
- [x] Pod2Egress on L3 works with LGW
- [ ] Pod2Egress on L2 needs more work with LGW ; there is a bug around routes which will be a separate PR


#### How to verify it
v4:
```
_uuid               : 084ad16e-7d46-495e-87d7-15ff11028d47
allowed_ext_ips     : []
exempted_ext_ips    : []
external_ids        : {}
external_ip         : "169.254.0.12"
external_mac        : []
external_port_range : ""
gateway_port        : []
logical_ip          : "10.128.0.0/24"
logical_port        : rtos-l3.network_ovn-control-plane
match               : "eth.dst == 76:23:f2:3b:a8:df"
options             : {stateless="false"}
priority            : 0
type                : snat
```
v6:
```
_uuid               : 40a02f3e-e24b-4f5e-a1a7-a7db84834628                                                                                                                   
allowed_ext_ips     : []                                                                                                                                                     
exempted_ext_ips    : []                                                                                                                                                     
external_ids        : {}                                                                                                                                                     
external_ip         : "fd69::c"                                                                                                                                         
external_mac        : []                                                                                                                                                     
external_port_range : ""                                                                                                                                                     
gateway_port        : []                                                                                                                                                     
logical_ip          : "2010:100:200::/64"                                                                                                                                    
logical_port        : rtos-l3.network_ovn-control-plane                                                                                                                      
match               : "eth.dst == 76:23:f2:3b:a8:df"                                                                                                                         
options             : {stateless="false"}                                                                                                                                    
priority            : 0                                                                                                                                                      
type                : snat
```
Given this is the last piece:
```
   10.128.1.4 > 8.8.8.8: ICMP echo request, id 7936, seq 5, length 64
17:27:32.294057 ovn-k8s-mp1 In  ifindex 9 0a:58:0a:80:01:01 ethertype IPv4 (0x0800), length 104: (tos 0x0, ttl 63, id 25309, offset 0, flags [DF], proto ICMP (1), length 84)
    169.254.0.12 > 8.8.8.8: ICMP echo request, id 7936, seq 5, length 64
17:27:32.294067 breth0 Out ifindex 5 02:42:ac:12:00:03 ethertype IPv4 (0x0800), length 104: (tos 0x0, ttl 62, id 25309, offset 0, flags [DF], proto ICMP (1), length 84)
    172.18.0.3 > 8.8.8.8: ICMP echo request, id 7936, seq 5, length 64
17:27:32.294070 eth0  Out ifindex 889 02:42:ac:12:00:03 ethertype IPv4 (0x0800), length 104: (tos 0x0, ttl 62, id 25309, offset 0, flags [DF], proto ICMP (1), length 84)
    172.18.0.3 > 8.8.8.8: ICMP echo request, id 7936, seq 5, length 64
17:27:32.316527 eth0  In  ifindex 889 02:42:ec:43:db:89 ethertype IPv4 (0x0800), length 104: (tos 0x0, ttl 116, id 0, offset 0, flags [none], proto ICMP (1), length 84)
    8.8.8.8 > 172.18.0.3: ICMP echo reply, id 7936, seq 5, length 64
17:27:32.316540 breth0 In  ifindex 5 02:42:ec:43:db:89 ethertype IPv4 (0x0800), length 104: (tos 0x0, ttl 116, id 0, offset 0, flags [none], proto ICMP (1), length 84)
    8.8.8.8 > 172.18.0.3: ICMP echo reply, id 7936, seq 5, length 64
17:27:32.316547 ovn-k8s-mp1 Out ifindex 9 3a:7f:f5:ac:a1:1d ethertype IPv4 (0x0800), length 104: (tos 0x0, ttl 115, id 0, offset 0, flags [none], proto ICMP (1), length 84)
    8.8.8.8 > 169.254.0.12: ICMP echo reply, id 7936, seq 5, length 64
17:27:32.316556 7120791f698f2_3 Out ifindex 14 0a:58:0a:80:01:01 ethertype IPv4 (0x0800), length 104: (tos 0x0, ttl 114, id 0, offset 0, flags [none], proto ICMP (1), length 84)
    8.8.8.8 > 10.128.1.4: ICMP echo reply, id 7936, seq 5, length 64
```
pod2Egress on LGW works on this PR