### PR TITLE
UDN L3 support for services

### DIFF
--- a/go-controller/pkg/clustermanager/egressservice/egressservice_cluster_endpointslices.go
+++ b/go-controller/pkg/clustermanager/egressservice/egressservice_cluster_endpointslices.go
@@ -61,7 +61,7 @@ func (c *Controller) onEndpointSliceDelete(obj interface{}) {
 }
 
 func (c *Controller) queueServiceForEndpointSlice(endpointSlice *discovery.EndpointSlice) {
-	key, err := services.ServiceControllerKey(endpointSlice)
+	key, err := services.GetServiceKeyFromEndpointSliceForDefaultNetwork(endpointSlice)
 	if err != nil {
 		// Do not log endpointsSlices missing service labels as errors.
 		// Once the service label is eventually added, we will get this event

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller_test.go
@@ -7,6 +7,11 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/endpointslicemirror"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -96,7 +101,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					},
 				}
 				staleEndpointSlice := mirrorEndpointSlice(&defaultEndpointSlice, "l3-network")
-				staleEndpointSlice.Labels[LabelSourceEndpointSlice] = "non-existing-endpointslice"
+				staleEndpointSlice.Labels[types.LabelSourceEndpointSlice] = "non-existing-endpointslice"
 
 				objs := []runtime.Object{
 					&v1.PodList{
@@ -144,7 +149,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 
 					// new mirrored EndpointSlice should get created
 					mirrorEndpointSliceSelector := labels.Set(map[string]string{
-						LabelSourceEndpointSlice: defaultEndpointSlice.Name,
+						types.LabelSourceEndpointSlice: defaultEndpointSlice.Name,
 						discovery.LabelManagedBy: types.EndpointSliceMirrorControllerName,
 					}).AsSelectorPreValidated()
 
@@ -343,7 +348,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 
 					// mirrored EndpointSlices should exist
 					mirrorEndpointSliceSelector := labels.Set(map[string]string{
-						LabelSourceEndpointSlice: defaultEndpointSlice.Name,
+						types.LabelSourceEndpointSlice: defaultEndpointSlice.Name,
 						discovery.LabelManagedBy: types.EndpointSliceMirrorControllerName,
 					}).AsSelectorPreValidated()
 
@@ -400,7 +405,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 					}
 
 					mirrorEndpointSliceSelector := labels.Set(map[string]string{
-						LabelSourceEndpointSlice: defaultEndpointSlice.Name,
+						types.LabelSourceEndpointSlice: defaultEndpointSlice.Name,
 						discovery.LabelManagedBy: types.EndpointSliceMirrorControllerName,
 					}).AsSelectorPreValidated()
 
@@ -427,7 +432,7 @@ var _ = ginkgo.Describe("Cluster manager EndpointSlice mirror controller", func(
 
 				gomega.Eventually(func() error {
 					mirrorEndpointSliceSelector := labels.Set(map[string]string{
-						LabelSourceEndpointSlice: defaultEndpointSlice.Name,
+						types.LabelSourceEndpointSlice: defaultEndpointSlice.Name,
 						discovery.LabelManagedBy: types.EndpointSliceMirrorControllerName,
 					}).AsSelectorPreValidated()
 
@@ -456,7 +461,7 @@ func mirrorEndpointSlice(defaultEndpointSlice *discovery.EndpointSlice, network 
 	mirror = defaultEndpointSlice.DeepCopy()
 	mirror.Name = defaultEndpointSlice.Name + "-mirrored"
 	mirror.Labels[discovery.LabelManagedBy] = types.EndpointSliceMirrorControllerName
-	mirror.Labels[LabelSourceEndpointSlice] = defaultEndpointSlice.Name
+	mirror.Labels[types.LabelSourceEndpointSlice] = defaultEndpointSlice.Name
 	mirror.Labels[types.LabelUserDefinedEndpointSliceNetwork] = network
 	mirror.Labels[types.LabelUserDefinedServiceName] = defaultEndpointSlice.Labels[discovery.LabelServiceName]
 	mirror.Endpoints = nil

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -1374,30 +1374,14 @@ func (wf *WatchFactory) GetEndpointSlice(namespace, name string) (*discovery.End
 
 // GetEndpointSlicesBySelector returns a list of EndpointSlices in a given namespace by the label selector
 func (wf *WatchFactory) GetEndpointSlicesBySelector(namespace string, labelSelector metav1.LabelSelector) ([]*discovery.EndpointSlice, error) {
-	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
-	if err != nil {
-		return nil, err
-	}
-	endpointSliceLister := wf.informers[EndpointSliceType].lister.(discoverylisters.EndpointSliceLister)
-	return endpointSliceLister.EndpointSlices(namespace).List(selector)
+	return util.GetEndpointSlicesBySelector(namespace, labelSelector, wf.informers[EndpointSliceType].lister.(discoverylisters.EndpointSliceLister))
 }
 
 // GetServiceEndpointSlices returns the endpointSlices associated with a service for the specified network
 // if network is DefaultNetworkName the default endpointSlices are returned, otherwise the function looks for mirror endpointslices
 // for the specified network.
 func (wf *WatchFactory) GetServiceEndpointSlices(namespace, svcName, network string) ([]*discovery.EndpointSlice, error) {
-	var selector metav1.LabelSelector
-	if network == types.DefaultNetworkName {
-		selector = metav1.LabelSelector{MatchLabels: map[string]string{
-			discovery.LabelServiceName: svcName,
-		}}
-	} else {
-		selector = metav1.LabelSelector{MatchLabels: map[string]string{
-			types.LabelUserDefinedServiceName:          svcName,
-			types.LabelUserDefinedEndpointSliceNetwork: network,
-		}}
-	}
-	return wf.GetEndpointSlicesBySelector(namespace, selector)
+	return util.GetServiceEndpointSlices(namespace, svcName, network, wf.informers[EndpointSliceType].lister.(discoverylisters.EndpointSliceLister))
 }
 
 // GetNamespaces returns a list of namespaces in the cluster

--- a/go-controller/pkg/libovsdb/ops/lbgroup.go
+++ b/go-controller/pkg/libovsdb/ops/lbgroup.go
@@ -4,15 +4,16 @@ import (
 	"context"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/ovsdb"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 )
 
-// CreateOrUpdateLoadBalancerGroup creates or updates the provided load balancer
-// group
-func CreateOrUpdateLoadBalancerGroup(nbClient libovsdbclient.Client, group *nbdb.LoadBalancerGroup) error {
+// CreateOrUpdateLoadBalancerGroupOps returns the ops to create or update the
+// provided load balancer group
+func CreateOrUpdateLoadBalancerGroupOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, group *nbdb.LoadBalancerGroup) ([]ovsdb.Operation, error) {
 	// lb group has no fields other than name, safe to update just with non-default values
 	opModel := operationModel{
 		Model:          group,
@@ -22,8 +23,11 @@ func CreateOrUpdateLoadBalancerGroup(nbClient libovsdbclient.Client, group *nbdb
 	}
 
 	m := newModelClient(nbClient)
-	_, err := m.CreateOrUpdate(opModel)
-	return err
+	ops, err := m.CreateOrUpdateOps(ops, opModel)
+	if err != nil {
+		return nil, err
+	}
+	return ops, nil
 }
 
 // AddLoadBalancersToGroupOps adds the provided load balancers to the provided

--- a/go-controller/pkg/libovsdb/ops/loadbalancer.go
+++ b/go-controller/pkg/libovsdb/ops/loadbalancer.go
@@ -137,3 +137,15 @@ func ListLoadBalancers(nbClient libovsdbclient.Client) ([]*nbdb.LoadBalancer, er
 	err := nbClient.List(ctx, &lbs)
 	return lbs, err
 }
+
+type loadBalancerPredicate func(*nbdb.LoadBalancer) bool
+
+// FindLoadBalancersWithPredicate looks up loadbalancers from the cache
+// based on a given predicate
+func FindLoadBalancersWithPredicate(nbClient libovsdbclient.Client, p loadBalancerPredicate) ([]*nbdb.LoadBalancer, error) {
+	found := []*nbdb.LoadBalancer{}
+	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
+	defer cancel()
+	err := nbClient.WhereCache(p).List(ctx, &found)
+	return found, err
+}

--- a/go-controller/pkg/node/controllers/egressservice/egressservice_node_endpointslice.go
+++ b/go-controller/pkg/node/controllers/egressservice/egressservice_node_endpointslice.go
@@ -62,7 +62,7 @@ func (c *Controller) onEndpointSliceDelete(obj interface{}) {
 
 func (c *Controller) queueServiceForEndpointSlice(endpointSlice *discovery.EndpointSlice) {
 
-	key, err := services.ServiceControllerKey(endpointSlice)
+	key, err := services.GetServiceKeyFromEndpointSliceForDefaultNetwork(endpointSlice)
 	if err != nil {
 		// Do not log endpointsSlices missing service labels as errors.
 		// Once the service label is eventually added, we will get this event

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -24,6 +24,7 @@ import (
 	ovnretry "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -322,13 +323,8 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 	logicalSwitch := nbdb.LogicalSwitch{
 		Name: switchName,
 	}
-	if bnc.IsSecondary() {
-		logicalSwitch.ExternalIDs = map[string]string{
-			types.NetworkExternalID:  bnc.GetNetworkName(),
-			types.TopologyExternalID: bnc.TopologyType(),
-		}
-	}
 
+	logicalSwitch.ExternalIDs = util.GenerateExternalIDsForSwitchOrRouter(bnc.NetInfo)
 	var v4Gateway, v6Gateway net.IP
 	logicalSwitch.OtherConfig = map[string]string{}
 	for _, hostSubnet := range hostSubnets {
@@ -762,10 +758,10 @@ func (bnc *BaseNetworkController) isLocalZoneNode(node *kapi.Node) bool {
 
 // getActiveNetworkForNamespace returns the active network for the given namespace
 // and is a wrapper around util.GetActiveNetworkForNamespace
-func (bnc *BaseNetworkController) getActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
+func (cnci *CommonNetworkControllerInfo) getActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
 	var nadLister nadlister.NetworkAttachmentDefinitionLister
 	if util.IsNetworkSegmentationSupportEnabled() {
-		nadLister = bnc.watchFactory.NADInformer().Lister()
+		nadLister = cnci.watchFactory.NADInformer().Lister()
 	}
 	return util.GetActiveNetworkForNamespace(namespace, nadLister)
 }
@@ -898,4 +894,44 @@ func (bnc *BaseNetworkController) findMigratablePodIPsForSubnets(subnets []*net.
 		}
 	}
 	return ipList, nil
+}
+
+func initLoadBalancerGroups(nbClient libovsdbclient.Client, netInfo util.NetInfo) (
+	clusterLoadBalancerGroupUUID, switchLoadBalancerGroupUUID, routerLoadBalancerGroupUUID string, err error) {
+
+	loadBalancerGroupName := netInfo.GetNetworkScopedLoadBalancerGroupName(ovntypes.ClusterLBGroupName)
+	clusterLBGroup := nbdb.LoadBalancerGroup{Name: loadBalancerGroupName}
+	ops, err := libovsdbops.CreateOrUpdateLoadBalancerGroupOps(nbClient, nil, &clusterLBGroup)
+	if err != nil {
+		klog.Errorf("Error creating operation for cluster-wide load balancer group %s: %v", loadBalancerGroupName, err)
+		return
+	}
+
+	loadBalancerGroupName = netInfo.GetNetworkScopedLoadBalancerGroupName(ovntypes.ClusterSwitchLBGroupName)
+	clusterSwitchLBGroup := nbdb.LoadBalancerGroup{Name: loadBalancerGroupName}
+	ops, err = libovsdbops.CreateOrUpdateLoadBalancerGroupOps(nbClient, ops, &clusterSwitchLBGroup)
+	if err != nil {
+		klog.Errorf("Error creating operation for cluster-wide switch load balancer group %s: %v", loadBalancerGroupName, err)
+		return
+	}
+
+	loadBalancerGroupName = netInfo.GetNetworkScopedLoadBalancerGroupName(ovntypes.ClusterRouterLBGroupName)
+	clusterRouterLBGroup := nbdb.LoadBalancerGroup{Name: loadBalancerGroupName}
+	ops, err = libovsdbops.CreateOrUpdateLoadBalancerGroupOps(nbClient, ops, &clusterRouterLBGroup)
+	if err != nil {
+		klog.Errorf("Error creating operation for cluster-wide router load balancer group %s: %v", loadBalancerGroupName, err)
+		return
+	}
+
+	lbs := []*nbdb.LoadBalancerGroup{&clusterLBGroup, &clusterSwitchLBGroup, &clusterRouterLBGroup}
+	if _, err = libovsdbops.TransactAndCheckAndSetUUIDs(nbClient, lbs, ops); err != nil {
+		klog.Errorf("Error creating cluster-wide router load balancer group %s: %v", loadBalancerGroupName, err)
+		return
+	}
+
+	clusterLoadBalancerGroupUUID = clusterLBGroup.UUID
+	switchLoadBalancerGroupUUID = clusterSwitchLBGroup.UUID
+	routerLoadBalancerGroupUUID = clusterRouterLBGroup.UUID
+
+	return
 }

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -8,6 +8,7 @@ import (
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -112,10 +113,8 @@ func (oc *BaseSecondaryLayer2NetworkController) initializeLogicalSwitch(switchNa
 	excludeSubnets []*net.IPNet) (*nbdb.LogicalSwitch, error) {
 	logicalSwitch := nbdb.LogicalSwitch{
 		Name:        switchName,
-		ExternalIDs: map[string]string{},
+		ExternalIDs: util.GenerateExternalIDsForSwitchOrRouter(oc.NetInfo),
 	}
-	logicalSwitch.ExternalIDs[types.NetworkExternalID] = oc.GetNetworkName()
-	logicalSwitch.ExternalIDs[types.TopologyExternalID] = oc.TopologyType()
 
 	hostSubnets := make([]*net.IPNet, 0, len(clusterSubnets))
 	for _, clusterSubnet := range clusterSubnets {

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_endpointslice.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_endpointslice.go
@@ -61,7 +61,7 @@ func (c *Controller) onEndpointSliceDelete(obj interface{}) {
 }
 
 func (c *Controller) queueServiceForEndpointSlice(endpointSlice *discovery.EndpointSlice) {
-	key, err := services.ServiceControllerKey(endpointSlice)
+	key, err := services.GetServiceKeyFromEndpointSliceForDefaultNetwork(endpointSlice)
 	if err != nil {
 		// Do not log endpointsSlices missing service labels as errors.
 		// Once the service label is eventually added, we will get this event

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -131,7 +131,9 @@ var protos = []v1.Protocol{
 // Template LBs will be created for
 //   - services with NodePort set but *without* ExternalTrafficPolicy=Local or
 //     affinity timeout set.
-func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice, nodeInfos []nodeInfo, useLBGroup, useTemplates bool) (perNodeConfigs, templateConfigs, clusterConfigs []lbConfig) {
+func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice, nodeInfos []nodeInfo,
+	useLBGroup, useTemplates bool, networkName string) (perNodeConfigs, templateConfigs, clusterConfigs []lbConfig) {
+
 	needsAffinityTimeout := hasSessionAffinityTimeOut(service)
 
 	nodes := sets.New[string]()
@@ -139,7 +141,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 		nodes.Insert(n.name)
 	}
 	// get all the endpoints classified by port and by port,node
-	portToClusterEndpoints, portToNodeToEndpoints := getEndpointsForService(endpointSlices, service, nodes)
+	portToClusterEndpoints, portToNodeToEndpoints := getEndpointsForService(endpointSlices, service, nodes, networkName)
 	for _, svcPort := range service.Spec.Ports {
 		svcPortKey := getServicePortKey(svcPort.Protocol, svcPort.Name)
 		clusterEndpoints := portToClusterEndpoints[svcPortKey]
@@ -226,12 +228,15 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 	return
 }
 
+func makeLBNameForNetwork(service *v1.Service, proto v1.Protocol, scope string, netInfo util.NetInfo) string {
+	return netInfo.GetNetworkScopedLoadBalancerName(makeLBName(service, proto, scope))
+}
+
 // makeLBName creates the load balancer name - used to minimize churn
 func makeLBName(service *v1.Service, proto v1.Protocol, scope string) string {
 	return fmt.Sprintf("Service_%s/%s_%s_%s",
 		service.Namespace, service.Name,
-		proto, scope,
-	)
+		proto, scope)
 }
 
 // buildClusterLBs takes a list of lbConfigs and aggregates them
@@ -240,14 +245,15 @@ func makeLBName(service *v1.Service, proto v1.Protocol, scope string) string {
 // It takes a list of (proto:[vips]:port -> [endpoints]) configs and re-aggregates
 // them to a list of (proto:[vip:port -> [endpoint:port]])
 // This load balancer is attached to all node switches. In shared-GW mode, it is also on all routers
-func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeInfo, useLBGroup bool) []LB {
+// The input netInfo is needed to get the right LB groups and network IDs for the specified network.
+func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeInfo, useLBGroup bool, netInfo util.NetInfo) []LB {
 	var nodeSwitches []string
 	var nodeRouters []string
 	var groups []string
 	if useLBGroup {
 		nodeSwitches = make([]string, 0)
 		nodeRouters = make([]string, 0)
-		groups = []string{types.ClusterLBGroupName}
+		groups = []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterLBGroupName)}
 	} else {
 		nodeSwitches = make([]string, 0, len(nodeInfos))
 		nodeRouters = make([]string, 0, len(nodeInfos))
@@ -273,9 +279,9 @@ func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeIn
 			continue
 		}
 		lb := LB{
-			Name:        makeLBName(service, proto, "cluster"),
+			Name:        makeLBNameForNetwork(service, proto, "cluster", netInfo),
 			Protocol:    string(proto),
-			ExternalIDs: util.ExternalIDsForObject(service),
+			ExternalIDs: getExternalIDsForLoadBalancer(service, netInfo),
 			Opts:        lbOpts(service),
 
 			Switches: nodeSwitches,
@@ -344,11 +350,13 @@ func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeIn
 // Note:
 // NodePort services with ETP=local or affinity timeout set still need
 // non-template per-node LBs.
+//
+// The input netInfo is needed to get the right LB groups and network IDs for the specified network.
 func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
-	nodeIPv4Templates, nodeIPv6Templates *NodeIPsTemplates) []LB {
+	nodeIPv4Templates, nodeIPv6Templates *NodeIPsTemplates, netInfo util.NetInfo) []LB {
 
 	cbp := configsByProto(configs)
-	eids := util.ExternalIDsForObject(service)
+	eids := getExternalIDsForLoadBalancer(service, netInfo)
 	out := make([]LB, 0, len(configs))
 
 	for _, proto := range protos {
@@ -370,23 +378,23 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 				makeTemplate(
 					makeLBTargetTemplateName(
 						service, proto, config.inport,
-						optsV4.AddressFamily, "node_switch_template"))
+						optsV4.AddressFamily, "node_switch_template", netInfo))
 			switchV6TemplateTarget :=
 				makeTemplate(
 					makeLBTargetTemplateName(
 						service, proto, config.inport,
-						optsV6.AddressFamily, "node_switch_template"))
+						optsV6.AddressFamily, "node_switch_template", netInfo))
 
 			routerV4TemplateTarget :=
 				makeTemplate(
 					makeLBTargetTemplateName(
 						service, proto, config.inport,
-						optsV4.AddressFamily, "node_router_template"))
+						optsV4.AddressFamily, "node_router_template", netInfo))
 			routerV6TemplateTarget :=
 				makeTemplate(
 					makeLBTargetTemplateName(
 						service, proto, config.inport,
-						optsV6.AddressFamily, "node_router_template"))
+						optsV6.AddressFamily, "node_router_template", netInfo))
 
 			allV4TargetIPs := config.clusterEndpoints.V4IPs
 			allV6TargetIPs := config.clusterEndpoints.V6IPs
@@ -504,22 +512,22 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 		if nodeIPv4Templates.Len() > 0 {
 			if len(switchV4Rules) > 0 {
 				out = append(out, LB{
-					Name:        makeLBName(service, proto, "node_switch_template_IPv4"),
+					Name:        makeLBNameForNetwork(service, proto, "node_switch_template_IPv4", netInfo),
 					Protocol:    string(proto),
 					ExternalIDs: eids,
 					Opts:        optsV4,
-					Groups:      []string{types.ClusterSwitchLBGroupName},
+					Groups:      []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterSwitchLBGroupName)},
 					Rules:       switchV4Rules,
 					Templates:   getTemplatesFromRulesTargets(switchV4Rules),
 				})
 			}
 			if len(routerV4Rules) > 0 {
 				out = append(out, LB{
-					Name:        makeLBName(service, proto, "node_router_template_IPv4"),
+					Name:        makeLBNameForNetwork(service, proto, "node_router_template_IPv4", netInfo),
 					Protocol:    string(proto),
 					ExternalIDs: eids,
 					Opts:        optsV4,
-					Groups:      []string{types.ClusterRouterLBGroupName},
+					Groups:      []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterRouterLBGroupName)},
 					Rules:       routerV4Rules,
 					Templates:   getTemplatesFromRulesTargets(routerV4Rules),
 				})
@@ -529,22 +537,22 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 		if nodeIPv6Templates.Len() > 0 {
 			if len(switchV6Rules) > 0 {
 				out = append(out, LB{
-					Name:        makeLBName(service, proto, "node_switch_template_IPv6"),
+					Name:        makeLBNameForNetwork(service, proto, "node_switch_template_IPv6", netInfo),
 					Protocol:    string(proto),
 					ExternalIDs: eids,
 					Opts:        optsV6,
-					Groups:      []string{types.ClusterSwitchLBGroupName},
+					Groups:      []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterSwitchLBGroupName)},
 					Rules:       switchV6Rules,
 					Templates:   getTemplatesFromRulesTargets(switchV6Rules),
 				})
 			}
 			if len(routerV6Rules) > 0 {
 				out = append(out, LB{
-					Name:        makeLBName(service, proto, "node_router_template_IPv6"),
+					Name:        makeLBNameForNetwork(service, proto, "node_router_template_IPv6", netInfo),
 					Protocol:    string(proto),
 					ExternalIDs: eids,
 					Opts:        optsV6,
-					Groups:      []string{types.ClusterRouterLBGroupName},
+					Groups:      []string{netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterRouterLBGroupName)},
 					Rules:       routerV6Rules,
 					Templates:   getTemplatesFromRulesTargets(routerV6Rules),
 				})
@@ -579,9 +587,11 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 // - SkipSNAT enabled
 // - NodePort LB on the switch will have masqueradeIP as the vip to handle etp=local for LGW case.
 // This results in the creation of an additional load balancer on the GatewayRouters and NodeSwitches.
-func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) []LB {
+//
+// The input netInfo is needed to get the right network IDs for the specified network.
+func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo, netInfo util.NetInfo) []LB {
 	cbp := configsByProto(configs)
-	eids := util.ExternalIDsForObject(service)
+	eids := getExternalIDsForLoadBalancer(service, netInfo)
 
 	out := make([]LB, 0, len(nodes)*len(configs))
 
@@ -690,7 +700,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 			// If switch and router rules are identical, coalesce
 			if reflect.DeepEqual(switchRules, routerRules) && len(switchRules) > 0 && node.gatewayRouterName != "" {
 				out = append(out, LB{
-					Name:        makeLBName(service, proto, "node_router+switch_"+node.name),
+					Name:        makeLBNameForNetwork(service, proto, "node_router+switch_"+node.name, netInfo),
 					Protocol:    string(proto),
 					ExternalIDs: eids,
 					Opts:        lbOpts(service),
@@ -701,7 +711,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 			} else {
 				if len(routerRules) > 0 && node.gatewayRouterName != "" {
 					out = append(out, LB{
-						Name:        makeLBName(service, proto, "node_router_"+node.name),
+						Name:        makeLBNameForNetwork(service, proto, "node_router_"+node.name, netInfo),
 						Protocol:    string(proto),
 						ExternalIDs: eids,
 						Opts:        lbOpts(service),
@@ -711,7 +721,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 				}
 				if len(noSNATRouterRules) > 0 && node.gatewayRouterName != "" {
 					lb := LB{
-						Name:        makeLBName(service, proto, "node_local_router_"+node.name),
+						Name:        makeLBNameForNetwork(service, proto, "node_local_router_"+node.name, netInfo),
 						Protocol:    string(proto),
 						ExternalIDs: eids,
 						Opts:        lbOpts(service),
@@ -724,7 +734,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 
 				if len(switchRules) > 0 {
 					out = append(out, LB{
-						Name:        makeLBName(service, proto, "node_switch_"+node.name),
+						Name:        makeLBNameForNetwork(service, proto, "node_switch_"+node.name, netInfo),
 						Protocol:    string(proto),
 						ExternalIDs: eids,
 						Opts:        lbOpts(service),
@@ -882,7 +892,9 @@ func getServicePortKey(protocol v1.Protocol, name string) string {
 // one classified by port, one classified by port,node. This second map is only filled in
 // when the service needs local (per-node) endpoints, that is when ETP=local or ITP=local.
 // The node list helps to keep the resulting map small, since we're only interested in local endpoints.
-func getEndpointsForService(slices []*discovery.EndpointSlice, service *v1.Service, nodes sets.Set[string]) (map[string]lbEndpoints, map[string]map[string]lbEndpoints) {
+func getEndpointsForService(slices []*discovery.EndpointSlice, service *v1.Service, nodes sets.Set[string],
+	networkName string) (map[string]lbEndpoints, map[string]map[string]lbEndpoints) {
+
 	// classify endpoints
 	ports := map[string]int32{}
 	portToEndpoints := map[string][]discovery.Endpoint{}

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -400,7 +400,8 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 			allV6TargetIPs := config.clusterEndpoints.V6IPs
 
 			for range config.vips {
-				klog.V(5).Infof("buildTemplateLBs() service %s/%s adding rules", service.Namespace, service.Name)
+				klog.V(5).Infof("buildTemplateLBs() service %s/%s adding rules for network=%s",
+					service.Namespace, service.Name, netInfo.GetNetworkName())
 
 				// If all targets have exactly the same IPs on all nodes there's
 				// no need to use a template, just use the same list of explicit
@@ -562,9 +563,9 @@ func buildTemplateLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo,
 
 	merged := mergeLBs(out)
 	if len(merged) != len(out) {
-		klog.V(5).Infof("Service %s/%s merged %d LBs to %d",
+		klog.V(5).Infof("Service %s/%s merged %d LBs to %d for network=%s",
 			service.Namespace, service.Name,
-			len(out), len(merged))
+			len(out), len(merged), netInfo.GetNetworkName())
 	}
 
 	return merged
@@ -748,9 +749,9 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo, 
 
 	merged := mergeLBs(out)
 	if len(merged) != len(out) {
-		klog.V(5).Infof("Service %s/%s merged %d LBs to %d",
+		klog.V(5).Infof("Service %s/%s merged %d LBs to %d for network=%s",
 			service.Namespace, service.Name,
-			len(out), len(merged))
+			len(out), len(merged), netInfo.GetNetworkName())
 	}
 
 	return merged
@@ -971,7 +972,8 @@ func getEndpointsForService(slices []*discovery.EndpointSlice, service *v1.Servi
 			}
 		}
 	}
-	klog.V(5).Infof("Cluster endpoints for %s/%s are: %v", service.Namespace, service.Name, portToLBEndpoints)
+	klog.V(5).Infof("Cluster endpoints for %s/%s for network=%s are: %v",
+		service.Namespace, service.Name, networkName, portToLBEndpoints)
 
 	for port, nodeToEndpoints := range portToNodeToEndpoints {
 		for node, endpoints := range nodeToEndpoints {
@@ -993,7 +995,8 @@ func getEndpointsForService(slices []*discovery.EndpointSlice, service *v1.Servi
 	}
 
 	if requiresLocalEndpoints {
-		klog.V(5).Infof("Local endpoints for %s/%s are: %v", service.Namespace, service.Name, portToNodeToLBEndpoints)
+		klog.V(5).Infof("Local endpoints for %s/%s for network=%s are: %v",
+			service.Namespace, service.Name, networkName, portToNodeToLBEndpoints)
 	}
 
 	return portToLBEndpoints, portToNodeToLBEndpoints

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -1218,11 +1218,6 @@ func Test_buildClusterLBs(t *testing.T) {
 		},
 	}
 
-	defaultExternalIDs := map[string]string{
-		types.LoadBalancerKindExternalID:  "Service",
-		types.LoadBalancerOwnerExternalID: fmt.Sprintf("%s/%s", namespace, name),
-	}
-
 	defaultRouters := []string{}
 	defaultSwitches := []string{}
 	defaultGroups := []string{"clusterLBGroup"}
@@ -1275,7 +1270,7 @@ func Test_buildClusterLBs(t *testing.T) {
 				{
 					Name:        fmt.Sprintf("Service_%s/%s_TCP_cluster", namespace, name),
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Rules: []LBRule{
 						{
 							Source:  Addr{IP: "1.2.3.4", Port: 80},
@@ -1334,7 +1329,7 @@ func Test_buildClusterLBs(t *testing.T) {
 				{
 					Name:        fmt.Sprintf("Service_%s/%s_TCP_cluster", namespace, name),
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Rules: []LBRule{
 						{
 							Source:  Addr{IP: "1.2.3.4", Port: 80},
@@ -1350,7 +1345,7 @@ func Test_buildClusterLBs(t *testing.T) {
 				{
 					Name:        fmt.Sprintf("Service_%s/%s_UDP_cluster", namespace, name),
 					Protocol:    "UDP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Rules: []LBRule{
 						{
 							Source:  Addr{IP: "1.2.3.4", Port: 443},
@@ -1411,7 +1406,7 @@ func Test_buildClusterLBs(t *testing.T) {
 				{
 					Name:        fmt.Sprintf("Service_%s/%s_TCP_cluster", namespace, name),
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Rules: []LBRule{
 						{
 							Source:  Addr{IP: "1.2.3.4", Port: 80},
@@ -1513,10 +1508,6 @@ func Test_buildPerNodeLBs(t *testing.T) {
 		},
 	}
 
-	defaultExternalIDs := map[string]string{
-		types.LoadBalancerKindExternalID:  "Service",
-		types.LoadBalancerOwnerExternalID: fmt.Sprintf("%s/%s", namespace, name),
-	}
 	defaultOpts := LBOpts{Reject: true}
 
 	//defaultRouters := []string{"gr-node-a", "gr-node-b"}
@@ -1552,7 +1543,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedShared: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -1565,7 +1556,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a_merged",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-a", "switch-node-b"},
 					Protocol:    "TCP",
@@ -1599,7 +1590,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedShared: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
@@ -1617,7 +1608,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
@@ -1633,7 +1624,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedLocal: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
@@ -1651,7 +1642,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
@@ -1703,7 +1694,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedShared: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -1724,7 +1715,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -1745,7 +1736,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
@@ -1765,7 +1756,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedLocal: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -1786,7 +1777,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -1807,7 +1798,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
@@ -1870,7 +1861,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				// switch clusterip + nodeport
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -1883,7 +1874,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 					Protocol:    "TCP",
@@ -1900,7 +1891,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -1934,7 +1925,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				// switch clusterip + nodeport
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -1951,7 +1942,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2019,7 +2010,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedShared: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a_merged",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a", "gr-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2036,7 +2027,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2053,7 +2044,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2072,7 +2063,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedLocal: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a_merged",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a", "gr-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2089,7 +2080,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2106,7 +2097,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2170,7 +2161,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedShared: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2187,7 +2178,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2204,7 +2195,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2221,7 +2212,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2240,7 +2231,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedLocal: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2257,7 +2248,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2274,7 +2265,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2291,7 +2282,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2352,7 +2343,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedShared: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2365,7 +2356,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 					Protocol:    "TCP",
@@ -2382,7 +2373,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2411,7 +2402,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2428,7 +2419,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2451,7 +2442,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedLocal: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2464,7 +2455,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 					Protocol:    "TCP",
@@ -2481,7 +2472,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2510,7 +2501,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2527,7 +2518,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -2600,7 +2591,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 
 					Rules: []LBRule{
@@ -2626,7 +2617,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        defaultOpts,
 					Rules: []LBRule{
 						{
@@ -2659,7 +2650,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 					Rules: []LBRule{
 						{
@@ -2680,7 +2671,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        defaultOpts,
 					Rules: []LBRule{
 						{
@@ -2743,7 +2734,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 
 					Rules: []LBRule{
@@ -2769,7 +2760,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        defaultOpts,
 					Rules: []LBRule{
 						{
@@ -2802,7 +2793,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 					Rules: []LBRule{
 						{
@@ -2823,7 +2814,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        defaultOpts,
 					Rules: []LBRule{
 						{
@@ -2878,7 +2869,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedShared: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
@@ -2896,7 +2887,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
@@ -2912,7 +2903,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			expectedLocal: []LB{
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Switches:    []string{"switch-node-a"},
 					Protocol:    "TCP",
@@ -2930,7 +2921,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 				{
 					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-b"},
 					Switches:    []string{"switch-node-b"},
 					Protocol:    "TCP",
@@ -2984,7 +2975,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 
 					Rules: []LBRule{
@@ -3010,7 +3001,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-a",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        defaultOpts,
 					Rules: []LBRule{
 						{
@@ -3043,7 +3034,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        LBOpts{SkipSNAT: true, Reject: true},
 					Rules: []LBRule{
 						{
@@ -3064,7 +3055,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				{
 					Name:        "Service_testns/foo_TCP_node_switch_node-b",
 					Protocol:    "TCP",
-					ExternalIDs: defaultExternalIDs,
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 					Opts:        defaultOpts,
 					Rules: []LBRule{
 						{

--- a/go-controller/pkg/ovn/controller/services/loadbalancer.go
+++ b/go-controller/pkg/ovn/controller/services/loadbalancer.go
@@ -131,8 +131,8 @@ func toNBTemplateList(tlbs []*templateLoadBalancer) []TemplateMap {
 //
 // It is assumed that names are meaningful and somewhat stable, to minimize churn. This
 // function doesn't work with Load_Balancers without a name.
-func EnsureLBs(nbClient libovsdbclient.Client, service *corev1.Service, existingCacheLBs []LB, LBs []LB) error {
-	externalIDs := util.ExternalIDsForObject(service)
+func EnsureLBs(nbClient libovsdbclient.Client, service *corev1.Service, existingCacheLBs []LB, LBs []LB, netInfo util.NetInfo) error {
+	externalIDs := getExternalIDsForLoadBalancer(service, netInfo)
 	existingByName := make(map[string]*LB, len(existingCacheLBs))
 	toDelete := make(map[string]*LB, len(existingCacheLBs))
 
@@ -425,25 +425,52 @@ func DeleteLBs(nbClient libovsdbclient.Client, uuids []string) error {
 	return nil
 }
 
-// getLBs returns a slice of load balancers found in OVN.
-func getLBs(nbClient libovsdbclient.Client, allTemplates TemplateMap) ([]*LB, error) {
-	_, out, err := _getLBsCommon(nbClient, allTemplates, false)
+// getAllLBs returns a slice of load balancers found in OVN.
+func getAllLBs(nbClient libovsdbclient.Client, allTemplates TemplateMap) ([]*LB, error) {
+	_, out, err := _getLBsCommon(nbClient, allTemplates, false, true, nil)
 	return out, err
 }
 
-// getServiceLBs returns a set of services as well as a slice of load balancers found in OVN.
-func getServiceLBs(nbClient libovsdbclient.Client, allTemplates TemplateMap) (sets.Set[string], []*LB, error) {
-	return _getLBsCommon(nbClient, allTemplates, true)
+// getServiceLBsForNetwork returns the services and OVN load balancers for the network specified in netInfo.
+func getServiceLBsForNetwork(nbClient libovsdbclient.Client, allTemplates TemplateMap, netInfo util.NetInfo) (sets.Set[string], []*LB, error) {
+	return _getLBsCommon(nbClient, allTemplates, true, false, netInfo)
 }
 
-func _getLBsCommon(nbClient libovsdbclient.Client, allTemplates TemplateMap, withServiceOwner bool) (sets.Set[string], []*LB, error) {
-	lbs, err := libovsdbops.ListLoadBalancers(nbClient)
+func _getLBsCommon(nbClient libovsdbclient.Client, allTemplates TemplateMap, withServiceOwner bool, includeAllNetworks bool, netInfo util.NetInfo) (sets.Set[string], []*LB, error) {
+
+	// Lookup network name and network role in the OVN external IDs to check whether
+	// the OVN element with the input externalIDs belongs to this network.
+	belongsToThisNetwork := func(externalIDs map[string]string) bool {
+		if !util.IsNetworkSegmentationSupportEnabled() {
+			return true
+		}
+
+		network, ok := externalIDs[types.NetworkExternalID]
+
+		if netInfo == nil {
+			return true
+		}
+
+		if netInfo.IsDefault() {
+			return !ok
+		}
+
+		// filter out anything belonging to default and (if any) secondary networks
+		role, ok := externalIDs[types.NetworkRoleExternalID]
+		return ok && role == types.NetworkRolePrimary && network == netInfo.GetNetworkName()
+	}
+
+	p := func(item *nbdb.LoadBalancer) bool {
+		return includeAllNetworks || belongsToThisNetwork(item.ExternalIDs)
+	}
+
+	lbs, err := libovsdbops.FindLoadBalancersWithPredicate(nbClient, p)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not list load_balancer: %w", err)
 	}
 
-	services := sets.New[string]()
-	outMap := make(map[string]*LB, len(lbs))
+	services := sets.New[string]()           // all services found in load balancers
+	outMap := make(map[string]*LB, len(lbs)) // UUID -> *LB
 	for _, lb := range lbs {
 
 		// Skip load balancers unrelated to service, or w/out an owner (aka namespace+name)
@@ -481,8 +508,9 @@ func _getLBsCommon(nbClient libovsdbclient.Client, allTemplates TemplateMap, wit
 
 	// Switches
 	ps := func(item *nbdb.LogicalSwitch) bool {
-		return len(item.LoadBalancer) > 0
+		return len(item.LoadBalancer) > 0 && (includeAllNetworks || belongsToThisNetwork(item.ExternalIDs))
 	}
+
 	switches, err := libovsdbops.FindLogicalSwitchesWithPredicate(nbClient, ps)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not list logical switches: %w", err)
@@ -497,7 +525,7 @@ func _getLBsCommon(nbClient libovsdbclient.Client, allTemplates TemplateMap, wit
 
 	// Routers
 	pr := func(item *nbdb.LogicalRouter) bool {
-		return len(item.LoadBalancer) > 0
+		return len(item.LoadBalancer) > 0 && (includeAllNetworks || belongsToThisNetwork(item.ExternalIDs))
 	}
 	routers, err := libovsdbops.FindLogicalRoutersWithPredicate(nbClient, pr)
 	if err != nil {
@@ -511,10 +539,39 @@ func _getLBsCommon(nbClient libovsdbclient.Client, allTemplates TemplateMap, wit
 		}
 	}
 
-	// Groups
+	// LB Groups
 	pg := func(item *nbdb.LoadBalancerGroup) bool {
-		return len(item.LoadBalancer) > 0
+		if len(item.LoadBalancer) == 0 {
+			return false
+		}
+
+		if !util.IsNetworkSegmentationSupportEnabled() || includeAllNetworks {
+			return true
+		}
+
+		if netInfo == nil {
+			return true
+		}
+
+		// LB groups have no external ID in OVN, so parse their name instead
+		if netInfo.IsDefault() {
+			knownDefaultLBGroups := []string{
+				types.ClusterLBGroupName,
+				types.ClusterSwitchLBGroupName,
+				types.ClusterRouterLBGroupName,
+			}
+			for _, knownGroup := range knownDefaultLBGroups {
+				if item.Name == knownGroup {
+					return true
+
+				}
+			}
+			return false
+		}
+		// UDN
+		return strings.HasPrefix(item.Name, netInfo.GetNetworkName())
 	}
+
 	groups, err := libovsdbops.FindLoadBalancerGroupsWithPredicate(nbClient, pg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not list load balancer groups: %w", err)

--- a/go-controller/pkg/ovn/controller/services/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/loadbalancer_test.go
@@ -6,11 +6,15 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilpointer "k8s.io/utils/pointer"
+)
+
+var (
+	name      string = "foo"
+	namespace string = "testns"
 )
 
 func TestEnsureStaleLBs(t *testing.T) {
@@ -19,12 +23,6 @@ func TestEnsureStaleLBs(t *testing.T) {
 		t.Fatalf("Error creating NB: %v", err)
 	}
 	t.Cleanup(cleanup.Cleanup)
-	name := "foo"
-	namespace := "testns"
-	defaultExternalIDs := map[string]string{
-		types.LoadBalancerKindExternalID:  "Service",
-		types.LoadBalancerOwnerExternalID: fmt.Sprintf("%s/%s", namespace, name),
-	}
 
 	defaultService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -36,7 +34,7 @@ func TestEnsureStaleLBs(t *testing.T) {
 	staleLBs := []LB{
 		{
 			Name:        "Service_testns/foo_TCP_node_router_node-a",
-			ExternalIDs: defaultExternalIDs,
+			ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 			Routers:     []string{"gr-node-a", "non-exisitng-router"},
 			Switches:    []string{"non-exisitng-switch"},
 			Groups:      []string{"non-existing-group"},
@@ -51,7 +49,7 @@ func TestEnsureStaleLBs(t *testing.T) {
 		},
 		{
 			Name:        "Service_testns/foo_TCP_node_is_gone",
-			ExternalIDs: defaultExternalIDs,
+			ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 			Routers:     []string{"gr-node-is-gone", "non-exisitng-router"},
 			Switches:    []string{"non-exisitng-switch"},
 			Groups:      []string{"non-existing-group"},
@@ -71,7 +69,7 @@ func TestEnsureStaleLBs(t *testing.T) {
 	LBs := []LB{
 		{
 			Name:        "Service_testns/foo_TCP_node_router_node-a",
-			ExternalIDs: defaultExternalIDs,
+			ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 			Routers:     []string{"gr-node-a"},
 			Protocol:    "TCP",
 			Rules: []LBRule{
@@ -102,7 +100,7 @@ func TestEnsureLBs(t *testing.T) {
 		{
 			desc: "create service with permanent session affinity",
 			service: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "testns"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 				Spec: v1.ServiceSpec{
 					Type:            v1.ServiceTypeClusterIP,
 					SessionAffinity: v1.ServiceAffinityClientIP,
@@ -115,13 +113,10 @@ func TestEnsureLBs(t *testing.T) {
 			},
 			LBs: []LB{
 				{
-					Name: "Service_foo/testns_TCP_cluster",
-					ExternalIDs: map[string]string{
-						types.LoadBalancerKindExternalID:  "Service",
-						types.LoadBalancerOwnerExternalID: fmt.Sprintf("%s/%s", "foo", "testns"),
-					},
-					Routers:  []string{"gr-node-a"},
-					Protocol: "TCP",
+					Name:        "Service_foo/testns_TCP_cluster",
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
+					Routers:     []string{"gr-node-a"},
+					Protocol:    "TCP",
 					Rules: []LBRule{
 						{
 							Source:  Addr{IP: "192.168.1.1", Port: 80},
@@ -136,21 +131,21 @@ func TestEnsureLBs(t *testing.T) {
 				},
 			},
 			finalLB: &nbdb.LoadBalancer{
-				UUID:     loadBalancerClusterWideTCPServiceName("foo", "testns"),
-				Name:     loadBalancerClusterWideTCPServiceName("foo", "testns"),
+				UUID:     loadBalancerClusterWideTCPServiceName(name, namespace),
+				Name:     loadBalancerClusterWideTCPServiceName(name, namespace),
 				Options:  servicesOptions(),
 				Protocol: &nbdb.LoadBalancerProtocolTCP,
 				Vips: map[string]string{
 					"192.168.1.1:80": "10.0.244.3:8080",
 				},
-				ExternalIDs:     serviceExternalIDs(namespacedServiceName("foo", "testns")),
+				ExternalIDs:     serviceExternalIDs(namespacedServiceName(namespace, name)),
 				SelectionFields: []string{"ip_src", "ip_dst"}, // permanent session affinity, no learn flows
 			},
 		},
 		{
 			desc: "create service with default session affinity timeout",
 			service: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "testns"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 				Spec: v1.ServiceSpec{
 					Type:            v1.ServiceTypeClusterIP,
 					SessionAffinity: v1.ServiceAffinityClientIP,
@@ -163,13 +158,10 @@ func TestEnsureLBs(t *testing.T) {
 			},
 			LBs: []LB{
 				{
-					Name: "Service_foo/testns_TCP_cluster",
-					ExternalIDs: map[string]string{
-						types.LoadBalancerKindExternalID:  "Service",
-						types.LoadBalancerOwnerExternalID: fmt.Sprintf("%s/%s", "foo", "testns"),
-					},
-					Routers:  []string{"gr-node-a"},
-					Protocol: "TCP",
+					Name:        "Service_foo/testns_TCP_cluster",
+					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
+					Routers:     []string{"gr-node-a"},
+					Protocol:    "TCP",
 					Rules: []LBRule{
 						{
 							Source:  Addr{IP: "192.168.1.1", Port: 80},
@@ -184,14 +176,14 @@ func TestEnsureLBs(t *testing.T) {
 				},
 			},
 			finalLB: &nbdb.LoadBalancer{
-				UUID:     loadBalancerClusterWideTCPServiceName("foo", "testns"),
-				Name:     loadBalancerClusterWideTCPServiceName("foo", "testns"),
+				UUID:     loadBalancerClusterWideTCPServiceName(name, namespace),
+				Name:     loadBalancerClusterWideTCPServiceName(name, namespace),
 				Options:  servicesOptionsWithAffinityTimeout(), // timeout set in the options
 				Protocol: &nbdb.LoadBalancerProtocolTCP,
 				Vips: map[string]string{
 					"192.168.1.1:80": "10.0.244.3:8080",
 				},
-				ExternalIDs: serviceExternalIDs(namespacedServiceName("foo", "testns")),
+				ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
 			},
 		},
 	}
@@ -217,7 +209,7 @@ func TestEnsureLBs(t *testing.T) {
 				tt.finalLB,
 				&nbdb.LogicalRouter{
 					Name:         "gr-node-a",
-					LoadBalancer: []string{loadBalancerClusterWideTCPServiceName("foo", "testns")},
+					LoadBalancer: []string{loadBalancerClusterWideTCPServiceName(name, namespace)},
 				},
 			})
 			success, err := matcher.Match(nbClient)

--- a/go-controller/pkg/ovn/controller/services/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/loadbalancer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilpointer "k8s.io/utils/pointer"
@@ -82,7 +83,7 @@ func TestEnsureStaleLBs(t *testing.T) {
 			UUID: "", // intentionally left empty to make sure EnsureLBs sets it properly
 		},
 	}
-	err = EnsureLBs(nbClient, defaultService, staleLBs, LBs)
+	err = EnsureLBs(nbClient, defaultService, staleLBs, LBs, &util.DefaultNetInfo{})
 	if err != nil {
 		t.Fatalf("Error EnsureLBs: %v", err)
 	}
@@ -208,7 +209,7 @@ func TestEnsureLBs(t *testing.T) {
 			}
 			t.Cleanup(cleanup.Cleanup)
 
-			err = EnsureLBs(nbClient, tt.service, []LB{}, tt.LBs)
+			err = EnsureLBs(nbClient, tt.service, []LB{}, tt.LBs, &util.DefaultNetInfo{})
 			if err != nil {
 				t.Fatalf("Error EnsureLBs: %v", err)
 			}

--- a/go-controller/pkg/ovn/controller/services/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/loadbalancer_test.go
@@ -34,9 +34,9 @@ func TestEnsureStaleLBs(t *testing.T) {
 	staleLBs := []LB{
 		{
 			Name:        "Service_testns/foo_TCP_node_router_node-a",
-			ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
-			Routers:     []string{"gr-node-a", "non-exisitng-router"},
-			Switches:    []string{"non-exisitng-switch"},
+			ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(namespace, name)),
+			Routers:     []string{"gr-node-a", "non-existing-router"},
+			Switches:    []string{"non-existing-switch"},
 			Groups:      []string{"non-existing-group"},
 			Protocol:    "TCP",
 			Rules: []LBRule{
@@ -49,9 +49,9 @@ func TestEnsureStaleLBs(t *testing.T) {
 		},
 		{
 			Name:        "Service_testns/foo_TCP_node_is_gone",
-			ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
-			Routers:     []string{"gr-node-is-gone", "non-exisitng-router"},
-			Switches:    []string{"non-exisitng-switch"},
+			ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(namespace, name)),
+			Routers:     []string{"gr-node-is-gone", "non-existing-router"},
+			Switches:    []string{"non-existing-switch"},
 			Groups:      []string{"non-existing-group"},
 			Protocol:    "TCP",
 			Rules: []LBRule{
@@ -69,7 +69,7 @@ func TestEnsureStaleLBs(t *testing.T) {
 	LBs := []LB{
 		{
 			Name:        "Service_testns/foo_TCP_node_router_node-a",
-			ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
+			ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(namespace, name)),
 			Routers:     []string{"gr-node-a"},
 			Protocol:    "TCP",
 			Rules: []LBRule{
@@ -114,7 +114,7 @@ func TestEnsureLBs(t *testing.T) {
 			LBs: []LB{
 				{
 					Name:        "Service_foo/testns_TCP_cluster",
-					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
+					ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -131,14 +131,14 @@ func TestEnsureLBs(t *testing.T) {
 				},
 			},
 			finalLB: &nbdb.LoadBalancer{
-				UUID:     loadBalancerClusterWideTCPServiceName(name, namespace),
-				Name:     loadBalancerClusterWideTCPServiceName(name, namespace),
+				UUID:     clusterWideTCPServiceLoadBalancerName(name, namespace),
+				Name:     clusterWideTCPServiceLoadBalancerName(name, namespace),
 				Options:  servicesOptions(),
 				Protocol: &nbdb.LoadBalancerProtocolTCP,
 				Vips: map[string]string{
 					"192.168.1.1:80": "10.0.244.3:8080",
 				},
-				ExternalIDs:     serviceExternalIDs(namespacedServiceName(namespace, name)),
+				ExternalIDs:     loadBalancerExternalIDs(namespacedServiceName(namespace, name)),
 				SelectionFields: []string{"ip_src", "ip_dst"}, // permanent session affinity, no learn flows
 			},
 		},
@@ -159,7 +159,7 @@ func TestEnsureLBs(t *testing.T) {
 			LBs: []LB{
 				{
 					Name:        "Service_foo/testns_TCP_cluster",
-					ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
+					ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(namespace, name)),
 					Routers:     []string{"gr-node-a"},
 					Protocol:    "TCP",
 					Rules: []LBRule{
@@ -176,14 +176,14 @@ func TestEnsureLBs(t *testing.T) {
 				},
 			},
 			finalLB: &nbdb.LoadBalancer{
-				UUID:     loadBalancerClusterWideTCPServiceName(name, namespace),
-				Name:     loadBalancerClusterWideTCPServiceName(name, namespace),
+				UUID:     clusterWideTCPServiceLoadBalancerName(name, namespace),
+				Name:     clusterWideTCPServiceLoadBalancerName(name, namespace),
 				Options:  servicesOptionsWithAffinityTimeout(), // timeout set in the options
 				Protocol: &nbdb.LoadBalancerProtocolTCP,
 				Vips: map[string]string{
 					"192.168.1.1:80": "10.0.244.3:8080",
 				},
-				ExternalIDs: serviceExternalIDs(namespacedServiceName(namespace, name)),
+				ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(namespace, name)),
 			},
 		},
 	}
@@ -209,7 +209,7 @@ func TestEnsureLBs(t *testing.T) {
 				tt.finalLB,
 				&nbdb.LogicalRouter{
 					Name:         "gr-node-a",
-					LoadBalancer: []string{loadBalancerClusterWideTCPServiceName(name, namespace)},
+					LoadBalancer: []string{clusterWideTCPServiceLoadBalancerName(name, namespace)},
 				},
 			})
 			success, err := matcher.Match(nbClient)

--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -8,6 +8,7 @@ import (
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -50,7 +51,7 @@ func newRepair(serviceLister corelisters.ServiceLister, nbClient libovsdbclient.
 }
 
 // runBeforeSync performs some cleanup of stale LBs and other miscellaneous setup.
-func (r *repair) runBeforeSync(useTemplates bool) {
+func (r *repair) runBeforeSync(useTemplates bool, netInfo util.NetInfo) {
 	// no need to lock, single-threaded.
 
 	startTime := time.Now()
@@ -80,7 +81,7 @@ func (r *repair) runBeforeSync(useTemplates bool) {
 	}
 
 	// Find all load-balancers associated with Services
-	existingLBs, err := getLBs(r.nbClient, allTemplates)
+	existingLBs, err := getAllLBs(r.nbClient, allTemplates)
 	if err != nil {
 		klog.Errorf("Unable to get service lbs for repair: %v", err)
 	}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -20,14 +21,15 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	discoverylisters "k8s.io/client-go/listers/discovery/v1"
 
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	discoverylisters "k8s.io/client-go/listers/discovery/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -47,7 +49,7 @@ const (
 	nodeControllerName = "node-tracker-controller"
 )
 
-var NoServiceLabelError = fmt.Errorf("endpointSlice missing %s label", discovery.LabelServiceName)
+var NoServiceLabelError = fmt.Errorf("endpointSlice missing the service name label")
 
 // NewController returns a new *Controller.
 func NewController(client clientset.Interface,
@@ -55,7 +57,9 @@ func NewController(client clientset.Interface,
 	serviceInformer coreinformers.ServiceInformer,
 	endpointSliceInformer discoveryinformers.EndpointSliceInformer,
 	nodeInformer coreinformers.NodeInformer,
+	nadLister nadlister.NetworkAttachmentDefinitionLister,
 	recorder record.EventRecorder,
+	netInfo util.NetInfo,
 ) (*Controller, error) {
 	klog.V(4).Info("Creating event broadcaster")
 	c := &Controller{
@@ -70,10 +74,13 @@ func NewController(client clientset.Interface,
 		serviceLister:         serviceInformer.Lister(),
 		endpointSliceInformer: endpointSliceInformer,
 		endpointSliceLister:   endpointSliceInformer.Lister(),
-		eventRecorder:         recorder,
-		repair:                newRepair(serviceInformer.Lister(), nbClient),
-		nodeInformer:          nodeInformer,
-		nodesSynced:           nodeInformer.Informer().HasSynced,
+		nadLister:             nadLister,
+
+		eventRecorder: recorder,
+		repair:        newRepair(serviceInformer.Lister(), nbClient),
+		nodeInformer:  nodeInformer,
+		nodesSynced:   nodeInformer.Informer().HasSynced,
+		netInfo:       netInfo,
 	}
 	zone, err := libovsdbutil.GetNBZone(c.nbClient)
 	if err != nil {
@@ -82,11 +89,10 @@ func NewController(client clientset.Interface,
 	// load balancers need to be applied to nodes, so
 	// we need to watch Node objects for changes.
 	// Need to re-sync all services when a node gains its switch or GWR
-	c.nodeTracker = newNodeTracker(zone, c.RequestFullSync)
+	c.nodeTracker = newNodeTracker(zone, c.RequestFullSync, netInfo)
 	if err != nil {
 		return nil, err
 	}
-
 	return c, nil
 }
 
@@ -103,9 +109,9 @@ type Controller struct {
 	serviceLister corelisters.ServiceLister
 
 	endpointSliceInformer discoveryinformers.EndpointSliceInformer
-	// endpointSliceLister is able to list/get endpoint slices and is populated
-	// by the shared informer passed to NewController
-	endpointSliceLister discoverylisters.EndpointSliceLister
+	endpointSliceLister   discoverylisters.EndpointSliceLister
+
+	nadLister nadlister.NetworkAttachmentDefinitionLister
 
 	nodesSynced cache.InformerSynced
 
@@ -154,6 +160,8 @@ type Controller struct {
 
 	// 'true' if Chassis_Template_Var is supported.
 	useTemplates bool
+
+	netInfo util.NetInfo
 }
 
 // Run will not return until stopCh is closed. workers determines how many
@@ -193,13 +201,15 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 
 	klog.Info("Setting up event handlers for endpoint slices")
 	endpointHandler, err := c.endpointSliceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(
-		// Filter out objects without the default serviceName label to exclude mirrored EndpointSlices
-		// This controller instance only handles services in the default cluster network
-		util.GetDefaultEndpointSlicesEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    c.onEndpointSliceAdd,
-			UpdateFunc: c.onEndpointSliceUpdate,
-			DeleteFunc: c.onEndpointSliceDelete,
-		})))
+		// Filter out endpointslices that don't belong to this network (i.e. keep only kube-generated endpointslices if
+		// on default network, keep only mirrored endpointslices for this network if on UDN)
+		util.GetEndpointSlicesEventHandlerForNetwork(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc:    c.onEndpointSliceAdd,
+				UpdateFunc: c.onEndpointSliceUpdate,
+				DeleteFunc: c.onEndpointSliceDelete,
+			},
+			c.netInfo)))
 	if err != nil {
 		return err
 	}
@@ -213,7 +223,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 		// Run the repair controller only once
 		// it keeps in sync Kubernetes and OVN
 		// and handles removal of stale data on upgrades
-		c.repair.runBeforeSync(c.useTemplates)
+		c.repair.runBeforeSync(c.useTemplates, c.netInfo)
 	}
 
 	if err := c.initTopLevelCache(); err != nil {
@@ -302,7 +312,7 @@ func (c *Controller) initTopLevelCache() error {
 	}
 
 	// Then list all load balancers and their respective services.
-	services, lbs, err := getServiceLBs(c.nbClient, allTemplates)
+	services, lbs, err := getServiceLBsForNetwork(c.nbClient, allTemplates, c.netInfo)
 	if err != nil {
 		return fmt.Errorf("failed to load balancers: %w", err)
 	}
@@ -380,7 +390,7 @@ func (c *Controller) syncService(key string) error {
 			// worker will be operating at a given service. That is why it is safe to have changes to this cache
 			// from multiple workers, because the `key` is always uniquely hashed to the same worker thread.
 
-			if err := EnsureLBs(c.nbClient, service, existingLBs, nil); err != nil {
+			if err := EnsureLBs(c.nbClient, service, existingLBs, nil, c.netInfo); err != nil {
 				return fmt.Errorf("failed to delete load balancers for service %s/%s: %w",
 					namespace, name, err)
 			}
@@ -394,38 +404,29 @@ func (c *Controller) syncService(key string) error {
 		return nil
 	}
 
-	//
 	// The Service exists in the cache: update it in OVN
+	klog.V(5).Infof("Service %s/%s retrieved from lister for network=%s: %v", service.Namespace, service.Name, c.netInfo.GetNetworkName(), service)
 
-	klog.V(5).Infof("Service %s retrieved from lister: %v", service.Name, service)
-
-	// Get the endpoint slices associated to the Service
-	esLabelSelector := labels.Set(map[string]string{
-		discovery.LabelServiceName: name,
-	}).AsSelectorPreValidated()
-	endpointSlices, err := c.endpointSliceLister.EndpointSlices(namespace).List(esLabelSelector)
+	endpointSlices, err := util.GetServiceEndpointSlices(namespace, service.Name, c.netInfo.GetNetworkName(), c.endpointSliceLister)
 	if err != nil {
-		// Since we're getting stuff from a local cache, it is basically impossible to get this error.
-		c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToListEndpointSlices",
-			"Error listing Endpoint Slices for Service %s/%s: %v", namespace, name, err)
-		return err
+		return fmt.Errorf("service %s/%s for network=%s, %w", service.Namespace, service.Name, c.netInfo.GetNetworkName(), err)
 	}
 
 	// Build the abstract LB configs for this service
-	perNodeConfigs, templateConfigs, clusterConfigs := buildServiceLBConfigs(service, endpointSlices, c.nodeInfos, c.useLBGroups, c.useTemplates)
-	klog.V(5).Infof("Built service %s LB cluster-wide configs %#v", key, clusterConfigs)
-	klog.V(5).Infof("Built service %s LB per-node configs %#v", key, perNodeConfigs)
-	klog.V(5).Infof("Built service %s LB template configs %#v", key, templateConfigs)
+	perNodeConfigs, templateConfigs, clusterConfigs := buildServiceLBConfigs(service, endpointSlices, c.nodeInfos, c.useLBGroups, c.useTemplates, c.netInfo.GetNetworkName())
+	klog.V(5).Infof("Built service %s LB cluster-wide configs for network=%s: %#v", key, c.netInfo.GetNetworkName(), clusterConfigs)
+	klog.V(5).Infof("Built service %s LB per-node configs for network=%s:  %#v", key, c.netInfo.GetNetworkName(), perNodeConfigs)
+	klog.V(5).Infof("Built service %s LB template configs for network=%s: %#v", key, c.netInfo.GetNetworkName(), templateConfigs)
 
 	// Convert the LB configs in to load-balancer objects
-	clusterLBs := buildClusterLBs(service, clusterConfigs, c.nodeInfos, c.useLBGroups)
-	templateLBs := buildTemplateLBs(service, templateConfigs, c.nodeInfos, c.nodeIPv4Templates, c.nodeIPv6Templates)
-	perNodeLBs := buildPerNodeLBs(service, perNodeConfigs, c.nodeInfos)
-	klog.V(5).Infof("Built service %s cluster-wide LB %#v", key, clusterLBs)
-	klog.V(5).Infof("Built service %s per-node LB %#v", key, perNodeLBs)
-	klog.V(5).Infof("Built service %s template LB %#v", key, templateLBs)
-	klog.V(5).Infof("Service %s has %d cluster-wide, %d per-node configs, %d template configs, making %d (cluster) %d (per node) and %d (template) load balancers",
-		key, len(clusterConfigs), len(perNodeConfigs), len(templateConfigs),
+	clusterLBs := buildClusterLBs(service, clusterConfigs, c.nodeInfos, c.useLBGroups, c.netInfo)
+	templateLBs := buildTemplateLBs(service, templateConfigs, c.nodeInfos, c.nodeIPv4Templates, c.nodeIPv6Templates, c.netInfo)
+	perNodeLBs := buildPerNodeLBs(service, perNodeConfigs, c.nodeInfos, c.netInfo)
+	klog.V(5).Infof("Built service %s cluster-wide LB for network=%s: %#v", key, c.netInfo.GetNetworkName(), clusterLBs)
+	klog.V(5).Infof("Built service %s per-node LB for network=%s: %#v", key, c.netInfo.GetNetworkName(), perNodeLBs)
+	klog.V(5).Infof("Built service %s template LB for network=%s:  %#v", key, c.netInfo.GetNetworkName(), templateLBs)
+	klog.V(5).Infof("Service %s for network=%s has %d cluster-wide, %d per-node configs, %d template configs, making %d (cluster) %d (per node) and %d (template) load balancers",
+		key, c.netInfo.GetNetworkName(), len(clusterConfigs), len(perNodeConfigs), len(templateConfigs),
 		len(clusterLBs), len(perNodeLBs), len(templateLBs))
 	lbs := append(clusterLBs, templateLBs...)
 	lbs = append(lbs, perNodeLBs...)
@@ -448,8 +449,8 @@ func (c *Controller) syncService(key string) error {
 		//
 		// Note: this may fail if a node was deleted between listing nodes and applying.
 		// If so, this will fail and we will resync.
-		if err := EnsureLBs(c.nbClient, service, existingLBs, lbs); err != nil {
-			return fmt.Errorf("failed to ensure service %s load balancers: %w", key, err)
+		if err := EnsureLBs(c.nbClient, service, existingLBs, lbs, c.netInfo); err != nil {
+			return fmt.Errorf("failed to ensure service %s load balancers for network=%s: %w", key, c.netInfo.GetNetworkName(), err)
 		}
 
 		c.alreadyAppliedRWLock.Lock()
@@ -544,16 +545,38 @@ func (c *Controller) RequestFullSync(nodeInfos []nodeInfo) {
 
 // handlers
 
+// skipService is used when UDN is enabled to know which services are to be skipped because they don't
+// belong to the network that this service controller is responsible for.
+func (c *Controller) skipService(name, namespace string) bool {
+	if util.IsNetworkSegmentationSupportEnabled() {
+		serviceNetwork, err := util.GetActiveNetworkForNamespace(namespace, c.nadLister)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to retrieve network for service %s/%s: %w",
+				namespace, name, err))
+			return true
+		}
+		if serviceNetwork.GetNetworkName() != c.netInfo.GetNetworkName() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // onServiceAdd queues the Service for processing.
 func (c *Controller) onServiceAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v for network=%s: %v", obj, c.netInfo.GetNetworkName(), err))
 		return
 	}
-	klog.V(5).Infof("Adding service %s", key)
+
 	service := obj.(*v1.Service)
+	if c.skipService(service.Name, service.Namespace) {
+		return
+	}
 	metrics.GetConfigDurationRecorder().Start("service", service.Namespace, service.Name)
+	klog.V(5).Infof("Adding service %s for network=%s", c.netInfo.GetNetworkName(), key)
 	c.queue.Add(key)
 }
 
@@ -570,6 +593,10 @@ func (c *Controller) onServiceUpdate(oldObj, newObj interface{}) {
 
 	key, err := cache.MetaNamespaceKeyFunc(newObj)
 	if err == nil {
+		if c.skipService(newService.Name, newService.Namespace) {
+			return
+		}
+
 		metrics.GetConfigDurationRecorder().Start("service", newService.Namespace, newService.Name)
 		c.queue.Add(key)
 	}
@@ -584,6 +611,11 @@ func (c *Controller) onServiceDelete(obj interface{}) {
 	}
 	klog.V(4).Infof("Deleting service %s", key)
 	service := obj.(*v1.Service)
+
+	if c.skipService(service.Name, service.Namespace) {
+		return
+	}
+
 	metrics.GetConfigDurationRecorder().Start("service", service.Namespace, service.Name)
 	c.queue.Add(key)
 }
@@ -637,7 +669,7 @@ func (c *Controller) onEndpointSliceDelete(obj interface{}) {
 // queueServiceForEndpointSlice attempts to queue the corresponding Service for
 // the provided EndpointSlice.
 func (c *Controller) queueServiceForEndpointSlice(endpointSlice *discovery.EndpointSlice) {
-	key, err := ServiceControllerKey(endpointSlice)
+	serviceNamespacedName, err := c.getServiceNamespacedNameFromEndpointSlice(endpointSlice)
 	if err != nil {
 		// Do not log endpointsSlices missing service labels as errors.
 		// Once the service label is eventually added, we will get this event
@@ -650,21 +682,49 @@ func (c *Controller) queueServiceForEndpointSlice(endpointSlice *discovery.Endpo
 		return
 	}
 
-	c.queue.Add(key)
+	if c.skipService(serviceNamespacedName.Name, serviceNamespacedName.Namespace) {
+		return
+	}
+	c.queue.Add(serviceNamespacedName.String())
 }
 
-// serviceControllerKey returns a controller key for a Service but derived from
+// GetServiceKeyFromEndpointSliceForDefaultNetwork returns a controller key for a Service but derived from
 // an EndpointSlice.
-func ServiceControllerKey(endpointSlice *discovery.EndpointSlice) (string, error) {
+// Not UDN-aware, is used for egress services
+func GetServiceKeyFromEndpointSliceForDefaultNetwork(endpointSlice *discovery.EndpointSlice) (string, error) {
+	var key string
+	nsn, err := _getServiceNameFromEndpointSlice(endpointSlice, true)
+	if err == nil {
+		key = nsn.String()
+	}
+	return key, err
+}
+
+func (c *Controller) getServiceNamespacedNameFromEndpointSlice(endpointSlice *discovery.EndpointSlice) (ktypes.NamespacedName, error) {
+	if c.netInfo.IsDefault() {
+		return _getServiceNameFromEndpointSlice(endpointSlice, true)
+	} else {
+		return _getServiceNameFromEndpointSlice(endpointSlice, false)
+	}
+}
+
+func _getServiceNameFromEndpointSlice(endpointSlice *discovery.EndpointSlice, inDefaultNetwork bool) (ktypes.NamespacedName, error) {
 	if endpointSlice == nil {
-		return "", fmt.Errorf("nil EndpointSlice passed to serviceControllerKey()")
+		return ktypes.NamespacedName{}, fmt.Errorf("nil EndpointSlice passed to _getServiceNameFromEndpointSlice()")
 	}
-	serviceName, ok := endpointSlice.Labels[discovery.LabelServiceName]
+
+	label := discovery.LabelServiceName
+	errTemplate := NoServiceLabelError
+	if !inDefaultNetwork {
+		label = types.LabelUserDefinedServiceName
+	}
+
+	serviceName, ok := endpointSlice.Labels[label]
 	if !ok || serviceName == "" {
-		return "", fmt.Errorf("%w: endpointSlice: %s/%s", NoServiceLabelError, endpointSlice.Namespace,
-			endpointSlice.Name)
+		return ktypes.NamespacedName{}, fmt.Errorf("%w: endpointSlice: %s/%s",
+			errTemplate, endpointSlice.Namespace, endpointSlice.Name)
 	}
-	return fmt.Sprintf("%s/%s", endpointSlice.Namespace, serviceName), nil
+	return ktypes.NamespacedName{Namespace: endpointSlice.Namespace, Name: serviceName}, nil
 }
 
 // newRateLimiter makes a queue rate limiter. This limits re-queues somewhat more significantly than base qps.

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	kube_test "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	v1nadmocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -75,7 +77,9 @@ func newControllerWithDBSetup(dbSetup libovsdbtest.TestSetup) (*serviceControlle
 		informerFactory.Core().V1().Services(),
 		informerFactory.Discovery().V1().EndpointSlices(),
 		informerFactory.Core().V1().Nodes(),
+		&v1nadmocks.NetworkAttachmentDefinitionLister{},
 		recorder,
+		&util.DefaultNetInfo{},
 	)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -785,6 +785,8 @@ func serviceExternalIDs(namespacedServiceName string) map[string]string {
 	return map[string]string{
 		types.LoadBalancerKindExternalID:  "Service",
 		types.LoadBalancerOwnerExternalID: namespacedServiceName,
+		types.NetworkExternalID:           types.DefaultNetworkName,
+		types.NetworkRoleExternalID:       types.NetworkRoleDefault,
 	}
 }
 

--- a/go-controller/pkg/ovn/controller/services/svc_template_var.go
+++ b/go-controller/pkg/ovn/controller/services/svc_template_var.go
@@ -10,6 +10,7 @@ import (
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -188,10 +189,10 @@ func isLBNodeIPTemplateName(name string) bool {
 
 // makeLBTargetTemplateName builds a load balancer target template name.
 func makeLBTargetTemplateName(service *corev1.Service, proto corev1.Protocol, port int32,
-	family corev1.IPFamily, scope string) string {
+	family corev1.IPFamily, scope string, netInfo util.NetInfo) string {
 	return makeTemplateName(
-		makeLBName(service, proto,
-			fmt.Sprintf("%d_%s_%v", port, scope, family)))
+		makeLBNameForNetwork(service, proto,
+			fmt.Sprintf("%d_%s_%v", port, scope, family), netInfo))
 }
 
 // getTemplatesFromRulesTargets returns the map of template variables referred

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -4,6 +4,11 @@ import (
 	"net"
 
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	v1 "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 )
 
 // hasHostEndpoints determines if a slice of endpoints contains a host networked pod
@@ -24,4 +29,22 @@ func IsHostEndpoint(endpointIP string) bool {
 		}
 	}
 	return true
+}
+
+func getExternalIDsForLoadBalancer(service *v1.Service, netInfo util.NetInfo) map[string]string {
+	nsn := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+
+	externalIDs := map[string]string{
+		types.LoadBalancerOwnerExternalID: nsn.String(),
+		types.LoadBalancerKindExternalID:  "Service",
+	}
+
+	if netInfo.IsDefault() {
+		return externalIDs
+	}
+
+	externalIDs[types.NetworkExternalID] = netInfo.GetNetworkName()
+	externalIDs[types.NetworkRoleExternalID] = util.GetUserDefinedNetworkRole(netInfo.IsPrimaryNetwork())
+
+	return externalIDs
 }

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -1,0 +1,73 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExternalIDsForLoadBalancer(t *testing.T) {
+	name := "svc-ab23"
+	namespace := "ns"
+	defaultNetInfo := util.DefaultNetInfo{}
+	UDNNetInfo := getSampleUDNNetInfo(namespace)
+	assert.Equal(t,
+		map[string]string{
+			types.LoadBalancerKindExternalID:  "Service",
+			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
+		},
+		getExternalIDsForLoadBalancer(&v1.Service{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+			},
+		}, &defaultNetInfo),
+	)
+
+	assert.Equal(t,
+		map[string]string{
+			types.LoadBalancerKindExternalID:  "Service",
+			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
+		},
+		getExternalIDsForLoadBalancer(&v1.Service{
+			// also handle no TypeMeta, which can happen.
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+			},
+		}, &defaultNetInfo),
+	)
+
+	assert.Equal(t,
+		map[string]string{
+			types.LoadBalancerKindExternalID:  "Service",
+			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
+			types.NetworkExternalID:           UDNNetInfo.GetNetworkName(),
+			types.NetworkRoleExternalID:       types.NetworkRolePrimary,
+		},
+		getExternalIDsForLoadBalancer(&v1.Service{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+			},
+		}, UDNNetInfo),
+	)
+
+}

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/exp/maps"
 	kapi "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -268,10 +269,7 @@ func (gw *GatewayManager) GatewayInit(
 	}
 
 	if gw.netInfo.IsSecondary() {
-		networkName := gw.netInfo.GetNetworkName()
-		topologyType := gw.netInfo.TopologyType()
-		logicalRouterExternalIDs[types.NetworkExternalID] = networkName
-		logicalRouterExternalIDs[types.TopologyExternalID] = topologyType
+		maps.Copy(logicalRouterExternalIDs, util.GenerateExternalIDsForSwitchOrRouter(gw.netInfo))
 	}
 
 	logicalRouter := nbdb.LogicalRouter{
@@ -832,10 +830,7 @@ func (gw *GatewayManager) addExternalSwitch(prefix, interfaceID, nodeName, gatew
 	}
 	sw := nbdb.LogicalSwitch{Name: externalSwitch}
 	if gw.netInfo.IsSecondary() {
-		sw.ExternalIDs = map[string]string{
-			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
-			types.TopologyExternalID: gw.netInfo.TopologyType(),
-		}
+		sw.ExternalIDs = util.GenerateExternalIDsForSwitchOrRouter(gw.netInfo)
 	}
 
 	err = libovsdbops.CreateOrUpdateLogicalSwitchPortsAndSwitch(gw.nbClient, &sw, &externalLogicalSwitchPort, &externalLogicalSwitchPortToRouter)

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -111,7 +111,7 @@ func withInterconnectCluster() option {
 	}
 }
 
-func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() []libovsdbtest.TestData {
+func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(isPrimary bool) []libovsdbtest.TestData {
 	data := []libovsdbtest.TestData{}
 	for _, ocInfo := range em.fakeOvn.secondaryControllers {
 		nodeslsps := make(map[string][]string)
@@ -235,10 +235,13 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 			}
 
 			data = append(data, &nbdb.LogicalSwitch{
-				UUID:        switchName + "-UUID",
-				Name:        switchName,
-				Ports:       nodeslsps[switchName],
-				ExternalIDs: map[string]string{ovntypes.NetworkExternalID: ocInfo.bnc.GetNetworkName()},
+				UUID:  switchName + "-UUID",
+				Name:  switchName,
+				Ports: nodeslsps[switchName],
+				ExternalIDs: map[string]string{
+					ovntypes.NetworkExternalID:     ocInfo.bnc.GetNetworkName(),
+					ovntypes.NetworkRoleExternalID: util.GetUserDefinedNetworkRole(isPrimary),
+				},
 				OtherConfig: otherConfig,
 				ACLs:        acls[switchName],
 			})
@@ -324,10 +327,11 @@ func expectedManagementPort(portName string, ip string) *nbdb.LogicalSwitchPort 
 
 func gwRouterExternalIDs(netInfo util.NetInfo, gwConfig util.L3GatewayConfig) map[string]string {
 	return map[string]string{
-		ovntypes.NetworkExternalID:  netInfo.GetNetworkName(),
-		ovntypes.TopologyExternalID: netInfo.TopologyType(),
-		"physical_ip":               hostPhysicalIP(gwConfig),
-		"physical_ips":              strings.Join(hostIPsFromGWConfig(gwConfig), ","),
+		ovntypes.NetworkExternalID:     netInfo.GetNetworkName(),
+		ovntypes.NetworkRoleExternalID: getNetworkRole(netInfo),
+		ovntypes.TopologyExternalID:    netInfo.TopologyType(),
+		"physical_ip":                  hostPhysicalIP(gwConfig),
+		"physical_ips":                 strings.Join(hostIPsFromGWConfig(gwConfig), ","),
 	}
 }
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -439,7 +439,6 @@ func shouldUpdateNode(node, oldNode *kapi.Node) (bool, error) {
 }
 
 func (oc *DefaultNetworkController) StartServiceController(wg *sync.WaitGroup, runRepair bool) error {
-	klog.Infof("Starting OVN Service Controller: Using Endpoint Slices")
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -439,7 +439,8 @@ func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAt
 
 		switch topoType {
 		case types.Layer3Topology:
-			l3Controller := NewSecondaryLayer3NetworkController(cnci, nInfo)
+			l3Controller, err := NewSecondaryLayer3NetworkController(cnci, nInfo)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			l3Controller.addressSetFactory = asf
 			secondaryController = &l3Controller.BaseSecondaryNetworkController
 		case types.Layer2Topology:

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -145,7 +145,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 							fakeOvn,
 							[]testPod{podInfo},
 							expectationOptions...,
-						).expectedLogicalSwitchesAndPorts()...))
+						).expectedLogicalSwitchesAndPorts(netInfo.isPrimary)...))
 
 				return nil
 			}

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -836,7 +836,8 @@ func standardNonDefaultNetworkExtIDs(netInfo util.NetInfo) map[string]string {
 }
 
 func newSecondaryLayer3NetworkController(cnci *CommonNetworkControllerInfo, netInfo util.NetInfo, nodeName string) *SecondaryLayer3NetworkController {
-	layer3NetworkController := NewSecondaryLayer3NetworkController(cnci, netInfo)
+	layer3NetworkController, err := NewSecondaryLayer3NetworkController(cnci, netInfo)
+	Expect(err).NotTo(HaveOccurred())
 	layer3NetworkController.gatewayManagers.Store(
 		nodeName,
 		newDummyGatewayManager(cnci.kube, cnci.nbClient, netInfo, cnci.watchFactory, nodeName),

--- a/go-controller/pkg/ovn/topology/topologyfactory_test.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory_test.go
@@ -160,8 +160,8 @@ var _ = Describe("Topology factory", func() {
 					"0a:58:c0:a8:c8:0a",
 					nil,
 					map[string]string{
-						"k8s.ovn.org/network":  "angrytenant",
-						"k8s.ovn.org/topology": "layer3",
+						ovntypes.NetworkExternalID:  "angrytenant",
+						ovntypes.TopologyExternalID: "layer3",
 					},
 					ips(gwRoutersIPs...)...,
 				),

--- a/go-controller/pkg/testing/kube.go
+++ b/go-controller/pkg/testing/kube.go
@@ -51,15 +51,17 @@ func MakeTerminatingNonServingEndpoint(node string, addresses ...string) discove
 	}
 }
 
-func MirrorEndpointSlice(defaultEndpointSlice *discovery.EndpointSlice, network string) *discovery.EndpointSlice {
-	var mirror *discovery.EndpointSlice
-
-	mirror = defaultEndpointSlice.DeepCopy()
+func MirrorEndpointSlice(defaultEndpointSlice *discovery.EndpointSlice, network string, keepEndpoints bool) *discovery.EndpointSlice {
+	mirror := defaultEndpointSlice.DeepCopy()
 	mirror.Name = defaultEndpointSlice.Name + "-mirrored"
 	mirror.Labels[discovery.LabelManagedBy] = types.EndpointSliceMirrorControllerName
 	mirror.Labels[types.LabelSourceEndpointSlice] = defaultEndpointSlice.Name
 	mirror.Labels[types.LabelUserDefinedEndpointSliceNetwork] = network
 	mirror.Labels[types.LabelUserDefinedServiceName] = defaultEndpointSlice.Labels[discovery.LabelServiceName]
-	mirror.Endpoints = nil
+
+	if !keepEndpoints {
+		mirror.Endpoints = nil
+	}
+
 	return mirror
 }

--- a/go-controller/pkg/testing/kube.go
+++ b/go-controller/pkg/testing/kube.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/utils/ptr"
 )
@@ -48,4 +49,17 @@ func MakeTerminatingNonServingEndpoint(node string, addresses ...string) discove
 		Addresses: addresses,
 		NodeName:  &node,
 	}
+}
+
+func MirrorEndpointSlice(defaultEndpointSlice *discovery.EndpointSlice, network string) *discovery.EndpointSlice {
+	var mirror *discovery.EndpointSlice
+
+	mirror = defaultEndpointSlice.DeepCopy()
+	mirror.Name = defaultEndpointSlice.Name + "-mirrored"
+	mirror.Labels[discovery.LabelManagedBy] = types.EndpointSliceMirrorControllerName
+	mirror.Labels[types.LabelSourceEndpointSlice] = defaultEndpointSlice.Name
+	mirror.Labels[types.LabelUserDefinedEndpointSliceNetwork] = network
+	mirror.Labels[types.LabelUserDefinedServiceName] = defaultEndpointSlice.Labels[discovery.LabelServiceName]
+	mirror.Endpoints = nil
+	return mirror
 }

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -120,6 +120,12 @@ const (
 	EndpointSliceMirrorControllerName = "endpointslice-mirror-controller.k8s.ovn.org"
 	// EndpointSliceDefaultControllerName default kubernetes EndpointSlice controller name (used as a value for the "endpointslice.kubernetes.io/managed-by" label)
 	EndpointSliceDefaultControllerName = "endpointslice-controller.k8s.io"
+	// LabelSourceEndpointSlice label key used in mirrored EndpointSlice
+	// that has the value of the default EndpointSlice name
+	LabelSourceEndpointSlice = "k8s.ovn.org/source-endpointslice"
+	// LabelSourceEndpointSliceVersion label key used in mirrored EndpointSlice
+	// that has the value of the last known default EndpointSlice ResourceVersion
+	LabelSourceEndpointSliceVersion = "k8s.ovn.org/source-endpointslice-version"
 	// LabelUserDefinedEndpointSliceNetwork label key used in mirrored EndpointSlices that contains the current primary user defined network name
 	LabelUserDefinedEndpointSliceNetwork = "k8s.ovn.org/endpointslice-network"
 	// LabelUserDefinedServiceName label key used in mirrored EndpointSlices that contains the service name matching the EndpointSlice

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -185,7 +185,10 @@ const (
 
 	// key for network name external-id
 	NetworkExternalID = OvnK8sPrefix + "/" + "network"
+	// key for network role external-id: possible values are "default", "primary", "secondary"
+	NetworkRoleExternalID = OvnK8sPrefix + "/" + "role"
 	// key for NAD name external-id, only used for secondary logical switch port of a pod
+	// key for network name external-id
 	NADExternalID = OvnK8sPrefix + "/" + "nad"
 	// key for topology type external-id, only used for secondary network logical entities
 	TopologyExternalID = OvnK8sPrefix + "/" + "topology"
@@ -203,6 +206,7 @@ const (
 	// defined in CNI netconf as a user defined network
 	NetworkRolePrimary   = "primary"
 	NetworkRoleSecondary = "secondary"
+	NetworkRoleDefault   = "default"
 	// defined internally by ovnkube to recognize "default"
 	// network's role as a "infrastructure-locked" network
 	// when user defined network is the primary network for

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	kube_test "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	kubetest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 
 	"github.com/stretchr/testify/assert"
 	kapi "k8s.io/api/core/v1"
@@ -663,9 +663,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible endpoints from an endpointslice with all ready endpoints, one of which is on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeReadyEndpoint(testNode, ep1Address),
-				kube_test.MakeReadyEndpoint(testNode, ep2Address),
-				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+				kubetest.MakeReadyEndpoint(testNode, ep1Address),
+				kubetest.MakeReadyEndpoint(testNode, ep2Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep3Address),
 			},
 			"", // get all endpoints
 			[]string{ep1Address, ep2Address, ep3Address},
@@ -673,9 +673,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice with all ready endpoints, one of which is on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeReadyEndpoint(testNode, ep1Address),
-				kube_test.MakeReadyEndpoint(testNode, ep2Address),
-				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+				kubetest.MakeReadyEndpoint(testNode, ep1Address),
+				kubetest.MakeReadyEndpoint(testNode, ep2Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{ep1Address, ep2Address},
@@ -683,9 +683,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice with all ready endpoints, all of which are on another node",
 			[]discovery.Endpoint{
-				kube_test.MakeReadyEndpoint(otherNode, ep1Address),
-				kube_test.MakeReadyEndpoint(otherNode, ep2Address),
-				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep1Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep2Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{},
@@ -693,9 +693,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible endpoints from an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
-				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kubetest.MakeTerminatingServingEndpoint(otherNode, ep3Address),
 			},
 			"",
 			[]string{ep1Address, ep2Address, ep3Address}, // with no ready endpoints, we fallback to terminating serving endpoints
@@ -703,9 +703,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice with all non-ready, serving, terminating endpoints, one of which is on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
-				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kubetest.MakeTerminatingServingEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{ep1Address, ep2Address}, // with no ready endpoints, we fallback to terminating serving endpoints
@@ -713,9 +713,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice with all non-ready, serving, terminating endpoints, all of which are on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingServingEndpoint(otherNode, ep1Address),
-				kube_test.MakeTerminatingServingEndpoint(otherNode, ep2Address),
-				kube_test.MakeTerminatingServingEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingServingEndpoint(otherNode, ep1Address),
+				kubetest.MakeTerminatingServingEndpoint(otherNode, ep2Address),
+				kubetest.MakeTerminatingServingEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{},
@@ -723,9 +723,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible endpoints from an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
-				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kubetest.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
 			},
 			"",
 			[]string{},
@@ -733,9 +733,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice with all non-ready, non-serving, terminating endpoints, one of which is on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
-				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kubetest.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{},
@@ -743,9 +743,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice with endpoints showing a mix of status conditions, one of which is on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeReadyEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
-				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+				kubetest.MakeReadyEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kubetest.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{ep1Address}, // only the ready endpoint is included
@@ -753,9 +753,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice with endpoints showing a mix of status conditions, all of which are on a different node",
 			[]discovery.Endpoint{
-				kube_test.MakeReadyEndpoint(otherNode, ep1Address),
-				kube_test.MakeTerminatingServingEndpoint(otherNode, ep2Address),
-				kube_test.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep1Address),
+				kubetest.MakeTerminatingServingEndpoint(otherNode, ep2Address),
+				kubetest.MakeTerminatingNonServingEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{},
@@ -763,9 +763,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible endpoints from an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
-				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep3Address),
 			},
 			"",
 			[]string{ep3Address}, // fallback to serving&terminating should apply
@@ -773,9 +773,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice where all local endpoints are serving and terminating and a remote endpoint is ready",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingServingEndpoint(testNode, ep2Address),
-				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingServingEndpoint(testNode, ep2Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{ep1Address, ep2Address}, // fallback to serving&terminating should apply
@@ -783,9 +783,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible endpoints from an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
-				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep3Address),
 			},
 			"",
 			[]string{ep3Address},
@@ -793,9 +793,9 @@ func TestGetEligibleEndpointAddresses(t *testing.T) {
 		{
 			"Get all eligible local endpoints from an endpointslice where all local endpoints are terminating and not serving and a remote endpoint is ready",
 			[]discovery.Endpoint{
-				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
-				kube_test.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
-				kube_test.MakeReadyEndpoint(otherNode, ep3Address),
+				kubetest.MakeTerminatingNonServingEndpoint(testNode, ep1Address),
+				kubetest.MakeTerminatingNonServingEndpoint(testNode, ep2Address),
+				kubetest.MakeReadyEndpoint(otherNode, ep3Address),
 			},
 			testNode,
 			[]string{},

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	kube_test "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	"github.com/stretchr/testify/assert"
 	kapi "k8s.io/api/core/v1"
@@ -455,39 +454,6 @@ func TestPodScheduled(t *testing.T) {
 			assert.Equal(t, tc.expResult, res)
 		})
 	}
-}
-
-func TestExternalIDsForObject(t *testing.T) {
-	assert.Equal(t,
-		ExternalIDsForObject(&v1.Service{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Service",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "svc-ab23",
-				Namespace: "ns",
-				Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-			},
-		}),
-		map[string]string{
-			types.LoadBalancerKindExternalID:  "Service",
-			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
-		})
-
-	assert.Equal(t,
-		ExternalIDsForObject(&v1.Service{
-			// also handle no TypeMeta, which can happen.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "svc-ab23",
-				Namespace: "ns",
-				Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-			},
-		}),
-		map[string]string{
-			types.LoadBalancerKindExternalID:  "Service",
-			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
-		})
 }
 
 var (

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -55,6 +55,8 @@ type BasicNetInfo interface {
 	GetNetworkScopedExtSwitchName(nodeName string) string
 	GetNetworkScopedPatchPortName(bridgeID, nodeName string) string
 	GetNetworkScopedExtPortName(bridgeID, nodeName string) string
+	GetNetworkScopedLoadBalancerName(lbName string) string
+	GetNetworkScopedLoadBalancerGroupName(lbGroupName string) string
 }
 
 // NetInfo correlates which NADs refer to a network in addition to the basic
@@ -136,6 +138,14 @@ func (nInfo *DefaultNetInfo) GetNetworkScopedPatchPortName(bridgeID, nodeName st
 
 func (nInfo *DefaultNetInfo) GetNetworkScopedExtPortName(bridgeID, nodeName string) string {
 	return GetExtPortName(bridgeID, nInfo.GetNetworkScopedName(nodeName))
+}
+
+func (nInfo *DefaultNetInfo) GetNetworkScopedLoadBalancerName(lbName string) string {
+	return nInfo.GetNetworkScopedName(lbName)
+}
+
+func (nInfo *DefaultNetInfo) GetNetworkScopedLoadBalancerGroupName(lbGroupName string) string {
+	return nInfo.GetNetworkScopedName(lbGroupName)
 }
 
 // GetNADs returns the NADs associated with the network, no op for default
@@ -335,6 +345,14 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedPatchPortName(bridgeID, nodeName 
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedExtPortName(bridgeID, nodeName string) string {
 	return GetExtPortName(bridgeID, nInfo.GetNetworkScopedName(nodeName))
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedLoadBalancerName(lbName string) string {
+	return nInfo.GetNetworkScopedName(lbName)
+}
+
+func (nInfo *secondaryNetInfo) GetNetworkScopedLoadBalancerGroupName(lbGroupName string) string {
+	return nInfo.GetNetworkScopedName(lbGroupName)
 }
 
 // getPrefix returns if the logical entities prefix for this network

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -1,0 +1,395 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+
+	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+)
+
+var _ = Describe("Network Segmentation: services", func() {
+	const ()
+
+	f := wrappedTestFramework("udn-services")
+
+	Context("on a user defined primary network", func() {
+		const (
+			nadName                      = "tenant-red"
+			servicePort                  = 80
+			serviceTargetPort            = 80
+			userDefinedNetworkIPv4Subnet = "10.128.0.0/16"
+			userDefinedNetworkIPv6Subnet = "2014:100:200::0/60"
+		)
+
+		var (
+			cs                  clientset.Interface
+			nadClient           nadclient.K8sCniCncfIoV1Interface
+			defaultNetNamespace string
+		)
+
+		BeforeEach(func() {
+			cs = f.ClientSet
+
+			var err error
+			nadClient, err = nadclient.NewForConfig(f.ClientConfig())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		cleanupFn := func() {
+			By("Removing the namespace so all resources get deleted")
+			err := cs.CoreV1().Namespaces().Delete(context.TODO(), f.Namespace.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "Failed to remove the namespace %s %v", f.Namespace.Name, err)
+			if defaultNetNamespace != "" {
+				err = cs.CoreV1().Namespaces().Delete(context.TODO(), defaultNetNamespace, metav1.DeleteOptions{})
+				framework.ExpectNoError(err, "Failed to remove the namespace %v", defaultNetNamespace, err)
+			}
+
+		}
+
+		AfterEach(func() {
+			cleanupFn()
+		})
+
+		DescribeTable(
+			// The test creates a client and nodeport service in a UDN backed by one pod and similarly
+			// a nodeport service and a client in the default network. We expect ClusterIPs to be
+			// reachable only within the same network. We expect NodePort services to be exposed
+			// to all networks.
+			// We verify the following scenarios:
+			// - UDN client --> UDN service, with backend pod and client running on the same node:
+			//   + clusterIP succeeds
+			//   + nodeIP:nodePort works, when we only target the local node (*)
+			//
+			// - UDN client --> UDN service, with backend pod and client running on different nodes:
+			//   + clusterIP succeeds
+			//   + nodeIP:nodePort succeeds, when we only target the local node (*)
+			//
+			// - default-network client --> UDN service:
+			//   + clusterIP fails
+			//   + nodeIP:nodePort fails FOR NOW, when we only target the local node (*)
+			//
+			// -  UDN service --> default-network:
+			//   + clusterIP fails
+			//   + nodeIP:nodePort fails FOR NOW, when we only target the local node (*)
+			//
+			// (*) TODO connect to node ports on other nodes too once ovnkube-node fully supports UDN,
+			//     that is when https://github.com/ovn-org/ovn-kubernetes/pull/4648 and
+			//     https://github.com/ovn-org/ovn-kubernetes/pull/4554 merge
+
+			"should be reachable through their cluster IP and node port",
+			func(
+				netConfigParams networkAttachmentConfigParams,
+			) {
+				namespace := f.Namespace.Name
+				jig := e2eservice.NewTestJig(cs, namespace, "udn-service")
+
+				By("Selecting 3 schedulable nodes")
+				nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(nodes.Items)).To(BeNumerically(">", 2))
+
+				By("Selecting nodes for pods and service")
+				serverPodNodeName := nodes.Items[0].Name
+				clientNode := nodes.Items[1].Name // when client runs on a different node than the server
+
+				By("Creating the attachment configuration")
+				netConfig := newNetworkAttachmentConfig(netConfigParams)
+				netConfig.namespace = f.Namespace.Name
+				_, err = nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
+					context.Background(),
+					generateNAD(netConfig),
+					metav1.CreateOptions{},
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				By(fmt.Sprintf("Creating a UDN NodePort service"))
+				policy := v1.IPFamilyPolicyPreferDualStack
+				udnService, err := jig.CreateUDPService(context.TODO(), func(s *v1.Service) {
+					s.Spec.Ports = []v1.ServicePort{
+						{
+							Name:       "udp",
+							Protocol:   v1.ProtocolUDP,
+							Port:       80,
+							TargetPort: intstr.FromInt(int(serviceTargetPort)),
+						},
+					}
+					s.Spec.Type = v1.ServiceTypeNodePort
+					s.Spec.IPFamilyPolicy = &policy
+				})
+				framework.ExpectNoError(err)
+
+				By("Creating a UDN backend pod")
+				udnServerPod := e2epod.NewAgnhostPod(
+					namespace, "backend-pod", nil, nil,
+					[]v1.ContainerPort{
+						{ContainerPort: (serviceTargetPort), Protocol: "UDP"}},
+					"netexec",
+					"--udp-port="+fmt.Sprint(serviceTargetPort))
+
+				udnServerPod.Labels = jig.Labels
+				udnServerPod.Spec.NodeName = serverPodNodeName
+				udnServerPod = e2epod.NewPodClient(f).CreateSync(context.TODO(), udnServerPod)
+
+				By(fmt.Sprintf("Creating a UDN client pod on the same node (%s)", udnServerPod.Spec.NodeName))
+				udnClientPod := e2epod.NewAgnhostPod(namespace, "udn-client", nil, nil, nil)
+				udnClientPod.Spec.NodeName = udnServerPod.Spec.NodeName
+				udnClientPod = e2epod.NewPodClient(f).CreateSync(context.TODO(), udnClientPod)
+
+				// UDN -> UDN
+				By("Connect to the UDN service cluster IP from the UDN client pod on the same node")
+				checkConnectionToClusterIPs(f, udnClientPod, udnService, udnServerPod.Name)
+				checkConnectionToNodePort(f, udnClientPod, udnService, &nodes.Items[0], "endpoint node", udnServerPod.Name)
+				// TODO uncomment below as soon as ovnkube-node supports UDN
+				// checkConnectionToNodePort(f, clientPod2, udnService, &nodes.Items[1], "client node", udnServerPod.Name)
+				// checkConnectionToNodePort(f, clientPod2, udnService, &nodes.Items[2], "other node", udnServerPod.Name)
+
+				By(fmt.Sprintf("Creating a UDN client pod on a different node (%s)", clientNode))
+				udnClientPod2 := e2epod.NewAgnhostPod(namespace, "udn-client2", nil, nil, nil)
+				udnClientPod2.Spec.NodeName = clientNode
+				udnClientPod2 = e2epod.NewPodClient(f).CreateSync(context.TODO(), udnClientPod2)
+
+				By("Connect to the UDN service from the UDN client pod on a different node")
+				checkConnectionToClusterIPs(f, udnClientPod2, udnService, udnServerPod.Name)
+				// TODO uncomment below as soon as ovnkube-node supports UDN
+				checkConnectionToNodePort(f, udnClientPod2, udnService, &nodes.Items[1], "local node", udnServerPod.Name)
+				// checkConnectionToNodePort(f, clientPod2, udnService, &nodes.Items[0], "server node", udnServerPod.Name)
+				// checkConnectionToNodePort(f, clientPod2, udnService, &nodes.Items[2], "other node", udnServerPod.Name)
+
+				// Default network -> UDN
+				// Check that it cannot connect
+				By(fmt.Sprintf("Create a client pod in the default network on node %s", clientNode))
+				defaultNetNamespace = f.Namespace.Name + "-default"
+				_, err = cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: defaultNetNamespace,
+					},
+				}, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				defaultClient, err := createPod(f, "default-net-pod", clientNode, defaultNetNamespace, []string{"sleep", "2000000"}, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verify that the client in the default network cannot connect to the UDN service")
+				checkNoConnectionToClusterIPs(f, defaultClient, udnService)
+				checkNoConnectionToNodePort(f, defaultClient, udnService, &nodes.Items[1], "local node") // TODO change to checkConnectionToNodePort when we have full UDN support in ovnkube-node
+				// TODO uncomment below as soon as ovnkube-node supports UDN
+				// checkConnectionToNodePort(f, defaultClient, udnService, &nodes.Items[0], "server node")
+				// checkConnectionToNodePort(f, defaultClient, udnService, &nodes.Items[2], "other node")
+
+				// UDN -> Default network
+				// Create a backend pod and service in the default network and verify that the client pod in the UDN
+				// cannot reach it
+				By(fmt.Sprintf("Creating a backend pod in the default network on node %s", serverPodNodeName))
+				defaultLabels := map[string]string{"app": "default-app"}
+
+				_, err = createPod(f, "backend-pod-default", serverPodNodeName,
+					defaultNetNamespace, []string{"/agnhost", "netexec", "--udp-port=" + fmt.Sprint(serviceTargetPort)}, defaultLabels,
+					func(pod *v1.Pod) {
+						pod.Spec.Containers[0].Ports = []v1.ContainerPort{{ContainerPort: (serviceTargetPort), Protocol: "UDP"}}
+					})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("create a node port service in the default network")
+				defaultService := &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "service-default"},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name:     "udp-port",
+								Port:     int32(servicePort),
+								Protocol: v1.ProtocolUDP,
+							},
+						},
+						Selector:       defaultLabels,
+						Type:           v1.ServiceTypeNodePort,
+						IPFamilyPolicy: &policy,
+					},
+				}
+
+				defaultService, err = f.ClientSet.CoreV1().Services(defaultNetNamespace).Create(context.TODO(), defaultService, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("verify that the client pod in the UDN cannot connect to the default-network service")
+				checkNoConnectionToClusterIPs(f, udnClientPod2, defaultService)
+				// TODO uncomment below when below OVN_DISABLE_SNAT_MULTIPLE_GWS=true is supported
+				// checkConnectionToNodePort(f, udnClientPod2, defaultService, &nodes.Items[0], "server node", defaultServerPod.Name)
+				// TODO change line below to checkConnectionToNodePort when we have full UDN support in ovnkube-node
+				checkNoConnectionToNodePort(f, udnClientPod2, defaultService, &nodes.Items[1], "local node")
+				// TODO uncomment below when OVN_DISABLE_SNAT_MULTIPLE_GWS=true is supported
+				// checkConnectionToNodePort(f, udnClientPod2, defaultService, &nodes.Items[2], "other node", defaultServerPod.Name)
+			},
+
+			Entry(
+				"L3 dualstack primary UDN, cluster-networked pods, NodePort service",
+				networkAttachmentConfigParams{
+					name:     nadName,
+					topology: "layer3",
+					cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					role:     "primary",
+				},
+			),
+
+			// TODO add L2 NADs once L2 UDN support is available for services
+		)
+
+	})
+
+})
+
+// TODO Once https://github.com/ovn-org/ovn-kubernetes/pull/4567 merges, use the vendored *TestJig.Run(), which tests
+// the reachability of a service through its name and through its cluster IP. For now only test the cluster IP.
+
+const OVNNodeHostCIDRs = "k8s.ovn.org/host-cidrs"
+
+// ParseNodeHostCIDRsDropNetMask returns the parsed host IP addresses found on a node's host CIDR annotation. Removes the mask.
+func ParseNodeHostCIDRsDropNetMask(node *kapi.Node) (sets.Set[string], error) {
+	addrAnnotation, ok := node.Annotations[OVNNodeHostCIDRs]
+	if !ok {
+		return nil, newAnnotationNotSetError("%s annotation not found for node %q", OVNNodeHostCIDRs, node.Name)
+	}
+
+	var cfg []string
+	if err := json.Unmarshal([]byte(addrAnnotation), &cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal host cidrs annotation %s for node %q: %v",
+			addrAnnotation, node.Name, err)
+	}
+
+	for i, cidr := range cfg {
+		ip, _, err := net.ParseCIDR(cidr)
+		if err != nil || ip == nil {
+			return nil, fmt.Errorf("failed to parse node host cidr: %v", err)
+		}
+		cfg[i] = ip.String()
+	}
+	return sets.New(cfg...), nil
+}
+
+func checkConnectionToAgnhostPod(f *framework.Framework, clientPod *v1.Pod, expectedOutput, cmd string) error {
+	return wait.PollImmediate(200*time.Millisecond, 5*time.Second, func() (bool, error) {
+		stdout, stderr, err2 := ExecShellInPodWithFullOutput(f, clientPod.Namespace, clientPod.Name, cmd)
+		fmt.Printf("stdout=%s\n", stdout)
+		fmt.Printf("stderr=%s\n", stderr)
+		fmt.Printf("err=%v\n", err2)
+
+		if stderr != "" {
+			return false, fmt.Errorf("stderr=%s", stderr)
+		}
+
+		if err2 != nil {
+			return false, err2
+		}
+		return stdout == expectedOutput, nil
+	})
+}
+
+func checkNoConnectionToAgnhostPod(f *framework.Framework, clientPod *v1.Pod, cmd string) error {
+	err := wait.PollImmediate(500*time.Millisecond, 2*time.Second, func() (bool, error) {
+		stdout, stderr, err2 := ExecShellInPodWithFullOutput(f, clientPod.Namespace, clientPod.Name, cmd)
+		fmt.Printf("stdout=%s\n", stdout)
+		fmt.Printf("stderr=%s\n", stderr)
+		fmt.Printf("err=%v\n", err2)
+
+		if stderr != "" {
+			return false, nil
+		}
+
+		if err2 != nil {
+			return false, err2
+		}
+		if stdout != "" {
+			return true, fmt.Errorf("Connection unexpectedly succeeded. Stdout: %s\n", stdout)
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		if wait.Interrupted(err) {
+			// The timeout occurred without the connection succeeding, which is what we expect
+			return nil
+		}
+		return err
+	}
+	return fmt.Errorf("Error: %s/%s was able to connect (cmd=%s) ", clientPod.Namespace, clientPod.Name, cmd)
+}
+
+func checkConnectionToClusterIPs(f *framework.Framework, clientPod *v1.Pod, service *v1.Service, expectedOutput string) {
+	checkConnectionOrNoConnectionToClusterIPs(f, clientPod, service, expectedOutput, true)
+}
+
+func checkNoConnectionToClusterIPs(f *framework.Framework, clientPod *v1.Pod, service *v1.Service) {
+	checkConnectionOrNoConnectionToClusterIPs(f, clientPod, service, "", false)
+}
+
+func checkConnectionOrNoConnectionToClusterIPs(f *framework.Framework, clientPod *v1.Pod, service *v1.Service, expectedOutput string, shouldConnect bool) {
+	var err error
+	targetPort := service.Spec.Ports[0].TargetPort.String()
+	notStr := ""
+	if !shouldConnect {
+		notStr = "not "
+	}
+
+	for _, clusterIP := range service.Spec.ClusterIPs {
+		msg := fmt.Sprintf("Client %s/%s should %sreach service %s/%s on cluster IP %s port %s",
+			clientPod.Namespace, clientPod.Name, notStr, service.Namespace, service.Name, clusterIP, targetPort)
+		By(msg)
+
+		cmd := fmt.Sprintf(`/bin/sh -c 'echo hostname | nc -u -w 1 %s %s '`, clusterIP, targetPort)
+
+		if shouldConnect {
+			err = checkConnectionToAgnhostPod(f, clientPod, expectedOutput, cmd)
+		} else {
+			err = checkNoConnectionToAgnhostPod(f, clientPod, cmd)
+		}
+		framework.ExpectNoError(err, fmt.Sprintf("Failed to verify that %s", msg))
+	}
+}
+
+func checkConnectionToNodePort(f *framework.Framework, clientPod *v1.Pod, service *v1.Service, node *v1.Node, nodeRoleMsg, expectedOutput string) {
+	checkConnectionOrNoConnectionToNodePort(f, clientPod, service, node, nodeRoleMsg, expectedOutput, true)
+}
+
+func checkNoConnectionToNodePort(f *framework.Framework, clientPod *v1.Pod, service *v1.Service, node *v1.Node, nodeRoleMsg string) {
+	checkConnectionOrNoConnectionToNodePort(f, clientPod, service, node, nodeRoleMsg, "", false)
+}
+
+func checkConnectionOrNoConnectionToNodePort(f *framework.Framework, clientPod *v1.Pod, service *v1.Service, node *v1.Node, nodeRoleMsg, expectedOutput string, shouldConnect bool) {
+	var err error
+	nodePort := service.Spec.Ports[0].NodePort
+	notStr := ""
+	if !shouldConnect {
+		notStr = "not "
+	}
+	nodeIPs, err := ParseNodeHostCIDRsDropNetMask(node)
+	Expect(err).NotTo(HaveOccurred())
+
+	for nodeIP := range nodeIPs {
+		msg := fmt.Sprintf("Client %s/%s should %sconnect to NodePort service %s/%s on %s:%d (node %s, %s)",
+			clientPod.Namespace, clientPod.Name, notStr, service.Namespace, service.Name, nodeIP, nodePort, node.Name, nodeRoleMsg)
+		By(msg)
+		cmd := fmt.Sprintf(`/bin/sh -c 'echo hostname | nc -u -w 1 %s %d '`, nodeIP, nodePort)
+
+		if shouldConnect {
+			err = checkConnectionToAgnhostPod(f, clientPod, expectedOutput, cmd)
+		} else {
+			err = checkNoConnectionToAgnhostPod(f, clientPod, cmd)
+		}
+		framework.ExpectNoError(err, fmt.Sprintf("Failed to verify that %s", msg))
+	}
+}

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -154,7 +154,7 @@ fi
 
 # Only run network segmentation tests if they are explicitly requested
 NETWORK_SEGMENTATION_TESTS="Network Segmentation"
-if [ "${WHAT}" != "${NETWORK_SEGMENTATION_TESTS}" ]; then
+if [[ "${WHAT}" != "${NETWORK_SEGMENTATION_TESTS}"* ]]; then
   if [ "$SKIPPED_TESTS" != "" ]; then
 	SKIPPED_TESTS+="|"
   fi


### PR DESCRIPTION
This PR adds UDN support for cluster IP services on L3. OVN LBs are added to the UDN-specific logical switch and gateway router.  Nodeport services are only supported if the client runs on the destination node. (For full support, ovnkube-node changes are necessary and that'll be for a separate PR)

This PR spins a service controller per network: one for the default network, as today, and one for each UDN. 

OVN External IDs have been extended for logical routers, switches and load balancers to include the network name and network role (default, primary, secondary), so that we can easily distinguish which OVN objects belong to which network.

Existing unit tests are now run also for the UDN scenario. 

E2E tests for services on UDN have been added.


