### PR TITLE
udn, config: a layer2 primary UDN requires subnets

### DIFF
--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -727,6 +727,10 @@ func ParseNetConf(netattachdef *nettypes.NetworkAttachmentDefinition) (*ovncnity
 		return nil, fmt.Errorf("localnet topology does not allow specifying join-subnet as services are not supported")
 	}
 
+	if netconf.Role == types.NetworkRolePrimary && netconf.Subnets == "" && netconf.Topology == types.Layer2Topology {
+		return nil, fmt.Errorf("the subnet attribute must be defined for layer2 primary user defined networks")
+	}
+
 	return netconf, nil
 }
 

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -449,6 +449,18 @@ func TestParseNetconf(t *testing.T) {
 `,
 			expectedError: fmt.Errorf("localnet topology does not allow specifying join-subnet as services are not supported"),
 		},
+		{
+			desc: "A layer2 primary UDN requires a subnet",
+			inputNetAttachDefConfigSpec: `
+{
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "layer2",
+            "netAttachDefName": "ns1/nad1",
+            "role": "primary"
+}`,
+			expectedError: fmt.Errorf("the subnet attribute must be defined for layer2 primary user defined networks"),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Throw an error if the subnets attribute is not defined for primary user defined networks of `layer2` topology.

The controllers require the subnet attribute to properly configure the GW for egressing the workload traffic.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
Primary user defined networks of layer2 topology must have the subnets attribute defined.
```
