### PR TITLE
Make annotation in pod sync only happen for local pods

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -187,6 +187,8 @@ var _ = Describe("Node IP Handler tests", func() {
 			Output: dummyBrInternalIPv4,
 		})
 		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
+		// Restore global default values before each testcase
+		Expect(config.PrepareTestConfig()).To(Succeed())
 		config.IPv4Mode = true
 		config.IPv6Mode = true
 		tc = configureKubeOVNContextWithNs(nodeName)


### PR DESCRIPTION
Otherwise there is a performance/start up hit in large clusters where we potentially try to annotate all pods in a cluster on each node.

Credit to @tssurya for identifying this issue
