### PR TITLE
UDN egress integration: create logical infra for primary UDNs to egress for layer2 networks 

### DIFF
--- a/go-controller/pkg/node/secondary_node_network_controller.go
+++ b/go-controller/pkg/node/secondary_node_network_controller.go
@@ -50,12 +50,10 @@ func NewSecondaryNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, n
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving network id for network %s: %v", netInfo.GetNetworkName(), err)
 		}
-		// FIXME (tssurya): Remove this match when L2 networks are supported
-		if snnc.NetInfo.TopologyType() == types.Layer3Topology {
-			snnc.gateway, err = NewUserDefinedNetworkGateway(snnc.NetInfo, networkID, node, snnc.watchFactory.NodeCoreInformer().Lister(), snnc.Kube, vrfManager, defaultNetworkGateway)
-			if err != nil {
-				return nil, fmt.Errorf("error creating UDN gateway for network %s: %v", netInfo.GetNetworkName(), err)
-			}
+
+		snnc.gateway, err = NewUserDefinedNetworkGateway(snnc.NetInfo, networkID, node, snnc.watchFactory.NodeCoreInformer().Lister(), snnc.Kube, vrfManager, defaultNetworkGateway)
+		if err != nil {
+			return nil, fmt.Errorf("error creating UDN gateway for network %s: %v", netInfo.GetNetworkName(), err)
 		}
 	}
 	return snnc, nil
@@ -73,8 +71,7 @@ func (nc *SecondaryNodeNetworkController) Start(ctx context.Context) error {
 		}
 		nc.podHandler = handler
 	}
-	// FIXME (tssurya): Remove L3 match when L2 networks are supported
-	if util.IsNetworkSegmentationSupportEnabled() && nc.IsPrimaryNetwork() && nc.TopologyType() == types.Layer3Topology {
+	if util.IsNetworkSegmentationSupportEnabled() && nc.IsPrimaryNetwork() {
 		if err := nc.gateway.AddNetwork(); err != nil {
 			return fmt.Errorf("failed to add network to node gateway for network %s at node %s: %w",
 				nc.GetNetworkName(), nc.name, err)

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -58,6 +58,30 @@ type GatewayManager struct {
 
 type GatewayOption func(*GatewayManager)
 
+func NewGatewayManagerForLayer2Topology(
+	nodeName string,
+	coopUUID string,
+	kube kube.InterfaceOVN,
+	nbClient libovsdbclient.Client,
+	netInfo util.NetInfo,
+	watchFactory *factory.WatchFactory,
+	opts ...GatewayOption,
+) *GatewayManager {
+	return newGWManager(
+		nodeName,
+		"",
+		netInfo.GetNetworkScopedGWRouterName(nodeName),
+		netInfo.GetNetworkScopedExtSwitchName(nodeName),
+		netInfo.GetNetworkScopedName(types.OVNLayer2Switch),
+		coopUUID,
+		kube,
+		nbClient,
+		netInfo,
+		watchFactory,
+		opts...,
+	)
+}
+
 func NewGatewayManager(
 	nodeName string,
 	coopUUID string,
@@ -67,12 +91,35 @@ func NewGatewayManager(
 	watchFactory *factory.WatchFactory,
 	opts ...GatewayOption,
 ) *GatewayManager {
+	return newGWManager(
+		nodeName,
+		netInfo.GetNetworkScopedClusterRouterName(),
+		netInfo.GetNetworkScopedGWRouterName(nodeName),
+		netInfo.GetNetworkScopedExtSwitchName(nodeName),
+		netInfo.GetNetworkScopedJoinSwitchName(),
+		coopUUID,
+		kube,
+		nbClient,
+		netInfo,
+		watchFactory,
+		opts...,
+	)
+}
+
+func newGWManager(
+	nodeName, clusterRouterName, gwRouterName, extSwitchName, joinSwitchName string,
+	coopUUID string,
+	kube kube.InterfaceOVN,
+	nbClient libovsdbclient.Client,
+	netInfo util.NetInfo,
+	watchFactory *factory.WatchFactory,
+	opts ...GatewayOption) *GatewayManager {
 	gwManager := &GatewayManager{
 		nodeName:          nodeName,
-		clusterRouterName: netInfo.GetNetworkScopedClusterRouterName(),
-		gwRouterName:      netInfo.GetNetworkScopedGWRouterName(nodeName),
-		extSwitchName:     netInfo.GetNetworkScopedExtSwitchName(nodeName),
-		joinSwitchName:    netInfo.GetNetworkScopedJoinSwitchName(),
+		clusterRouterName: clusterRouterName,
+		gwRouterName:      gwRouterName,
+		extSwitchName:     extSwitchName,
+		joinSwitchName:    joinSwitchName,
 		coppUUID:          coopUUID,
 		kube:              kube,
 		nbClient:          nbClient,

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -480,7 +480,6 @@ func (gw *GatewayManager) GatewayInit(
 			return fmt.Errorf("error creating service static route %+v in GR %s: %v", lrsr, gatewayRouter, err)
 		}
 	}
-
 	// Add default gateway routes in GR
 	for _, nextHop := range nextHops {
 		var allIPs string
@@ -533,16 +532,22 @@ func (gw *GatewayManager) GatewayInit(
 			return item.IPPrefix == lrsr.IPPrefix &&
 				libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 		}
-		err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(gw.nbClient,
-			gw.clusterRouterName, &lrsr, p, &lrsr.Nexthop)
-		if err != nil {
-			return fmt.Errorf("error creating static route %+v in %s: %v", lrsr, gw.clusterRouterName, err)
+
+		if gw.clusterRouterName != "" {
+			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(gw.nbClient,
+				gw.clusterRouterName, &lrsr, p, &lrsr.Nexthop)
+			if err != nil {
+				return fmt.Errorf("error creating static route %+v in %s: %v", lrsr, gw.clusterRouterName, err)
+			}
 		}
 	}
 
 	// Add source IP address based routes in distributed router
 	// for this gateway router.
 	for _, hostSubnet := range hostSubnets {
+		if gw.clusterRouterName == "" {
+			break
+		}
 		gwLRPIP, err := util.MatchIPFamily(utilnet.IsIPv6CIDR(hostSubnet), gwLRPIPs)
 		if err != nil {
 			return fmt.Errorf("failed to add source IP address based "+
@@ -572,23 +577,28 @@ func (gw *GatewayManager) GatewayInit(
 			mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
 			gw.staticRouteCleanup([]net.IP{mgmtIfAddr.IP})
 
-			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(gw.nbClient, gw.clusterRouterName,
-				&lrsr, p, &lrsr.Nexthop)
-			if err != nil {
+			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(
+				gw.nbClient,
+				gw.clusterRouterName,
+				&lrsr,
+				p,
+				&lrsr.Nexthop,
+			); err != nil {
 				return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, gw.clusterRouterName, err)
 			}
 		} else if config.Gateway.Mode == config.GatewayModeLocal {
 			// If migrating from shared to local gateway, let's remove the static routes towards
 			// join switch for the hostSubnet prefix
 			// Note syncManagementPort happens before gateway sync so only remove things pointing to join subnet
-
-			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-				return item.IPPrefix == lrsr.IPPrefix && item.Policy != nil && *item.Policy == *lrsr.Policy &&
-					config.ContainsJoinIP(net.ParseIP(item.Nexthop))
-			}
-			err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(gw.nbClient, gw.clusterRouterName, p)
-			if err != nil {
-				return fmt.Errorf("error deleting static route %+v in GR %s: %v", lrsr, gw.clusterRouterName, err)
+			if gw.clusterRouterName != "" {
+				p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+					return item.IPPrefix == lrsr.IPPrefix && item.Policy != nil && *item.Policy == *lrsr.Policy &&
+						config.ContainsJoinIP(net.ParseIP(item.Nexthop))
+				}
+				err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(gw.nbClient, gw.clusterRouterName, p)
+				if err != nil {
+					return fmt.Errorf("error deleting static route %+v in GR %s: %v", lrsr, gw.clusterRouterName, err)
+				}
 			}
 		}
 	}
@@ -660,6 +670,13 @@ func (gw *GatewayManager) GatewayInit(
 	}
 
 	// REMOVEME(trozet) workaround - create join subnet SNAT to handle ICMP needs frag return
+	var extIDs map[string]string
+	if gw.netInfo.IsSecondary() {
+		extIDs = map[string]string{
+			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
+			types.TopologyExternalID: gw.netInfo.TopologyType(),
+		}
+	}
 	joinNATs := make([]*nbdb.NAT, 0, len(gwLRPIPs))
 	for _, gwLRPIP := range gwLRPIPs {
 		externalIP, err := util.MatchIPFamily(utilnet.IsIPv6(gwLRPIP), externalIPs)
@@ -671,7 +688,7 @@ func (gw *GatewayManager) GatewayInit(
 		if err != nil {
 			return fmt.Errorf("failed to parse full CIDR mask for join subnet IP: %s", gwLRPIP)
 		}
-		nat := libovsdbops.BuildSNAT(&externalIP[0], joinIPNet, "", nil)
+		nat := libovsdbops.BuildSNAT(&externalIP[0], joinIPNet, "", extIDs)
 		joinNATs = append(joinNATs, nat)
 	}
 	err = libovsdbops.CreateOrUpdateNATs(gw.nbClient, &logicalRouter, joinNATs...)
@@ -690,7 +707,7 @@ func (gw *GatewayManager) GatewayInit(
 				return fmt.Errorf("failed to create default SNAT rules for gateway router %s: %v",
 					gatewayRouter, err)
 			}
-			nat = libovsdbops.BuildSNAT(&externalIP[0], entry, "", nil)
+			nat = libovsdbops.BuildSNAT(&externalIP[0], entry, "", extIDs)
 			nats = append(nats, nat)
 		}
 		err := libovsdbops.CreateOrUpdateNATs(gw.nbClient, &logicalRouter, nats...)
@@ -700,7 +717,7 @@ func (gw *GatewayManager) GatewayInit(
 	} else {
 		// ensure we do not have any leftover SNAT entries after an upgrade
 		for _, logicalSubnet := range clusterIPSubnet {
-			nat = libovsdbops.BuildSNAT(nil, logicalSubnet, "", nil)
+			nat = libovsdbops.BuildSNAT(nil, logicalSubnet, "", extIDs)
 			nats = append(nats, nat)
 		}
 		err := libovsdbops.DeleteNATs(gw.nbClient, &logicalRouter, nats...)
@@ -1167,22 +1184,24 @@ func (gw *GatewayManager) syncGatewayLogicalNetwork(
 		return fmt.Errorf("failed to init gateway for network %q: %v", gw.netInfo.GetNetworkName(), err)
 	}
 
-	for _, subnet := range hostSubnets {
-		hostIfAddr := util.GetNodeManagementIfAddr(subnet)
-		if hostIfAddr == nil {
-			return fmt.Errorf("host interface address not found for subnet %q on network %q", subnet, gw.netInfo.GetNetworkName())
-		}
-		l3GatewayConfigIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
-		if err != nil {
-			return fmt.Errorf("failed to extract the gateway IP addr for network %q: %v", gw.netInfo.GetNetworkName(), err)
-		}
-		relevantHostIPs, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(hostIfAddr.IP), hostAddrs)
-		if err != nil && err != util.ErrorNoIP {
-			return fmt.Errorf("failed to extract the host IP addrs for network %q: %v", gw.netInfo.GetNetworkName(), err)
-		}
-		pbrMngr := gatewayrouter.NewPolicyBasedRoutesManager(gw.nbClient, gw.clusterRouterName, gw.netInfo)
-		if err := pbrMngr.Add(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
-			return fmt.Errorf("failed to configure the policy based routes for network %q: %v", gw.netInfo.GetNetworkName(), err)
+	if gw.clusterRouterName != "" {
+		for _, subnet := range hostSubnets {
+			hostIfAddr := util.GetNodeManagementIfAddr(subnet)
+			if hostIfAddr == nil {
+				return fmt.Errorf("host interface address not found for subnet %q on network %q", subnet, gw.netInfo.GetNetworkName())
+			}
+			l3GatewayConfigIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
+			if err != nil {
+				return fmt.Errorf("failed to extract the gateway IP addr for network %q: %v", gw.netInfo.GetNetworkName(), err)
+			}
+			relevantHostIPs, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(hostIfAddr.IP), hostAddrs)
+			if err != nil && err != util.ErrorNoIP {
+				return fmt.Errorf("failed to extract the host IP addrs for network %q: %v", gw.netInfo.GetNetworkName(), err)
+			}
+			pbrMngr := gatewayrouter.NewPolicyBasedRoutesManager(gw.nbClient, gw.clusterRouterName, gw.netInfo)
+			if err := pbrMngr.Add(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
+				return fmt.Errorf("failed to configure the policy based routes for network %q: %v", gw.netInfo.GetNetworkName(), err)
+			}
 		}
 	}
 

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -1185,24 +1185,26 @@ func (gw *GatewayManager) syncGatewayLogicalNetwork(
 		return fmt.Errorf("failed to init gateway for network %q: %v", gw.netInfo.GetNetworkName(), err)
 	}
 
-	if gw.clusterRouterName != "" {
-		for _, subnet := range hostSubnets {
-			hostIfAddr := util.GetNodeManagementIfAddr(subnet)
-			if hostIfAddr == nil {
-				return fmt.Errorf("host interface address not found for subnet %q on network %q", subnet, gw.netInfo.GetNetworkName())
-			}
-			l3GatewayConfigIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
-			if err != nil {
-				return fmt.Errorf("failed to extract the gateway IP addr for network %q: %v", gw.netInfo.GetNetworkName(), err)
-			}
-			relevantHostIPs, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(hostIfAddr.IP), hostAddrs)
-			if err != nil && err != util.ErrorNoIP {
-				return fmt.Errorf("failed to extract the host IP addrs for network %q: %v", gw.netInfo.GetNetworkName(), err)
-			}
-			pbrMngr := gatewayrouter.NewPolicyBasedRoutesManager(gw.nbClient, gw.clusterRouterName, gw.netInfo)
-			if err := pbrMngr.Add(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
-				return fmt.Errorf("failed to configure the policy based routes for network %q: %v", gw.netInfo.GetNetworkName(), err)
-			}
+	routerName := gw.clusterRouterName
+	if gw.clusterRouterName == "" {
+		routerName = gw.gwRouterName
+	}
+	for _, subnet := range hostSubnets {
+		hostIfAddr := util.GetNodeManagementIfAddr(subnet)
+		if hostIfAddr == nil {
+			return fmt.Errorf("host interface address not found for subnet %q on network %q", subnet, gw.netInfo.GetNetworkName())
+		}
+		l3GatewayConfigIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
+		if err != nil {
+			return fmt.Errorf("failed to extract the gateway IP addr for network %q: %v", gw.netInfo.GetNetworkName(), err)
+		}
+		relevantHostIPs, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(hostIfAddr.IP), hostAddrs)
+		if err != nil && err != util.ErrorNoIP {
+			return fmt.Errorf("failed to extract the host IP addrs for network %q: %v", gw.netInfo.GetNetworkName(), err)
+		}
+		pbrMngr := gatewayrouter.NewPolicyBasedRoutesManager(gw.nbClient, routerName, gw.netInfo)
+		if err := pbrMngr.Add(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
+			return fmt.Errorf("failed to configure the policy based routes for network %q: %v", gw.netInfo.GetNetworkName(), err)
 		}
 	}
 

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -372,46 +372,47 @@ func (gw *GatewayManager) GatewayInit(
 	if err != nil {
 		return fmt.Errorf("failed to create port %+v on router %+v: %v", logicalRouterPort, logicalRouter, err)
 	}
-
-	for _, entry := range clusterIPSubnet {
-		drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
-		if err != nil {
-			return fmt.Errorf("failed to add a static route in GR %s with distributed "+
-				"router as the nexthop: %v",
-				gatewayRouter, err)
-		}
-
-		// TODO There has to be a better way to do this. It seems like the
-		// whole purpose is to update the appropriate route in case it already
-		// exists *only* in the context of this router. But then it does not
-		// make sense to refresh it on every loop, unless it is also way to
-		// check for duplicate cluster IP subnets for which there would also be
-		// a better way to do it. Adding support for indirection in ModelClients
-		// opModel (being able to operate on thins pointed to from another model)
-		// would be a great way to simplify this.
-		updatedLogicalRouter, err := libovsdbops.GetLogicalRouter(gw.nbClient, &logicalRouter)
-		if err != nil {
-			return fmt.Errorf("unable to retrieve logical router %+v: %v", logicalRouter, err)
-		}
-
-		lrsr := nbdb.LogicalRouterStaticRoute{
-			IPPrefix: entry.String(),
-			Nexthop:  drLRPIfAddr.IP.String(),
-		}
-		if gw.netInfo.IsSecondary() {
-			lrsr.ExternalIDs = map[string]string{
-				types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
-				types.TopologyExternalID: gw.netInfo.TopologyType(),
+	if len(drLRPIfAddrs) > 0 {
+		for _, entry := range clusterIPSubnet {
+			drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
+			if err != nil {
+				return fmt.Errorf("failed to add a static route in GR %s with distributed "+
+					"router as the nexthop: %v",
+					gatewayRouter, err)
 			}
-		}
-		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy) &&
-				util.SliceHasStringItem(updatedLogicalRouter.StaticRoutes, item.UUID)
-		}
-		err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(gw.nbClient, gatewayRouter, &lrsr, p,
-			&lrsr.Nexthop)
-		if err != nil {
-			return fmt.Errorf("failed to add a static route %+v in GR %s with distributed router as the nexthop, err: %v", lrsr, gatewayRouter, err)
+
+			// TODO There has to be a better way to do this. It seems like the
+			// whole purpose is to update the appropriate route in case it already
+			// exists *only* in the context of this router. But then it does not
+			// make sense to refresh it on every loop, unless it is also way to
+			// check for duplicate cluster IP subnets for which there would also be
+			// a better way to do it. Adding support for indirection in ModelClients
+			// opModel (being able to operate on thins pointed to from another model)
+			// would be a great way to simplify this.
+			updatedLogicalRouter, err := libovsdbops.GetLogicalRouter(gw.nbClient, &logicalRouter)
+			if err != nil {
+				return fmt.Errorf("unable to retrieve logical router %+v: %v", logicalRouter, err)
+			}
+
+			lrsr := nbdb.LogicalRouterStaticRoute{
+				IPPrefix: entry.String(),
+				Nexthop:  drLRPIfAddr.IP.String(),
+			}
+			if gw.netInfo.IsSecondary() {
+				lrsr.ExternalIDs = map[string]string{
+					types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
+					types.TopologyExternalID: gw.netInfo.TopologyType(),
+				}
+			}
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy) &&
+					util.SliceHasStringItem(updatedLogicalRouter.StaticRoutes, item.UUID)
+			}
+			err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(gw.nbClient, gatewayRouter, &lrsr, p,
+				&lrsr.Nexthop)
+			if err != nil {
+				return fmt.Errorf("failed to add a static route %+v in GR %s with distributed router as the nexthop, err: %v", lrsr, gatewayRouter, err)
+			}
 		}
 	}
 

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -143,7 +143,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 				switch ocInfo.bnc.TopologyType() {
 				case ovntypes.Layer3Topology:
 					switchName = ocInfo.bnc.GetNetworkScopedName(pod.nodeName)
-					managementIP := managementPortIP(subnet)
+					managementIP := managementPortIP(subnet.CIDR)
 
 					switchToRouterPortName := "stor-" + switchName
 					switchToRouterPortUUID := switchToRouterPortName + "-UUID"
@@ -165,7 +165,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 					}
 				case ovntypes.Layer2Topology:
 					switchName = ocInfo.bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch)
-					managementIP := managementPortIP(subnet)
+					managementIP := managementPortIP(subnet.CIDR)
 
 					if em.gatewayConfig != nil {
 						// there are multiple mgmt ports in the cluster, thus the ports must be scoped with the node name
@@ -211,7 +211,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts() 
 			var otherConfig map[string]string
 			if hasSubnets {
 				otherConfig = map[string]string{
-					"exclude_ips": managementPortIP(subnet).String(),
+					"exclude_ips": managementPortIP(subnet.CIDR).String(),
 					"subnet":      subnet.CIDR.String(),
 				}
 			}
@@ -351,4 +351,8 @@ func newDummyGatewayManager(
 		netInfo,
 		factory,
 	)
+}
+
+func managementPortIP(subnet *net.IPNet) net.IP {
+	return util.GetNodeManagementIfAddr(subnet).IP
 }

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -5,7 +5,11 @@ import (
 	"net"
 	"strings"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -330,4 +334,21 @@ func hostIPsFromGWConfig(gwConfig util.L3GatewayConfig) []string {
 		hostIPs = append(hostIPs, ip.IP.String())
 	}
 	return hostIPs
+}
+
+func newDummyGatewayManager(
+	kube kube.InterfaceOVN,
+	nbClient libovsdbclient.Client,
+	netInfo util.NetInfo,
+	factory *factory.WatchFactory,
+	nodeName string,
+) *GatewayManager {
+	return NewGatewayManager(
+		nodeName,
+		"",
+		kube,
+		nbClient,
+		netInfo,
+		factory,
+	)
 }

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -356,3 +356,27 @@ func newDummyGatewayManager(
 func managementPortIP(subnet *net.IPNet) net.IP {
 	return util.GetNodeManagementIfAddr(subnet).IP
 }
+
+func minimalFeatureConfig() *config.OVNKubernetesFeatureConfig {
+	return &config.OVNKubernetesFeatureConfig{
+		EnableNetworkSegmentation: true,
+		EnableMultiNetwork:        true,
+	}
+}
+
+func enableICFeatureConfig() *config.OVNKubernetesFeatureConfig {
+	featConfig := minimalFeatureConfig()
+	featConfig.EnableInterconnect = true
+	return featConfig
+}
+
+func icClusterTestConfiguration() testConfiguration {
+	return testConfiguration{
+		configToOverride:   enableICFeatureConfig(),
+		expectationOptions: []option{withInterconnectCluster()},
+	}
+}
+
+func nonICClusterTestConfiguration() testConfiguration {
+	return testConfiguration{}
+}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -446,7 +446,7 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 					node,
 					gwConfig.config,
 					gwConfig.hostSubnets,
-					gwConfig.hostAddrs,
+					nil,
 					gwConfig.hostSubnets,
 					gwConfig.gwLRPIPs,
 					oc.SCTPSupport,
@@ -485,7 +485,6 @@ type SecondaryL2GatewayConfig struct {
 	config      *util.L3GatewayConfig
 	hostSubnets []*net.IPNet
 	gwLRPIPs    []*net.IPNet
-	hostAddrs   []string
 	externalIPs []net.IP
 }
 
@@ -535,12 +534,6 @@ func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node)
 		externalIPs = append(externalIPs, v6MasqIP.IP)
 	}
 
-	// TODO: is this right ? just copied from L3
-	var hostAddrs []string
-	for _, externalIP := range externalIPs {
-		hostAddrs = append(hostAddrs, externalIP.String())
-	}
-
 	// Use the host subnets present in the network attachment definition.
 	hostSubnets := make([]*net.IPNet, 0, len(oc.Subnets()))
 	for _, subnet := range oc.Subnets() {
@@ -567,7 +560,6 @@ func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node)
 		config:      l3GatewayConfig,
 		hostSubnets: hostSubnets,
 		gwLRPIPs:    gwLRPIPs,
-		hostAddrs:   hostAddrs,
 		externalIPs: externalIPs,
 	}, nil
 }

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/generator/udn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
@@ -107,9 +108,10 @@ func (h *secondaryLayer2NetworkControllerEventHandler) AddResource(obj interface
 			var nodeParams *nodeSyncs
 			if fromRetryLoop {
 				_, syncMgmtPort := h.oc.mgmtPortFailed.Load(node.Name)
-				nodeParams = &nodeSyncs{syncMgmtPort: syncMgmtPort}
+				_, syncGw := h.oc.gatewaysFailed.Load(node.Name)
+				nodeParams = &nodeSyncs{syncMgmtPort: syncMgmtPort, syncGw: syncGw}
 			} else {
-				nodeParams = &nodeSyncs{syncMgmtPort: true}
+				nodeParams = &nodeSyncs{syncMgmtPort: true, syncGw: true}
 			}
 			return h.oc.addUpdateLocalNodeEvent(node, nodeParams)
 		}
@@ -157,12 +159,19 @@ func (h *secondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, ne
 			if h.oc.isLocalZoneNode(oldNode) {
 				// determine what actually changed in this update
 				syncMgmtPort := macAddressChanged(oldNode, newNode, h.oc.NetInfo.GetNetworkName()) || nodeSubnetChanged
-				nodeSyncsParam = &nodeSyncs{syncMgmtPort: syncMgmtPort}
+
+				_, gwUpdateFailed := h.oc.gatewaysFailed.Load(newNode.Name)
+				shouldSyncGW := gwUpdateFailed ||
+					gatewayChanged(oldNode, newNode) ||
+					hostCIDRsChanged(oldNode, newNode) ||
+					nodeGatewayMTUSupportChanged(oldNode, newNode)
+
+				nodeSyncsParam = &nodeSyncs{syncMgmtPort: syncMgmtPort, syncGw: shouldSyncGW}
 			} else {
 				klog.Infof("Node %s moved from the remote zone %s to local zone %s.",
 					newNode.Name, util.GetNodeZone(oldNode), util.GetNodeZone(newNode))
 				// The node is now a local zone node. Trigger a full node sync.
-				nodeSyncsParam = &nodeSyncs{syncMgmtPort: true}
+				nodeSyncsParam = &nodeSyncs{syncMgmtPort: true, syncGw: true}
 			}
 
 			return h.oc.addUpdateLocalNodeEvent(newNode, nodeSyncsParam)
@@ -220,6 +229,12 @@ type SecondaryLayer2NetworkController struct {
 
 	// Node-specific syncMaps used by node event handler
 	mgmtPortFailed sync.Map
+	gatewaysFailed sync.Map
+
+	// Cluster-wide router default Control Plane Protection (COPP) UUID
+	defaultCOPPUUID string
+
+	gatewayManagers sync.Map
 }
 
 // NewSecondaryLayer2NetworkController create a new OVN controller for the given secondary layer2 nad
@@ -257,7 +272,8 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 				},
 			},
 		},
-		mgmtPortFailed: sync.Map{},
+		mgmtPortFailed:  sync.Map{},
+		gatewayManagers: sync.Map{},
 	}
 
 	if config.OVNKubernetesFeature.EnableInterconnect {
@@ -313,7 +329,27 @@ func (oc *SecondaryLayer2NetworkController) run(ctx context.Context) error {
 // Cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
 func (oc *SecondaryLayer2NetworkController) Cleanup() error {
-	return oc.BaseSecondaryLayer2NetworkController.cleanup()
+	networkName := oc.GetNetworkName()
+	if err := oc.BaseSecondaryLayer2NetworkController.cleanup(); err != nil {
+		return fmt.Errorf("failed to cleanup network %q: %w", networkName, err)
+	}
+
+	oc.gatewayManagers.Range(func(nodeName, value any) bool {
+		gwManager, isGWManagerType := value.(*GatewayManager)
+		if !isGWManagerType {
+			klog.Errorf(
+				"Failed to cleanup GW manager for network %q on node %s: could not retrieve GWManager",
+				networkName,
+				nodeName,
+			)
+			return true
+		}
+		if err := gwManager.Cleanup(); err != nil {
+			klog.Errorf("Failed to cleanup GW manager for network %q on node %s: %v", networkName, nodeName, err)
+		}
+		return true
+	})
+	return nil
 }
 
 func (oc *SecondaryLayer2NetworkController) Init() error {
@@ -397,6 +433,33 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 				oc.mgmtPortFailed.Delete(node.Name)
 			}
 		}
+		if nSyncs.syncGw {
+			gwManager := oc.gatewayManagerForNode(node.Name)
+			oc.gatewayManagers.Store(node.Name, gwManager)
+
+			gwConfig, err := oc.nodeGatewayConfig(node)
+			if err != nil {
+				errs = append(errs, err)
+				oc.gatewaysFailed.Store(node.Name, true)
+			} else {
+				if err := gwManager.syncNodeGateway(
+					node,
+					gwConfig.config,
+					gwConfig.hostSubnets,
+					gwConfig.hostAddrs,
+					gwConfig.hostSubnets,
+					gwConfig.gwLRPIPs,
+					oc.SCTPSupport,
+					oc.ovnClusterLRPToJoinIfAddrs,
+					gwConfig.externalIPs,
+				); err != nil {
+					errs = append(errs, err)
+					oc.gatewaysFailed.Store(node.Name, true)
+				} else {
+					oc.gatewaysFailed.Delete(node.Name)
+				}
+			}
+		}
 	}
 
 	errs = append(errs, oc.BaseSecondaryLayer2NetworkController.addUpdateLocalNodeEvent(node))
@@ -409,7 +472,117 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 }
 
 func (oc *SecondaryLayer2NetworkController) deleteNodeEvent(node *corev1.Node) error {
+	if err := oc.gatewayManagerForNode(node.Name).Cleanup(); err != nil {
+		return fmt.Errorf("failed to cleanup gateway on node %q: %w", node.Name, err)
+	}
+	oc.gatewayManagers.Delete(node.Name)
 	oc.localZoneNodes.Delete(node.Name)
 	oc.mgmtPortFailed.Delete(node.Name)
 	return nil
+}
+
+type SecondaryL2GatewayConfig struct {
+	config      *util.L3GatewayConfig
+	hostSubnets []*net.IPNet
+	gwLRPIPs    []*net.IPNet
+	hostAddrs   []string
+	externalIPs []net.IP
+}
+
+func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node) (*SecondaryL2GatewayConfig, error) {
+	l3GatewayConfig, err := util.ParseNodeL3GatewayAnnotation(node)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %s network %s L3 gateway config: %v", node.Name, oc.GetNetworkName(), err)
+	}
+
+	networkName := oc.GetNetworkName()
+	networkID, err := oc.getNetworkID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get networkID for network %q: %v", networkName, err)
+	}
+
+	var (
+		masqIPs  []*net.IPNet
+		v4MasqIP *net.IPNet
+		v6MasqIP *net.IPNet
+	)
+
+	if config.IPv4Mode {
+		v4MasqIPs, err := udn.AllocateV4MasqueradeIPs(networkID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get v4 masquerade IP, network %s (%d): %v", networkName, networkID, err)
+		}
+		v4MasqIP = v4MasqIPs.GatewayRouter
+		masqIPs = append(masqIPs, v4MasqIP)
+	}
+	if config.IPv6Mode {
+		v6MasqIPs, err := udn.AllocateV6MasqueradeIPs(networkID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get v6 masquerade IP, network %s (%d): %v", networkName, networkID, err)
+		}
+		v6MasqIP = v6MasqIPs.GatewayRouter
+		masqIPs = append(masqIPs, v6MasqIP)
+	}
+
+	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
+
+	// Always SNAT to the per network masquerade IP.
+	var externalIPs []net.IP
+	if config.IPv4Mode && v4MasqIP != nil {
+		externalIPs = append(externalIPs, v4MasqIP.IP)
+	}
+	if config.IPv6Mode && v6MasqIP != nil {
+		externalIPs = append(externalIPs, v6MasqIP.IP)
+	}
+
+	// TODO: is this right ? just copied from L3
+	var hostAddrs []string
+	for _, externalIP := range externalIPs {
+		hostAddrs = append(hostAddrs, externalIP.String())
+	}
+
+	// Use the host subnets present in the network attachment definition.
+	hostSubnets := make([]*net.IPNet, 0, len(oc.Subnets()))
+	for _, subnet := range oc.Subnets() {
+		hostSubnets = append(hostSubnets, subnet.CIDR)
+	}
+
+	// Overwrite the primary interface ID with the correct, per-network one.
+	l3GatewayConfig.InterfaceID = oc.GetNetworkScopedExtPortName(l3GatewayConfig.BridgeID, node.Name)
+	return &SecondaryL2GatewayConfig{
+		config:      l3GatewayConfig,
+		hostSubnets: hostSubnets,
+		gwLRPIPs:    oc.ovnClusterLRPToJoinIfAddrs,
+		hostAddrs:   hostAddrs,
+		externalIPs: externalIPs,
+	}, nil
+}
+
+func (oc *SecondaryLayer2NetworkController) newGatewayManager(nodeName string) *GatewayManager {
+	return NewGatewayManagerForLayer2Topology(
+		nodeName,
+		oc.defaultCOPPUUID,
+		oc.kube,
+		oc.nbClient,
+		oc.NetInfo,
+		oc.watchFactory,
+	)
+}
+
+func (oc *SecondaryLayer2NetworkController) gatewayManagerForNode(nodeName string) *GatewayManager {
+	obj, isFound := oc.gatewayManagers.Load(nodeName)
+	if !isFound {
+		return oc.newGatewayManager(nodeName)
+	} else {
+		gwManager, isGWManagerType := obj.(*GatewayManager)
+		if !isGWManagerType {
+			klog.Errorf(
+				"failed to extract a gateway manager from the network %q on node %s; creating new one",
+				oc.GetNetworkName(),
+				nodeName,
+			)
+			return oc.newGatewayManager(nodeName)
+		}
+		return gwManager
+	}
 }

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -547,9 +547,12 @@ func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node)
 		hostSubnets = append(hostSubnets, subnet.CIDR)
 	}
 
-	// at layer2 the GR similar to layer3 ovn_cluster_router so we use
-	// the join subnet too
-	gwLRPIPs := oc.ovnClusterLRPToJoinIfAddrs
+	// at layer2 the GR LRP should be different per node same we do for layer3
+	// since they should not collide at the distributed switch later on
+	gwLRPIPs, err := util.ParseNodeGatewayRouterJoinAddrs(node, networkName)
+	if err != nil {
+		return nil, fmt.Errorf("failed composing LRP addresses for layer2 network %s: %w", oc.GetNetworkName(), err)
+	}
 
 	// At layer2 GR LRP acts as the layer3 ovn_cluster_router so we need
 	// to configure here the .1 address, this will work only for IC with

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -450,7 +450,7 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 					gwConfig.hostSubnets,
 					gwConfig.gwLRPIPs,
 					oc.SCTPSupport,
-					oc.ovnClusterLRPToJoinIfAddrs,
+					nil, // no need for ovnClusterLRPToJoinIfAddrs
 					gwConfig.externalIPs,
 				); err != nil {
 					errs = append(errs, err)

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -317,7 +317,18 @@ func (oc *SecondaryLayer2NetworkController) Cleanup() error {
 }
 
 func (oc *SecondaryLayer2NetworkController) Init() error {
-	_, err := oc.initializeLogicalSwitch(oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), oc.Subnets(), oc.ExcludeSubnets())
+	// Create default Control Plane Protection (COPP) entry for routers
+	defaultCOPPUUID, err := EnsureDefaultCOPP(oc.nbClient)
+	if err != nil {
+		return fmt.Errorf("unable to create router control plane protection: %w", err)
+	}
+	oc.defaultCOPPUUID = defaultCOPPUUID
+
+	_, err = oc.initializeLogicalSwitch(
+		oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch),
+		oc.Subnets(),
+		oc.ExcludeSubnets(),
+	)
 	return err
 }
 

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -327,7 +327,6 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		sr1               = "sr1-UUID"
 		sr2               = "sr2-UUID"
 		routerPolicyUUID1 = "lrp1-UUID"
-		routerPolicyUUID2 = "lrp2-UUID"
 	)
 	gwRouterName := fmt.Sprintf("GR_%s_test-node", netInfo.GetNetworkName())
 	staticRouteOutputPort := ovntypes.GWRouterToExtSwitchPrefix + gwRouterName
@@ -343,7 +342,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 			StaticRoutes: []string{sr1, sr2},
 			ExternalIDs:  gwRouterExternalIDs(netInfo, gwConfig),
 			Options:      gwRouterOptions(gwConfig),
-			Policies:     []string{routerPolicyUUID1, routerPolicyUUID2},
+			Policies:     []string{routerPolicyUUID1},
 		},
 		expectedGWToNetworkSwitchRouterPort(gwRouterToNetworkSwitchPortName, netInfo, gwRouterIPAddress(), layer2SubnetGWAddr()),
 		expectedGRStaticRoute(sr1, dummyMasqueradeSubnet().String(), nextHopMasqueradeIP().String(), nil, &staticRouteOutputPort, netInfo),
@@ -357,7 +356,6 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		expectedStaticMACBinding(gwRouterName, nextHopMasqueradeIP()),
 
 		expectedLogicalRouterPolicy(routerPolicyUUID1, netInfo, nodeName, nodeIP().IP.String(), managementPortIP(layer2Subnet()).String()),
-		expectedLogicalRouterPolicy(routerPolicyUUID2, netInfo, nodeName, dummyJoinIP().IP.String(), managementPortIP(layer2Subnet()).String()),
 	}
 
 	for _, entity := range expectedExternalSwitchAndLSPs(netInfo, gwConfig, nodeName) {

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -1,0 +1,217 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/urfave/cli/v2"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = XDescribe("OVN Multi-Homed pod operations for layer2 network", func() {
+	var (
+		app       *cli.App
+		fakeOvn   *FakeOVN
+		initialDB libovsdbtest.TestSetup
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed()) // reset defaults
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fakeOvn = NewFakeOVN(true)
+		initialDB = libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{},
+		}
+
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	table.DescribeTable(
+		"reconciles a new",
+		func(netInfo secondaryNetInfo) {
+			podInfo := dummyL2TestPod(ns, netInfo)
+			app.Action = func(ctx *cli.Context) error {
+				By(fmt.Sprintf("creating a network attachment definition for network: %s", netInfo.netName))
+				nad, err := newNetworkAttachmentDefinition(
+					ns,
+					nadName,
+					*netInfo.netconf(),
+				)
+				Expect(err).NotTo(HaveOccurred())
+				By("setting up the OVN DB without any entities in it")
+				Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
+
+				const nodeIPv4CIDR = "192.168.126.202/24"
+				By(fmt.Sprintf("Creating a node named %q, with IP: %s", nodeName, nodeIPv4CIDR))
+				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
+				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.startWithDBSetup(
+					initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							*newNamespace(ns),
+						},
+					},
+					&v1.NodeList{Items: []v1.Node{*testNode}},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newMultiHomedPod(podInfo.namespace, podInfo.podName, podInfo.nodeName, podInfo.podIP, netInfo),
+						},
+					},
+					&nadapi.NetworkAttachmentDefinitionList{
+						Items: []nadapi.NetworkAttachmentDefinition{*nad},
+					},
+				)
+				podInfo.populateLogicalSwitchCache(fakeOvn)
+
+				By("asserting the pod originally does *not* feature the OVN pod networks annotation")
+				// pod exists, networks annotations don't
+				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
+				Expect(ok).To(BeFalse())
+
+				Expect(fakeOvn.controller.WatchNamespaces()).NotTo(HaveOccurred())
+				Expect(fakeOvn.controller.WatchPods()).NotTo(HaveOccurred())
+				By("asserting the pod (once reconciled) *features* the OVN pod networks annotation")
+				secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
+				Expect(ok).To(BeTrue())
+
+				secondaryNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+				podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
+				Expect(secondaryNetController.bnc.WatchNodes()).To(Succeed())
+				Expect(secondaryNetController.bnc.WatchPods()).To(Succeed())
+
+				By("asserting the pod OVN pod networks annotation are the expected ones")
+				// check that after start networks annotations and nbdb will be updated
+				Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, podInfo.namespace, podInfo.podName)
+				}).WithTimeout(2 * time.Second).Should(MatchJSON(podInfo.getAnnotationsJson()))
+
+				var expectationOptions []option
+				if netInfo.isPrimary {
+					By("configuring the expectation machine with the GW related configuration")
+					gwConfig, err := util.ParseNodeL3GatewayAnnotation(testNode)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(gwConfig.NextHops).NotTo(BeEmpty())
+					expectationOptions = append(expectationOptions, withGatewayConfig(gwConfig))
+				}
+				By("asserting the OVN entities provisioned in the NBDB are the expected ones")
+				Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(
+						newSecondaryNetworkExpectationMachine(
+							fakeOvn,
+							[]testPod{podInfo},
+							expectationOptions...,
+						).expectedLogicalSwitchesAndPorts()...))
+
+				return nil
+			}
+
+			Expect(app.Run([]string{app.Name})).To(Succeed())
+		},
+		table.Entry("pod on a user defined secondary network",
+			secondaryNetInfo{
+				netName:  secondaryNetworkName,
+				nadName:  namespacedName(ns, nadName),
+				topology: ovntypes.Layer2Topology,
+				subnets:  "100.200.0.0/16",
+			},
+		),
+
+		table.Entry("pod on a user defined primary network",
+			secondaryNetInfo{
+				netName:   secondaryNetworkName,
+				nadName:   namespacedName(ns, nadName),
+				topology:  ovntypes.Layer2Topology,
+				subnets:   "100.200.0.0/16",
+				isPrimary: true,
+			},
+		),
+	)
+
+})
+
+func dummyL2TestPod(nsName string, info secondaryNetInfo) testPod {
+	const nodeSubnet = "10.128.1.0/24"
+	if info.isPrimary {
+		pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "", "myPod", "10.128.1.3", "0a:58:0a:80:01:03", nsName)
+		pod.networkRole = "infrastructure-locked"
+		pod.routes = append(
+			pod.routes,
+			util.PodRoute{
+				Dest:    testing.MustParseIPNet("10.128.0.0/14"),
+				NextHop: testing.MustParseIP("10.128.1.1"),
+			},
+			util.PodRoute{
+				Dest:    testing.MustParseIPNet("100.64.0.0/16"),
+				NextHop: testing.MustParseIP("10.128.1.1"),
+			},
+		)
+		pod.addNetwork(
+			info.netName,
+			info.nadName,
+			info.subnets,
+			"",
+			"100.200.0.1",
+			"100.200.0.3/16",
+			"0a:58:64:c8:00:03",
+			"primary",
+			0,
+			[]util.PodRoute{
+				{
+					Dest:    testing.MustParseIPNet("172.16.1.0/24"),
+					NextHop: testing.MustParseIP("100.200.0.1"),
+				},
+				{
+					Dest:    testing.MustParseIPNet("100.65.0.0/16"),
+					NextHop: testing.MustParseIP("100.200.0.1"),
+				},
+			},
+		)
+		return pod
+	}
+	pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "10.128.1.1", podName, "10.128.1.3", "0a:58:0a:80:01:03", nsName)
+	pod.addNetwork(
+		info.netName,
+		info.nadName,
+		info.subnets,
+		"",
+		"",
+		"100.200.0.1/16",
+		"0a:58:64:c8:00:01",
+		"secondary",
+		0,
+		[]util.PodRoute{},
+	)
+	return pod
+}
+
+func expectedLayer2EgressEntities(networkName string) []libovsdbtest.TestData {
+	expectedEntities := []libovsdbtest.TestData{}
+	return expectedEntities
+}

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -741,14 +741,14 @@ func expectedGRStaticRoute(uuid, ipPrefix, nextHop string, policy *nbdb.LogicalR
 	}
 }
 
-func allowAllFromMgmtPort(aclUUID string, mgmtPortIP string) *nbdb.ACL {
+func allowAllFromMgmtPort(aclUUID string, mgmtPortIP string, switchName string) *nbdb.ACL {
 	meterName := "acl-logging"
 	return &nbdb.ACL{
 		UUID:      aclUUID,
 		Action:    "allow-related",
 		Direction: "to-lport",
 		ExternalIDs: map[string]string{
-			"k8s.ovn.org/name":             "isolatednet_test-node",
+			"k8s.ovn.org/name":             switchName,
 			"ip":                           mgmtPortIP,
 			"k8s.ovn.org/id":               fmt.Sprintf("isolatednet-network-controller:NetpolNode:isolatednet_test-node:%s", mgmtPortIP),
 			"k8s.ovn.org/owner-controller": "isolatednet-network-controller",

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -685,8 +685,8 @@ func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		&nbdb.LogicalRouterPort{UUID: rtosLRPUUID, Name: rtosLRPName, Networks: []string{"192.168.0.1/16"}, MAC: "0a:58:c0:a8:00:01", GatewayChassis: []string{gatewayChassisUUID}},
 		expectedGRStaticRoute(staticRouteUUID1, networkIPv4Subnet, gwRouterIPAddress().IP.String(), &nbdb.LogicalRouterStaticRoutePolicySrcIP, nil, netInfo),
 		expectedGRStaticRoute(staticRouteUUID2, gwRouterIPAddress().IP.String(), gwRouterIPAddress().IP.String(), nil, nil, netInfo),
-		expectedLogicalRouterPolicy(routerPolicyUUID1, netInfo, nodeName, nodeIP, managementPortIP(subnet).String()),
-		expectedLogicalRouterPolicy(routerPolicyUUID2, netInfo, nodeName, joinIPAddr, managementPortIP(subnet).String()),
+		expectedLogicalRouterPolicy(routerPolicyUUID1, netInfo, nodeName, nodeIP, managementPortIP(subnet.CIDR).String()),
+		expectedLogicalRouterPolicy(routerPolicyUUID2, netInfo, nodeName, joinIPAddr, managementPortIP(subnet.CIDR).String()),
 	}
 	return expectedEntities
 }
@@ -838,10 +838,6 @@ func gwRouterIPAddress() *net.IPNet {
 		IP:   net.ParseIP("100.65.0.4"),
 		Mask: net.CIDRMask(16, 32),
 	}
-}
-
-func managementPortIP(subnet config.CIDRNetworkEntry) net.IP {
-	return util.GetNodeManagementIfAddr(subnet.CIDR).IP
 }
 
 func networkSubnet(netInfo util.NetInfo) string {

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -618,8 +618,8 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 			Nat:          []string{nat1, nat2},
 			StaticRoutes: []string{staticRoute1, staticRoute2, staticRoute3},
 		},
-		newNATEntry(nat1, dummyJoinIP().IP.String(), gwRouterIPAddress().IP.String()),
-		newNATEntry(nat2, dummyJoinIP().IP.String(), networkSubnet(netInfo)),
+		newNATEntry(nat1, dummyJoinIP().IP.String(), gwRouterIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo)),
+		newNATEntry(nat2, dummyJoinIP().IP.String(), networkSubnet(netInfo), standardNonDefaultNetworkExtIDs(netInfo)),
 		expectedGRStaticRoute(staticRoute1, ipv4Subnet, dummyJoinIP().IP.String(), nil, nil),
 		expectedGRStaticRoute(staticRoute2, ipv4DefaultRoute, nextHopIP, nil, &staticRouteOutputPort),
 		expectedGRStaticRoute(staticRoute3, masqSubnet, nextHopMasqIP, nil, &staticRouteOutputPort),
@@ -774,13 +774,14 @@ func udnGWSNATAddress() *net.IPNet {
 	}
 }
 
-func newNATEntry(uuid string, externalIP string, logicalIP string) *nbdb.NAT {
+func newNATEntry(uuid string, externalIP string, logicalIP string, extIDs map[string]string) *nbdb.NAT {
 	return &nbdb.NAT{
-		UUID:       uuid,
-		ExternalIP: externalIP,
-		LogicalIP:  logicalIP,
-		Type:       "snat",
-		Options:    map[string]string{"stateless": "false"},
+		UUID:        uuid,
+		ExternalIP:  externalIP,
+		LogicalIP:   logicalIP,
+		Type:        "snat",
+		Options:     map[string]string{"stateless": "false"},
+		ExternalIDs: extIDs,
 	}
 }
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -2,7 +2,6 @@ package ovn
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -353,31 +352,6 @@ func newPodWithPrimaryUDN(
 			},
 		},
 	)
-	return pod
-}
-
-func newMultiHomedPod(namespace, name, node, podIP string, multiHomingConfigs ...secondaryNetInfo) *v1.Pod {
-	pod := newPod(namespace, name, node, podIP)
-	var secondaryNetworks []nadapi.NetworkSelectionElement
-	for _, multiHomingConf := range multiHomingConfigs {
-		if multiHomingConf.isPrimary {
-			continue // these will be automatically plugged in
-		}
-		nadNamePair := strings.Split(multiHomingConf.nadName, "/")
-		ns := pod.Namespace
-		attachmentName := multiHomingConf.nadName
-		if len(nadNamePair) > 1 {
-			ns = nadNamePair[0]
-			attachmentName = nadNamePair[1]
-		}
-		nse := nadapi.NetworkSelectionElement{
-			Name:      attachmentName,
-			Namespace: ns,
-		}
-		secondaryNetworks = append(secondaryNetworks, nse)
-	}
-	serializedNetworkSelectionElements, _ := json.Marshal(secondaryNetworks)
-	pod.Annotations = map[string]string{nadapi.NetworkAttachmentAnnot: string(serializedNetworkSelectionElements)}
 	return pod
 }
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -20,12 +20,8 @@ import (
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
-
 	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -900,21 +896,4 @@ func newSecondaryLayer3NetworkController(cnci *CommonNetworkControllerInfo, netI
 		newDummyGatewayManager(cnci.kube, cnci.nbClient, netInfo, cnci.watchFactory, nodeName),
 	)
 	return layer3NetworkController
-}
-
-func newDummyGatewayManager(
-	kube kube.InterfaceOVN,
-	nbClient libovsdbclient.Client,
-	netInfo util.NetInfo,
-	factory *factory.WatchFactory,
-	nodeName string,
-) *GatewayManager {
-	return NewGatewayManager(
-		nodeName,
-		"",
-		kube,
-		nbClient,
-		netInfo,
-		factory,
-	)
 }

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -861,30 +861,6 @@ func standardNonDefaultNetworkExtIDs(netInfo util.NetInfo) map[string]string {
 	}
 }
 
-func minimalFeatureConfig() *config.OVNKubernetesFeatureConfig {
-	return &config.OVNKubernetesFeatureConfig{
-		EnableNetworkSegmentation: true,
-		EnableMultiNetwork:        true,
-	}
-}
-
-func enableICFeatureConfig() *config.OVNKubernetesFeatureConfig {
-	featConfig := minimalFeatureConfig()
-	featConfig.EnableInterconnect = true
-	return featConfig
-}
-
-func icClusterTestConfiguration() testConfiguration {
-	return testConfiguration{
-		configToOverride:   enableICFeatureConfig(),
-		expectationOptions: []option{withInterconnectCluster()},
-	}
-}
-
-func nonICClusterTestConfiguration() testConfiguration {
-	return testConfiguration{}
-}
-
 func newSecondaryLayer3NetworkController(cnci *CommonNetworkControllerInfo, netInfo util.NetInfo, nodeName string) *SecondaryLayer3NetworkController {
 	layer3NetworkController := NewSecondaryLayer3NetworkController(cnci, netInfo)
 	layer3NetworkController.gatewayManagers.Store(

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -710,6 +710,12 @@ var _ = Describe("Network Segmentation", func() {
 						"These tests are known to fail on Local Gateway deployments. Upstream issue: %s", upstreamIssue,
 					)
 				}
+				if netConfigParams.topology == "layer2" && !isInterconnectEnabled() {
+					const upstreamIssue = "https://github.com/ovn-org/ovn-kubernetes/issues/4642"
+					e2eskipper.Skipf(
+						"Egress e2e tests for layer2 topologies are known to fail on non-IC deployments. Upstream issue: %s", upstreamIssue,
+					)
+				}
 				netConfig := newNetworkAttachmentConfig(netConfigParams)
 
 				netConfig.namespace = f.Namespace.Name

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -759,8 +759,7 @@ var _ = Describe("Network Segmentation", func() {
 					return connectToServer(clientPodConfig, externalIpv6, port)
 				}, 2*time.Minute, 6*time.Second).Should(Succeed())
 			},
-			// FIXME(tssurya): Unskip when L2 egress support is done
-			XEntry("by one pod with dualstack addresses over a layer2 network",
+			Entry("by one pod with dualstack addresses over a layer2 network",
 				networkAttachmentConfigParams{
 					name:     userDefinedNetworkName,
 					topology: "layer2",

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -747,7 +747,7 @@ var _ = Describe("Network Segmentation", func() {
 				podAnno, err := unmarshalPodAnnotation(updatedPod.Annotations, f.Namespace.Name+"/"+userDefinedNetworkName)
 				Expect(err).NotTo(HaveOccurred())
 				framework.Logf("Client pod's annotation for network %s is %v", userDefinedNetworkName, podAnno)
-				Expect(len(podAnno.Routes)).To(Equal(6)) // 3 v4 routes + 3 v6 routes for UDN
+				Expect(podAnno.Routes).To(HaveLen(expectedNumberOfRoutes(netConfig)))
 
 				By("asserting the *client* pod can contact the server's v4 IP located outside the cluster")
 				Eventually(func() error {
@@ -1048,4 +1048,11 @@ func connectToServerViaDefaultNetwork(clientPodConfig podConfiguration, serverIP
 
 func runExternalContainerCmd() []string {
 	return []string{"--network", "kind"}
+}
+
+func expectedNumberOfRoutes(netConfig networkAttachmentConfig) int {
+	if netConfig.topology == "layer2" {
+		return 4 // 2 routes per family
+	}
+	return 6 // 3 v4 routes + 3 v6 routes for UDN
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR reacts to the creation of layer2 primary used defined networks by establishing the OVN logical infrastructure (GW routers and external switches in each node) to allow pods connected to that primary user defined network to egress the cluster.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Run the unit tests - this PR introduces unit tests to ensure the ovn topology created is the expected.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Create logical infrastructure to allow egress for primary layer2 user defined networks

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
Create logical infrastructure to allow egress for primary layer2 user defined networks
```
