### PR TITLE
Add VRF support for EIP assigned to secondary interface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,6 +183,13 @@ jobs:
         cache-dependency-path: "**/*.sum"
       id: go
 
+    - name: Install VRF kernel module
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
+      run: |
+        set -x
+        sudo apt-get install linux-modules-extra-$(uname -r) -y
+        sudo modprobe vrf
+
     - name: Build and Test - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       run: |
@@ -453,6 +460,13 @@ jobs:
       OVN_DISABLE_FORWARDING: "${{ matrix.forwarding == 'disable-forwarding' }}"
       USE_HELM: "${{ matrix.target == 'control-plane-helm' || matrix.target == 'multi-homing-helm' }}"
     steps:
+
+  - name: Install VRF kernel module
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
+      run: |
+        set -x
+        sudo apt-get install linux-modules-extra-$(uname -r) -y
+        sudo modprobe vrf
 
     - name: Free up disk space
       run: |

--- a/docs/features/cluster-egress-controls/egress-ip.md
+++ b/docs/features/cluster-egress-controls/egress-ip.md
@@ -130,6 +130,8 @@ And the default route in the correct table `1111`:
 sh-5.2# ip route show table 1111
 default dev dummy
 ```
+Routes associated with the egress interface are copied from the main routing table to the routing table, shown above, that is created to support EgressIP.
+If the interface is enslaved to a VRF device, routes are copied from the VRF interfaces associated routing table.
 
 No NAT is required on the OVN primary network gateway router.
 OVN-Kubernetes (ovnkube-node) takes care of adding a rule to the rule table with src IP of the pod and routed towards a

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -623,12 +623,27 @@ func generateEIPConfig(link netlink.Link, eIPNet *net.IPNet, isEIPV6 bool) (*eIP
 }
 
 func generateRoutesForLink(link netlink.Link, isV6 bool) ([]netlink.Route, error) {
-	linkRoutes, err := netlink.RouteList(link, util.GetIPFamily(isV6))
+	routeTable := 254 // main table number
+	// check if device is a slave to a VRF device and if so, use VRF devices associated routing table to lookup routes instead of main table
+	if isVRFSlaveDevice(link) {
+		vrfLink, err := util.GetNetLinkOps().LinkByIndex(link.Attrs().MasterIndex)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get VRF link from interface index %d: %v", link.Attrs().MasterIndex, err)
+		}
+		vrf, ok := vrfLink.(*netlink.Vrf)
+		if !ok {
+			return nil, fmt.Errorf("expected link %s to be VRF", vrfLink.Attrs().Name)
+		}
+		routeTable = int(vrf.Table)
+	}
+	filterRoute, filterMask := filterRouteByLinkTable(link.Attrs().Index, routeTable)
+	linkRoutes, err := util.GetNetLinkOps().RouteListFiltered(util.GetIPFamily(isV6), filterRoute, filterMask)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get routes for link %s: %v", link.Attrs().Name, err)
 	}
 	linkRoutes = ensureAtLeastOneDefaultRoute(linkRoutes, link.Attrs().Index, isV6)
 	overwriteRoutesTableID(linkRoutes, util.CalculateRouteTableID(link.Attrs().Index))
+	clearSrcFromRoutes(linkRoutes)
 	return linkRoutes, nil
 }
 
@@ -1320,6 +1335,12 @@ func overwriteRoutesTableID(routes []netlink.Route, tableID int) {
 	}
 }
 
+func clearSrcFromRoutes(routes []netlink.Route) {
+	for i := range routes {
+		routes[i].Src = nil
+	}
+}
+
 func findLinkOnSameNetworkAsIP(ip net.IP, v4, v6 bool) (bool, netlink.Link, error) {
 	found, link, err := findLinkOnSameNetworkAsIPUsingLPM(ip, v4, v6)
 	if err != nil {
@@ -1509,4 +1530,8 @@ func getNodeIPFwMarkIPRule(ipFamily int) netlink.Rule {
 	r.Table = 254 // main
 	r.Family = ipFamily
 	return *r
+}
+
+func isVRFSlaveDevice(link netlink.Link) bool {
+	return link != nil && link.Attrs().Slave != nil && link.Attrs().Slave.SlaveType() == "vrf"
 }

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -229,6 +229,21 @@ func setupFakeTestNode(nodeInitialState nodeConfig) (ns.NetNS, cleanupFn, error)
 	return testNS, cleanupFn, nil
 }
 
+func createVRFAndEnslaveLink(testNS ns.NetNS, linkName, vrfName string, vrfTable int) error {
+	return testNS.Do(func(netNS ns.NetNS) error {
+		exec := kexec.New()
+		out, err := exec.Command("ip", "link", "add", vrfName, "type", "vrf", "table", fmt.Sprintf("%d", vrfTable)).CombinedOutput()
+		if len(out) > 0 || err != nil {
+			return fmt.Errorf("failed to create VRF: err: %v, out: %v", err, string(out))
+		}
+		out, err = exec.Command("ip", "link", "set", "dev", linkName, "master", vrfName).CombinedOutput()
+		if len(out) > 0 || err != nil {
+			return fmt.Errorf("failed to add link %s to VRF %s: err: %v, out: %v", linkName, vrfName, err, string(out))
+		}
+		return nil
+	})
+}
+
 func initController(namespaces []corev1.Namespace, pods []corev1.Pod, egressIPs []egressipv1.EgressIP, node nodeConfig, v4, v6, createEIPAnnot bool) (*Controller, *egressipfake.Clientset, error) {
 
 	kubeClient := fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{getNodeObj(node, createEIPAnnot)}},
@@ -697,7 +712,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink1Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork, dummy1IPv4)},
+					getDstRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP1IPV4, egressIPv4Mask),
 				dummyLink1Name,
 				[]testPodConfig{
@@ -772,7 +787,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink1Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork, dummy1IPv4)},
+					getDstRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP1IPV4, egressIPv4Mask),
 				dummyLink1Name,
 				[]testPodConfig{
@@ -836,7 +851,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink1Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork, dummy1IPv4)},
+					getDstRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP1IPV4, egressIPv4Mask),
 				dummyLink1Name,
 				[]testPodConfig{
@@ -902,7 +917,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink1Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork, dummy1IPv4)},
+					getDstRoute(getLinkIndex(dummyLink1Name), dummy1IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP1IPV4, egressIPv4Mask),
 				dummyLink1Name,
 				[]testPodConfig{
@@ -921,7 +936,7 @@ var _ = table.DescribeTable("EgressIP selectors",
 			{
 				newEgressIP(egressIP2Name, egressIP2IPV4, node1Name, namespace2Label, egressPodLabel),
 				[]netlink.Route{getDefaultIPv4Route(getLinkIndex(dummyLink2Name)),
-					getDstWithSrcRoute(getLinkIndex(dummyLink2Name), dummy2IPv4CIDRNetwork, dummy2IPv4)},
+					getDstRoute(getLinkIndex(dummyLink2Name), dummy2IPv4CIDRNetwork)},
 				getNetlinkAddr(egressIP2IPV4, egressIPv4Mask),
 				dummyLink2Name,
 				[]testPodConfig{
@@ -1067,6 +1082,51 @@ var _ = ginkgo.Describe("label to annotations migration", func() {
 	ginkgo.AfterEach(func() {
 		defer runtime.UnlockOSThread()
 		gomega.Expect(cleanupFn()).Should(gomega.Succeed())
+	})
+})
+
+var _ = ginkgo.Describe("VRF", func() {
+	ginkgo.It("copies routes from the VRF routing table for a link enslaved by VRF device", func() {
+		defer ginkgo.GinkgoRecover()
+		if os.Getenv("NOROOT") == "TRUE" {
+			ginkgo.Skip("Test requires root privileges")
+		}
+		vrfName := "vrf-dummy"
+		vrfTable := 55555
+		ginkgo.By("setup link")
+		nodeConfig := nodeConfig{routes: []netlink.Route{}, linkConfigs: []linkConfig{
+			{dummyLink1Name, []address{{dummy1IPv4CIDR, false}}},
+		}}
+		testNS, cleanupNodeFn, err := setupFakeTestNode(nodeConfig)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "fake node setup should succeed")
+		ginkgo.By("create VRF and add link")
+		gomega.Expect(createVRFAndEnslaveLink(testNS, dummyLink1Name, vrfName, vrfTable)).Should(gomega.Succeed())
+		ginkgo.By("add route to routing table associated with VRF")
+		vrfRoute := getDstRouteForTable(getLinkIndex(dummyLink1Name), vrfTable, dummy3IPv4CIDR)
+		gomega.Expect(testNS.Do(func(netNS ns.NetNS) error {
+			return netlink.RouteAdd(&vrfRoute)
+		})).Should(gomega.Succeed())
+		egressIPList := []egressipv1.EgressIP{*newEgressIP(egressIP1Name, egressIP1IPV4, node1Name, namespace1Label, egressPodLabel)}
+		pods := []corev1.Pod{newPodWithLabels(namespace1, pod1Name, node1Name, pod1IPv4, egressPodLabel)}
+		namespaces := []corev1.Namespace{newNamespaceWithLabels(namespace1, namespace1Label)}
+		ginkgo.By("start controller")
+		c, _, err := initController(namespaces, pods, egressIPList, nodeConfig, true, false, true)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		cleanupControllerFn, err := runController(testNS, c)
+		ginkgo.By("ensure route previously added is copied to new routing table")
+		eipTable := util.CalculateRouteTableID(getLinkIndex(dummyLink1Name))
+		gomega.Eventually(func() bool {
+			eipRoutes, err := getRoutesFromTable(testNS, eipTable, netlink.FAMILY_V4)
+			gomega.Expect(err).Should(gomega.Succeed())
+			for _, eipRoute := range eipRoutes {
+				if eipRoute.Dst.String() == vrfRoute.Dst.String() {
+					return true
+				}
+			}
+			return false
+		}).Should(gomega.BeTrue(), "route should be copied to new routing table")
+		gomega.Expect(cleanupControllerFn()).ShouldNot(gomega.HaveOccurred())
+		gomega.Expect(cleanupNodeFn()).ShouldNot(gomega.HaveOccurred())
 	})
 })
 
@@ -1415,7 +1475,7 @@ func getRoutesForLinkFromTable(testNS ns.NetNS, linkName string) ([]netlink.Rout
 		if err != nil {
 			return err
 		}
-		filterRoute, filterMask := filterRouteByTable(link.Attrs().Index, util.CalculateRouteTableID(link.Attrs().Index))
+		filterRoute, filterMask := filterRouteByLinkTable(link.Attrs().Index, util.CalculateRouteTableID(link.Attrs().Index))
 		routes, err = netlink.RouteListFiltered(netlink.FAMILY_ALL, filterRoute, filterMask)
 		if err != nil {
 			return err
@@ -1425,12 +1485,25 @@ func getRoutesForLinkFromTable(testNS ns.NetNS, linkName string) ([]netlink.Rout
 	return routes, err
 }
 
-func filterRouteByTable(linkIndex, table int) (*netlink.Route, uint64) {
+func getRoutesFromTable(testNS ns.NetNS, table, family int) ([]netlink.Route, error) {
+	var err error
+	var routes []netlink.Route
+	err = testNS.Do(func(netNS ns.NetNS) error {
+		filterRoute, filterMask := filterRouteByTable(table)
+		routes, err = netlink.RouteListFiltered(family, filterRoute, filterMask)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return routes, err
+}
+
+func filterRouteByTable(table int) (*netlink.Route, uint64) {
 	return &netlink.Route{
-			LinkIndex: linkIndex,
-			Table:     table,
+			Table: table,
 		},
-		netlink.RT_FILTER_OIF | netlink.RT_FILTER_TABLE
+		netlink.RT_FILTER_TABLE
 }
 
 func newEgressIPMeta(name string) metav1.ObjectMeta {
@@ -1549,11 +1622,16 @@ func getDefaultIPv6Route(linkIndex int) netlink.Route {
 }
 
 func getDstRoute(linkIndex int, dst string) netlink.Route {
+	return getDstRouteForTable(linkIndex, util.CalculateRouteTableID(linkIndex), dst)
+
+}
+
+func getDstRouteForTable(linkIndex, table int, dst string) netlink.Route {
 	_, dstIPNet, err := net.ParseCIDR(dst)
 	if err != nil {
 		panic(err.Error())
 	}
-	return netlink.Route{LinkIndex: linkIndex, Dst: dstIPNet, Table: util.CalculateRouteTableID(linkIndex)}
+	return netlink.Route{LinkIndex: linkIndex, Dst: dstIPNet, Table: table}
 }
 
 func getDstWithSrcRoute(linkIndex int, dst, src string) netlink.Route {

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -140,7 +140,13 @@ func (c *Controller) DelAddress(address netlink.Addr) error {
 		return fmt.Errorf("address (%s) is not valid", address.String())
 	}
 	link, err := util.GetNetLinkOps().LinkByIndex(address.LinkIndex)
-	if err != nil && !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+	if err != nil {
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			c.mu.Lock()
+			c.delLinkFromStoreByIndex(address.LinkIndex)
+			c.mu.Unlock()
+			return nil
+		}
 		return fmt.Errorf("no valid link associated with addresses %s: %v", address.String(), err)
 	}
 	klog.Infof("Link manager: deleting address %s from link %s", address.String(), link.Attrs().Name)
@@ -247,7 +253,26 @@ func (c *Controller) delAddressFromStore(linkName string, address netlink.Addr) 
 			temp = append(temp, addressSaved)
 		}
 	}
-	c.store[linkName] = temp
+	if len(temp) == 0 {
+		delete(c.store, linkName)
+	} else {
+		c.store[linkName] = temp
+	}
+}
+
+func (c *Controller) delLinkFromStoreByIndex(linkToDelIndex int) {
+	var linkNameToDelete string
+	for linkName, addresses := range c.store {
+		if len(addresses) > 0 {
+			if linkToDelIndex == addresses[0].LinkIndex {
+				linkNameToDelete = linkName
+				break
+			}
+		}
+	}
+	if linkNameToDelete != "" {
+		delete(c.store, linkNameToDelete)
+	}
 }
 
 func (c *Controller) isAddressValid(address netlink.Addr) bool {

--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -273,6 +273,7 @@ func (c *Controller) sync() {
 				link, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
 				if err != nil {
 					klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					continue
 				}
 				if err := c.applyRoute(link, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table); err != nil {
 					klog.Errorf("Route Manager: failed to apply route (%s): %v", managedRoute.String(), err)

--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -115,6 +115,10 @@ func (c *Controller) delRoute(r netlink.Route) error {
 	klog.Infof("Route Manager: attempting to delete route: %s", r.String())
 	link, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
 	if err != nil {
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			delete(c.store, r.LinkIndex)
+			return nil
+		}
 		return fmt.Errorf("failed to delete route (%s) because unable to get link: %v", r.String(), err)
 	}
 	if err := c.netlinkDelRoute(link, r.Dst, r.Table); err != nil {
@@ -254,6 +258,7 @@ func (c *Controller) addRouteToStore(r netlink.Route) bool {
 // sync will iterate through all routes seen on a node and ensure any route manager managed routes are applied. Any additional
 // routes for this link are preserved. sync only inspects routes for links which we managed and ignore routes for non-managed links.
 func (c *Controller) sync() {
+	deletedLinkIndexes := make([]int, 0)
 	for linkIndex, managedRoutes := range c.store {
 		for _, managedRoute := range managedRoutes {
 			filterRoute, filterMask := filterRouteByDstAndTable(linkIndex, managedRoute.Dst, managedRoute.Table)
@@ -272,7 +277,11 @@ func (c *Controller) sync() {
 			if !found {
 				link, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
 				if err != nil {
-					klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+						deletedLinkIndexes = append(deletedLinkIndexes, linkIndex)
+					} else {
+						klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					}
 					continue
 				}
 				if err := c.applyRoute(link, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table); err != nil {
@@ -280,6 +289,10 @@ func (c *Controller) sync() {
 				}
 			}
 		}
+	}
+	for _, linkIndex := range deletedLinkIndexes {
+		klog.Infof("Route Manager: removing all routes associated with link index %d because link deleted", linkIndex)
+		delete(c.store, linkIndex)
 	}
 }
 


### PR DESCRIPTION
If EIP assigned to secondary interface thats enslaved by a VRF device, use the associated  VRF devices routing table instead of main. Added unit tests + e2e.


