### PR TITLE
Add support for Pod->KAPI/DNS traffic in user-defined primary networks

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/safchain/ethtool v0.3.1-0.20231027162144-83e5e0097c91
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.8.4
-	github.com/urfave/cli/v2 v2.2.0
+	github.com/urfave/cli/v2 v2.27.2
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20231024175852-77df5d35f725
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/net v0.25.0
@@ -71,7 +71,7 @@ require (
 	github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
@@ -114,6 +114,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
+	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -228,8 +228,8 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
-github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
@@ -774,8 +774,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
-github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=
+github.com/urfave/cli/v2 v2.27.2/go.mod h1:g0+79LmHHATl7DAcHO99smiR/T7uGLw84w8Y42x+4eM=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
@@ -793,6 +793,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe9UDgpxAWQrhbbBXOYJFQDq/dtJw=
+github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913/go.mod h1:4aEEwZQutDLsQv2Deui4iYQ6DWTxR14g6m8Wv88+Xqk=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -60,19 +60,20 @@ var (
 
 	// Default holds parsed config file parameters and command-line overrides
 	Default = DefaultConfig{
-		MTU:                   1400,
-		ConntrackZone:         64000,
-		EncapType:             "geneve",
-		EncapIP:               "",
-		EncapPort:             DefaultEncapPort,
-		InactivityProbe:       100000, // in Milliseconds
-		OpenFlowProbe:         180,    // in Seconds
-		OfctrlWaitBeforeClear: 0,      // in Milliseconds
-		MonitorAll:            true,
-		OVSDBTxnTimeout:       DefaultDBTxnTimeout,
-		LFlowCacheEnable:      true,
-		RawClusterSubnets:     "10.128.0.0/14/23",
-		Zone:                  types.OvnDefaultZone,
+		MTU:                       1400,
+		ConntrackZone:             64000,
+		EncapType:                 "geneve",
+		EncapIP:                   "",
+		EncapPort:                 DefaultEncapPort,
+		InactivityProbe:           100000, // in Milliseconds
+		OpenFlowProbe:             180,    // in Seconds
+		OfctrlWaitBeforeClear:     0,      // in Milliseconds
+		MonitorAll:                true,
+		OVSDBTxnTimeout:           DefaultDBTxnTimeout,
+		LFlowCacheEnable:          true,
+		RawClusterSubnets:         "10.128.0.0/14/23",
+		Zone:                      types.OvnDefaultZone,
+		UDNAllowedDefaultServices: *cli.NewStringSlice("default/kubernetes", "kube-system/kube-dns"),
 	}
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
@@ -280,6 +281,10 @@ type DefaultConfig struct {
 
 	// Zone name to which ovnkube-node/ovnkube-controller belongs to
 	Zone string `gcfg:"zone"`
+
+	// UDNAllowedDefaultServices holds a list of namespaced names of
+	// default cluster network services accessible from primary user-defined networks
+	UDNAllowedDefaultServices cli.StringSlice `gcfg:"udn-allowed-default-services"`
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -920,6 +925,14 @@ var CommonFlags = []cli.Flag{
 		Usage:       "zone name to which ovnkube-node/ovnkube-controller belongs to",
 		Value:       Default.Zone,
 		Destination: &cliConfig.Default.Zone,
+	},
+	&cli.StringSliceFlag{
+		Name: "udn-allowed-default-services",
+		Usage: "a list of namespaced names of default cluster network services accessible from primary" +
+			"user-defined networks. If not specified defaults to [\"default/kubernetes\", \"kube-system/kube-dns\"]." +
+			"Only used when enable-network-segmentation is set",
+		Value:       &Default.UDNAllowedDefaultServices,
+		Destination: &cliConfig.Default.UDNAllowedDefaultServices,
 	},
 }
 

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -12,6 +12,13 @@ import (
 	anpinformerfactory "sigs.k8s.io/network-policy-api/pkg/client/informers/externalversions"
 	anpinformer "sigs.k8s.io/network-policy-api/pkg/client/informers/externalversions/apis/v1alpha1"
 
+	certificatesinformers "k8s.io/client-go/informers/certificates/v1"
+
+	ocpnetworkapiv1alpha1 "github.com/openshift/api/network/v1alpha1"
+	ocpnetworkscheme "github.com/openshift/client-go/network/clientset/versioned/scheme"
+	ocpnetworkinformerfactory "github.com/openshift/client-go/network/informers/externalversions"
+	ocpnetworkinformerv1alpha1 "github.com/openshift/client-go/network/informers/externalversions/network/v1alpha1"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewallapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	egressfirewallscheme "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/scheme"
@@ -20,12 +27,6 @@ import (
 	egressfirewalllister "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/listers/egressfirewall/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	certificatesinformers "k8s.io/client-go/informers/certificates/v1"
-
-	ocpnetworkapiv1alpha1 "github.com/openshift/api/network/v1alpha1"
-	ocpnetworkscheme "github.com/openshift/client-go/network/clientset/versioned/scheme"
-	ocpnetworkinformerfactory "github.com/openshift/client-go/network/informers/externalversions"
-	ocpnetworkinformerv1alpha1 "github.com/openshift/client-go/network/informers/externalversions/network/v1alpha1"
 
 	egressipapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipscheme "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned/fake"
 	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
@@ -1275,6 +1276,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			)
 			expectedTables["nat"]["OVN-KUBE-UDN-MASQUERADE"] = append(expectedTables["nat"]["OVN-KUBE-UDN-MASQUERADE"],
 				"-s 169.254.169.2/29 -j RETURN",     // this guarantees we don't SNAT default network masqueradeIPs
+				"-d 172.16.1.0/24 -j RETURN",        // this guarantees we don't SNAT service traffic
 				"-s 169.254.169.0/29 -j MASQUERADE", // this guarantees we SNAT all UDN MasqueradeIPs traffic leaving the node
 			)
 		}

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -12,6 +12,7 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	"github.com/coreos/go-iptables/iptables"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice"
 	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
@@ -493,6 +494,7 @@ func getUDNMasqueradeRules(protocol iptables.Protocol) []nodeipt.Rule {
 	// the following rules are actively used only for the UDN Feature:
 	// -A POSTROUTING -j OVN-KUBE-UDN-MASQUERADE
 	// -A OVN-KUBE-UDN-MASQUERADE -s 169.254.0.0/29 -j RETURN
+	// -A OVN-KUBE-UDN-MASQUERADE -d 10.96.0.0/16 -j RETURN
 	// -A OVN-KUBE-UDN-MASQUERADE -s 169.254.0.0/17 -j MASQUERADE
 	// NOTE: Ordering is important here, the RETURN must come before
 	// the MASQUERADE rule. Please don't change the ordering.
@@ -500,11 +502,13 @@ func getUDNMasqueradeRules(protocol iptables.Protocol) []nodeipt.Rule {
 	// defaultNetworkReservedMasqueradePrefix contains the first 6IPs in the masquerade
 	// range that shouldn't be MASQUERADED. Hence /29 and /125 is intentionally hardcoded here
 	defaultNetworkReservedMasqueradePrefix := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String() + "/29"
+	ipFamily := utilnet.IPv4
 	if protocol == iptables.ProtocolIPv6 {
 		srcUDNMasqueradePrefix = config.Gateway.V6MasqueradeSubnet
 		defaultNetworkReservedMasqueradePrefix = config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String() + "/125"
+		ipFamily = utilnet.IPv6
 	}
-	return []nodeipt.Rule{
+	rules := []nodeipt.Rule{
 		{
 			Table:    "nat",
 			Chain:    "POSTROUTING",
@@ -520,7 +524,25 @@ func getUDNMasqueradeRules(protocol iptables.Protocol) []nodeipt.Rule {
 			},
 			Protocol: protocol,
 		},
-		{
+	}
+	for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+		if utilnet.IPFamilyOfCIDR(svcCIDR) != ipFamily {
+			continue
+		}
+		rules = append(rules,
+			nodeipt.Rule{
+				Table: "nat",
+				Chain: iptableUDNMasqueradeChain,
+				Args: []string{
+					"-d", svcCIDR.String(),
+					"-j", "RETURN",
+				},
+				Protocol: protocol,
+			},
+		)
+	}
+	rules = append(rules,
+		nodeipt.Rule{
 			Table: "nat",
 			Chain: iptableUDNMasqueradeChain,
 			Args: []string{
@@ -529,7 +551,8 @@ func getUDNMasqueradeRules(protocol iptables.Protocol) []nodeipt.Rule {
 			},
 			Protocol: protocol,
 		},
-	}
+	)
+	return rules
 }
 
 // initLocalGatewayNATRules sets up iptables rules for interfaces

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -8,6 +8,7 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/ovsdb"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -3,18 +3,23 @@ package services
 import (
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+	"golang.org/x/time/rate"
+
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	networkAttachDefController "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"golang.org/x/time/rate"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -25,6 +30,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	discoverylisters "k8s.io/client-go/listers/discovery/v1"
+	utilnet "k8s.io/utils/net"
 
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
@@ -219,7 +225,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 		// Run the repair controller only once
 		// it keeps in sync Kubernetes and OVN
 		// and handles removal of stale data on upgrades
-		c.repair.runBeforeSync(c.useTemplates, c.netInfo)
+		c.repair.runBeforeSync(c.useTemplates, c.netInfo, c.nodeTracker.nodes)
 	}
 
 	if err := c.initTopLevelCache(); err != nil {
@@ -357,6 +363,21 @@ func (c *Controller) syncService(key string) error {
 	// because we are getting the object from the informer´s cache
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
+	}
+
+	// Handle default network services enabled for UDN in shared gateway mode
+	if c.netInfo.IsPrimaryNetwork() &&
+		util.IsUDNEnabledService(key) {
+
+		if service == nil {
+			return c.cleanupUDNEnabledServiceRoute(key)
+		}
+
+		err = c.configureUDNEnabledServiceRoute(service)
+		if err != nil {
+			return fmt.Errorf("failed to configure the UDN enabled service route: %v", err)
+		}
+		return nil
 	}
 
 	// Delete the Service's LB(s) from OVN if:
@@ -551,6 +572,15 @@ func (c *Controller) skipService(name, namespace string) bool {
 				namespace, name, err))
 			return true
 		}
+
+		// Do not skip default network services enabled for UDN
+		if serviceNetwork.IsDefault() &&
+			c.netInfo.IsPrimaryNetwork() &&
+			globalconfig.Gateway.Mode == globalconfig.GatewayModeShared &&
+			util.IsUDNEnabledService(ktypes.NamespacedName{Namespace: namespace, Name: name}.String()) {
+			return false
+		}
+
 		if serviceNetwork.GetNetworkName() != c.netInfo.GetNetworkName() {
 			return true
 		}
@@ -702,6 +732,80 @@ func (c *Controller) getServiceNamespacedNameFromEndpointSlice(endpointSlice *di
 	} else {
 		return _getServiceNameFromEndpointSlice(endpointSlice, false)
 	}
+}
+
+func (c *Controller) cleanupUDNEnabledServiceRoute(key string) error {
+	klog.Infof("Removing UDN enabled service route for service %s in network: %s", key, c.netInfo.GetNetworkName())
+	delPredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+		return route.ExternalIDs[types.NetworkExternalID] == c.netInfo.GetNetworkName() &&
+			route.ExternalIDs[types.TopologyExternalID] == c.netInfo.TopologyType() &&
+			route.ExternalIDs[types.UDNEnabledServiceExternalID] == key
+	}
+
+	var ops []libovsdb.Operation
+	var err error
+	if c.netInfo.TopologyType() == types.Layer2Topology {
+		for _, node := range c.nodeInfos {
+			if ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, c.netInfo.GetNetworkScopedGWRouterName(node.name), delPredicate); err != nil {
+				return err
+			}
+		}
+	} else {
+		if ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, c.netInfo.GetNetworkScopedClusterRouterName(), delPredicate); err != nil {
+			return err
+		}
+	}
+	_, err = libovsdbops.TransactAndCheck(c.nbClient, ops)
+	return err
+}
+
+func (c *Controller) configureUDNEnabledServiceRoute(service *v1.Service) error {
+	klog.Infof("Configuring UDN enabled service route for service %s/%s in network: %s", service.Namespace, service.Name, c.netInfo.GetNetworkName())
+
+	extIDs := map[string]string{
+		types.NetworkExternalID:           c.netInfo.GetNetworkName(),
+		types.TopologyExternalID:          c.netInfo.TopologyType(),
+		types.UDNEnabledServiceExternalID: ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}.String(),
+	}
+	routesEqual := func(a, b *nbdb.LogicalRouterStaticRoute) bool {
+		return a.IPPrefix == b.IPPrefix &&
+			a.ExternalIDs[types.NetworkExternalID] == b.ExternalIDs[types.NetworkExternalID] &&
+			a.ExternalIDs[types.TopologyExternalID] == b.ExternalIDs[types.TopologyExternalID] &&
+			a.ExternalIDs[types.UDNEnabledServiceExternalID] == b.ExternalIDs[types.UDNEnabledServiceExternalID] &&
+			libovsdbops.PolicyEqualPredicate(a.Policy, b.Policy) &&
+			a.Nexthop == b.Nexthop
+
+	}
+	var ops []libovsdb.Operation
+	for _, nodeInfo := range c.nodeInfos {
+		var mgmtPortIPs []net.IP
+		for _, subnet := range nodeInfo.podSubnets {
+			mgmtPortIPs = append(mgmtPortIPs, util.GetNodeManagementIfAddr(&subnet).IP)
+		}
+		mgmtIP, err := util.MatchFirstIPFamily(utilnet.IsIPv6String(service.Spec.ClusterIP), mgmtPortIPs)
+		if err != nil {
+			return err
+		}
+		staticRoute := nbdb.LogicalRouterStaticRoute{
+			Policy:      &nbdb.LogicalRouterStaticRoutePolicyDstIP,
+			IPPrefix:    service.Spec.ClusterIP,
+			Nexthop:     mgmtIP.String(),
+			ExternalIDs: extIDs,
+		}
+		routerName := c.netInfo.GetNetworkScopedClusterRouterName()
+		if c.netInfo.TopologyType() == types.Layer2Topology {
+			routerName = nodeInfo.gatewayRouterName
+		}
+		ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, nil, routerName, &staticRoute, func(item *nbdb.LogicalRouterStaticRoute) bool {
+			return routesEqual(item, &staticRoute)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := libovsdbops.TransactAndCheck(c.nbClient, ops)
+	return err
 }
 
 func _getServiceNameFromEndpointSlice(endpointSlice *discovery.EndpointSlice, inDefaultNetwork bool) (ktypes.NamespacedName, error) {

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -598,7 +598,7 @@ func (gw *GatewayManager) GatewayInit(
 			// management port interface for the hostSubnet prefix before adding the routes
 			// towards join switch.
 			mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
-			gw.staticRouteCleanup([]net.IP{mgmtIfAddr.IP})
+			gw.staticRouteCleanup([]net.IP{mgmtIfAddr.IP}, hostSubnet)
 
 			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(
 				gw.nbClient,
@@ -611,10 +611,13 @@ func (gw *GatewayManager) GatewayInit(
 			}
 		} else if config.Gateway.Mode == config.GatewayModeLocal {
 			// If migrating from shared to local gateway, let's remove the static routes towards
-			// join switch for the hostSubnet prefix
+			// join switch for the hostSubnet prefix and any potential routes for UDN enabled services.
 			// Note syncManagementPort happens before gateway sync so only remove things pointing to join subnet
 			if gw.clusterRouterName != "" {
 				p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+					if _, ok := item.ExternalIDs[types.UDNEnabledServiceExternalID]; ok {
+						return true
+					}
 					return item.IPPrefix == lrsr.IPPrefix && item.Policy != nil && *item.Policy == *lrsr.Policy &&
 						gw.containsJoinIP(net.ParseIP(item.Nexthop))
 				}
@@ -1035,7 +1038,7 @@ func (gw *GatewayManager) Cleanup() error {
 	for _, gwIPAddr := range gwIPAddrs {
 		nextHops = append(nextHops, gwIPAddr.IP)
 	}
-	gw.staticRouteCleanup(nextHops)
+	gw.staticRouteCleanup(nextHops, nil)
 	gw.policyRouteCleanup(nextHops)
 
 	// Remove the patch port that connects join switch to gateway router
@@ -1103,7 +1106,7 @@ func (gw *GatewayManager) delPbrAndNatRules(nodeName string) {
 	gw.removeLRPolicies(nodeName)
 }
 
-func (gw *GatewayManager) staticRouteCleanup(nextHops []net.IP) {
+func (gw *GatewayManager) staticRouteCleanup(nextHops []net.IP, ipPrefix *net.IPNet) {
 	if len(nextHops) == 0 {
 		return // if we do not have next hops, we do not have any routes to cleanup
 	}
@@ -1117,6 +1120,9 @@ func (gw *GatewayManager) staticRouteCleanup(nextHops []net.IP) {
 			networkName = types.DefaultNetworkName
 		}
 		if networkName != gw.netInfo.GetNetworkName() {
+			return false
+		}
+		if ipPrefix != nil && item.IPPrefix != ipPrefix.String() {
 			return false
 		}
 		return ips.Has(item.Nexthop)

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -365,8 +365,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		ginkgo.It("creates an IPv4 gateway in OVN", func() {
 			routeUUID := "route-UUID"
 			leftoverMgmtIPRoute := &nbdb.LogicalRouterStaticRoute{
-				Nexthop: "10.130.0.2",
-				UUID:    routeUUID,
+				Nexthop:  "10.130.0.2",
+				IPPrefix: "10.130.0.0/23",
+				UUID:     routeUUID,
 			}
 			expectedOVNClusterRouter := &nbdb.LogicalRouter{
 				UUID:         types.OVNClusterRouter + "-UUID",
@@ -675,8 +676,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		ginkgo.It("creates an IPv4 gateway in OVN without next hops", func() {
 			routeUUID := "route-UUID"
 			leftoverMgmtIPRoute := &nbdb.LogicalRouterStaticRoute{
-				Nexthop: "10.130.0.2",
-				UUID:    routeUUID,
+				Nexthop:  "10.130.0.2",
+				IPPrefix: "10.130.0.0/23",
+				UUID:     routeUUID,
 			}
 			expectedOVNClusterRouter := &nbdb.LogicalRouter{
 				UUID:         types.OVNClusterRouter + "-UUID",

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -197,6 +197,8 @@ const (
 	LoadBalancerKindExternalID = OvnK8sPrefix + "/" + "kind"
 	// key for load_balancer service external-id
 	LoadBalancerOwnerExternalID = OvnK8sPrefix + "/" + "owner"
+	// key for UDN enabled services routes
+	UDNEnabledServiceExternalID = OvnK8sPrefix + "/" + "udn-enabled-default-service"
 
 	// different secondary network topology type defined in CNI netconf
 	Layer3Topology   = "layer3"

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -579,3 +579,13 @@ func GetServiceEndpointSlices(namespace, svcName, network string, endpointSliceL
 	}
 	return GetEndpointSlicesBySelector(namespace, selector, endpointSliceLister)
 }
+
+// IsUDNEnabledService checks whether the provided namespaced name key is a UDN enabled service specified in config.Default.UDNAllowedDefaultServices
+func IsUDNEnabledService(key string) bool {
+	for _, enabledService := range config.Default.UDNAllowedDefaultServices.Value() {
+		if enabledService == key {
+			return true
+		}
+	}
+	return false
+}

--- a/go-controller/vendor/github.com/urfave/cli/v2/.gitignore
+++ b/go-controller/vendor/github.com/urfave/cli/v2/.gitignore
@@ -1,7 +1,14 @@
 *.coverprofile
+*.exe
 *.orig
-node_modules/
-vendor
+.*envrc
+.envrc
 .idea
-internal/*/built-example
+# goimports is installed here if not available
+/.local/
+/site/
 coverage.txt
+internal/*/built-example
+vendor
+/cmd/urfave-cli-genflags/urfave-cli-genflags
+*.exe

--- a/go-controller/vendor/github.com/urfave/cli/v2/.golangci.yaml
+++ b/go-controller/vendor/github.com/urfave/cli/v2/.golangci.yaml
@@ -1,0 +1,4 @@
+# https://golangci-lint.run/usage/configuration/
+linters:
+  enable:
+    - misspell

--- a/go-controller/vendor/github.com/urfave/cli/v2/CODE_OF_CONDUCT.md
+++ b/go-controller/vendor/github.com/urfave/cli/v2/CODE_OF_CONDUCT.md
@@ -55,11 +55,12 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting Dan Buch at dan@meatballhat.com. All complaints will be
-reviewed and investigated and will result in a response that is deemed necessary
-and appropriate to the circumstances. The project team is obligated to maintain
-confidentiality with regard to the reporter of an incident.  Further details of
-specific enforcement policies may be posted separately.
+reported by contacting urfave-governance@googlegroups.com, a members-only group
+that is world-postable. All complaints will be reviewed and investigated and
+will result in a response that is deemed necessary and appropriate to the
+circumstances. The project team is obligated to maintain confidentiality with
+regard to the reporter of an incident. Further details of specific enforcement
+policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other

--- a/go-controller/vendor/github.com/urfave/cli/v2/LICENSE
+++ b/go-controller/vendor/github.com/urfave/cli/v2/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Jeremy Saenz & Contributors
+Copyright (c) 2022 urfave/cli maintainers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/go-controller/vendor/github.com/urfave/cli/v2/Makefile
+++ b/go-controller/vendor/github.com/urfave/cli/v2/Makefile
@@ -1,0 +1,26 @@
+# NOTE: this Makefile is meant to provide a simplified entry point for humans to
+# run all of the critical steps to verify one's changes are harmonious in
+# nature. Keeping target bodies to one line each and abstaining from make magic
+# are very important so that maintainers and contributors can focus their
+# attention on files that are primarily Go.
+
+GO_RUN_BUILD := go run internal/build/build.go
+
+.PHONY: all
+all: generate vet test check-binary-size gfmrun yamlfmt v2diff
+
+# NOTE: this is a special catch-all rule to run any of the commands
+# defined in internal/build/build.go with optional arguments passed
+# via GFLAGS (global flags) and FLAGS (command-specific flags), e.g.:
+#
+#   $ make test GFLAGS='--packages cli'
+%:
+	$(GO_RUN_BUILD) $(GFLAGS) $* $(FLAGS)
+
+.PHONY: docs
+docs:
+	mkdocs build
+
+.PHONY: serve-docs
+serve-docs:
+	mkdocs serve

--- a/go-controller/vendor/github.com/urfave/cli/v2/README.md
+++ b/go-controller/vendor/github.com/urfave/cli/v2/README.md
@@ -1,66 +1,19 @@
-cli
-===
+# cli
 
-[![GoDoc](https://godoc.org/github.com/urfave/cli?status.svg)](https://godoc.org/github.com/urfave/cli)
-[![codebeat](https://codebeat.co/badges/0a8f30aa-f975-404b-b878-5fab3ae1cc5f)](https://codebeat.co/projects/github-com-urfave-cli)
-[![Go Report Card](https://goreportcard.com/badge/urfave/cli)](https://goreportcard.com/report/urfave/cli)
-[![codecov](https://codecov.io/gh/urfave/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/urfave/cli)
+[![Run Tests](https://github.com/urfave/cli/actions/workflows/cli.yml/badge.svg?branch=v2-maint)](https://github.com/urfave/cli/actions/workflows/cli.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/urfave/cli/v2.svg)](https://pkg.go.dev/github.com/urfave/cli/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/urfave/cli/v2)](https://goreportcard.com/report/github.com/urfave/cli/v2)
+[![codecov](https://codecov.io/gh/urfave/cli/branch/v2-maint/graph/badge.svg?token=t9YGWLh05g)](https://app.codecov.io/gh/urfave/cli/tree/v2-maint)
 
 cli is a simple, fast, and fun package for building command line apps in Go. The
 goal is to enable developers to write fast and distributable command line
 applications in an expressive way.
 
-## Usage Documentation
+## Documentation
 
-Usage documentation exists for each major version. Don't know what version you're on? You're probably using the version from the `master` branch, which is currently `v2`.
+More documentation is available in [`./docs`](./docs) or the hosted
+documentation site at <https://cli.urfave.org>.
 
-- `v2` - [./docs/v2/manual.md](./docs/v2/manual.md)
-- `v1` - [./docs/v1/manual.md](./docs/v1/manual.md)
+## License
 
-## Installation
-
-Make sure you have a working Go environment.  Go version 1.11+ is supported. [See the install instructions for Go](http://golang.org/doc/install.html).
-
-Go Modules are strongly recommended when using this package. [See the go blog guide on using Go Modules](https://blog.golang.org/using-go-modules).
-
-### Using `v2` releases
-
-```
-$ GO111MODULE=on go get github.com/urfave/cli/v2
-```
-
-```go
-...
-import (
-  "github.com/urfave/cli/v2" // imports as package "cli"
-)
-...
-```
-
-### Using `v1` releases
-
-```
-$ GO111MODULE=on go get github.com/urfave/cli
-```
-
-```go
-...
-import (
-  "github.com/urfave/cli"
-)
-...
-```
-
-### GOPATH
-
-Make sure your `PATH` includes the `$GOPATH/bin` directory so your commands can
-be easily used:
-```
-export PATH=$PATH:$GOPATH/bin
-```
-
-### Supported platforms
-
-cli is tested against multiple versions of Go on Linux, and against the latest
-released version of Go on OS X and Windows. This project uses Github Actions for
-builds. For more build info, please look at the [./.github/workflows/cli.yml](https://github.com/urfave/cli/blob/master/.github/workflows/cli.yml).
+See [`LICENSE`](./LICENSE)

--- a/go-controller/vendor/github.com/urfave/cli/v2/app.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/app.go
@@ -8,16 +8,24 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 )
 
+const suggestDidYouMeanTemplate = "Did you mean %q?"
+
 var (
-	changeLogURL            = "https://github.com/urfave/cli/blob/master/docs/CHANGELOG.md"
+	changeLogURL            = "https://github.com/urfave/cli/blob/main/docs/CHANGELOG.md"
 	appActionDeprecationURL = fmt.Sprintf("%s#deprecated-cli-app-action-signature", changeLogURL)
 	contactSysadmin         = "This is an error in the application.  Please contact the distributor of this application if this is not you."
 	errInvalidActionType    = NewExitError("ERROR invalid Action type. "+
 		fmt.Sprintf("Must be `func(*Context`)` or `func(*Context) error).  %s", contactSysadmin)+
 		fmt.Sprintf("See %s", appActionDeprecationURL), 2)
+	ignoreFlagPrefix = "test." // this is to ignore test flags when adding flags from other packages
+
+	SuggestFlag               SuggestFlagFunc    = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestCommand            SuggestCommandFunc = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
 )
 
 // App is the main structure of a cli application. It is recommended that
@@ -31,12 +39,17 @@ type App struct {
 	Usage string
 	// Text to override the USAGE section of help
 	UsageText string
+	// Whether this command supports arguments
+	Args bool
 	// Description of the program argument format.
 	ArgsUsage string
 	// Version of the program
 	Version string
 	// Description of the program
 	Description string
+	// DefaultCommand is the (optional) name of a command
+	// to run if no command names are passed as CLI arguments.
+	DefaultCommand string
 	// List of commands to execute
 	Commands []*Command
 	// List of flags to parse
@@ -52,6 +65,8 @@ type App struct {
 	HideVersion bool
 	// categories contains the categorized commands and is populated on app startup
 	categories CommandCategories
+	// flagCategories contains the categorized flags and is populated on app startup
+	flagCategories FlagCategories
 	// An action to execute when the shell completion flag is set
 	BashComplete BashCompleteFunc
 	// An action to execute before any subcommands are run, but after the context is ready
@@ -64,20 +79,25 @@ type App struct {
 	Action ActionFunc
 	// Execute this function if the proper command cannot be found
 	CommandNotFound CommandNotFoundFunc
-	// Execute this function if an usage error occurs
+	// Execute this function if a usage error occurs
 	OnUsageError OnUsageErrorFunc
+	// Execute this function when an invalid flag is accessed from the context
+	InvalidFlagAccessHandler InvalidFlagAccessFunc
 	// Compilation date
 	Compiled time.Time
 	// List of all authors who contributed
 	Authors []*Author
 	// Copyright of the binary if any
 	Copyright string
+	// Reader reader to write input to (useful for tests)
+	Reader io.Reader
 	// Writer writer to write output to
 	Writer io.Writer
 	// ErrWriter writes error output
 	ErrWriter io.Writer
-	// Execute this function to handle ExitErrors. If not provided, HandleExitCoder is provided to
-	// function as a default, so this is optional.
+	// ExitErrHandler processes any error encountered while running an App before
+	// it is returned to the caller. If no function is provided, HandleExitCoder
+	// is used as the default behavior.
 	ExitErrHandler ExitErrHandlerFunc
 	// Other custom info
 	Metadata map[string]interface{}
@@ -87,13 +107,31 @@ type App struct {
 	// cli.go uses text/template to render templates. You can
 	// render custom help text by setting this variable.
 	CustomAppHelpTemplate string
+	// SliceFlagSeparator is used to customize the separator for SliceFlag, the default is ","
+	SliceFlagSeparator string
+	// DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
+	DisableSliceFlagSeparator bool
 	// Boolean to enable short-option handling so user can combine several
 	// single-character bool arguments into one
 	// i.e. foobar -o -v -> foobar -ov
 	UseShortOptionHandling bool
+	// Enable suggestions for commands and flags
+	Suggest bool
+	// Allows global flags set by libraries which use flag.XXXVar(...) directly
+	// to be parsed through this library
+	AllowExtFlags bool
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
 
-	didSetup bool
+	didSetup  bool
+	separator separatorSpec
+
+	rootCommand *Command
 }
+
+type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
+
+type SuggestCommandFunc func(commands []*Command, provided string) string
 
 // Tries to find out when this binary was compiled.
 // Returns the current time if it fails to find it.
@@ -110,13 +148,14 @@ func compileTime() time.Time {
 func NewApp() *App {
 	return &App{
 		Name:         filepath.Base(os.Args[0]),
-		HelpName:     filepath.Base(os.Args[0]),
 		Usage:        "A new cli application",
 		UsageText:    "",
 		BashComplete: DefaultAppComplete,
 		Action:       helpCommand.Action,
 		Compiled:     compileTime(),
+		Reader:       os.Stdin,
 		Writer:       os.Stdout,
+		ErrWriter:    os.Stderr,
 	}
 }
 
@@ -135,7 +174,7 @@ func (a *App) Setup() {
 	}
 
 	if a.HelpName == "" {
-		a.HelpName = filepath.Base(os.Args[0])
+		a.HelpName = a.Name
 	}
 
 	if a.Usage == "" {
@@ -158,19 +197,47 @@ func (a *App) Setup() {
 		a.Compiled = compileTime()
 	}
 
+	if a.Reader == nil {
+		a.Reader = os.Stdin
+	}
+
 	if a.Writer == nil {
 		a.Writer = os.Stdout
 	}
 
-	var newCommands []*Command
+	if a.ErrWriter == nil {
+		a.ErrWriter = os.Stderr
+	}
+
+	if a.AllowExtFlags {
+		// add global flags added by other packages
+		flag.VisitAll(func(f *flag.Flag) {
+			// skip test flags
+			if !strings.HasPrefix(f.Name, ignoreFlagPrefix) {
+				a.Flags = append(a.Flags, &extFlag{f})
+			}
+		})
+	}
+
+	if len(a.SliceFlagSeparator) != 0 {
+		a.separator.customized = true
+		a.separator.sep = a.SliceFlagSeparator
+	}
+
+	if a.DisableSliceFlagSeparator {
+		a.separator.customized = true
+		a.separator.disabled = true
+	}
 
 	for _, c := range a.Commands {
-		if c.HelpName == "" {
-			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		cname := c.Name
+		if c.HelpName != "" {
+			cname = c.HelpName
 		}
-		newCommands = append(newCommands, c)
+		c.separator = a.separator
+		c.HelpName = fmt.Sprintf("%s %s", a.HelpName, cname)
+		c.flagCategories = newFlagCategoriesFromFlags(c.Flags)
 	}
-	a.Commands = newCommands
 
 	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
 		if !a.HideHelpCommand {
@@ -192,17 +259,42 @@ func (a *App) Setup() {
 	}
 	sort.Sort(a.categories.(*commandCategories))
 
+	a.flagCategories = newFlagCategoriesFromFlags(a.Flags)
+
 	if a.Metadata == nil {
 		a.Metadata = make(map[string]interface{})
 	}
+}
 
-	if a.Writer == nil {
-		a.Writer = os.Stdout
+func (a *App) newRootCommand() *Command {
+	return &Command{
+		Name:                   a.Name,
+		Usage:                  a.Usage,
+		UsageText:              a.UsageText,
+		Description:            a.Description,
+		ArgsUsage:              a.ArgsUsage,
+		BashComplete:           a.BashComplete,
+		Before:                 a.Before,
+		After:                  a.After,
+		Action:                 a.Action,
+		OnUsageError:           a.OnUsageError,
+		Subcommands:            a.Commands,
+		Flags:                  a.Flags,
+		flagCategories:         a.flagCategories,
+		HideHelp:               a.HideHelp,
+		HideHelpCommand:        a.HideHelpCommand,
+		UseShortOptionHandling: a.UseShortOptionHandling,
+		HelpName:               a.HelpName,
+		CustomHelpTemplate:     a.CustomAppHelpTemplate,
+		categories:             a.categories,
+		SkipFlagParsing:        a.SkipFlagParsing,
+		isRoot:                 true,
+		separator:              a.separator,
 	}
 }
 
 func (a *App) newFlagSet() (*flag.FlagSet, error) {
-	return flagSet(a.Name, a.Flags)
+	return flagSet(a.Name, a.Flags, a.separator)
 }
 
 func (a *App) useShortOptionHandling() bool {
@@ -229,210 +321,70 @@ func (a *App) RunContext(ctx context.Context, arguments []string) (err error) {
 	// always appends the completion flag at the end of the command
 	shellComplete, arguments := checkShellCompleteFlag(a, arguments)
 
-	set, err := a.newFlagSet()
-	if err != nil {
+	cCtx := NewContext(a, nil, &Context{Context: ctx})
+	cCtx.shellComplete = shellComplete
+
+	a.rootCommand = a.newRootCommand()
+	cCtx.Command = a.rootCommand
+
+	if err := checkDuplicatedCmds(a.rootCommand); err != nil {
 		return err
 	}
+	return a.rootCommand.Run(cCtx, arguments...)
+}
 
-	err = parseIter(set, a, arguments[1:], shellComplete)
-	nerr := normalizeFlags(a.Flags, set)
-	context := NewContext(a, set, &Context{Context: ctx})
-	if nerr != nil {
-		_, _ = fmt.Fprintln(a.Writer, nerr)
-		_ = ShowAppHelp(context)
-		return nerr
+// RunAsSubcommand is for legacy/compatibility purposes only. New code should only
+// use App.RunContext. This function is slated to be removed in v3.
+func (a *App) RunAsSubcommand(ctx *Context) (err error) {
+	a.Setup()
+
+	cCtx := NewContext(a, nil, ctx)
+	cCtx.shellComplete = ctx.shellComplete
+
+	a.rootCommand = a.newRootCommand()
+	cCtx.Command = a.rootCommand
+
+	return a.rootCommand.Run(cCtx, ctx.Args().Slice()...)
+}
+
+func (a *App) suggestFlagFromError(err error, command string) (string, error) {
+	flag, parseErr := flagFromError(err)
+	if parseErr != nil {
+		return "", err
 	}
-	context.shellComplete = shellComplete
 
-	if checkCompletions(context) {
-		return nil
-	}
-
-	if err != nil {
-		if a.OnUsageError != nil {
-			err := a.OnUsageError(context, err, false)
-			a.handleExitCoder(context, err)
-			return err
+	flags := a.Flags
+	hideHelp := a.HideHelp
+	if command != "" {
+		cmd := a.Command(command)
+		if cmd == nil {
+			return "", err
 		}
-		_, _ = fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
-		_ = ShowAppHelp(context)
-		return err
+		flags = cmd.Flags
+		hideHelp = hideHelp || cmd.HideHelp
 	}
 
-	if !a.HideHelp && checkHelp(context) {
-		_ = ShowAppHelp(context)
-		return nil
+	if SuggestFlag == nil {
+		return "", err
+	}
+	suggestion := SuggestFlag(flags, flag, hideHelp)
+	if len(suggestion) == 0 {
+		return "", err
 	}
 
-	if !a.HideVersion && checkVersion(context) {
-		ShowVersion(context)
-		return nil
-	}
-
-	cerr := checkRequiredFlags(a.Flags, context)
-	if cerr != nil {
-		_ = ShowAppHelp(context)
-		return cerr
-	}
-
-	if a.After != nil {
-		defer func() {
-			if afterErr := a.After(context); afterErr != nil {
-				if err != nil {
-					err = newMultiError(err, afterErr)
-				} else {
-					err = afterErr
-				}
-			}
-		}()
-	}
-
-	if a.Before != nil {
-		beforeErr := a.Before(context)
-		if beforeErr != nil {
-			_, _ = fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
-			_ = ShowAppHelp(context)
-			a.handleExitCoder(context, beforeErr)
-			err = beforeErr
-			return err
-		}
-	}
-
-	args := context.Args()
-	if args.Present() {
-		name := args.First()
-		c := a.Command(name)
-		if c != nil {
-			return c.Run(context)
-		}
-	}
-
-	if a.Action == nil {
-		a.Action = helpCommand.Action
-	}
-
-	// Run default Action
-	err = a.Action(context)
-
-	a.handleExitCoder(context, err)
-	return err
+	return fmt.Sprintf(SuggestDidYouMeanTemplate+"\n\n", suggestion), nil
 }
 
 // RunAndExitOnError calls .Run() and exits non-zero if an error was returned
 //
 // Deprecated: instead you should return an error that fulfills cli.ExitCoder
-// to cli.App.Run. This will cause the application to exit with the given eror
+// to cli.App.Run. This will cause the application to exit with the given error
 // code in the cli.ExitCoder
 func (a *App) RunAndExitOnError() {
 	if err := a.Run(os.Args); err != nil {
-		_, _ = fmt.Fprintln(a.errWriter(), err)
+		_, _ = fmt.Fprintln(a.ErrWriter, err)
 		OsExiter(1)
 	}
-}
-
-// RunAsSubcommand invokes the subcommand given the context, parses ctx.Args() to
-// generate command-specific flags
-func (a *App) RunAsSubcommand(ctx *Context) (err error) {
-	// Setup also handles HideHelp and HideHelpCommand
-	a.Setup()
-
-	var newCmds []*Command
-	for _, c := range a.Commands {
-		if c.HelpName == "" {
-			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
-		}
-		newCmds = append(newCmds, c)
-	}
-	a.Commands = newCmds
-
-	set, err := a.newFlagSet()
-	if err != nil {
-		return err
-	}
-
-	err = parseIter(set, a, ctx.Args().Tail(), ctx.shellComplete)
-	nerr := normalizeFlags(a.Flags, set)
-	context := NewContext(a, set, ctx)
-
-	if nerr != nil {
-		_, _ = fmt.Fprintln(a.Writer, nerr)
-		_, _ = fmt.Fprintln(a.Writer)
-		if len(a.Commands) > 0 {
-			_ = ShowSubcommandHelp(context)
-		} else {
-			_ = ShowCommandHelp(ctx, context.Args().First())
-		}
-		return nerr
-	}
-
-	if checkCompletions(context) {
-		return nil
-	}
-
-	if err != nil {
-		if a.OnUsageError != nil {
-			err = a.OnUsageError(context, err, true)
-			a.handleExitCoder(context, err)
-			return err
-		}
-		_, _ = fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
-		_ = ShowSubcommandHelp(context)
-		return err
-	}
-
-	if len(a.Commands) > 0 {
-		if checkSubcommandHelp(context) {
-			return nil
-		}
-	} else {
-		if checkCommandHelp(ctx, context.Args().First()) {
-			return nil
-		}
-	}
-
-	cerr := checkRequiredFlags(a.Flags, context)
-	if cerr != nil {
-		_ = ShowSubcommandHelp(context)
-		return cerr
-	}
-
-	if a.After != nil {
-		defer func() {
-			afterErr := a.After(context)
-			if afterErr != nil {
-				a.handleExitCoder(context, err)
-				if err != nil {
-					err = newMultiError(err, afterErr)
-				} else {
-					err = afterErr
-				}
-			}
-		}()
-	}
-
-	if a.Before != nil {
-		beforeErr := a.Before(context)
-		if beforeErr != nil {
-			a.handleExitCoder(context, beforeErr)
-			err = beforeErr
-			return err
-		}
-	}
-
-	args := context.Args()
-	if args.Present() {
-		name := args.First()
-		c := a.Command(name)
-		if c != nil {
-			return c.Run(context)
-		}
-	}
-
-	// Run default Action
-	err = a.Action(context)
-
-	a.handleExitCoder(context, err)
-	return err
 }
 
 // Command returns the named command on App. Returns nil if the command does not exist
@@ -474,18 +426,17 @@ func (a *App) VisibleCommands() []*Command {
 	return ret
 }
 
+// VisibleFlagCategories returns a slice containing all the categories with the flags they contain
+func (a *App) VisibleFlagCategories() []VisibleFlagCategory {
+	if a.flagCategories == nil {
+		return []VisibleFlagCategory{}
+	}
+	return a.flagCategories.VisibleCategories()
+}
+
 // VisibleFlags returns a slice of the Flags with Hidden=false
 func (a *App) VisibleFlags() []Flag {
 	return visibleFlags(a.Flags)
-}
-
-func (a *App) errWriter() io.Writer {
-	// When the app ErrWriter is nil use the package level one.
-	if a.ErrWriter == nil {
-		return ErrWriter
-	}
-
-	return a.ErrWriter
 }
 
 func (a *App) appendFlag(fl Flag) {
@@ -500,12 +451,43 @@ func (a *App) appendCommand(c *Command) {
 	}
 }
 
-func (a *App) handleExitCoder(context *Context, err error) {
+func (a *App) handleExitCoder(cCtx *Context, err error) {
 	if a.ExitErrHandler != nil {
-		a.ExitErrHandler(context, err)
+		a.ExitErrHandler(cCtx, err)
 	} else {
 		HandleExitCoder(err)
 	}
+}
+
+func (a *App) argsWithDefaultCommand(oldArgs Args) Args {
+	if a.DefaultCommand != "" {
+		rawArgs := append([]string{a.DefaultCommand}, oldArgs.Slice()...)
+		newArgs := args(rawArgs)
+
+		return &newArgs
+	}
+
+	return oldArgs
+}
+
+func runFlagActions(c *Context, fs []Flag) error {
+	for _, f := range fs {
+		isSet := false
+		for _, name := range f.Names() {
+			if c.IsSet(name) {
+				isSet = true
+				break
+			}
+		}
+		if isSet {
+			if af, ok := f.(ActionableFlag); ok {
+				if err := af.RunAction(c); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // Author represents someone who has contributed to a cli project.
@@ -527,16 +509,28 @@ func (a *Author) String() string {
 // HandleAction attempts to figure out which Action signature was used.  If
 // it's an ActionFunc or a func with the legacy signature for Action, the func
 // is run!
-func HandleAction(action interface{}, context *Context) (err error) {
+func HandleAction(action interface{}, cCtx *Context) (err error) {
 	switch a := action.(type) {
 	case ActionFunc:
-		return a(context)
+		return a(cCtx)
 	case func(*Context) error:
-		return a(context)
+		return a(cCtx)
 	case func(*Context): // deprecated function signature
-		a(context)
+		a(cCtx)
 		return nil
 	}
 
 	return errInvalidActionType
+}
+
+func checkStringSliceIncludes(want string, sSlice []string) bool {
+	found := false
+	for _, s := range sSlice {
+		if want == s {
+			found = true
+			break
+		}
+	}
+
+	return found
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/category.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/category.go
@@ -1,10 +1,12 @@
 package cli
 
+import "sort"
+
 // CommandCategories interface allows for category manipulation
 type CommandCategories interface {
 	// AddCommand adds a command to a category, creating a new category if necessary.
 	AddCommand(category string, command *Command)
-	// categories returns a copy of the category slice
+	// Categories returns a slice of categories sorted by name
 	Categories() []CommandCategory
 }
 
@@ -75,5 +77,110 @@ func (c *commandCategory) VisibleCommands() []*Command {
 			ret = append(ret, command)
 		}
 	}
+	return ret
+}
+
+// FlagCategories interface allows for category manipulation
+type FlagCategories interface {
+	// AddFlags adds a flag to a category, creating a new category if necessary.
+	AddFlag(category string, fl Flag)
+	// VisibleCategories returns a slice of visible flag categories sorted by name
+	VisibleCategories() []VisibleFlagCategory
+}
+
+type defaultFlagCategories struct {
+	m map[string]*defaultVisibleFlagCategory
+}
+
+func newFlagCategories() FlagCategories {
+	return &defaultFlagCategories{
+		m: map[string]*defaultVisibleFlagCategory{},
+	}
+}
+
+func newFlagCategoriesFromFlags(fs []Flag) FlagCategories {
+	fc := newFlagCategories()
+
+	var categorized bool
+	for _, fl := range fs {
+		if cf, ok := fl.(CategorizableFlag); ok {
+			if cat := cf.GetCategory(); cat != "" && cf.IsVisible() {
+				fc.AddFlag(cat, cf)
+				categorized = true
+			}
+		}
+	}
+
+	if categorized {
+		for _, fl := range fs {
+			if cf, ok := fl.(CategorizableFlag); ok {
+				if cf.GetCategory() == "" && cf.IsVisible() {
+					fc.AddFlag("", fl)
+				}
+			}
+		}
+	}
+
+	return fc
+}
+
+func (f *defaultFlagCategories) AddFlag(category string, fl Flag) {
+	if _, ok := f.m[category]; !ok {
+		f.m[category] = &defaultVisibleFlagCategory{name: category, m: map[string]Flag{}}
+	}
+
+	f.m[category].m[fl.String()] = fl
+}
+
+func (f *defaultFlagCategories) VisibleCategories() []VisibleFlagCategory {
+	catNames := []string{}
+	for name := range f.m {
+		catNames = append(catNames, name)
+	}
+
+	sort.Strings(catNames)
+
+	ret := make([]VisibleFlagCategory, len(catNames))
+	for i, name := range catNames {
+		ret[i] = f.m[name]
+	}
+
+	return ret
+}
+
+// VisibleFlagCategory is a category containing flags.
+type VisibleFlagCategory interface {
+	// Name returns the category name string
+	Name() string
+	// Flags returns a slice of VisibleFlag sorted by name
+	Flags() []VisibleFlag
+}
+
+type defaultVisibleFlagCategory struct {
+	name string
+	m    map[string]Flag
+}
+
+func (fc *defaultVisibleFlagCategory) Name() string {
+	return fc.name
+}
+
+func (fc *defaultVisibleFlagCategory) Flags() []VisibleFlag {
+	vfNames := []string{}
+	for flName, fl := range fc.m {
+		if vf, ok := fl.(VisibleFlag); ok {
+			if vf.IsVisible() {
+				vfNames = append(vfNames, flName)
+			}
+		}
+	}
+
+	sort.Strings(vfNames)
+
+	ret := make([]VisibleFlag, len(vfNames))
+	for i, flName := range vfNames {
+		ret[i] = fc.m[flName].(VisibleFlag)
+	}
+
 	return ret
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/cli.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/cli.go
@@ -1,23 +1,25 @@
 // Package cli provides a minimal framework for creating and organizing command line
 // Go applications. cli is designed to be easy to understand and write, the most simple
 // cli application can be written as follows:
-//   func main() {
-//     (&cli.App{}).Run(os.Args)
-//   }
+//
+//	func main() {
+//		(&cli.App{}).Run(os.Args)
+//	}
 //
 // Of course this application does not do much, so let's make this an actual application:
-//   func main() {
-//     app := &cli.App{
-//			 Name: "greet",
-//			 Usage: "say a greeting",
-//			 Action: func(c *cli.Context) error {
-//				 fmt.Println("Greetings")
-//				 return nil
-//			 },
-//		 }
 //
-//     app.Run(os.Args)
-//   }
+//	func main() {
+//		app := &cli.App{
+//	  		Name: "greet",
+//	  		Usage: "say a greeting",
+//	  		Action: func(c *cli.Context) error {
+//	  			fmt.Println("Greetings")
+//	  			return nil
+//	  		},
+//		}
+//
+//		app.Run(os.Args)
+//	}
 package cli
 
-//go:generate go run flag-gen/main.go flag-gen/assets_vfsdata.go
+//go:generate make -C cmd/urfave-cli-genflags run

--- a/go-controller/vendor/github.com/urfave/cli/v2/command.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/command.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 )
@@ -19,6 +20,8 @@ type Command struct {
 	UsageText string
 	// A longer explanation of how the command works
 	Description string
+	// Whether this command supports arguments
+	Args bool
 	// A short description of the arguments of this command
 	ArgsUsage string
 	// The category the command is part of
@@ -38,7 +41,8 @@ type Command struct {
 	// List of child commands
 	Subcommands []*Command
 	// List of flags to parse
-	Flags []Flag
+	Flags          []Flag
+	flagCategories FlagCategories
 	// Treat all flags as normal arguments if true
 	SkipFlagParsing bool
 	// Boolean to hide built-in help command and help flag
@@ -61,6 +65,14 @@ type Command struct {
 	// cli.go uses text/template to render templates. You can
 	// render custom help text by setting this variable.
 	CustomHelpTemplate string
+
+	// categories contains the categorized commands and is populated on app startup
+	categories CommandCategories
+
+	// if this is a root "special" command
+	isRoot bool
+
+	separator separatorSpec
 }
 
 type Commands []*Command
@@ -88,10 +100,21 @@ func (c *Command) FullName() string {
 	return strings.Join(c.commandNamePath, " ")
 }
 
-// Run invokes the command given the context, parses ctx.Args() to generate command-specific flags
-func (c *Command) Run(ctx *Context) (err error) {
-	if len(c.Subcommands) > 0 {
-		return c.startApp(ctx)
+func (cmd *Command) Command(name string) *Command {
+	for _, c := range cmd.Subcommands {
+		if c.HasName(name) {
+			return c
+		}
+	}
+
+	return nil
+}
+
+func (c *Command) setup(ctx *Context) {
+	if c.Command(helpCommand.Name) == nil && !c.HideHelp {
+		if !c.HideHelpCommand {
+			c.Subcommands = append(c.Subcommands, helpCommand)
+		}
 	}
 
 	if !c.HideHelp && HelpFlag != nil {
@@ -103,41 +126,77 @@ func (c *Command) Run(ctx *Context) (err error) {
 		c.UseShortOptionHandling = true
 	}
 
-	set, err := c.parseFlags(ctx.Args(), ctx.shellComplete)
+	c.categories = newCommandCategories()
+	for _, command := range c.Subcommands {
+		c.categories.AddCommand(command.Category, command)
+	}
+	sort.Sort(c.categories.(*commandCategories))
 
-	context := NewContext(ctx.App, set, ctx)
-	context.Command = c
-	if checkCommandCompletions(context, c.Name) {
+	for _, scmd := range c.Subcommands {
+		if scmd.HelpName == "" {
+			scmd.HelpName = fmt.Sprintf("%s %s", c.HelpName, scmd.Name)
+		}
+		scmd.separator = c.separator
+	}
+
+	if c.BashComplete == nil {
+		c.BashComplete = DefaultCompleteWithFlags(c)
+	}
+}
+
+func (c *Command) Run(cCtx *Context, arguments ...string) (err error) {
+
+	if !c.isRoot {
+		c.setup(cCtx)
+		if err := checkDuplicatedCmds(c); err != nil {
+			return err
+		}
+	}
+
+	a := args(arguments)
+	set, err := c.parseFlags(&a, cCtx.shellComplete)
+	cCtx.flagSet = set
+
+	if checkCompletions(cCtx) {
 		return nil
 	}
 
 	if err != nil {
 		if c.OnUsageError != nil {
-			err = c.OnUsageError(context, err, false)
-			context.App.handleExitCoder(context, err)
+			err = c.OnUsageError(cCtx, err, !c.isRoot)
+			cCtx.App.handleExitCoder(cCtx, err)
 			return err
 		}
-		_, _ = fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
-		_, _ = fmt.Fprintln(context.App.Writer)
-		_ = ShowCommandHelp(context, c.Name)
+		_, _ = fmt.Fprintf(cCtx.App.Writer, "%s %s\n\n", "Incorrect Usage:", err.Error())
+		if cCtx.App.Suggest {
+			if suggestion, err := c.suggestFlagFromError(err, ""); err == nil {
+				fmt.Fprintf(cCtx.App.Writer, "%s", suggestion)
+			}
+		}
+		if !c.HideHelp {
+			if c.isRoot {
+				_ = ShowAppHelp(cCtx)
+			} else {
+				_ = ShowCommandHelp(cCtx.parentContext, c.Name)
+			}
+		}
 		return err
 	}
 
-	if checkCommandHelp(context, c.Name) {
+	if checkHelp(cCtx) {
+		return helpCommand.Action(cCtx)
+	}
+
+	if c.isRoot && !cCtx.App.HideVersion && checkVersion(cCtx) {
+		ShowVersion(cCtx)
 		return nil
 	}
 
-	cerr := checkRequiredFlags(c.Flags, context)
-	if cerr != nil {
-		_ = ShowCommandHelp(context, c.Name)
-		return cerr
-	}
-
-	if c.After != nil {
+	if c.After != nil && !cCtx.shellComplete {
 		defer func() {
-			afterErr := c.After(context)
+			afterErr := c.After(cCtx)
 			if afterErr != nil {
-				context.App.handleExitCoder(context, err)
+				cCtx.App.handleExitCoder(cCtx, err)
 				if err != nil {
 					err = newMultiError(err, afterErr)
 				} else {
@@ -147,34 +206,110 @@ func (c *Command) Run(ctx *Context) (err error) {
 		}()
 	}
 
-	if c.Before != nil {
-		err = c.Before(context)
-		if err != nil {
-			_ = ShowCommandHelp(context, c.Name)
-			context.App.handleExitCoder(context, err)
+	cerr := cCtx.checkRequiredFlags(c.Flags)
+	if cerr != nil {
+		_ = helpCommand.Action(cCtx)
+		return cerr
+	}
+
+	if c.Before != nil && !cCtx.shellComplete {
+		beforeErr := c.Before(cCtx)
+		if beforeErr != nil {
+			cCtx.App.handleExitCoder(cCtx, beforeErr)
+			err = beforeErr
 			return err
 		}
 	}
 
+	if err = runFlagActions(cCtx, c.Flags); err != nil {
+		return err
+	}
+
+	var cmd *Command
+	args := cCtx.Args()
+	if args.Present() {
+		name := args.First()
+		cmd = c.Command(name)
+		if cmd == nil {
+			hasDefault := cCtx.App.DefaultCommand != ""
+			isFlagName := checkStringSliceIncludes(name, cCtx.FlagNames())
+
+			var (
+				isDefaultSubcommand   = false
+				defaultHasSubcommands = false
+			)
+
+			if hasDefault {
+				dc := cCtx.App.Command(cCtx.App.DefaultCommand)
+				defaultHasSubcommands = len(dc.Subcommands) > 0
+				for _, dcSub := range dc.Subcommands {
+					if checkStringSliceIncludes(name, dcSub.Names()) {
+						isDefaultSubcommand = true
+						break
+					}
+				}
+			}
+
+			if isFlagName || (hasDefault && (defaultHasSubcommands && isDefaultSubcommand)) {
+				argsWithDefault := cCtx.App.argsWithDefaultCommand(args)
+				if !reflect.DeepEqual(args, argsWithDefault) {
+					cmd = cCtx.App.rootCommand.Command(argsWithDefault.First())
+				}
+			}
+		}
+	} else if c.isRoot && cCtx.App.DefaultCommand != "" {
+		if dc := cCtx.App.Command(cCtx.App.DefaultCommand); dc != c {
+			cmd = dc
+		}
+	}
+
+	if cmd != nil {
+		newcCtx := NewContext(cCtx.App, nil, cCtx)
+		newcCtx.Command = cmd
+		return cmd.Run(newcCtx, cCtx.Args().Slice()...)
+	}
+
 	if c.Action == nil {
-		c.Action = helpSubcommand.Action
+		c.Action = helpCommand.Action
 	}
 
-	context.Command = c
-	err = c.Action(context)
+	err = c.Action(cCtx)
 
-	if err != nil {
-		context.App.handleExitCoder(context, err)
-	}
+	cCtx.App.handleExitCoder(cCtx, err)
 	return err
 }
 
 func (c *Command) newFlagSet() (*flag.FlagSet, error) {
-	return flagSet(c.Name, c.Flags)
+	return flagSet(c.Name, c.Flags, c.separator)
 }
 
 func (c *Command) useShortOptionHandling() bool {
 	return c.UseShortOptionHandling
+}
+
+func (c *Command) suggestFlagFromError(err error, command string) (string, error) {
+	flag, parseErr := flagFromError(err)
+	if parseErr != nil {
+		return "", err
+	}
+
+	flags := c.Flags
+	hideHelp := c.HideHelp
+	if command != "" {
+		cmd := c.Command(command)
+		if cmd == nil {
+			return "", err
+		}
+		flags = cmd.Flags
+		hideHelp = hideHelp || cmd.HideHelp
+	}
+
+	suggestion := SuggestFlag(flags, flag, hideHelp)
+	if len(suggestion) == 0 {
+		return "", err
+	}
+
+	return fmt.Sprintf(SuggestDidYouMeanTemplate, suggestion) + "\n\n", nil
 }
 
 func (c *Command) parseFlags(args Args, shellComplete bool) (*flag.FlagSet, error) {
@@ -215,68 +350,40 @@ func (c *Command) HasName(name string) bool {
 	return false
 }
 
-func (c *Command) startApp(ctx *Context) error {
-	app := &App{
-		Metadata: ctx.App.Metadata,
-		Name:     fmt.Sprintf("%s %s", ctx.App.Name, c.Name),
+// VisibleCategories returns a slice of categories and commands that are
+// Hidden=false
+func (c *Command) VisibleCategories() []CommandCategory {
+	ret := []CommandCategory{}
+	for _, category := range c.categories.Categories() {
+		if visible := func() CommandCategory {
+			if len(category.VisibleCommands()) > 0 {
+				return category
+			}
+			return nil
+		}(); visible != nil {
+			ret = append(ret, visible)
+		}
 	}
+	return ret
+}
 
-	if c.HelpName == "" {
-		app.HelpName = c.HelpName
-	} else {
-		app.HelpName = app.Name
-	}
-
-	app.Usage = c.Usage
-	app.Description = c.Description
-	app.ArgsUsage = c.ArgsUsage
-
-	// set CommandNotFound
-	app.CommandNotFound = ctx.App.CommandNotFound
-	app.CustomAppHelpTemplate = c.CustomHelpTemplate
-
-	// set the flags and commands
-	app.Commands = c.Subcommands
-	app.Flags = c.Flags
-	app.HideHelp = c.HideHelp
-	app.HideHelpCommand = c.HideHelpCommand
-
-	app.Version = ctx.App.Version
-	app.HideVersion = ctx.App.HideVersion
-	app.Compiled = ctx.App.Compiled
-	app.Writer = ctx.App.Writer
-	app.ErrWriter = ctx.App.ErrWriter
-	app.ExitErrHandler = ctx.App.ExitErrHandler
-	app.UseShortOptionHandling = ctx.App.UseShortOptionHandling
-
-	app.categories = newCommandCategories()
+// VisibleCommands returns a slice of the Commands with Hidden=false
+func (c *Command) VisibleCommands() []*Command {
+	var ret []*Command
 	for _, command := range c.Subcommands {
-		app.categories.AddCommand(command.Category, command)
+		if !command.Hidden {
+			ret = append(ret, command)
+		}
 	}
+	return ret
+}
 
-	sort.Sort(app.categories.(*commandCategories))
-
-	// bash completion
-	app.EnableBashCompletion = ctx.App.EnableBashCompletion
-	if c.BashComplete != nil {
-		app.BashComplete = c.BashComplete
+// VisibleFlagCategories returns a slice containing all the visible flag categories with the flags they contain
+func (c *Command) VisibleFlagCategories() []VisibleFlagCategory {
+	if c.flagCategories == nil {
+		c.flagCategories = newFlagCategoriesFromFlags(c.Flags)
 	}
-
-	// set the actions
-	app.Before = c.Before
-	app.After = c.After
-	if c.Action != nil {
-		app.Action = c.Action
-	} else {
-		app.Action = helpSubcommand.Action
-	}
-	app.OnUsageError = c.OnUsageError
-
-	for index, cc := range app.Commands {
-		app.Commands[index].commandNamePath = []string{c.Name, cc.Name}
-	}
-
-	return app.RunAsSubcommand(ctx)
+	return c.flagCategories.VisibleCategories()
 }
 
 // VisibleFlags returns a slice of the Flags with Hidden=false
@@ -298,4 +405,17 @@ func hasCommand(commands []*Command, command *Command) bool {
 	}
 
 	return false
+}
+
+func checkDuplicatedCmds(parent *Command) error {
+	seen := make(map[string]struct{})
+	for _, c := range parent.Subcommands {
+		for _, name := range c.Names() {
+			if _, exists := seen[name]; exists {
+				return fmt.Errorf("parent command [%s] has duplicated subcommand name or alias: %s", parent.Name, name)
+			}
+			seen[name] = struct{}{}
+		}
+	}
+	return nil
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/context.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/context.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -42,88 +41,140 @@ func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
 }
 
 // NumFlags returns the number of flags set
-func (c *Context) NumFlags() int {
-	return c.flagSet.NFlag()
+func (cCtx *Context) NumFlags() int {
+	return cCtx.flagSet.NFlag()
 }
 
 // Set sets a context flag to a value.
-func (c *Context) Set(name, value string) error {
-	return c.flagSet.Set(name, value)
+func (cCtx *Context) Set(name, value string) error {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return fs.Set(name, value)
+	}
+
+	return fmt.Errorf("no such flag -%s", name)
 }
 
 // IsSet determines if the flag was actually set
-func (c *Context) IsSet(name string) bool {
-	if fs := lookupFlagSet(name, c); fs != nil {
-		if fs := lookupFlagSet(name, c); fs != nil {
-			isSet := false
-			fs.Visit(func(f *flag.Flag) {
-				if f.Name == name {
-					isSet = true
-				}
-			})
-			if isSet {
-				return true
+func (cCtx *Context) IsSet(name string) bool {
+
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		isSet := false
+		fs.Visit(func(f *flag.Flag) {
+			if f.Name == name {
+				isSet = true
 			}
+		})
+		if isSet {
+			return true
 		}
 
-		f := lookupFlag(name, c)
+		f := cCtx.lookupFlag(name)
 		if f == nil {
 			return false
 		}
 
-		return f.IsSet()
+		if f.IsSet() {
+			return true
+		}
+
+		// now redo flagset search on aliases
+		aliases := f.Names()
+		fs.Visit(func(f *flag.Flag) {
+			for _, alias := range aliases {
+				if f.Name == alias {
+					isSet = true
+				}
+			}
+		})
+
+		if isSet {
+			return true
+		}
 	}
 
 	return false
 }
 
 // LocalFlagNames returns a slice of flag names used in this context.
-func (c *Context) LocalFlagNames() []string {
+func (cCtx *Context) LocalFlagNames() []string {
 	var names []string
-	c.flagSet.Visit(makeFlagNameVisitor(&names))
-	return names
+	cCtx.flagSet.Visit(makeFlagNameVisitor(&names))
+	// Check the flags which have been set via env or file
+	if cCtx.Command != nil && cCtx.Command.Flags != nil {
+		for _, f := range cCtx.Command.Flags {
+			if f.IsSet() {
+				names = append(names, f.Names()...)
+			}
+		}
+	}
+
+	// Sort out the duplicates since flag could be set via multiple
+	// paths
+	m := map[string]struct{}{}
+	var unames []string
+	for _, name := range names {
+		if _, ok := m[name]; !ok {
+			m[name] = struct{}{}
+			unames = append(unames, name)
+		}
+	}
+
+	return unames
 }
 
 // FlagNames returns a slice of flag names used by the this context and all of
 // its parent contexts.
-func (c *Context) FlagNames() []string {
+func (cCtx *Context) FlagNames() []string {
 	var names []string
-	for _, ctx := range c.Lineage() {
-		ctx.flagSet.Visit(makeFlagNameVisitor(&names))
+	for _, pCtx := range cCtx.Lineage() {
+		names = append(names, pCtx.LocalFlagNames()...)
 	}
 	return names
 }
 
 // Lineage returns *this* context and all of its ancestor contexts in order from
 // child to parent
-func (c *Context) Lineage() []*Context {
+func (cCtx *Context) Lineage() []*Context {
 	var lineage []*Context
 
-	for cur := c; cur != nil; cur = cur.parentContext {
+	for cur := cCtx; cur != nil; cur = cur.parentContext {
 		lineage = append(lineage, cur)
 	}
 
 	return lineage
 }
 
+// Count returns the num of occurrences of this flag
+func (cCtx *Context) Count(name string) int {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		if cf, ok := fs.Lookup(name).Value.(Countable); ok {
+			return cf.Count()
+		}
+	}
+	return 0
+}
+
 // Value returns the value of the flag corresponding to `name`
-func (c *Context) Value(name string) interface{} {
-	return c.flagSet.Lookup(name).Value.(flag.Getter).Get()
+func (cCtx *Context) Value(name string) interface{} {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return fs.Lookup(name).Value.(flag.Getter).Get()
+	}
+	return nil
 }
 
 // Args returns the command line arguments associated with the context.
-func (c *Context) Args() Args {
-	ret := args(c.flagSet.Args())
+func (cCtx *Context) Args() Args {
+	ret := args(cCtx.flagSet.Args())
 	return &ret
 }
 
 // NArg returns the number of the command line arguments.
-func (c *Context) NArg() int {
-	return c.Args().Len()
+func (cCtx *Context) NArg() int {
+	return cCtx.Args().Len()
 }
 
-func lookupFlag(name string, ctx *Context) Flag {
-	for _, c := range ctx.Lineage() {
+func (cCtx *Context) lookupFlag(name string) Flag {
+	for _, c := range cCtx.Lineage() {
 		if c.Command == nil {
 			continue
 		}
@@ -137,8 +188,8 @@ func lookupFlag(name string, ctx *Context) Flag {
 		}
 	}
 
-	if ctx.App != nil {
-		for _, f := range ctx.App.Flags {
+	if cCtx.App != nil {
+		for _, f := range cCtx.App.Flags {
 			for _, n := range f.Names() {
 				if n == name {
 					return f
@@ -150,56 +201,56 @@ func lookupFlag(name string, ctx *Context) Flag {
 	return nil
 }
 
-func lookupFlagSet(name string, ctx *Context) *flag.FlagSet {
-	for _, c := range ctx.Lineage() {
+func (cCtx *Context) lookupFlagSet(name string) *flag.FlagSet {
+	for _, c := range cCtx.Lineage() {
+		if c.flagSet == nil {
+			continue
+		}
 		if f := c.flagSet.Lookup(name); f != nil {
 			return c.flagSet
 		}
 	}
-
+	cCtx.onInvalidFlag(name)
 	return nil
 }
 
-func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
-	switch ff.Value.(type) {
-	case Serializer:
-		_ = set.Set(name, ff.Value.(Serializer).Serialize())
-	default:
-		_ = set.Set(name, ff.Value.String())
-	}
-}
-
-func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
-	visited := make(map[string]bool)
-	set.Visit(func(f *flag.Flag) {
-		visited[f.Name] = true
-	})
+func (cCtx *Context) checkRequiredFlags(flags []Flag) requiredFlagsErr {
+	var missingFlags []string
 	for _, f := range flags {
-		parts := f.Names()
-		if len(parts) == 1 {
-			continue
-		}
-		var ff *flag.Flag
-		for _, name := range parts {
-			name = strings.Trim(name, " ")
-			if visited[name] {
-				if ff != nil {
-					return errors.New("Cannot use two forms of the same flag: " + name + " " + ff.Name)
+		if rf, ok := f.(RequiredFlag); ok && rf.IsRequired() {
+			var flagPresent bool
+			var flagName string
+
+			flagNames := f.Names()
+			flagName = flagNames[0]
+
+			for _, key := range flagNames {
+				if cCtx.IsSet(strings.TrimSpace(key)) {
+					flagPresent = true
 				}
-				ff = set.Lookup(name)
 			}
-		}
-		if ff == nil {
-			continue
-		}
-		for _, name := range parts {
-			name = strings.Trim(name, " ")
-			if !visited[name] {
-				copyFlag(name, ff, set)
+
+			if !flagPresent && flagName != "" {
+				missingFlags = append(missingFlags, flagName)
 			}
 		}
 	}
+
+	if len(missingFlags) != 0 {
+		return &errRequiredFlags{missingFlags: missingFlags}
+	}
+
 	return nil
+}
+
+func (cCtx *Context) onInvalidFlag(name string) {
+	for cCtx != nil {
+		if cCtx.App != nil && cCtx.App.InvalidFlagAccessHandler != nil {
+			cCtx.App.InvalidFlagAccessHandler(cCtx, name)
+			break
+		}
+		cCtx = cCtx.parentContext
+	}
 }
 
 func makeFlagNameVisitor(names *[]string) func(*flag.Flag) {
@@ -218,56 +269,4 @@ func makeFlagNameVisitor(names *[]string) func(*flag.Flag) {
 			*names = append(*names, name)
 		}
 	}
-}
-
-type requiredFlagsErr interface {
-	error
-	getMissingFlags() []string
-}
-
-type errRequiredFlags struct {
-	missingFlags []string
-}
-
-func (e *errRequiredFlags) Error() string {
-	numberOfMissingFlags := len(e.missingFlags)
-	if numberOfMissingFlags == 1 {
-		return fmt.Sprintf("Required flag %q not set", e.missingFlags[0])
-	}
-	joinedMissingFlags := strings.Join(e.missingFlags, ", ")
-	return fmt.Sprintf("Required flags %q not set", joinedMissingFlags)
-}
-
-func (e *errRequiredFlags) getMissingFlags() []string {
-	return e.missingFlags
-}
-
-func checkRequiredFlags(flags []Flag, context *Context) requiredFlagsErr {
-	var missingFlags []string
-	for _, f := range flags {
-		if rf, ok := f.(RequiredFlag); ok && rf.IsRequired() {
-			var flagPresent bool
-			var flagName string
-
-			for _, key := range f.Names() {
-				if len(key) > 1 {
-					flagName = key
-				}
-
-				if context.IsSet(strings.TrimSpace(key)) {
-					flagPresent = true
-				}
-			}
-
-			if !flagPresent && flagName != "" {
-				missingFlags = append(missingFlags, flagName)
-			}
-		}
-	}
-
-	if len(missingFlags) != 0 {
-		return &errRequiredFlags{missingFlags: missingFlags}
-	}
-
-	return nil
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/docs.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/docs.go
@@ -1,3 +1,6 @@
+//go:build !urfave_cli_no_docs
+// +build !urfave_cli_no_docs
+
 package cli
 
 import (
@@ -15,31 +18,39 @@ import (
 // The function errors if either parsing or writing of the string fails.
 func (a *App) ToMarkdown() (string, error) {
 	var w bytes.Buffer
-	if err := a.writeDocTemplate(&w); err != nil {
+	if err := a.writeDocTemplate(&w, 0); err != nil {
 		return "", err
 	}
 	return w.String(), nil
 }
 
-// ToMan creates a man page string for the `*App`
+// ToMan creates a man page string with section number for the `*App`
 // The function errors if either parsing or writing of the string fails.
-func (a *App) ToMan() (string, error) {
+func (a *App) ToManWithSection(sectionNumber int) (string, error) {
 	var w bytes.Buffer
-	if err := a.writeDocTemplate(&w); err != nil {
+	if err := a.writeDocTemplate(&w, sectionNumber); err != nil {
 		return "", err
 	}
 	man := md2man.Render(w.Bytes())
 	return string(man), nil
 }
 
+// ToMan creates a man page string for the `*App`
+// The function errors if either parsing or writing of the string fails.
+func (a *App) ToMan() (string, error) {
+	man, err := a.ToManWithSection(8)
+	return man, err
+}
+
 type cliTemplate struct {
 	App          *App
+	SectionNum   int
 	Commands     []string
 	GlobalArgs   []string
 	SynopsisArgs []string
 }
 
-func (a *App) writeDocTemplate(w io.Writer) error {
+func (a *App) writeDocTemplate(w io.Writer, sectionNum int) error {
 	const name = "cli"
 	t, err := template.New(name).Parse(MarkdownDocTemplate)
 	if err != nil {
@@ -47,6 +58,7 @@ func (a *App) writeDocTemplate(w io.Writer) error {
 	}
 	return t.ExecuteTemplate(w, name, &cliTemplate{
 		App:          a,
+		SectionNum:   sectionNum,
 		Commands:     prepareCommands(a.Commands, 0),
 		GlobalArgs:   prepareArgsWithValues(a.VisibleFlags()),
 		SynopsisArgs: prepareArgsSynopsis(a.VisibleFlags()),
@@ -59,25 +71,26 @@ func prepareCommands(commands []*Command, level int) []string {
 		if command.Hidden {
 			continue
 		}
-		usage := ""
-		if command.Usage != "" {
-			usage = command.Usage
-		}
 
-		prepared := fmt.Sprintf("%s %s\n\n%s\n",
+		usageText := prepareUsageText(command)
+
+		usage := prepareUsage(command, usageText)
+
+		prepared := fmt.Sprintf("%s %s\n\n%s%s",
 			strings.Repeat("#", level+2),
 			strings.Join(command.Names(), ", "),
 			usage,
+			usageText,
 		)
 
-		flags := prepareArgsWithValues(command.Flags)
+		flags := prepareArgsWithValues(command.VisibleFlags())
 		if len(flags) > 0 {
 			prepared += fmt.Sprintf("\n%s", strings.Join(flags, "\n"))
 		}
 
 		coms = append(coms, prepared)
 
-		// recursevly iterate subcommands
+		// recursively iterate subcommands
 		if len(command.Subcommands) > 0 {
 			coms = append(
 				coms,
@@ -140,9 +153,51 @@ func prepareFlags(
 // flagDetails returns a string containing the flags metadata
 func flagDetails(flag DocGenerationFlag) string {
 	description := flag.GetUsage()
-	value := flag.GetValue()
-	if value != "" {
-		description += " (default: " + value + ")"
+	if flag.TakesValue() {
+		defaultText := flag.GetDefaultText()
+		if defaultText == "" {
+			defaultText = flag.GetValue()
+		}
+		if defaultText != "" {
+			description += " (default: " + defaultText + ")"
+		}
 	}
 	return ": " + description
+}
+
+func prepareUsageText(command *Command) string {
+	if command.UsageText == "" {
+		return ""
+	}
+
+	// Remove leading and trailing newlines
+	preparedUsageText := strings.Trim(command.UsageText, "\n")
+
+	var usageText string
+	if strings.Contains(preparedUsageText, "\n") {
+		// Format multi-line string as a code block using the 4 space schema to allow for embedded markdown such
+		// that it will not break the continuous code block.
+		for _, ln := range strings.Split(preparedUsageText, "\n") {
+			usageText += fmt.Sprintf("    %s\n", ln)
+		}
+	} else {
+		// Style a single line as a note
+		usageText = fmt.Sprintf(">%s\n", preparedUsageText)
+	}
+
+	return usageText
+}
+
+func prepareUsage(command *Command, usageText string) string {
+	if command.Usage == "" {
+		return ""
+	}
+
+	usage := command.Usage + "\n"
+	// Add a newline to the Usage IFF there is a UsageText
+	if usageText != "" {
+		usage += "\n"
+	}
+
+	return usage
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/errors.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/errors.go
@@ -17,11 +17,10 @@ var ErrWriter io.Writer = os.Stderr
 // MultiError is an error that wraps multiple errors.
 type MultiError interface {
 	error
-	// Errors returns a copy of the errors slice
 	Errors() []error
 }
 
-// NewMultiError creates a new MultiError. Pass in one or more errors.
+// newMultiError creates a new MultiError. Pass in one or more errors.
 func newMultiError(err ...error) MultiError {
 	ret := multiError(err)
 	return &ret
@@ -48,6 +47,28 @@ func (m *multiError) Errors() []error {
 	return errs
 }
 
+type requiredFlagsErr interface {
+	error
+	getMissingFlags() []string
+}
+
+type errRequiredFlags struct {
+	missingFlags []string
+}
+
+func (e *errRequiredFlags) Error() string {
+	numberOfMissingFlags := len(e.missingFlags)
+	if numberOfMissingFlags == 1 {
+		return fmt.Sprintf("Required flag %q not set", e.missingFlags[0])
+	}
+	joinedMissingFlags := strings.Join(e.missingFlags, ", ")
+	return fmt.Sprintf("Required flags %q not set", joinedMissingFlags)
+}
+
+func (e *errRequiredFlags) getMissingFlags() []string {
+	return e.missingFlags
+}
+
 // ErrorFormatter is the interface that will suitably format the error output
 type ErrorFormatter interface {
 	Format(s fmt.State, verb rune)
@@ -62,35 +83,61 @@ type ExitCoder interface {
 
 type exitError struct {
 	exitCode int
-	message  interface{}
+	err      error
 }
 
-// NewExitError makes a new *exitError
+// NewExitError calls Exit to create a new ExitCoder.
+//
+// Deprecated: This function is a duplicate of Exit and will eventually be removed.
 func NewExitError(message interface{}, exitCode int) ExitCoder {
 	return Exit(message, exitCode)
 }
 
-// Exit wraps a message and exit code into an ExitCoder suitable for handling by
-// HandleExitCoder
+// Exit wraps a message and exit code into an error, which by default is
+// handled with a call to os.Exit during default error handling.
+//
+// This is the simplest way to trigger a non-zero exit code for an App without
+// having to call os.Exit manually. During testing, this behavior can be avoided
+// by overriding the ExitErrHandler function on an App or the package-global
+// OsExiter function.
 func Exit(message interface{}, exitCode int) ExitCoder {
+	var err error
+
+	switch e := message.(type) {
+	case ErrorFormatter:
+		err = fmt.Errorf("%+v", message)
+	case error:
+		err = e
+	default:
+		err = fmt.Errorf("%+v", message)
+	}
+
 	return &exitError{
-		message:  message,
+		err:      err,
 		exitCode: exitCode,
 	}
 }
 
 func (ee *exitError) Error() string {
-	return fmt.Sprintf("%v", ee.message)
+	return ee.err.Error()
 }
 
 func (ee *exitError) ExitCode() int {
 	return ee.exitCode
 }
 
-// HandleExitCoder checks if the error fulfills the ExitCoder interface, and if
-// so prints the error to stderr (if it is non-empty) and calls OsExiter with the
-// given exit code.  If the given error is a MultiError, then this func is
-// called on all members of the Errors slice and calls OsExiter with the last exit code.
+func (ee *exitError) Unwrap() error {
+	return ee.err
+}
+
+// HandleExitCoder handles errors implementing ExitCoder by printing their
+// message and calling OsExiter with the given exit code.
+//
+// If the given error instead implements MultiError, each error will be checked
+// for the ExitCoder interface, and OsExiter will be called with the last exit
+// code found, or exit code 1 if no ExitCoder is found.
+//
+// This function is the default error-handling behavior for an App.
 func HandleExitCoder(err error) {
 	if err == nil {
 		return

--- a/go-controller/vendor/github.com/urfave/cli/v2/fish.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/fish.go
@@ -95,10 +95,10 @@ func (a *App) prepareFishCommands(commands []*Command, allCommands *[]string, pr
 		completions = append(completions, completion.String())
 		completions = append(
 			completions,
-			a.prepareFishFlags(command.Flags, command.Names())...,
+			a.prepareFishFlags(command.VisibleFlags(), command.Names())...,
 		)
 
-		// recursevly iterate subcommands
+		// recursively iterate subcommands
 		if len(command.Subcommands) > 0 {
 			completions = append(
 				completions,
@@ -168,6 +168,10 @@ func fishAddFileFlag(flag Flag, completion *strings.Builder) {
 			return
 		}
 	case *StringSliceFlag:
+		if f.TakesFile {
+			return
+		}
+	case *PathFlag:
 		if f.TakesFile {
 			return
 		}

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag-spec.yaml
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag-spec.yaml
@@ -1,0 +1,131 @@
+# NOTE: this file is used by the tool defined in
+# ./cmd/urfave-cli-genflags/main.go which uses the
+# `Spec` type that maps to this file structure.
+flag_types:
+  bool:
+    struct_fields:
+      - name: Count
+        type: int
+        pointer: true
+      - name: DisableDefaultText
+        type: bool
+      - name: Action
+        type: "func(*Context, bool) error"
+  float64:
+    struct_fields:
+      - name: Action
+        type: "func(*Context, float64) error"
+  Float64Slice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []float64) error"
+  int:
+    struct_fields:
+      - name: Base
+        type: int
+      - name: Action
+        type: "func(*Context, int) error"
+  IntSlice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []int) error"
+  int64:
+    struct_fields:
+      - name: Base
+        type: int
+      - name: Action
+        type: "func(*Context, int64) error"
+  Int64Slice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []int64) error"
+  uint:
+    struct_fields:
+      - name: Base
+        type: int
+      - name: Action
+        type: "func(*Context, uint) error"
+  UintSlice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []uint) error"
+  uint64:
+    struct_fields:
+      - name: Base
+        type: int
+      - name: Action
+        type: "func(*Context, uint64) error"
+  Uint64Slice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: Action
+        type: "func(*Context, []uint64) error"
+  string:
+    struct_fields:
+      - name: TakesFile
+        type: bool
+      - name: Action
+        type: "func(*Context, string) error"
+  StringSlice:
+    value_pointer: true
+    skip_interfaces:
+      - fmt.Stringer
+    struct_fields:
+      - name: separator
+        type: separatorSpec
+      - name: TakesFile
+        type: bool
+      - name: Action
+        type: "func(*Context, []string) error"
+      - name: KeepSpace
+        type: bool
+  time.Duration:
+    struct_fields:
+      - name: Action
+        type: "func(*Context, time.Duration) error"
+  Timestamp:
+    value_pointer: true
+    struct_fields:
+      - name: Layout
+        type: string
+      - name: Timezone
+        type: "*time.Location"
+      - name: Action
+        type: "func(*Context, *time.Time) error"
+  Generic:
+    no_destination_pointer: true
+    struct_fields:
+      - name: TakesFile
+        type: bool
+      - name: Action
+        type: "func(*Context, interface{}) error"
+  Path:
+    struct_fields:
+      - name: TakesFile
+        type: bool
+      - name: Action
+        type: "func(*Context, Path) error"

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag.go
@@ -1,19 +1,24 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"reflect"
+	"io"
+	"os"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
 
 const defaultPlaceholder = "value"
+
+const (
+	defaultSliceFlagSeparator = ","
+	disableSliceFlagSeparator = false
+)
 
 var (
 	slPfx = fmt.Sprintf("sl:::%d:::", time.Now().UTC().UnixNano())
@@ -29,18 +34,20 @@ var BashCompletionFlag Flag = &BoolFlag{
 
 // VersionFlag prints the version for the application
 var VersionFlag Flag = &BoolFlag{
-	Name:    "version",
-	Aliases: []string{"v"},
-	Usage:   "print the version",
+	Name:               "version",
+	Aliases:            []string{"v"},
+	Usage:              "print the version",
+	DisableDefaultText: true,
 }
 
 // HelpFlag prints the help for all commands and subcommands.
 // Set to nil to disable the flag.  The subcommand
 // will still be added unless HideHelp or HideHelpCommand is set to true.
 var HelpFlag Flag = &BoolFlag{
-	Name:    "help",
-	Aliases: []string{"h"},
-	Usage:   "show help",
+	Name:               "help",
+	Aliases:            []string{"h"},
+	Usage:              "show help",
+	DisableDefaultText: true,
 }
 
 // FlagStringer converts a flag definition to a string. This is used by help
@@ -84,6 +91,12 @@ func (f FlagsByName) Swap(i, j int) {
 	f[i], f[j] = f[j], f[i]
 }
 
+// ActionableFlag is an interface that wraps Flag interface and RunAction operation.
+type ActionableFlag interface {
+	Flag
+	RunAction(*Context) error
+}
+
 // Flag is a common interface related to parsing flags in cli.
 // For more advanced flag parsing techniques, it is recommended that
 // this interface be implemented.
@@ -116,25 +129,105 @@ type DocGenerationFlag interface {
 	// GetValue returns the flags value as string representation and an empty
 	// string if the flag takes no value at all.
 	GetValue() string
+
+	// GetDefaultText returns the default text for this flag
+	GetDefaultText() string
+
+	// GetEnvVars returns the env vars for this flag
+	GetEnvVars() []string
 }
 
-func flagSet(name string, flags []Flag) (*flag.FlagSet, error) {
+// DocGenerationSliceFlag extends DocGenerationFlag for slice-based flags.
+type DocGenerationSliceFlag interface {
+	DocGenerationFlag
+
+	// IsSliceFlag returns true for flags that can be given multiple times.
+	IsSliceFlag() bool
+}
+
+// VisibleFlag is an interface that allows to check if a flag is visible
+type VisibleFlag interface {
+	Flag
+
+	// IsVisible returns true if the flag is not hidden, otherwise false
+	IsVisible() bool
+}
+
+// CategorizableFlag is an interface that allows us to potentially
+// use a flag in a categorized representation.
+type CategorizableFlag interface {
+	VisibleFlag
+
+	GetCategory() string
+}
+
+// Countable is an interface to enable detection of flag values which support
+// repetitive flags
+type Countable interface {
+	Count() int
+}
+
+func flagSet(name string, flags []Flag, spec separatorSpec) (*flag.FlagSet, error) {
 	set := flag.NewFlagSet(name, flag.ContinueOnError)
 
 	for _, f := range flags {
+		if c, ok := f.(customizedSeparator); ok {
+			c.WithSeparatorSpec(spec)
+		}
 		if err := f.Apply(set); err != nil {
 			return nil, err
 		}
 	}
-	set.SetOutput(ioutil.Discard)
+	set.SetOutput(io.Discard)
 	return set, nil
+}
+
+func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
+	switch ff.Value.(type) {
+	case Serializer:
+		_ = set.Set(name, ff.Value.(Serializer).Serialize())
+	default:
+		_ = set.Set(name, ff.Value.String())
+	}
+}
+
+func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
+	visited := make(map[string]bool)
+	set.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+	for _, f := range flags {
+		parts := f.Names()
+		if len(parts) == 1 {
+			continue
+		}
+		var ff *flag.Flag
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if visited[name] {
+				if ff != nil {
+					return errors.New("Cannot use two forms of the same flag: " + name + " " + ff.Name)
+				}
+				ff = set.Lookup(name)
+			}
+		}
+		if ff == nil {
+			continue
+		}
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if !visited[name] {
+				copyFlag(name, ff, set)
+			}
+		}
+	}
+	return nil
 }
 
 func visibleFlags(fl []Flag) []Flag {
 	var visible []Flag
 	for _, f := range fl {
-		field := flagValue(f).FieldByName("Hidden")
-		if !field.IsValid() || !field.Bool() {
+		if vf, ok := f.(VisibleFlag); ok && vf.IsVisible() {
 			visible = append(visible, f)
 		}
 	}
@@ -186,24 +279,28 @@ func prefixedNames(names []string, placeholder string) string {
 	return prefixed
 }
 
+func envFormat(envVars []string, prefix, sep, suffix string) string {
+	if len(envVars) > 0 {
+		return fmt.Sprintf(" [%s%s%s]", prefix, strings.Join(envVars, sep), suffix)
+	}
+	return ""
+}
+
+func defaultEnvFormat(envVars []string) string {
+	return envFormat(envVars, "$", ", $", "")
+}
+
 func withEnvHint(envVars []string, str string) string {
 	envText := ""
-	if envVars != nil && len(envVars) > 0 {
-		prefix := "$"
-		suffix := ""
-		sep := ", $"
-		if runtime.GOOS == "windows" {
-			prefix = "%"
-			suffix = "%"
-			sep = "%, %"
-		}
-
-		envText = fmt.Sprintf(" [%s%s%s]", prefix, strings.Join(envVars, sep), suffix)
+	if runtime.GOOS != "windows" || os.Getenv("PSHOME") != "" {
+		envText = defaultEnvFormat(envVars)
+	} else {
+		envText = envFormat(envVars, "%", "%, %", "%")
 	}
 	return str + envText
 }
 
-func flagNames(name string, aliases []string) []string {
+func FlagNames(name string, aliases []string) []string {
 	var ret []string
 
 	for _, part := range append([]string{name}, aliases...) {
@@ -217,17 +314,6 @@ func flagNames(name string, aliases []string) []string {
 	return ret
 }
 
-func flagStringSliceField(f Flag, name string) []string {
-	fv := flagValue(f)
-	field := fv.FieldByName(name)
-
-	if field.IsValid() {
-		return field.Interface().([]string)
-	}
-
-	return []string{}
-}
-
 func withFileHint(filePath, str string) string {
 	fileText := ""
 	if filePath != "" {
@@ -236,130 +322,44 @@ func withFileHint(filePath, str string) string {
 	return str + fileText
 }
 
-func flagValue(f Flag) reflect.Value {
-	fv := reflect.ValueOf(f)
-	for fv.Kind() == reflect.Ptr {
-		fv = reflect.Indirect(fv)
-	}
-	return fv
-}
-
 func formatDefault(format string) string {
 	return " (default: " + format + ")"
 }
 
 func stringifyFlag(f Flag) string {
-	fv := flagValue(f)
-
-	switch f := f.(type) {
-	case *IntSliceFlag:
-		return withEnvHint(flagStringSliceField(f, "EnvVars"),
-			stringifyIntSliceFlag(f))
-	case *Int64SliceFlag:
-		return withEnvHint(flagStringSliceField(f, "EnvVars"),
-			stringifyInt64SliceFlag(f))
-	case *Float64SliceFlag:
-		return withEnvHint(flagStringSliceField(f, "EnvVars"),
-			stringifyFloat64SliceFlag(f))
-	case *StringSliceFlag:
-		return withEnvHint(flagStringSliceField(f, "EnvVars"),
-			stringifyStringSliceFlag(f))
+	// enforce DocGeneration interface on flags to avoid reflection
+	df, ok := f.(DocGenerationFlag)
+	if !ok {
+		return ""
 	}
 
-	placeholder, usage := unquoteUsage(fv.FieldByName("Usage").String())
-
-	needsPlaceholder := false
-	defaultValueString := ""
-	val := fv.FieldByName("Value")
-	if val.IsValid() {
-		needsPlaceholder = val.Kind() != reflect.Bool
-		defaultValueString = fmt.Sprintf(formatDefault("%v"), val.Interface())
-
-		if val.Kind() == reflect.String && val.String() != "" {
-			defaultValueString = fmt.Sprintf(formatDefault("%q"), val.String())
-		}
-	}
-
-	helpText := fv.FieldByName("DefaultText")
-	if helpText.IsValid() && helpText.String() != "" {
-		needsPlaceholder = val.Kind() != reflect.Bool
-		defaultValueString = fmt.Sprintf(formatDefault("%s"), helpText.String())
-	}
-
-	if defaultValueString == formatDefault("") {
-		defaultValueString = ""
-	}
+	placeholder, usage := unquoteUsage(df.GetUsage())
+	needsPlaceholder := df.TakesValue()
 
 	if needsPlaceholder && placeholder == "" {
 		placeholder = defaultPlaceholder
 	}
 
+	defaultValueString := ""
+
+	// set default text for all flags except bool flags
+	// for bool flags display default text if DisableDefaultText is not
+	// set
+	if bf, ok := f.(*BoolFlag); !ok || !bf.DisableDefaultText {
+		if s := df.GetDefaultText(); s != "" {
+			defaultValueString = fmt.Sprintf(formatDefault("%s"), s)
+		}
+	}
+
 	usageWithDefault := strings.TrimSpace(usage + defaultValueString)
 
-	return withEnvHint(flagStringSliceField(f, "EnvVars"),
-		fmt.Sprintf("%s\t%s", prefixedNames(f.Names(), placeholder), usageWithDefault))
-}
-
-func stringifyIntSliceFlag(f *IntSliceFlag) string {
-	var defaultVals []string
-	if f.Value != nil && len(f.Value.Value()) > 0 {
-		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, strconv.Itoa(i))
-		}
+	pn := prefixedNames(df.Names(), placeholder)
+	sliceFlag, ok := f.(DocGenerationSliceFlag)
+	if ok && sliceFlag.IsSliceFlag() {
+		pn = pn + " [ " + pn + " ]"
 	}
 
-	return stringifySliceFlag(f.Usage, f.Names(), defaultVals)
-}
-
-func stringifyInt64SliceFlag(f *Int64SliceFlag) string {
-	var defaultVals []string
-	if f.Value != nil && len(f.Value.Value()) > 0 {
-		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, strconv.FormatInt(i, 10))
-		}
-	}
-
-	return stringifySliceFlag(f.Usage, f.Names(), defaultVals)
-}
-
-func stringifyFloat64SliceFlag(f *Float64SliceFlag) string {
-	var defaultVals []string
-
-	if f.Value != nil && len(f.Value.Value()) > 0 {
-		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", i), "0"), "."))
-		}
-	}
-
-	return stringifySliceFlag(f.Usage, f.Names(), defaultVals)
-}
-
-func stringifyStringSliceFlag(f *StringSliceFlag) string {
-	var defaultVals []string
-	if f.Value != nil && len(f.Value.Value()) > 0 {
-		for _, s := range f.Value.Value() {
-			if len(s) > 0 {
-				defaultVals = append(defaultVals, strconv.Quote(s))
-			}
-		}
-	}
-
-	return stringifySliceFlag(f.Usage, f.Names(), defaultVals)
-}
-
-func stringifySliceFlag(usage string, names, defaultVals []string) string {
-	placeholder, usage := unquoteUsage(usage)
-	if placeholder == "" {
-		placeholder = defaultPlaceholder
-	}
-
-	defaultVal := ""
-	if len(defaultVals) > 0 {
-		defaultVal = fmt.Sprintf(formatDefault("%s"), strings.Join(defaultVals, ", "))
-	}
-
-	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultVal))
-	return fmt.Sprintf("%s\t%s", prefixedNames(names, placeholder), usageWithDefault)
+	return withEnvHint(df.GetEnvVars(), fmt.Sprintf("%s\t%s", pn, usageWithDefault))
 }
 
 func hasFlag(flags []Flag, fl Flag) bool {
@@ -372,17 +372,48 @@ func hasFlag(flags []Flag, fl Flag) bool {
 	return false
 }
 
-func flagFromEnvOrFile(envVars []string, filePath string) (val string, ok bool) {
+// Return the first value from a list of environment variables and files
+// (which may or may not exist), a description of where the value was found,
+// and a boolean which is true if a value was found.
+func flagFromEnvOrFile(envVars []string, filePath string) (value string, fromWhere string, found bool) {
 	for _, envVar := range envVars {
 		envVar = strings.TrimSpace(envVar)
-		if val, ok := syscall.Getenv(envVar); ok {
-			return val, true
+		if value, found := syscall.Getenv(envVar); found {
+			return value, fmt.Sprintf("environment variable %q", envVar), true
 		}
 	}
 	for _, fileVar := range strings.Split(filePath, ",") {
-		if data, err := ioutil.ReadFile(fileVar); err == nil {
-			return string(data), true
+		if fileVar != "" {
+			if data, err := os.ReadFile(fileVar); err == nil {
+				return string(data), fmt.Sprintf("file %q", filePath), true
+			}
 		}
 	}
-	return "", false
+	return "", "", false
+}
+
+type customizedSeparator interface {
+	WithSeparatorSpec(separatorSpec)
+}
+
+type separatorSpec struct {
+	sep        string
+	disabled   bool
+	customized bool
+}
+
+func (s separatorSpec) flagSplitMultiValues(val string) []string {
+	var (
+		disabled bool   = s.disabled
+		sep      string = s.sep
+	)
+	if !s.customized {
+		disabled = disableSliceFlagSeparator
+		sep = defaultSliceFlagSeparator
+	}
+	if disabled {
+		return []string{val}
+	}
+
+	return strings.Split(val, sep)
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_bool.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_bool.go
@@ -1,45 +1,61 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"strconv"
 )
 
-// BoolFlag is a flag with type bool
-type BoolFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       bool
-	DefaultText string
-	Destination *bool
-	HasBeenSet  bool
+// boolValue needs to implement the boolFlag internal interface in flag
+// to be able to capture bool fields and values
+//
+//	type boolFlag interface {
+//		  Value
+//		  IsBoolFlag() bool
+//	}
+type boolValue struct {
+	destination *bool
+	count       *int
 }
 
-// IsSet returns whether or not the flag has been set through env or file
-func (f *BoolFlag) IsSet() bool {
-	return f.HasBeenSet
+func newBoolValue(val bool, p *bool, count *int) *boolValue {
+	*p = val
+	return &boolValue{
+		destination: p,
+		count:       count,
+	}
 }
 
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *BoolFlag) String() string {
-	return FlagStringer(f)
+func (b *boolValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		err = errors.New("parse error")
+		return err
+	}
+	*b.destination = v
+	if b.count != nil {
+		*b.count = *b.count + 1
+	}
+	return err
 }
 
-// Names returns the names of the flag
-func (f *BoolFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
+func (b *boolValue) Get() interface{} { return *b.destination }
+
+func (b *boolValue) String() string {
+	if b.destination != nil {
+		return strconv.FormatBool(*b.destination)
+	}
+	return strconv.FormatBool(false)
 }
 
-// IsRequired returns whether or not the flag is required
-func (f *BoolFlag) IsRequired() bool {
-	return f.Required
+func (b *boolValue) IsBoolFlag() bool { return true }
+
+func (b *boolValue) Count() int {
+	if b.count != nil && *b.count > 0 {
+		return *b.count
+	}
+	return 0
 }
 
 // TakesValue returns true of the flag takes a value, otherwise false
@@ -52,42 +68,98 @@ func (f *BoolFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *BoolFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *BoolFlag) GetValue() string {
 	return ""
 }
 
-// Apply populates the flag given the flag set and environment
-func (f *BoolFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
-		if val != "" {
-			valBool, err := strconv.ParseBool(val)
-
-			if err != nil {
-				return fmt.Errorf("could not parse %q as bool value for flag %s: %s", val, f.Name, err)
-			}
-
-			f.Value = valBool
-			f.HasBeenSet = true
-		}
+// GetDefaultText returns the default text for this flag
+func (f *BoolFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
 	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%v", f.defaultValue)
+	}
+	return fmt.Sprintf("%v", f.Value)
+}
 
-	for _, name := range f.Names() {
-		if f.Destination != nil {
-			set.BoolVar(f.Destination, name, f.Value, f.Usage)
-			continue
-		}
-		set.Bool(name, f.Value, f.Usage)
+// GetEnvVars returns the env vars for this flag
+func (f *BoolFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// RunAction executes flag action if set
+func (f *BoolFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Bool(f.Name))
 	}
 
 	return nil
 }
 
+// Apply populates the flag given the flag set and environment
+func (f *BoolFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valBool, err := strconv.ParseBool(val)
+
+			if err != nil {
+				return fmt.Errorf("could not parse %q as bool value from %s for flag %s: %s", val, source, f.Name, err)
+			}
+
+			f.Value = valBool
+		} else {
+			// empty value implies that the env is defined but set to empty string, we have to assume that this is
+			// what the user wants. If user doesnt want this then the env needs to be deleted or the flag removed from
+			// file
+			f.Value = false
+		}
+		f.HasBeenSet = true
+	}
+
+	count := f.Count
+	dest := f.Destination
+
+	if count == nil {
+		count = new(int)
+	}
+
+	// since count will be incremented for each alias as well
+	// subtract number of aliases from overall count
+	*count -= len(f.Aliases)
+
+	if dest == nil {
+		dest = new(bool)
+	}
+
+	for _, name := range f.Names() {
+		value := newBoolValue(f.Value, dest, count)
+		set.Var(value, name, f.Usage)
+	}
+
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *BoolFlag) Get(ctx *Context) bool {
+	return ctx.Bool(f.Name)
+}
+
 // Bool looks up the value of a local BoolFlag, returns
 // false if not found
-func (c *Context) Bool(name string) bool {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Bool(name string) bool {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupBool(name, fs)
 	}
 	return false

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_duration.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_duration.go
@@ -6,42 +6,6 @@ import (
 	"time"
 )
 
-// DurationFlag is a flag with type time.Duration (see https://golang.org/pkg/time/#ParseDuration)
-type DurationFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       time.Duration
-	DefaultText string
-	Destination *time.Duration
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *DurationFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *DurationFlag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *DurationFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *DurationFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *DurationFlag) TakesValue() bool {
 	return true
@@ -52,20 +16,45 @@ func (f *DurationFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *DurationFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *DurationFlag) GetValue() string {
 	return f.Value.String()
 }
 
+// GetDefaultText returns the default text for this flag
+func (f *DurationFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return f.defaultValue.String()
+	}
+	return f.Value.String()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *DurationFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
 // Apply populates the flag given the flag set and environment
 func (f *DurationFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		if val != "" {
 			valDuration, err := time.ParseDuration(val)
 
 			if err != nil {
-				return fmt.Errorf("could not parse %q as duration value for flag %s: %s", val, f.Name, err)
+				return fmt.Errorf("could not parse %q as duration value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 
 			f.Value = valDuration
@@ -83,10 +72,24 @@ func (f *DurationFlag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
+// Get returns the flag’s value in the given Context.
+func (f *DurationFlag) Get(ctx *Context) time.Duration {
+	return ctx.Duration(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *DurationFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Duration(f.Name))
+	}
+
+	return nil
+}
+
 // Duration looks up the value of a local DurationFlag, returns
 // 0 if not found
-func (c *Context) Duration(name string) time.Duration {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Duration(name string) time.Duration {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupDuration(name, fs)
 	}
 	return 0

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_ext.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_ext.go
@@ -1,0 +1,48 @@
+package cli
+
+import "flag"
+
+type extFlag struct {
+	f *flag.Flag
+}
+
+func (e *extFlag) Apply(fs *flag.FlagSet) error {
+	fs.Var(e.f.Value, e.f.Name, e.f.Usage)
+	return nil
+}
+
+func (e *extFlag) Names() []string {
+	return []string{e.f.Name}
+}
+
+func (e *extFlag) IsSet() bool {
+	return false
+}
+
+func (e *extFlag) String() string {
+	return FlagStringer(e)
+}
+
+func (e *extFlag) IsVisible() bool {
+	return true
+}
+
+func (e *extFlag) TakesValue() bool {
+	return false
+}
+
+func (e *extFlag) GetUsage() string {
+	return e.f.Usage
+}
+
+func (e *extFlag) GetValue() string {
+	return e.f.Value.String()
+}
+
+func (e *extFlag) GetDefaultText() string {
+	return e.f.DefValue
+}
+
+func (e *extFlag) GetEnvVars() []string {
+	return nil
+}

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_float64.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_float64.go
@@ -6,42 +6,6 @@ import (
 	"strconv"
 )
 
-// Float64Flag is a flag with type float64
-type Float64Flag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       float64
-	DefaultText string
-	Destination *float64
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *Float64Flag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *Float64Flag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *Float64Flag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *Float64Flag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *Float64Flag) TakesValue() bool {
 	return true
@@ -52,20 +16,43 @@ func (f *Float64Flag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *Float64Flag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *Float64Flag) GetValue() string {
-	return fmt.Sprintf("%f", f.Value)
+	return fmt.Sprintf("%v", f.Value)
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *Float64Flag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%v", f.defaultValue)
+	}
+	return fmt.Sprintf("%v", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Float64Flag) GetEnvVars() []string {
+	return f.EnvVars
 }
 
 // Apply populates the flag given the flag set and environment
 func (f *Float64Flag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
-		if val != "" {
-			valFloat, err := strconv.ParseFloat(val, 10)
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
 
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			valFloat, err := strconv.ParseFloat(val, 64)
 			if err != nil {
-				return fmt.Errorf("could not parse %q as float64 value for flag %s: %s", val, f.Name, err)
+				return fmt.Errorf("could not parse %q as float64 value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 
 			f.Value = valFloat
@@ -84,10 +71,24 @@ func (f *Float64Flag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
+// Get returns the flag’s value in the given Context.
+func (f *Float64Flag) Get(ctx *Context) float64 {
+	return ctx.Float64(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *Float64Flag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Float64(f.Name))
+	}
+
+	return nil
+}
+
 // Float64 looks up the value of a local Float64Flag, returns
 // 0 if not found
-func (c *Context) Float64(name string) float64 {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Float64(name string) float64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupFloat64(name, fs)
 	}
 	return 0

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_float64_slice.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_float64_slice.go
@@ -11,12 +11,27 @@ import (
 // Float64Slice wraps []float64 to satisfy flag.Value
 type Float64Slice struct {
 	slice      []float64
+	separator  separatorSpec
 	hasBeenSet bool
 }
 
 // NewFloat64Slice makes a *Float64Slice with default values
 func NewFloat64Slice(defaults ...float64) *Float64Slice {
 	return &Float64Slice{slice: append([]float64{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (f *Float64Slice) clone() *Float64Slice {
+	n := &Float64Slice{
+		slice:      make([]float64, len(f.slice)),
+		hasBeenSet: f.hasBeenSet,
+	}
+	copy(n.slice, f.slice)
+	return n
+}
+
+func (f *Float64Slice) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
 }
 
 // Set parses the value into a float64 and appends it to the list of values
@@ -33,18 +48,25 @@ func (f *Float64Slice) Set(value string) error {
 		return nil
 	}
 
-	tmp, err := strconv.ParseFloat(value, 64)
-	if err != nil {
-		return err
-	}
+	for _, s := range f.separator.flagSplitMultiValues(value) {
+		tmp, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return err
+		}
 
-	f.slice = append(f.slice, tmp)
+		f.slice = append(f.slice, tmp)
+	}
 	return nil
 }
 
 // String returns a readable representation of this value (for usage defaults)
 func (f *Float64Slice) String() string {
-	return fmt.Sprintf("%#v", f.slice)
+	v := f.slice
+	if v == nil {
+		// treat nil the same as zero length non-nil
+		v = make([]float64, 0)
+	}
+	return fmt.Sprintf("%#v", v)
 }
 
 // Serialize allows Float64Slice to fulfill Serializer
@@ -63,39 +85,10 @@ func (f *Float64Slice) Get() interface{} {
 	return *f
 }
 
-// Float64SliceFlag is a flag with type *Float64Slice
-type Float64SliceFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       *Float64Slice
-	DefaultText string
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *Float64SliceFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
 // String returns a readable representation of this value
 // (for usage defaults)
 func (f *Float64SliceFlag) String() string {
 	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *Float64SliceFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *Float64SliceFlag) IsRequired() bool {
-	return f.Required
 }
 
 // TakesValue returns true if the flag takes a value, otherwise false
@@ -108,36 +101,96 @@ func (f *Float64SliceFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *Float64SliceFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *Float64SliceFlag) GetValue() string {
-	if f.Value != nil {
-		return f.Value.String()
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", i), "0"), "."))
+		}
 	}
-	return ""
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *Float64SliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Float64SliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *Float64SliceFlag) IsSliceFlag() bool {
+	return true
 }
 
 // Apply populates the flag given the flag set and environment
 func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
-		if val != "" {
-			f.Value = &Float64Slice{}
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]float64, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
 
-			for _, s := range strings.Split(val, ",") {
-				if err := f.Value.Set(strings.TrimSpace(s)); err != nil {
-					return fmt.Errorf("could not parse %q as float64 slice value for flag %s: %s", f.Value, f.Name, err)
+	// resolve setValue (what we will assign to the set)
+	var setValue *Float64Slice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(Float64Slice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		if val != "" {
+			for _, s := range f.separator.flagSplitMultiValues(val) {
+				if err := setValue.Set(strings.TrimSpace(s)); err != nil {
+					return fmt.Errorf("could not parse %q as float64 slice value from %s for flag %s: %s", val, source, f.Name, err)
 				}
 			}
 
+			// Set this to false so that we reset the slice if we then set values from
+			// flags that have already been set by the environment.
+			setValue.hasBeenSet = false
 			f.HasBeenSet = true
 		}
 	}
 
 	for _, name := range f.Names() {
-		if f.Value == nil {
-			f.Value = &Float64Slice{}
-		}
-		set.Var(f.Value, name, f.Usage)
+		set.Var(setValue, name, f.Usage)
+	}
+
+	return nil
+}
+
+func (f *Float64SliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *Float64SliceFlag) Get(ctx *Context) []float64 {
+	return ctx.Float64Slice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *Float64SliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Float64Slice(f.Name))
 	}
 
 	return nil
@@ -145,8 +198,8 @@ func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error {
 
 // Float64Slice looks up the value of a local Float64SliceFlag, returns
 // nil if not found
-func (c *Context) Float64Slice(name string) []float64 {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Float64Slice(name string) []float64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupFloat64Slice(name, fs)
 	}
 	return nil
@@ -155,7 +208,7 @@ func (c *Context) Float64Slice(name string) []float64 {
 func lookupFloat64Slice(name string, set *flag.FlagSet) []float64 {
 	f := set.Lookup(name)
 	if f != nil {
-		if slice, ok := f.Value.(*Float64Slice); ok {
+		if slice, ok := unwrapFlagValue(f.Value).(*Float64Slice); ok {
 			return slice.Value()
 		}
 	}

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_generic.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_generic.go
@@ -11,40 +11,17 @@ type Generic interface {
 	String() string
 }
 
-// GenericFlag is a flag with type Generic
-type GenericFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	TakesFile   bool
-	Value       Generic
-	DefaultText string
-	HasBeenSet  bool
+type stringGeneric struct {
+	value string
 }
 
-// IsSet returns whether or not the flag has been set through env or file
-func (f *GenericFlag) IsSet() bool {
-	return f.HasBeenSet
+func (s *stringGeneric) Set(value string) error {
+	s.value = value
+	return nil
 }
 
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *GenericFlag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *GenericFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *GenericFlag) IsRequired() bool {
-	return f.Required
+func (s *stringGeneric) String() string {
+	return s.value
 }
 
 // TakesValue returns true of the flag takes a value, otherwise false
@@ -57,6 +34,11 @@ func (f *GenericFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *GenericFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *GenericFlag) GetValue() string {
@@ -66,13 +48,41 @@ func (f *GenericFlag) GetValue() string {
 	return ""
 }
 
+// GetDefaultText returns the default text for this flag
+func (f *GenericFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	val := f.Value
+	if f.defaultValueSet {
+		val = f.defaultValue
+	}
+
+	if val != nil {
+		return val.String()
+	}
+
+	return ""
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *GenericFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
 // Apply takes the flagset and calls Set on the generic flag with the value
 // provided by the user for parsing by the flag
-func (f GenericFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+func (f *GenericFlag) Apply(set *flag.FlagSet) error {
+	// set default value so that environment wont be able to overwrite it
+	if f.Value != nil {
+		f.defaultValue = &stringGeneric{value: f.Value.String()}
+		f.defaultValueSet = true
+	}
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		if val != "" {
 			if err := f.Value.Set(val); err != nil {
-				return fmt.Errorf("could not parse %q as value for flag %s: %s", val, f.Name, err)
+				return fmt.Errorf("could not parse %q from %s as value for flag %s: %s", val, source, f.Name, err)
 			}
 
 			f.HasBeenSet = true
@@ -80,7 +90,25 @@ func (f GenericFlag) Apply(set *flag.FlagSet) error {
 	}
 
 	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.Var(f.Destination, name, f.Usage)
+			continue
+		}
 		set.Var(f.Value, name, f.Usage)
+	}
+
+	return nil
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *GenericFlag) Get(ctx *Context) interface{} {
+	return ctx.Generic(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *GenericFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Generic(f.Name))
 	}
 
 	return nil
@@ -88,21 +116,16 @@ func (f GenericFlag) Apply(set *flag.FlagSet) error {
 
 // Generic looks up the value of a local GenericFlag, returns
 // nil if not found
-func (c *Context) Generic(name string) interface{} {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Generic(name string) interface{} {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupGeneric(name, fs)
 	}
 	return nil
 }
 
 func lookupGeneric(name string, set *flag.FlagSet) interface{} {
-	f := set.Lookup(name)
-	if f != nil {
-		parsed, err := f.Value, error(nil)
-		if err != nil {
-			return nil
-		}
-		return parsed
+	if f := set.Lookup(name); f != nil {
+		return f.Value
 	}
 	return nil
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_int.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_int.go
@@ -6,42 +6,6 @@ import (
 	"strconv"
 )
 
-// IntFlag is a flag with type int
-type IntFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       int
-	DefaultText string
-	Destination *int
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *IntFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *IntFlag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *IntFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *IntFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *IntFlag) TakesValue() bool {
 	return true
@@ -52,20 +16,45 @@ func (f *IntFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *IntFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *IntFlag) GetValue() string {
 	return fmt.Sprintf("%d", f.Value)
 }
 
+// GetDefaultText returns the default text for this flag
+func (f *IntFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%d", f.defaultValue)
+	}
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *IntFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
 // Apply populates the flag given the flag set and environment
 func (f *IntFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		if val != "" {
-			valInt, err := strconv.ParseInt(val, 0, 64)
+			valInt, err := strconv.ParseInt(val, f.Base, 64)
 
 			if err != nil {
-				return fmt.Errorf("could not parse %q as int value for flag %s: %s", val, f.Name, err)
+				return fmt.Errorf("could not parse %q as int value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 
 			f.Value = int(valInt)
@@ -84,10 +73,24 @@ func (f *IntFlag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
+// Get returns the flag’s value in the given Context.
+func (f *IntFlag) Get(ctx *Context) int {
+	return ctx.Int(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *IntFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Int(f.Name))
+	}
+
+	return nil
+}
+
 // Int looks up the value of a local IntFlag, returns
 // 0 if not found
-func (c *Context) Int(name string) int {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Int(name string) int {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupInt(name, fs)
 	}
 	return 0

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_int64.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_int64.go
@@ -6,42 +6,6 @@ import (
 	"strconv"
 )
 
-// Int64Flag is a flag with type int64
-type Int64Flag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       int64
-	DefaultText string
-	Destination *int64
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *Int64Flag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *Int64Flag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *Int64Flag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *Int64Flag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *Int64Flag) TakesValue() bool {
 	return true
@@ -52,20 +16,45 @@ func (f *Int64Flag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *Int64Flag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *Int64Flag) GetValue() string {
 	return fmt.Sprintf("%d", f.Value)
 }
 
+// GetDefaultText returns the default text for this flag
+func (f *Int64Flag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%d", f.defaultValue)
+	}
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Int64Flag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
 // Apply populates the flag given the flag set and environment
 func (f *Int64Flag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		if val != "" {
-			valInt, err := strconv.ParseInt(val, 0, 64)
+			valInt, err := strconv.ParseInt(val, f.Base, 64)
 
 			if err != nil {
-				return fmt.Errorf("could not parse %q as int value for flag %s: %s", val, f.Name, err)
+				return fmt.Errorf("could not parse %q as int value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 
 			f.Value = valInt
@@ -83,10 +72,24 @@ func (f *Int64Flag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
+// Get returns the flag’s value in the given Context.
+func (f *Int64Flag) Get(ctx *Context) int64 {
+	return ctx.Int64(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *Int64Flag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Int64(f.Name))
+	}
+
+	return nil
+}
+
 // Int64 looks up the value of a local Int64Flag, returns
 // 0 if not found
-func (c *Context) Int64(name string) int64 {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Int64(name string) int64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupInt64(name, fs)
 	}
 	return 0

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_int_slice.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_int_slice.go
@@ -11,12 +11,23 @@ import (
 // IntSlice wraps []int to satisfy flag.Value
 type IntSlice struct {
 	slice      []int
+	separator  separatorSpec
 	hasBeenSet bool
 }
 
 // NewIntSlice makes an *IntSlice with default values
 func NewIntSlice(defaults ...int) *IntSlice {
 	return &IntSlice{slice: append([]int{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (i *IntSlice) clone() *IntSlice {
+	n := &IntSlice{
+		slice:      make([]int, len(i.slice)),
+		hasBeenSet: i.hasBeenSet,
+	}
+	copy(n.slice, i.slice)
+	return n
 }
 
 // TODO: Consistently have specific Set function for Int64 and Float64 ?
@@ -28,6 +39,10 @@ func (i *IntSlice) SetInt(value int) {
 	}
 
 	i.slice = append(i.slice, value)
+}
+
+func (i *IntSlice) WithSeparatorSpec(spec separatorSpec) {
+	i.separator = spec
 }
 
 // Set parses the value into an integer and appends it to the list of values
@@ -44,19 +59,26 @@ func (i *IntSlice) Set(value string) error {
 		return nil
 	}
 
-	tmp, err := strconv.ParseInt(value, 0, 64)
-	if err != nil {
-		return err
-	}
+	for _, s := range i.separator.flagSplitMultiValues(value) {
+		tmp, err := strconv.ParseInt(strings.TrimSpace(s), 0, 64)
+		if err != nil {
+			return err
+		}
 
-	i.slice = append(i.slice, int(tmp))
+		i.slice = append(i.slice, int(tmp))
+	}
 
 	return nil
 }
 
 // String returns a readable representation of this value (for usage defaults)
 func (i *IntSlice) String() string {
-	return fmt.Sprintf("%#v", i.slice)
+	v := i.slice
+	if v == nil {
+		// treat nil the same as zero length non-nil
+		v = make([]int, 0)
+	}
+	return fmt.Sprintf("%#v", v)
 }
 
 // Serialize allows IntSlice to fulfill Serializer
@@ -75,39 +97,10 @@ func (i *IntSlice) Get() interface{} {
 	return *i
 }
 
-// IntSliceFlag is a flag with type *IntSlice
-type IntSliceFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       *IntSlice
-	DefaultText string
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *IntSliceFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
 // String returns a readable representation of this value
 // (for usage defaults)
 func (f *IntSliceFlag) String() string {
 	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *IntSliceFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *IntSliceFlag) IsRequired() bool {
-	return f.Required
 }
 
 // TakesValue returns true of the flag takes a value, otherwise false
@@ -116,38 +109,98 @@ func (f *IntSliceFlag) TakesValue() bool {
 }
 
 // GetUsage returns the usage string for the flag
-func (f IntSliceFlag) GetUsage() string {
+func (f *IntSliceFlag) GetUsage() string {
 	return f.Usage
+}
+
+// GetCategory returns the category for the flag
+func (f *IntSliceFlag) GetCategory() string {
+	return f.Category
 }
 
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *IntSliceFlag) GetValue() string {
-	if f.Value != nil {
-		return f.Value.String()
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strconv.Itoa(i))
+		}
 	}
-	return ""
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *IntSliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *IntSliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *IntSliceFlag) IsSliceFlag() bool {
+	return true
 }
 
 // Apply populates the flag given the flag set and environment
 func (f *IntSliceFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
-		f.Value = &IntSlice{}
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]int, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
 
-		for _, s := range strings.Split(val, ",") {
-			if err := f.Value.Set(strings.TrimSpace(s)); err != nil {
-				return fmt.Errorf("could not parse %q as int slice value for flag %s: %s", val, f.Name, err)
+	// resolve setValue (what we will assign to the set)
+	var setValue *IntSlice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(IntSlice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	if val, source, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok && val != "" {
+		for _, s := range f.separator.flagSplitMultiValues(val) {
+			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
+				return fmt.Errorf("could not parse %q as int slice value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 		}
 
+		// Set this to false so that we reset the slice if we then set values from
+		// flags that have already been set by the environment.
+		setValue.hasBeenSet = false
 		f.HasBeenSet = true
 	}
 
 	for _, name := range f.Names() {
-		if f.Value == nil {
-			f.Value = &IntSlice{}
-		}
-		set.Var(f.Value, name, f.Usage)
+		set.Var(setValue, name, f.Usage)
+	}
+
+	return nil
+}
+
+func (f *IntSliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *IntSliceFlag) Get(ctx *Context) []int {
+	return ctx.IntSlice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *IntSliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.IntSlice(f.Name))
 	}
 
 	return nil
@@ -155,9 +208,9 @@ func (f *IntSliceFlag) Apply(set *flag.FlagSet) error {
 
 // IntSlice looks up the value of a local IntSliceFlag, returns
 // nil if not found
-func (c *Context) IntSlice(name string) []int {
-	if fs := lookupFlagSet(name, c); fs != nil {
-		return lookupIntSlice(name, c.flagSet)
+func (cCtx *Context) IntSlice(name string) []int {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
+		return lookupIntSlice(name, fs)
 	}
 	return nil
 }
@@ -165,7 +218,7 @@ func (c *Context) IntSlice(name string) []int {
 func lookupIntSlice(name string, set *flag.FlagSet) []int {
 	f := set.Lookup(name)
 	if f != nil {
-		if slice, ok := f.Value.(*IntSlice); ok {
+		if slice, ok := unwrapFlagValue(f.Value).(*IntSlice); ok {
 			return slice.Value()
 		}
 	}

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_path.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_path.go
@@ -1,42 +1,11 @@
 package cli
 
-import "flag"
+import (
+	"flag"
+	"fmt"
+)
 
-type PathFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	TakesFile   bool
-	Value       string
-	DefaultText string
-	Destination *string
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *PathFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *PathFlag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *PathFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *PathFlag) IsRequired() bool {
-	return f.Required
-}
+type Path = string
 
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *PathFlag) TakesValue() bool {
@@ -48,15 +17,44 @@ func (f *PathFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *PathFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *PathFlag) GetValue() string {
 	return f.Value
 }
 
+// GetDefaultText returns the default text for this flag
+func (f *PathFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	val := f.Value
+	if f.defaultValueSet {
+		val = f.defaultValue
+	}
+	if val == "" {
+		return val
+	}
+	return fmt.Sprintf("%q", val)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *PathFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
 // Apply populates the flag given the flag set and environment
 func (f *PathFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, _, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		f.Value = val
 		f.HasBeenSet = true
 	}
@@ -72,10 +70,24 @@ func (f *PathFlag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
+// Get returns the flag’s value in the given Context.
+func (f *PathFlag) Get(ctx *Context) string {
+	return ctx.Path(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *PathFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Path(f.Name))
+	}
+
+	return nil
+}
+
 // Path looks up the value of a local PathFlag, returns
 // "" if not found
-func (c *Context) Path(name string) string {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Path(name string) string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupPath(name, fs)
 	}
 
@@ -83,13 +95,8 @@ func (c *Context) Path(name string) string {
 }
 
 func lookupPath(name string, set *flag.FlagSet) string {
-	f := set.Lookup(name)
-	if f != nil {
-		parsed, err := f.Value.String(), error(nil)
-		if err != nil {
-			return ""
-		}
-		return parsed
+	if f := set.Lookup(name); f != nil {
+		return f.Value.String()
 	}
 	return ""
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_string.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_string.go
@@ -1,43 +1,9 @@
 package cli
 
-import "flag"
-
-// StringFlag is a flag with type string
-type StringFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	TakesFile   bool
-	Value       string
-	DefaultText string
-	Destination *string
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *StringFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *StringFlag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *StringFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *StringFlag) IsRequired() bool {
-	return f.Required
-}
+import (
+	"flag"
+	"fmt"
+)
 
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *StringFlag) TakesValue() bool {
@@ -49,15 +15,45 @@ func (f *StringFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *StringFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *StringFlag) GetValue() string {
 	return f.Value
 }
 
+// GetDefaultText returns the default text for this flag
+func (f *StringFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	val := f.Value
+	if f.defaultValueSet {
+		val = f.defaultValue
+	}
+
+	if val == "" {
+		return val
+	}
+	return fmt.Sprintf("%q", val)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *StringFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
 // Apply populates the flag given the flag set and environment
 func (f *StringFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, _, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		f.Value = val
 		f.HasBeenSet = true
 	}
@@ -73,23 +69,32 @@ func (f *StringFlag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
+// Get returns the flag’s value in the given Context.
+func (f *StringFlag) Get(ctx *Context) string {
+	return ctx.String(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *StringFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.String(f.Name))
+	}
+
+	return nil
+}
+
 // String looks up the value of a local StringFlag, returns
 // "" if not found
-func (c *Context) String(name string) string {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) String(name string) string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupString(name, fs)
 	}
 	return ""
 }
 
 func lookupString(name string, set *flag.FlagSet) string {
-	f := set.Lookup(name)
-	if f != nil {
-		parsed, err := f.Value.String(), error(nil)
-		if err != nil {
-			return ""
-		}
-		return parsed
+	if f := set.Lookup(name); f != nil {
+		return f.Value.String()
 	}
 	return ""
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_string_slice.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_string_slice.go
@@ -4,18 +4,31 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
 // StringSlice wraps a []string to satisfy flag.Value
 type StringSlice struct {
 	slice      []string
+	separator  separatorSpec
 	hasBeenSet bool
+	keepSpace  bool
 }
 
 // NewStringSlice creates a *StringSlice with default values
 func NewStringSlice(defaults ...string) *StringSlice {
 	return &StringSlice{slice: append([]string{}, defaults...)}
+}
+
+// clone allocate a copy of self object
+func (s *StringSlice) clone() *StringSlice {
+	n := &StringSlice{
+		slice:      make([]string, len(s.slice)),
+		hasBeenSet: s.hasBeenSet,
+	}
+	copy(n.slice, s.slice)
+	return n
 }
 
 // Set appends the string value to the list of values
@@ -32,9 +45,18 @@ func (s *StringSlice) Set(value string) error {
 		return nil
 	}
 
-	s.slice = append(s.slice, value)
+	for _, t := range s.separator.flagSplitMultiValues(value) {
+		if !s.keepSpace {
+			t = strings.TrimSpace(t)
+		}
+		s.slice = append(s.slice, t)
+	}
 
 	return nil
+}
+
+func (s *StringSlice) WithSeparatorSpec(spec separatorSpec) {
+	s.separator = spec
 }
 
 // String returns a readable representation of this value (for usage defaults)
@@ -58,41 +80,10 @@ func (s *StringSlice) Get() interface{} {
 	return *s
 }
 
-// StringSliceFlag is a flag with type *StringSlice
-type StringSliceFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	TakesFile   bool
-	Value       *StringSlice
-	DefaultText string
-	HasBeenSet  bool
-	Destination *StringSlice
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *StringSliceFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
 // String returns a readable representation of this value
 // (for usage defaults)
 func (f *StringSliceFlag) String() string {
 	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *StringSliceFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *StringSliceFlag) IsRequired() bool {
-	return f.Required
 }
 
 // TakesValue returns true of the flag takes a value, otherwise false
@@ -105,47 +96,101 @@ func (f *StringSliceFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *StringSliceFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *StringSliceFlag) GetValue() string {
-	if f.Value != nil {
-		return f.Value.String()
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, s := range f.Value.Value() {
+			if len(s) > 0 {
+				defaultVals = append(defaultVals, strconv.Quote(s))
+			}
+		}
 	}
-	return ""
+	return strings.Join(defaultVals, ", ")
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *StringSliceFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	return f.GetValue()
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *StringSliceFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// IsSliceFlag implements DocGenerationSliceFlag.
+func (f *StringSliceFlag) IsSliceFlag() bool {
+	return true
 }
 
 // Apply populates the flag given the flag set and environment
 func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
-		f.Value = &StringSlice{}
-		destination := f.Value
-		if f.Destination != nil {
-			destination = f.Destination
-		}
+	// apply any default
+	if f.Destination != nil && f.Value != nil {
+		f.Destination.slice = make([]string, len(f.Value.slice))
+		copy(f.Destination.slice, f.Value.slice)
+	}
 
-		for _, s := range strings.Split(val, ",") {
-			if err := destination.Set(strings.TrimSpace(s)); err != nil {
-				return fmt.Errorf("could not parse %q as string value for flag %s: %s", val, f.Name, err)
+	// resolve setValue (what we will assign to the set)
+	var setValue *StringSlice
+	switch {
+	case f.Destination != nil:
+		setValue = f.Destination
+	case f.Value != nil:
+		setValue = f.Value.clone()
+	default:
+		setValue = new(StringSlice)
+		setValue.WithSeparatorSpec(f.separator)
+	}
+
+	setValue.keepSpace = f.KeepSpace
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
+		for _, s := range f.separator.flagSplitMultiValues(val) {
+			if !f.KeepSpace {
+				s = strings.TrimSpace(s)
+			}
+			if err := setValue.Set(s); err != nil {
+				return fmt.Errorf("could not parse %q as string value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 		}
 
 		// Set this to false so that we reset the slice if we then set values from
 		// flags that have already been set by the environment.
-		destination.hasBeenSet = false
+		setValue.hasBeenSet = false
 		f.HasBeenSet = true
 	}
 
 	for _, name := range f.Names() {
-		if f.Value == nil {
-			f.Value = &StringSlice{}
-		}
+		set.Var(setValue, name, f.Usage)
+	}
 
-		if f.Destination != nil {
-			set.Var(f.Destination, name, f.Usage)
-			continue
-		}
+	return nil
+}
 
-		set.Var(f.Value, name, f.Usage)
+func (f *StringSliceFlag) WithSeparatorSpec(spec separatorSpec) {
+	f.separator = spec
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *StringSliceFlag) Get(ctx *Context) []string {
+	return ctx.StringSlice(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *StringSliceFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.StringSlice(f.Name))
 	}
 
 	return nil
@@ -153,8 +198,8 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 
 // StringSlice looks up the value of a local StringSliceFlag, returns
 // nil if not found
-func (c *Context) StringSlice(name string) []string {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) StringSlice(name string) []string {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupStringSlice(name, fs)
 	}
 	return nil
@@ -163,7 +208,7 @@ func (c *Context) StringSlice(name string) []string {
 func lookupStringSlice(name string, set *flag.FlagSet) []string {
 	f := set.Lookup(name)
 	if f != nil {
-		if slice, ok := f.Value.(*StringSlice); ok {
+		if slice, ok := unwrapFlagValue(f.Value).(*StringSlice); ok {
 			return slice.Value()
 		}
 	}

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_timestamp.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_timestamp.go
@@ -11,6 +11,7 @@ type Timestamp struct {
 	timestamp  *time.Time
 	hasBeenSet bool
 	layout     string
+	location   *time.Location
 }
 
 // Timestamp constructor
@@ -31,9 +32,22 @@ func (t *Timestamp) SetLayout(layout string) {
 	t.layout = layout
 }
 
+// Set perceived timezone of the to-be parsed time string
+func (t *Timestamp) SetLocation(loc *time.Location) {
+	t.location = loc
+}
+
 // Parses the string value to timestamp
 func (t *Timestamp) Set(value string) error {
-	timestamp, err := time.Parse(t.layout, value)
+	var timestamp time.Time
+	var err error
+
+	if t.location != nil {
+		timestamp, err = time.ParseInLocation(t.layout, value, t.location)
+	} else {
+		timestamp, err = time.Parse(t.layout, value)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -58,40 +72,23 @@ func (t *Timestamp) Get() interface{} {
 	return *t
 }
 
-// TimestampFlag is a flag with type time
-type TimestampFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Layout      string
-	Value       *Timestamp
-	DefaultText string
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *TimestampFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *TimestampFlag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *TimestampFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *TimestampFlag) IsRequired() bool {
-	return f.Required
+// clone timestamp
+func (t *Timestamp) clone() *Timestamp {
+	tc := &Timestamp{
+		timestamp:  nil,
+		hasBeenSet: t.hasBeenSet,
+		layout:     t.layout,
+		location:   nil,
+	}
+	if t.timestamp != nil {
+		tts := *t.timestamp
+		tc.timestamp = &tts
+	}
+	if t.location != nil {
+		loc := *t.location
+		tc.location = &loc
+	}
+	return tc
 }
 
 // TakesValue returns true of the flag takes a value, otherwise false
@@ -104,13 +101,40 @@ func (f *TimestampFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *TimestampFlag) GetCategory() string {
+	return f.Category
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *TimestampFlag) GetValue() string {
-	if f.Value != nil {
+	if f.Value != nil && f.Value.timestamp != nil {
 		return f.Value.timestamp.String()
 	}
 	return ""
+}
+
+// GetDefaultText returns the default text for this flag
+func (f *TimestampFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	val := f.Value
+	if f.defaultValueSet {
+		val = f.defaultValue
+	}
+
+	if val != nil && val.timestamp != nil {
+		return val.timestamp.String()
+	}
+
+	return ""
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *TimestampFlag) GetEnvVars() []string {
+	return f.EnvVars
 }
 
 // Apply populates the flag given the flag set and environment
@@ -118,25 +142,54 @@ func (f *TimestampFlag) Apply(set *flag.FlagSet) error {
 	if f.Layout == "" {
 		return fmt.Errorf("timestamp Layout is required")
 	}
-	f.Value = &Timestamp{}
+	if f.Value == nil {
+		f.Value = &Timestamp{}
+	}
 	f.Value.SetLayout(f.Layout)
+	f.Value.SetLocation(f.Timezone)
 
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+	f.defaultValue = f.Value.clone()
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		if err := f.Value.Set(val); err != nil {
-			return fmt.Errorf("could not parse %q as timestamp value for flag %s: %s", val, f.Name, err)
+			return fmt.Errorf("could not parse %q as timestamp value from %s for flag %s: %s", val, source, f.Name, err)
 		}
 		f.HasBeenSet = true
 	}
 
+	if f.Destination != nil {
+		*f.Destination = *f.Value
+	}
+
 	for _, name := range f.Names() {
+		if f.Destination != nil {
+			set.Var(f.Destination, name, f.Usage)
+			continue
+		}
+
 		set.Var(f.Value, name, f.Usage)
 	}
 	return nil
 }
 
+// Get returns the flag’s value in the given Context.
+func (f *TimestampFlag) Get(ctx *Context) *time.Time {
+	return ctx.Timestamp(f.Name)
+}
+
+// RunAction executes flag action if set
+func (f *TimestampFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Timestamp(f.Name))
+	}
+
+	return nil
+}
+
 // Timestamp gets the timestamp from a flag name
-func (c *Context) Timestamp(name string) *time.Time {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Timestamp(name string) *time.Time {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupTimestamp(name, fs)
 	}
 	return nil

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_uint.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_uint.go
@@ -6,42 +6,6 @@ import (
 	"strconv"
 )
 
-// UintFlag is a flag with type uint
-type UintFlag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       uint
-	DefaultText string
-	Destination *uint
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *UintFlag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *UintFlag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *UintFlag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *UintFlag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *UintFlag) TakesValue() bool {
 	return true
@@ -52,13 +16,22 @@ func (f *UintFlag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *UintFlag) GetCategory() string {
+	return f.Category
+}
+
 // Apply populates the flag given the flag set and environment
 func (f *UintFlag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		if val != "" {
-			valInt, err := strconv.ParseUint(val, 0, 64)
+			valInt, err := strconv.ParseUint(val, f.Base, 64)
 			if err != nil {
-				return fmt.Errorf("could not parse %q as uint value for flag %s: %s", val, f.Name, err)
+				return fmt.Errorf("could not parse %q as uint value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 
 			f.Value = uint(valInt)
@@ -77,16 +50,46 @@ func (f *UintFlag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
+// RunAction executes flag action if set
+func (f *UintFlag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Uint(f.Name))
+	}
+
+	return nil
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *UintFlag) GetValue() string {
 	return fmt.Sprintf("%d", f.Value)
 }
 
+// GetDefaultText returns the default text for this flag
+func (f *UintFlag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%d", f.defaultValue)
+	}
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *UintFlag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *UintFlag) Get(ctx *Context) uint {
+	return ctx.Uint(f.Name)
+}
+
 // Uint looks up the value of a local UintFlag, returns
 // 0 if not found
-func (c *Context) Uint(name string) uint {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Uint(name string) uint {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupUint(name, fs)
 	}
 	return 0

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_uint64.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_uint64.go
@@ -6,42 +6,6 @@ import (
 	"strconv"
 )
 
-// Uint64Flag is a flag with type uint64
-type Uint64Flag struct {
-	Name        string
-	Aliases     []string
-	Usage       string
-	EnvVars     []string
-	FilePath    string
-	Required    bool
-	Hidden      bool
-	Value       uint64
-	DefaultText string
-	Destination *uint64
-	HasBeenSet  bool
-}
-
-// IsSet returns whether or not the flag has been set through env or file
-func (f *Uint64Flag) IsSet() bool {
-	return f.HasBeenSet
-}
-
-// String returns a readable representation of this value
-// (for usage defaults)
-func (f *Uint64Flag) String() string {
-	return FlagStringer(f)
-}
-
-// Names returns the names of the flag
-func (f *Uint64Flag) Names() []string {
-	return flagNames(f.Name, f.Aliases)
-}
-
-// IsRequired returns whether or not the flag is required
-func (f *Uint64Flag) IsRequired() bool {
-	return f.Required
-}
-
 // TakesValue returns true of the flag takes a value, otherwise false
 func (f *Uint64Flag) TakesValue() bool {
 	return true
@@ -52,13 +16,22 @@ func (f *Uint64Flag) GetUsage() string {
 	return f.Usage
 }
 
+// GetCategory returns the category for the flag
+func (f *Uint64Flag) GetCategory() string {
+	return f.Category
+}
+
 // Apply populates the flag given the flag set and environment
 func (f *Uint64Flag) Apply(set *flag.FlagSet) error {
-	if val, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok {
+	// set default value so that environment wont be able to overwrite it
+	f.defaultValue = f.Value
+	f.defaultValueSet = true
+
+	if val, source, found := flagFromEnvOrFile(f.EnvVars, f.FilePath); found {
 		if val != "" {
-			valInt, err := strconv.ParseUint(val, 0, 64)
+			valInt, err := strconv.ParseUint(val, f.Base, 64)
 			if err != nil {
-				return fmt.Errorf("could not parse %q as uint64 value for flag %s: %s", val, f.Name, err)
+				return fmt.Errorf("could not parse %q as uint64 value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 
 			f.Value = valInt
@@ -77,16 +50,46 @@ func (f *Uint64Flag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
+// RunAction executes flag action if set
+func (f *Uint64Flag) RunAction(c *Context) error {
+	if f.Action != nil {
+		return f.Action(c, c.Uint64(f.Name))
+	}
+
+	return nil
+}
+
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
 func (f *Uint64Flag) GetValue() string {
 	return fmt.Sprintf("%d", f.Value)
 }
 
+// GetDefaultText returns the default text for this flag
+func (f *Uint64Flag) GetDefaultText() string {
+	if f.DefaultText != "" {
+		return f.DefaultText
+	}
+	if f.defaultValueSet {
+		return fmt.Sprintf("%d", f.defaultValue)
+	}
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// GetEnvVars returns the env vars for this flag
+func (f *Uint64Flag) GetEnvVars() []string {
+	return f.EnvVars
+}
+
+// Get returns the flag’s value in the given Context.
+func (f *Uint64Flag) Get(ctx *Context) uint64 {
+	return ctx.Uint64(f.Name)
+}
+
 // Uint64 looks up the value of a local Uint64Flag, returns
 // 0 if not found
-func (c *Context) Uint64(name string) uint64 {
-	if fs := lookupFlagSet(name, c); fs != nil {
+func (cCtx *Context) Uint64(name string) uint64 {
+	if fs := cCtx.lookupFlagSet(name); fs != nil {
 		return lookupUint64(name, fs)
 	}
 	return 0

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_uint64_slice.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_uint64_slice.go
@@ -8,36 +8,32 @@ import (
 	"strings"
 )
 
-// Int64Slice wraps []int64 to satisfy flag.Value
-type Int64Slice struct {
-	slice      []int64
+// Uint64Slice wraps []int64 to satisfy flag.Value
+type Uint64Slice struct {
+	slice      []uint64
 	separator  separatorSpec
 	hasBeenSet bool
 }
 
-// NewInt64Slice makes an *Int64Slice with default values
-func NewInt64Slice(defaults ...int64) *Int64Slice {
-	return &Int64Slice{slice: append([]int64{}, defaults...)}
+// NewUint64Slice makes an *Uint64Slice with default values
+func NewUint64Slice(defaults ...uint64) *Uint64Slice {
+	return &Uint64Slice{slice: append([]uint64{}, defaults...)}
 }
 
 // clone allocate a copy of self object
-func (i *Int64Slice) clone() *Int64Slice {
-	n := &Int64Slice{
-		slice:      make([]int64, len(i.slice)),
+func (i *Uint64Slice) clone() *Uint64Slice {
+	n := &Uint64Slice{
+		slice:      make([]uint64, len(i.slice)),
 		hasBeenSet: i.hasBeenSet,
 	}
 	copy(n.slice, i.slice)
 	return n
 }
 
-func (i *Int64Slice) WithSeparatorSpec(spec separatorSpec) {
-	i.separator = spec
-}
-
 // Set parses the value into an integer and appends it to the list of values
-func (i *Int64Slice) Set(value string) error {
+func (i *Uint64Slice) Set(value string) error {
 	if !i.hasBeenSet {
-		i.slice = []int64{}
+		i.slice = []uint64{}
 		i.hasBeenSet = true
 	}
 
@@ -49,7 +45,7 @@ func (i *Int64Slice) Set(value string) error {
 	}
 
 	for _, s := range i.separator.flagSplitMultiValues(value) {
-		tmp, err := strconv.ParseInt(strings.TrimSpace(s), 0, 64)
+		tmp, err := strconv.ParseUint(strings.TrimSpace(s), 0, 64)
 		if err != nil {
 			return err
 		}
@@ -60,67 +56,75 @@ func (i *Int64Slice) Set(value string) error {
 	return nil
 }
 
+func (i *Uint64Slice) WithSeparatorSpec(spec separatorSpec) {
+	i.separator = spec
+}
+
 // String returns a readable representation of this value (for usage defaults)
-func (i *Int64Slice) String() string {
+func (i *Uint64Slice) String() string {
 	v := i.slice
 	if v == nil {
 		// treat nil the same as zero length non-nil
-		v = make([]int64, 0)
+		v = make([]uint64, 0)
 	}
-	return fmt.Sprintf("%#v", v)
+	str := fmt.Sprintf("%d", v)
+	str = strings.Replace(str, " ", ", ", -1)
+	str = strings.Replace(str, "[", "{", -1)
+	str = strings.Replace(str, "]", "}", -1)
+	return fmt.Sprintf("[]uint64%s", str)
 }
 
-// Serialize allows Int64Slice to fulfill Serializer
-func (i *Int64Slice) Serialize() string {
+// Serialize allows Uint64Slice to fulfill Serializer
+func (i *Uint64Slice) Serialize() string {
 	jsonBytes, _ := json.Marshal(i.slice)
 	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
 }
 
 // Value returns the slice of ints set by this flag
-func (i *Int64Slice) Value() []int64 {
+func (i *Uint64Slice) Value() []uint64 {
 	return i.slice
 }
 
 // Get returns the slice of ints set by this flag
-func (i *Int64Slice) Get() interface{} {
+func (i *Uint64Slice) Get() interface{} {
 	return *i
 }
 
 // String returns a readable representation of this value
 // (for usage defaults)
-func (f *Int64SliceFlag) String() string {
+func (f *Uint64SliceFlag) String() string {
 	return FlagStringer(f)
 }
 
 // TakesValue returns true of the flag takes a value, otherwise false
-func (f *Int64SliceFlag) TakesValue() bool {
+func (f *Uint64SliceFlag) TakesValue() bool {
 	return true
 }
 
 // GetUsage returns the usage string for the flag
-func (f *Int64SliceFlag) GetUsage() string {
+func (f *Uint64SliceFlag) GetUsage() string {
 	return f.Usage
 }
 
 // GetCategory returns the category for the flag
-func (f *Int64SliceFlag) GetCategory() string {
+func (f *Uint64SliceFlag) GetCategory() string {
 	return f.Category
 }
 
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
-func (f *Int64SliceFlag) GetValue() string {
+func (f *Uint64SliceFlag) GetValue() string {
 	var defaultVals []string
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, strconv.FormatInt(i, 10))
+			defaultVals = append(defaultVals, strconv.FormatUint(i, 10))
 		}
 	}
 	return strings.Join(defaultVals, ", ")
 }
 
 // GetDefaultText returns the default text for this flag
-func (f *Int64SliceFlag) GetDefaultText() string {
+func (f *Uint64SliceFlag) GetDefaultText() string {
 	if f.DefaultText != "" {
 		return f.DefaultText
 	}
@@ -128,39 +132,39 @@ func (f *Int64SliceFlag) GetDefaultText() string {
 }
 
 // GetEnvVars returns the env vars for this flag
-func (f *Int64SliceFlag) GetEnvVars() []string {
+func (f *Uint64SliceFlag) GetEnvVars() []string {
 	return f.EnvVars
 }
 
 // IsSliceFlag implements DocGenerationSliceFlag.
-func (f *Int64SliceFlag) IsSliceFlag() bool {
+func (f *Uint64SliceFlag) IsSliceFlag() bool {
 	return true
 }
 
 // Apply populates the flag given the flag set and environment
-func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
+func (f *Uint64SliceFlag) Apply(set *flag.FlagSet) error {
 	// apply any default
 	if f.Destination != nil && f.Value != nil {
-		f.Destination.slice = make([]int64, len(f.Value.slice))
+		f.Destination.slice = make([]uint64, len(f.Value.slice))
 		copy(f.Destination.slice, f.Value.slice)
 	}
 
 	// resolve setValue (what we will assign to the set)
-	var setValue *Int64Slice
+	var setValue *Uint64Slice
 	switch {
 	case f.Destination != nil:
 		setValue = f.Destination
 	case f.Value != nil:
 		setValue = f.Value.clone()
 	default:
-		setValue = new(Int64Slice)
+		setValue = new(Uint64Slice)
 		setValue.WithSeparatorSpec(f.separator)
 	}
 
 	if val, source, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok && val != "" {
 		for _, s := range f.separator.flagSplitMultiValues(val) {
 			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
-				return fmt.Errorf("could not parse %q as int64 slice value from %s for flag %s: %s", val, source, f.Name, err)
+				return fmt.Errorf("could not parse %q as uint64 slice value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 		}
 
@@ -177,37 +181,37 @@ func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
-func (f *Int64SliceFlag) WithSeparatorSpec(spec separatorSpec) {
+func (f *Uint64SliceFlag) WithSeparatorSpec(spec separatorSpec) {
 	f.separator = spec
 }
 
 // Get returns the flag’s value in the given Context.
-func (f *Int64SliceFlag) Get(ctx *Context) []int64 {
-	return ctx.Int64Slice(f.Name)
+func (f *Uint64SliceFlag) Get(ctx *Context) []uint64 {
+	return ctx.Uint64Slice(f.Name)
 }
 
 // RunAction executes flag action if set
-func (f *Int64SliceFlag) RunAction(c *Context) error {
+func (f *Uint64SliceFlag) RunAction(c *Context) error {
 	if f.Action != nil {
-		return f.Action(c, c.Int64Slice(f.Name))
+		return f.Action(c, c.Uint64Slice(f.Name))
 	}
 
 	return nil
 }
 
-// Int64Slice looks up the value of a local Int64SliceFlag, returns
+// Uint64Slice looks up the value of a local Uint64SliceFlag, returns
 // nil if not found
-func (cCtx *Context) Int64Slice(name string) []int64 {
+func (cCtx *Context) Uint64Slice(name string) []uint64 {
 	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupInt64Slice(name, fs)
+		return lookupUint64Slice(name, fs)
 	}
 	return nil
 }
 
-func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
+func lookupUint64Slice(name string, set *flag.FlagSet) []uint64 {
 	f := set.Lookup(name)
 	if f != nil {
-		if slice, ok := unwrapFlagValue(f.Value).(*Int64Slice); ok {
+		if slice, ok := unwrapFlagValue(f.Value).(*Uint64Slice); ok {
 			return slice.Value()
 		}
 	}

--- a/go-controller/vendor/github.com/urfave/cli/v2/flag_uint_slice.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/flag_uint_slice.go
@@ -8,36 +8,43 @@ import (
 	"strings"
 )
 
-// Int64Slice wraps []int64 to satisfy flag.Value
-type Int64Slice struct {
-	slice      []int64
+// UintSlice wraps []int to satisfy flag.Value
+type UintSlice struct {
+	slice      []uint
 	separator  separatorSpec
 	hasBeenSet bool
 }
 
-// NewInt64Slice makes an *Int64Slice with default values
-func NewInt64Slice(defaults ...int64) *Int64Slice {
-	return &Int64Slice{slice: append([]int64{}, defaults...)}
+// NewUintSlice makes an *UintSlice with default values
+func NewUintSlice(defaults ...uint) *UintSlice {
+	return &UintSlice{slice: append([]uint{}, defaults...)}
 }
 
 // clone allocate a copy of self object
-func (i *Int64Slice) clone() *Int64Slice {
-	n := &Int64Slice{
-		slice:      make([]int64, len(i.slice)),
+func (i *UintSlice) clone() *UintSlice {
+	n := &UintSlice{
+		slice:      make([]uint, len(i.slice)),
 		hasBeenSet: i.hasBeenSet,
 	}
 	copy(n.slice, i.slice)
 	return n
 }
 
-func (i *Int64Slice) WithSeparatorSpec(spec separatorSpec) {
-	i.separator = spec
+// TODO: Consistently have specific Set function for Int64 and Float64 ?
+// SetInt directly adds an integer to the list of values
+func (i *UintSlice) SetUint(value uint) {
+	if !i.hasBeenSet {
+		i.slice = []uint{}
+		i.hasBeenSet = true
+	}
+
+	i.slice = append(i.slice, value)
 }
 
 // Set parses the value into an integer and appends it to the list of values
-func (i *Int64Slice) Set(value string) error {
+func (i *UintSlice) Set(value string) error {
 	if !i.hasBeenSet {
-		i.slice = []int64{}
+		i.slice = []uint{}
 		i.hasBeenSet = true
 	}
 
@@ -49,78 +56,86 @@ func (i *Int64Slice) Set(value string) error {
 	}
 
 	for _, s := range i.separator.flagSplitMultiValues(value) {
-		tmp, err := strconv.ParseInt(strings.TrimSpace(s), 0, 64)
+		tmp, err := strconv.ParseUint(strings.TrimSpace(s), 0, 32)
 		if err != nil {
 			return err
 		}
 
-		i.slice = append(i.slice, tmp)
+		i.slice = append(i.slice, uint(tmp))
 	}
 
 	return nil
 }
 
+func (i *UintSlice) WithSeparatorSpec(spec separatorSpec) {
+	i.separator = spec
+}
+
 // String returns a readable representation of this value (for usage defaults)
-func (i *Int64Slice) String() string {
+func (i *UintSlice) String() string {
 	v := i.slice
 	if v == nil {
 		// treat nil the same as zero length non-nil
-		v = make([]int64, 0)
+		v = make([]uint, 0)
 	}
-	return fmt.Sprintf("%#v", v)
+	str := fmt.Sprintf("%d", v)
+	str = strings.Replace(str, " ", ", ", -1)
+	str = strings.Replace(str, "[", "{", -1)
+	str = strings.Replace(str, "]", "}", -1)
+	return fmt.Sprintf("[]uint%s", str)
 }
 
-// Serialize allows Int64Slice to fulfill Serializer
-func (i *Int64Slice) Serialize() string {
+// Serialize allows UintSlice to fulfill Serializer
+func (i *UintSlice) Serialize() string {
 	jsonBytes, _ := json.Marshal(i.slice)
 	return fmt.Sprintf("%s%s", slPfx, string(jsonBytes))
 }
 
 // Value returns the slice of ints set by this flag
-func (i *Int64Slice) Value() []int64 {
+func (i *UintSlice) Value() []uint {
 	return i.slice
 }
 
 // Get returns the slice of ints set by this flag
-func (i *Int64Slice) Get() interface{} {
+func (i *UintSlice) Get() interface{} {
 	return *i
 }
 
 // String returns a readable representation of this value
 // (for usage defaults)
-func (f *Int64SliceFlag) String() string {
+func (f *UintSliceFlag) String() string {
 	return FlagStringer(f)
 }
 
 // TakesValue returns true of the flag takes a value, otherwise false
-func (f *Int64SliceFlag) TakesValue() bool {
+func (f *UintSliceFlag) TakesValue() bool {
 	return true
 }
 
 // GetUsage returns the usage string for the flag
-func (f *Int64SliceFlag) GetUsage() string {
+func (f *UintSliceFlag) GetUsage() string {
 	return f.Usage
 }
 
 // GetCategory returns the category for the flag
-func (f *Int64SliceFlag) GetCategory() string {
+func (f *UintSliceFlag) GetCategory() string {
 	return f.Category
 }
 
 // GetValue returns the flags value as string representation and an empty
 // string if the flag takes no value at all.
-func (f *Int64SliceFlag) GetValue() string {
+func (f *UintSliceFlag) GetValue() string {
 	var defaultVals []string
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, strconv.FormatInt(i, 10))
+			defaultVals = append(defaultVals, strconv.FormatUint(uint64(i), 10))
 		}
 	}
 	return strings.Join(defaultVals, ", ")
 }
 
 // GetDefaultText returns the default text for this flag
-func (f *Int64SliceFlag) GetDefaultText() string {
+func (f *UintSliceFlag) GetDefaultText() string {
 	if f.DefaultText != "" {
 		return f.DefaultText
 	}
@@ -128,39 +143,39 @@ func (f *Int64SliceFlag) GetDefaultText() string {
 }
 
 // GetEnvVars returns the env vars for this flag
-func (f *Int64SliceFlag) GetEnvVars() []string {
+func (f *UintSliceFlag) GetEnvVars() []string {
 	return f.EnvVars
 }
 
 // IsSliceFlag implements DocGenerationSliceFlag.
-func (f *Int64SliceFlag) IsSliceFlag() bool {
+func (f *UintSliceFlag) IsSliceFlag() bool {
 	return true
 }
 
 // Apply populates the flag given the flag set and environment
-func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
+func (f *UintSliceFlag) Apply(set *flag.FlagSet) error {
 	// apply any default
 	if f.Destination != nil && f.Value != nil {
-		f.Destination.slice = make([]int64, len(f.Value.slice))
+		f.Destination.slice = make([]uint, len(f.Value.slice))
 		copy(f.Destination.slice, f.Value.slice)
 	}
 
 	// resolve setValue (what we will assign to the set)
-	var setValue *Int64Slice
+	var setValue *UintSlice
 	switch {
 	case f.Destination != nil:
 		setValue = f.Destination
 	case f.Value != nil:
 		setValue = f.Value.clone()
 	default:
-		setValue = new(Int64Slice)
+		setValue = new(UintSlice)
 		setValue.WithSeparatorSpec(f.separator)
 	}
 
 	if val, source, ok := flagFromEnvOrFile(f.EnvVars, f.FilePath); ok && val != "" {
 		for _, s := range f.separator.flagSplitMultiValues(val) {
 			if err := setValue.Set(strings.TrimSpace(s)); err != nil {
-				return fmt.Errorf("could not parse %q as int64 slice value from %s for flag %s: %s", val, source, f.Name, err)
+				return fmt.Errorf("could not parse %q as uint slice value from %s for flag %s: %s", val, source, f.Name, err)
 			}
 		}
 
@@ -177,37 +192,37 @@ func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error {
 	return nil
 }
 
-func (f *Int64SliceFlag) WithSeparatorSpec(spec separatorSpec) {
+func (f *UintSliceFlag) WithSeparatorSpec(spec separatorSpec) {
 	f.separator = spec
 }
 
 // Get returns the flag’s value in the given Context.
-func (f *Int64SliceFlag) Get(ctx *Context) []int64 {
-	return ctx.Int64Slice(f.Name)
+func (f *UintSliceFlag) Get(ctx *Context) []uint {
+	return ctx.UintSlice(f.Name)
 }
 
 // RunAction executes flag action if set
-func (f *Int64SliceFlag) RunAction(c *Context) error {
+func (f *UintSliceFlag) RunAction(c *Context) error {
 	if f.Action != nil {
-		return f.Action(c, c.Int64Slice(f.Name))
+		return f.Action(c, c.UintSlice(f.Name))
 	}
 
 	return nil
 }
 
-// Int64Slice looks up the value of a local Int64SliceFlag, returns
+// UintSlice looks up the value of a local UintSliceFlag, returns
 // nil if not found
-func (cCtx *Context) Int64Slice(name string) []int64 {
+func (cCtx *Context) UintSlice(name string) []uint {
 	if fs := cCtx.lookupFlagSet(name); fs != nil {
-		return lookupInt64Slice(name, fs)
+		return lookupUintSlice(name, fs)
 	}
 	return nil
 }
 
-func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
+func lookupUintSlice(name string, set *flag.FlagSet) []uint {
 	f := set.Lookup(name)
 	if f != nil {
-		if slice, ok := unwrapFlagValue(f.Value).(*Int64Slice); ok {
+		if slice, ok := unwrapFlagValue(f.Value).(*UintSlice); ok {
 			return slice.Value()
 		}
 	}

--- a/go-controller/vendor/github.com/urfave/cli/v2/funcs.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/funcs.go
@@ -17,15 +17,18 @@ type ActionFunc func(*Context) error
 // CommandNotFoundFunc is executed if the proper command cannot be found
 type CommandNotFoundFunc func(*Context, string)
 
-// OnUsageErrorFunc is executed if an usage error occurs. This is useful for displaying
+// OnUsageErrorFunc is executed if a usage error occurs. This is useful for displaying
 // customized usage error messages.  This function is able to replace the
 // original error messages.  If this function is not set, the "Incorrect usage"
 // is displayed and the execution is interrupted.
-type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
+type OnUsageErrorFunc func(cCtx *Context, err error, isSubcommand bool) error
+
+// InvalidFlagAccessFunc is executed when an invalid flag is accessed from the context.
+type InvalidFlagAccessFunc func(*Context, string)
 
 // ExitErrHandlerFunc is executed if provided in order to handle exitError values
 // returned by Actions and Before/After functions.
-type ExitErrHandlerFunc func(context *Context, err error)
+type ExitErrHandlerFunc func(cCtx *Context, err error)
 
 // FlagStringFunc is used by the help generation to display a flag, which is
 // expected to be a single line.

--- a/go-controller/vendor/github.com/urfave/cli/v2/godoc-current.txt
+++ b/go-controller/vendor/github.com/urfave/cli/v2/godoc-current.txt
@@ -1,0 +1,2724 @@
+package cli // import "github.com/urfave/cli/v2"
+
+Package cli provides a minimal framework for creating and organizing command
+line Go applications. cli is designed to be easy to understand and write,
+the most simple cli application can be written as follows:
+
+    func main() {
+    	(&cli.App{}).Run(os.Args)
+    }
+
+Of course this application does not do much, so let's make this an actual
+application:
+
+    func main() {
+    	app := &cli.App{
+      		Name: "greet",
+      		Usage: "say a greeting",
+      		Action: func(c *cli.Context) error {
+      			fmt.Println("Greetings")
+      			return nil
+      		},
+    	}
+
+    	app.Run(os.Args)
+    }
+
+VARIABLES
+
+var (
+	SuggestFlag               SuggestFlagFunc    = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestCommand            SuggestCommandFunc = nil // initialized in suggestions.go unless built with urfave_cli_no_suggest
+	SuggestDidYouMeanTemplate string             = suggestDidYouMeanTemplate
+)
+var AppHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}}[arguments...]{{end}}{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}
+{{- if len .Authors}}
+
+AUTHOR{{template "authorsTemplate" .}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+GLOBAL OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}{{if .Copyright}}
+
+COPYRIGHT:
+   {{template "copyrightTemplate" .}}{{end}}
+`
+    AppHelpTemplate is the text template for the Default help topic. cli.go
+    uses text/template to render templates. You can render custom help text by
+    setting this variable.
+
+var CommandHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{template "usageTemplate" .}}{{if .Category}}
+
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+`
+    CommandHelpTemplate is the text template for the command help topic. cli.go
+    uses text/template to render templates. You can render custom help text by
+    setting this variable.
+
+var ErrWriter io.Writer = os.Stderr
+    ErrWriter is used to write errors to the user. This can be anything
+    implementing the io.Writer interface and defaults to os.Stderr.
+
+var FishCompletionTemplate = `# {{ .App.Name }} fish shell completion
+
+function __fish_{{ .App.Name }}_no_subcommand --description 'Test if there has been any subcommand yet'
+    for i in (commandline -opc)
+        if contains -- $i{{ range $v := .AllCommands }} {{ $v }}{{ end }}
+            return 1
+        end
+    end
+    return 0
+end
+
+{{ range $v := .Completions }}{{ $v }}
+{{ end }}`
+var MarkdownDocTemplate = `{{if gt .SectionNum 0}}% {{ .App.Name }} {{ .SectionNum }}
+
+{{end}}# NAME
+
+{{ .App.Name }}{{ if .App.Usage }} - {{ .App.Usage }}{{ end }}
+
+# SYNOPSIS
+
+{{ .App.Name }}
+{{ if .SynopsisArgs }}
+` + "```" + `
+{{ range $v := .SynopsisArgs }}{{ $v }}{{ end }}` + "```" + `
+{{ end }}{{ if .App.Description }}
+# DESCRIPTION
+
+{{ .App.Description }}
+{{ end }}
+**Usage**:
+
+` + "```" + `{{ if .App.UsageText }}
+{{ .App.UsageText }}
+{{ else }}
+{{ .App.Name }} [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+{{ end }}` + "```" + `
+{{ if .GlobalArgs }}
+# GLOBAL OPTIONS
+{{ range $v := .GlobalArgs }}
+{{ $v }}{{ end }}
+{{ end }}{{ if .Commands }}
+# COMMANDS
+{{ range $v := .Commands }}
+{{ $v }}{{ end }}{{ end }}`
+var OsExiter = os.Exit
+    OsExiter is the function used when the app exits. If not set defaults to
+    os.Exit.
+
+var SubcommandHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}} {{if .VisibleFlags}}command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}}[arguments...]{{end}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
+`
+    SubcommandHelpTemplate is the text template for the subcommand help topic.
+    cli.go uses text/template to render templates. You can render custom help
+    text by setting this variable.
+
+var VersionPrinter = printVersion
+    VersionPrinter prints the version for the App
+
+var HelpPrinter helpPrinter = printHelp
+    HelpPrinter is a function that writes the help output. If not set
+    explicitly, this calls HelpPrinterCustom using only the default template
+    functions.
+
+    If custom logic for printing help is required, this function can be
+    overridden. If the ExtraInfo field is defined on an App, this function
+    should not be modified, as HelpPrinterCustom will be used directly in order
+    to capture the extra information.
+
+var HelpPrinterCustom helpPrinterCustom = printHelpCustom
+    HelpPrinterCustom is a function that writes the help output. It is used as
+    the default implementation of HelpPrinter, and may be called directly if the
+    ExtraInfo field is set on an App.
+
+    In the default implementation, if the customFuncs argument contains a
+    "wrapAt" key, which is a function which takes no arguments and returns an
+    int, this int value will be used to produce a "wrap" function used by the
+    default template to wrap long lines.
+
+
+FUNCTIONS
+
+func DefaultAppComplete(cCtx *Context)
+    DefaultAppComplete prints the list of subcommands as the default app
+    completion method
+
+func DefaultCompleteWithFlags(cmd *Command) func(cCtx *Context)
+func FlagNames(name string, aliases []string) []string
+func HandleAction(action interface{}, cCtx *Context) (err error)
+    HandleAction attempts to figure out which Action signature was used.
+    If it's an ActionFunc or a func with the legacy signature for Action,
+    the func is run!
+
+func HandleExitCoder(err error)
+    HandleExitCoder handles errors implementing ExitCoder by printing their
+    message and calling OsExiter with the given exit code.
+
+    If the given error instead implements MultiError, each error will be checked
+    for the ExitCoder interface, and OsExiter will be called with the last exit
+    code found, or exit code 1 if no ExitCoder is found.
+
+    This function is the default error-handling behavior for an App.
+
+func ShowAppHelp(cCtx *Context) error
+    ShowAppHelp is an action that displays the help.
+
+func ShowAppHelpAndExit(c *Context, exitCode int)
+    ShowAppHelpAndExit - Prints the list of subcommands for the app and exits
+    with exit code.
+
+func ShowCommandCompletions(ctx *Context, command string)
+    ShowCommandCompletions prints the custom completions for a given command
+
+func ShowCommandHelp(ctx *Context, command string) error
+    ShowCommandHelp prints help for the given command
+
+func ShowCommandHelpAndExit(c *Context, command string, code int)
+    ShowCommandHelpAndExit - exits with code after showing help
+
+func ShowCompletions(cCtx *Context)
+    ShowCompletions prints the lists of commands within a given context
+
+func ShowSubcommandHelp(cCtx *Context) error
+    ShowSubcommandHelp prints help for the given subcommand
+
+func ShowSubcommandHelpAndExit(c *Context, exitCode int)
+    ShowSubcommandHelpAndExit - Prints help for the given subcommand and exits
+    with exit code.
+
+func ShowVersion(cCtx *Context)
+    ShowVersion prints the version number of the App
+
+
+TYPES
+
+type ActionFunc func(*Context) error
+    ActionFunc is the action to execute when no subcommands are specified
+
+type ActionableFlag interface {
+	Flag
+	RunAction(*Context) error
+}
+    ActionableFlag is an interface that wraps Flag interface and RunAction
+    operation.
+
+type AfterFunc func(*Context) error
+    AfterFunc is an action to execute after any subcommands are run, but after
+    the subcommand has finished it is run even if Action() panics
+
+type App struct {
+	// The name of the program. Defaults to path.Base(os.Args[0])
+	Name string
+	// Full name of command for help, defaults to Name
+	HelpName string
+	// Description of the program.
+	Usage string
+	// Text to override the USAGE section of help
+	UsageText string
+	// Whether this command supports arguments
+	Args bool
+	// Description of the program argument format.
+	ArgsUsage string
+	// Version of the program
+	Version string
+	// Description of the program
+	Description string
+	// DefaultCommand is the (optional) name of a command
+	// to run if no command names are passed as CLI arguments.
+	DefaultCommand string
+	// List of commands to execute
+	Commands []*Command
+	// List of flags to parse
+	Flags []Flag
+	// Boolean to enable bash completion commands
+	EnableBashCompletion bool
+	// Boolean to hide built-in help command and help flag
+	HideHelp bool
+	// Boolean to hide built-in help command but keep help flag.
+	// Ignored if HideHelp is true.
+	HideHelpCommand bool
+	// Boolean to hide built-in version flag and the VERSION section of help
+	HideVersion bool
+
+	// An action to execute when the shell completion flag is set
+	BashComplete BashCompleteFunc
+	// An action to execute before any subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+	// The action to execute when no subcommands are specified
+	Action ActionFunc
+	// Execute this function if the proper command cannot be found
+	CommandNotFound CommandNotFoundFunc
+	// Execute this function if a usage error occurs
+	OnUsageError OnUsageErrorFunc
+	// Execute this function when an invalid flag is accessed from the context
+	InvalidFlagAccessHandler InvalidFlagAccessFunc
+	// Compilation date
+	Compiled time.Time
+	// List of all authors who contributed
+	Authors []*Author
+	// Copyright of the binary if any
+	Copyright string
+	// Reader reader to write input to (useful for tests)
+	Reader io.Reader
+	// Writer writer to write output to
+	Writer io.Writer
+	// ErrWriter writes error output
+	ErrWriter io.Writer
+	// ExitErrHandler processes any error encountered while running an App before
+	// it is returned to the caller. If no function is provided, HandleExitCoder
+	// is used as the default behavior.
+	ExitErrHandler ExitErrHandlerFunc
+	// Other custom info
+	Metadata map[string]interface{}
+	// Carries a function which returns app specific info.
+	ExtraInfo func() map[string]string
+	// CustomAppHelpTemplate the text template for app help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomAppHelpTemplate string
+	// SliceFlagSeparator is used to customize the separator for SliceFlag, the default is ","
+	SliceFlagSeparator string
+	// DisableSliceFlagSeparator is used to disable SliceFlagSeparator, the default is false
+	DisableSliceFlagSeparator bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguments into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
+	// Enable suggestions for commands and flags
+	Suggest bool
+	// Allows global flags set by libraries which use flag.XXXVar(...) directly
+	// to be parsed through this library
+	AllowExtFlags bool
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+
+	// Has unexported fields.
+}
+    App is the main structure of a cli application. It is recommended that an
+    app be created with the cli.NewApp() function
+
+func NewApp() *App
+    NewApp creates a new cli Application with some reasonable defaults for Name,
+    Usage, Version and Action.
+
+func (a *App) Command(name string) *Command
+    Command returns the named command on App. Returns nil if the command does
+    not exist
+
+func (a *App) Run(arguments []string) (err error)
+    Run is the entry point to the cli app. Parses the arguments slice and routes
+    to the proper flag/args combination
+
+func (a *App) RunAndExitOnError()
+    RunAndExitOnError calls .Run() and exits non-zero if an error was returned
+
+    Deprecated: instead you should return an error that fulfills cli.ExitCoder
+    to cli.App.Run. This will cause the application to exit with the given error
+    code in the cli.ExitCoder
+
+func (a *App) RunAsSubcommand(ctx *Context) (err error)
+    RunAsSubcommand is for legacy/compatibility purposes only. New code should
+    only use App.RunContext. This function is slated to be removed in v3.
+
+func (a *App) RunContext(ctx context.Context, arguments []string) (err error)
+    RunContext is like Run except it takes a Context that will be passed to
+    its commands and sub-commands. Through this, you can propagate timeouts and
+    cancellation requests
+
+func (a *App) Setup()
+    Setup runs initialization code to ensure all data structures are ready
+    for `Run` or inspection prior to `Run`. It is internally called by `Run`,
+    but will return early if setup has already happened.
+
+func (a *App) ToFishCompletion() (string, error)
+    ToFishCompletion creates a fish completion string for the `*App` The
+    function errors if either parsing or writing of the string fails.
+
+func (a *App) ToMan() (string, error)
+    ToMan creates a man page string for the `*App` The function errors if either
+    parsing or writing of the string fails.
+
+func (a *App) ToManWithSection(sectionNumber int) (string, error)
+    ToMan creates a man page string with section number for the `*App` The
+    function errors if either parsing or writing of the string fails.
+
+func (a *App) ToMarkdown() (string, error)
+    ToMarkdown creates a markdown string for the `*App` The function errors if
+    either parsing or writing of the string fails.
+
+func (a *App) VisibleCategories() []CommandCategory
+    VisibleCategories returns a slice of categories and commands that are
+    Hidden=false
+
+func (a *App) VisibleCommands() []*Command
+    VisibleCommands returns a slice of the Commands with Hidden=false
+
+func (a *App) VisibleFlagCategories() []VisibleFlagCategory
+    VisibleFlagCategories returns a slice containing all the categories with the
+    flags they contain
+
+func (a *App) VisibleFlags() []Flag
+    VisibleFlags returns a slice of the Flags with Hidden=false
+
+type Args interface {
+	// Get returns the nth argument, or else a blank string
+	Get(n int) string
+	// First returns the first argument, or else a blank string
+	First() string
+	// Tail returns the rest of the arguments (not the first one)
+	// or else an empty string slice
+	Tail() []string
+	// Len returns the length of the wrapped slice
+	Len() int
+	// Present checks if there are any arguments present
+	Present() bool
+	// Slice returns a copy of the internal slice
+	Slice() []string
+}
+
+type Author struct {
+	Name  string // The Authors name
+	Email string // The Authors email
+}
+    Author represents someone who has contributed to a cli project.
+
+func (a *Author) String() string
+    String makes Author comply to the Stringer interface, to allow an easy print
+    in the templating process
+
+type BashCompleteFunc func(*Context)
+    BashCompleteFunc is an action to execute when the shell completion flag is
+    set
+
+type BeforeFunc func(*Context) error
+    BeforeFunc is an action to execute before any subcommands are run, but after
+    the context is ready if a non-nil error is returned, no subcommands are run
+
+type BoolFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       bool
+	Destination *bool
+
+	Aliases []string
+	EnvVars []string
+
+	Count *int
+
+	DisableDefaultText bool
+
+	Action func(*Context, bool) error
+	// Has unexported fields.
+}
+    BoolFlag is a flag with type bool
+
+func (f *BoolFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *BoolFlag) Get(ctx *Context) bool
+    Get returns the flag’s value in the given Context.
+
+func (f *BoolFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *BoolFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *BoolFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *BoolFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *BoolFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *BoolFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *BoolFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *BoolFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *BoolFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *BoolFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *BoolFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *BoolFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type CategorizableFlag interface {
+	VisibleFlag
+
+	GetCategory() string
+}
+    CategorizableFlag is an interface that allows us to potentially use a flag
+    in a categorized representation.
+
+type Command struct {
+	// The name of the command
+	Name string
+	// A list of aliases for the command
+	Aliases []string
+	// A short description of the usage of this command
+	Usage string
+	// Custom text to show on USAGE section of help
+	UsageText string
+	// A longer explanation of how the command works
+	Description string
+	// Whether this command supports arguments
+	Args bool
+	// A short description of the arguments of this command
+	ArgsUsage string
+	// The category the command is part of
+	Category string
+	// The function to call when checking for bash command completions
+	BashComplete BashCompleteFunc
+	// An action to execute before any sub-subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no sub-subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+	// The function to call when this command is invoked
+	Action ActionFunc
+	// Execute this function if a usage error occurs.
+	OnUsageError OnUsageErrorFunc
+	// List of child commands
+	Subcommands []*Command
+	// List of flags to parse
+	Flags []Flag
+
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+	// Boolean to hide built-in help command and help flag
+	HideHelp bool
+	// Boolean to hide built-in help command but keep help flag
+	// Ignored if HideHelp is true.
+	HideHelpCommand bool
+	// Boolean to hide this command from help or completion
+	Hidden bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguments into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
+
+	// Full name of command for help, defaults to full command name, including parent commands.
+	HelpName string
+
+	// CustomHelpTemplate the text template for the command help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomHelpTemplate string
+
+	// Has unexported fields.
+}
+    Command is a subcommand for a cli.App.
+
+func (cmd *Command) Command(name string) *Command
+
+func (c *Command) FullName() string
+    FullName returns the full name of the command. For subcommands this ensures
+    that parent commands are part of the command path
+
+func (c *Command) HasName(name string) bool
+    HasName returns true if Command.Name matches given name
+
+func (c *Command) Names() []string
+    Names returns the names including short names and aliases.
+
+func (c *Command) Run(cCtx *Context, arguments ...string) (err error)
+
+func (c *Command) VisibleCategories() []CommandCategory
+    VisibleCategories returns a slice of categories and commands that are
+    Hidden=false
+
+func (c *Command) VisibleCommands() []*Command
+    VisibleCommands returns a slice of the Commands with Hidden=false
+
+func (c *Command) VisibleFlagCategories() []VisibleFlagCategory
+    VisibleFlagCategories returns a slice containing all the visible flag
+    categories with the flags they contain
+
+func (c *Command) VisibleFlags() []Flag
+    VisibleFlags returns a slice of the Flags with Hidden=false
+
+type CommandCategories interface {
+	// AddCommand adds a command to a category, creating a new category if necessary.
+	AddCommand(category string, command *Command)
+	// Categories returns a slice of categories sorted by name
+	Categories() []CommandCategory
+}
+    CommandCategories interface allows for category manipulation
+
+type CommandCategory interface {
+	// Name returns the category name string
+	Name() string
+	// VisibleCommands returns a slice of the Commands with Hidden=false
+	VisibleCommands() []*Command
+}
+    CommandCategory is a category containing commands.
+
+type CommandNotFoundFunc func(*Context, string)
+    CommandNotFoundFunc is executed if the proper command cannot be found
+
+type Commands []*Command
+
+type CommandsByName []*Command
+
+func (c CommandsByName) Len() int
+
+func (c CommandsByName) Less(i, j int) bool
+
+func (c CommandsByName) Swap(i, j int)
+
+type Context struct {
+	context.Context
+	App     *App
+	Command *Command
+
+	// Has unexported fields.
+}
+    Context is a type that is passed through to each Handler action in a cli
+    application. Context can be used to retrieve context-specific args and
+    parsed command-line options.
+
+func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context
+    NewContext creates a new context. For use in when invoking an App or Command
+    action.
+
+func (cCtx *Context) Args() Args
+    Args returns the command line arguments associated with the context.
+
+func (cCtx *Context) Bool(name string) bool
+    Bool looks up the value of a local BoolFlag, returns false if not found
+
+func (cCtx *Context) Count(name string) int
+    Count returns the num of occurrences of this flag
+
+func (cCtx *Context) Duration(name string) time.Duration
+    Duration looks up the value of a local DurationFlag, returns 0 if not found
+
+func (cCtx *Context) FlagNames() []string
+    FlagNames returns a slice of flag names used by the this context and all of
+    its parent contexts.
+
+func (cCtx *Context) Float64(name string) float64
+    Float64 looks up the value of a local Float64Flag, returns 0 if not found
+
+func (cCtx *Context) Float64Slice(name string) []float64
+    Float64Slice looks up the value of a local Float64SliceFlag, returns nil if
+    not found
+
+func (cCtx *Context) Generic(name string) interface{}
+    Generic looks up the value of a local GenericFlag, returns nil if not found
+
+func (cCtx *Context) Int(name string) int
+    Int looks up the value of a local IntFlag, returns 0 if not found
+
+func (cCtx *Context) Int64(name string) int64
+    Int64 looks up the value of a local Int64Flag, returns 0 if not found
+
+func (cCtx *Context) Int64Slice(name string) []int64
+    Int64Slice looks up the value of a local Int64SliceFlag, returns nil if not
+    found
+
+func (cCtx *Context) IntSlice(name string) []int
+    IntSlice looks up the value of a local IntSliceFlag, returns nil if not
+    found
+
+func (cCtx *Context) IsSet(name string) bool
+    IsSet determines if the flag was actually set
+
+func (cCtx *Context) Lineage() []*Context
+    Lineage returns *this* context and all of its ancestor contexts in order
+    from child to parent
+
+func (cCtx *Context) LocalFlagNames() []string
+    LocalFlagNames returns a slice of flag names used in this context.
+
+func (cCtx *Context) NArg() int
+    NArg returns the number of the command line arguments.
+
+func (cCtx *Context) NumFlags() int
+    NumFlags returns the number of flags set
+
+func (cCtx *Context) Path(name string) string
+    Path looks up the value of a local PathFlag, returns "" if not found
+
+func (cCtx *Context) Set(name, value string) error
+    Set sets a context flag to a value.
+
+func (cCtx *Context) String(name string) string
+    String looks up the value of a local StringFlag, returns "" if not found
+
+func (cCtx *Context) StringSlice(name string) []string
+    StringSlice looks up the value of a local StringSliceFlag, returns nil if
+    not found
+
+func (cCtx *Context) Timestamp(name string) *time.Time
+    Timestamp gets the timestamp from a flag name
+
+func (cCtx *Context) Uint(name string) uint
+    Uint looks up the value of a local UintFlag, returns 0 if not found
+
+func (cCtx *Context) Uint64(name string) uint64
+    Uint64 looks up the value of a local Uint64Flag, returns 0 if not found
+
+func (cCtx *Context) Uint64Slice(name string) []uint64
+    Uint64Slice looks up the value of a local Uint64SliceFlag, returns nil if
+    not found
+
+func (cCtx *Context) UintSlice(name string) []uint
+    UintSlice looks up the value of a local UintSliceFlag, returns nil if not
+    found
+
+func (cCtx *Context) Value(name string) interface{}
+    Value returns the value of the flag corresponding to `name`
+
+type Countable interface {
+	Count() int
+}
+    Countable is an interface to enable detection of flag values which support
+    repetitive flags
+
+type DocGenerationFlag interface {
+	Flag
+
+	// TakesValue returns true if the flag takes a value, otherwise false
+	TakesValue() bool
+
+	// GetUsage returns the usage string for the flag
+	GetUsage() string
+
+	// GetValue returns the flags value as string representation and an empty
+	// string if the flag takes no value at all.
+	GetValue() string
+
+	// GetDefaultText returns the default text for this flag
+	GetDefaultText() string
+
+	// GetEnvVars returns the env vars for this flag
+	GetEnvVars() []string
+}
+    DocGenerationFlag is an interface that allows documentation generation for
+    the flag
+
+type DocGenerationSliceFlag interface {
+	DocGenerationFlag
+
+	// IsSliceFlag returns true for flags that can be given multiple times.
+	IsSliceFlag() bool
+}
+    DocGenerationSliceFlag extends DocGenerationFlag for slice-based flags.
+
+type DurationFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       time.Duration
+	Destination *time.Duration
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, time.Duration) error
+	// Has unexported fields.
+}
+    DurationFlag is a flag with type time.Duration
+
+func (f *DurationFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *DurationFlag) Get(ctx *Context) time.Duration
+    Get returns the flag’s value in the given Context.
+
+func (f *DurationFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *DurationFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *DurationFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *DurationFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *DurationFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *DurationFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *DurationFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *DurationFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *DurationFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *DurationFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *DurationFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *DurationFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type ErrorFormatter interface {
+	Format(s fmt.State, verb rune)
+}
+    ErrorFormatter is the interface that will suitably format the error output
+
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+    ExitCoder is the interface checked by `App` and `Command` for a custom exit
+    code
+
+func Exit(message interface{}, exitCode int) ExitCoder
+    Exit wraps a message and exit code into an error, which by default is
+    handled with a call to os.Exit during default error handling.
+
+    This is the simplest way to trigger a non-zero exit code for an App
+    without having to call os.Exit manually. During testing, this behavior
+    can be avoided by overriding the ExitErrHandler function on an App or the
+    package-global OsExiter function.
+
+func NewExitError(message interface{}, exitCode int) ExitCoder
+    NewExitError calls Exit to create a new ExitCoder.
+
+    Deprecated: This function is a duplicate of Exit and will eventually be
+    removed.
+
+type ExitErrHandlerFunc func(cCtx *Context, err error)
+    ExitErrHandlerFunc is executed if provided in order to handle exitError
+    values returned by Actions and Before/After functions.
+
+type Flag interface {
+	fmt.Stringer
+	// Apply Flag settings to the given flag set
+	Apply(*flag.FlagSet) error
+	Names() []string
+	IsSet() bool
+}
+    Flag is a common interface related to parsing flags in cli. For more
+    advanced flag parsing techniques, it is recommended that this interface be
+    implemented.
+
+var BashCompletionFlag Flag = &BoolFlag{
+	Name:   "generate-bash-completion",
+	Hidden: true,
+}
+    BashCompletionFlag enables bash-completion for all commands and subcommands
+
+var HelpFlag Flag = &BoolFlag{
+	Name:               "help",
+	Aliases:            []string{"h"},
+	Usage:              "show help",
+	DisableDefaultText: true,
+}
+    HelpFlag prints the help for all commands and subcommands. Set to nil to
+    disable the flag. The subcommand will still be added unless HideHelp or
+    HideHelpCommand is set to true.
+
+var VersionFlag Flag = &BoolFlag{
+	Name:               "version",
+	Aliases:            []string{"v"},
+	Usage:              "print the version",
+	DisableDefaultText: true,
+}
+    VersionFlag prints the version for the application
+
+type FlagCategories interface {
+	// AddFlags adds a flag to a category, creating a new category if necessary.
+	AddFlag(category string, fl Flag)
+	// VisibleCategories returns a slice of visible flag categories sorted by name
+	VisibleCategories() []VisibleFlagCategory
+}
+    FlagCategories interface allows for category manipulation
+
+type FlagEnvHintFunc func(envVars []string, str string) string
+    FlagEnvHintFunc is used by the default FlagStringFunc to annotate flag help
+    with the environment variable details.
+
+var FlagEnvHinter FlagEnvHintFunc = withEnvHint
+    FlagEnvHinter annotates flag help message with the environment variable
+    details. This is used by the default FlagStringer.
+
+type FlagFileHintFunc func(filePath, str string) string
+    FlagFileHintFunc is used by the default FlagStringFunc to annotate flag help
+    with the file path details.
+
+var FlagFileHinter FlagFileHintFunc = withFileHint
+    FlagFileHinter annotates flag help message with the environment variable
+    details. This is used by the default FlagStringer.
+
+type FlagNamePrefixFunc func(fullName []string, placeholder string) string
+    FlagNamePrefixFunc is used by the default FlagStringFunc to create prefix
+    text for a flag's full name.
+
+var FlagNamePrefixer FlagNamePrefixFunc = prefixedNames
+    FlagNamePrefixer converts a full flag name and its placeholder into the help
+    message flag prefix. This is used by the default FlagStringer.
+
+type FlagStringFunc func(Flag) string
+    FlagStringFunc is used by the help generation to display a flag, which is
+    expected to be a single line.
+
+var FlagStringer FlagStringFunc = stringifyFlag
+    FlagStringer converts a flag definition to a string. This is used by help to
+    display a flag.
+
+type FlagsByName []Flag
+    FlagsByName is a slice of Flag.
+
+func (f FlagsByName) Len() int
+
+func (f FlagsByName) Less(i, j int) bool
+
+func (f FlagsByName) Swap(i, j int)
+
+type Float64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       float64
+	Destination *float64
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, float64) error
+	// Has unexported fields.
+}
+    Float64Flag is a flag with type float64
+
+func (f *Float64Flag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Float64Flag) Get(ctx *Context) float64
+    Get returns the flag’s value in the given Context.
+
+func (f *Float64Flag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Float64Flag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Float64Flag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Float64Flag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Float64Flag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Float64Flag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Float64Flag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Float64Flag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Float64Flag) Names() []string
+    Names returns the names of the flag
+
+func (f *Float64Flag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Float64Flag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Float64Flag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Float64Slice struct {
+	// Has unexported fields.
+}
+    Float64Slice wraps []float64 to satisfy flag.Value
+
+func NewFloat64Slice(defaults ...float64) *Float64Slice
+    NewFloat64Slice makes a *Float64Slice with default values
+
+func (f *Float64Slice) Get() interface{}
+    Get returns the slice of float64s set by this flag
+
+func (f *Float64Slice) Serialize() string
+    Serialize allows Float64Slice to fulfill Serializer
+
+func (f *Float64Slice) Set(value string) error
+    Set parses the value into a float64 and appends it to the list of values
+
+func (f *Float64Slice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Float64Slice) Value() []float64
+    Value returns the slice of float64s set by this flag
+
+func (f *Float64Slice) WithSeparatorSpec(spec separatorSpec)
+
+type Float64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Float64Slice
+	Destination *Float64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []float64) error
+	// Has unexported fields.
+}
+    Float64SliceFlag is a flag with type *Float64Slice
+
+func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Float64SliceFlag) Get(ctx *Context) []float64
+    Get returns the flag’s value in the given Context.
+
+func (f *Float64SliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Float64SliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Float64SliceFlag) GetDestination() []float64
+
+func (f *Float64SliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Float64SliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Float64SliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Float64SliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Float64SliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Float64SliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *Float64SliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Float64SliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *Float64SliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Float64SliceFlag) SetDestination(slice []float64)
+
+func (f *Float64SliceFlag) SetValue(slice []float64)
+
+func (f *Float64SliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Float64SliceFlag) TakesValue() bool
+    TakesValue returns true if the flag takes a value, otherwise false
+
+func (f *Float64SliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type Generic interface {
+	Set(value string) error
+	String() string
+}
+    Generic is a generic parseable type identified by a specific flag
+
+type GenericFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       Generic
+	Destination Generic
+
+	Aliases []string
+	EnvVars []string
+
+	TakesFile bool
+
+	Action func(*Context, interface{}) error
+	// Has unexported fields.
+}
+    GenericFlag is a flag with type Generic
+
+func (f *GenericFlag) Apply(set *flag.FlagSet) error
+    Apply takes the flagset and calls Set on the generic flag with the value
+    provided by the user for parsing by the flag
+
+func (f *GenericFlag) Get(ctx *Context) interface{}
+    Get returns the flag’s value in the given Context.
+
+func (f *GenericFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *GenericFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *GenericFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *GenericFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *GenericFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *GenericFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *GenericFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *GenericFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *GenericFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *GenericFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *GenericFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *GenericFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Int64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       int64
+	Destination *int64
+
+	Aliases []string
+	EnvVars []string
+
+	Base int
+
+	Action func(*Context, int64) error
+	// Has unexported fields.
+}
+    Int64Flag is a flag with type int64
+
+func (f *Int64Flag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Int64Flag) Get(ctx *Context) int64
+    Get returns the flag’s value in the given Context.
+
+func (f *Int64Flag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Int64Flag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Int64Flag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Int64Flag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Int64Flag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Int64Flag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Int64Flag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Int64Flag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Int64Flag) Names() []string
+    Names returns the names of the flag
+
+func (f *Int64Flag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Int64Flag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Int64Flag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Int64Slice struct {
+	// Has unexported fields.
+}
+    Int64Slice wraps []int64 to satisfy flag.Value
+
+func NewInt64Slice(defaults ...int64) *Int64Slice
+    NewInt64Slice makes an *Int64Slice with default values
+
+func (i *Int64Slice) Get() interface{}
+    Get returns the slice of ints set by this flag
+
+func (i *Int64Slice) Serialize() string
+    Serialize allows Int64Slice to fulfill Serializer
+
+func (i *Int64Slice) Set(value string) error
+    Set parses the value into an integer and appends it to the list of values
+
+func (i *Int64Slice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (i *Int64Slice) Value() []int64
+    Value returns the slice of ints set by this flag
+
+func (i *Int64Slice) WithSeparatorSpec(spec separatorSpec)
+
+type Int64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Int64Slice
+	Destination *Int64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []int64) error
+	// Has unexported fields.
+}
+    Int64SliceFlag is a flag with type *Int64Slice
+
+func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Int64SliceFlag) Get(ctx *Context) []int64
+    Get returns the flag’s value in the given Context.
+
+func (f *Int64SliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Int64SliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Int64SliceFlag) GetDestination() []int64
+
+func (f *Int64SliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Int64SliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Int64SliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Int64SliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Int64SliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Int64SliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *Int64SliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Int64SliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *Int64SliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Int64SliceFlag) SetDestination(slice []int64)
+
+func (f *Int64SliceFlag) SetValue(slice []int64)
+
+func (f *Int64SliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Int64SliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *Int64SliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type IntFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       int
+	Destination *int
+
+	Aliases []string
+	EnvVars []string
+
+	Base int
+
+	Action func(*Context, int) error
+	// Has unexported fields.
+}
+    IntFlag is a flag with type int
+
+func (f *IntFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *IntFlag) Get(ctx *Context) int
+    Get returns the flag’s value in the given Context.
+
+func (f *IntFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *IntFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *IntFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *IntFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *IntFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *IntFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *IntFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *IntFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *IntFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *IntFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *IntFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *IntFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type IntSlice struct {
+	// Has unexported fields.
+}
+    IntSlice wraps []int to satisfy flag.Value
+
+func NewIntSlice(defaults ...int) *IntSlice
+    NewIntSlice makes an *IntSlice with default values
+
+func (i *IntSlice) Get() interface{}
+    Get returns the slice of ints set by this flag
+
+func (i *IntSlice) Serialize() string
+    Serialize allows IntSlice to fulfill Serializer
+
+func (i *IntSlice) Set(value string) error
+    Set parses the value into an integer and appends it to the list of values
+
+func (i *IntSlice) SetInt(value int)
+    TODO: Consistently have specific Set function for Int64 and Float64 ? SetInt
+    directly adds an integer to the list of values
+
+func (i *IntSlice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (i *IntSlice) Value() []int
+    Value returns the slice of ints set by this flag
+
+func (i *IntSlice) WithSeparatorSpec(spec separatorSpec)
+
+type IntSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *IntSlice
+	Destination *IntSlice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []int) error
+	// Has unexported fields.
+}
+    IntSliceFlag is a flag with type *IntSlice
+
+func (f *IntSliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *IntSliceFlag) Get(ctx *Context) []int
+    Get returns the flag’s value in the given Context.
+
+func (f *IntSliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *IntSliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *IntSliceFlag) GetDestination() []int
+
+func (f *IntSliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *IntSliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *IntSliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *IntSliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *IntSliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *IntSliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *IntSliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *IntSliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *IntSliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *IntSliceFlag) SetDestination(slice []int)
+
+func (f *IntSliceFlag) SetValue(slice []int)
+
+func (f *IntSliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *IntSliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *IntSliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type InvalidFlagAccessFunc func(*Context, string)
+    InvalidFlagAccessFunc is executed when an invalid flag is accessed from the
+    context.
+
+type MultiError interface {
+	error
+	Errors() []error
+}
+    MultiError is an error that wraps multiple errors.
+
+type MultiFloat64Flag = SliceFlag[*Float64SliceFlag, []float64, float64]
+    MultiFloat64Flag extends Float64SliceFlag with support for using slices
+    directly, as Value and/or Destination. See also SliceFlag.
+
+type MultiInt64Flag = SliceFlag[*Int64SliceFlag, []int64, int64]
+    MultiInt64Flag extends Int64SliceFlag with support for using slices
+    directly, as Value and/or Destination. See also SliceFlag.
+
+type MultiIntFlag = SliceFlag[*IntSliceFlag, []int, int]
+    MultiIntFlag extends IntSliceFlag with support for using slices directly,
+    as Value and/or Destination. See also SliceFlag.
+
+type MultiStringFlag = SliceFlag[*StringSliceFlag, []string, string]
+    MultiStringFlag extends StringSliceFlag with support for using slices
+    directly, as Value and/or Destination. See also SliceFlag.
+
+type OnUsageErrorFunc func(cCtx *Context, err error, isSubcommand bool) error
+    OnUsageErrorFunc is executed if a usage error occurs. This is useful for
+    displaying customized usage error messages. This function is able to replace
+    the original error messages. If this function is not set, the "Incorrect
+    usage" is displayed and the execution is interrupted.
+
+type Path = string
+
+type PathFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       Path
+	Destination *Path
+
+	Aliases []string
+	EnvVars []string
+
+	TakesFile bool
+
+	Action func(*Context, Path) error
+	// Has unexported fields.
+}
+    PathFlag is a flag with type Path
+
+func (f *PathFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *PathFlag) Get(ctx *Context) string
+    Get returns the flag’s value in the given Context.
+
+func (f *PathFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *PathFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *PathFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *PathFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *PathFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *PathFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *PathFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *PathFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *PathFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *PathFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *PathFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *PathFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type RequiredFlag interface {
+	Flag
+
+	IsRequired() bool
+}
+    RequiredFlag is an interface that allows us to mark flags as required
+    it allows flags required flags to be backwards compatible with the Flag
+    interface
+
+type Serializer interface {
+	Serialize() string
+}
+    Serializer is used to circumvent the limitations of flag.FlagSet.Set
+
+type SliceFlag[T SliceFlagTarget[E], S ~[]E, E any] struct {
+	Target      T
+	Value       S
+	Destination *S
+}
+    SliceFlag extends implementations like StringSliceFlag and IntSliceFlag
+    with support for using slices directly, as Value and/or Destination.
+    See also SliceFlagTarget, MultiStringFlag, MultiFloat64Flag, MultiInt64Flag,
+    MultiIntFlag.
+
+func (x *SliceFlag[T, S, E]) Apply(set *flag.FlagSet) error
+
+func (x *SliceFlag[T, S, E]) GetCategory() string
+
+func (x *SliceFlag[T, S, E]) GetDefaultText() string
+
+func (x *SliceFlag[T, S, E]) GetDestination() S
+
+func (x *SliceFlag[T, S, E]) GetEnvVars() []string
+
+func (x *SliceFlag[T, S, E]) GetUsage() string
+
+func (x *SliceFlag[T, S, E]) GetValue() string
+
+func (x *SliceFlag[T, S, E]) IsRequired() bool
+
+func (x *SliceFlag[T, S, E]) IsSet() bool
+
+func (x *SliceFlag[T, S, E]) IsVisible() bool
+
+func (x *SliceFlag[T, S, E]) Names() []string
+
+func (x *SliceFlag[T, S, E]) SetDestination(slice S)
+
+func (x *SliceFlag[T, S, E]) SetValue(slice S)
+
+func (x *SliceFlag[T, S, E]) String() string
+
+func (x *SliceFlag[T, S, E]) TakesValue() bool
+
+type SliceFlagTarget[E any] interface {
+	Flag
+	RequiredFlag
+	DocGenerationFlag
+	VisibleFlag
+	CategorizableFlag
+
+	// SetValue should propagate the given slice to the target, ideally as a new value.
+	// Note that a nil slice should nil/clear any existing value (modelled as ~[]E).
+	SetValue(slice []E)
+	// SetDestination should propagate the given slice to the target, ideally as a new value.
+	// Note that a nil slice should nil/clear any existing value (modelled as ~*[]E).
+	SetDestination(slice []E)
+	// GetDestination should return the current value referenced by any destination, or nil if nil/unset.
+	GetDestination() []E
+}
+    SliceFlagTarget models a target implementation for use with SliceFlag. The
+    three methods, SetValue, SetDestination, and GetDestination, are necessary
+    to propagate Value and Destination, where Value is propagated inwards
+    (initially), and Destination is propagated outwards (on every update).
+
+type StringFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       string
+	Destination *string
+
+	Aliases []string
+	EnvVars []string
+
+	TakesFile bool
+
+	Action func(*Context, string) error
+	// Has unexported fields.
+}
+    StringFlag is a flag with type string
+
+func (f *StringFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *StringFlag) Get(ctx *Context) string
+    Get returns the flag’s value in the given Context.
+
+func (f *StringFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *StringFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *StringFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *StringFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *StringFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *StringFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *StringFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *StringFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *StringFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *StringFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *StringFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *StringFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type StringSlice struct {
+	// Has unexported fields.
+}
+    StringSlice wraps a []string to satisfy flag.Value
+
+func NewStringSlice(defaults ...string) *StringSlice
+    NewStringSlice creates a *StringSlice with default values
+
+func (s *StringSlice) Get() interface{}
+    Get returns the slice of strings set by this flag
+
+func (s *StringSlice) Serialize() string
+    Serialize allows StringSlice to fulfill Serializer
+
+func (s *StringSlice) Set(value string) error
+    Set appends the string value to the list of values
+
+func (s *StringSlice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (s *StringSlice) Value() []string
+    Value returns the slice of strings set by this flag
+
+func (s *StringSlice) WithSeparatorSpec(spec separatorSpec)
+
+type StringSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *StringSlice
+	Destination *StringSlice
+
+	Aliases []string
+	EnvVars []string
+
+	TakesFile bool
+
+	Action func(*Context, []string) error
+
+	KeepSpace bool
+	// Has unexported fields.
+}
+    StringSliceFlag is a flag with type *StringSlice
+
+func (f *StringSliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *StringSliceFlag) Get(ctx *Context) []string
+    Get returns the flag’s value in the given Context.
+
+func (f *StringSliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *StringSliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *StringSliceFlag) GetDestination() []string
+
+func (f *StringSliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *StringSliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *StringSliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *StringSliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *StringSliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *StringSliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *StringSliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *StringSliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *StringSliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *StringSliceFlag) SetDestination(slice []string)
+
+func (f *StringSliceFlag) SetValue(slice []string)
+
+func (f *StringSliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *StringSliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *StringSliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type SuggestCommandFunc func(commands []*Command, provided string) string
+
+type SuggestFlagFunc func(flags []Flag, provided string, hideHelp bool) string
+
+type Timestamp struct {
+	// Has unexported fields.
+}
+    Timestamp wrap to satisfy golang's flag interface.
+
+func NewTimestamp(timestamp time.Time) *Timestamp
+    Timestamp constructor
+
+func (t *Timestamp) Get() interface{}
+    Get returns the flag structure
+
+func (t *Timestamp) Set(value string) error
+    Parses the string value to timestamp
+
+func (t *Timestamp) SetLayout(layout string)
+    Set the timestamp string layout for future parsing
+
+func (t *Timestamp) SetLocation(loc *time.Location)
+    Set perceived timezone of the to-be parsed time string
+
+func (t *Timestamp) SetTimestamp(value time.Time)
+    Set the timestamp value directly
+
+func (t *Timestamp) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (t *Timestamp) Value() *time.Time
+    Value returns the timestamp value stored in the flag
+
+type TimestampFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Timestamp
+	Destination *Timestamp
+
+	Aliases []string
+	EnvVars []string
+
+	Layout string
+
+	Timezone *time.Location
+
+	Action func(*Context, *time.Time) error
+	// Has unexported fields.
+}
+    TimestampFlag is a flag with type *Timestamp
+
+func (f *TimestampFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *TimestampFlag) Get(ctx *Context) *time.Time
+    Get returns the flag’s value in the given Context.
+
+func (f *TimestampFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *TimestampFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *TimestampFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *TimestampFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *TimestampFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *TimestampFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *TimestampFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *TimestampFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *TimestampFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *TimestampFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *TimestampFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *TimestampFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Uint64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       uint64
+	Destination *uint64
+
+	Aliases []string
+	EnvVars []string
+
+	Base int
+
+	Action func(*Context, uint64) error
+	// Has unexported fields.
+}
+    Uint64Flag is a flag with type uint64
+
+func (f *Uint64Flag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Uint64Flag) Get(ctx *Context) uint64
+    Get returns the flag’s value in the given Context.
+
+func (f *Uint64Flag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Uint64Flag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Uint64Flag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Uint64Flag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Uint64Flag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Uint64Flag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Uint64Flag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Uint64Flag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Uint64Flag) Names() []string
+    Names returns the names of the flag
+
+func (f *Uint64Flag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Uint64Flag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Uint64Flag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type Uint64Slice struct {
+	// Has unexported fields.
+}
+    Uint64Slice wraps []int64 to satisfy flag.Value
+
+func NewUint64Slice(defaults ...uint64) *Uint64Slice
+    NewUint64Slice makes an *Uint64Slice with default values
+
+func (i *Uint64Slice) Get() interface{}
+    Get returns the slice of ints set by this flag
+
+func (i *Uint64Slice) Serialize() string
+    Serialize allows Uint64Slice to fulfill Serializer
+
+func (i *Uint64Slice) Set(value string) error
+    Set parses the value into an integer and appends it to the list of values
+
+func (i *Uint64Slice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (i *Uint64Slice) Value() []uint64
+    Value returns the slice of ints set by this flag
+
+func (i *Uint64Slice) WithSeparatorSpec(spec separatorSpec)
+
+type Uint64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Uint64Slice
+	Destination *Uint64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []uint64) error
+	// Has unexported fields.
+}
+    Uint64SliceFlag is a flag with type *Uint64Slice
+
+func (f *Uint64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *Uint64SliceFlag) Get(ctx *Context) []uint64
+    Get returns the flag’s value in the given Context.
+
+func (f *Uint64SliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *Uint64SliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *Uint64SliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *Uint64SliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *Uint64SliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *Uint64SliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *Uint64SliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *Uint64SliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *Uint64SliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *Uint64SliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *Uint64SliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *Uint64SliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *Uint64SliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *Uint64SliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type UintFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       uint
+	Destination *uint
+
+	Aliases []string
+	EnvVars []string
+
+	Base int
+
+	Action func(*Context, uint) error
+	// Has unexported fields.
+}
+    UintFlag is a flag with type uint
+
+func (f *UintFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *UintFlag) Get(ctx *Context) uint
+    Get returns the flag’s value in the given Context.
+
+func (f *UintFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *UintFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *UintFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *UintFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *UintFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *UintFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *UintFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *UintFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *UintFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *UintFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *UintFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *UintFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+type UintSlice struct {
+	// Has unexported fields.
+}
+    UintSlice wraps []int to satisfy flag.Value
+
+func NewUintSlice(defaults ...uint) *UintSlice
+    NewUintSlice makes an *UintSlice with default values
+
+func (i *UintSlice) Get() interface{}
+    Get returns the slice of ints set by this flag
+
+func (i *UintSlice) Serialize() string
+    Serialize allows UintSlice to fulfill Serializer
+
+func (i *UintSlice) Set(value string) error
+    Set parses the value into an integer and appends it to the list of values
+
+func (i *UintSlice) SetUint(value uint)
+    TODO: Consistently have specific Set function for Int64 and Float64 ? SetInt
+    directly adds an integer to the list of values
+
+func (i *UintSlice) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (i *UintSlice) Value() []uint
+    Value returns the slice of ints set by this flag
+
+func (i *UintSlice) WithSeparatorSpec(spec separatorSpec)
+
+type UintSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *UintSlice
+	Destination *UintSlice
+
+	Aliases []string
+	EnvVars []string
+
+	Action func(*Context, []uint) error
+	// Has unexported fields.
+}
+    UintSliceFlag is a flag with type *UintSlice
+
+func (f *UintSliceFlag) Apply(set *flag.FlagSet) error
+    Apply populates the flag given the flag set and environment
+
+func (f *UintSliceFlag) Get(ctx *Context) []uint
+    Get returns the flag’s value in the given Context.
+
+func (f *UintSliceFlag) GetCategory() string
+    GetCategory returns the category for the flag
+
+func (f *UintSliceFlag) GetDefaultText() string
+    GetDefaultText returns the default text for this flag
+
+func (f *UintSliceFlag) GetEnvVars() []string
+    GetEnvVars returns the env vars for this flag
+
+func (f *UintSliceFlag) GetUsage() string
+    GetUsage returns the usage string for the flag
+
+func (f *UintSliceFlag) GetValue() string
+    GetValue returns the flags value as string representation and an empty
+    string if the flag takes no value at all.
+
+func (f *UintSliceFlag) IsRequired() bool
+    IsRequired returns whether or not the flag is required
+
+func (f *UintSliceFlag) IsSet() bool
+    IsSet returns whether or not the flag has been set through env or file
+
+func (f *UintSliceFlag) IsSliceFlag() bool
+    IsSliceFlag implements DocGenerationSliceFlag.
+
+func (f *UintSliceFlag) IsVisible() bool
+    IsVisible returns true if the flag is not hidden, otherwise false
+
+func (f *UintSliceFlag) Names() []string
+    Names returns the names of the flag
+
+func (f *UintSliceFlag) RunAction(c *Context) error
+    RunAction executes flag action if set
+
+func (f *UintSliceFlag) String() string
+    String returns a readable representation of this value (for usage defaults)
+
+func (f *UintSliceFlag) TakesValue() bool
+    TakesValue returns true of the flag takes a value, otherwise false
+
+func (f *UintSliceFlag) WithSeparatorSpec(spec separatorSpec)
+
+type VisibleFlag interface {
+	Flag
+
+	// IsVisible returns true if the flag is not hidden, otherwise false
+	IsVisible() bool
+}
+    VisibleFlag is an interface that allows to check if a flag is visible
+
+type VisibleFlagCategory interface {
+	// Name returns the category name string
+	Name() string
+	// Flags returns a slice of VisibleFlag sorted by name
+	Flags() []VisibleFlag
+}
+    VisibleFlagCategory is a category containing flags.
+
+package altsrc // import "github.com/urfave/cli/v2/altsrc"
+
+
+FUNCTIONS
+
+func ApplyInputSourceValues(cCtx *cli.Context, inputSourceContext InputSourceContext, flags []cli.Flag) error
+    ApplyInputSourceValues iterates over all provided flags and executes
+    ApplyInputSourceValue on flags implementing the FlagInputSourceExtension
+    interface to initialize these flags to an alternate input source.
+
+func InitInputSource(flags []cli.Flag, createInputSource func() (InputSourceContext, error)) cli.BeforeFunc
+    InitInputSource is used to to setup an InputSourceContext on a cli.Command
+    Before method. It will create a new input source based on the func provided.
+    If there is no error it will then apply the new input source to any flags
+    that are supported by the input source
+
+func InitInputSourceWithContext(flags []cli.Flag, createInputSource func(cCtx *cli.Context) (InputSourceContext, error)) cli.BeforeFunc
+    InitInputSourceWithContext is used to to setup an InputSourceContext on
+    a cli.Command Before method. It will create a new input source based on
+    the func provided with potentially using existing cli.Context values to
+    initialize itself. If there is no error it will then apply the new input
+    source to any flags that are supported by the input source
+
+func NewJSONSourceFromFlagFunc(flag string) func(c *cli.Context) (InputSourceContext, error)
+    NewJSONSourceFromFlagFunc returns a func that takes a cli.Context and
+    returns an InputSourceContext suitable for retrieving config variables from
+    a file containing JSON data with the file name defined by the given flag.
+
+func NewTomlSourceFromFlagFunc(flagFileName string) func(cCtx *cli.Context) (InputSourceContext, error)
+    NewTomlSourceFromFlagFunc creates a new TOML InputSourceContext from a
+    provided flag name and source context.
+
+func NewYamlSourceFromFlagFunc(flagFileName string) func(cCtx *cli.Context) (InputSourceContext, error)
+    NewYamlSourceFromFlagFunc creates a new Yaml InputSourceContext from a
+    provided flag name and source context.
+
+
+TYPES
+
+type BoolFlag struct {
+	*cli.BoolFlag
+	// Has unexported fields.
+}
+    BoolFlag is the flag type that wraps cli.BoolFlag to allow for other values
+    to be specified
+
+func NewBoolFlag(fl *cli.BoolFlag) *BoolFlag
+    NewBoolFlag creates a new BoolFlag
+
+func (f *BoolFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    BoolFlag.Apply
+
+func (f *BoolFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Bool value to the flagSet if required
+
+type DurationFlag struct {
+	*cli.DurationFlag
+	// Has unexported fields.
+}
+    DurationFlag is the flag type that wraps cli.DurationFlag to allow for other
+    values to be specified
+
+func NewDurationFlag(fl *cli.DurationFlag) *DurationFlag
+    NewDurationFlag creates a new DurationFlag
+
+func (f *DurationFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    DurationFlag.Apply
+
+func (f *DurationFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Duration value to the flagSet if required
+
+type FlagInputSourceExtension interface {
+	cli.Flag
+	ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+}
+    FlagInputSourceExtension is an extension interface of cli.Flag that allows a
+    value to be set on the existing parsed flags.
+
+type Float64Flag struct {
+	*cli.Float64Flag
+	// Has unexported fields.
+}
+    Float64Flag is the flag type that wraps cli.Float64Flag to allow for other
+    values to be specified
+
+func NewFloat64Flag(fl *cli.Float64Flag) *Float64Flag
+    NewFloat64Flag creates a new Float64Flag
+
+func (f *Float64Flag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Float64Flag.Apply
+
+func (f *Float64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Float64 value to the flagSet if required
+
+type Float64SliceFlag struct {
+	*cli.Float64SliceFlag
+	// Has unexported fields.
+}
+    Float64SliceFlag is the flag type that wraps cli.Float64SliceFlag to allow
+    for other values to be specified
+
+func NewFloat64SliceFlag(fl *cli.Float64SliceFlag) *Float64SliceFlag
+    NewFloat64SliceFlag creates a new Float64SliceFlag
+
+func (f *Float64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Float64SliceFlag.Apply
+
+func (f *Float64SliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Float64Slice value if required
+
+type GenericFlag struct {
+	*cli.GenericFlag
+	// Has unexported fields.
+}
+    GenericFlag is the flag type that wraps cli.GenericFlag to allow for other
+    values to be specified
+
+func NewGenericFlag(fl *cli.GenericFlag) *GenericFlag
+    NewGenericFlag creates a new GenericFlag
+
+func (f *GenericFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    GenericFlag.Apply
+
+func (f *GenericFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a generic value to the flagSet if required
+
+type InputSourceContext interface {
+	Source() string
+
+	Int(name string) (int, error)
+	Int64(name string) (int64, error)
+	Uint(name string) (uint, error)
+	Uint64(name string) (uint64, error)
+	Duration(name string) (time.Duration, error)
+	Float64(name string) (float64, error)
+	String(name string) (string, error)
+	StringSlice(name string) ([]string, error)
+	IntSlice(name string) ([]int, error)
+	Int64Slice(name string) ([]int64, error)
+	Float64Slice(name string) ([]float64, error)
+	Generic(name string) (cli.Generic, error)
+	Bool(name string) (bool, error)
+
+	// Has unexported methods.
+}
+    InputSourceContext is an interface used to allow other input sources to be
+    implemented as needed.
+
+    Source returns an identifier for the input source. In case of file source it
+    should return path to the file.
+
+func NewJSONSource(data []byte) (InputSourceContext, error)
+    NewJSONSource returns an InputSourceContext suitable for retrieving config
+    variables from raw JSON data.
+
+func NewJSONSourceFromFile(f string) (InputSourceContext, error)
+    NewJSONSourceFromFile returns an InputSourceContext suitable for retrieving
+    config variables from a file (or url) containing JSON data.
+
+func NewJSONSourceFromReader(r io.Reader) (InputSourceContext, error)
+    NewJSONSourceFromReader returns an InputSourceContext suitable for
+    retrieving config variables from an io.Reader that returns JSON data.
+
+func NewTomlSourceFromFile(file string) (InputSourceContext, error)
+    NewTomlSourceFromFile creates a new TOML InputSourceContext from a filepath.
+
+func NewYamlSourceFromFile(file string) (InputSourceContext, error)
+    NewYamlSourceFromFile creates a new Yaml InputSourceContext from a filepath.
+
+type Int64Flag struct {
+	*cli.Int64Flag
+	// Has unexported fields.
+}
+    Int64Flag is the flag type that wraps cli.Int64Flag to allow for other
+    values to be specified
+
+func NewInt64Flag(fl *cli.Int64Flag) *Int64Flag
+    NewInt64Flag creates a new Int64Flag
+
+func (f *Int64Flag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Int64Flag.Apply
+
+func (f *Int64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+
+type Int64SliceFlag struct {
+	*cli.Int64SliceFlag
+	// Has unexported fields.
+}
+    Int64SliceFlag is the flag type that wraps cli.Int64SliceFlag to allow for
+    other values to be specified
+
+func NewInt64SliceFlag(fl *cli.Int64SliceFlag) *Int64SliceFlag
+    NewInt64SliceFlag creates a new Int64SliceFlag
+
+func (f *Int64SliceFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Int64SliceFlag.Apply
+
+func (f *Int64SliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Int64Slice value if required
+
+type IntFlag struct {
+	*cli.IntFlag
+	// Has unexported fields.
+}
+    IntFlag is the flag type that wraps cli.IntFlag to allow for other values to
+    be specified
+
+func NewIntFlag(fl *cli.IntFlag) *IntFlag
+    NewIntFlag creates a new IntFlag
+
+func (f *IntFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    IntFlag.Apply
+
+func (f *IntFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a int value to the flagSet if required
+
+type IntSliceFlag struct {
+	*cli.IntSliceFlag
+	// Has unexported fields.
+}
+    IntSliceFlag is the flag type that wraps cli.IntSliceFlag to allow for other
+    values to be specified
+
+func NewIntSliceFlag(fl *cli.IntSliceFlag) *IntSliceFlag
+    NewIntSliceFlag creates a new IntSliceFlag
+
+func (f *IntSliceFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    IntSliceFlag.Apply
+
+func (f *IntSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a IntSlice value if required
+
+type MapInputSource struct {
+	// Has unexported fields.
+}
+    MapInputSource implements InputSourceContext to return data from the map
+    that is loaded.
+
+func NewMapInputSource(file string, valueMap map[interface{}]interface{}) *MapInputSource
+    NewMapInputSource creates a new MapInputSource for implementing custom input
+    sources.
+
+func (fsm *MapInputSource) Bool(name string) (bool, error)
+    Bool returns an bool from the map otherwise returns false
+
+func (fsm *MapInputSource) Duration(name string) (time.Duration, error)
+    Duration returns a duration from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Float64(name string) (float64, error)
+    Float64 returns an float64 from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Float64Slice(name string) ([]float64, error)
+    Float64Slice returns an []float64 from the map if it exists otherwise
+    returns nil
+
+func (fsm *MapInputSource) Generic(name string) (cli.Generic, error)
+    Generic returns an cli.Generic from the map if it exists otherwise returns
+    nil
+
+func (fsm *MapInputSource) Int(name string) (int, error)
+    Int returns an int from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Int64(name string) (int64, error)
+    Int64 returns an int64 from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Int64Slice(name string) ([]int64, error)
+    Int64Slice returns an []int64 from the map if it exists otherwise returns
+    nil
+
+func (fsm *MapInputSource) IntSlice(name string) ([]int, error)
+    IntSlice returns an []int from the map if it exists otherwise returns nil
+
+func (fsm *MapInputSource) Source() string
+    Source returns the path of the source file
+
+func (fsm *MapInputSource) String(name string) (string, error)
+    String returns a string from the map if it exists otherwise returns an empty
+    string
+
+func (fsm *MapInputSource) StringSlice(name string) ([]string, error)
+    StringSlice returns an []string from the map if it exists otherwise returns
+    nil
+
+func (fsm *MapInputSource) Uint(name string) (uint, error)
+    Int64 returns an int64 from the map if it exists otherwise returns 0
+
+func (fsm *MapInputSource) Uint64(name string) (uint64, error)
+    UInt64 returns an uint64 from the map if it exists otherwise returns 0
+
+type PathFlag struct {
+	*cli.PathFlag
+	// Has unexported fields.
+}
+    PathFlag is the flag type that wraps cli.PathFlag to allow for other values
+    to be specified
+
+func NewPathFlag(fl *cli.PathFlag) *PathFlag
+    NewPathFlag creates a new PathFlag
+
+func (f *PathFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    PathFlag.Apply
+
+func (f *PathFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a Path value to the flagSet if required
+
+type StringFlag struct {
+	*cli.StringFlag
+	// Has unexported fields.
+}
+    StringFlag is the flag type that wraps cli.StringFlag to allow for other
+    values to be specified
+
+func NewStringFlag(fl *cli.StringFlag) *StringFlag
+    NewStringFlag creates a new StringFlag
+
+func (f *StringFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    StringFlag.Apply
+
+func (f *StringFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a String value to the flagSet if required
+
+type StringSliceFlag struct {
+	*cli.StringSliceFlag
+	// Has unexported fields.
+}
+    StringSliceFlag is the flag type that wraps cli.StringSliceFlag to allow for
+    other values to be specified
+
+func NewStringSliceFlag(fl *cli.StringSliceFlag) *StringSliceFlag
+    NewStringSliceFlag creates a new StringSliceFlag
+
+func (f *StringSliceFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    StringSliceFlag.Apply
+
+func (f *StringSliceFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+    ApplyInputSourceValue applies a StringSlice value to the flagSet if required
+
+type Uint64Flag struct {
+	*cli.Uint64Flag
+	// Has unexported fields.
+}
+    Uint64Flag is the flag type that wraps cli.Uint64Flag to allow for other
+    values to be specified
+
+func NewUint64Flag(fl *cli.Uint64Flag) *Uint64Flag
+    NewUint64Flag creates a new Uint64Flag
+
+func (f *Uint64Flag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    Uint64Flag.Apply
+
+func (f *Uint64Flag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+
+type UintFlag struct {
+	*cli.UintFlag
+	// Has unexported fields.
+}
+    UintFlag is the flag type that wraps cli.UintFlag to allow for other values
+    to be specified
+
+func NewUintFlag(fl *cli.UintFlag) *UintFlag
+    NewUintFlag creates a new UintFlag
+
+func (f *UintFlag) Apply(set *flag.FlagSet) error
+    Apply saves the flagSet for later usage calls, then calls the wrapped
+    UintFlag.Apply
+
+func (f *UintFlag) ApplyInputSourceValue(cCtx *cli.Context, isc InputSourceContext) error
+

--- a/go-controller/vendor/github.com/urfave/cli/v2/help.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/help.go
@@ -10,34 +10,77 @@ import (
 	"unicode/utf8"
 )
 
-var helpCommand = &Command{
-	Name:      "help",
-	Aliases:   []string{"h"},
+const (
+	helpName  = "help"
+	helpAlias = "h"
+)
+
+// this instance is to avoid recursion in the ShowCommandHelp which can
+// add a help command again
+var helpCommandDontUse = &Command{
+	Name:      helpName,
+	Aliases:   []string{helpAlias},
 	Usage:     "Shows a list of commands or help for one command",
 	ArgsUsage: "[command]",
-	Action: func(c *Context) error {
-		args := c.Args()
-		if args.Present() {
-			return ShowCommandHelp(c, args.First())
-		}
-
-		_ = ShowAppHelp(c)
-		return nil
-	},
 }
 
-var helpSubcommand = &Command{
-	Name:      "help",
-	Aliases:   []string{"h"},
+var helpCommand = &Command{
+	Name:      helpName,
+	Aliases:   []string{helpAlias},
 	Usage:     "Shows a list of commands or help for one command",
 	ArgsUsage: "[command]",
-	Action: func(c *Context) error {
-		args := c.Args()
-		if args.Present() {
-			return ShowCommandHelp(c, args.First())
+	Action: func(cCtx *Context) error {
+		args := cCtx.Args()
+		argsPresent := args.First() != ""
+		firstArg := args.First()
+
+		// This action can be triggered by a "default" action of a command
+		// or via cmd.Run when cmd == helpCmd. So we have following possibilities
+		//
+		// 1 $ app
+		// 2 $ app help
+		// 3 $ app foo
+		// 4 $ app help foo
+		// 5 $ app foo help
+		// 6 $ app foo -h (with no other sub-commands nor flags defined)
+
+		// Case 4. when executing a help command set the context to parent
+		// to allow resolution of subsequent args. This will transform
+		// $ app help foo
+		//     to
+		// $ app foo
+		// which will then be handled as case 3
+		if cCtx.Command.Name == helpName || cCtx.Command.Name == helpAlias {
+			cCtx = cCtx.parentContext
 		}
 
-		return ShowSubcommandHelp(c)
+		// Case 4. $ app hello foo
+		// foo is the command for which help needs to be shown
+		if argsPresent {
+			return ShowCommandHelp(cCtx, firstArg)
+		}
+
+		// Case 1 & 2
+		// Special case when running help on main app itself as opposed to individual
+		// commands/subcommands
+		if cCtx.parentContext.App == nil {
+			_ = ShowAppHelp(cCtx)
+			return nil
+		}
+
+		// Case 3, 5
+		if (len(cCtx.Command.Subcommands) == 1 && !cCtx.Command.HideHelp && !cCtx.Command.HideHelpCommand) ||
+			(len(cCtx.Command.Subcommands) == 0 && cCtx.Command.HideHelp) {
+			templ := cCtx.Command.CustomHelpTemplate
+			if templ == "" {
+				templ = CommandHelpTemplate
+			}
+			HelpPrinter(cCtx.App.Writer, templ, cCtx.Command)
+			return nil
+		}
+
+		// Case 6, handling incorporated in the callee itself
+		return ShowSubcommandHelp(cCtx)
 	},
 }
 
@@ -59,6 +102,11 @@ var HelpPrinter helpPrinter = printHelp
 // HelpPrinterCustom is a function that writes the help output. It is used as
 // the default implementation of HelpPrinter, and may be called directly if
 // the ExtraInfo field is set on an App.
+//
+// In the default implementation, if the customFuncs argument contains a
+// "wrapAt" key, which is a function which takes no arguments and returns
+// an int, this int value will be used to produce a "wrap" function used
+// by the default template to wrap long lines.
 var HelpPrinterCustom helpPrinterCustom = printHelpCustom
 
 // VersionPrinter prints the version for the App
@@ -71,30 +119,30 @@ func ShowAppHelpAndExit(c *Context, exitCode int) {
 }
 
 // ShowAppHelp is an action that displays the help.
-func ShowAppHelp(c *Context) error {
-	template := c.App.CustomAppHelpTemplate
-	if template == "" {
-		template = AppHelpTemplate
+func ShowAppHelp(cCtx *Context) error {
+	tpl := cCtx.App.CustomAppHelpTemplate
+	if tpl == "" {
+		tpl = AppHelpTemplate
 	}
 
-	if c.App.ExtraInfo == nil {
-		HelpPrinter(c.App.Writer, template, c.App)
+	if cCtx.App.ExtraInfo == nil {
+		HelpPrinter(cCtx.App.Writer, tpl, cCtx.App)
 		return nil
 	}
 
 	customAppData := func() map[string]interface{} {
 		return map[string]interface{}{
-			"ExtraInfo": c.App.ExtraInfo,
+			"ExtraInfo": cCtx.App.ExtraInfo,
 		}
 	}
-	HelpPrinterCustom(c.App.Writer, template, c.App, customAppData())
+	HelpPrinterCustom(cCtx.App.Writer, tpl, cCtx.App, customAppData())
 
 	return nil
 }
 
 // DefaultAppComplete prints the list of subcommands as the default app completion method
-func DefaultAppComplete(c *Context) {
-	DefaultCompleteWithFlags(nil)(c)
+func DefaultAppComplete(cCtx *Context) {
+	DefaultCompleteWithFlags(nil)(cCtx)
 }
 
 func printCommandSuggestions(commands []*Command, writer io.Writer) {
@@ -102,7 +150,7 @@ func printCommandSuggestions(commands []*Command, writer io.Writer) {
 		if command.Hidden {
 			continue
 		}
-		if os.Getenv("_CLI_ZSH_AUTOCOMPLETE_HACK") == "1" {
+		if strings.HasSuffix(os.Getenv("SHELL"), "zsh") {
 			for _, name := range command.Names() {
 				_, _ = fmt.Fprintf(writer, "%s:%s\n", name, command.Usage)
 			}
@@ -143,7 +191,7 @@ func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
 			// this will get total count utf8 letters in flag name
 			count := utf8.RuneCountInString(name)
 			if count > 2 {
-				count = 2 // resuse this count to generate single - or -- in flag completion
+				count = 2 // reuse this count to generate single - or -- in flag completion
 			}
 			// if flag name has more than one utf8 letter and last argument in cli has -- prefix then
 			// skip flag completion for short flags example -v or -x
@@ -159,23 +207,36 @@ func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
 	}
 }
 
-func DefaultCompleteWithFlags(cmd *Command) func(c *Context) {
-	return func(c *Context) {
+func DefaultCompleteWithFlags(cmd *Command) func(cCtx *Context) {
+	return func(cCtx *Context) {
+		var lastArg string
+
+		// TODO: This shouldnt depend on os.Args rather it should
+		// depend on root arguments passed to App
 		if len(os.Args) > 2 {
-			lastArg := os.Args[len(os.Args)-2]
+			lastArg = os.Args[len(os.Args)-2]
+		}
+
+		if lastArg != "" {
 			if strings.HasPrefix(lastArg, "-") {
-				printFlagSuggestions(lastArg, c.App.Flags, c.App.Writer)
 				if cmd != nil {
-					printFlagSuggestions(lastArg, cmd.Flags, c.App.Writer)
+					printFlagSuggestions(lastArg, cmd.Flags, cCtx.App.Writer)
+
+					return
 				}
+
+				printFlagSuggestions(lastArg, cCtx.App.Flags, cCtx.App.Writer)
+
 				return
 			}
 		}
+
 		if cmd != nil {
-			printCommandSuggestions(cmd.Subcommands, c.App.Writer)
-		} else {
-			printCommandSuggestions(c.App.Commands, c.App.Writer)
+			printCommandSuggestions(cmd.Subcommands, cCtx.App.Writer)
+			return
 		}
+
+		printCommandSuggestions(cCtx.Command.Subcommands, cCtx.App.Writer)
 	}
 }
 
@@ -187,17 +248,26 @@ func ShowCommandHelpAndExit(c *Context, command string, code int) {
 
 // ShowCommandHelp prints help for the given command
 func ShowCommandHelp(ctx *Context, command string) error {
-	// show the subcommand help for a command with subcommands
-	if command == "" {
-		HelpPrinter(ctx.App.Writer, SubcommandHelpTemplate, ctx.App)
-		return nil
-	}
 
-	for _, c := range ctx.App.Commands {
+	commands := ctx.App.Commands
+	if ctx.Command.Subcommands != nil {
+		commands = ctx.Command.Subcommands
+	}
+	for _, c := range commands {
 		if c.HasName(command) {
+			if !ctx.App.HideHelpCommand && !c.HasName(helpName) && len(c.Subcommands) != 0 && c.Command(helpName) == nil {
+				c.Subcommands = append(c.Subcommands, helpCommandDontUse)
+			}
+			if !ctx.App.HideHelp && HelpFlag != nil {
+				c.appendFlag(HelpFlag)
+			}
 			templ := c.CustomHelpTemplate
 			if templ == "" {
-				templ = CommandHelpTemplate
+				if len(c.Subcommands) == 0 {
+					templ = CommandHelpTemplate
+				} else {
+					templ = SubcommandHelpTemplate
+				}
 			}
 
 			HelpPrinter(ctx.App.Writer, templ, c)
@@ -207,46 +277,59 @@ func ShowCommandHelp(ctx *Context, command string) error {
 	}
 
 	if ctx.App.CommandNotFound == nil {
-		return Exit(fmt.Sprintf("No help topic for '%v'", command), 3)
+		errMsg := fmt.Sprintf("No help topic for '%v'", command)
+		if ctx.App.Suggest && SuggestCommand != nil {
+			if suggestion := SuggestCommand(ctx.Command.Subcommands, command); suggestion != "" {
+				errMsg += ". " + suggestion
+			}
+		}
+		return Exit(errMsg, 3)
 	}
 
 	ctx.App.CommandNotFound(ctx, command)
 	return nil
 }
 
+// ShowSubcommandHelpAndExit - Prints help for the given subcommand and exits with exit code.
+func ShowSubcommandHelpAndExit(c *Context, exitCode int) {
+	_ = ShowSubcommandHelp(c)
+	os.Exit(exitCode)
+}
+
 // ShowSubcommandHelp prints help for the given subcommand
-func ShowSubcommandHelp(c *Context) error {
-	if c == nil {
+func ShowSubcommandHelp(cCtx *Context) error {
+	if cCtx == nil {
 		return nil
 	}
-
-	if c.Command != nil {
-		return ShowCommandHelp(c, c.Command.Name)
+	// use custom template when provided (fixes #1703)
+	templ := SubcommandHelpTemplate
+	if cCtx.Command != nil && cCtx.Command.CustomHelpTemplate != "" {
+		templ = cCtx.Command.CustomHelpTemplate
 	}
-
-	return ShowCommandHelp(c, "")
+	HelpPrinter(cCtx.App.Writer, templ, cCtx.Command)
+	return nil
 }
 
 // ShowVersion prints the version number of the App
-func ShowVersion(c *Context) {
-	VersionPrinter(c)
+func ShowVersion(cCtx *Context) {
+	VersionPrinter(cCtx)
 }
 
-func printVersion(c *Context) {
-	_, _ = fmt.Fprintf(c.App.Writer, "%v version %v\n", c.App.Name, c.App.Version)
+func printVersion(cCtx *Context) {
+	_, _ = fmt.Fprintf(cCtx.App.Writer, "%v version %v\n", cCtx.App.Name, cCtx.App.Version)
 }
 
 // ShowCompletions prints the lists of commands within a given context
-func ShowCompletions(c *Context) {
-	a := c.App
-	if a != nil && a.BashComplete != nil {
-		a.BashComplete(c)
+func ShowCompletions(cCtx *Context) {
+	c := cCtx.Command
+	if c != nil && c.BashComplete != nil {
+		c.BashComplete(cCtx)
 	}
 }
 
 // ShowCommandCompletions prints the custom completions for a given command
 func ShowCommandCompletions(ctx *Context, command string) {
-	c := ctx.App.Command(command)
+	c := ctx.Command.Command(command)
 	if c != nil {
 		if c.BashComplete != nil {
 			c.BashComplete(ctx)
@@ -262,15 +345,57 @@ func ShowCommandCompletions(ctx *Context, command string) {
 // The customFuncs map will be combined with a default template.FuncMap to
 // allow using arbitrary functions in template rendering.
 func printHelpCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
+
+	const maxLineLength = 10000
+
 	funcMap := template.FuncMap{
-		"join": strings.Join,
+		"join":           strings.Join,
+		"subtract":       subtract,
+		"indent":         indent,
+		"nindent":        nindent,
+		"trim":           strings.TrimSpace,
+		"wrap":           func(input string, offset int) string { return wrap(input, offset, maxLineLength) },
+		"offset":         offset,
+		"offsetCommands": offsetCommands,
 	}
+
+	if customFuncs["wrapAt"] != nil {
+		if wa, ok := customFuncs["wrapAt"]; ok {
+			if waf, ok := wa.(func() int); ok {
+				wrapAt := waf()
+				customFuncs["wrap"] = func(input string, offset int) string {
+					return wrap(input, offset, wrapAt)
+				}
+			}
+		}
+	}
+
 	for key, value := range customFuncs {
 		funcMap[key] = value
 	}
 
 	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)
 	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
+	templates := map[string]string{
+		"helpNameTemplate":                  helpNameTemplate,
+		"usageTemplate":                     usageTemplate,
+		"descriptionTemplate":               descriptionTemplate,
+		"visibleCommandTemplate":            visibleCommandTemplate,
+		"copyrightTemplate":                 copyrightTemplate,
+		"versionTemplate":                   versionTemplate,
+		"visibleFlagCategoryTemplate":       visibleFlagCategoryTemplate,
+		"visibleFlagTemplate":               visibleFlagTemplate,
+		"visibleGlobalFlagCategoryTemplate": strings.Replace(visibleFlagCategoryTemplate, "OPTIONS", "GLOBAL OPTIONS", -1),
+		"authorsTemplate":                   authorsTemplate,
+		"visibleCommandCategoryTemplate":    visibleCommandCategoryTemplate,
+	}
+	for name, value := range templates {
+		if _, err := t.New(name).Parse(value); err != nil {
+			if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
+				_, _ = fmt.Fprintf(ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
+			}
+		}
+	}
 
 	err := t.Execute(w, data)
 	if err != nil {
@@ -288,42 +413,29 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 	HelpPrinterCustom(out, templ, data, nil)
 }
 
-func checkVersion(c *Context) bool {
+func checkVersion(cCtx *Context) bool {
 	found := false
 	for _, name := range VersionFlag.Names() {
-		if c.Bool(name) {
+		if cCtx.Bool(name) {
 			found = true
 		}
 	}
 	return found
 }
 
-func checkHelp(c *Context) bool {
+func checkHelp(cCtx *Context) bool {
+	if HelpFlag == nil {
+		return false
+	}
 	found := false
 	for _, name := range HelpFlag.Names() {
-		if c.Bool(name) {
+		if cCtx.Bool(name) {
 			found = true
+			break
 		}
 	}
+
 	return found
-}
-
-func checkCommandHelp(c *Context, name string) bool {
-	if c.Bool("h") || c.Bool("help") {
-		_ = ShowCommandHelp(c, name)
-		return true
-	}
-
-	return false
-}
-
-func checkSubcommandHelp(c *Context) bool {
-	if c.Bool("h") || c.Bool("help") {
-		_ = ShowSubcommandHelp(c)
-		return true
-	}
-
-	return false
 }
 
 func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
@@ -341,28 +453,112 @@ func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
 	return true, arguments[:pos]
 }
 
-func checkCompletions(c *Context) bool {
-	if !c.shellComplete {
+func checkCompletions(cCtx *Context) bool {
+	if !cCtx.shellComplete {
 		return false
 	}
 
-	if args := c.Args(); args.Present() {
+	if args := cCtx.Args(); args.Present() {
 		name := args.First()
-		if cmd := c.App.Command(name); cmd != nil {
+		if cmd := cCtx.Command.Command(name); cmd != nil {
 			// let the command handle the completion
 			return false
 		}
 	}
 
-	ShowCompletions(c)
+	ShowCompletions(cCtx)
 	return true
 }
 
-func checkCommandCompletions(c *Context, name string) bool {
-	if !c.shellComplete {
-		return false
+func subtract(a, b int) int {
+	return a - b
+}
+
+func indent(spaces int, v string) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+}
+
+func nindent(spaces int, v string) string {
+	return "\n" + indent(spaces, v)
+}
+
+func wrap(input string, offset int, wrapAt int) string {
+	var ss []string
+
+	lines := strings.Split(input, "\n")
+
+	padding := strings.Repeat(" ", offset)
+
+	for i, line := range lines {
+		if line == "" {
+			ss = append(ss, line)
+		} else {
+			wrapped := wrapLine(line, offset, wrapAt, padding)
+			if i == 0 {
+				ss = append(ss, wrapped)
+			} else {
+				ss = append(ss, padding+wrapped)
+
+			}
+
+		}
 	}
 
-	ShowCommandCompletions(c, name)
-	return true
+	return strings.Join(ss, "\n")
+}
+
+func wrapLine(input string, offset int, wrapAt int, padding string) string {
+	if wrapAt <= offset || len(input) <= wrapAt-offset {
+		return input
+	}
+
+	lineWidth := wrapAt - offset
+	words := strings.Fields(input)
+	if len(words) == 0 {
+		return input
+	}
+
+	wrapped := words[0]
+	spaceLeft := lineWidth - len(wrapped)
+	for _, word := range words[1:] {
+		if len(word)+1 > spaceLeft {
+			wrapped += "\n" + padding + word
+			spaceLeft = lineWidth - len(word)
+		} else {
+			wrapped += " " + word
+			spaceLeft -= 1 + len(word)
+		}
+	}
+
+	return wrapped
+}
+
+func offset(input string, fixed int) int {
+	return len(input) + fixed
+}
+
+// this function tries to find the max width of the names column
+// so say we have the following rows for help
+//
+//	foo1, foo2, foo3  some string here
+//	bar1, b2 some other string here
+//
+// We want to offset the 2nd row usage by some amount so that everything
+// is aligned
+//
+//	foo1, foo2, foo3  some string here
+//	bar1, b2          some other string here
+//
+// to find that offset we find the length of all the rows and use the max
+// to calculate the offset
+func offsetCommands(cmds []*Command, fixed int) int {
+	var max int = 0
+	for _, cmd := range cmds {
+		s := strings.Join(cmd.Names(), ", ")
+		if len(s) > max {
+			max = len(s)
+		}
+	}
+	return max + fixed
 }

--- a/go-controller/vendor/github.com/urfave/cli/v2/mkdocs-reqs.txt
+++ b/go-controller/vendor/github.com/urfave/cli/v2/mkdocs-reqs.txt
@@ -1,0 +1,5 @@
+mkdocs-git-revision-date-localized-plugin~=1.0
+mkdocs-material-extensions~=1.0
+mkdocs-material~=8.2
+mkdocs~=1.3
+pygments~=2.12

--- a/go-controller/vendor/github.com/urfave/cli/v2/mkdocs.yml
+++ b/go-controller/vendor/github.com/urfave/cli/v2/mkdocs.yml
@@ -1,0 +1,107 @@
+# NOTE: the mkdocs dependencies will need to be installed out of
+# band until this whole thing gets more automated:
+#
+#     pip install -r mkdocs-reqs.txt
+#
+
+site_name: urfave/cli
+site_url: https://cli.urfave.org/
+repo_url: https://github.com/urfave/cli
+edit_uri: edit/main/docs/
+nav:
+  - Home:
+      - Welcome: index.md
+      - Contributing: CONTRIBUTING.md
+      - Code of Conduct: CODE_OF_CONDUCT.md
+      - Releasing: RELEASING.md
+      - Security: SECURITY.md
+      - Migrate v1 to v2: migrate-v1-to-v2.md
+  - v2 Manual:
+      - Getting Started: v2/getting-started.md
+      - Migrating From Older Releases: v2/migrating-from-older-releases.md
+      - Examples:
+          - Greet: v2/examples/greet.md
+          - Arguments: v2/examples/arguments.md
+          - Flags: v2/examples/flags.md
+          - Subcommands: v2/examples/subcommands.md
+          - Subcommands Categories: v2/examples/subcommands-categories.md
+          - Exit Codes: v2/examples/exit-codes.md
+          - Combining Short Options: v2/examples/combining-short-options.md
+          - Bash Completions: v2/examples/bash-completions.md
+          - Generated Help Text: v2/examples/generated-help-text.md
+          - Version Flag: v2/examples/version-flag.md
+          - Timestamp Flag: v2/examples/timestamp-flag.md
+          - Suggestions: v2/examples/suggestions.md
+          - Full API Example: v2/examples/full-api-example.md
+  - v1 Manual:
+      - Getting Started: v1/getting-started.md
+      - Migrating to v2: v1/migrating-to-v2.md
+      - Examples:
+          - Greet: v1/examples/greet.md
+          - Arguments: v1/examples/arguments.md
+          - Flags: v1/examples/flags.md
+          - Subcommands: v1/examples/subcommands.md
+          - Subcommands (Categories): v1/examples/subcommands-categories.md
+          - Exit Codes: v1/examples/exit-codes.md
+          - Combining Short Options: v1/examples/combining-short-options.md
+          - Bash Completions: v1/examples/bash-completions.md
+          - Generated Help Text: v1/examples/generated-help-text.md
+          - Version Flag: v1/examples/version-flag.md
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-4
+        name: dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-7
+        name: light mode
+  features:
+    - content.code.annotate
+    - navigation.top
+    - navigation.instant
+    - navigation.expand
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+plugins:
+  - git-revision-date-localized
+  - search
+  - tags
+# NOTE: this is the recommended configuration from
+# https://squidfunk.github.io/mkdocs-material/setup/extensions/#recommended-configuration
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - meta
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde

--- a/go-controller/vendor/github.com/urfave/cli/v2/sliceflag.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/sliceflag.go
@@ -1,0 +1,290 @@
+package cli
+
+import (
+	"flag"
+	"reflect"
+)
+
+type (
+	// SliceFlag extends implementations like StringSliceFlag and IntSliceFlag with support for using slices directly,
+	// as Value and/or Destination.
+	// See also SliceFlagTarget, MultiStringFlag, MultiFloat64Flag, MultiInt64Flag, MultiIntFlag.
+	SliceFlag[T SliceFlagTarget[E], S ~[]E, E any] struct {
+		Target      T
+		Value       S
+		Destination *S
+	}
+
+	// SliceFlagTarget models a target implementation for use with SliceFlag.
+	// The three methods, SetValue, SetDestination, and GetDestination, are necessary to propagate Value and
+	// Destination, where Value is propagated inwards (initially), and Destination is propagated outwards (on every
+	// update).
+	SliceFlagTarget[E any] interface {
+		Flag
+		RequiredFlag
+		DocGenerationFlag
+		VisibleFlag
+		CategorizableFlag
+
+		// SetValue should propagate the given slice to the target, ideally as a new value.
+		// Note that a nil slice should nil/clear any existing value (modelled as ~[]E).
+		SetValue(slice []E)
+		// SetDestination should propagate the given slice to the target, ideally as a new value.
+		// Note that a nil slice should nil/clear any existing value (modelled as ~*[]E).
+		SetDestination(slice []E)
+		// GetDestination should return the current value referenced by any destination, or nil if nil/unset.
+		GetDestination() []E
+	}
+
+	// MultiStringFlag extends StringSliceFlag with support for using slices directly, as Value and/or Destination.
+	// See also SliceFlag.
+	MultiStringFlag = SliceFlag[*StringSliceFlag, []string, string]
+
+	// MultiFloat64Flag extends Float64SliceFlag with support for using slices directly, as Value and/or Destination.
+	// See also SliceFlag.
+	MultiFloat64Flag = SliceFlag[*Float64SliceFlag, []float64, float64]
+
+	// MultiInt64Flag extends Int64SliceFlag with support for using slices directly, as Value and/or Destination.
+	// See also SliceFlag.
+	MultiInt64Flag = SliceFlag[*Int64SliceFlag, []int64, int64]
+
+	// MultiIntFlag extends IntSliceFlag with support for using slices directly, as Value and/or Destination.
+	// See also SliceFlag.
+	MultiIntFlag = SliceFlag[*IntSliceFlag, []int, int]
+
+	flagValueHook struct {
+		value Generic
+		hook  func()
+	}
+)
+
+var (
+	// compile time assertions
+
+	_ SliceFlagTarget[string]  = (*StringSliceFlag)(nil)
+	_ SliceFlagTarget[string]  = (*SliceFlag[*StringSliceFlag, []string, string])(nil)
+	_ SliceFlagTarget[string]  = (*MultiStringFlag)(nil)
+	_ SliceFlagTarget[float64] = (*MultiFloat64Flag)(nil)
+	_ SliceFlagTarget[int64]   = (*MultiInt64Flag)(nil)
+	_ SliceFlagTarget[int]     = (*MultiIntFlag)(nil)
+
+	_ Generic    = (*flagValueHook)(nil)
+	_ Serializer = (*flagValueHook)(nil)
+)
+
+func (x *SliceFlag[T, S, E]) Apply(set *flag.FlagSet) error {
+	x.Target.SetValue(x.convertSlice(x.Value))
+
+	destination := x.Destination
+	if destination == nil {
+		x.Target.SetDestination(nil)
+
+		return x.Target.Apply(set)
+	}
+
+	x.Target.SetDestination(x.convertSlice(*destination))
+
+	return applyFlagValueHook(set, x.Target.Apply, func() {
+		*destination = x.Target.GetDestination()
+	})
+}
+
+func (x *SliceFlag[T, S, E]) convertSlice(slice S) []E {
+	result := make([]E, len(slice))
+	copy(result, slice)
+	return result
+}
+
+func (x *SliceFlag[T, S, E]) SetValue(slice S) {
+	x.Value = slice
+}
+
+func (x *SliceFlag[T, S, E]) SetDestination(slice S) {
+	if slice != nil {
+		x.Destination = &slice
+	} else {
+		x.Destination = nil
+	}
+}
+
+func (x *SliceFlag[T, S, E]) GetDestination() S {
+	if destination := x.Destination; destination != nil {
+		return *destination
+	}
+	return nil
+}
+
+func (x *SliceFlag[T, S, E]) String() string         { return x.Target.String() }
+func (x *SliceFlag[T, S, E]) Names() []string        { return x.Target.Names() }
+func (x *SliceFlag[T, S, E]) IsSet() bool            { return x.Target.IsSet() }
+func (x *SliceFlag[T, S, E]) IsRequired() bool       { return x.Target.IsRequired() }
+func (x *SliceFlag[T, S, E]) TakesValue() bool       { return x.Target.TakesValue() }
+func (x *SliceFlag[T, S, E]) GetUsage() string       { return x.Target.GetUsage() }
+func (x *SliceFlag[T, S, E]) GetValue() string       { return x.Target.GetValue() }
+func (x *SliceFlag[T, S, E]) GetDefaultText() string { return x.Target.GetDefaultText() }
+func (x *SliceFlag[T, S, E]) GetEnvVars() []string   { return x.Target.GetEnvVars() }
+func (x *SliceFlag[T, S, E]) IsVisible() bool        { return x.Target.IsVisible() }
+func (x *SliceFlag[T, S, E]) GetCategory() string    { return x.Target.GetCategory() }
+
+func (x *flagValueHook) Set(value string) error {
+	if err := x.value.Set(value); err != nil {
+		return err
+	}
+	x.hook()
+	return nil
+}
+
+func (x *flagValueHook) String() string {
+	// note: this is necessary due to the way Go's flag package handles defaults
+	isZeroValue := func(f flag.Value, v string) bool {
+		/*
+			https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/flag/flag.go;drc=2580d0e08d5e9f979b943758d3c49877fb2324cb;l=453
+
+			Copyright (c) 2009 The Go Authors. All rights reserved.
+			Redistribution and use in source and binary forms, with or without
+			modification, are permitted provided that the following conditions are
+			met:
+			   * Redistributions of source code must retain the above copyright
+			notice, this list of conditions and the following disclaimer.
+			   * Redistributions in binary form must reproduce the above
+			copyright notice, this list of conditions and the following disclaimer
+			in the documentation and/or other materials provided with the
+			distribution.
+			   * Neither the name of Google Inc. nor the names of its
+			contributors may be used to endorse or promote products derived from
+			this software without specific prior written permission.
+			THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+			"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+			LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+			A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+			OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+			SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+			LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+			DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+			THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+			(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+			OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+		*/
+		// Build a zero value of the flag's Value type, and see if the
+		// result of calling its String method equals the value passed in.
+		// This works unless the Value type is itself an interface type.
+		typ := reflect.TypeOf(f)
+		var z reflect.Value
+		if typ.Kind() == reflect.Pointer {
+			z = reflect.New(typ.Elem())
+		} else {
+			z = reflect.Zero(typ)
+		}
+		return v == z.Interface().(flag.Value).String()
+	}
+	if x.value != nil {
+		// only return non-empty if not the same string as returned by the zero value
+		if s := x.value.String(); !isZeroValue(x.value, s) {
+			return s
+		}
+	}
+	return ``
+}
+
+func (x *flagValueHook) Serialize() string {
+	if value, ok := x.value.(Serializer); ok {
+		return value.Serialize()
+	}
+	return x.String()
+}
+
+// applyFlagValueHook wraps calls apply then wraps flags to call a hook function on update and after initial apply.
+func applyFlagValueHook(set *flag.FlagSet, apply func(set *flag.FlagSet) error, hook func()) error {
+	if apply == nil || set == nil || hook == nil {
+		panic(`invalid input`)
+	}
+	var tmp flag.FlagSet
+	if err := apply(&tmp); err != nil {
+		return err
+	}
+	tmp.VisitAll(func(f *flag.Flag) { set.Var(&flagValueHook{value: f.Value, hook: hook}, f.Name, f.Usage) })
+	hook()
+	return nil
+}
+
+// newSliceFlagValue is for implementing SliceFlagTarget.SetValue and SliceFlagTarget.SetDestination.
+// It's e.g. as part of StringSliceFlag.SetValue, using the factory NewStringSlice.
+func newSliceFlagValue[R any, S ~[]E, E any](factory func(defaults ...E) *R, defaults S) *R {
+	if defaults == nil {
+		return nil
+	}
+	return factory(defaults...)
+}
+
+// unwrapFlagValue strips any/all *flagValueHook wrappers.
+func unwrapFlagValue(v flag.Value) flag.Value {
+	for {
+		h, ok := v.(*flagValueHook)
+		if !ok {
+			return v
+		}
+		v = h.value
+	}
+}
+
+// NOTE: the methods below are in this file to make use of the build constraint
+
+func (f *Float64SliceFlag) SetValue(slice []float64) {
+	f.Value = newSliceFlagValue(NewFloat64Slice, slice)
+}
+
+func (f *Float64SliceFlag) SetDestination(slice []float64) {
+	f.Destination = newSliceFlagValue(NewFloat64Slice, slice)
+}
+
+func (f *Float64SliceFlag) GetDestination() []float64 {
+	if destination := f.Destination; destination != nil {
+		return destination.Value()
+	}
+	return nil
+}
+
+func (f *Int64SliceFlag) SetValue(slice []int64) {
+	f.Value = newSliceFlagValue(NewInt64Slice, slice)
+}
+
+func (f *Int64SliceFlag) SetDestination(slice []int64) {
+	f.Destination = newSliceFlagValue(NewInt64Slice, slice)
+}
+
+func (f *Int64SliceFlag) GetDestination() []int64 {
+	if destination := f.Destination; destination != nil {
+		return destination.Value()
+	}
+	return nil
+}
+
+func (f *IntSliceFlag) SetValue(slice []int) {
+	f.Value = newSliceFlagValue(NewIntSlice, slice)
+}
+
+func (f *IntSliceFlag) SetDestination(slice []int) {
+	f.Destination = newSliceFlagValue(NewIntSlice, slice)
+}
+
+func (f *IntSliceFlag) GetDestination() []int {
+	if destination := f.Destination; destination != nil {
+		return destination.Value()
+	}
+	return nil
+}
+
+func (f *StringSliceFlag) SetValue(slice []string) {
+	f.Value = newSliceFlagValue(NewStringSlice, slice)
+}
+
+func (f *StringSliceFlag) SetDestination(slice []string) {
+	f.Destination = newSliceFlagValue(NewStringSlice, slice)
+}
+
+func (f *StringSliceFlag) GetDestination() []string {
+	if destination := f.Destination; destination != nil {
+		return destination.Value()
+	}
+	return nil
+}

--- a/go-controller/vendor/github.com/urfave/cli/v2/suggestions.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/suggestions.go
@@ -1,0 +1,68 @@
+//go:build !urfave_cli_no_suggest
+// +build !urfave_cli_no_suggest
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/xrash/smetrics"
+)
+
+func init() {
+	SuggestFlag = suggestFlag
+	SuggestCommand = suggestCommand
+}
+
+func jaroWinkler(a, b string) float64 {
+	// magic values are from https://github.com/xrash/smetrics/blob/039620a656736e6ad994090895784a7af15e0b80/jaro-winkler.go#L8
+	const (
+		boostThreshold = 0.7
+		prefixSize     = 4
+	)
+	return smetrics.JaroWinkler(a, b, boostThreshold, prefixSize)
+}
+
+func suggestFlag(flags []Flag, provided string, hideHelp bool) string {
+	distance := 0.0
+	suggestion := ""
+
+	for _, flag := range flags {
+		flagNames := flag.Names()
+		if !hideHelp && HelpFlag != nil {
+			flagNames = append(flagNames, HelpFlag.Names()...)
+		}
+		for _, name := range flagNames {
+			newDistance := jaroWinkler(name, provided)
+			if newDistance > distance {
+				distance = newDistance
+				suggestion = name
+			}
+		}
+	}
+
+	if len(suggestion) == 1 {
+		suggestion = "-" + suggestion
+	} else if len(suggestion) > 1 {
+		suggestion = "--" + suggestion
+	}
+
+	return suggestion
+}
+
+// suggestCommand takes a list of commands and a provided string to suggest a
+// command name
+func suggestCommand(commands []*Command, provided string) (suggestion string) {
+	distance := 0.0
+	for _, command := range commands {
+		for _, name := range append(command.Names(), helpName, helpAlias) {
+			newDistance := jaroWinkler(name, provided)
+			if newDistance > distance {
+				distance = newDistance
+				suggestion = name
+			}
+		}
+	}
+
+	return fmt.Sprintf(SuggestDidYouMeanTemplate, suggestion)
+}

--- a/go-controller/vendor/github.com/urfave/cli/v2/template.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/template.go
@@ -1,82 +1,103 @@
 package cli
 
+var helpNameTemplate = `{{$v := offset .HelpName 6}}{{wrap .HelpName 3}}{{if .Usage}} - {{wrap .Usage $v}}{{end}}`
+var usageTemplate = `{{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}}{{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}`
+var descriptionTemplate = `{{wrap .Description 3}}`
+var authorsTemplate = `{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
+   {{range $index, $author := .Authors}}{{if $index}}
+   {{end}}{{$author}}{{end}}`
+var visibleCommandTemplate = `{{ $cv := offsetCommands .VisibleCommands 5}}{{range .VisibleCommands}}
+   {{$s := join .Names ", "}}{{$s}}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}}{{wrap .Usage $cv}}{{end}}`
+var visibleCommandCategoryTemplate = `{{range .VisibleCategories}}{{if .Name}}
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{template "visibleCommandTemplate" .}}{{end}}{{end}}`
+var visibleFlagCategoryTemplate = `{{range .VisibleFlagCategories}}
+   {{if .Name}}{{.Name}}
+
+   {{end}}{{$flglen := len .Flags}}{{range $i, $e := .Flags}}{{if eq (subtract $flglen $i) 1}}{{$e}}
+{{else}}{{$e}}
+   {{end}}{{end}}{{end}}`
+
+var visibleFlagTemplate = `{{range $i, $e := .VisibleFlags}}
+   {{wrap $e.String 6}}{{end}}`
+
+var versionTemplate = `{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}`
+
+var copyrightTemplate = `{{wrap .Copyright 3}}`
+
 // AppHelpTemplate is the text template for the Default help topic.
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var AppHelpTemplate = `NAME:
-   {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
+   {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}}[arguments...]{{end}}{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
 
 VERSION:
    {{.Version}}{{end}}{{end}}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{if len .Authors}}
+   {{template "descriptionTemplate" .}}{{end}}
+{{- if len .Authors}}
 
-AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
-   {{range $index, $author := .Authors}}{{if $index}}
-   {{end}}{{$author}}{{end}}{{end}}{{if .VisibleCommands}}
+AUTHOR{{template "authorsTemplate" .}}{{end}}{{if .VisibleCommands}}
 
-COMMANDS:{{range .VisibleCategories}}{{if .Name}}
-   {{.Name}}:{{range .VisibleCommands}}
-     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
-   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
 
-GLOBAL OPTIONS:
-   {{range $index, $option := .VisibleFlags}}{{if $index}}
-   {{end}}{{$option}}{{end}}{{end}}{{if .Copyright}}
+GLOBAL OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+GLOBAL OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}{{if .Copyright}}
 
 COPYRIGHT:
-   {{.Copyright}}{{end}}
+   {{template "copyrightTemplate" .}}{{end}}
 `
 
 // CommandHelpTemplate is the text template for the command help topic.
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var CommandHelpTemplate = `NAME:
-   {{.HelpName}} - {{.Usage}}
+   {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
+   {{template "usageTemplate" .}}{{if .Category}}
 
 CATEGORY:
    {{.Category}}{{end}}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}{{if .VisibleFlags}}
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
 
-OPTIONS:
-   {{range .VisibleFlags}}{{.}}
-   {{end}}{{end}}
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 `
 
 // SubcommandHelpTemplate is the text template for the subcommand help topic.
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var SubcommandHelpTemplate = `NAME:
-   {{.HelpName}} - {{.Usage}}
+   {{template "helpNameTemplate" .}}
 
 USAGE:
-   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Description}}
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}} {{if .VisibleFlags}}command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}}[arguments...]{{end}}{{end}}{{end}}{{if .Description}}
 
 DESCRIPTION:
-   {{.Description}}{{end}}
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleCommands}}
 
-COMMANDS:{{range .VisibleCategories}}{{if .Name}}
-   {{.Name}}:{{range .VisibleCommands}}
-     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
-   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+COMMANDS:{{template "visibleCommandCategoryTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
 
-OPTIONS:
-   {{range .VisibleFlags}}{{.}}
-   {{end}}{{end}}
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{template "visibleFlagTemplate" .}}{{end}}
 `
 
-var MarkdownDocTemplate = `% {{ .App.Name }} 8
+var MarkdownDocTemplate = `{{if gt .SectionNum 0}}% {{ .App.Name }} {{ .SectionNum }}
 
-# NAME
+{{end}}# NAME
 
 {{ .App.Name }}{{ if .App.Usage }} - {{ .App.Usage }}{{ end }}
 
@@ -86,16 +107,18 @@ var MarkdownDocTemplate = `% {{ .App.Name }} 8
 {{ if .SynopsisArgs }}
 ` + "```" + `
 {{ range $v := .SynopsisArgs }}{{ $v }}{{ end }}` + "```" + `
-{{ end }}{{ if .App.UsageText }}
+{{ end }}{{ if .App.Description }}
 # DESCRIPTION
 
-{{ .App.UsageText }}
+{{ .App.Description }}
 {{ end }}
 **Usage**:
 
-` + "```" + `
+` + "```" + `{{ if .App.UsageText }}
+{{ .App.UsageText }}
+{{ else }}
 {{ .App.Name }} [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
-` + "```" + `
+{{ end }}` + "```" + `
 {{ if .GlobalArgs }}
 # GLOBAL OPTIONS
 {{ range $v := .GlobalArgs }}

--- a/go-controller/vendor/github.com/urfave/cli/v2/zz_generated.flags.go
+++ b/go-controller/vendor/github.com/urfave/cli/v2/zz_generated.flags.go
@@ -1,0 +1,865 @@
+// WARNING: this file is generated. DO NOT EDIT
+
+package cli
+
+import "time"
+
+// Float64SliceFlag is a flag with type *Float64Slice
+type Float64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Float64Slice
+	Destination *Float64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *Float64Slice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []float64) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Float64SliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Float64SliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Float64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Float64SliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// GenericFlag is a flag with type Generic
+type GenericFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       Generic
+	Destination Generic
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    Generic
+	defaultValueSet bool
+
+	TakesFile bool
+
+	Action func(*Context, interface{}) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *GenericFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *GenericFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *GenericFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *GenericFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *GenericFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Int64SliceFlag is a flag with type *Int64Slice
+type Int64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Int64Slice
+	Destination *Int64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *Int64Slice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []int64) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Int64SliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Int64SliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Int64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Int64SliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// IntSliceFlag is a flag with type *IntSlice
+type IntSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *IntSlice
+	Destination *IntSlice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *IntSlice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []int) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *IntSliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *IntSliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *IntSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *IntSliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// PathFlag is a flag with type Path
+type PathFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       Path
+	Destination *Path
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    Path
+	defaultValueSet bool
+
+	TakesFile bool
+
+	Action func(*Context, Path) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *PathFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *PathFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *PathFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *PathFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *PathFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// StringSliceFlag is a flag with type *StringSlice
+type StringSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *StringSlice
+	Destination *StringSlice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *StringSlice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	TakesFile bool
+
+	Action func(*Context, []string) error
+
+	KeepSpace bool
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *StringSliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *StringSliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *StringSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *StringSliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// TimestampFlag is a flag with type *Timestamp
+type TimestampFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Timestamp
+	Destination *Timestamp
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *Timestamp
+	defaultValueSet bool
+
+	Layout string
+
+	Timezone *time.Location
+
+	Action func(*Context, *time.Time) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *TimestampFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *TimestampFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *TimestampFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *TimestampFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *TimestampFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Uint64SliceFlag is a flag with type *Uint64Slice
+type Uint64SliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *Uint64Slice
+	Destination *Uint64Slice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *Uint64Slice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []uint64) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Uint64SliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Uint64SliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Uint64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Uint64SliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// UintSliceFlag is a flag with type *UintSlice
+type UintSliceFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       *UintSlice
+	Destination *UintSlice
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    *UintSlice
+	defaultValueSet bool
+
+	separator separatorSpec
+
+	Action func(*Context, []uint) error
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *UintSliceFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *UintSliceFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *UintSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *UintSliceFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// BoolFlag is a flag with type bool
+type BoolFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       bool
+	Destination *bool
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    bool
+	defaultValueSet bool
+
+	Count *int
+
+	DisableDefaultText bool
+
+	Action func(*Context, bool) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *BoolFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *BoolFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *BoolFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *BoolFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *BoolFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Float64Flag is a flag with type float64
+type Float64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       float64
+	Destination *float64
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    float64
+	defaultValueSet bool
+
+	Action func(*Context, float64) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Float64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Float64Flag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Float64Flag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Float64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Float64Flag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// IntFlag is a flag with type int
+type IntFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       int
+	Destination *int
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    int
+	defaultValueSet bool
+
+	Base int
+
+	Action func(*Context, int) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *IntFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *IntFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *IntFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *IntFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *IntFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Int64Flag is a flag with type int64
+type Int64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       int64
+	Destination *int64
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    int64
+	defaultValueSet bool
+
+	Base int
+
+	Action func(*Context, int64) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Int64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Int64Flag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Int64Flag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Int64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Int64Flag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// StringFlag is a flag with type string
+type StringFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       string
+	Destination *string
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    string
+	defaultValueSet bool
+
+	TakesFile bool
+
+	Action func(*Context, string) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *StringFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *StringFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *StringFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *StringFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *StringFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// DurationFlag is a flag with type time.Duration
+type DurationFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       time.Duration
+	Destination *time.Duration
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    time.Duration
+	defaultValueSet bool
+
+	Action func(*Context, time.Duration) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *DurationFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *DurationFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *DurationFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *DurationFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *DurationFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// UintFlag is a flag with type uint
+type UintFlag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       uint
+	Destination *uint
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    uint
+	defaultValueSet bool
+
+	Base int
+
+	Action func(*Context, uint) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *UintFlag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *UintFlag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *UintFlag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *UintFlag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *UintFlag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// Uint64Flag is a flag with type uint64
+type Uint64Flag struct {
+	Name string
+
+	Category    string
+	DefaultText string
+	FilePath    string
+	Usage       string
+
+	Required   bool
+	Hidden     bool
+	HasBeenSet bool
+
+	Value       uint64
+	Destination *uint64
+
+	Aliases []string
+	EnvVars []string
+
+	defaultValue    uint64
+	defaultValueSet bool
+
+	Base int
+
+	Action func(*Context, uint64) error
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Uint64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// IsSet returns whether or not the flag has been set through env or file
+func (f *Uint64Flag) IsSet() bool {
+	return f.HasBeenSet
+}
+
+// Names returns the names of the flag
+func (f *Uint64Flag) Names() []string {
+	return FlagNames(f.Name, f.Aliases)
+}
+
+// IsRequired returns whether or not the flag is required
+func (f *Uint64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// IsVisible returns true if the flag is not hidden, otherwise false
+func (f *Uint64Flag) IsVisible() bool {
+	return !f.Hidden
+}
+
+// vim:ro

--- a/go-controller/vendor/github.com/xrash/smetrics/.travis.yml
+++ b/go-controller/vendor/github.com/xrash/smetrics/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+    - 1.11
+    - 1.12
+    - 1.13
+    - 1.14.x
+    - master
+script:
+    - cd tests && make

--- a/go-controller/vendor/github.com/xrash/smetrics/LICENSE
+++ b/go-controller/vendor/github.com/xrash/smetrics/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2016 Felipe da Cunha Gonçalves
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/go-controller/vendor/github.com/xrash/smetrics/README.md
+++ b/go-controller/vendor/github.com/xrash/smetrics/README.md
@@ -1,0 +1,49 @@
+[![Build Status](https://travis-ci.org/xrash/smetrics.svg?branch=master)](http://travis-ci.org/xrash/smetrics)
+
+# smetrics
+
+`smetrics` is "string metrics".
+
+Package smetrics provides a bunch of algorithms for calculating the distance between strings.
+
+There are implementations for calculating the popular Levenshtein distance (aka Edit Distance or Wagner-Fischer), as well as the Jaro distance, the Jaro-Winkler distance, and more.
+
+# How to import
+
+```go
+import "github.com/xrash/smetrics"
+```
+
+# Documentation
+
+Go to [https://pkg.go.dev/github.com/xrash/smetrics](https://pkg.go.dev/github.com/xrash/smetrics) for complete documentation.
+
+# Example
+
+```go
+package main
+
+import (
+	"github.com/xrash/smetrics"
+)
+
+func main() {
+	smetrics.WagnerFischer("POTATO", "POTATTO", 1, 1, 2)
+	smetrics.WagnerFischer("MOUSE", "HOUSE", 2, 2, 4)
+
+	smetrics.Ukkonen("POTATO", "POTATTO", 1, 1, 2)
+	smetrics.Ukkonen("MOUSE", "HOUSE", 2, 2, 4)
+
+	smetrics.Jaro("AL", "AL")
+	smetrics.Jaro("MARTHA", "MARHTA")
+
+	smetrics.JaroWinkler("AL", "AL", 0.7, 4)
+	smetrics.JaroWinkler("MARTHA", "MARHTA", 0.7, 4)
+
+	smetrics.Soundex("Euler")
+	smetrics.Soundex("Ellery")
+
+	smetrics.Hamming("aaa", "aaa")
+	smetrics.Hamming("aaa", "aab")
+}
+```

--- a/go-controller/vendor/github.com/xrash/smetrics/doc.go
+++ b/go-controller/vendor/github.com/xrash/smetrics/doc.go
@@ -1,0 +1,19 @@
+/*
+Package smetrics provides a bunch of algorithms for calculating
+the distance between strings.
+
+There are implementations for calculating the popular Levenshtein
+distance (aka Edit Distance or Wagner-Fischer), as well as the Jaro
+distance, the Jaro-Winkler distance, and more.
+
+For the Levenshtein distance, you can use the functions WagnerFischer()
+and Ukkonen(). Read the documentation on these functions.
+
+For the Jaro and Jaro-Winkler algorithms, check the functions
+Jaro() and JaroWinkler(). Read the documentation on these functions.
+
+For the Soundex algorithm, check the function Soundex().
+
+For the Hamming distance algorithm, check the function Hamming().
+*/
+package smetrics

--- a/go-controller/vendor/github.com/xrash/smetrics/hamming.go
+++ b/go-controller/vendor/github.com/xrash/smetrics/hamming.go
@@ -1,0 +1,25 @@
+package smetrics
+
+import (
+	"fmt"
+)
+
+// The Hamming distance is the minimum number of substitutions required to change string A into string B. Both strings must have the same size. If the strings have different sizes, the function returns an error.
+func Hamming(a, b string) (int, error) {
+	al := len(a)
+	bl := len(b)
+
+	if al != bl {
+		return -1, fmt.Errorf("strings are not equal (len(a)=%d, len(b)=%d)", al, bl)
+	}
+
+	var difference = 0
+
+	for i := range a {
+		if a[i] != b[i] {
+			difference = difference + 1
+		}
+	}
+
+	return difference, nil
+}

--- a/go-controller/vendor/github.com/xrash/smetrics/jaro-winkler.go
+++ b/go-controller/vendor/github.com/xrash/smetrics/jaro-winkler.go
@@ -1,0 +1,28 @@
+package smetrics
+
+import (
+	"math"
+)
+
+// The Jaro-Winkler distance. The result is 1 for equal strings, and 0 for completely different strings. It is commonly used on Record Linkage stuff, thus it tries to be accurate for common typos when writing real names such as  person names and street names.
+// Jaro-Winkler is a modification of the Jaro algorithm. It works by first running Jaro, then boosting the score of exact matches at the beginning of the strings. Because of that, it introduces two more parameters: the boostThreshold and the prefixSize. These are commonly set to 0.7 and 4, respectively.
+func JaroWinkler(a, b string, boostThreshold float64, prefixSize int) float64 {
+	j := Jaro(a, b)
+
+	if j <= boostThreshold {
+		return j
+	}
+
+	prefixSize = int(math.Min(float64(len(a)), math.Min(float64(prefixSize), float64(len(b)))))
+
+	var prefixMatch float64
+	for i := 0; i < prefixSize; i++ {
+		if a[i] == b[i] {
+			prefixMatch++
+		} else {
+			break
+		}
+	}
+
+	return j + 0.1*prefixMatch*(1.0-j)
+}

--- a/go-controller/vendor/github.com/xrash/smetrics/jaro.go
+++ b/go-controller/vendor/github.com/xrash/smetrics/jaro.go
@@ -1,0 +1,86 @@
+package smetrics
+
+import (
+	"math"
+)
+
+// The Jaro distance. The result is 1 for equal strings, and 0 for completely different strings.
+func Jaro(a, b string) float64 {
+	// If both strings are zero-length, they are completely equal,
+	// therefore return 1.
+	if len(a) == 0 && len(b) == 0 {
+		return 1
+	}
+
+	// If one string is zero-length, strings are completely different,
+	// therefore return 0.
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+
+	// Define the necessary variables for the algorithm.
+	la := float64(len(a))
+	lb := float64(len(b))
+	matchRange := int(math.Max(0, math.Floor(math.Max(la, lb)/2.0)-1))
+	matchesA := make([]bool, len(a))
+	matchesB := make([]bool, len(b))
+	var matches float64 = 0
+
+	// Step 1: Matches
+	// Loop through each character of the first string,
+	// looking for a matching character in the second string.
+	for i := 0; i < len(a); i++ {
+		start := int(math.Max(0, float64(i-matchRange)))
+		end := int(math.Min(lb-1, float64(i+matchRange)))
+
+		for j := start; j <= end; j++ {
+			if matchesB[j] {
+				continue
+			}
+
+			if a[i] == b[j] {
+				matchesA[i] = true
+				matchesB[j] = true
+				matches++
+				break
+			}
+		}
+	}
+
+	// If there are no matches, strings are completely different,
+	// therefore return 0.
+	if matches == 0 {
+		return 0
+	}
+
+	// Step 2: Transpositions
+	// Loop through the matches' arrays, looking for
+	// unaligned matches. Count the number of unaligned matches.
+	unaligned := 0
+	j := 0
+	for i := 0; i < len(a); i++ {
+		if !matchesA[i] {
+			continue
+		}
+
+		for !matchesB[j] {
+			j++
+		}
+
+		if a[i] != b[j] {
+			unaligned++
+		}
+
+		j++
+	}
+
+	// The number of unaligned matches divided by two, is the number of _transpositions_.
+	transpositions := math.Floor(float64(unaligned / 2))
+
+	// Jaro distance is the average between these three numbers:
+	// 1. matches / length of string A
+	// 2. matches / length of string B
+	// 3. (matches - transpositions/matches)
+	// So, all that divided by three is the final result.
+	return ((matches / la) + (matches / lb) + ((matches - transpositions) / matches)) / 3.0
+}

--- a/go-controller/vendor/github.com/xrash/smetrics/soundex.go
+++ b/go-controller/vendor/github.com/xrash/smetrics/soundex.go
@@ -1,0 +1,63 @@
+package smetrics
+
+import (
+	"strings"
+)
+
+// The Soundex encoding. It is a phonetic algorithm that considers how the words sound in English. Soundex maps a string to a 4-byte code consisting of the first letter of the original string and three numbers. Strings that sound similar should map to the same code.
+func Soundex(s string) string {
+	b := strings.Builder{}
+	b.Grow(4)
+
+	p := s[0]
+	if p <= 'z' && p >= 'a' {
+		p -= 32 // convert to uppercase
+	}
+	b.WriteByte(p)
+
+	n := 0
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+
+		if c <= 'z' && c >= 'a' {
+			c -= 32 // convert to uppercase
+		} else if c < 'A' || c > 'Z' {
+			continue
+		}
+
+		if c == p {
+			continue
+		}
+
+		p = c
+
+		switch c {
+		case 'B', 'P', 'F', 'V':
+			c = '1'
+		case 'C', 'S', 'K', 'G', 'J', 'Q', 'X', 'Z':
+			c = '2'
+		case 'D', 'T':
+			c = '3'
+		case 'L':
+			c = '4'
+		case 'M', 'N':
+			c = '5'
+		case 'R':
+			c = '6'
+		default:
+			continue
+		}
+
+		b.WriteByte(c)
+		n++
+		if n == 3 {
+			break
+		}
+	}
+
+	for i := n; i < 3; i++ {
+		b.WriteByte('0')
+	}
+
+	return b.String()
+}

--- a/go-controller/vendor/github.com/xrash/smetrics/ukkonen.go
+++ b/go-controller/vendor/github.com/xrash/smetrics/ukkonen.go
@@ -1,0 +1,94 @@
+package smetrics
+
+import (
+	"math"
+)
+
+// The Ukkonen algorithm for calculating the Levenshtein distance. The algorithm is described in http://www.cs.helsinki.fi/u/ukkonen/InfCont85.PDF, or in docs/InfCont85.PDF. It runs on O(t . min(m, n)) where t is the actual distance between strings a and b. It needs O(min(t, m, n)) space. This function might be preferred over WagnerFischer() for *very* similar strings. But test it out yourself.
+// The first two parameters are the two strings to be compared. The last three parameters are the insertion cost, the deletion cost and the substitution cost. These are normally defined as 1, 1 and 2 respectively.
+func Ukkonen(a, b string, icost, dcost, scost int) int {
+	var lowerCost int
+
+	if icost < dcost && icost < scost {
+		lowerCost = icost
+	} else if dcost < scost {
+		lowerCost = dcost
+	} else {
+		lowerCost = scost
+	}
+
+	infinite := math.MaxInt32 / 2
+
+	var r []int
+	var k, kprime, p, t int
+	var ins, del, sub int
+
+	if len(a) > len(b) {
+		t = (len(a) - len(b) + 1) * lowerCost
+	} else {
+		t = (len(b) - len(a) + 1) * lowerCost
+	}
+
+	for {
+		if (t / lowerCost) < (len(b) - len(a)) {
+			continue
+		}
+
+		// This is the right damn thing since the original Ukkonen
+		// paper minimizes the expression result only, but the uncommented version
+		// doesn't need to deal with floats so it's faster.
+		// p = int(math.Floor(0.5*((float64(t)/float64(lowerCost)) - float64(len(b) - len(a)))))
+		p = ((t / lowerCost) - (len(b) - len(a))) / 2
+
+		k = -p
+		kprime = k
+
+		rowlength := (len(b) - len(a)) + (2 * p)
+
+		r = make([]int, rowlength+2)
+
+		for i := 0; i < rowlength+2; i++ {
+			r[i] = infinite
+		}
+
+		for i := 0; i <= len(a); i++ {
+			for j := 0; j <= rowlength; j++ {
+				if i == j+k && i == 0 {
+					r[j] = 0
+				} else {
+					if j-1 < 0 {
+						ins = infinite
+					} else {
+						ins = r[j-1] + icost
+					}
+
+					del = r[j+1] + dcost
+					sub = r[j] + scost
+
+					if i-1 < 0 || i-1 >= len(a) || j+k-1 >= len(b) || j+k-1 < 0 {
+						sub = infinite
+					} else if a[i-1] == b[j+k-1] {
+						sub = r[j]
+					}
+
+					if ins < del && ins < sub {
+						r[j] = ins
+					} else if del < sub {
+						r[j] = del
+					} else {
+						r[j] = sub
+					}
+				}
+			}
+			k++
+		}
+
+		if r[(len(b)-len(a))+(2*p)+kprime] <= t {
+			break
+		} else {
+			t *= 2
+		}
+	}
+
+	return r[(len(b)-len(a))+(2*p)+kprime]
+}

--- a/go-controller/vendor/github.com/xrash/smetrics/wagner-fischer.go
+++ b/go-controller/vendor/github.com/xrash/smetrics/wagner-fischer.go
@@ -1,0 +1,48 @@
+package smetrics
+
+// The Wagner-Fischer algorithm for calculating the Levenshtein distance.
+// The first two parameters are the two strings to be compared. The last three parameters are the insertion cost, the deletion cost and the substitution cost. These are normally defined as 1, 1 and 2 respectively.
+func WagnerFischer(a, b string, icost, dcost, scost int) int {
+
+	// Allocate both rows.
+	row1 := make([]int, len(b)+1)
+	row2 := make([]int, len(b)+1)
+	var tmp []int
+
+	// Initialize the first row.
+	for i := 1; i <= len(b); i++ {
+		row1[i] = i * icost
+	}
+
+	// For each row...
+	for i := 1; i <= len(a); i++ {
+		row2[0] = i * dcost
+
+		// For each column...
+		for j := 1; j <= len(b); j++ {
+			if a[i-1] == b[j-1] {
+				row2[j] = row1[j-1]
+			} else {
+				ins := row2[j-1] + icost
+				del := row1[j] + dcost
+				sub := row1[j-1] + scost
+
+				if ins < del && ins < sub {
+					row2[j] = ins
+				} else if del < sub {
+					row2[j] = del
+				} else {
+					row2[j] = sub
+				}
+			}
+		}
+
+		// Swap the rows at the end of each row.
+		tmp = row1
+		row1 = row2
+		row2 = tmp
+	}
+
+	// Because we swapped the rows, the final result is in row1 instead of row2.
+	return row1[len(row1)-1]
+}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -77,7 +77,7 @@ github.com/containernetworking/plugins/pkg/utils/sysctl
 # github.com/coreos/go-iptables v0.6.0 => github.com/trozet/go-iptables v0.0.0-20240328221912-077e672b3808
 ## explicit; go 1.16
 github.com/coreos/go-iptables/iptables
-# github.com/cpuguy83/go-md2man/v2 v2.0.3
+# github.com/cpuguy83/go-md2man/v2 v2.0.4
 ## explicit; go 1.11
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/davecgh/go-spew v1.1.1
@@ -427,8 +427,8 @@ github.com/stretchr/objx
 ## explicit; go 1.20
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
-# github.com/urfave/cli/v2 v2.2.0
-## explicit; go 1.11
+# github.com/urfave/cli/v2 v2.27.2
+## explicit; go 1.18
 github.com/urfave/cli/v2
 # github.com/vishvananda/netlink v1.2.1-beta.2.0.20231024175852-77df5d35f725
 ## explicit; go 1.12
@@ -437,6 +437,9 @@ github.com/vishvananda/netlink/nl
 # github.com/vishvananda/netns v0.0.4
 ## explicit; go 1.17
 github.com/vishvananda/netns
+# github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913
+## explicit; go 1.15.0
+github.com/xrash/smetrics
 # go.opencensus.io v0.24.0
 ## explicit; go 1.13
 go.opencensus.io


### PR DESCRIPTION
Depends on https://github.com/ovn-org/ovn-kubernetes/pull/4694.

The PR adds OVS flows that redirect traffic from the masquerade subnet to the specified services to the default gateway router.
For shared gateway mode a static route is added to redirect the service traffic to the management port. Modified the
staticRouteCleanup to ensure that the new routes are not getting removed.

This change does not work on non-IC clusters for l3 networks in shared gateway, tracked here: https://github.com/ovn-org/ovn-kubernetes/issues/4741. 