### PR TITLE
udn, cni: Unconfigure interface

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -252,7 +252,7 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 		NetdevName:    netdevName,
 	}
 	if !config.UnprivilegedMode {
-		err := pr.UnconfigureInterface(podInterfaceInfo)
+		err := podRequestInterfaceOps.UnconfigureInterface(pr, podInterfaceInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -272,7 +272,7 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 				if err != nil {
 					return nil, err
 				}
-				if err := primaryUDNPodRequest.UnconfigureInterface(primaryUDNPodInfo); err != nil {
+				if err := podRequestInterfaceOps.UnconfigureInterface(primaryUDNPodRequest, primaryUDNPodInfo); err != nil {
 					return nil, err
 				}
 			}
@@ -338,7 +338,7 @@ func HandlePodRequest(request *PodRequest, clientset *ClientSet, kubeAuth *KubeA
 // instance of the pod in the apiserver, see checkCancelSandbox for more info.
 // If kube api is not available from the CNI, pass nil to skip this check.
 func getCNIResult(pr *PodRequest, getter PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
-	interfacesArray, err := pr.ConfigureInterface(getter, podInterfaceInfo)
+	interfacesArray, err := podRequestInterfaceOps.ConfigureInterface(pr, getter, podInterfaceInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure pod interface: %v", err)
 	}

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -256,6 +256,27 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if util.IsNetworkSegmentationSupportEnabled() {
+			pod, err := clientset.getPod(pr.PodNamespace, pr.PodName)
+			if err != nil {
+				return nil, err
+			}
+			primaryUDN := udn.NewPrimaryNetwork(clientset.nadLister)
+			if err := primaryUDN.Ensure(namespace, pod.Annotations, pr.nadName); err != nil {
+				return nil, err
+			}
+			if primaryUDN.Found() {
+				primaryUDNPodRequest := pr.buildPrimaryUDNPodRequest(pod, primaryUDN)
+				primaryUDNPodInfo, err := primaryUDNPodRequest.buildPodInterfaceInfo(pod.Annotations, primaryUDN.Annotation(), primaryUDN.NetworkDevice())
+				if err != nil {
+					return nil, err
+				}
+				if err := primaryUDNPodRequest.UnconfigureInterface(primaryUDNPodInfo); err != nil {
+					return nil, err
+				}
+			}
+		}
 	} else {
 		// pass the isDPU flag and vfNetdevName back to cniShim
 		response.Result = nil

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -320,7 +320,7 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 			}
 		}
 
-		err = pr.UnconfigureInterface(response.PodIFInfo)
+		err = podRequestInterfaceOps.UnconfigureInterface(pr, response.PodIFInfo)
 	}
 	return err
 }

--- a/go-controller/pkg/cni/udn/primary_network.go
+++ b/go-controller/pkg/cni/udn/primary_network.go
@@ -74,32 +74,50 @@ func (p *UserDefinedPrimaryNetwork) WaitForPrimaryAnnotationFn(namespace string,
 		if annotation == nil {
 			return nil, false
 		}
-
-		// CmdAdd from non default network is not realted to primary UDNs
-		if nadName != types.DefaultNetworkName {
-			return annotation, isReady
-		}
-
-		// If these are pods created before primary UDN functionality the
-		// default network without role is the primary network
-		if annotation.Role == "" {
-			annotation.Role = types.NetworkRolePrimary
-		}
-
-		if annotation.Role == types.NetworkRolePrimary {
-			return annotation, isReady
-		}
-
-		if err := p.ensureAnnotation(annotations); err != nil {
-			klog.Errorf("Failed looking for primary network annotation: %v", err)
-			return nil, false
-		}
-		if err := p.ensureActiveNetwork(namespace); err != nil {
-			klog.Errorf("Failed looking for primary network name: %v", err)
+		if err := p.ensure(namespace, annotations, nadName, annotation); err != nil {
+			klog.Errorf("Failed ensuring user defined primary network: %v", err)
 			return nil, false
 		}
 		return annotation, isReady
 	}
+}
+
+func (p *UserDefinedPrimaryNetwork) Ensure(namespace string, annotations map[string]string, nadName string) error {
+	return p.ensure(namespace, annotations, nadName, nil /* parse annotation */)
+}
+
+func (p *UserDefinedPrimaryNetwork) ensure(namespace string, annotations map[string]string, nadName string, annotation *util.PodAnnotation) error {
+	// non default network is not related to primary UDNs
+	if nadName != types.DefaultNetworkName {
+		return nil
+	}
+
+	if annotation == nil {
+		var err error
+		annotation, err = util.UnmarshalPodAnnotation(annotations, nadName)
+		if err != nil {
+			return fmt.Errorf("failed looking for ovn pod annotations for nad '%s': %w", nadName, err)
+		}
+	}
+
+	// If these are pods created before primary UDN functionality the
+	// default network without role is the primary network
+	if annotation.Role == "" {
+		annotation.Role = types.NetworkRolePrimary
+	}
+
+	// If default network is the primary there is nothing else to do
+	if annotation.Role == types.NetworkRolePrimary {
+		return nil
+	}
+
+	if err := p.ensureAnnotation(annotations); err != nil {
+		return fmt.Errorf("failed looking for primary network annotation: %w", err)
+	}
+	if err := p.ensureActiveNetwork(namespace); err != nil {
+		return fmt.Errorf("failed looking for primary network name: %w", err)
+	}
+	return nil
 }
 
 func (p *UserDefinedPrimaryNetwork) ensureActiveNetwork(namespace string) error {


### PR DESCRIPTION
#### What this PR does and why is it needed
When a pod with a primary UDN is deleted it has to call the unconfigure interface to delete ovs resources.

#### How to verify it
It will have unit test


```release-note
NONE
```
