### PR TITLE
Add VRF support for EIP assigned to secondary interface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,6 +183,13 @@ jobs:
         cache-dependency-path: "**/*.sum"
       id: go
 
+    - name: Install VRF kernel module
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
+      run: |
+        set -x
+        sudo apt-get install linux-modules-extra-$(uname -r) -y
+        sudo modprobe vrf
+
     - name: Build and Test - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       run: |
@@ -455,6 +462,12 @@ jobs:
       USE_HELM: "${{ matrix.target == 'control-plane-helm' || matrix.target == 'multi-homing-helm' }}"
       OVN_ENABLE_DNSNAMERESOLVER: "${{ matrix.dns-name-resolver == 'enable-dns-name-resolver' }}"
     steps:
+
+    - name: Install VRF kernel module
+      run: |
+        set -x
+        sudo apt-get install linux-modules-extra-$(uname -r) -y
+        sudo modprobe vrf
 
     - name: Free up disk space
       run: |

--- a/docs/features/cluster-egress-controls/egress-ip.md
+++ b/docs/features/cluster-egress-controls/egress-ip.md
@@ -130,6 +130,8 @@ And the default route in the correct table `1111`:
 sh-5.2# ip route show table 1111
 default dev dummy
 ```
+Routes associated with the egress interface are copied from the main routing table to the routing table that was created to support EgressIP, as shown above.
+If the interface is enslaved to a VRF device, routes are copied from the VRF interfaces associated routing table.
 
 No NAT is required on the OVN primary network gateway router.
 OVN-Kubernetes (ovnkube-node) takes care of adding a rule to the rule table with src IP of the pod and routed towards a

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -140,7 +140,13 @@ func (c *Controller) DelAddress(address netlink.Addr) error {
 		return fmt.Errorf("address (%s) is not valid", address.String())
 	}
 	link, err := util.GetNetLinkOps().LinkByIndex(address.LinkIndex)
-	if err != nil && !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+	if err != nil {
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			c.mu.Lock()
+			c.delLinkFromStoreByIndex(address.LinkIndex)
+			c.mu.Unlock()
+			return nil
+		}
 		return fmt.Errorf("no valid link associated with addresses %s: %v", address.String(), err)
 	}
 	klog.Infof("Link manager: deleting address %s from link %s", address.String(), link.Attrs().Name)
@@ -247,7 +253,26 @@ func (c *Controller) delAddressFromStore(linkName string, address netlink.Addr) 
 			temp = append(temp, addressSaved)
 		}
 	}
-	c.store[linkName] = temp
+	if len(temp) == 0 {
+		delete(c.store, linkName)
+	} else {
+		c.store[linkName] = temp
+	}
+}
+
+func (c *Controller) delLinkFromStoreByIndex(linkToDelIndex int) {
+	var linkNameToDelete string
+	for linkName, addresses := range c.store {
+		if len(addresses) > 0 {
+			if linkToDelIndex == addresses[0].LinkIndex {
+				linkNameToDelete = linkName
+				break
+			}
+		}
+	}
+	if linkNameToDelete != "" {
+		delete(c.store, linkNameToDelete)
+	}
 }
 
 func (c *Controller) isAddressValid(address netlink.Addr) bool {

--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -273,6 +273,7 @@ func (c *Controller) sync() {
 				link, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
 				if err != nil {
 					klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					continue
 				}
 				if err := c.applyRoute(link, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table); err != nil {
 					klog.Errorf("Route Manager: failed to apply route (%s): %v", managedRoute.String(), err)

--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -115,6 +115,10 @@ func (c *Controller) delRoute(r netlink.Route) error {
 	klog.Infof("Route Manager: attempting to delete route: %s", r.String())
 	link, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
 	if err != nil {
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			delete(c.store, r.LinkIndex)
+			return nil
+		}
 		return fmt.Errorf("failed to delete route (%s) because unable to get link: %v", r.String(), err)
 	}
 	if err := c.netlinkDelRoute(link, r.Dst, r.Table); err != nil {
@@ -254,6 +258,7 @@ func (c *Controller) addRouteToStore(r netlink.Route) bool {
 // sync will iterate through all routes seen on a node and ensure any route manager managed routes are applied. Any additional
 // routes for this link are preserved. sync only inspects routes for links which we managed and ignore routes for non-managed links.
 func (c *Controller) sync() {
+	deletedLinkIndexes := make([]int, 0)
 	for linkIndex, managedRoutes := range c.store {
 		for _, managedRoute := range managedRoutes {
 			filterRoute, filterMask := filterRouteByDstAndTable(linkIndex, managedRoute.Dst, managedRoute.Table)
@@ -272,7 +277,11 @@ func (c *Controller) sync() {
 			if !found {
 				link, err := util.GetNetLinkOps().LinkByIndex(managedRoute.LinkIndex)
 				if err != nil {
-					klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+						deletedLinkIndexes = append(deletedLinkIndexes, linkIndex)
+					} else {
+						klog.Errorf("Route Manager: failed to apply route (%s) because unable to retrieve associated link: %v", managedRoute.String(), err)
+					}
 					continue
 				}
 				if err := c.applyRoute(link, managedRoute.Gw, managedRoute.Dst, managedRoute.MTU, managedRoute.Src, managedRoute.Table); err != nil {
@@ -280,6 +289,10 @@ func (c *Controller) sync() {
 				}
 			}
 		}
+	}
+	for _, linkIndex := range deletedLinkIndexes {
+		klog.Infof("Route Manager: removing all routes associated with link index %d because link deleted", linkIndex)
+		delete(c.store, linkIndex)
 	}
 }
 


### PR DESCRIPTION
If EIP assigned to secondary interface thats enslaved by a VRF device, use the associated VRF devices routing table instead of main. Added unit tests + e2e.