### PR TITLE
OCPBUGS-37433: ignore localnet patch ports while bootstrapping the cluster default network

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -712,7 +712,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	}
 
 	// Bootstrap flows in OVS if just normal flow is present
-	if err := bootstrapOVSFlows(); err != nil {
+	if err := bootstrapOVSFlows(nc.name); err != nil {
 		return fmt.Errorf("failed to bootstrap OVS flows: %w", err)
 	}
 

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -253,7 +253,7 @@ func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
 
 // bootstrapOVSFlows handles ensuring basic, required flows are in place. This is done before OpenFlow manager has
 // been created/started, and only done when there is just a NORMAL flow programmed and OVN/OVS is already setup
-func bootstrapOVSFlows() error {
+func bootstrapOVSFlows(nodeName string) error {
 	// see if patch port exists already
 	var portsOutput string
 	var stderr string
@@ -266,8 +266,11 @@ func bootstrapOVSFlows() error {
 
 	var bridge string
 	var patchPort string
-	// patch-br-int-to-<bridge name>_<node>
-	r := regexp.MustCompile("^patch-(.*)_.*?-to-br-int$")
+	// This needs to work with:
+	// - default network: patch-<bridge name>_<node>-to-br-int
+	// but not with:
+	// - secondary network: patch-<bridge name>_<node>-to-br-int
+	r := regexp.MustCompile(fmt.Sprintf("^patch-([^_]*)_%s-to-br-int$", nodeName))
 	for _, line := range strings.Split(portsOutput, "\n") {
 		matches := r.FindStringSubmatch(line)
 		if len(matches) == 2 {

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -264,21 +264,7 @@ func bootstrapOVSFlows(nodeName string) error {
 		return fmt.Errorf("failed to list ports on existing bridge br-int: %s, %w", stderr, err)
 	}
 
-	var bridge string
-	var patchPort string
-	// This needs to work with:
-	// - default network: patch-<bridge name>_<node>-to-br-int
-	// but not with:
-	// - secondary network: patch-<bridge name>_<node>-to-br-int
-	r := regexp.MustCompile(fmt.Sprintf("^patch-([^_]*)_%s-to-br-int$", nodeName))
-	for _, line := range strings.Split(portsOutput, "\n") {
-		matches := r.FindStringSubmatch(line)
-		if len(matches) == 2 {
-			patchPort = matches[0]
-			bridge = matches[1]
-			break
-		}
-	}
+	bridge, patchPort := localnetPortInfo(nodeName, portsOutput)
 
 	if len(bridge) == 0 {
 		// bridge exists but no patch port was found
@@ -340,4 +326,22 @@ func bootstrapOVSFlows(nodeName string) error {
 	}
 
 	return nil
+}
+
+// localnetPortInfo returns the name of the bridge and the patch port name for the default cluster network
+func localnetPortInfo(nodeName string, portsOutput string) (string, string) {
+	// This needs to work with:
+	// - default network: patch-<bridge name>_<node>-to-br-int
+	// but not with:
+	// - user defined primary network: patch-<bridge name>_<network-name>_<node>-to-br-int
+	// - user defined secondary localnet network: patch-<bridge name>_<network-name>_ovn_localnet_port-to-br-int
+	// TODO: going forward, maybe it would preferable to just read the bridge name from the config.
+	r := regexp.MustCompile(fmt.Sprintf("^patch-([^_]*)_%s-to-br-int$", nodeName))
+	for _, line := range strings.Split(portsOutput, "\n") {
+		matches := r.FindStringSubmatch(line)
+		if len(matches) == 2 {
+			return matches[1], matches[0]
+		}
+	}
+	return "", ""
 }

--- a/go-controller/pkg/node/openflow_manager_test.go
+++ b/go-controller/pkg/node/openflow_manager_test.go
@@ -1,0 +1,79 @@
+package node
+
+import "testing"
+
+func TestOpenFlowManagerDefaultNetOVSBridgeFinder(t *testing.T) {
+	const nodeName = "multi-homing-worker-0.maiqueb.org"
+
+	testCases := []struct {
+		name                  string
+		desc                  string
+		inputPortInfo         string
+		expectedBridgeName    string
+		expectedPatchPortName string
+	}{
+		{
+			name:                  "empty input ports",
+			inputPortInfo:         "",
+			expectedBridgeName:    "",
+			expectedPatchPortName: "",
+		},
+		{
+			name:                  "input ports without patch ports",
+			inputPortInfo:         "port1",
+			expectedBridgeName:    "",
+			expectedPatchPortName: "",
+		},
+		{
+			name: "input ports with a patch port",
+			inputPortInfo: `
+port1
+port2
+patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int`,
+			expectedBridgeName:    "br-ex",
+			expectedPatchPortName: "patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int",
+		},
+		{
+			name: "input ports with a patch port for a localnet network",
+			inputPortInfo: `
+port1
+port2
+patch-vlan2003_ovn_localnet_port-to-br-int`,
+			expectedBridgeName:    "",
+			expectedPatchPortName: "",
+		},
+		{
+			name: "input ports with a patch port for the default network and a localnet",
+			inputPortInfo: `
+port1
+port2
+patch-vlan2003_ovn_localnet_port-to-br-int
+patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int`,
+			expectedBridgeName:    "br-ex",
+			expectedPatchPortName: "patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int",
+		},
+		{
+			name: "input ports with a patch port for the default network, a localnet, and an extra primary UDN",
+			inputPortInfo: `
+port1
+port2
+patch-vlan2003_ovn_localnet_port-to-br-int
+patch-br-ex_tenant-blue_multi-homing-worker-0.maiqueb.org-to-br-int
+patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int`,
+			expectedBridgeName:    "br-ex",
+			expectedPatchPortName: "patch-br-ex_multi-homing-worker-0.maiqueb.org-to-br-int",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bridgeName, patchPortName := localnetPortInfo(nodeName, tc.inputPortInfo)
+			if bridgeName != tc.expectedBridgeName {
+				t.Errorf("Expected bridge name %q got %q", tc.expectedBridgeName, bridgeName)
+			}
+			if patchPortName != tc.expectedPatchPortName {
+				t.Errorf("Expected patch port name %q got %q", tc.expectedPatchPortName, patchPortName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This commit changes the openflow manager to ignore localnet patch ports when bootstrapping the default cluster network - these have a different format (they feature the physical network name for which the port was created instead of a physical bridge), which leads to the following error:

```
failed to start node network controller: failed to start default node network
controller: failed to bootstrap OVS flows: failed to get flows on bridge
"vlan2002_ovn_localnet":, stderr: "ovs-ofctl: vlan2002_ovn_localnet is not a
bridge or a socket\n", error: exit status 1
```

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-37433

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
