### PR TITLE
hack/lint.sh: Mount local golangci-lint cache

### DIFF
--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -6,7 +6,9 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-$1 run --security-opt label=disable --rm -v $(pwd):/app -w /app -e GO111MODULE=on golangci/golangci-lint:${VERSION} \
+$1 run --security-opt label=disable --rm \
+  -v  ${HOME}/.cache/golangci-lint:/cache -e GOLANGCI_LINT_CACHE=/cache \
+  -v $(pwd):/app -w /app -e GO111MODULE=on golangci/golangci-lint:${VERSION} \
 	golangci-lint run --verbose --print-resources-usage \
 	--modules-download-mode=vendor --timeout=15m0s && \
 	echo "lint OK!"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Currently, `make lint` runs golangci-linter in a container but wont mount golangci-lint local cache.
linter time can be optimized by using the local cache, in tested env lint time droped from 1:11 minutes to 45 seconds.

This PR changes hack/lint.sh to mount golangci-lint local cache to the subject container.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
NONE
```
