### PR TITLE
Use more exact name match when deleting static routes to HO nodes

### DIFF
--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -1374,7 +1374,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			gomega.Eventually(func() ([]*nbdb.LogicalRouterStaticRoute, error) {
 				p := func(item *nbdb.LogicalRouterStaticRoute) bool {
 					if item.ExternalIDs["name"] == "hybrid-subnet-node1-gr" ||
-						strings.Contains(item.ExternalIDs["name"], "hybrid-subnet-node1") {
+						item.ExternalIDs["name"] == "hybrid-subnet-node1:node-windows" {
 						return true
 					}
 					return false

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -815,7 +815,7 @@ func (oc *DefaultNetworkController) deleteHoNodeEvent(node *kapi.Node) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse hybridOverlay node subnet for node %s: %w", node.Name, err)
 		}
-		err = oc.removeRoutesToHONodeSubnet(nodeSubnet)
+		err = oc.removeRoutesToHONodeSubnet(node.Name, nodeSubnet)
 		if err != nil {
 			return fmt.Errorf("failed to remove hybrid overlay static routes and route policy: %w", err)
 		}


### PR DESCRIPTION
#### What this PR does and why is it needed
It can help to avoid the unintended match when the '-gr' substring exists in a node name.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-37855

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
