### PR TITLE
fix: link to kind usage docs in contrib README.md

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,3 +1,3 @@
 # OVN kubernetes KIND Setup
 
-Refer to kind.md under the folder docs for the details.
+See [launching-ovn-kubernetes-on-kind.md](/docs/installation/launching-ovn-kubernetes-on-kind.md).


### PR DESCRIPTION
#### What this PR does and why is it needed

The README.md under `contrib/` referred to a `kind.md` file which did not appear to exist. I've added a hyperlink to the `./docs/installation/launching-ovn-kubernetes-on-kind.md` file which appears to be the appropriate documentation.