### PR TITLE
Fix retry handling in case IP pool is empty

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -319,6 +319,7 @@ func (h *networkClusterControllerEventHandler) AddResource(obj interface{}, from
 		if err != nil {
 			klog.Infof("Pod add failed for %s/%s, will try again later: %v",
 				pod.Namespace, pod.Name, err)
+			return err
 		}
 	case factory.NodeType:
 		node, ok := obj.(*corev1.Node)
@@ -359,6 +360,7 @@ func (h *networkClusterControllerEventHandler) UpdateResource(oldObj, newObj int
 		if err != nil {
 			klog.Infof("Pod update failed for %s/%s, will try again later: %v",
 				new.Namespace, new.Name, err)
+			return err
 		}
 	case factory.NodeType:
 		node, ok := newObj.(*corev1.Node)

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -317,8 +317,6 @@ func (h *networkClusterControllerEventHandler) AddResource(obj interface{}, from
 		}
 		err := h.ncc.podAllocator.Reconcile(nil, pod)
 		if err != nil {
-			klog.Infof("Pod add failed for %s/%s, will try again later: %v",
-				pod.Namespace, pod.Name, err)
 			return err
 		}
 	case factory.NodeType:
@@ -358,8 +356,6 @@ func (h *networkClusterControllerEventHandler) UpdateResource(oldObj, newObj int
 		}
 		err := h.ncc.podAllocator.Reconcile(old, new)
 		if err != nil {
-			klog.Infof("Pod update failed for %s/%s, will try again later: %v",
-				new.Namespace, new.Name, err)
 			return err
 		}
 	case factory.NodeType:
@@ -392,8 +388,6 @@ func (h *networkClusterControllerEventHandler) DeleteResource(obj, cachedObj int
 		}
 		err := h.ncc.podAllocator.Reconcile(pod, nil)
 		if err != nil {
-			klog.Infof("Pod delete failed for %s/%s, will try again later: %v",
-				pod.Namespace, pod.Name, err)
 			return err
 		}
 	case factory.NodeType:

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -394,6 +394,7 @@ func (h *networkClusterControllerEventHandler) DeleteResource(obj, cachedObj int
 		if err != nil {
 			klog.Infof("Pod delete failed for %s/%s, will try again later: %v",
 				pod.Namespace, pod.Name, err)
+			return err
 		}
 	case factory.NodeType:
 		node, ok := obj.(*corev1.Node)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
When a pod is created, and the IP pool is empty,
the pod will stuck forever in creation state, even if IPs are released.

To simulate the bug:
1. Create a NAD with a pool with just 1 available IP (others excluded; first and last reserved).
2. Create 2 pods that use this NAD:
a. One pod will take the IP.
b. The second pod will remain in "creation" state.
3. Wait around 1 minute and then delete the Running pod.

The bug: The pending pod stays pending forever, even though an IP is available.

Without the fix, update / add Pod retry mechanism isn't triggered at all, because it will be triggered
only if a non nil error is returned.

Note: 
Even with the fix, the retry mechanism is capped in 15 retries [1], which total for around 15m.
After 15m the pod will be pending forever, even if IPs are released, because its annotations
won't be updated anymore.
User will need to manually recreate the pod (unless the pod has a controller of course).

[1] https://github.com/ovn-org/ovn-kubernetes/blob/87fdae7bde5e51cbd6ab50682f9ed6e5e407ca62/go-controller/pkg/retry/obj_retry.go#L258

Added also the missing "return err" of pod delete event just because it was missing as well.
Removed the logs in case of an error, it will be printed anyhow on higher level.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
Please find in the comments below manifests that allow simulating the bug easily upon needs.

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
None
```
