### PR TITLE
Udn egress layer2

### DIFF
--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -58,6 +58,20 @@ type GatewayManager struct {
 
 type GatewayOption func(*GatewayManager)
 
+func NewGatewayManagerForLayer2Topology(
+	nodeName string,
+	coopUUID string,
+	kube kube.InterfaceOVN,
+	nbClient libovsdbclient.Client,
+	netInfo util.NetInfo,
+	watchFactory *factory.WatchFactory,
+	opts ...GatewayOption,
+) *GatewayManager {
+	gwManager := NewGatewayManager(nodeName, coopUUID, kube, nbClient, netInfo, watchFactory, opts...)
+	gwManager.clusterRouterName = ""
+	return gwManager
+}
+
 func NewGatewayManager(
 	nodeName string,
 	coopUUID string,

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -1208,9 +1208,8 @@ func (gw *GatewayManager) syncNodeGateway(
 }
 
 func physNetName(netInfo util.NetInfo) string {
-	physnetName := types.PhysicalNetworkName
-	if netInfo.IsSecondary() {
-		physnetName = netInfo.GetNetworkName()
+	if netInfo.IsDefault() || netInfo.IsPrimaryNetwork() {
+		return types.PhysicalNetworkName
 	}
-	return physnetName
+	return netInfo.GetNetworkName()
 }

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -335,46 +335,47 @@ func (gw *GatewayManager) GatewayInit(
 	if err != nil {
 		return fmt.Errorf("failed to create port %+v on router %+v: %v", logicalRouterPort, logicalRouter, err)
 	}
-
-	for _, entry := range clusterIPSubnet {
-		drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
-		if err != nil {
-			return fmt.Errorf("failed to add a static route in GR %s with distributed "+
-				"router as the nexthop: %v",
-				gatewayRouter, err)
-		}
-
-		// TODO There has to be a better way to do this. It seems like the
-		// whole purpose is to update the appropriate route in case it already
-		// exists *only* in the context of this router. But then it does not
-		// make sense to refresh it on every loop, unless it is also way to
-		// check for duplicate cluster IP subnets for which there would also be
-		// a better way to do it. Adding support for indirection in ModelClients
-		// opModel (being able to operate on thins pointed to from another model)
-		// would be a great way to simplify this.
-		updatedLogicalRouter, err := libovsdbops.GetLogicalRouter(gw.nbClient, &logicalRouter)
-		if err != nil {
-			return fmt.Errorf("unable to retrieve logical router %+v: %v", logicalRouter, err)
-		}
-
-		lrsr := nbdb.LogicalRouterStaticRoute{
-			IPPrefix: entry.String(),
-			Nexthop:  drLRPIfAddr.IP.String(),
-		}
-		if gw.netInfo.IsSecondary() {
-			lrsr.ExternalIDs = map[string]string{
-				types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
-				types.TopologyExternalID: gw.netInfo.TopologyType(),
+	if len(drLRPIfAddrs) > 0 {
+		for _, entry := range clusterIPSubnet {
+			drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
+			if err != nil {
+				return fmt.Errorf("failed to add a static route in GR %s with distributed "+
+					"router as the nexthop: %v",
+					gatewayRouter, err)
 			}
-		}
-		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy) &&
-				util.SliceHasStringItem(updatedLogicalRouter.StaticRoutes, item.UUID)
-		}
-		err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(gw.nbClient, gatewayRouter, &lrsr, p,
-			&lrsr.Nexthop)
-		if err != nil {
-			return fmt.Errorf("failed to add a static route %+v in GR %s with distributed router as the nexthop, err: %v", lrsr, gatewayRouter, err)
+
+			// TODO There has to be a better way to do this. It seems like the
+			// whole purpose is to update the appropriate route in case it already
+			// exists *only* in the context of this router. But then it does not
+			// make sense to refresh it on every loop, unless it is also way to
+			// check for duplicate cluster IP subnets for which there would also be
+			// a better way to do it. Adding support for indirection in ModelClients
+			// opModel (being able to operate on thins pointed to from another model)
+			// would be a great way to simplify this.
+			updatedLogicalRouter, err := libovsdbops.GetLogicalRouter(gw.nbClient, &logicalRouter)
+			if err != nil {
+				return fmt.Errorf("unable to retrieve logical router %+v: %v", logicalRouter, err)
+			}
+
+			lrsr := nbdb.LogicalRouterStaticRoute{
+				IPPrefix: entry.String(),
+				Nexthop:  drLRPIfAddr.IP.String(),
+			}
+			if gw.netInfo.IsSecondary() {
+				lrsr.ExternalIDs = map[string]string{
+					types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
+					types.TopologyExternalID: gw.netInfo.TopologyType(),
+				}
+			}
+			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy) &&
+					util.SliceHasStringItem(updatedLogicalRouter.StaticRoutes, item.UUID)
+			}
+			err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(gw.nbClient, gatewayRouter, &lrsr, p,
+				&lrsr.Nexthop)
+			if err != nil {
+				return fmt.Errorf("failed to add a static route %+v in GR %s with distributed router as the nexthop, err: %v", lrsr, gatewayRouter, err)
+			}
 		}
 	}
 

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/pod"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/generator/udn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
@@ -107,9 +108,10 @@ func (h *secondaryLayer2NetworkControllerEventHandler) AddResource(obj interface
 			var nodeParams *nodeSyncs
 			if fromRetryLoop {
 				_, syncMgmtPort := h.oc.mgmtPortFailed.Load(node.Name)
-				nodeParams = &nodeSyncs{syncMgmtPort: syncMgmtPort}
+				_, syncGw := h.oc.gatewaysFailed.Load(node.Name)
+				nodeParams = &nodeSyncs{syncMgmtPort: syncMgmtPort, syncGw: syncGw}
 			} else {
-				nodeParams = &nodeSyncs{syncMgmtPort: true}
+				nodeParams = &nodeSyncs{syncMgmtPort: true, syncGw: true}
 			}
 			return h.oc.addUpdateLocalNodeEvent(node, nodeParams)
 		}
@@ -157,12 +159,19 @@ func (h *secondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, ne
 			if h.oc.isLocalZoneNode(oldNode) {
 				// determine what actually changed in this update
 				syncMgmtPort := macAddressChanged(oldNode, newNode, h.oc.NetInfo.GetNetworkName()) || nodeSubnetChanged
-				nodeSyncsParam = &nodeSyncs{syncMgmtPort: syncMgmtPort}
+
+				_, gwUpdateFailed := h.oc.gatewaysFailed.Load(newNode.Name)
+				shouldSyncGW := gwUpdateFailed ||
+					gatewayChanged(oldNode, newNode) ||
+					hostCIDRsChanged(oldNode, newNode) ||
+					nodeGatewayMTUSupportChanged(oldNode, newNode)
+
+				nodeSyncsParam = &nodeSyncs{syncMgmtPort: syncMgmtPort, syncGw: shouldSyncGW}
 			} else {
 				klog.Infof("Node %s moved from the remote zone %s to local zone %s.",
 					newNode.Name, util.GetNodeZone(oldNode), util.GetNodeZone(newNode))
 				// The node is now a local zone node. Trigger a full node sync.
-				nodeSyncsParam = &nodeSyncs{syncMgmtPort: true}
+				nodeSyncsParam = &nodeSyncs{syncMgmtPort: true, syncGw: true}
 			}
 
 			return h.oc.addUpdateLocalNodeEvent(newNode, nodeSyncsParam)
@@ -220,6 +229,12 @@ type SecondaryLayer2NetworkController struct {
 
 	// Node-specific syncMaps used by node event handler
 	mgmtPortFailed sync.Map
+	gatewaysFailed sync.Map
+
+	// Cluster-wide router default Control Plane Protection (COPP) UUID
+	defaultCOPPUUID string
+
+	gatewayManagers sync.Map
 }
 
 // NewSecondaryLayer2NetworkController create a new OVN controller for the given secondary layer2 nad
@@ -257,7 +272,8 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 				},
 			},
 		},
-		mgmtPortFailed: sync.Map{},
+		mgmtPortFailed:  sync.Map{},
+		gatewayManagers: sync.Map{},
 	}
 
 	if config.OVNKubernetesFeature.EnableInterconnect {
@@ -313,7 +329,27 @@ func (oc *SecondaryLayer2NetworkController) run(ctx context.Context) error {
 // Cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
 func (oc *SecondaryLayer2NetworkController) Cleanup() error {
-	return oc.BaseSecondaryLayer2NetworkController.cleanup()
+	networkName := oc.GetNetworkName()
+	if err := oc.BaseSecondaryLayer2NetworkController.cleanup(); err != nil {
+		return fmt.Errorf("failed to cleanup network %q: %w", networkName, err)
+	}
+
+	oc.gatewayManagers.Range(func(nodeName, value any) bool {
+		gwManager, isGWManagerType := value.(*GatewayManager)
+		if !isGWManagerType {
+			klog.Errorf(
+				"Failed to cleanup GW manager for network %q on node %s: could not retrieve GWManager",
+				networkName,
+				nodeName,
+			)
+			return true
+		}
+		if err := gwManager.Cleanup(); err != nil {
+			klog.Errorf("Failed to cleanup GW manager for network %q on node %s: %v", networkName, nodeName, err)
+		}
+		return true
+	})
+	return nil
 }
 
 func (oc *SecondaryLayer2NetworkController) Init() error {
@@ -397,6 +433,33 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 				oc.mgmtPortFailed.Delete(node.Name)
 			}
 		}
+		if nSyncs.syncGw {
+			gwManager := oc.gatewayManagerForNode(node.Name)
+			oc.gatewayManagers.Store(node.Name, gwManager)
+
+			gwConfig, err := oc.nodeGatewayConfig(node)
+			if err != nil {
+				errs = append(errs, err)
+				oc.gatewaysFailed.Store(node.Name, true)
+			} else {
+				if err := gwManager.syncNodeGateway(
+					node,
+					gwConfig.config,
+					gwConfig.hostSubnets,
+					gwConfig.hostAddrs,
+					gwConfig.hostSubnets,
+					gwConfig.gwLRPIPs,
+					oc.SCTPSupport,
+					oc.ovnClusterLRPToJoinIfAddrs,
+					gwConfig.externalIPs,
+				); err != nil {
+					errs = append(errs, err)
+					oc.gatewaysFailed.Store(node.Name, true)
+				} else {
+					oc.gatewaysFailed.Delete(node.Name)
+				}
+			}
+		}
 	}
 
 	errs = append(errs, oc.BaseSecondaryLayer2NetworkController.addUpdateLocalNodeEvent(node))
@@ -409,7 +472,120 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 }
 
 func (oc *SecondaryLayer2NetworkController) deleteNodeEvent(node *corev1.Node) error {
+	if err := oc.gatewayManagerForNode(node.Name).Cleanup(); err != nil {
+		return fmt.Errorf("failed to cleanup gateway on node %q: %w", node.Name, err)
+	}
+	oc.gatewayManagers.Delete(node.Name)
 	oc.localZoneNodes.Delete(node.Name)
 	oc.mgmtPortFailed.Delete(node.Name)
 	return nil
+}
+
+type SecondaryL2GatewayConfig struct {
+	config      *util.L3GatewayConfig
+	hostSubnets []*net.IPNet
+	gwLRPIPs    []*net.IPNet
+	hostAddrs   []string
+	externalIPs []net.IP
+}
+
+func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node) (*SecondaryL2GatewayConfig, error) {
+	// TODO: is this right ? just copied from L3
+	l3GatewayConfig, err := util.ParseNodeL3GatewayAnnotation(node)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %s network %s L3 gateway config: %v", node.Name, oc.GetNetworkName(), err)
+	}
+
+	networkName := oc.GetNetworkName()
+	networkID, err := oc.getNetworkID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get networkID for network %q: %v", networkName, err)
+	}
+
+	var (
+		masqIPs  []*net.IPNet
+		v4MasqIP *net.IPNet
+		v6MasqIP *net.IPNet
+	)
+
+	if config.IPv4Mode {
+		v4MasqIPs, err := udn.AllocateV4MasqueradeIPs(networkID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get v4 masquerade IP, network %s (%d): %v", networkName, networkID, err)
+		}
+		v4MasqIP = v4MasqIPs.GatewayRouter
+		masqIPs = append(masqIPs, v4MasqIP)
+	}
+	if config.IPv6Mode {
+		v6MasqIPs, err := udn.AllocateV6MasqueradeIPs(networkID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get v6 masquerade IP, network %s (%d): %v", networkName, networkID, err)
+		}
+		v6MasqIP = v6MasqIPs.GatewayRouter
+		masqIPs = append(masqIPs, v6MasqIP)
+	}
+
+	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
+
+	// TODO: is this right ? just copied from L3
+	// Always SNAT to the per network masquerade IP.
+	var externalIPs []net.IP
+	if config.IPv4Mode && v4MasqIP != nil {
+		externalIPs = append(externalIPs, v4MasqIP.IP)
+	}
+	if config.IPv6Mode && v6MasqIP != nil {
+		externalIPs = append(externalIPs, v6MasqIP.IP)
+	}
+
+	// TODO: is this right ? just copied from L3
+	var hostAddrs []string
+	for _, externalIP := range externalIPs {
+		hostAddrs = append(hostAddrs, externalIP.String())
+	}
+
+	// TODO: is this right ? just copied from L3
+	// Use the host subnets present in the network attachment definition.
+	hostSubnets := make([]*net.IPNet, 0, len(oc.Subnets()))
+	for _, subnet := range oc.Subnets() {
+		hostSubnets = append(hostSubnets, subnet.CIDR)
+	}
+
+	// Overwrite the primary interface ID with the correct, per-network one.
+	l3GatewayConfig.InterfaceID = oc.GetNetworkScopedExtPortName(l3GatewayConfig.BridgeID, node.Name)
+	return &SecondaryL2GatewayConfig{
+		config:      l3GatewayConfig,
+		hostSubnets: hostSubnets,
+		gwLRPIPs:    oc.ovnClusterLRPToJoinIfAddrs,
+		hostAddrs:   hostAddrs,
+		externalIPs: externalIPs,
+	}, nil
+}
+
+func (oc *SecondaryLayer2NetworkController) newGatewayManager(nodeName string) *GatewayManager {
+	return NewGatewayManagerForLayer2Topology(
+		nodeName,
+		oc.defaultCOPPUUID,
+		oc.kube,
+		oc.nbClient,
+		oc.NetInfo,
+		oc.watchFactory,
+	)
+}
+
+func (oc *SecondaryLayer2NetworkController) gatewayManagerForNode(nodeName string) *GatewayManager {
+	obj, isFound := oc.gatewayManagers.Load(nodeName)
+	if !isFound {
+		return oc.newGatewayManager(nodeName)
+	} else {
+		gwManager, isGWManagerType := obj.(*GatewayManager)
+		if !isGWManagerType {
+			klog.Errorf(
+				"failed to extract a gateway manager from the network %q on node %s; creating new one",
+				oc.GetNetworkName(),
+				nodeName,
+			)
+			return oc.newGatewayManager(nodeName)
+		}
+		return gwManager
+	}
 }

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -550,9 +550,12 @@ func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node)
 		hostSubnets = append(hostSubnets, subnet.CIDR)
 	}
 
-	// at layer2 the GR similar to layer3 ovn_cluster_router so we use
-	// the join subnet too
-	gwLRPIPs := oc.ovnClusterLRPToJoinIfAddrs
+	// at layer2 the GR LRP should be different per node same we do for layer3
+	// since they should not collide at the distributed switch later on
+	gwLRPIPs, err := util.ParseNodeGatewayRouterJoinAddrs(node, networkName)
+	if err != nil {
+		return nil, fmt.Errorf("failed composing LRP addresses for layer2 network %s: %w", oc.GetNetworkName(), err)
+	}
 
 	// At layer2 GR LRP acts as the layer3 ovn_cluster_router so we need
 	// to configure here the .1 address, this will work only for IC with

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -450,7 +450,7 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 					gwConfig.hostSubnets,
 					gwConfig.gwLRPIPs,
 					oc.SCTPSupport,
-					oc.ovnClusterLRPToJoinIfAddrs,
+					nil, // no need for ovnClusterLRPToJoinIfAddrs
 					gwConfig.externalIPs,
 				); err != nil {
 					errs = append(errs, err)

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -317,7 +317,18 @@ func (oc *SecondaryLayer2NetworkController) Cleanup() error {
 }
 
 func (oc *SecondaryLayer2NetworkController) Init() error {
-	_, err := oc.initializeLogicalSwitch(oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), oc.Subnets(), oc.ExcludeSubnets())
+	// Create default Control Plane Protection (COPP) entry for routers
+	defaultCOPPUUID, err := EnsureDefaultCOPP(oc.nbClient)
+	if err != nil {
+		return fmt.Errorf("unable to create router control plane protection: %w", err)
+	}
+	oc.defaultCOPPUUID = defaultCOPPUUID
+
+	_, err = oc.initializeLogicalSwitch(
+		oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch),
+		oc.Subnets(),
+		oc.ExcludeSubnets(),
+	)
 	return err
 }
 

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -550,12 +550,23 @@ func (oc *SecondaryLayer2NetworkController) nodeGatewayConfig(node *corev1.Node)
 		hostSubnets = append(hostSubnets, subnet.CIDR)
 	}
 
+	// at layer2 the GR similar to layer3 ovn_cluster_router so we use
+	// the join subnet too
+	gwLRPIPs := oc.ovnClusterLRPToJoinIfAddrs
+
+	// At layer2 GR LRP acts as the layer3 ovn_cluster_router so we need
+	// to configure here the .1 address, this will work only for IC with
+	// one node per zone, since ARPs for .1 will not go beyond local switch.
+	for _, subnet := range oc.Subnets() {
+		gwLRPIPs = append(gwLRPIPs, util.GetNodeGatewayIfAddr(subnet.CIDR))
+	}
+
 	// Overwrite the primary interface ID with the correct, per-network one.
 	l3GatewayConfig.InterfaceID = oc.GetNetworkScopedExtPortName(l3GatewayConfig.BridgeID, node.Name)
 	return &SecondaryL2GatewayConfig{
 		config:      l3GatewayConfig,
 		hostSubnets: hostSubnets,
-		gwLRPIPs:    oc.ovnClusterLRPToJoinIfAddrs,
+		gwLRPIPs:    gwLRPIPs,
 		hostAddrs:   hostAddrs,
 		externalIPs: externalIPs,
 	}, nil

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -1,0 +1,242 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/urfave/cli/v2"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
+	var (
+		app       *cli.App
+		fakeOvn   *FakeOVN
+		initialDB libovsdbtest.TestSetup
+
+		isNetworkSegmentationOriginallyEnabled bool
+		isMultiNetworkOriginallyEnabled        bool
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed()) // reset defaults
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fakeOvn = NewFakeOVN(true)
+		initialDB = libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					Name: nodeName,
+				},
+			},
+		}
+
+		isNetworkSegmentationOriginallyEnabled = config.OVNKubernetesFeature.EnableNetworkSegmentation
+		isMultiNetworkOriginallyEnabled = config.OVNKubernetesFeature.EnableMultiNetwork
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = isNetworkSegmentationOriginallyEnabled
+		config.OVNKubernetesFeature.EnableMultiNetwork = isMultiNetworkOriginallyEnabled
+	})
+
+	table.DescribeTable(
+		"reconciles a new",
+		func(netInfo secondaryNetInfo) {
+			podInfo := dummyL2TestPod(ns, netInfo)
+			app.Action = func(ctx *cli.Context) error {
+				nad, err := newNetworkAttachmentDefinition(
+					ns,
+					nadName,
+					*netInfo.netconf(),
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(netInfo.setupOVNDependencies(&initialDB)).To(Succeed())
+
+				const nodeIPv4CIDR = "192.168.126.202/24"
+				testNode, err := newNodeWithSecondaryNets(nodeName, nodeIPv4CIDR, netInfo)
+				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.startWithDBSetup(
+					initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							*newNamespace(ns),
+						},
+					},
+					&v1.NodeList{Items: []v1.Node{*testNode}},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newMultiHomedPod(podInfo.namespace, podInfo.podName, podInfo.nodeName, podInfo.podIP, netInfo),
+						},
+					},
+					&nadapi.NetworkAttachmentDefinitionList{
+						Items: []nadapi.NetworkAttachmentDefinition{*nad},
+					},
+				)
+				podInfo.populateLogicalSwitchCache(fakeOvn)
+
+				// pod exists, networks annotations don't
+				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
+				Expect(ok).To(BeFalse())
+
+				Expect(fakeOvn.controller.WatchNamespaces()).NotTo(HaveOccurred())
+				Expect(fakeOvn.controller.WatchPods()).NotTo(HaveOccurred())
+				secondaryNetController, ok := fakeOvn.secondaryControllers[secondaryNetworkName]
+				Expect(ok).To(BeTrue())
+
+				secondaryNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+				podInfo.populateSecondaryNetworkLogicalSwitchCache(fakeOvn, secondaryNetController)
+				Expect(secondaryNetController.bnc.WatchNodes()).To(Succeed())
+				Expect(secondaryNetController.bnc.WatchPods()).To(Succeed())
+
+				// check that after start networks annotations and nbdb will be updated
+				Eventually(func() string {
+					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, podInfo.namespace, podInfo.podName)
+				}).WithTimeout(2 * time.Second).Should(MatchJSON(podInfo.getAnnotationsJson()))
+
+				defaultNetExpectations := getDefaultNetExpectedPodsAndSwitches([]testPod{podInfo}, []string{nodeName})
+				if netInfo.isPrimary {
+					defaultNetExpectations = emptyDefaultClusterNetworkNodeSwitch(podInfo.nodeName)
+				}
+
+				var expectationOptions []option
+				if netInfo.isPrimary {
+					gwConfig, err := util.ParseNodeL3GatewayAnnotation(testNode)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(gwConfig.NextHops).NotTo(BeEmpty())
+					expectationOptions = append(expectationOptions, withGatewayConfig(gwConfig))
+				}
+				Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(
+						append(
+							defaultNetExpectations,
+							newSecondaryNetworkExpectationMachine(
+								fakeOvn,
+								[]testPod{podInfo},
+								expectationOptions...,
+							).expectedLogicalSwitchesAndPorts()...)))
+
+				return nil
+			}
+
+			Expect(app.Run([]string{app.Name})).To(Succeed())
+		},
+		table.Entry("pod on a user defined secondary network",
+			secondaryNetInfo{
+				netName:  secondaryNetworkName,
+				nadName:  namespacedName(ns, nadName),
+				topology: ovntypes.Layer2Topology,
+				subnets:  "100.200.0.0/16",
+			},
+		),
+
+		table.Entry("pod on a user defined primary network",
+			secondaryNetInfo{
+				netName:   secondaryNetworkName,
+				nadName:   namespacedName(ns, nadName),
+				topology:  ovntypes.Layer2Topology,
+				subnets:   "100.200.0.0/16",
+				isPrimary: true,
+			},
+		),
+	)
+
+})
+
+func dummyL2TestPod(nsName string, info secondaryNetInfo) testPod {
+	const nodeSubnet = "10.128.1.0/24"
+	if info.isPrimary {
+		pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "", "myPod", "10.128.1.3", "0a:58:0a:80:01:03", nsName)
+		pod.networkRole = "infrastructure-locked"
+		pod.routes = append(
+			pod.routes,
+			util.PodRoute{
+				Dest:    testing.MustParseIPNet("10.128.0.0/14"),
+				NextHop: testing.MustParseIP("10.128.1.1"),
+			},
+			util.PodRoute{
+				Dest:    testing.MustParseIPNet("100.64.0.0/16"),
+				NextHop: testing.MustParseIP("10.128.1.1"),
+			},
+		)
+		pod.addNetwork(
+			info.netName,
+			info.nadName,
+			info.subnets,
+			"",
+			"100.200.0.1",
+			"100.200.0.3/16",
+			"0a:58:64:c8:00:03",
+			"primary",
+			0,
+			[]util.PodRoute{
+				{
+					Dest:    testing.MustParseIPNet("172.16.1.0/24"),
+					NextHop: testing.MustParseIP("100.200.0.1"),
+				},
+				{
+					Dest:    testing.MustParseIPNet("100.65.0.0/16"),
+					NextHop: testing.MustParseIP("100.200.0.1"),
+				},
+			},
+		)
+		return pod
+	}
+	pod := newTPod(nodeName, nodeSubnet, "10.128.1.2", "10.128.1.1", podName, "10.128.1.3", "0a:58:0a:80:01:03", nsName)
+	pod.addNetwork(
+		info.netName,
+		info.nadName,
+		info.subnets,
+		"",
+		"",
+		"100.200.0.1/16",
+		"0a:58:64:c8:00:01",
+		"secondary",
+		0,
+		[]util.PodRoute{},
+	)
+	return pod
+}
+
+func expectedLayer2EgressEntities(networkName string) []libovsdbtest.TestData {
+	clusterRouterName := fmt.Sprintf("GR_%s_test-node", networkName)
+	expectedEntities := []libovsdbtest.TestData{
+		&nbdb.LogicalRouter{
+			Name:         clusterRouterName,
+			UUID:         clusterRouterName + "-UUID",
+			Ports:        []string{"rtoj-isolatednet_ovn_layer2_switch-UUID"},
+			StaticRoutes: []string{"sr1-UUID", "sr2-UUID"},
+			Policies:     []string{"lrpol1-UUID", "lrpol2-UUID"},
+		},
+		&nbdb.LogicalRouterPort{UUID: "rtoj-isolatednet_ovn_layer2_switch-UUID", Name: "rtoj-isolatednet_ovn_layer2_switch", Networks: []string{"100.200.0.1/16"}, MAC: "0a:58:64:c8:00:03", GatewayChassis: []string{"rtos-isolatednet_test-node-abdcef-UUID"}},
+		expectedGRStaticRoute("sr1-UUID", "192.168.0.0/16", "10.10.10.0", &nbdb.LogicalRouterStaticRoutePolicySrcIP, nil),
+		expectedGRStaticRoute("sr2-UUID", "10.10.10.0", "10.10.10.0", nil, nil),
+		&nbdb.LogicalRouterPolicy{UUID: "lrpol1-UUID", Action: "reroute", ExternalIDs: map[string]string{"k8s.ovn.org/topology": "layer3", "k8s.ovn.org/network": "isolatednet"}, Match: "inport == \"rtos-isolatednet_test-node\" && ip4.dst == 10.89.0.14 /* isolatednet_test-node */", Nexthops: []string{"192.168.0.2"}, Priority: 1004},
+		&nbdb.LogicalRouterPolicy{UUID: "lrpol2-UUID", Action: "reroute", ExternalIDs: map[string]string{"k8s.ovn.org/topology": "layer3", "k8s.ovn.org/network": "isolatednet"}, Match: "inport == \"rtos-isolatednet_test-node\" && ip4.dst == 169.254.169.13 /* isolatednet_test-node */", Nexthops: []string{"192.168.0.2"}, Priority: 1004},
+	}
+	return expectedEntities
+}

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -509,8 +509,8 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 			Nat:          []string{nat1, nat2},
 			StaticRoutes: []string{staticRoute1, staticRoute2, staticRoute3},
 		},
-		newNATEntry(nat1, dummyJoinIP().IP.String(), gwRouterIPAddress().IP.String()),
-		newNATEntry(nat2, dummyJoinIP().IP.String(), networkSubnet(netInfo)),
+		newNATEntry(nat1, dummyJoinIP().IP.String(), gwRouterIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo)),
+		newNATEntry(nat2, dummyJoinIP().IP.String(), networkSubnet(netInfo), standardNonDefaultNetworkExtIDs(netInfo)),
 		expectedGRStaticRoute(staticRoute1, ipv4Subnet, dummyJoinIP().IP.String(), nil, nil),
 		expectedGRStaticRoute(staticRoute2, ipv4DefaultRoute, nextHopIP, nil, &staticRouteOutputPort),
 		expectedGRStaticRoute(staticRoute3, masqSubnet, nextHopMasqIP, nil, &staticRouteOutputPort),
@@ -664,13 +664,14 @@ func udnGWSNATAddress() *net.IPNet {
 	}
 }
 
-func newNATEntry(uuid string, externalIP string, logicalIP string) *nbdb.NAT {
+func newNATEntry(uuid string, externalIP string, logicalIP string, extIDs map[string]string) *nbdb.NAT {
 	return &nbdb.NAT{
-		UUID:       uuid,
-		ExternalIP: externalIP,
-		LogicalIP:  logicalIP,
-		Type:       "snat",
-		Options:    map[string]string{"stateless": "false"},
+		UUID:        uuid,
+		ExternalIP:  externalIP,
+		LogicalIP:   logicalIP,
+		Type:        "snat",
+		Options:     map[string]string{"stateless": "false"},
+		ExternalIDs: extIDs,
 	}
 }
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -693,7 +693,7 @@ func expectedExternalSwitchAndLSPs(netInfo util.NetInfo, gwConfig util.L3Gateway
 			Name:        netInfo.GetNetworkScopedExtPortName(gwConfig.BridgeID, nodeName),
 			Addresses:   []string{"unknown"},
 			ExternalIDs: standardNonDefaultNetworkExtIDs(netInfo),
-			Options:     map[string]string{"network_name": netInfo.GetNetworkName()},
+			Options:     map[string]string{"network_name": ovntypes.PhysicalNetworkName},
 			Type:        ovntypes.LocalnetTopology,
 		},
 		&nbdb.LogicalSwitchPort{


### PR DESCRIPTION
This PR supersedes #4579 whose author is going on vacation.

TODO: write up 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
