### PR TITLE
Set gomega poll interval on retry to allow ~5 retries instead of just 1.

### DIFF
--- a/test/e2e/status_manager.go
+++ b/test/e2e/status_manager.go
@@ -113,8 +113,8 @@ func checkEgressFirewallStatus(namespace string, empty bool, success bool, event
 		return empty && output == "" || success && strings.Contains(output, "EgressFirewall Rules applied")
 	}
 	if eventually {
-		gomega.Eventually(checkStatus, 1*time.Second).Should(gomega.BeTrue())
+		gomega.Eventually(checkStatus, 1*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
 	} else {
-		gomega.Consistently(checkStatus, 1*time.Second).Should(gomega.BeTrue())
+		gomega.Consistently(checkStatus, 1*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
 	}
 }


### PR DESCRIPTION
Fixes [e2e (control-plane, HA, shared, ipv4, snatGW, 1br, ic-disabled)](https://github.com/ovn-org/ovn-kubernetes/actions/runs/10290466858/job/28482170103?pr=4596#logs)
Default are set to `5min, 2s` by k8s https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/test/e2e/framework/timeouts.go#L22-L23
with this comment https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/test_context.go#L503-L506. So when you set timeout to `1s`, poll interval is still `2s`, which gives 1 retry.
There is a chance other tests also don't expect that.