### PR TITLE
UT flake: fix race condition for nad controller tests

### DIFF
--- a/go-controller/pkg/network-attach-def-controller/network_manager.go
+++ b/go-controller/pkg/network-attach-def-controller/network_manager.go
@@ -153,6 +153,8 @@ func (nm *networkManagerImpl) sync(network string) error {
 }
 
 func (nm *networkManagerImpl) syncAll() error {
+	nm.Lock()
+	defer nm.Unlock()
 	// as we sync upon start, consider networks that have not been ensured as
 	// stale and clean them up
 	validNetworks := make([]util.BasicNetInfo, 0, len(nm.networks))


### PR DESCRIPTION
 Synchronizes access to `nm.networks` map to avoid race condition while running the tests.

Fixes https://github.com/ovn-org/ovn-kubernetes/issues/4602.