### PR TITLE
EIP e2e: skip test if VRF kernel module isn't loaded on target node

### DIFF
--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -2534,6 +2534,9 @@ spec:
 	// 4. Create a pod matching the EgressIP
 	// 5. Check connectivity from a pod to an external "node" hosted on a secondary host network and verify the expected IP
 	ginkgo.It("[secondary-host-eip] uses VRF routing table if EIP assigned interface is VRF slave", func() {
+		if !isKernelModuleLoaded(egress1Node.name, "vrf") {
+			ginkgo.Skip("Node doesn't have VRF kernel module loaded")
+		}
 		var egressIP1 string
 		if utilnet.IsIPv6(net.ParseIP(egress1Node.nodeIP)) {
 			egressIP1 = "2001:db8:abcd:1234:c001::"

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1243,3 +1243,16 @@ func getGatewayMTUSupport(node *v1.Node) bool {
 	}
 	return false
 }
+
+func isKernelModuleLoaded(nodeName, kernelModuleName string) bool {
+	out, err := runCommand(containerRuntime, "exec", nodeName, "lsmod")
+	if err != nil {
+		framework.Failf("failed to list kernel modules for node %s: %v", nodeName, err)
+	}
+	for _, module := range strings.Split(out, "\n") {
+		if strings.HasPrefix(module, kernelModuleName) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Folks not using our GH CI may not be able to execute the EIP E2E test if they do not have a test dependent kernel module loaded. Skip test if not loaded.