### PR TITLE
EndpointSlice mirror controller: ensure enqueued objects are endpoint slice

### DIFF
--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go
@@ -88,7 +88,12 @@ func (c *Controller) getDefaultEndpointSliceKey(endpointSlice *v1.EndpointSlice)
 }
 
 func (c *Controller) enqueueEndpointSlice(obj interface{}) {
-	if key := c.getDefaultEndpointSliceKey(obj.(*v1.EndpointSlice)); key != "" {
+	eps, ok := obj.(*v1.EndpointSlice)
+	if !ok {
+		klog.Errorf("Enqueued non-endpointSlice object %+v, skipping", obj)
+		return
+	}
+	if key := c.getDefaultEndpointSliceKey(eps); key != "" {
 		c.queue.AddRateLimited(key)
 	}
 }


### PR DESCRIPTION
There is a small chance that objects from the informer are not of type v1.EndpointSlice, add a check to handle this scenario. Example error seen:
```
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2205280, 0xc0001861b0})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0006b1a40?})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x2205280?, 0xc0001861b0?})
	/usr/lib/golang/src/runtime/panic.go:770 +0x132
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/endpointslicemirror.(*Controller).enqueueEndpointSlice(0xc0004fd080?, {0x22dd7e0?, 0xc0001214e0?})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go:91 +0x77
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/endpointslicemirror.(*Controller).onEndpointSliceDelete(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go:101
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:253
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/endpointslicemirror.NewController.WithUpdateHandlingForObjReplace.func3({0x22dd7e0?, 0xc0001214e0?})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/factory/factory.go:1635 +0x2f
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:253
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/shared_informer.go:983 +0x9f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0008abf70, {0x2977c20, 0xc000032630}, 0x1, 0xc0000b8d20)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0005c7770, 0x3b9aca00, 0x0, 0x1, 0xc0000b8d20)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
k8s.io/client-go/tools/cache.(*processorListener).run(0xc000565170)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/shared_informer.go:972 +0x69
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x52
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 24
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
panic: interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *v1.EndpointSlice [recovered]
	panic: interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *v1.EndpointSlice
```