### PR TITLE
UT egress firewall: stop node controller in AfterEach.

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -280,6 +280,9 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 	ginkgo.AfterEach(func() {
 		fakeOVN.shutdown()
+		if fakeOVN.controller.efNodeController != nil {
+			controller.Stop(fakeOVN.controller.efNodeController)
+		}
 	})
 
 	for _, gwMode := range []config.GatewayMode{config.GatewayModeLocal, config.GatewayModeShared} {


### PR DESCRIPTION
an attempt to fix data race https://github.com/ovn-org/ovn-kubernetes/actions/runs/10300314435/job/28509457479?pr=4590
We start nodeController here in the test https://github.com/ovn-org/ovn-kubernetes/blob/1e4527557ec1f14c1a9534387ee1288872d9f6bf/go-controller/pkg/ovn/egressfirewall_test.go#L233-L234
but it is never stopped