### PR TITLE
Don't use zone 0 for UDN Networks

### DIFF
--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -208,8 +208,12 @@ func (gw *GatewayManager) GatewayInit(
 		"dynamic_neigh_routers":         "true",
 		"chassis":                       l3GatewayConfig.ChassisID,
 		"lb_force_snat_ip":              "router_ip",
-		"snat-ct-zone":                  "0",
 		"mac_binding_age_threshold":     types.GRMACBindingAgeThreshold,
+	}
+	// set the snat-ct-zone only for the default network
+	// for UDN's OVN will pick a random one
+	if gw.netInfo.GetNetworkName() == types.DefaultNetworkName {
+		logicalRouterOptions["snat-ct-zone"] = "0"
 	}
 	logicalRouterExternalIDs := map[string]string{
 		"physical_ip":  physicalIPs[0],

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -453,12 +453,8 @@ func expectedGWEntities(nodeName string, netInfo util.NetInfo, gwConfig util.L3G
 		expectedGatewayChassis(nodeName, netInfo, gwConfig),
 		expectedStaticMACBinding(gwRouterName, nextHopMasqueradeIP()),
 	)
-	for _, entity := range expectedExternalSwitchAndLSPs(netInfo, gwConfig, nodeName) {
-		expectedEntities = append(expectedEntities, entity)
-	}
-	for _, entity := range expectedJoinSwitchAndLSPs(netInfo, nodeName) {
-		expectedEntities = append(expectedEntities, entity)
-	}
+	expectedEntities = append(expectedEntities, expectedExternalSwitchAndLSPs(netInfo, gwConfig, nodeName)...)
+	expectedEntities = append(expectedEntities, expectedJoinSwitchAndLSPs(netInfo, nodeName)...)
 	return expectedEntities
 }
 
@@ -757,7 +753,6 @@ func networkSubnet(netInfo util.NetInfo) string {
 func gwRouterOptions(gwConfig util.L3GatewayConfig) map[string]string {
 	return map[string]string{
 		"lb_force_snat_ip":              "router_ip",
-		"snat-ct-zone":                  "0",
 		"mac_binding_age_threshold":     "300",
 		"chassis":                       gwConfig.ChassisID,
 		"always_learn_from_arp_request": "false",


### PR DESCRIPTION
```
sh-5.2# ovn-nbctl list logical-router GR_l3.network_ovn-control-plane
_uuid               : b2a4db8a-54b2-44c9-89f5-dacf381dca17
copp                : d51232db-7768-4d6c-aab0-9303a7856e8c
enabled             : []
external_ids        : {"k8s.ovn.org/network"=l3-network, "k8s.ovn.org/topology"=layer3, physical_ip="172.18.0.4", physical_ips="172.18.0.4,fc00:f853:ccd:e793::4,169.254.0.11,fd69::b"}
load_balancer       : []
load_balancer_group : []
name                : GR_l3.network_ovn-control-plane
nat                 : []
options             : {always_learn_from_arp_request="false", chassis="53db7ce4-f836-41ca-a176-8e237073f602", dynamic_neigh_routers="true", lb_force_snat_ip=router_ip, mac_binding_age_threshold="300", snat-ct-zone="0"}
policies            : []
ports               : [29589cd0-a17c-4a60-b484-8bac3f9cbaac, df65b326-689a-463c-98e1-9037f54cce05]
static_routes       : [439fb202-8981-4313-b524-cee44c243bbd, 9245d6a3-b918-4699-ac11-43b7cf3132f7, c0ea5743-7f72-4e37-bff8-9c4982fb31da, c52e12b7-d374-4e3b-9222-d1ed02e73820, da67514d-ff82-4627-bd11-dd6b3a704bb5]
```

everytime we create a UDN we were causing disruption to services for default network.
Don't set the UDN GR's snat zone option to 0.