### PR TITLE
corrections to user defined networking 

### DIFF
--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -569,6 +569,8 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 
 			config.OVNKubernetesFeature.EnableInterconnect = tt.idAllocation
 
+			// config.IPv4Mode needs to be set so that the ipv4 of the userdefined primary networks can match the running cluster
+			config.IPv4Mode = true
 			netInfo, err := util.NewNetInfo(netConf)
 			if err != nil {
 				t.Fatalf("Invalid netConf")

--- a/go-controller/pkg/clustermanager/secondary_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/secondary_network_unit_test.go
@@ -114,6 +114,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 			)
 
 			ginkgo.BeforeEach(func() {
+
 				fakeClient = &util.OVNClusterManagerClientset{
 					KubeClient:            fake.NewSimpleClientset(&v1.NodeList{Items: nodes()}),
 					IPAMClaimsClient:      fakeipamclaimclient.NewSimpleClientset(),
@@ -674,24 +675,6 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 				netInfo    util.NetInfo
 			)
 
-			ginkgo.BeforeEach(func() {
-				var err error
-				netInfo, err = util.NewNetInfo(
-					&ovncnitypes.NetConf{
-						NetConf:  types.NetConf{Name: "blue"},
-						Role:     ovntypes.NetworkRolePrimary,
-						Subnets:  subnets,
-						Topology: ovntypes.Layer2Topology,
-					})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				fakeClient = &util.OVNClusterManagerClientset{
-					KubeClient:            fake.NewSimpleClientset(&v1.NodeList{Items: nodes()}),
-					IPAMClaimsClient:      fakeipamclaimclient.NewSimpleClientset(),
-					NetworkAttchDefClient: fakenadclient.NewSimpleClientset(),
-				}
-			})
-
 			ginkgo.It("Automatically reserves IPs for the GW (.1) and mgmt port (.2)", func() {
 				app.Action = func(ctx *cli.Context) error {
 					gomega.Expect(
@@ -701,6 +684,20 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						)).To(gomega.Succeed())
 
 					var err error
+					netInfo, err = util.NewNetInfo(
+						&ovncnitypes.NetConf{
+							NetConf:  types.NetConf{Name: "blue"},
+							Role:     ovntypes.NetworkRolePrimary,
+							Subnets:  subnets,
+							Topology: ovntypes.Layer2Topology,
+						})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					fakeClient = &util.OVNClusterManagerClientset{
+						KubeClient:            fake.NewSimpleClientset(&v1.NodeList{Items: nodes()}),
+						IPAMClaimsClient:      fakeipamclaimclient.NewSimpleClientset(),
+						NetworkAttchDefClient: fakenadclient.NewSimpleClientset(),
+					}
 					f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(f.Start()).NotTo(gomega.HaveOccurred())
@@ -740,7 +737,12 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					return nil
 				}
 
-				gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+				gomega.Expect(app.Run([]string{
+					app.Name,
+					// define the cluster as dualstack so the user defined primary network matches the ip family
+					"--cluster-subnets=10.128.0.0/14,fd00:10:244::/48",
+					"--k8s-service-cidrs=172.16.1.0/24,fd02::/112",
+				})).To(gomega.Succeed())
 			})
 
 		})

--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template_test.go
@@ -10,6 +10,7 @@ import (
 
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	udnv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 )
 
@@ -211,6 +212,9 @@ var _ = Describe("NetAttachDefTemplate", func() {
 				Spec: netv1.NetworkAttachmentDefinitionSpec{Config: expectedNadNetConf},
 			}
 
+			// must be defined so the primary user defined network can match the ip families of the underlying cluster
+			config.IPv4Mode = true
+			config.IPv6Mode = true
 			nad, err := RenderNetAttachDefManifest(testUdn)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nad.TypeMeta).To(Equal(expectedNAD.TypeMeta))

--- a/go-controller/pkg/cni/udn/primary_network_test.go
+++ b/go-controller/pkg/cni/udn/primary_network_test.go
@@ -177,6 +177,9 @@ func TestWaitForPrimaryAnnotationFn(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			g := NewWithT(t)
+			// needs to be set so the primary user defined networks can use ipfamilies supported by the underlying cluster
+			config.IPv4Mode = true
+			config.IPv6Mode = true
 			nadLister := v1nadmocks.NetworkAttachmentDefinitionLister{}
 			nadNamespaceLister := v1nadmocks.NetworkAttachmentDefinitionNamespaceLister{}
 			nadLister.On("NetworkAttachmentDefinitions", tt.namespace).Return(&nadNamespaceLister)

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -311,6 +311,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		}
 		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
 			types.Layer3Topology, "100.128.0.0/16/24,ae70::66/60", types.NetworkRolePrimary)
+		// must be defined so that the primary user defined network can match the ip families of the underlying cluster
+		config.IPv4Mode = true
+		config.IPv6Mode = true
 		netInfo, err := util.ParseNADInfo(nad)
 		Expect(err).NotTo(HaveOccurred())
 		udnGateway, err := NewUserDefinedNetworkGateway(netInfo, 3, node, factoryMock.NodeCoreInformer().Lister(),
@@ -380,6 +383,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		}
 		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
 			types.Layer2Topology, "100.128.0.0/16,ae70::66/60", types.NetworkRolePrimary)
+		// must be defined so that the primary user defined network can match the ip families of the underlying cluster
+		config.IPv4Mode = true
+		config.IPv6Mode = true
 		netInfo, err := util.ParseNADInfo(nad)
 		Expect(err).NotTo(HaveOccurred())
 		udnGateway, err := NewUserDefinedNetworkGateway(netInfo, 3, node, factoryMock.NodeCoreInformer().Lister(),
@@ -920,8 +926,18 @@ func TestConstructUDNVRFIPRules(t *testing.T) {
 			g := gomega.NewWithT(t)
 			config.IPv4Mode = test.v4mode
 			config.IPv6Mode = test.v6mode
+			cidr := ""
+			if config.IPv4Mode {
+				cidr = "100.128.0.0/16/24"
+
+			}
+			if config.IPv4Mode && config.IPv6Mode {
+				cidr += ",ae70::66/60"
+			} else if config.IPv6Mode {
+				cidr = "ae70::66/60"
+			}
 			nad := ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
-				types.Layer3Topology, "100.128.0.0/16/24,ae70::66/60", types.NetworkRolePrimary)
+				types.Layer3Topology, cidr, types.NetworkRolePrimary)
 			netInfo, err := util.ParseNADInfo(nad)
 			g.Expect(err).NotTo(HaveOccurred())
 			udnGateway, err := NewUserDefinedNetworkGateway(netInfo, 3, nil, nil, nil, nil, nil, &gateway{})

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -1200,8 +1200,10 @@ func Test_buildClusterLBs(t *testing.T) {
 	namespace := "testns"
 
 	oldGwMode := globalconfig.Gateway.Mode
+	oldIPv4Mode := globalconfig.IPv4Mode
 	defer func() {
 		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.IPv4Mode = oldIPv4Mode
 	}()
 	globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
 
@@ -1217,7 +1219,9 @@ func Test_buildClusterLBs(t *testing.T) {
 	defaultGroups := []string{types.ClusterLBGroupName}
 	defaultOpts := LBOpts{Reject: true}
 
-	UDNNetInfo := getSampleUDNNetInfo(namespace)
+	globalconfig.IPv4Mode = true
+	UDNNetInfo, err := getSampleUDNNetInfo(namespace)
+	assert.Equal(t, err, nil)
 	UDNGroups := []string{UDNNetInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterLBGroupName)}
 
 	tc := []struct {
@@ -1455,7 +1459,9 @@ func Test_buildPerNodeLBs(t *testing.T) {
 	oldClusterSubnet := globalconfig.Default.ClusterSubnets
 	oldGwMode := globalconfig.Gateway.Mode
 	oldServiceCIDRs := globalconfig.Kubernetes.ServiceCIDRs
+	oldIPv4Mode := globalconfig.IPv4Mode
 	defer func() {
+		globalconfig.IPv4Mode = oldIPv4Mode
 		globalconfig.Gateway.Mode = oldGwMode
 		globalconfig.Default.ClusterSubnets = oldClusterSubnet
 		globalconfig.Kubernetes.ServiceCIDRs = oldServiceCIDRs
@@ -1468,11 +1474,13 @@ func Test_buildPerNodeLBs(t *testing.T) {
 	_, svcCIDRv6, _ := net.ParseCIDR("fd92::0/80")
 
 	globalconfig.Kubernetes.ServiceCIDRs = []*net.IPNet{svcCIDRv4}
+	globalconfig.IPv4Mode = true
 
 	name := "foo"
 	namespace := "testns"
 
-	UDNNetInfo := getSampleUDNNetInfo(namespace)
+	UDNNetInfo, err := getSampleUDNNetInfo(namespace)
+	assert.Equal(t, nil, err)
 
 	defaultService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"testing"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -16,7 +17,9 @@ func TestExternalIDsForLoadBalancer(t *testing.T) {
 	name := "svc-ab23"
 	namespace := "ns"
 	defaultNetInfo := util.DefaultNetInfo{}
-	UDNNetInfo := getSampleUDNNetInfo(namespace)
+	config.IPv4Mode = true
+	UDNNetInfo, err := getSampleUDNNetInfo(namespace)
+	assert.Equal(t, err, nil)
 	assert.Equal(t,
 		map[string]string{
 			types.LoadBalancerKindExternalID:  "Service",

--- a/go-controller/pkg/ovn/topology/topologyfactory_test.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory_test.go
@@ -11,6 +11,7 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 
 	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -33,6 +34,9 @@ var _ = Describe("Topology factory", func() {
 
 	When("the original OVN DBs are empty", func() {
 		BeforeEach(func() {
+			// required so that NewNetInfo can properly determine the IP families the cluster supports
+			config.IPv4Mode = true
+			config.IPv6Mode = true
 			initialNBDB := []libovsdbtest.TestData{}
 			initialSBDB := []libovsdbtest.TestData{}
 			dbSetup := libovsdbtest.TestSetup{

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -644,6 +644,7 @@ var _ = Describe("Multi Homing", func() {
 		Context("localnet OVN-K secondary network", func() {
 			const (
 				clientPodName          = "client-pod"
+				nodeHostnameKey        = "kubernetes.io/hostname"
 				servicePort            = 9000
 				dockerNetworkName      = "underlay"
 				underlayServiceIP      = "60.128.0.1"

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -25,6 +25,22 @@ func netCIDR(netCIDR string, netPrefixLengthPerNode int) string {
 	return fmt.Sprintf("%s/%d", netCIDR, netPrefixLengthPerNode)
 }
 
+// takes ipv4 and ipv6 cidrs and returns the correct type for the cluster under test
+func correctCIDRFamily(ipv4CIDR, ipv6CIDR string) string {
+	// dual stack cluster
+	if isIPv6Supported() && isIPv4Supported() {
+		return strings.Join([]string{ipv4CIDR, ipv6CIDR}, ",")
+	}
+	// is an ipv6 only cluster
+	if isIPv6Supported() {
+		return ipv6CIDR
+	}
+
+	//ipv4 only cluster
+	return ipv4CIDR
+
+}
+
 func getNetCIDRSubnet(netCIDR string) (string, error) {
 	subStrings := strings.Split(netCIDR, "/")
 	if len(subStrings) == 3 {

--- a/test/e2e/network_segmentation_endpointslices_mirror.go
+++ b/test/e2e/network_segmentation_endpointslices_mirror.go
@@ -111,41 +111,41 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 
 					},
 					Entry(
-						"L2 dualstack primary UDN, cluster-networked pods",
+						"L2 primary UDN, cluster-networked pods",
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						false,
 					),
 					Entry(
-						"L3 dualstack primary UDN, cluster-networked pods",
+						"L3 primary UDN, cluster-networked pods",
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						false,
 					),
 					Entry(
-						"L2 dualstack primary UDN, host-networked pods",
+						"L2 primary UDN, host-networked pods",
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						true,
 					),
 					Entry(
-						"L3 dualstack primary UDN, host-networked pods",
+						"L3 primary UDN, host-networked pods",
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						true,
@@ -214,7 +214,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "secondary",
 						},
 					),
@@ -223,7 +223,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", func() {
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     correctCIDRFamily(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "secondary",
 						},
 					),

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -185,7 +185,6 @@ func unmarshalPodAnnotation(annotations map[string]string, networkName string) (
 
 	podAnnotation := &PodAnnotation{Primary: a.Primary}
 	var err error
-
 	podAnnotation.MAC, err = net.ParseMAC(a.MAC)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse pod MAC %q: %v", a.MAC, err)


### PR DESCRIPTION
this PR does three things 
1. ensure that user defined primary networks only use ip families the cluster supports
2. ensure that e2e tests select the correct families for primary networks under test
3. increase the testing of NAD and UDN CRDS to CIDR overlap and pod2Egress e2e tests 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
