### PR TITLE
Fix IPv6 network mgnt port IP address assignment

### DIFF
--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -269,9 +269,10 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		kubeMock.On("UpdateNodeStatus", cnode).Return(nil)
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
-			mpLink, err := udnGateway.addUDNManagementPort()
+			mpLink, _, err := udnGateway.addUDNManagementPort()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mpLink).NotTo(BeNil())
+			Expect(udnGateway.addUDNManagementPortIPs(mpLink)).Should(Succeed())
 			exists, err := util.LinkAddrExist(mpLink, ovntest.MustParseIPNet("100.128.0.2/24"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exists).To(BeTrue())
@@ -336,9 +337,10 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		kubeMock.On("UpdateNodeStatus", cnode).Return(nil)
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
-			mpLink, err := udnGateway.addUDNManagementPort()
+			mpLink, _, err := udnGateway.addUDNManagementPort()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mpLink).NotTo(BeNil())
+			Expect(udnGateway.addUDNManagementPortIPs(mpLink)).Should(Succeed())
 			exists, err := util.LinkAddrExist(mpLink, ovntest.MustParseIPNet("100.128.0.2/16"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exists).To(BeTrue())

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -213,7 +213,7 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = controller.Start(context.Background())
 		Expect(err).To(HaveOccurred()) // we don't have the gateway pieces setup so its expected to fail here
-		Expect(err.Error()).To(ContainSubstring("no annotation found"))
+		Expect(err.Error()).To(ContainSubstring("could not create management port"), err.Error())
 		Expect(controller.gateway).To(Not(BeNil()))
 	})
 	It("ensure UDNGateway is not invoked for Primary UDNs when feature gate is ON but network is not Primary", func() {


### PR DESCRIPTION
For IPv6, if you enslave a link to a VRF device, then any non-Link Local addresses maybe removed.

This commit adds the link addresses only after the link is enslaved.

cc @tssurya 