### PR TITLE
Fixes deleting CNI DEL with UDN

### DIFF
--- a/go-controller/pkg/cni/bandwidth.go
+++ b/go-controller/pkg/cni/bandwidth.go
@@ -13,9 +13,13 @@ func clearPodBandwidth(sandboxID string) error {
 		return err
 	}
 
+	return clearPodBandwidthForPorts(portList, sandboxID)
+}
+
+func clearPodBandwidthForPorts(portList []string, sandboxID string) error {
 	// Clear the QoS for any ports of this sandbox
 	for _, port := range portList {
-		if err = ovsClear("port", port, "qos"); err != nil {
+		if err := ovsClear("port", port, "qos"); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -256,27 +256,6 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		if util.IsNetworkSegmentationSupportEnabled() {
-			pod, err := clientset.getPod(pr.PodNamespace, pr.PodName)
-			if err != nil {
-				return nil, err
-			}
-			primaryUDN := udn.NewPrimaryNetwork(clientset.nadLister)
-			if err := primaryUDN.Ensure(namespace, pod.Annotations, pr.nadName); err != nil {
-				return nil, err
-			}
-			if primaryUDN.Found() {
-				primaryUDNPodRequest := pr.buildPrimaryUDNPodRequest(pod, primaryUDN)
-				primaryUDNPodInfo, err := primaryUDNPodRequest.buildPodInterfaceInfo(pod.Annotations, primaryUDN.Annotation(), primaryUDN.NetworkDevice())
-				if err != nil {
-					return nil, err
-				}
-				if err := podRequestInterfaceOps.UnconfigureInterface(primaryUDNPodRequest, primaryUDNPodInfo); err != nil {
-					return nil, err
-				}
-			}
-		}
 	} else {
 		// pass the isDPU flag and vfNetdevName back to cniShim
 		response.Result = nil

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -606,7 +606,7 @@ func (*defaultPodRequestInterfaceOps) ConfigureInterface(pr *PodRequest, getter 
 	if !ifInfo.IsDPUHostMode {
 		err = ConfigureOVS(pr.ctx, pr.PodNamespace, pr.PodName, hostIface.Name, ifInfo, pr.SandboxID, pr.CNIConf.DeviceID, getter)
 		if err != nil {
-			pr.deletePorts(hostIface.Name, pr.PodNamespace, pr.PodName)
+			pr.deletePort(hostIface.Name, pr.PodNamespace, pr.PodName)
 			return nil, err
 		}
 	}
@@ -666,6 +666,7 @@ func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInf
 	}
 
 	ifnameSuffix := ""
+	isSecondary := pr.netName != types.DefaultNetworkName
 	// nothing needs to be done for the VFIO case in the container namespace
 	if !pr.IsVFIO {
 		netns, err := ns.GetNS(pr.Netns)
@@ -683,7 +684,6 @@ func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInf
 		// 1. For SRIOV case, we'd need to move device from container namespace back to the host namespace
 		// 2. If it is secondary network and not dpu-host mode, then get the container interface index
 		//    so that we know the host-side interface name.
-		isSecondary := pr.netName != types.DefaultNetworkName
 		err = netns.Do(func(_ ns.NetNS) error {
 			// container side interface deletion
 			link, err := util.GetNetLinkOps().LinkByName(pr.IfName)
@@ -728,7 +728,11 @@ func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInf
 	if !ifInfo.IsDPUHostMode {
 		var err error
 		// host side interface deletion
-		hostIfName := pr.SandboxID[:(15-len(ifnameSuffix))] + ifnameSuffix
+		var hostIfName string
+		if !util.IsNetworkSegmentationSupportEnabled() || isSecondary {
+			// this is a secondary network (not primary) or segmentation is not enabled
+			hostIfName = pr.SandboxID[:(15-len(ifnameSuffix))] + ifnameSuffix
+		}
 		if pr.CNIConf.DeviceID != "" {
 			hostIfName, err = util.GetFunctionRepresentorName(pr.CNIConf.DeviceID)
 			if err != nil {
@@ -736,10 +740,27 @@ func (*defaultPodRequestInterfaceOps) UnconfigureInterface(pr *PodRequest, ifInf
 					pr.CNIConf.DeviceID, podDesc, err)
 			}
 		}
-		if hostIfName != "" {
-			pr.deletePorts(hostIfName, pr.PodNamespace, pr.PodName)
+		portList, err := ovsFind("interface", "name", "external-ids:sandbox="+pr.SandboxID)
+		if err != nil {
+			return fmt.Errorf("failed to list interfaces in OVS during delete for sandbox: %s, err: %w",
+				pr.SandboxID, err)
 		}
-		err = clearPodBandwidth(pr.SandboxID)
+		// hostIfName is not empty if using device ID, a secondary network, or segmentation not enabled
+		// delete the port in traditional fashion
+		if hostIfName != "" {
+			pr.deletePort(hostIfName, pr.PodNamespace, pr.PodName)
+		} else {
+			// this is a primary interface deletion and segmentation is enabled, delete all ports
+			// delete happens in reverse order for attached networks, so this is the final deletion
+			// In other words we dont have to worry about accidentally deleting a secondary network interface at
+			// this point.
+			if len(portList) > 1 {
+				klog.V(5).Infof("Removing multiple interfaces for primary network segmentation (%+v) %s: %s",
+					*pr, podDesc, strings.Join(portList, ","))
+			}
+			pr.deletePorts(portList, pr.PodNamespace, pr.PodName)
+		}
+		err = clearPodBandwidthForPorts(portList, pr.SandboxID)
 		if err != nil {
 			klog.Errorf("Failed to clearPodBandwidth sandbox %v %s: %v", pr.SandboxID, podDesc, err)
 		}
@@ -775,7 +796,7 @@ func (pr *PodRequest) deletePodConntrack() {
 	}
 }
 
-func (pr *PodRequest) deletePorts(ifaceName, podNamespace, podName string) {
+func (pr *PodRequest) deletePort(ifaceName, podNamespace, podName string) {
 	podDesc := fmt.Sprintf("%s/%s", podNamespace, podName)
 
 	out, err := ovsExec("del-port", "br-int", ifaceName)
@@ -788,5 +809,11 @@ func (pr *PodRequest) deletePorts(ifaceName, podNamespace, podName string) {
 		if err = util.LinkDelete(ifaceName); err != nil {
 			klog.Warningf("Failed to delete pod %q interface %s: %v", podDesc, ifaceName, err)
 		}
+	}
+}
+
+func (pr *PodRequest) deletePorts(ifaces []string, podNamespace, podName string) {
+	for _, iface := range ifaces {
+		pr.deletePort(iface, podNamespace, podName)
 	}
 }


### PR DESCRIPTION
The previous implementation had several issues:
 - If a NAD was removed while pods were active, CNI DEL would fail.
 - If a pod was force removed, CNI DEL would fail.

The above issues were due to:
 - Searching for the NAD to be able to do the CNI DEL
 - Searching for the pod in the informer cache for CNI DEL

This PR simplifies deletion by not relying on the pod object or the NAD
object. When primary CNI deletion happens with this patch, we simply
find any interfaces that belong to this pod's sandbox ID. There is no
performance impact, because clearPodBandwidth was already finding all of
these ports anyway.

CNI deletion happens in reverse order, so we can be sure that secondary
interfaces have already been deleted by the time we search and delete
interfaces for the primary CNI.

Signed-off-by: Tim Rozet <trozet@redhat.com>