### PR TITLE
Network Segmentation E2E: Use current pod state when checking readiness 

### DIFF
--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -259,14 +259,15 @@ var _ = Describe("Network Segmentation", func() {
 							}, 5*time.Second).Should(BeTrue())
 						}
 
-						By("asserting healthcheck works (kubelet can access the UDN pod)")
-						// The pod should be ready
-						Expect(podutils.IsPodReady(udnPod)).To(BeTrue())
-
 						// connectivity check is run every second + 1sec initialDelay
 						// By this time we have spent at least 8 seconds doing the above checks
 						udnPod, err = cs.CoreV1().Pods(udnPod.Namespace).Get(context.Background(), udnPod.Name, metav1.GetOptions{})
 						Expect(err).NotTo(HaveOccurred())
+
+						By("asserting healthcheck works (kubelet can access the UDN pod)")
+						// The pod should be ready
+						Expect(podutils.IsPodReady(udnPod)).To(BeTrue(), fmt.Sprintf("UDN pod is not ready: %v", udnPod))
+
 						Expect(udnPod.Status.ContainerStatuses[0].RestartCount).To(Equal(int32(0)))
 
 						// TODO


### PR DESCRIPTION
Use the current UDN pod state to avoid a race in which the condition is not yet set during pod creation.
Additionally print the pod object in case of failure for easier debugging in the future. 

Seen flaking in CI, example run:
```
2024-08-17T05:12:27.5807666Z   [1mSTEP:[0m asserting healthcheck works (kubelet can access the UDN pod) [38;5;243m@ 08/17/24 05:12:27.58[0m
2024-08-17T05:12:27.5853305Z   [38;5;9m[FAILED][0m in [It] - /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/network_segmentation.go:264 [38;5;243m@ 08/17/24 05:12:27.584[0m
...
2024-08-17T05:13:08.7407141Z [38;5;243m/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/network_segmentation.go:347[0m
2024-08-17T05:13:08.7408176Z 
2024-08-17T05:13:08.7408593Z   [38;5;9m[FAILED] Expected
2024-08-17T05:13:08.7409460Z       <bool>: false
2024-08-17T05:13:08.7410113Z   to be true[0m
2024-08-17T05:13:08.7412025Z   [38;5;9mIn [1m[It][0m[38;5;9m at: [1m/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/network_segmentation.go:264[0m [38;5;243m@ 08/17/24 05:13:07.736[0m
2024-08-17T05:13:08.7413481Z 
2024-08-17T05:13:08.7414534Z   There were [1m[38;5;9madditional failures[0m detected.  To view them in detail run [1mginkgo -vv[0m
```
https://productionresultssa15.blob.core.windows.net/actions-results/cb5813ee-1872-45db-a937-37c606686e6a/workflow-job-run-94acd78b-a87c-500c-57e3-6b4881d1ab9d/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-08-19T12%3A41%3A45Z&sig=S1dDakZaeweVuFaxA4t3lInArJkwj9BX7z%2Fb66N0eNU%3D&ske=2024-08-20T00%3A19%3A38Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-08-19T12%3A19%3A38Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-05-04&sp=r&spr=https&sr=b&st=2024-08-19T12%3A31%3A40Z&sv=2024-05-04

/cc @tssurya 