### PR TITLE
Improve error reporting for UDN

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -134,8 +134,12 @@ func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.W
 			ovnClient.UserDefinedNetworkClient, wf.UserDefinedNetworkInformer(),
 			udntemplate.RenderNetAttachDefManifest,
 			wf.PodCoreInformer(),
+			cm.recorder,
 		)
 		cm.userDefinedNetworkController = udnController
+		if cm.secondaryNetClusterManager != nil {
+			cm.secondaryNetClusterManager.SetNetworkStatusReporter(udnController.UpdateSubsystemCondition)
+		}
 	}
 
 	return cm, nil

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -8,9 +8,8 @@ import (
 	"reflect"
 	"sync"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -31,6 +30,8 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
+
+type NetworkStatusReporter func(networkName string, fieldManager string, condition *metav1.Condition, events ...*util.EventDetails) error
 
 // networkClusterController is the cluster controller for the networks. An
 // instance of this struct is expected to be created for each network. A network
@@ -67,10 +68,21 @@ type networkClusterController struct {
 	// event recorder used to post events to k8s
 	recorder record.EventRecorder
 
+	statusReporter NetworkStatusReporter
+
+	// nodeName: errMessage
+	nodeErrors     map[string]string
+	nodeErrorsLock sync.Mutex
+	// Error condition only reports one of the failed nodes.
+	// To avoid changing that error report with every update, we store reported error node.
+	reportedErrorNode string
+
 	util.NetInfo
 }
 
-func newNetworkClusterController(networkIDAllocator idallocator.NamedAllocator, netInfo util.NetInfo, ovnClient *util.OVNClusterManagerClientset, wf *factory.WatchFactory, recorder record.EventRecorder, nadController *networkAttachDefController.NetAttachDefinitionController) *networkClusterController {
+func newNetworkClusterController(networkIDAllocator idallocator.NamedAllocator, netInfo util.NetInfo,
+	ovnClient *util.OVNClusterManagerClientset, wf *factory.WatchFactory, recorder record.EventRecorder,
+	nadController *networkAttachDefController.NetAttachDefinitionController, errorReporter NetworkStatusReporter) *networkClusterController {
 	kube := &kube.KubeOVN{
 		Kube: kube.Kube{
 			KClient: ovnClient.KubeClient,
@@ -89,6 +101,9 @@ func newNetworkClusterController(networkIDAllocator idallocator.NamedAllocator, 
 		networkIDAllocator: networkIDAllocator,
 		recorder:           recorder,
 		nadController:      nadController,
+		statusReporter:     errorReporter,
+		nodeErrors:         make(map[string]string),
+		nodeErrorsLock:     sync.Mutex{},
 	}
 
 	return ncc
@@ -108,7 +123,7 @@ func newDefaultNetworkClusterController(netInfo util.NetInfo, ovnClient *util.OV
 	}
 
 	namedIDAllocator := networkIDAllocator.ForName(types.DefaultNetworkName)
-	return newNetworkClusterController(namedIDAllocator, netInfo, ovnClient, wf, recorder, nil)
+	return newNetworkClusterController(namedIDAllocator, netInfo, ovnClient, wf, recorder, nil, nil)
 }
 
 func (ncc *networkClusterController) hasPodAllocation() bool {
@@ -147,6 +162,11 @@ func (ncc *networkClusterController) allowPersistentIPs() bool {
 }
 
 func (ncc *networkClusterController) init() error {
+	// report no errors on restart, then propagate any new errors by the started handlers
+	if err := ncc.resetStatus(); err != nil {
+		return fmt.Errorf("failed to reset network status: %w", err)
+	}
+
 	networkID, err := ncc.networkIDAllocator.AllocateID()
 	if err != nil {
 		return err
@@ -200,6 +220,96 @@ func (ncc *networkClusterController) init() error {
 	}
 
 	return nil
+}
+
+// updateNetworkStatus allows to report a status for networkClusterController's network via a UDN status condition
+// of type "NetworkAllocationSucceeded", if the network was created by UDN.
+// When at least one node reports an error, condition will be set to false and an event with node-specific error will be
+// generated.
+// Call this function after every node event handling, set handlerErr to nil to report no error.
+// There are potential optimization to when an error should be reported, see https://github.com/ovn-org/ovn-kubernetes/pull/4647#discussion_r1763352619.
+func (ncc *networkClusterController) updateNetworkStatus(nodeName string, handlerErr error) error {
+	if ncc.statusReporter == nil {
+		return nil
+	}
+	errorMsg := ""
+	if handlerErr != nil {
+		errorMsg = handlerErr.Error()
+	}
+
+	ncc.nodeErrorsLock.Lock()
+	defer ncc.nodeErrorsLock.Unlock()
+	if ncc.nodeErrors[nodeName] == errorMsg {
+		// error message didn't change for that node, no need to update
+		return nil
+	}
+
+	reportedErrorNode := ncc.reportedErrorNode
+	if ncc.reportedErrorNode == "" && errorMsg != "" {
+		reportedErrorNode = nodeName
+	}
+	if ncc.reportedErrorNode == nodeName && errorMsg == "" {
+		// error for this node is fixed, report next error node
+		reportedErrorNode = ""
+		for errorNode := range ncc.nodeErrors {
+			if errorNode != nodeName {
+				reportedErrorNode = errorNode
+				break
+			}
+		}
+	}
+
+	var condition *metav1.Condition
+	if reportedErrorNode != ncc.reportedErrorNode {
+		// We know condition only changes if ncc.reportedErrorNode value changes.
+		// Otherwise, condition will stay nil and the error message will be reflected in an event.
+		condition = getNetworkAllocationUDNCondition(reportedErrorNode)
+	}
+	events := make([]*util.EventDetails, 0, 1)
+	if errorMsg != "" {
+		events = append(events, &util.EventDetails{
+			EventType: util.EventTypeWarning,
+			Reason:    "NetworkAllocationFailed",
+			Note:      fmt.Sprintf("Error occurred for node %s: %s", nodeName, errorMsg),
+		})
+	}
+
+	netName := ncc.NetInfo.GetNetworkName()
+	if err := ncc.statusReporter(netName, "NetworkClusterController", condition, events...); err != nil {
+		return fmt.Errorf("failed to report network status: %w", err)
+	}
+	ncc.nodeErrors[nodeName] = errorMsg
+	ncc.reportedErrorNode = reportedErrorNode
+
+	return nil
+}
+
+// resetStatus should be called on startup before any handler is started to avoid status race.
+func (ncc *networkClusterController) resetStatus() error {
+	if ncc.statusReporter == nil {
+		return nil
+	}
+	netName := ncc.NetInfo.GetNetworkName()
+	return ncc.statusReporter(netName, "NetworkClusterController", getNetworkAllocationUDNCondition(""))
+}
+
+// We only report one failed node in condition to avoid too long messages and too many condition updates.
+// The node to be reported is passed as errorNode, if empty, all nodes are considered to be succeeded.
+func getNetworkAllocationUDNCondition(errorNode string) *metav1.Condition {
+	condition := &metav1.Condition{
+		Type:               "NetworkAllocationSucceeded",
+		LastTransitionTime: metav1.Now(),
+	}
+	if errorNode == "" {
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = "NetworkAllocationSucceeded"
+		condition.Message = "Network allocation succeeded for all synced nodes."
+	} else {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = "InternalError"
+		condition.Message = fmt.Sprintf("Network allocation failed for at least one node: %v, check UDN events for more info.", errorNode)
+	}
+	return condition
 }
 
 // Start the network cluster controller. Depending on the cluster configuration
@@ -322,12 +432,17 @@ func (h *networkClusterControllerEventHandler) AddResource(obj interface{}, from
 		if !ok {
 			return fmt.Errorf("could not cast %T object to *corev1.Node", obj)
 		}
-		if err = h.ncc.nodeAllocator.HandleAddUpdateNodeEvent(node); err != nil {
-			klog.Infof("Node add failed for %s, will try again later: %v",
-				node.Name, err)
-			return err
+		err = h.ncc.nodeAllocator.HandleAddUpdateNodeEvent(node)
+		if err == nil {
+			h.clearInitialNodeNetworkUnavailableCondition(node)
 		}
-		h.clearInitialNodeNetworkUnavailableCondition(node)
+		statusErr := h.ncc.updateNetworkStatus(node.Name, err)
+		joinedErr := errors.Join(err, statusErr)
+		if joinedErr != nil {
+			klog.Infof("Node add failed for %s, will try again later: %v",
+				node.Name, joinedErr)
+			return joinedErr
+		}
 	case factory.IPAMClaimsType:
 		return nil
 	default:
@@ -361,12 +476,17 @@ func (h *networkClusterControllerEventHandler) UpdateResource(oldObj, newObj int
 		if !ok {
 			return fmt.Errorf("could not cast %T object to *corev1.Node", newObj)
 		}
-		if err = h.ncc.nodeAllocator.HandleAddUpdateNodeEvent(node); err != nil {
+		err = h.ncc.nodeAllocator.HandleAddUpdateNodeEvent(node)
+		if err == nil {
+			h.clearInitialNodeNetworkUnavailableCondition(node)
+		}
+		statusErr := h.ncc.updateNetworkStatus(node.Name, err)
+		joinedErr := errors.Join(err, statusErr)
+		if joinedErr != nil {
 			klog.Infof("Node update failed for %s, will try again later: %v",
 				node.Name, err)
 			return err
 		}
-		h.clearInitialNodeNetworkUnavailableCondition(node)
 	case factory.IPAMClaimsType:
 		return nil
 	default:
@@ -393,7 +513,9 @@ func (h *networkClusterControllerEventHandler) DeleteResource(obj, cachedObj int
 		if !ok {
 			return fmt.Errorf("could not cast obj of type %T to *knet.Node", obj)
 		}
-		return h.ncc.nodeAllocator.HandleDeleteNode(node)
+		err := h.ncc.nodeAllocator.HandleDeleteNode(node)
+		statusErr := h.ncc.updateNetworkStatus(node.Name, err)
+		return errors.Join(err, statusErr)
 	case factory.IPAMClaimsType:
 		ipamClaim, ok := obj.(*ipamclaimsapi.IPAMClaim)
 		if !ok {

--- a/go-controller/pkg/clustermanager/secondary_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/secondary_network_unit_test.go
@@ -193,6 +193,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						sncm.watchFactory,
 						sncm.recorder,
 						sncm.nadController,
+						nil,
 					)
 					gomega.Expect(nc.init()).To(gomega.Succeed())
 					gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -320,6 +321,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					sncm.watchFactory,
 					sncm.recorder,
 					sncm.nadController,
+					nil,
 				)
 				err = oc.init()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -411,6 +413,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.watchFactory,
 							sncm.recorder,
 							sncm.nadController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -460,6 +463,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.watchFactory,
 							sncm.recorder,
 							sncm.nadController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -510,6 +514,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.watchFactory,
 							sncm.recorder,
 							sncm.nadController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -580,6 +585,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.watchFactory,
 							sncm.recorder,
 							sncm.nadController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -653,6 +659,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.watchFactory,
 							sncm.recorder,
 							sncm.nadController,
+							nil,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -720,6 +727,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						sncm.watchFactory,
 						sncm.recorder,
 						sncm.nadController,
+						nil,
 					)
 					gomega.Expect(nc.init()).To(gomega.Succeed())
 					gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -87,7 +87,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedNAD := testNAD()
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), renderNadStub(expectedNAD), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), renderNadStub(expectedNAD), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -114,7 +114,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 			renderErr := errors.New("render NAD fails")
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), failRenderNadStub(renderErr), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), failRenderNadStub(renderErr), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -141,7 +141,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				return true, nil, expectedError
 			})
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -171,7 +171,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			foreignNad, err = nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(udn.Namespace).Create(context.Background(), foreignNad, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -194,7 +194,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 			expectedNAD := testNAD()
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), renderNadStub(expectedNAD), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), renderNadStub(expectedNAD), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -227,7 +227,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), renderNadStub(expectedNAD), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), renderNadStub(expectedNAD), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -287,7 +287,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			primaryUDN, err = udnClient.K8sV1().UserDefinedNetworks(targetNs).Create(context.Background(), primaryUDN, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -316,7 +316,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			primaryUDN, err = udnClient.K8sV1().UserDefinedNetworks(targetNs).Create(context.Background(), primaryUDN, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -337,7 +337,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []string {
@@ -357,7 +357,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				return true, nil, expectedErr
 			})
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer())
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), noopRenderNadStub(), f.PodCoreInformer(), nil)
 			Expect(c.Run()).To(Succeed())
 
 			Eventually(func() []metav1.Condition {
@@ -394,7 +394,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				testPods = append(testPods, pod)
 			}
 
-			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), renderNadStub(nad), podInf)
+			c := New(nadClient, f.NADInformer(), udnClient, f.UserDefinedNetworkInformer(), renderNadStub(nad), podInf, nil)
 			// user short interval to make the controller re-enqueue requests
 			c.networkInUseRequeueInterval = 50 * time.Millisecond
 			Expect(c.Run()).To(Succeed())
@@ -425,7 +425,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			nad := testNAD()
-			c := New(nadClient, nadInformer, udnClient, udnInformer, renderNadStub(nad), nil)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, renderNadStub(nad), nil, nil)
 
 			mutetedNAD := nad.DeepCopy()
 			mutetedNAD.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{Kind: "DifferentKind"}}
@@ -437,7 +437,7 @@ var _ = Describe("User Defined Network Controller", func() {
 		})
 
 		It("when UDN is being deleted, should not remove finalizer from non managed NAD", func() {
-			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 			udn := testsUDNWithDeletionTimestamp(time.Now())
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
@@ -456,7 +456,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(unmanagedNAD.Finalizers).To(Equal(expectedFinalizers))
 		})
 		It("when UDN is being deleted, and NAD exist, should remove finalizer from NAD", func() {
-			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 			udn := testsUDNWithDeletionTimestamp(time.Now())
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
@@ -471,7 +471,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(nad.Finalizers).To(BeEmpty())
 		})
 		It("when UDN is being deleted, and NAD exist, should fail when remove NAD finalizer fails", func() {
-			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 			udn := testsUDNWithDeletionTimestamp(time.Now())
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
@@ -491,7 +491,7 @@ var _ = Describe("User Defined Network Controller", func() {
 		})
 
 		It("when UDN is being deleted, and NAD exist w/o finalizer, should remove finalizer from UDN", func() {
-			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 			udn := testsUDNWithDeletionTimestamp(time.Now())
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
@@ -507,7 +507,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(udn.Finalizers).To(BeEmpty())
 		})
 		It("when UDN is being deleted, and NAD not exist, should remove finalizer from UDN", func() {
-			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 			udn := testsUDNWithDeletionTimestamp(time.Now())
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
@@ -518,7 +518,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			Expect(udn.Finalizers).To(BeEmpty())
 		})
 		It("when UDN is being deleted, should fail removing finalizer from UDN when patch fails", func() {
-			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 			udn := testsUDNWithDeletionTimestamp(time.Now())
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
@@ -558,7 +558,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				},
 			}
 			Expect(podInformer.Informer().GetIndexer().Add(pod)).Should(Succeed())
-			c := New(nadClient, nadInformer, udnClient, udnInformer, renderNadStub(nad), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, renderNadStub(nad), podInformer, nil)
 
 			nad, err = c.syncUserDefinedNetwork(udn, nad)
 			Expect(err).ToNot(HaveOccurred())
@@ -585,7 +585,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Expect(podInformer.Informer().GetIndexer().Add(pod)).Should(Succeed())
 				}
 
-				c := New(nadClient, nadInformer, udnClient, udnInformer, renderNadStub(nad), podInformer)
+				c := New(nadClient, nadInformer, udnClient, udnInformer, renderNadStub(nad), podInformer, nil)
 
 				_, err := c.syncUserDefinedNetwork(udn, nad)
 				Expect(err).To(MatchError(ContainSubstring(expectedErr.Error())))
@@ -632,7 +632,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+				c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 				Expect(c.updateUserDefinedNetworkStatus(udn, nad, syncErr)).To(Succeed(), "should update status successfully")
 
@@ -687,7 +687,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			udn, err := udnClient.K8sV1().UserDefinedNetworks(udn.Namespace).Create(context.Background(), udn, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 			nad := testNAD()
 			syncErr := errors.New("sync error")
@@ -722,7 +722,7 @@ var _ = Describe("User Defined Network Controller", func() {
 		})
 
 		It("should fail when client update status fails", func() {
-			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer)
+			c := New(nadClient, nadInformer, udnClient, udnInformer, noopRenderNadStub(), podInformer, nil)
 
 			expectedError := errors.New("test err")
 			udnClient.PrependReactor("patch", "userdefinednetworks/status", func(action testing.Action) (bool, runtime.Object, error) {

--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
@@ -69,8 +69,20 @@ func validateTopology(udn *userdefinednetworkv1.UserDefinedNetwork) error {
 	return nil
 }
 
+func getNetworkName(udn *userdefinednetworkv1.UserDefinedNetwork) string {
+	return udn.Namespace + "." + udn.Name
+}
+
+func ParseNetworkName(networkName string) (udnNamespace, udnName string) {
+	parts := strings.Split(networkName, ".")
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", ""
+}
+
 func renderCNINetworkConfig(udn *userdefinednetworkv1.UserDefinedNetwork) (map[string]interface{}, error) {
-	networkName := udn.Namespace + "." + udn.Name
+	networkName := getNetworkName(udn)
 	nadName := util.GetNADName(udn.Namespace, udn.Name)
 
 	netConfSpec := &ovncnitypes.NetConf{

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -839,7 +839,7 @@ func ParseNodeGatewayRouterJoinNetwork(node *kapi.Node, netName string) (primary
 	}
 	val, ok := joinSubnetMap[netName]
 	if !ok {
-		return val, fmt.Errorf("unable to fetch annotation value on node %s for network %s",
+		return val, newAnnotationNotSetError("unable to fetch annotation value on node %s for network %s",
 			node.Name, netName)
 	}
 	return val, nil

--- a/go-controller/pkg/util/status.go
+++ b/go-controller/pkg/util/status.go
@@ -1,0 +1,19 @@
+package util
+
+import corev1 "k8s.io/api/core/v1"
+
+type EventType = string
+
+// There are only 2 allowed event types for now: Normal and Warning
+const (
+	EventTypeNormal  EventType = corev1.EventTypeNormal
+	EventTypeWarning EventType = corev1.EventTypeWarning
+)
+
+// EventDetails may be used to pass event details to the event recorder, that is not used directly.
+// It based on the EventRecorder interface for core.Events. It doesn't have related objects,
+// as they are not used in the current implementation.
+type EventDetails struct {
+	EventType    EventType
+	Reason, Note string
+}

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -117,7 +117,7 @@ fi
 
 # Only run Node IP/MAC address migration tests if they are explicitly requested
 IP_MIGRATION_TESTS="Node IP and MAC address migration"
-if [ "${WHAT}" != "${IP_MIGRATION_TESTS}" ]; then
+if [[ "${WHAT}" != "${IP_MIGRATION_TESTS}"* ]]; then
   if [ "$SKIPPED_TESTS" != "" ]; then
 	SKIPPED_TESTS+="|"
   fi
@@ -126,7 +126,7 @@ fi
 
 # Only run Multi node zones interconnect tests if they are explicitly requested
 MULTI_NODE_ZONES_TESTS="Multi node zones interconnect"
-if [ "${WHAT}" != "${MULTI_NODE_ZONES_TESTS}" ]; then
+if [[ "${WHAT}" != "${MULTI_NODE_ZONES_TESTS}"* ]]; then
   if [ "$SKIPPED_TESTS" != "" ]; then
 	SKIPPED_TESTS+="|"
   fi
@@ -144,7 +144,7 @@ fi
 
 # Only run kubevirt virtual machines tests if they are explicitly requested
 KV_LIVE_MIGRATION_TESTS="Kubevirt Virtual Machines"
-if [ "${WHAT}" != "${KV_LIVE_MIGRATION_TESTS}" ]; then
+if [[ "${WHAT}" != "${KV_LIVE_MIGRATION_TESTS}"* ]]; then
   if [ "$SKIPPED_TESTS" != "" ]; then
 	SKIPPED_TESTS+="|"
   fi


### PR DESCRIPTION
Cluster manager controllers may have errors related to the UDN network. For example, if Network's cluster subnet doesn't have enough node subnets for all existing nodes. This will cause pod creation error for the nodes, that were not allocated a subnet for a given UDN, and finding the real cause may be cumbersome.

I propose the following framework to report errors that are related to other objects (e.g. nodes in this case).
We use one Success condition, which is true when all related objects were handled fine (all nodes in this case), and is false if at least one error was. The error message in this case should report one failed node to simplify debugging in case events will disappear, but the condition will not be updated until reported node is fixed changed to limit the amount of api calls.
To provide per-related-object info (per-node error in this case) we can use events, that will be related to the UDN, but will contain the related object type+name. If a related object (node) is listed in the UDN condition as failed, the latest event will reflect error message.

Here is a part of ` k describe userdefinednetwork` (##<string> are my comments, not a real output)
```
Status:
  Conditions:
    Last Transition Time:  2024-09-13T13:18:05Z
    Message:               NetworkAttachmentDefinition has been created
    Reason:                NetworkAttachmentDefinitionReady
    Status:                True
    Type:                  NetworkReady
    Last Transition Time:  2024-09-13T13:18:05Z
## generic message with only 1 node name
    Message:             Network allocation failed for at least one node: udn-worker2, check UDN events for more info.
    Reason:                InternalError
    Status:                False
    Type:                  NetworkAllocationSucceeded
Events:
  Type     Reason                   Age   From          Message
  ----     ------                   ----  ----          -------
## node-specific event
  Warning  NetworkAllocationFailed  4s    controlplane  Error occurred for node udn-worker2: Node add failed: error allocating network for node udn-worker2: no subnets available
```
To make this work:
1. add UDN controller interface to allow other subsystems reporting their conditions
2. use NetworkStatusReporter interface to report errors from the `network_cluster_controller` for node handling failures.