### PR TITLE
UT: Skip eip test when iptables doesn't exist

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -1099,6 +1099,9 @@ var _ = ginkgo.Describe("VRF", func() {
 		if os.Getenv("NOROOT") == "TRUE" {
 			ginkgo.Skip("Test requires root privileges")
 		}
+		if !commandExists("iptables") {
+			ginkgo.Skip("Test requires iptables tools to be available in PATH")
+		}
 		vrfName := "vrf-dummy"
 		var vrfTable uint32 = 55555
 		ginkgo.By("setup link")
@@ -1121,6 +1124,7 @@ var _ = ginkgo.Describe("VRF", func() {
 		c, _, err := initController(namespaces, pods, egressIPList, nodeConfig, true, false, true)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		cleanupControllerFn, err := runController(testNS, c)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		ginkgo.By("ensure route previously added is copied to new routing table")
 		eipTable := util.CalculateRouteTableID(getLinkIndex(dummyLink1Name))
 		gomega.Eventually(func() bool {


### PR DESCRIPTION
IPTables doesn't exist inside the containers.. other modules and EIP tests skip running in that case but this one seems to fail?
```
------------------------------
VRF 
  copies routes from the VRF routing table for a link enslaved by VRF device
  /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressip/egressip_test.go:1097
STEP: setup link
I0822 13:32:00.166208   17044 iptables.go:224] "Error checking iptables version, assuming version at least" version="1.4.11" err="executable file not found in $PATH"
I0822 13:32:00.166899   17044 iptables.go:224] "Error checking iptables version, assuming version at least" version="1.4.11" err="executable file not found in $PATH"
STEP: create VRF and add link
STEP: add route to routing table associated with VRF
STEP: start controller
I0822 13:32:00.169072   17044 factory.go:426] Starting watch factory
I0822 13:32:00.370962   17044 iptables.go:224] "Error checking iptables version, assuming version at least" version="1.4.11" err="executable file not found in $PATH"
I0822 13:32:00.371230   17044 iptables.go:224] "Error checking iptables version, assuming version at least" version="1.4.11" err="executable file not found in $PATH"
I0822 13:32:00.371756   17044 shared_informer.go:313] Waiting for caches to sync for eipeip
I0822 13:32:00.371825   17044 shared_informer.go:320] Caches are synced for eipeip
I0822 13:32:00.371873   17044 shared_informer.go:313] Waiting for caches to sync for eipnamespace
I0822 13:32:00.371912   17044 shared_informer.go:320] Caches are synced for eipnamespace
I0822 13:32:00.371956   17044 shared_informer.go:313] Waiting for caches to sync for eippod
I0822 13:32:00.371989   17044 shared_informer.go:320] Caches are synced for eippod
I0822 13:32:00.372033   17044 link_network_manager.go:118] Link manager is running
I0822 13:32:00.373332   17044 iptables_manager.go:96] IPTables manager: own chain: table nat, chain OVN-KUBE-EGRESS-IP-MULTI-NIC, protocol IPv4
I0822 13:32:00.374773   17044 iptables_manager.go:164] IPTables manager: ensure rule - table nat, chain OVN-KUBE-EGRESS-IP-MULTI-NIC, protocol IPv4, rule: {[-s 192.168.100.2/32 -o dummy1 -j SNAT --to-source 5.5.5.50]}

• Failure [0.223 seconds]
VRF
/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressip/egressip_test.go:1096
  copies routes from the VRF routing table for a link enslaved by VRF device [It]
  /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressip/egressip_test.go:1097

  Unexpected error:
      <*errors.errorString | 0xc0004f4350>: 
      failed to ensure chain OVN-KUBE-EGRESS-IP-MULTI-NIC: error creating chain "OVN-KUBE-EGRESS-IP-MULTI-NIC": executable file not found in $PATH: 
      {
          s: "failed to ensure chain OVN-KUBE-EGRESS-IP-MULTI-NIC: error creating chain \"OVN-KUBE-EGRESS-IP-MULTI-NIC\": executable file not found in $PATH: ",
      }
  occurred

  /go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressip/egressip_test.go:1124
```