### PR TITLE
Fixes panic in DPU mgmt port tests

### DIFF
--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -445,7 +445,7 @@ func UpdateNodeManagementPortMACAddressesWithRetry(node *kapi.Node, nodeLister l
 		return kubeInterface.UpdateNodeStatus(cnode)
 	})
 	if resultErr != nil {
-		return fmt.Errorf("failed to update node %s annotation", node.Name)
+		return fmt.Errorf("failed to update node %s annotation: %w", node.Name, resultErr)
 	}
 	return nil
 }


### PR DESCRIPTION
The tests were missing kubeclient and node informer setup. Additionally another test was missing expected OVS commands.

Fixes: #4656

