### PR TITLE
Make GetActiveNetworkForNamespace use a controller

### DIFF
--- a/dist/templates/rbac-ovnkube-node.yaml.j2
+++ b/dist/templates/rbac-ovnkube-node.yaml.j2
@@ -181,6 +181,7 @@ rules:
           - egressqoses
           - egressservices
           - adminpolicybasedexternalroutes
+          - userdefinednetworks
       verbs: [ "get", "list", "watch" ]
     {% if ovn_enable_ovnkube_identity == "true" -%}
     - apiGroups: ["certificates.k8s.io"]

--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -114,7 +114,7 @@ func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.W
 		}
 	}
 	if util.IsNetworkSegmentationSupportEnabled() {
-		cm.endpointSliceMirrorController, err = endpointslicemirror.NewController(ovnClient, wf)
+		cm.endpointSliceMirrorController, err = endpointslicemirror.NewController(ovnClient, wf, cm.secondaryNetClusterManager.nadController)
 		if err != nil {
 			return nil, err
 		}
@@ -150,18 +150,19 @@ func (cm *ClusterManager) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Start secondary CM first so that NAD controller initializes before other controllers
+	if config.OVNKubernetesFeature.EnableMultiNetwork {
+		if err := cm.secondaryNetClusterManager.Start(); err != nil {
+			return err
+		}
+	}
+
 	if err := cm.defaultNetClusterController.Start(ctx); err != nil {
 		return err
 	}
 
 	if err := cm.zoneClusterController.Start(ctx); err != nil {
 		return fmt.Errorf("could not start zone controller, err: %w", err)
-	}
-
-	if config.OVNKubernetesFeature.EnableMultiNetwork {
-		if err := cm.secondaryNetClusterManager.Start(); err != nil {
-			return err
-		}
 	}
 
 	if config.OVNKubernetesFeature.EnableEgressIP {

--- a/go-controller/pkg/clustermanager/fake_cluster_manager_test.go
+++ b/go-controller/pkg/clustermanager/fake_cluster_manager_test.go
@@ -16,6 +16,7 @@ import (
 	egresssvc "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1"
 	egresssvcfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,7 +90,8 @@ func (o *FakeClusterManager) init() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
 	if util.IsNetworkSegmentationSupportEnabled() {
-		o.epsMirror, err = endpointslicemirror.NewController(o.fakeClient, o.watcher)
+		nadController := &nad.NetAttachDefinitionController{}
+		o.epsMirror, err = endpointslicemirror.NewController(o.fakeClient, o.watcher, nadController)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		err = o.epsMirror.Start(context.TODO(), 1)

--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -114,7 +114,7 @@ func (sncm *secondaryNetworkClusterManager) NewNetworkController(nInfo util.NetI
 	klog.Infof("Creating new network controller for network %s of topology %s", nInfo.GetNetworkName(), nInfo.TopologyType())
 
 	namedIDAllocator := sncm.networkIDAllocator.ForName(nInfo.GetNetworkName())
-	sncc := newNetworkClusterController(namedIDAllocator, nInfo, sncm.ovnClient, sncm.watchFactory, sncm.recorder)
+	sncc := newNetworkClusterController(namedIDAllocator, nInfo, sncm.ovnClient, sncm.watchFactory, sncm.recorder, sncm.nadController)
 	return sncc, nil
 }
 
@@ -194,7 +194,7 @@ func (sncm *secondaryNetworkClusterManager) CleanupDeletedNetworks(validNetworks
 func (sncm *secondaryNetworkClusterManager) newDummyLayer3NetworkController(netName string) (nad.NetworkController, error) {
 	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: netName}, Topology: ovntypes.Layer3Topology})
 	namedIDAllocator := sncm.networkIDAllocator.ForName(netInfo.GetNetworkName())
-	nc := newNetworkClusterController(namedIDAllocator, netInfo, sncm.ovnClient, sncm.watchFactory, sncm.recorder)
+	nc := newNetworkClusterController(namedIDAllocator, netInfo, sncm.ovnClient, sncm.watchFactory, sncm.recorder, sncm.nadController)
 	err := nc.init()
 	return nc, err
 }

--- a/go-controller/pkg/clustermanager/secondary_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/secondary_network_unit_test.go
@@ -192,6 +192,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						sncm.ovnClient,
 						sncm.watchFactory,
 						sncm.recorder,
+						sncm.nadController,
 					)
 					gomega.Expect(nc.init()).To(gomega.Succeed())
 					gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -318,6 +319,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 					sncm.ovnClient,
 					sncm.watchFactory,
 					sncm.recorder,
+					sncm.nadController,
 				)
 				err = oc.init()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -408,6 +410,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.ovnClient,
 							sncm.watchFactory,
 							sncm.recorder,
+							sncm.nadController,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -456,6 +459,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.ovnClient,
 							sncm.watchFactory,
 							sncm.recorder,
+							sncm.nadController,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -505,6 +509,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.ovnClient,
 							sncm.watchFactory,
 							sncm.recorder,
+							sncm.nadController,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -574,6 +579,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.ovnClient,
 							sncm.watchFactory,
 							sncm.recorder,
+							sncm.nadController,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -646,6 +652,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 							sncm.ovnClient,
 							sncm.watchFactory,
 							sncm.recorder,
+							sncm.nadController,
 						)
 						gomega.Expect(nc.init()).To(gomega.Succeed())
 						gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())
@@ -712,6 +719,7 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 						sncm.ovnClient,
 						sncm.watchFactory,
 						sncm.recorder,
+						sncm.nadController,
 					)
 					gomega.Expect(nc.init()).To(gomega.Succeed())
 					gomega.Expect(nc.Start(ctx.Context)).To(gomega.Succeed())

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -209,7 +209,7 @@ func (c *Controller) syncUserDefinedNetwork(udn *userdefinednetworkv1.UserDefine
 		// any other thread that create NADs.
 		// Since the UserDefinedNetwork controller use single thread (threadiness=1),
 		// and being the only controller that create NADs, this conditions is fulfilled.
-		if primaryNetwork(udn.Spec) {
+		if util.IsPrimaryNetwork(udn.Spec) {
 			actualNads, lerr := c.nadLister.NetworkAttachmentDefinitions(udn.Namespace).List(labels.Everything())
 			if lerr != nil {
 				return nil, fmt.Errorf("failed to list  NetworkAttachmetDefinition: %w", lerr)
@@ -241,18 +241,6 @@ func (c *Controller) syncUserDefinedNetwork(udn *userdefinednetworkv1.UserDefine
 	}
 
 	return nad, nil
-}
-
-func primaryNetwork(spec userdefinednetworkv1.UserDefinedNetworkSpec) bool {
-	var role userdefinednetworkv1.NetworkRole
-	switch spec.Topology {
-	case userdefinednetworkv1.NetworkTopologyLayer3:
-		role = spec.Layer3.Role
-	case userdefinednetworkv1.NetworkTopologyLayer2:
-		role = spec.Layer2.Role
-	}
-
-	return role == userdefinednetworkv1.NetworkRolePrimary
 }
 
 func (c *Controller) verifyNetAttachDefNotInUse(nad *netv1.NetworkAttachmentDefinition) error {

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kubevirt"
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -105,10 +106,12 @@ func (pr *PodRequest) checkOrUpdatePodUID(pod *kapi.Pod) error {
 	return nil
 }
 
-func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Response, error) {
-	return pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientset, getCNIResult)
+func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet,
+	nadController *nad.NetAttachDefinitionController) (*Response, error) {
+	return pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientset, getCNIResult, nadController)
 }
-func (pr *PodRequest) cmdAddWithGetCNIResultFunc(kubeAuth *KubeAPIAuth, clientset *ClientSet, getCNIResultFn getCNIResultFunc) (*Response, error) {
+func (pr *PodRequest) cmdAddWithGetCNIResultFunc(kubeAuth *KubeAPIAuth, clientset *ClientSet,
+	getCNIResultFn getCNIResultFunc, nadController nad.NADController) (*Response, error) {
 	namespace := pr.PodNamespace
 	podName := pr.PodName
 	if namespace == "" || podName == "" {
@@ -141,7 +144,7 @@ func (pr *PodRequest) cmdAddWithGetCNIResultFunc(kubeAuth *KubeAPIAuth, clientse
 	// Get the IP address and MAC address of the pod
 	// for DPU, ensure connection-details is present
 
-	primaryUDN := udn.NewPrimaryNetwork(clientset.nadLister)
+	primaryUDN := udn.NewPrimaryNetwork(nadController)
 	if util.IsNetworkSegmentationSupportEnabled() {
 		annotCondFn = primaryUDN.WaitForPrimaryAnnotationFn(namespace, annotCondFn)
 	}
@@ -290,7 +293,7 @@ func (pr *PodRequest) cmdCheck() error {
 // Argument '*PodRequest' encapsulates all the necessary information
 // kclient is passed in so that clientset can be reused from the server
 // Return value is the actual bytes to be sent back without further processing.
-func HandlePodRequest(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error) {
+func HandlePodRequest(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth, nadController *nad.NetAttachDefinitionController) ([]byte, error) {
 	var result, resultForLogging []byte
 	var response *Response
 	var err, err1 error
@@ -298,7 +301,7 @@ func HandlePodRequest(request *PodRequest, clientset *ClientSet, kubeAuth *KubeA
 	klog.Infof("%s %s starting CNI request %+v", request, request.Command, request)
 	switch request.Command {
 	case CNIAdd:
-		response, err = request.cmdAdd(kubeAuth, clientset)
+		response, err = request.cmdAdd(kubeAuth, clientset, nadController)
 	case CNIDel:
 		response, err = request.cmdDel(clientset)
 	case CNICheck:

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	v1nadmocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 	v1mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/nad"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 type podRequestInterfaceOpsStub struct {
@@ -55,6 +57,7 @@ var _ = Describe("Network Segmentation", func() {
 		}
 		prInterfaceOpsStub                            = &podRequestInterfaceOpsStub{}
 		enableMultiNetwork, enableNetworkSegmentation bool
+		nadController                                 *ovntest.FakeNADController
 	)
 
 	BeforeEach(func() {
@@ -90,7 +93,6 @@ var _ = Describe("Network Segmentation", func() {
 		nadLister = v1nadmocks.NetworkAttachmentDefinitionLister{}
 		clientSet = &ClientSet{
 			podLister: &podLister,
-			nadLister: &nadLister,
 			kclient:   fakeClientset,
 		}
 		kubeAuth = &KubeAPIAuth{
@@ -124,7 +126,7 @@ var _ = Describe("Network Segmentation", func() {
 		})
 		It("should not fail at cmdAdd", func() {
 			podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
-			Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub)).NotTo(BeNil())
+			Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub, nil)).NotTo(BeNil())
 			Expect(obtainedPodIterfaceInfos).ToNot(BeEmpty())
 		})
 		It("should not fail at cmdDel", func() {
@@ -151,10 +153,13 @@ var _ = Describe("Network Segmentation", func() {
 						},
 					},
 				}
+				nadController = &ovntest.FakeNADController{
+					PrimaryNetworks: make(map[string]util.NetInfo),
+				}
 			})
 			It("should not fail at cmdAdd", func() {
 				podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
-				Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub)).NotTo(BeNil())
+				Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub, nadController)).NotTo(BeNil())
 				Expect(obtainedPodIterfaceInfos).ToNot(BeEmpty())
 			})
 			It("should not fail at cmdDel", func() {
@@ -214,8 +219,7 @@ var _ = Describe("Network Segmentation", func() {
 						},
 					},
 				}
-				nadNamespaceLister := &v1nadmocks.NetworkAttachmentDefinitionNamespaceLister{}
-				nadNamespaceLister.On("List", labels.Everything()).Return([]*nadv1.NetworkAttachmentDefinition{{
+				nad := &nadv1.NetworkAttachmentDefinition{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      nadName,
 						Namespace: namespace,
@@ -223,15 +227,22 @@ var _ = Describe("Network Segmentation", func() {
 					Spec: nadv1.NetworkAttachmentDefinitionSpec{
 						Config: dummyPrimaryUDNConfig(namespace, nadName),
 					},
-				}}, nil)
+				}
+				nadNamespaceLister := &v1nadmocks.NetworkAttachmentDefinitionNamespaceLister{}
+				nadNamespaceLister.On("List", labels.Everything()).Return([]*nadv1.NetworkAttachmentDefinition{nad}, nil)
 				nadLister.On("NetworkAttachmentDefinitions", "foo-ns").Return(nadNamespaceLister)
-
+				nadNetwork, err := util.ParseNADInfo(nad)
+				Expect(err).NotTo(HaveOccurred())
+				nadController = &ovntest.FakeNADController{
+					PrimaryNetworks: make(map[string]util.NetInfo),
+				}
+				nadController.PrimaryNetworks[nad.Namespace] = nadNetwork
 				getCNIResultStub = dummyGetCNIResult
 			})
 
 			It("should return the information of both the default net and the primary UDN in the result", func() {
 				podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
-				response, err := pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub)
+				response, err := pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub, nadController)
 				Expect(err).NotTo(HaveOccurred())
 				// for every interface added, we return 2 interfaces; the host side of the
 				// veth, then the pod side of the veth.

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -23,6 +23,7 @@ import (
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -48,7 +49,7 @@ func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) 
 
 var expectedResult cnitypes.Result
 
-func serverHandleCNI(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error) {
+func serverHandleCNI(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth, nadController *nad.NetAttachDefinitionController) ([]byte, error) {
 	if request.Command == CNIAdd {
 		return json.Marshal(&expectedResult)
 	} else if request.Command == CNIDel || request.Command == CNIUpdate || request.Command == CNICheck {
@@ -90,7 +91,7 @@ func TestCNIServer(t *testing.T) {
 		t.Fatalf("failed to start watch factory: %v", err)
 	}
 
-	s, err := NewCNIServer(wf, fakeClient)
+	s, err := NewCNIServer(wf, fakeClient, nil)
 	if err != nil {
 		t.Fatalf("error creating CNI server: %v", err)
 	}

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -12,11 +12,10 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
-
 	kapi "k8s.io/api/core/v1"
 )
 
@@ -169,7 +168,7 @@ type PodRequest struct {
 	deviceInfo nadapi.DeviceInfo
 }
 
-type podRequestFunc func(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error)
+type podRequestFunc func(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth, nadController *nad.NetAttachDefinitionController) ([]byte, error)
 type getCNIResultFunc func(request *PodRequest, getter PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error)
 
 type PodInfoGetter interface {
@@ -180,7 +179,6 @@ type ClientSet struct {
 	PodInfoGetter
 	kclient   kubernetes.Interface
 	podLister corev1listers.PodLister
-	nadLister nadlister.NetworkAttachmentDefinitionLister
 }
 
 func NewClientSet(kclient kubernetes.Interface, podLister corev1listers.PodLister) *ClientSet {
@@ -197,4 +195,5 @@ type Server struct {
 	handlePodRequestFunc podRequestFunc
 	clientSet            *ClientSet
 	kubeAuth             *KubeAPIAuth
+	nadController        *nad.NetAttachDefinitionController
 }

--- a/go-controller/pkg/cni/udn/primary_network.go
+++ b/go-controller/pkg/cni/udn/primary_network.go
@@ -5,8 +5,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
-
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -15,14 +14,14 @@ import (
 type podAnnotWaitCond = func(map[string]string, string) (*util.PodAnnotation, bool)
 
 type UserDefinedPrimaryNetwork struct {
-	nadLister     nadlister.NetworkAttachmentDefinitionLister
+	nadController nad.NADController
 	annotation    *util.PodAnnotation
 	activeNetwork util.NetInfo
 }
 
-func NewPrimaryNetwork(nadLister nadlister.NetworkAttachmentDefinitionLister) *UserDefinedPrimaryNetwork {
+func NewPrimaryNetwork(nadController nad.NADController) *UserDefinedPrimaryNetwork {
 	return &UserDefinedPrimaryNetwork{
-		nadLister: nadLister,
+		nadController: nadController,
 	}
 }
 
@@ -124,7 +123,7 @@ func (p *UserDefinedPrimaryNetwork) ensureActiveNetwork(namespace string) error 
 	if p.activeNetwork != nil {
 		return nil
 	}
-	activeNetwork, err := util.GetActiveNetworkForNamespace(namespace, p.nadLister)
+	activeNetwork, err := p.nadController.GetActiveNetworkForNamespace(namespace)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -212,18 +212,6 @@ func NewMasterWatchFactory(ovnClientset *util.OVNMasterClientset) (*WatchFactory
 		}
 	}
 
-	if util.IsNetworkSegmentationSupportEnabled() {
-		if err := userdefinednetworkapi.AddToScheme(userdefinednetworkscheme.Scheme); err != nil {
-			return nil, err
-		}
-
-		wf.udnFactory = userdefinednetworkapiinformerfactory.NewSharedInformerFactory(ovnClientset.UserDefinedNetworkClient, resyncInterval)
-		wf.informers[UserDefinedNetworkType], err = newInformer(UserDefinedNetworkType, wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer())
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return wf, nil
 }
 
@@ -403,6 +391,14 @@ func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClient
 			if err != nil {
 				return nil, err
 			}
+		}
+	}
+
+	if util.IsNetworkSegmentationSupportEnabled() {
+		wf.udnFactory = userdefinednetworkapiinformerfactory.NewSharedInformerFactory(ovnClientset.UserDefinedNetworkClient, resyncInterval)
+		wf.informers[UserDefinedNetworkType], err = newInformer(UserDefinedNetworkType, wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer())
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -704,6 +700,14 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 	if config.OVNKubernetesFeature.EnableMultiNetwork || config.OVNKubernetesFeature.EnableNetworkSegmentation {
 		wf.nadFactory = nadinformerfactory.NewSharedInformerFactory(ovnClientset.NetworkAttchDefClient, resyncInterval)
 		wf.informers[NetworkAttachmentDefinitionType], err = newInformer(NetworkAttachmentDefinitionType, wf.nadFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions().Informer())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if util.IsNetworkSegmentationSupportEnabled() {
+		wf.udnFactory = userdefinednetworkapiinformerfactory.NewSharedInformerFactory(ovnClientset.UserDefinedNetworkClient, resyncInterval)
+		wf.informers[UserDefinedNetworkType], err = newInformer(UserDefinedNetworkType, wf.udnFactory.K8s().V1().UserDefinedNetworks().Informer())
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/factory/mocks/NodeWatchFactory.go
+++ b/go-controller/pkg/factory/mocks/NodeWatchFactory.go
@@ -20,6 +20,8 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
+	userdefinednetworkv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/userdefinednetwork/v1"
+
 	v1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/informers/externalversions/adminpolicybasedroute/v1"
 )
 
@@ -736,6 +738,26 @@ func (_m *NodeWatchFactory) Start() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UserDefinedNetworkInformer provides a mock function with given fields:
+func (_m *NodeWatchFactory) UserDefinedNetworkInformer() userdefinednetworkv1.UserDefinedNetworkInformer {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for UserDefinedNetworkInformer")
+	}
+
+	var r0 userdefinednetworkv1.UserDefinedNetworkInformer
+	if rf, ok := ret.Get(0).(func() userdefinednetworkv1.UserDefinedNetworkInformer); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(userdefinednetworkv1.UserDefinedNetworkInformer)
+		}
 	}
 
 	return r0

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -3,6 +3,7 @@ package factory
 import (
 	adminpolicybasedrouteinformer "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/informers/externalversions/adminpolicybasedroute/v1"
 	egressipinformer "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions/egressip/v1"
+	userdefinednetworkinformer "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/userdefinednetwork/v1"
 
 	nadinformer "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/k8s.cni.cncf.io/v1"
 
@@ -60,6 +61,7 @@ type NodeWatchFactory interface {
 	APBRouteInformer() adminpolicybasedrouteinformer.AdminPolicyBasedExternalRouteInformer
 	EgressIPInformer() egressipinformer.EgressIPInformer
 	NADInformer() nadinformer.NetworkAttachmentDefinitionInformer
+	UserDefinedNetworkInformer() userdefinednetworkinformer.UserDefinedNetworkInformer
 
 	GetPods(namespace string) ([]*kapi.Pod, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -312,6 +312,9 @@ func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []l
 	m := newModelClient(nbClient)
 	ops, err := m.CreateOrUpdateOps(ops, opModels...)
 	sw.Ports = originalPorts
+	if err != nil && errors.Is(err, libovsdbclient.ErrNotFound) && !createSwitch {
+		err = fmt.Errorf("could not find switch: %q, %w", sw.Name, err)
+	}
 	return ops, err
 }
 

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller_test.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -31,6 +32,7 @@ type testNetworkController struct {
 func (tnc *testNetworkController) Start(context.Context) error {
 	tnc.tncm.Lock()
 	defer tnc.tncm.Unlock()
+	fmt.Printf("starting network: %s\n", testNetworkKey(tnc))
 	tnc.tncm.started = append(tnc.tncm.started, testNetworkKey(tnc))
 	return nil
 }
@@ -85,33 +87,45 @@ func (tncm *testNetworkControllerManager) CleanupDeletedNetworks(validNetworks .
 }
 
 func TestNetAttachDefinitionController(t *testing.T) {
-	network_A := &ovncnitypes.NetConf{
+	networkAPrimary := &ovncnitypes.NetConf{
 		Topology: types.Layer2Topology,
 		NetConf: cnitypes.NetConf{
-			Name: "network_A",
+			Name: "networkAPrimary",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Subnets: "10.1.130.0/24",
+		Role:    types.NetworkRolePrimary,
+		MTU:     1400,
+	}
+	networkAIncompatible := &ovncnitypes.NetConf{
+		Topology: types.LocalnetTopology,
+		NetConf: cnitypes.NetConf{
+			Name: "networkAPrimary",
 			Type: "ovn-k8s-cni-overlay",
 		},
 		MTU: 1400,
 	}
-	network_A_incompatible := &ovncnitypes.NetConf{
+	networkASecondary := &ovncnitypes.NetConf{
+		Topology: types.Layer2Topology,
+		NetConf: cnitypes.NetConf{
+			Name: "networkAPrimary",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Subnets: "10.1.130.0/24",
+		Role:    types.NetworkRoleSecondary,
+		MTU:     1400,
+	}
+
+	networkBSecondary := &ovncnitypes.NetConf{
 		Topology: types.LocalnetTopology,
 		NetConf: cnitypes.NetConf{
-			Name: "network_A",
+			Name: "networkBSecondary",
 			Type: "ovn-k8s-cni-overlay",
 		},
 		MTU: 1400,
 	}
 
-	network_B := &ovncnitypes.NetConf{
-		Topology: types.LocalnetTopology,
-		NetConf: cnitypes.NetConf{
-			Name: "network_B",
-			Type: "ovn-k8s-cni-overlay",
-		},
-		MTU: 1400,
-	}
-
-	network_Default := &ovncnitypes.NetConf{
+	networkDefault := &ovncnitypes.NetConf{
 		Topology: types.Layer3Topology,
 		NetConf: cnitypes.NetConf{
 			Name: "default",
@@ -139,7 +153,7 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_Default,
+					network: networkDefault,
 				},
 			},
 			expected: []expected{},
@@ -149,12 +163,12 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkAPrimary,
 				},
 			},
 			expected: []expected{
 				{
-					network: network_A,
+					network: networkAPrimary,
 					nads:    []string{"test/nad_1"},
 				},
 			},
@@ -164,7 +178,7 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkAPrimary,
 				},
 				{
 					nad: "test/nad_1",
@@ -176,17 +190,59 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad:     "test/nad_2",
-					network: network_A,
+					network: networkASecondary,
 				},
 			},
 			expected: []expected{
 				{
-					network: network_A,
+					network: networkASecondary,
 					nads:    []string{"test/nad_1", "test/nad_2"},
+				},
+			},
+		},
+		{
+			name: "Two Primary NADs added for same namespace",
+			args: []args{
+				{
+					nad:     "test/nad_1",
+					network: networkAPrimary,
+				},
+				{
+					nad:     "test/nad_2",
+					network: networkAPrimary,
+					wantErr: true,
+				},
+			},
+			expected: []expected{
+				{
+					network: networkAPrimary,
+					nads:    []string{"test/nad_1"},
+				},
+			},
+		},
+		{
+			name: "two Primary NADs added then one deleted",
+			args: []args{
+				{
+					nad:     "test/nad_1",
+					network: networkAPrimary,
+				},
+				{
+					nad:     "test2/nad_2",
+					network: networkAPrimary,
+				},
+				{
+					nad: "test/nad_1",
+				},
+			},
+			expected: []expected{
+				{
+					network: networkAPrimary,
+					nads:    []string{"test2/nad_2"},
 				},
 			},
 		},
@@ -195,11 +251,11 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad:     "test/nad_2",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad: "test/nad_1",
@@ -207,7 +263,7 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			},
 			expected: []expected{
 				{
-					network: network_A,
+					network: networkASecondary,
 					nads:    []string{"test/nad_2"},
 				},
 			},
@@ -217,11 +273,11 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad:     "test/nad_2",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad: "test/nad_2",
@@ -236,16 +292,16 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkAPrimary,
 				},
 				{
 					nad:     "test/nad_1",
-					network: network_B,
+					network: networkBSecondary,
 				},
 			},
 			expected: []expected{
 				{
-					network: network_B,
+					network: networkBSecondary,
 					nads:    []string{"test/nad_1"},
 				},
 			},
@@ -255,24 +311,24 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad:     "test/nad_2",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad:     "test/nad_1",
-					network: network_B,
+					network: networkBSecondary,
 				},
 			},
 			expected: []expected{
 				{
-					network: network_A,
+					network: networkASecondary,
 					nads:    []string{"test/nad_2"},
 				},
 				{
-					network: network_B,
+					network: networkBSecondary,
 					nads:    []string{"test/nad_1"},
 				},
 			},
@@ -282,20 +338,20 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkAPrimary,
 				},
 				{
 					nad:     "test/nad_2",
-					network: network_B,
+					network: networkBSecondary,
 				},
 				{
 					nad:     "test/nad_1",
-					network: network_B,
+					network: networkBSecondary,
 				},
 			},
 			expected: []expected{
 				{
-					network: network_B,
+					network: networkBSecondary,
 					nads:    []string{"test/nad_1", "test/nad_2"},
 				},
 			},
@@ -305,17 +361,17 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkAPrimary,
 				},
 				{
 					nad:     "test/nad_2",
-					network: network_A_incompatible,
+					network: networkAIncompatible,
 					wantErr: true,
 				},
 			},
 			expected: []expected{
 				{
-					network: network_A,
+					network: networkAPrimary,
 					nads:    []string{"test/nad_1"},
 				},
 			},
@@ -325,16 +381,16 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkAPrimary,
 				},
 				{
 					nad:     "test/nad_1",
-					network: network_A_incompatible,
+					network: networkAIncompatible,
 				},
 			},
 			expected: []expected{
 				{
-					network: network_A_incompatible,
+					network: networkAIncompatible,
 					nads:    []string{"test/nad_1"},
 				},
 			},
@@ -344,21 +400,21 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			args: []args{
 				{
 					nad:     "test/nad_1",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad:     "test/nad_2",
-					network: network_A,
+					network: networkASecondary,
 				},
 				{
 					nad:     "test/nad_1",
-					network: network_A_incompatible,
+					network: networkAIncompatible,
 					wantErr: true,
 				},
 			},
 			expected: []expected{
 				{
-					network: network_A,
+					network: networkASecondary,
 					nads:    []string{"test/nad_2"},
 				},
 			},
@@ -367,13 +423,17 @@ func TestNetAttachDefinitionController(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
+			err := config.PrepareTestConfig()
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
 			tncm := &testNetworkControllerManager{
 				controllers: map[string]NetworkController{},
 			}
 			nadController := &NetAttachDefinitionController{
-				networks:       map[string]util.NetInfo{},
 				nads:           map[string]string{},
 				networkManager: newNetworkManager("", tncm),
+				primaryNADs:    map[string]string{},
 			}
 
 			g.Expect(nadController.networkManager.Start()).To(gomega.Succeed())
@@ -399,9 +459,6 @@ func TestNetAttachDefinitionController(t *testing.T) {
 			}
 
 			meetsExpectations := func(g gomega.Gomega) {
-				tncm.Lock()
-				defer tncm.Unlock()
-
 				var expectRunning []string
 				for _, expected := range tt.expected {
 					netInfo, err := util.NewNetInfo(expected.network)
@@ -409,17 +466,30 @@ func TestNetAttachDefinitionController(t *testing.T) {
 
 					name := netInfo.GetNetworkName()
 					testNetworkKey := testNetworkKey(netInfo)
-
-					// test that the controller have the expected config and NADs
-					g.Expect(tncm.controllers).To(gomega.HaveKey(testNetworkKey))
-					g.Expect(tncm.controllers[testNetworkKey].Equals(netInfo)).To(gomega.BeTrue(),
-						fmt.Sprintf("matching network config for network %s", name))
-					g.Expect(tncm.controllers[testNetworkKey].GetNADs()).To(gomega.ConsistOf(expected.nads),
-						fmt.Sprintf("matching NADs for network %s", name))
+					func() {
+						tncm.Lock()
+						defer tncm.Unlock()
+						// test that the controller have the expected config and NADs
+						g.Expect(tncm.controllers).To(gomega.HaveKey(testNetworkKey))
+						g.Expect(tncm.controllers[testNetworkKey].Equals(netInfo)).To(gomega.BeTrue(),
+							fmt.Sprintf("matching network config for network %s", name))
+						g.Expect(tncm.controllers[testNetworkKey].GetNADs()).To(gomega.ConsistOf(expected.nads),
+							fmt.Sprintf("matching NADs for network %s", name))
+					}()
 					expectRunning = append(expectRunning, testNetworkKey)
+					if netInfo.IsPrimaryNetwork() && !netInfo.IsDefault() {
+						netInfo.SetNADs(expected.nads...)
+						key := expected.nads[0]
+						namespace, _, err := cache.SplitMetaNamespaceKey(key)
+						g.Expect(err).ToNot(gomega.HaveOccurred())
+						netInfoFound, err := nadController.GetActiveNetworkForNamespace(namespace)
+						g.Expect(err).ToNot(gomega.HaveOccurred())
+						g.Expect(reflect.DeepEqual(netInfoFound, netInfo)).To(gomega.BeTrue())
+					}
 				}
+				tncm.Lock()
+				defer tncm.Unlock()
 				expectStopped := sets.New(tncm.started...).Difference(sets.New(expectRunning...)).UnsortedList()
-
 				// test that the controllers are started, stopped and cleaned up as expected
 				g.Expect(tncm.started).To(gomega.ContainElements(expectRunning), "started network controllers")
 				g.Expect(tncm.stopped).To(gomega.ConsistOf(expectStopped), "stopped network controllers")
@@ -434,13 +504,15 @@ func TestNetAttachDefinitionController(t *testing.T) {
 
 func TestSyncAll(t *testing.T) {
 	network_A := &ovncnitypes.NetConf{
-		Topology: types.Layer2Topology,
+		Topology: types.Layer3Topology,
 		NetConf: cnitypes.NetConf{
 			Name: "network_A",
 			Type: "ovn-k8s-cni-overlay",
 		},
-		MTU: 1400,
+		Role: types.NetworkRolePrimary,
+		MTU:  1400,
 	}
+	network_A_Copy := *network_A
 	network_B := &ovncnitypes.NetConf{
 		Topology: types.LocalnetTopology,
 		NetConf: cnitypes.NetConf{
@@ -469,8 +541,8 @@ func TestSyncAll(t *testing.T) {
 					netconf: network_B,
 				},
 				{
-					name:    "test/nad3",
-					netconf: network_A,
+					name:    "test2/nad3",
+					netconf: &network_A_Copy,
 				},
 			},
 		},
@@ -479,6 +551,9 @@ func TestSyncAll(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 
+			err := config.PrepareTestConfig()
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 			config.OVNKubernetesFeature.EnableMultiNetwork = true
 			fakeClient := util.GetOVNClientset().GetOVNKubeControllerClientset()
 			wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClient)
@@ -496,6 +571,7 @@ func TestSyncAll(t *testing.T) {
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
 			expectedNetworks := map[string]util.NetInfo{}
+			expectedPrimaryNetworks := map[string]util.BasicNetInfo{}
 			for _, testNAD := range tt.testNADs {
 				namespace, name, err := cache.SplitMetaNamespaceKey(testNAD.name)
 				g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -513,6 +589,9 @@ func TestSyncAll(t *testing.T) {
 					netInfo, err = util.NewNetInfo(testNAD.netconf)
 					g.Expect(err).ToNot(gomega.HaveOccurred())
 					expectedNetworks[testNAD.netconf.Name] = netInfo
+					if netInfo.IsPrimaryNetwork() && !netInfo.IsDefault() {
+						expectedPrimaryNetworks[netInfo.GetNetworkName()] = netInfo
+					}
 				}
 			}
 
@@ -535,6 +614,11 @@ func TestSyncAll(t *testing.T) {
 				g.Expect(actualNetworks).To(gomega.HaveKey(name))
 				g.Expect(actualNetworks[name].Equals(network)).To(gomega.BeTrue())
 			}
+
+			actualPrimaryNetwork, err := nadController.GetActiveNetworkForNamespace("test")
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(expectedPrimaryNetworks).To(gomega.HaveKey(actualPrimaryNetwork.GetNetworkName()))
+			g.Expect(expectedPrimaryNetworks[actualPrimaryNetwork.GetNetworkName()].Equals(actualPrimaryNetwork)).To(gomega.BeTrue())
 		})
 	}
 }

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -64,11 +64,11 @@ func (cm *NetworkControllerManager) NewNetworkController(nInfo util.NetInfo) (na
 	topoType := nInfo.TopologyType()
 	switch topoType {
 	case ovntypes.Layer3Topology:
-		return ovn.NewSecondaryLayer3NetworkController(cnci, nInfo)
+		return ovn.NewSecondaryLayer3NetworkController(cnci, nInfo, cm.nadController)
 	case ovntypes.Layer2Topology:
-		return ovn.NewSecondaryLayer2NetworkController(cnci, nInfo), nil
+		return ovn.NewSecondaryLayer2NetworkController(cnci, nInfo, cm.nadController), nil
 	case ovntypes.LocalnetTopology:
-		return ovn.NewSecondaryLocalnetNetworkController(cnci, nInfo), nil
+		return ovn.NewSecondaryLocalnetNetworkController(cnci, nInfo, cm.nadController), nil
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
 }
@@ -82,11 +82,11 @@ func (cm *NetworkControllerManager) newDummyNetworkController(topoType, netName 
 	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: netName}, Topology: topoType})
 	switch topoType {
 	case ovntypes.Layer3Topology:
-		return ovn.NewSecondaryLayer3NetworkController(cnci, netInfo)
+		return ovn.NewSecondaryLayer3NetworkController(cnci, netInfo, cm.nadController)
 	case ovntypes.Layer2Topology:
-		return ovn.NewSecondaryLayer2NetworkController(cnci, netInfo), nil
+		return ovn.NewSecondaryLayer2NetworkController(cnci, netInfo, cm.nadController), nil
 	case ovntypes.LocalnetTopology:
-		return ovn.NewSecondaryLocalnetNetworkController(cnci, netInfo), nil
+		return ovn.NewSecondaryLocalnetNetworkController(cnci, netInfo, cm.nadController), nil
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
 }
@@ -285,12 +285,13 @@ func (cm *NetworkControllerManager) newCommonNetworkControllerInfo() (*ovn.Commo
 }
 
 // initDefaultNetworkController creates the controller for default network
-func (cm *NetworkControllerManager) initDefaultNetworkController(observManager *observability.Manager) error {
+func (cm *NetworkControllerManager) initDefaultNetworkController(nadController *nad.NetAttachDefinitionController,
+	observManager *observability.Manager) error {
 	cnci, err := cm.newCommonNetworkControllerInfo()
 	if err != nil {
 		return fmt.Errorf("failed to create common network controller info: %w", err)
 	}
-	defaultController, err := ovn.NewDefaultNetworkController(cnci, observManager)
+	defaultController, err := ovn.NewDefaultNetworkController(cnci, nadController, observManager)
 	if err != nil {
 		return err
 	}
@@ -385,6 +386,12 @@ func (cm *NetworkControllerManager) Start(ctx context.Context) error {
 		metrics.GetConfigDurationRecorder().Run(cm.nbClient, cm.kube, 10, time.Second*5, cm.stopChan)
 	}
 	cm.podRecorder.Run(cm.sbClient, cm.stopChan)
+	// nadController is nil if multi-network is disabled
+	if cm.nadController != nil {
+		if err = cm.nadController.Start(); err != nil {
+			return fmt.Errorf("failed to start NAD Controller :%v", err)
+		}
+	}
 
 	var observabilityManager *observability.Manager
 	if config.OVNKubernetesFeature.EnableObservability {
@@ -398,18 +405,13 @@ func (cm *NetworkControllerManager) Start(ctx context.Context) error {
 			klog.Warningf("Observability cleanup failed, expected if not all Samples ware deleted yet: %v", err)
 		}
 	}
-	err = cm.initDefaultNetworkController(observabilityManager)
+	err = cm.initDefaultNetworkController(cm.nadController, observabilityManager)
 	if err != nil {
 		return fmt.Errorf("failed to init default network controller: %v", err)
 	}
 	err = cm.defaultNetworkController.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to start default network controller: %v", err)
-	}
-
-	// nadController is nil if multi-network is disabled
-	if cm.nadController != nil {
-		return cm.nadController.Start()
 	}
 
 	return nil

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
@@ -129,6 +129,7 @@ var _ = Describe("Healthcheck tests", func() {
 
 		BeforeEach(func() {
 			// setup kube output
+			factoryMock.On("NADInformer").Return(nil)
 			ncm, err = NewNodeNetworkControllerManager(fakeClient, &factoryMock, nodeName, &sync.WaitGroup{}, nil, routeManager)
 			Expect(err).NotTo(HaveOccurred())
 			factoryMock.On("GetPods", "").Return(podList, nil)
@@ -144,7 +145,6 @@ var _ = Describe("Healthcheck tests", func() {
 						"stale-pod-ifc,sandbox=123abcfaa iface-id=stale-ns_stale-pod iface-id-ver=pod-stale-uuid-3 vf-netdev-name=blah\n",
 					Err: nil,
 				})
-
 				// mock calls to remove only stale-port
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    genDeleteStaleRepPortCmd("stale-pod-ifc"),

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
@@ -223,6 +223,7 @@ var _ = Describe("Healthcheck tests", func() {
 			factoryMock.On("GetNode", nodeName).Return(nodeList[0], nil)
 			factoryMock.On("GetNodes").Return(nodeList, nil)
 			factoryMock.On("NADInformer").Return(nil)
+			factoryMock.On("UserDefinedNetworkInformer").Return(nil)
 
 			ncm, err := NewNodeNetworkControllerManager(fakeClient, &factoryMock, nodeName, &sync.WaitGroup{}, nil, routeManager)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -21,8 +21,6 @@ import (
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/klog/v2"
-
-	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 )
 
 // Gateway responds to Service and Endpoint K8s events
@@ -570,23 +568,4 @@ func bridgeForInterface(intfName, nodeName, physicalNetworkName string, gwIPs []
 	}
 
 	return &res, nil
-}
-
-// baseNodeServiceWatcher is a base structure to be inherited by all node-side
-// watchers that handle Service changes.
-type baseNodeServiceWatcher struct {
-	watchFactory factory.NodeWatchFactory
-}
-
-// getActiveNetworkForNamespace returns the active network for the given namespace
-// and is a wrapper around util.GetActiveNetworkForNamespace
-//
-// FIXME(dceara): This is inefficient, instead use the new controller that will
-// be added by https://github.com/ovn-org/ovn-kubernetes/pull/4662.
-func (bnsw *baseNodeServiceWatcher) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
-	var nadLister nadlister.NetworkAttachmentDefinitionLister
-	if util.IsNetworkSegmentationSupportEnabled() {
-		nadLister = bnsw.watchFactory.NADInformer().Lister()
-	}
-	return util.GetActiveNetworkForNamespace(namespace, nadLister)
 }

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 // bridgedGatewayNodeSetup enables forwarding on bridge interface, sets up the physical network name mappings for the bridge,
@@ -361,11 +361,11 @@ func (nc *DefaultNodeNetworkController) initGateway(subnets []*net.IPNet, nodeAn
 	case config.GatewayModeLocal:
 		klog.Info("Preparing Local Gateway")
 		gw, err = newLocalGateway(nc.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator,
-			managementPortConfig, nc.Kube, nc.watchFactory, nc.routeManager)
+			managementPortConfig, nc.Kube, nc.watchFactory, nc.routeManager, nc.nadController)
 	case config.GatewayModeShared:
 		klog.Info("Preparing Shared Gateway")
 		gw, err = newSharedGateway(nc.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator, nc.Kube,
-			managementPortConfig, nc.watchFactory, nc.routeManager)
+			managementPortConfig, nc.watchFactory, nc.routeManager, nc.nadController)
 	case config.GatewayModeDisabled:
 		var chassisID string
 		klog.Info("Gateway Mode is disabled")
@@ -497,7 +497,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost(kubeNodeIP net.IP) er
 		if err := initSharedGatewayIPTables(); err != nil {
 			return err
 		}
-		gw.nodePortWatcherIptables = newNodePortWatcherIptables(nc.watchFactory)
+		gw.nodePortWatcherIptables = newNodePortWatcherIptables(nc.nadController)
 		gw.loadBalancerHealthChecker = newLoadBalancerHealthChecker(nc.name, nc.watchFactory)
 		portClaimWatcher, err := newPortClaimWatcher(nc.recorder)
 		if err != nil {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -28,6 +28,7 @@ import (
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned/fake"
+	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	networkAttachDefController "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
@@ -1110,8 +1111,9 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			&endpointSlice,
 		)
 		fakeClient := &util.OVNNodeClientset{
-			KubeClient:            kubeFakeClient,
-			NetworkAttchDefClient: nadfake.NewSimpleClientset(),
+			KubeClient:               kubeFakeClient,
+			NetworkAttchDefClient:    nadfake.NewSimpleClientset(),
+			UserDefinedNetworkClient: udnfakeclient.NewSimpleClientset(),
 		}
 
 		stop := make(chan struct{})

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -30,9 +30,11 @@ import (
 	adminpolicybasedrouteclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	networkAttachDefController "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	linkMock "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/nad"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilMock "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
@@ -218,7 +220,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Items: []v1.Node{existingNode},
 		})
 		fakeClient := &util.OVNNodeClientset{
-			KubeClient: kubeFakeClient,
+			KubeClient:            kubeFakeClient,
+			NetworkAttchDefClient: nadfake.NewSimpleClientset(),
 		}
 
 		stop := make(chan struct{})
@@ -244,6 +247,16 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		err = nodeAnnotator.Run()
 		Expect(err).NotTo(HaveOccurred())
 		rm := routemanager.NewController()
+		var nadController *networkAttachDefController.NetAttachDefinitionController
+		if util.IsNetworkSegmentationSupportEnabled() {
+			testNCM := &nad.FakeNetworkControllerManager{}
+			nadController, err = networkAttachDefController.NewNetAttachDefinitionController("test", testNCM, wf, nil)
+			Expect(err).NotTo(HaveOccurred())
+			err = nadController.Start()
+			Expect(err).NotTo(HaveOccurred())
+			defer nadController.Stop()
+		}
+		Expect(err).NotTo(HaveOccurred())
 		wg.Add(1)
 		go testNS.Do(func(netNS ns.NetNS) error {
 			defer GinkgoRecover()
@@ -291,7 +304,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs, nodeAnnotator, k,
-				&fakeMgmtPortConfig, wf, rm)
+				&fakeMgmtPortConfig, wf, rm, nadController)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())
@@ -622,7 +635,8 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Items: []v1.Node{existingNode},
 		})
 		fakeClient := &util.OVNNodeClientset{
-			KubeClient: kubeFakeClient,
+			KubeClient:            kubeFakeClient,
+			NetworkAttchDefClient: nadfake.NewSimpleClientset(),
 		}
 
 		_, nodeNet, err := net.ParseCIDR(nodeSubnet)
@@ -670,6 +684,15 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 		rm := routemanager.NewController()
+		var nadController *networkAttachDefController.NetAttachDefinitionController
+		if util.IsNetworkSegmentationSupportEnabled() {
+			testNCM := &nad.FakeNetworkControllerManager{}
+			nadController, err = networkAttachDefController.NewNetAttachDefinitionController("test", testNCM, wf, nil)
+			Expect(err).NotTo(HaveOccurred())
+			err = nadController.Start()
+			Expect(err).NotTo(HaveOccurred())
+			defer nadController.Stop()
+		}
 		wg.Add(1)
 		go testNS.Do(func(netNS ns.NetNS) error {
 			defer GinkgoRecover()
@@ -677,7 +700,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			wg.Done()
 			return nil
 		})
-		// FIXME(mk): starting the gateaway causing go routines to be spawned within sub functions and therefore they escape the
+		// FIXME(mk): starting the gateway causing go routines to be spawned within sub functions and therefore they escape the
 		// netns we wanted to set it to originally here. Refactor test cases to not spawn a go routine or just fake out everything
 		// and remove need to create netns
 		err = testNS.Do(func(ns.NetNS) error {
@@ -686,7 +709,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
-				gatewayIntf, "", ifAddrs, nodeAnnotator, k, &fakeMgmtPortConfig, wf, rm)
+				gatewayIntf, "", ifAddrs, nodeAnnotator, k, &fakeMgmtPortConfig, wf, rm, nadController)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())
@@ -773,6 +796,7 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 		fakeClient := &util.OVNNodeClientset{
 			KubeClient:             kubeFakeClient,
 			AdminPolicyRouteClient: adminpolicybasedrouteclient.NewSimpleClientset(),
+			NetworkAttchDefClient:  nadfake.NewSimpleClientset(),
 		}
 
 		stop := make(chan struct{})
@@ -1086,10 +1110,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			&endpointSlice,
 		)
 		fakeClient := &util.OVNNodeClientset{
-			KubeClient: kubeFakeClient,
-		}
-		if util.IsNetworkSegmentationSupportEnabled() {
-			fakeClient.NetworkAttchDefClient = nadfake.NewSimpleClientset()
+			KubeClient:            kubeFakeClient,
+			NetworkAttchDefClient: nadfake.NewSimpleClientset(),
 		}
 
 		stop := make(chan struct{})
@@ -1116,6 +1138,15 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		ip, ipNet, _ := net.ParseCIDR(eth0CIDR)
 		ipNet.IP = ip
 		rm := routemanager.NewController()
+		var nadController *networkAttachDefController.NetAttachDefinitionController
+		if util.IsNetworkSegmentationSupportEnabled() {
+			testNCM := &nad.FakeNetworkControllerManager{}
+			nadController, err = networkAttachDefController.NewNetAttachDefinitionController("test", testNCM, wf, nil)
+			Expect(err).NotTo(HaveOccurred())
+			err = nadController.Start()
+			Expect(err).NotTo(HaveOccurred())
+			defer nadController.Stop()
+		}
 		go testNS.Do(func(netNS ns.NetNS) error {
 			defer GinkgoRecover()
 			rm.Run(stop, 10*time.Second)
@@ -1129,7 +1160,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
 			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs,
-				nodeAnnotator, &fakeMgmtPortConfig, k, wf, rm)
+				nodeAnnotator, &fakeMgmtPortConfig, k, wf, rm, nadController)
 			Expect(err).NotTo(HaveOccurred())
 			err = localGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -5,6 +5,7 @@ package node
 
 import (
 	"fmt"
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"net"
 	"strings"
 
@@ -22,7 +23,7 @@ import (
 
 func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, gwIPs []*net.IPNet,
 	nodeAnnotator kube.Annotator, cfg *managementPortConfig, kube kube.Interface, watchFactory factory.NodeWatchFactory,
-	routeManager *routemanager.Controller) (*gateway, error) {
+	routeManager *routemanager.Controller, nadController *nad.NetAttachDefinitionController) (*gateway, error) {
 	klog.Info("Creating new local gateway")
 	gw := &gateway{}
 
@@ -159,7 +160,7 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 					return err
 				}
 			}
-			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge, gw.openflowManager, gw.nodeIPManager, watchFactory)
+			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge, gw.openflowManager, gw.nodeIPManager, watchFactory, nadController)
 			if err != nil {
 				return err
 			}

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -22,6 +22,7 @@ import (
 
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	udnfakeclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	factoryMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory/mocks"
 	kubemocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
@@ -445,8 +446,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			},
 		)
 		fakeClient := &util.OVNNodeClientset{
-			KubeClient:            kubeFakeClient,
-			NetworkAttchDefClient: nadfake.NewSimpleClientset(),
+			KubeClient:               kubeFakeClient,
+			NetworkAttchDefClient:    nadfake.NewSimpleClientset(),
+			UserDefinedNetworkClient: udnfakeclient.NewSimpleClientset(),
 		}
 
 		stop := make(chan struct{})
@@ -619,8 +621,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			},
 		)
 		fakeClient := &util.OVNNodeClientset{
-			KubeClient:            kubeFakeClient,
-			NetworkAttchDefClient: nadfake.NewSimpleClientset(),
+			KubeClient:               kubeFakeClient,
+			NetworkAttchDefClient:    nadfake.NewSimpleClientset(),
+			UserDefinedNetworkClient: udnfakeclient.NewSimpleClientset(),
 		}
 
 		stop := make(chan struct{})

--- a/go-controller/pkg/node/healthcheck_node_test.go
+++ b/go-controller/pkg/node/healthcheck_node_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"

--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	egressipv1fake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -265,7 +265,9 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 	_, err = config.InitConfig(ctx, fexec, nil)
 	Expect(err).NotTo(HaveOccurred())
-	kubeInterface := &kube.KubeOVN{Kube: kube.Kube{KClient: fakeClient}, ANPClient: anpfake.NewSimpleClientset(), EIPClient: egressipv1fake.NewSimpleClientset(), EgressFirewallClient: &egressfirewallfake.Clientset{}, EgressServiceClient: &egressservicefake.Clientset{}}
+	kubeInterface := &kube.KubeOVN{Kube: kube.Kube{KClient: fakeClient}, ANPClient: anpfake.NewSimpleClientset(),
+		EIPClient: egressipv1fake.NewSimpleClientset(), EgressFirewallClient: &egressfirewallfake.Clientset{},
+		EgressServiceClient: &egressservicefake.Clientset{}}
 	nodeAnnotator := kube.NewNodeAnnotator(kubeInterface, existingNode.Name)
 	watchFactory, err := factory.NewNodeWatchFactory(fakeNodeClient, nodeName)
 	Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	. "github.com/onsi/gomega"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteclient "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned/fake"
@@ -59,6 +60,7 @@ func (o *FakeOVNNode) start(ctx *cli.Context, objects ...runtime.Object) {
 		KubeClient:             fake.NewSimpleClientset(v1Objects...),
 		EgressServiceClient:    egressservicefake.NewSimpleClientset(egressServiceObjects...),
 		AdminPolicyRouteClient: adminpolicybasedrouteclient.NewSimpleClientset(),
+		NetworkAttchDefClient:  nadfake.NewSimpleClientset(),
 	}
 	o.init() // initializes the node
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
-	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
@@ -18,8 +17,10 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	networkAttachDefController "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	kubetest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/nad"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"golang.org/x/exp/maps"
@@ -83,9 +84,10 @@ func newControllerWithDBSetupForNetwork(dbSetup libovsdbtest.TestSetup, netInfo 
 			return nil, err
 		}
 	}
-	var nadLister nadlister.NetworkAttachmentDefinitionLister
-	if testUDN {
-		nadLister = factoryMock.NADInformer().Lister()
+	testNCM := &nad.FakeNetworkControllerManager{}
+	nadController, err := networkAttachDefController.NewNetAttachDefinitionController("test", testNCM, factoryMock, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	controller, err := NewController(client.KubeClient,
@@ -93,7 +95,7 @@ func newControllerWithDBSetupForNetwork(dbSetup libovsdbtest.TestSetup, netInfo 
 		factoryMock.ServiceCoreInformer(),
 		factoryMock.EndpointSliceCoreInformer(),
 		factoryMock.NodeCoreInformer(),
-		nadLister,
+		nadController,
 		recorder,
 		netInfo,
 	)
@@ -1106,6 +1108,10 @@ func TestSyncServices(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Error creating controller: %v", err)
 				}
+				if err := controller.nadController.Start(); err != nil {
+					t.Fatalf("Error starting NAD controller: %v", err)
+				}
+				defer controller.nadController.Stop()
 				defer controller.close()
 
 				// Add k8s objects

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -16,6 +16,7 @@ import (
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	zoneinterconnect "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
@@ -242,7 +243,7 @@ type SecondaryLayer2NetworkController struct {
 }
 
 // NewSecondaryLayer2NetworkController create a new OVN controller for the given secondary layer2 nad
-func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netInfo util.NetInfo) *SecondaryLayer2NetworkController {
+func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netInfo util.NetInfo, nadController nad.NADController) *SecondaryLayer2NetworkController {
 
 	stopChan := make(chan struct{})
 
@@ -273,6 +274,7 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 					wg:                          &sync.WaitGroup{},
 					localZoneNodes:              &sync.Map{},
 					cancelableCtx:               util.NewCancelableContext(),
+					nadController:               nadController,
 				},
 			},
 		},

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -13,6 +13,7 @@ import (
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	networkAttachDefController "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/persistentips"
@@ -183,7 +184,8 @@ type SecondaryLocalnetNetworkController struct {
 }
 
 // NewSecondaryLocalnetNetworkController create a new OVN controller for the given secondary localnet NAD
-func NewSecondaryLocalnetNetworkController(cnci *CommonNetworkControllerInfo, netInfo util.NetInfo) *SecondaryLocalnetNetworkController {
+func NewSecondaryLocalnetNetworkController(cnci *CommonNetworkControllerInfo, netInfo util.NetInfo,
+	nadController networkAttachDefController.NADController) *SecondaryLocalnetNetworkController {
 
 	stopChan := make(chan struct{})
 
@@ -208,6 +210,7 @@ func NewSecondaryLocalnetNetworkController(cnci *CommonNetworkControllerInfo, ne
 					wg:                          &sync.WaitGroup{},
 					cancelableCtx:               util.NewCancelableContext(),
 					localZoneNodes:              &sync.Map{},
+					nadController:               nadController,
 				},
 			},
 		},

--- a/go-controller/pkg/testing/nad/netattach.go
+++ b/go-controller/pkg/testing/nad/netattach.go
@@ -1,0 +1,45 @@
+package nad
+
+import (
+	"context"
+	networkAttachDefController "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+type FakeNetworkController struct {
+	util.NetInfo
+}
+
+func (nc *FakeNetworkController) Start(ctx context.Context) error {
+	return nil
+}
+
+func (nc *FakeNetworkController) Stop() {}
+
+func (nc *FakeNetworkController) Cleanup() error {
+	return nil
+}
+
+type FakeNetworkControllerManager struct{}
+
+func (ncm *FakeNetworkControllerManager) NewNetworkController(netInfo util.NetInfo) (networkAttachDefController.NetworkController, error) {
+	return &FakeNetworkController{netInfo}, nil
+}
+
+func (ncm *FakeNetworkControllerManager) CleanupDeletedNetworks(validNetworks ...util.BasicNetInfo) error {
+	return nil
+}
+
+type FakeNADController struct {
+	// namespace -> netInfo
+	PrimaryNetworks map[string]util.NetInfo
+}
+
+func (nc *FakeNADController) Start() error { return nil }
+func (nc *FakeNADController) Stop()        {}
+func (nc *FakeNADController) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
+	if primaryNetworks, ok := nc.PrimaryNetworks[namespace]; ok && primaryNetworks != nil {
+		return primaryNetworks, nil
+	}
+	return &util.DefaultNetInfo{}, nil
+}

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -101,11 +101,12 @@ type OVNKubeControllerClientset struct {
 }
 
 type OVNNodeClientset struct {
-	KubeClient             kubernetes.Interface
-	EgressServiceClient    egressserviceclientset.Interface
-	EgressIPClient         egressipclientset.Interface
-	AdminPolicyRouteClient adminpolicybasedrouteclientset.Interface
-	NetworkAttchDefClient  networkattchmentdefclientset.Interface
+	KubeClient               kubernetes.Interface
+	EgressServiceClient      egressserviceclientset.Interface
+	EgressIPClient           egressipclientset.Interface
+	AdminPolicyRouteClient   adminpolicybasedrouteclientset.Interface
+	NetworkAttchDefClient    networkattchmentdefclientset.Interface
+	UserDefinedNetworkClient userdefinednetworkclientset.Interface
 }
 
 type OVNClusterManagerClientset struct {
@@ -164,6 +165,7 @@ func (cs *OVNMasterClientset) GetOVNKubeControllerClientset() *OVNKubeController
 		AdminPolicyRouteClient:   cs.AdminPolicyRouteClient,
 		IPAMClaimsClient:         cs.IPAMClaimsClient,
 		NetworkAttchDefClient:    cs.NetworkAttchDefClient,
+		UserDefinedNetworkClient: cs.UserDefinedNetworkClient,
 	}
 }
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -203,11 +203,12 @@ func (cs *OVNClientset) GetClusterManagerClientset() *OVNClusterManagerClientset
 
 func (cs *OVNClientset) GetNodeClientset() *OVNNodeClientset {
 	return &OVNNodeClientset{
-		KubeClient:             cs.KubeClient,
-		EgressServiceClient:    cs.EgressServiceClient,
-		EgressIPClient:         cs.EgressIPClient,
-		AdminPolicyRouteClient: cs.AdminPolicyRouteClient,
-		NetworkAttchDefClient:  cs.NetworkAttchDefClient,
+		KubeClient:               cs.KubeClient,
+		EgressServiceClient:      cs.EgressServiceClient,
+		EgressIPClient:           cs.EgressIPClient,
+		AdminPolicyRouteClient:   cs.AdminPolicyRouteClient,
+		NetworkAttchDefClient:    cs.NetworkAttchDefClient,
+		UserDefinedNetworkClient: cs.UserDefinedNetworkClient,
 	}
 }
 

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -17,6 +17,7 @@ import (
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	userdefinednetworkv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
@@ -997,4 +998,16 @@ func AllowsPersistentIPs(netInfo NetInfo) bool {
 	default:
 		return false
 	}
+}
+
+func IsPrimaryNetwork(spec userdefinednetworkv1.UserDefinedNetworkSpec) bool {
+	var role userdefinednetworkv1.NetworkRole
+	switch spec.Topology {
+	case userdefinednetworkv1.NetworkTopologyLayer3:
+		role = spec.Layer3.Role
+	case userdefinednetworkv1.NetworkTopologyLayer2:
+		role = spec.Layer2.Role
+	}
+
+	return role == userdefinednetworkv1.NetworkRolePrimary
 }

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -947,7 +947,7 @@ func GetPodNADToNetworkMappingWithActiveNetwork(pod *kapi.Pod, nInfo NetInfo, ac
 	// Add the active network to the NSE map if it is configured
 	activeNetworkNADs := activeNetwork.GetNADs()
 	if len(activeNetworkNADs) < 1 {
-		return false, nil, fmt.Errorf("missing NADs at active network '%s' for namesapce '%s'", activeNetwork.GetNetworkName(), pod.Namespace)
+		return false, nil, fmt.Errorf("missing NADs at active network %q for namespace %q", activeNetwork.GetNetworkName(), pod.Namespace)
 	}
 	activeNetworkNADKey := strings.Split(activeNetworkNADs[0], "/")
 	if len(networkSelections) == 0 {

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -15,11 +15,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-
-	nadlister "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"crypto/rand"
 
@@ -372,65 +369,23 @@ func IsClusterIP(svcVIP string) bool {
 	return false
 }
 
-type UnknownActiveNetworkError struct {
+type UnprocessedActiveNetworkError struct {
 	namespace string
+	udnName   string
 }
 
-func (m *UnknownActiveNetworkError) Error() string {
-	return fmt.Sprintf("unable to determine what is the "+
-		"primary role network for namespace '%s'; please remove multiple primary role network"+
-		"NADs from it", m.namespace)
+func (m *UnprocessedActiveNetworkError) Error() string {
+	return fmt.Sprintf("primary UDN %q exists in namespace %s, but NAD has not been processed yet",
+		m.udnName, m.namespace)
 }
 
-func IsUnknownActiveNetworkError(err error) bool {
-	var unknownActiveNetworkError *UnknownActiveNetworkError
-	return errors.As(err, &unknownActiveNetworkError)
+func IsUnprocessedActiveNetworkError(err error) bool {
+	var unprocessedActiveNetworkError *UnprocessedActiveNetworkError
+	return errors.As(err, &unprocessedActiveNetworkError)
 }
 
-// GetActiveNetworkForNamespace returns the NetInfo struct of the active network
-// for the given namespace based on the NADs present in that namespace.
-// active network here means the network managing this namespace and responsible for
-// plumbing all the entities for this namespace
-// this is:
-// 1) &DefaultNetInfo if there are no NADs in the namespace OR all NADs are Role: "primary"
-// 2) &NetConf{Name: "<secondary-network-name>"} if there is exactly ONE NAD with Role: "primary"
-// 3) Multiple primary network role NADs ActiveNetworkUnknown error
-// 4) error under all other conditions
-func GetActiveNetworkForNamespace(namespace string, nadLister nadlister.NetworkAttachmentDefinitionLister) (NetInfo, error) {
-	if nadLister == nil {
-		return &DefaultNetInfo{}, nil
-	}
-	if !IsNetworkSegmentationSupportEnabled() {
-		return &DefaultNetInfo{}, nil
-	}
-	namespaceNADs, err := nadLister.NetworkAttachmentDefinitions(namespace).List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-	if len(namespaceNADs) == 0 {
-		return &DefaultNetInfo{}, nil
-	}
-	numberOfPrimaryNetworks := 0
-	var primaryNetwork NetInfo
-	for _, nad := range namespaceNADs {
-		netInfo, err := ParseNADInfo(nad)
-		if err != nil {
-			klog.Warningf("Skipping nad '%s/%s' as active network after failing parsing it with %v", nad.Namespace, nad.Name, err)
-			continue
-		}
-
-		if netInfo.IsPrimaryNetwork() {
-			primaryNetwork = netInfo
-			numberOfPrimaryNetworks++
-			primaryNetwork.AddNADs(GetNADName(nad.Namespace, nad.Name))
-		}
-	}
-	if numberOfPrimaryNetworks == 1 {
-		return primaryNetwork, nil
-	} else if numberOfPrimaryNetworks == 0 {
-		return &DefaultNetInfo{}, nil
-	}
-	return nil, &UnknownActiveNetworkError{namespace: namespace}
+func NewUnprocessedActiveNetworkError(namespace, udnName string) *UnprocessedActiveNetworkError {
+	return &UnprocessedActiveNetworkError{namespace: namespace, udnName: udnName}
 }
 
 func GetUserDefinedNetworkRole(isPrimary bool) string {
@@ -441,7 +396,7 @@ func GetUserDefinedNetworkRole(isPrimary bool) string {
 	return networkRole
 }
 
-// generateExternalIDs returns the external IDs for logical switches and logical routers
+// GenerateExternalIDsForSwitchOrRouter returns the external IDs for logical switches and logical routers
 // when it runs on a primary or secondary network. It returns an empty map
 // when on the default cluster network, for backward compatibility.
 func GenerateExternalIDsForSwitchOrRouter(netInfo NetInfo) map[string]string {


### PR DESCRIPTION
Leverages the NAD Controller to also track primary networks. This should be faster than listing all NADs in a namespace and iterating through them to find the primary network for a namespace.
