### PR TITLE
UDN: Fix per pod SNATing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,8 +433,8 @@ jobs:
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled", "num-workers": "3"}
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3"}
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
-          - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
-          - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
     needs: [ build-pr ]

--- a/go-controller/pkg/generator/udn/masquerade_ips.go
+++ b/go-controller/pkg/generator/udn/masquerade_ips.go
@@ -66,3 +66,23 @@ func allocateMasqueradeIPs(idName string, masqueradeSubnet string, networkID int
 	}
 	return masqueradeIPs, nil
 }
+
+// GetUDNGatewayMasqueradeIPs returns the list of gateway router masqueradeIPs for the given UDN's networkID
+func GetUDNGatewayMasqueradeIPs(networkID int) ([]*net.IPNet, error) {
+	var masqIPs []*net.IPNet
+	if config.IPv4Mode {
+		v4MasqIPs, err := AllocateV4MasqueradeIPs(networkID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get v4 masquerade IP, networkID %d: %v", networkID, err)
+		}
+		masqIPs = append(masqIPs, v4MasqIPs.GatewayRouter)
+	}
+	if config.IPv6Mode {
+		v6MasqIPs, err := AllocateV6MasqueradeIPs(networkID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get v6 masquerade IP, networkID %d: %v", networkID, err)
+		}
+		masqIPs = append(masqIPs, v6MasqIPs.GatewayRouter)
+	}
+	return masqIPs, nil
+}

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/generator/udn"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -338,6 +339,18 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 		ops = append(ops, addOps...)
 	}
 
+	if util.IsNetworkSegmentationSupportEnabled() && bsnc.IsPrimaryNetwork() && config.Gateway.DisableSNATMultipleGWs {
+		// we need to add per-pod SNATs for UDN networks
+		snatOps, err := bsnc.addPerPodSNATOps(pod, podAnnotation.IPs)
+		if err != nil {
+			return fmt.Errorf("failed to construct SNAT for pod %s/%s which is part of network %s, err: %v",
+				pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
+		}
+		if snatOps != nil {
+			ops = append(ops, snatOps...)
+		}
+	}
+
 	recordOps, txOkCallBack, _, err := bsnc.AddConfigDurationRecord("pod", pod.Namespace, pod.Name)
 	if err != nil {
 		klog.Errorf("Config duration recorder: %v", err)
@@ -374,6 +387,30 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 	}
 
 	return nil
+}
+
+// addPerPodSNATOps returns the ops that will add the SNAT towards masqueradeIP for this given pod
+func (bsnc *BaseSecondaryNetworkController) addPerPodSNATOps(pod *kapi.Pod, podIPs []*net.IPNet) ([]ovsdb.Operation, error) {
+	if !bsnc.isPodScheduledinLocalZone(pod) {
+		// nothing to do if its a remote zone pod
+		return nil, nil
+	}
+	// we need to add per-pod SNATs for UDN networks
+	networkID, err := bsnc.getNetworkID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get networkID for network %q: %v", bsnc.GetNetworkName(), err)
+	}
+	masqIPs, err := udn.GetUDNGatewayMasqueradeIPs(networkID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", bsnc.GetNetworkName(), networkID, err)
+	}
+	ops, err := addOrUpdatePodSNATOps(bsnc.nbClient, bsnc.GetNetworkScopedGWRouterName(pod.Spec.NodeName),
+		masqIPs, podIPs, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct SNAT pods for pod %s/%s which is part of network %s, err: %v",
+			pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
+	}
+	return ops, nil
 }
 
 // removePodForSecondaryNetwork tried to tear down a pod. It returns nil on success and error on failure;

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -877,38 +877,20 @@ func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *kapi.Node) (
 		return nil, fmt.Errorf("failed to get networkID for network %q: %v", networkName, err)
 	}
 
-	var (
-		masqIPs  []*net.IPNet
-		v4MasqIP *net.IPNet
-		v6MasqIP *net.IPNet
-	)
-
-	if config.IPv4Mode {
-		v4MasqIPs, err := udn.AllocateV4MasqueradeIPs(networkID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get v4 masquerade IP, network %s (%d): %v", networkName, networkID, err)
-		}
-		v4MasqIP = v4MasqIPs.GatewayRouter
-		masqIPs = append(masqIPs, v4MasqIP)
-	}
-	if config.IPv6Mode {
-		v6MasqIPs, err := udn.AllocateV6MasqueradeIPs(networkID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get v6 masquerade IP, network %s (%d): %v", networkName, networkID, err)
-		}
-		v6MasqIP = v6MasqIPs.GatewayRouter
-		masqIPs = append(masqIPs, v6MasqIP)
+	masqIPs, err := udn.GetUDNGatewayMasqueradeIPs(networkID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", networkName, networkID, err)
 	}
 
 	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
 
 	// Always SNAT to the per network masquerade IP.
 	var externalIPs []net.IP
-	if config.IPv4Mode && v4MasqIP != nil {
-		externalIPs = append(externalIPs, v4MasqIP.IP)
-	}
-	if config.IPv6Mode && v6MasqIP != nil {
-		externalIPs = append(externalIPs, v6MasqIP.IP)
+	for _, masqIP := range masqIPs {
+		if masqIP == nil {
+			continue
+		}
+		externalIPs = append(externalIPs, masqIP.IP)
 	}
 
 	var hostAddrs []string


### PR DESCRIPTION
```
sh-5.2# ovn-nbctl lr-nat-list GR_l3.network_ovn-worker2
TYPE             GATEWAY_PORT          EXTERNAL_IP        EXTERNAL_PORT    LOGICAL_IP          EXTERNAL_MAC         LOGICAL_PORT
snat                                   169.254.0.11                        10.128.2.5
sh-5.2# ovn-nbctl lr-nat-list GR_l3.network_ovn-worker2
sh-5.2# ovn-nbctl lr-nat-list GR_l3.network_ovn-worker2
sh-5.2#
```
let's see how this looks in CI...

TODO:
- [x] We have e2e coverage for this
- [ ] Need to add UT which is tracked here: https://github.com/ovn-org/ovn-kubernetes/issues/4684