### PR TITLE
udn, cni: report UDN iface info on network-status

### DIFF
--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -2,6 +2,8 @@ package cni
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -9,14 +11,17 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
-	v1nadmocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
+
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	v1nadmocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 	v1mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
@@ -157,6 +162,148 @@ var _ = Describe("Network Segmentation", func() {
 			})
 		})
 
+		Context("pod with a user defined primary network", func() {
+			const (
+				dummyMACHostSide = "07:06:05:04:03:02"
+				nadName          = "tenantred"
+				namespace        = "foo-ns"
+			)
+
+			dummyGetCNIResult := func(request *PodRequest, getter PodInfoGetter, podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
+				var gatewayIP net.IP
+				if len(podInterfaceInfo.Gateways) > 0 {
+					gatewayIP = podInterfaceInfo.Gateways[0]
+				}
+				var ips []*current.IPConfig
+				ifaceIdx := 1 // host side of the veth is 0; pod side of the veth is 1
+				for _, ip := range podInterfaceInfo.IPs {
+					ips = append(ips, &current.IPConfig{Address: *ip, Gateway: gatewayIP, Interface: &ifaceIdx})
+				}
+				ifaceName := "eth0"
+				if request.netName != "default" {
+					ifaceName = "ovn-udn1"
+				}
+
+				interfaces := []*current.Interface{
+					{
+						Name: "host_" + ifaceName,
+						Mac:  dummyMACHostSide,
+					},
+					{
+						Name:    ifaceName,
+						Mac:     podInterfaceInfo.MAC.String(),
+						Sandbox: "bobloblaw",
+					},
+				}
+				return &current.Result{
+					CNIVersion: "0.3.1",
+					Interfaces: interfaces,
+					IPs:        ips,
+				}, nil
+			}
+
+			BeforeEach(func() {
+				pod = &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pr.PodName,
+						Namespace: pr.PodNamespace,
+						Annotations: map[string]string{
+							"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"100.10.10.3/24","mac_address":"0a:58:fd:98:00:01", "role":"infrastructure-locked"}, "meganet":{"ip_addresses":["10.10.10.30/24","fd10::3/64"],"mac_address":"02:03:04:05:06:07", "role":"primary"}}`,
+						},
+					},
+				}
+				nadNamespaceLister := &v1nadmocks.NetworkAttachmentDefinitionNamespaceLister{}
+				nadNamespaceLister.On("List", labels.Everything()).Return([]*nadv1.NetworkAttachmentDefinition{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      nadName,
+						Namespace: namespace,
+					},
+					Spec: nadv1.NetworkAttachmentDefinitionSpec{
+						Config: dummyPrimaryUDNConfig(namespace, nadName),
+					},
+				}}, nil)
+				nadLister.On("NetworkAttachmentDefinitions", "foo-ns").Return(nadNamespaceLister)
+
+				getCNIResultStub = dummyGetCNIResult
+			})
+
+			It("should return the information of both the default net and the primary UDN in the result", func() {
+				podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+				response, err := pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub)
+				Expect(err).NotTo(HaveOccurred())
+				// for every interface added, we return 2 interfaces; the host side of the
+				// veth, then the pod side of the veth.
+				// thus, the UDN interface idx will be 3:
+				// idx: iface
+				//   0: host side primary UDN
+				//   1: pod side primary UDN
+				//   2: host side default network
+				//   3: pod side default network
+				podDefaultClusterNetIfaceIDX := 3
+				podUDNIfaceIDX := 1
+				Expect(response.Result).To(Equal(
+					&current.Result{
+						CNIVersion: "0.3.1",
+						Interfaces: []*current.Interface{
+							{
+								Name: "host_ovn-udn1",
+								Mac:  dummyMACHostSide,
+							},
+							{
+								Name:    "ovn-udn1",
+								Mac:     "02:03:04:05:06:07",
+								Sandbox: "bobloblaw",
+							}, {
+								Name: "host_eth0",
+								Mac:  dummyMACHostSide,
+							},
+							{
+								Name:    "eth0",
+								Mac:     "0a:58:fd:98:00:01",
+								Sandbox: "bobloblaw",
+							},
+						},
+						IPs: []*current.IPConfig{
+							{
+								Address: net.IPNet{
+									IP:   net.ParseIP("10.10.10.30"),
+									Mask: net.CIDRMask(24, 32),
+								},
+								Interface: &podUDNIfaceIDX,
+							},
+							{
+								Address: net.IPNet{
+									IP:   net.ParseIP("fd10::3"),
+									Mask: net.CIDRMask(64, 128),
+								},
+								Interface: &podUDNIfaceIDX,
+							},
+							{
+								Address: net.IPNet{
+									IP:   net.ParseIP("100.10.10.3"),
+									Mask: net.CIDRMask(24, 32),
+								},
+								Interface: &podDefaultClusterNetIfaceIDX,
+							},
+						},
+					},
+				))
+			})
+		})
 	})
 
 })
+
+func dummyPrimaryUDNConfig(ns, nadName string) string {
+	namespacedName := fmt.Sprintf("%s/%s", ns, nadName)
+	return fmt.Sprintf(`
+    {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "layer2",
+            "subnets": "10.10.0.0/16,fd10::0/64",
+            "netAttachDefName": %q,
+            "role": "primary"
+    }
+`, namespacedName)
+}

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -59,6 +59,8 @@ var _ = Describe("Network Segmentation", func() {
 
 	BeforeEach(func() {
 
+		config.IPv4Mode = true
+		config.IPv6Mode = true
 		enableMultiNetwork = config.OVNKubernetesFeature.EnableMultiNetwork
 		enableNetworkSegmentation = config.OVNKubernetesFeature.EnableNetworkSegmentation
 

--- a/go-controller/pkg/cni/cni_test.go
+++ b/go-controller/pkg/cni/cni_test.go
@@ -131,25 +131,30 @@ var _ = Describe("Network Segmentation", func() {
 		BeforeEach(func() {
 			config.OVNKubernetesFeature.EnableMultiNetwork = true
 			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
-			pod = &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      pr.PodName,
-					Namespace: pr.PodNamespace,
-					Annotations: map[string]string{
-						"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"100.10.10.3/24","mac_address":"0a:58:fd:98:00:01", "role":"primary"}}`,
+		})
+
+		Context("pod with default primary network", func() {
+			BeforeEach(func() {
+				pod = &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pr.PodName,
+						Namespace: pr.PodNamespace,
+						Annotations: map[string]string{
+							"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"100.10.10.3/24","mac_address":"0a:58:fd:98:00:01", "role":"primary"}}`,
+						},
 					},
-				},
-			}
-		})
-		It("should not fail at cmdAdd", func() {
-			podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
-			Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub)).NotTo(BeNil())
-			Expect(obtainedPodIterfaceInfos).ToNot(BeEmpty())
-		})
-		It("should not fail at cmdDel", func() {
-			podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
-			Expect(pr.cmdDel(clientSet)).NotTo(BeNil())
-			Expect(prInterfaceOpsStub.unconfiguredInterfaces).To(HaveLen(2))
+				}
+			})
+			It("should not fail at cmdAdd", func() {
+				podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+				Expect(pr.cmdAddWithGetCNIResultFunc(kubeAuth, clientSet, getCNIResultStub)).NotTo(BeNil())
+				Expect(obtainedPodIterfaceInfos).ToNot(BeEmpty())
+			})
+			It("should not fail at cmdDel", func() {
+				podNamespaceLister.On("Get", pr.PodName).Return(pod, nil)
+				Expect(pr.cmdDel(clientSet)).NotTo(BeNil())
+				Expect(prInterfaceOpsStub.unconfiguredInterfaces).To(HaveLen(2))
+			})
 		})
 
 	})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Before this commit, this was the network status we reported for a UDN pod:
```
kubectl get pods pod -ojsonpath="{@.metadata.annotations.k8s\.v1\.cni\.cncf\.io\/network-status}" | jq
[
  {
    "name": "ovn-kubernetes",
    "interface": "eth0",
    "ips": [
      "10.244.1.9",
      "fd00:10:244:2::9"
    ],
    "mac": "0a:58:0a:f4:01:09",
    "default": true,
    "dns": {}
  }
]
```

With it, we now report:
```
[
  {
    "name": "ovn-kubernetes",
    "interface": "ovn-udn1",
    "ips": [
      "10.128.0.4"
    ],
    "mac": "0a:58:0a:80:00:04",
    "default": true,
    "dns": {}
  },
  {
    "name": "ovn-kubernetes",
    "interface": "eth0",
    "ips": [
      "10.244.0.4"
    ],
    "mac": "0a:58:0a:f4:00:04",
    "dns": {}
  }
]
```

This way, applications complying to the k8snetworkplumbingwg de-facto standard can be aware of the UDN interface information.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Run the unit tests. I've added one that asserts this behavior.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Report the primary UDN information in the multi-network de-facto standard `network-status` annotation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
Report the primary UDN information in the multi-network de-facto standard `network-status` annotation.
```
