### PR TITLE
UDN: Design routes and policies on L2's GR correctly.

### DIFF
--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -644,7 +644,7 @@ func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclien
 	lr := &nbdb.LogicalRouter{Name: routerName}
 	router, err := GetLogicalRouter(nbClient, lr)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to get logical router %s: %w", routerName, err)
 	}
 	newPredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
 		for _, routeUUID := range router.StaticRoutes {
@@ -656,7 +656,7 @@ func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclien
 	}
 	routes, err := FindLogicalRouterStaticRoutesWithPredicate(nbClient, newPredicate)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to get logical router static routes with predicate on router %s: %w", routerName, err)
 	}
 
 	var ops []libovsdb.Operation
@@ -697,7 +697,7 @@ func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclien
 
 	ops, err = CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient, ops, routerName, lrsr, nil, fields...)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to get create or update logical router static routes on router %s: %w", routerName, err)
 	}
 	_, err = TransactAndCheck(nbClient, ops)
 	return err

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -615,7 +615,7 @@ func (bnc *BaseNetworkController) deleteNamespaceLocked(ns string) (*namespaceIn
 	return nsInfo, nil
 }
 
-func (bnc *BaseNetworkController) syncNodeManagementPort(node *kapi.Node, switchName string, hostSubnets []*net.IPNet, routeHostSubnets bool) ([]net.IP, error) {
+func (bnc *BaseNetworkController) syncNodeManagementPort(node *kapi.Node, switchName, routerName string, hostSubnets []*net.IPNet) ([]net.IP, error) {
 	macAddress, err := util.ParseNodeManagementPortMACAddresses(node, bnc.GetNetworkName())
 	if err != nil {
 		return nil, err
@@ -636,19 +636,25 @@ func (bnc *BaseNetworkController) syncNodeManagementPort(node *kapi.Node, switch
 		if !utilnet.IsIPv6CIDR(hostSubnet) {
 			v4Subnet = hostSubnet
 		}
-		if config.Gateway.Mode == config.GatewayModeLocal && routeHostSubnets {
+		if config.Gateway.Mode == config.GatewayModeLocal {
 			lrsr := nbdb.LogicalRouterStaticRoute{
 				Policy:   &nbdb.LogicalRouterStaticRoutePolicySrcIP,
 				IPPrefix: hostSubnet.String(),
 				Nexthop:  mgmtIfAddr.IP.String(),
 			}
+			if bnc.IsSecondary() {
+				lrsr.ExternalIDs = map[string]string{
+					ovntypes.NetworkExternalID:  bnc.GetNetworkName(),
+					ovntypes.TopologyExternalID: bnc.TopologyType(),
+				}
+			}
 			p := func(item *nbdb.LogicalRouterStaticRoute) bool {
 				return item.IPPrefix == lrsr.IPPrefix && libovsdbops.PolicyEqualPredicate(lrsr.Policy, item.Policy)
 			}
-			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(bnc.nbClient, bnc.GetNetworkScopedClusterRouterName(),
+			err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(bnc.nbClient, routerName,
 				&lrsr, p, &lrsr.Nexthop)
 			if err != nil {
-				return nil, fmt.Errorf("error creating static route %+v on router %s: %v", lrsr, bnc.GetNetworkScopedClusterRouterName(), err)
+				return nil, fmt.Errorf("error creating static route %+v on router %s: %v", lrsr, routerName, err)
 			}
 		}
 	}
@@ -678,14 +684,6 @@ func (bnc *BaseNetworkController) syncNodeManagementPort(node *kapi.Node, switch
 	}
 
 	return mgmtPortIPs, nil
-}
-
-func (bnc *BaseNetworkController) syncNodeManagementPortRouteHostSubnets(node *kapi.Node, switchName string, hostSubnets []*net.IPNet) ([]net.IP, error) {
-	return bnc.syncNodeManagementPort(node, switchName, hostSubnets, true)
-}
-
-func (bnc *BaseNetworkController) syncNodeManagementPortNoRouteHostSubnets(node *kapi.Node, switchName string, hostSubnets []*net.IPNet) ([]net.IP, error) {
-	return bnc.syncNodeManagementPort(node, switchName, hostSubnets, false)
 }
 
 // WatchNodes starts the watching of the nodes resource and calls back the appropriate handler logic

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -1242,6 +1242,12 @@ func (gw *GatewayManager) syncGatewayLogicalNetwork(
 		if err := pbrMngr.AddSameNodeIPPolicy(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
 			return fmt.Errorf("failed to configure the policy based routes for network %q: %v", gw.netInfo.GetNetworkName(), err)
 		}
+		if gw.netInfo.TopologyType() == types.Layer2Topology && config.Gateway.Mode == config.GatewayModeLocal {
+			if err := pbrMngr.AddHostCIDRPolicy(node, hostIfAddr.IP.String(), subnet.String()); err != nil {
+				return fmt.Errorf("failed to configure the hostCIDR policy for L2 network %q on local gateway: %v",
+					gw.netInfo.GetNetworkName(), err)
+			}
+		}
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -1226,24 +1226,24 @@ func (gw *GatewayManager) syncGatewayLogicalNetwork(
 		routerName = gw.gwRouterName
 	}
 	for _, subnet := range hostSubnets {
-		hostIfAddr := util.GetNodeManagementIfAddr(subnet)
-		if hostIfAddr == nil {
-			return fmt.Errorf("host interface address not found for subnet %q on network %q", subnet, gw.netInfo.GetNetworkName())
+		mgmtIfAddr := util.GetNodeManagementIfAddr(subnet)
+		if mgmtIfAddr == nil {
+			return fmt.Errorf("management interface address not found for subnet %q on network %q", subnet, gw.netInfo.GetNetworkName())
 		}
-		l3GatewayConfigIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
+		l3GatewayConfigIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(mgmtIfAddr.IP), l3GatewayConfig.IPAddresses)
 		if err != nil {
 			return fmt.Errorf("failed to extract the gateway IP addr for network %q: %v", gw.netInfo.GetNetworkName(), err)
 		}
-		relevantHostIPs, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(hostIfAddr.IP), hostAddrs)
+		relevantHostIPs, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(mgmtIfAddr.IP), hostAddrs)
 		if err != nil && err != util.ErrorNoIP {
 			return fmt.Errorf("failed to extract the host IP addrs for network %q: %v", gw.netInfo.GetNetworkName(), err)
 		}
 		pbrMngr := gatewayrouter.NewPolicyBasedRoutesManager(gw.nbClient, routerName, gw.netInfo)
-		if err := pbrMngr.AddSameNodeIPPolicy(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
+		if err := pbrMngr.AddSameNodeIPPolicy(node.Name, mgmtIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
 			return fmt.Errorf("failed to configure the policy based routes for network %q: %v", gw.netInfo.GetNetworkName(), err)
 		}
 		if gw.netInfo.TopologyType() == types.Layer2Topology && config.Gateway.Mode == config.GatewayModeLocal {
-			if err := pbrMngr.AddHostCIDRPolicy(node, hostIfAddr.IP.String(), subnet.String()); err != nil {
+			if err := pbrMngr.AddHostCIDRPolicy(node, mgmtIfAddr.IP.String(), subnet.String()); err != nil {
 				return fmt.Errorf("failed to configure the hostCIDR policy for L2 network %q on local gateway: %v",
 					gw.netInfo.GetNetworkName(), err)
 			}

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -1239,7 +1239,7 @@ func (gw *GatewayManager) syncGatewayLogicalNetwork(
 			return fmt.Errorf("failed to extract the host IP addrs for network %q: %v", gw.netInfo.GetNetworkName(), err)
 		}
 		pbrMngr := gatewayrouter.NewPolicyBasedRoutesManager(gw.nbClient, routerName, gw.netInfo)
-		if err := pbrMngr.Add(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
+		if err := pbrMngr.AddSameNodeIPPolicy(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
 			return fmt.Errorf("failed to configure the policy based routes for network %q: %v", gw.netInfo.GetNetworkName(), err)
 		}
 	}

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes.go
@@ -31,7 +31,7 @@ func NewPolicyBasedRoutesManager(nbClient client.Client, clusterRouterName strin
 	}
 }
 
-func (pbr *PolicyBasedRoutesManager) Add(nodeName, mgmtPortIP string, hostIfCIDR *net.IPNet, otherHostAddrs []string) error {
+func (pbr *PolicyBasedRoutesManager) AddSameNodeIPPolicy(nodeName, mgmtPortIP string, hostIfCIDR *net.IPNet, otherHostAddrs []string) error {
 	if hostIfCIDR == nil {
 		return fmt.Errorf("<nil> host interface CIDR")
 	}

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes.go
@@ -50,7 +50,7 @@ func (pbr *PolicyBasedRoutesManager) Add(nodeName, mgmtPortIP string, hostIfCIDR
 		// embed nodeName as comment so that it is easier to delete these rules later on.
 		// logical router policy doesn't support external_ids to stash metadata
 		networkScopedSwitchName := pbr.netInfo.GetNetworkScopedSwitchName(nodeName)
-		matchStr := generateMatch(networkScopedSwitchName, l3Prefix, hostIP)
+		matchStr := generateNodeIPMatch(networkScopedSwitchName, l3Prefix, hostIP)
 		matches = matches.Insert(matchStr)
 	}
 
@@ -218,7 +218,7 @@ func (pbr *PolicyBasedRoutesManager) createPolicyBasedRoutes(match, priority, ne
 	return nil
 }
 
-func generateMatch(switchName, ipPrefix, hostIP string) string {
+func generateNodeIPMatch(switchName, ipPrefix, hostIP string) string {
 	return fmt.Sprintf(`inport == "%s%s" && %s.dst == %s /* %s */`, ovntypes.RouterToSwitchPrefix, switchName, ipPrefix, hostIP, switchName)
 }
 

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
@@ -91,7 +91,7 @@ type test struct {
 	expectErr   bool
 }
 
-func TestAdd(t *testing.T) {
+func TestAddSameNodeIPPolicy(t *testing.T) {
 	const (
 		node1Name                 = "node1"
 		node1HostIPv4Str          = "192.168.1.10"
@@ -484,7 +484,7 @@ func TestAdd(t *testing.T) {
 				if utilnet.IsIPv6(p.hostInfCIDR.IP) {
 					mgntIP = targetNet.mgntIPv6
 				}
-				err = mgr.Add(p.nodeName, mgntIP, p.hostInfCIDR, p.otherHostInfAddrs)
+				err = mgr.AddSameNodeIPPolicy(p.nodeName, mgntIP, p.hostInfCIDR, p.otherHostInfAddrs)
 				if tt.expectErr && err == nil {
 					t.Fatalf("test: \"%s\", expected error but none occured", tt.desc)
 				}

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
@@ -159,7 +159,7 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
@@ -186,14 +186,14 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip2-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostOtherAddrIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostOtherAddrIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
@@ -234,7 +234,7 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv6Str},
 				},
@@ -267,14 +267,14 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-v4-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-v6-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv6Str},
 				},
@@ -312,14 +312,14 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-v4-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-v6-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(udnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
+					Match:    generateNodeIPMatch(udnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1UDNMgntIPv6Str},
 					ExternalIDs: map[string]string{
@@ -344,7 +344,7 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				})},
@@ -357,7 +357,7 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
@@ -378,7 +378,7 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				})},
@@ -391,7 +391,7 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
@@ -419,7 +419,7 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				}),
@@ -438,14 +438,14 @@ func TestAdd(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp2-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateMatch(udnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(udnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1UDNMgntIPv4Str},
 					ExternalIDs: map[string]string{

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
@@ -12,6 +12,8 @@ import (
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -37,7 +39,7 @@ func (n network) copyNetworkAndSetLRPs(lrps ...*nbdb.LogicalRouterPolicy) networ
 	return nCopy
 }
 
-func (n network) generateTestData() []libovsdbtest.TestData {
+func (n network) generateTestData(nodeName string) []libovsdbtest.TestData {
 	data := make([]libovsdbtest.TestData, 0, 0)
 	lrpUUIDs := make([]string, 0, len(n.initialLRPs))
 	for _, lrp := range n.initialLRPs {
@@ -57,15 +59,19 @@ func (n network) generateTestData() []libovsdbtest.TestData {
 		Name:     n.info.GetNetworkScopedClusterRouterName(),
 		Policies: lrpUUIDs,
 	}
+	if n.info.TopologyType() == types.Layer2Topology {
+		lr.Name = n.info.GetNetworkScopedGWRouterName(nodeName)
+		lr.UUID = getLRUUID(n.info.GetNetworkScopedGWRouterName(nodeName))
+	}
 	return append(data, lr)
 }
 
 type networks []network
 
-func (ns networks) generateTestData() []libovsdbtest.TestData {
+func (ns networks) generateTestData(nodeName string) []libovsdbtest.TestData {
 	data := make([]libovsdbtest.TestData, 0)
 	for _, n := range ns {
-		data = append(data, n.generateTestData()...)
+		data = append(data, n.generateTestData(nodeName)...)
 	}
 	return data
 }
@@ -460,7 +466,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			dbSetup := libovsdbtest.TestSetup{
-				NBData: tt.initialDB.generateTestData(),
+				NBData: tt.initialDB.generateTestData(node1Name),
 			}
 			nbdbClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
 			if err != nil {
@@ -490,6 +496,144 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				}
 				if tt.expectErr && err != nil {
 					return
+				}
+			}
+			matcher := libovsdbtest.HaveData(tt.expectedDB)
+			success, err := matcher.Match(nbdbClient)
+			if !success {
+				t.Fatal(fmt.Errorf("test: \"%s\" didn't match expected with actual, err: %v", tt.desc, matcher.FailureMessage(nbdbClient)))
+			}
+			if err != nil {
+				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tt.desc, err))
+			}
+		})
+	}
+}
+
+func TestAddHostCIDRPolicy(t *testing.T) {
+	const (
+		node1Name              = "node1"
+		hostCIDRV4RangeStr     = "192.168.1.0/24"
+		hostCIDRV6RangeStr     = "fc00:f853:ccd:e793::/64"
+		node1HostIPv4Str       = "192.168.1.10"
+		node1HostCIDR24IPv4Str = node1HostIPv4Str + "/24"
+		node1HostIPv6Str       = "fc00:f853:ccd:e793::3"
+		node1HostCIDR64IPv6Str = node1HostIPv6Str + "/64"
+		joinSubnetIPv4Str      = "100.10.1.0/24"
+		clusterSubnetIPv4Str   = "10.128.0.0/16"
+		clusterSubnetIPv6Str   = "2002:0:0:1234::/64"
+		node1UDNMgntIPv4Str    = "10.200.1.2"
+		node1UDNMgntIPv6Str    = "fd00:20:244::2"
+		v4Prefix               = "ip4"
+		v6Prefix               = "ip6"
+		udnNetworkName         = "network1"
+	)
+
+	var (
+		hostCIDRPolicyPrio, _ = strconv.Atoi(types.UDNHostCIDRPolicyPriority)
+		_, hostCIDRV4Range, _ = net.ParseCIDR(hostCIDRV4RangeStr)
+		_, hostCIDRV6Range, _ = net.ParseCIDR(hostCIDRV6RangeStr)
+		l2NetInfo, _          = util.NewNetInfo(&types2.NetConf{
+			NetConf:    cnitypes.NetConf{Name: udnNetworkName},
+			Topology:   types.Layer2Topology,
+			JoinSubnet: joinSubnetIPv4Str,                                 // not required, but adding so NewNetInfo doesn't fail
+			Subnets:    clusterSubnetIPv4Str + "," + clusterSubnetIPv6Str, // not required, but adding so NewNetInfo doesn't fail
+		})
+		udnL2Network = network{
+			initialLRPs: nil,
+			info:        l2NetInfo,
+			mgntIPv4:    node1UDNMgntIPv4Str,
+			mgntIPv6:    node1UDNMgntIPv6Str,
+		}
+		node = &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: node1Name,
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}",
+						node1HostCIDR24IPv4Str, node1HostCIDR64IPv6Str),
+				},
+			},
+		}
+	)
+
+	tests := []test{
+		{
+			desc: "[udn][l2][ipv4][ipv6] add hostCIDR policy for L2",
+			addPolicies: []policy{
+				{
+					targetNetwork: udnL2Network.info.GetNetworkName(),
+					hostInfCIDR:   hostCIDRV4Range,
+				},
+				{
+					targetNetwork: udnL2Network.info.GetNetworkName(),
+					hostInfCIDR:   hostCIDRV6Range,
+				},
+			},
+			initialDB: networks{udnL2Network},
+			expectedDB: []libovsdbtest.TestData{
+				&nbdb.LogicalRouter{
+					UUID:     "udn-gr-uuid",
+					Name:     udnL2Network.info.GetNetworkScopedGWRouterName(node1Name),
+					Policies: []string{"node-ip-lrp-v4-uuid", "node-ip-lrp-v6-uuid"},
+				},
+				&nbdb.LogicalRouterPolicy{
+					UUID:     "node-ip-lrp-v4-uuid",
+					Priority: hostCIDRPolicyPrio,
+					Match:    generateHostCIDRMatch(v4Prefix, hostCIDRV4RangeStr, clusterSubnetIPv4Str),
+					Action:   nbdb.LogicalRouterPolicyActionReroute,
+					Nexthops: []string{node1UDNMgntIPv4Str},
+					ExternalIDs: map[string]string{
+						types.NetworkExternalID:  udnL2Network.info.GetNetworkName(),
+						types.TopologyExternalID: udnL2Network.info.TopologyType(),
+					},
+				},
+				&nbdb.LogicalRouterPolicy{
+					UUID:     "node-ip-lrp-v6-uuid",
+					Priority: hostCIDRPolicyPrio,
+					Match:    generateHostCIDRMatch(v6Prefix, hostCIDRV6RangeStr, clusterSubnetIPv6Str),
+					Action:   nbdb.LogicalRouterPolicyActionReroute,
+					Nexthops: []string{node1UDNMgntIPv6Str},
+					ExternalIDs: map[string]string{
+						types.NetworkExternalID:  udnL2Network.info.GetNetworkName(),
+						types.TopologyExternalID: udnL2Network.info.TopologyType(),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			dbSetup := libovsdbtest.TestSetup{
+				NBData: tt.initialDB.generateTestData(node1Name),
+			}
+			nbdbClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
+			if err != nil {
+				t.Errorf("libovsdb client error: %v", err)
+				return
+			}
+			t.Cleanup(cleanup.Cleanup)
+			netToMgr := map[string]*PolicyBasedRoutesManager{}
+			for _, net := range tt.initialDB {
+				netToMgr[net.info.GetNetworkName()] = NewPolicyBasedRoutesManager(nbdbClient, net.info.GetNetworkScopedGWRouterName(node1Name), net.info)
+			}
+			// verify all polices have a valid network name
+			for _, p := range tt.addPolicies {
+				mgr, ok := netToMgr[p.targetNetwork]
+				if !ok {
+					t.Errorf("policy defined a network %q but no associated network defined with this name", p.targetNetwork)
+					return
+				}
+				targetNet := tt.initialDB.getNetwork(p.targetNetwork)
+				mgntIP := targetNet.mgntIPv4
+				clustersubnet := clusterSubnetIPv4Str
+				if utilnet.IsIPv6(p.hostInfCIDR.IP) {
+					mgntIP = targetNet.mgntIPv6
+					clustersubnet = clusterSubnetIPv6Str
+				}
+				err = mgr.AddHostCIDRPolicy(node, mgntIP, clustersubnet)
+				if err != nil {
+					t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tt.desc, err))
 				}
 			}
 			matcher := libovsdbtest.HaveData(tt.expectedDB)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -130,7 +130,7 @@ func (oc *DefaultNetworkController) newClusterRouter() (*nbdb.LogicalRouter, err
 }
 
 func (oc *DefaultNetworkController) syncNodeManagementPortDefault(node *kapi.Node, switchName string, hostSubnets []*net.IPNet) error {
-	mgmtPortIPs, err := oc.syncNodeManagementPortRouteHostSubnets(node, switchName, hostSubnets)
+	mgmtPortIPs, err := oc.syncNodeManagementPort(node, switchName, oc.GetNetworkScopedClusterRouterName(), hostSubnets)
 	if err == nil {
 		return oc.setupUDNACLs(mgmtPortIPs)
 	}

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -184,13 +184,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(is
 						data = append(data, mgmtPort)
 						nodeslsps[switchName] = append(nodeslsps[switchName], mgmtPortUUID)
 
-						// there are multiple GRs in the cluster, thus their names must be scoped with the node name
-						gwRouterName := fmt.Sprintf(
-							"%s%s",
-							ovntypes.GWRouterPrefix,
-							ocInfo.bnc.GetNetworkScopedName(nodeName),
-						)
-						networkSwitchToGWRouterLSPName := ovntypes.JoinSwitchToGWRouterPrefix + gwRouterName
+						networkSwitchToGWRouterLSPName := ovntypes.SwitchToRouterPrefix + switchName
 						networkSwitchToGWRouterLSPUUID := networkSwitchToGWRouterLSPName + "-UUID"
 
 						data = append(data, &nbdb.LogicalSwitchPort{
@@ -201,7 +195,7 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(is
 								"k8s.ovn.org/topology": ocInfo.bnc.TopologyType(),
 								"k8s.ovn.org/network":  ocInfo.bnc.GetNetworkName(),
 							},
-							Options: map[string]string{"router-port": ovntypes.GWRouterToJoinSwitchPrefix + gwRouterName},
+							Options: map[string]string{"router-port": ovntypes.RouterToSwitchPrefix + switchName},
 							Type:    "router",
 						})
 						nodeslsps[switchName] = append(nodeslsps[switchName], networkSwitchToGWRouterLSPUUID)

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -428,7 +428,7 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 			for _, subnet := range oc.Subnets() {
 				hostSubnets = append(hostSubnets, subnet.CIDR)
 			}
-			if _, err := oc.syncNodeManagementPortNoRouteHostSubnets(node, oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), hostSubnets); err != nil {
+			if _, err := oc.syncNodeManagementPort(node, oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), oc.GetNetworkScopedGWRouterName(node.Name), hostSubnets); err != nil {
 				errs = append(errs, err)
 				oc.mgmtPortFailed.Store(node.Name, true)
 			} else {

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -419,22 +419,6 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 	var errs []error
 
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
-		if nSyncs.syncMgmtPort {
-			// Layer 2 networks have a single, large subnet, that's the one
-			// associated to the controller.  Take the management port IP from
-			// there.
-			subnets := oc.Subnets()
-			hostSubnets := make([]*net.IPNet, 0, len(subnets))
-			for _, subnet := range oc.Subnets() {
-				hostSubnets = append(hostSubnets, subnet.CIDR)
-			}
-			if _, err := oc.syncNodeManagementPort(node, oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), oc.GetNetworkScopedGWRouterName(node.Name), hostSubnets); err != nil {
-				errs = append(errs, err)
-				oc.mgmtPortFailed.Store(node.Name, true)
-			} else {
-				oc.mgmtPortFailed.Delete(node.Name)
-			}
-		}
 		if nSyncs.syncGw {
 			gwManager := oc.gatewayManagerForNode(node.Name)
 			oc.gatewayManagers.Store(node.Name, gwManager)
@@ -467,6 +451,22 @@ func (oc *SecondaryLayer2NetworkController) addUpdateLocalNodeEvent(node *corev1
 						}
 					}
 				}
+			}
+		}
+		if nSyncs.syncMgmtPort {
+			// Layer 2 networks have a single, large subnet, that's the one
+			// associated to the controller.  Take the management port IP from
+			// there.
+			subnets := oc.Subnets()
+			hostSubnets := make([]*net.IPNet, 0, len(subnets))
+			for _, subnet := range oc.Subnets() {
+				hostSubnets = append(hostSubnets, subnet.CIDR)
+			}
+			if _, err := oc.syncNodeManagementPort(node, oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch), oc.GetNetworkScopedGWRouterName(node.Name), hostSubnets); err != nil {
+				errs = append(errs, err)
+				oc.mgmtPortFailed.Store(node.Name, true)
+			} else {
+				oc.mgmtPortFailed.Delete(node.Name)
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -383,7 +383,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	)
 	gwRouterName := fmt.Sprintf("GR_%s_test-node", netInfo.GetNetworkName())
 	staticRouteOutputPort := ovntypes.GWRouterToExtSwitchPrefix + gwRouterName
-	gwRouterToNetworkSwitchPortName := ovntypes.GWRouterToJoinSwitchPrefix + gwRouterName
+	gwRouterToNetworkSwitchPortName := ovntypes.RouterToSwitchPrefix + netInfo.GetNetworkScopedName(ovntypes.OVNLayer2Switch)
 	gwRouterToExtSwitchPortName := fmt.Sprintf("%s%s", ovntypes.GWRouterToExtSwitchPrefix, gwRouterName)
 	masqSNAT := newMasqueradeManagementNATEntry(masqSNATUUID1, "169.254.169.14", layer2Subnet().String(), netInfo)
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -653,7 +653,7 @@ func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *kapi.N
 				errs = append(errs, err)
 				oc.mgmtPortFailed.Store(node.Name, true)
 			} else {
-				_, err = oc.syncNodeManagementPortRouteHostSubnets(node, oc.GetNetworkScopedSwitchName(node.Name), hostSubnets)
+				_, err = oc.syncNodeManagementPort(node, oc.GetNetworkScopedSwitchName(node.Name), oc.GetNetworkScopedClusterRouterName(), hostSubnets)
 				if err != nil {
 					errs = append(errs, err)
 					oc.mgmtPortFailed.Store(node.Name, true)

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -168,6 +168,7 @@ func (h *secondaryLayer3NetworkControllerEventHandler) UpdateResource(oldObj, ne
 				_, nodeSync := h.oc.addNodeFailed.Load(newNode.Name)
 				_, failed := h.oc.nodeClusterRouterPortFailed.Load(newNode.Name)
 				clusterRtrSync := failed || nodeChassisChanged(oldNode, newNode) || nodeSubnetChanged
+				_, failed = h.oc.mgmtPortFailed.Load(newNode.Name)
 				syncMgmtPort := failed || macAddressChanged(oldNode, newNode, h.oc.GetNetworkName()) || nodeSubnetChanged
 				_, syncZoneIC := h.oc.syncZoneICFailed.Load(newNode.Name)
 				syncZoneIC = syncZoneIC || zoneClusterChanged

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -730,7 +730,7 @@ func expectedLogicalRouterPolicy(routerPolicyUUID1 string, netInfo util.NetInfo,
 		priority      = 1004
 		rerouteAction = "reroute"
 	)
-	networkScopedNodeName := netInfo.GetNetworkScopedName(nodeName)
+	networkScopedNodeName := netInfo.GetNetworkScopedSwitchName(nodeName)
 	lrpName := fmt.Sprintf("%s%s", ovntypes.RouterToSwitchPrefix, networkScopedNodeName)
 	return &nbdb.LogicalRouterPolicy{
 		UUID:        routerPolicyUUID1,

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -108,6 +108,7 @@ const (
 	MGMTPortPolicyPriority                = "1005"
 	NodeSubnetPolicyPriority              = "1004"
 	InterNodePolicyPriority               = "1003"
+	UDNHostCIDRPolicyPriority             = "99"
 	HybridOverlaySubnetPriority           = 1002
 	HybridOverlayReroutePriority          = 501
 	DefaultNoRereoutePriority             = 102

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -328,6 +328,10 @@ func (nInfo *secondaryNetInfo) GetNetworkScopedGWRouterName(nodeName string) str
 }
 
 func (nInfo *secondaryNetInfo) GetNetworkScopedSwitchName(nodeName string) string {
+	// In Layer2Topology there is just one global switch
+	if nInfo.TopologyType() == types.Layer2Topology {
+		return fmt.Sprintf("%s%s", nInfo.getPrefix(), types.OVNLayer2Switch)
+	}
 	return nInfo.GetNetworkScopedName(nodeName)
 }
 

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -725,7 +725,7 @@ type ParsedNodeEgressIPConfiguration struct {
 	Capacity Capacity
 }
 
-func getNodeIfAddrAnnotation(node *kapi.Node) (*primaryIfAddrAnnotation, error) {
+func GetNodeIfAddrAnnotation(node *kapi.Node) (*primaryIfAddrAnnotation, error) {
 	nodeIfAddrAnnotation, ok := node.Annotations[OvnNodeIfAddr]
 	if !ok {
 		return nil, newAnnotationNotSetError("%s annotation not found for node %q", OvnNodeIfAddr, node.Name)
@@ -742,7 +742,7 @@ func getNodeIfAddrAnnotation(node *kapi.Node) (*primaryIfAddrAnnotation, error) 
 
 // ParseNodePrimaryIfAddr returns the IPv4 / IPv6 values for the node's primary network interface
 func ParseNodePrimaryIfAddr(node *kapi.Node) (*ParsedNodeEgressIPConfiguration, error) {
-	nodeIfAddr, err := getNodeIfAddrAnnotation(node)
+	nodeIfAddr, err := GetNodeIfAddrAnnotation(node)
 	if err != nil {
 		return nil, err
 	}
@@ -932,7 +932,7 @@ func ParseCloudEgressIPConfig(node *kapi.Node) (*ParsedNodeEgressIPConfiguration
 
 	// ParsedNodeEgressIPConfiguration.V[4|6].IP is used to verify if an egress IP matches node IP to disable its creation
 	// use node IP instead of the value assigned from cloud egress CIDR config
-	nodeIfAddr, err := getNodeIfAddrAnnotation(node)
+	nodeIfAddr, err := GetNodeIfAddrAnnotation(node)
 	if err != nil {
 		return nil, err
 	}
@@ -1080,7 +1080,7 @@ func ParseNodeHostCIDRsExcludeOVNNetworks(node *kapi.Node) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	ovnNetworks, err := getNodeIfAddrAnnotation(node)
+	ovnNetworks, err := GetNodeIfAddrAnnotation(node)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -752,12 +752,6 @@ var _ = Describe("Network Segmentation", func() {
 				DescribeTable(
 					"can be accessed to from the pods running in the Kubernetes cluster",
 					func(netConfigParams networkAttachmentConfigParams, clientPodConfig podConfiguration) {
-						if netConfigParams.topology == "layer2" && IsGatewayModeLocal() {
-							const upstreamIssue = "https://github.com/ovn-org/ovn-kubernetes/issues/4686"
-							e2eskipper.Skipf(
-								"These tests are known to fail on Local Gateway deployments. Upstream issue: %s", upstreamIssue,
-							)
-						}
 						if netConfigParams.topology == "layer2" && !isInterconnectEnabled() {
 							const upstreamIssue = "https://github.com/ovn-org/ovn-kubernetes/issues/4642"
 							e2eskipper.Skipf(


### PR DESCRIPTION
Depends on https://github.com/ovn-org/ovn-kubernetes/pull/4554

#### What this PR does and why is it needed
Fixes: #4686
Fixes: #4682

Design:

What are the routes we need on L2 GR? It needs to be a combo of routes on L3's GR and ovn_cluster_router

Today this is what we have:
```
sh-5.2# ovn-nbctl lr-route-list GR_l2.network_ovn-worker                                                                                                                     
IPv4 Routes                                                                                                                                                                  
Route Table <main>:                                                                                                                                                          
           169.254.0.0/17               169.254.0.4 dst-ip rtoe-GR_l2.network_ovn-worker                                                                                     
                0.0.0.0/0                172.18.0.1 dst-ip rtoe-GR_l2.network_ovn-worker                                                                                     
                                                                                                                                                                             
IPv6 Routes                                                                                                                                                                  
Route Table <main>:                                                                                                                                                          
               fd69::/112                   fd69::4 dst-ip rtoe-GR_l2.network_ovn-worker                                                                                     
                     ::/0     fc00:f853:ccd:e793::1 dst-ip rtoe-GR_l2.network_ovn-worker        
```

which won't work for pod2Egress on LGW because we need to steer that traffic via mpX not via br-ex

In L3, we have the following in ovn_cluster_router:
```
               100.65.0.2                100.88.0.2 dst-ip --> not needed in L2 because SWITCH is directly connected to each of the GR
               100.65.0.3                100.65.0.3 dst-ip --> not needed in L2 because SWITCH is directly connected to each of the GR
               100.65.0.4                100.88.0.4 dst-ip --> not needed in L2 because SWITCH is directly connected to each of the GR
            10.128.0.0/24                100.88.0.2 dst-ip --> not needed in L2 because pod subnet is directly connected to GR
            10.128.2.0/24                100.88.0.4 dst-ip --> not needed in L2 because pod subnet is directly connected to GR
            10.128.1.0/24                10.128.1.2 src-ip --> NEEDED IN L2 on GR

```
So L2 routes will be:
```
sh-5.2# ovn-nbctl lr-route-list GR_l2.network_ovn-worker
IPv4 Routes
Route Table <main>:
          10.100.200.0/24              10.100.200.2 src-ip ----> this one
           169.254.0.0/17               169.254.0.4 dst-ip rtoe-GR_l2.network_ovn-worker
                0.0.0.0/0                172.18.0.1 dst-ip rtoe-GR_l2.network_ovn-worker

IPv6 Routes
Route Table <main>:
               fd69::/112                   fd69::4 dst-ip rtoe-GR_l2.network_ovn-worker
        2010:100:200::/60           2010:100:200::2 src-ip ---> this one
                     ::/0     fc00:f853:ccd:e793::1 dst-ip rtoe-GR_l2.network_ovn-worker
```

We also need this LRP:
```
        99 ip4.dst == 172.18.0.0/16 && ip4.src == 10.100.200.0/24         reroute              10.100.200.2
        99 ip6.dst == fc00:f853:ccd:e793::/64 && ip6.src == 2010:100:200::/60         reroute           2010:100:200::2
```
for pod2Egress to work properly on L2 if its pod2OtherNode traffic in addition to the LRSR we are adding because primary node subnet is a directly attached network to the GR

EIP on L2 will need appropriate changes to accommodate that.

TODO:

- [ ] Evaluate if SNATing to 100.65 is needed for services reply of ingress traffic to work properly -> will be another PR