### PR TITLE
UDN: Ensure pod2service isolation in local gw mode.

### DIFF
--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
@@ -178,6 +179,69 @@ func setUpUDNOpenflowManagerFakeOVSCommands(fexec *ovntest.FakeExec) {
 		Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_bluenet_worker1-to-br-int ofport",
 		Output: "15",
 	})
+}
+
+func checkDefaultSvcIsolationOVSFlows(flows []string, defaultConfig *bridgeUDNConfiguration, ofPortHost, bridgeMAC string, svcCIDR *net.IPNet) {
+	By(fmt.Sprintf("Checking default service isolation flows for %s", svcCIDR.String()))
+
+	var masqIP string
+	var masqSubnet string
+	var protoPrefix string
+	if utilnet.IsIPv4CIDR(svcCIDR) {
+		protoPrefix = "ip"
+		masqIP = config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String()
+		masqSubnet = config.Gateway.V4MasqueradeSubnet
+	} else {
+		protoPrefix = "ip6"
+		masqIP = config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String()
+		masqSubnet = config.Gateway.V6MasqueradeSubnet
+	}
+
+	var nTable0DefaultFlows int
+	var nTable0UDNMasqFlows int
+	var nTable2Flows int
+	for _, flow := range flows {
+		if strings.Contains(flow, fmt.Sprintf("priority=500, in_port=%s, %s, %s_dst=%s, actions=ct(commit,zone=%d,nat(src=%s),table=2)",
+			ofPortHost, protoPrefix, protoPrefix, svcCIDR, config.Default.HostMasqConntrackZone,
+			masqIP)) {
+			nTable0DefaultFlows++
+		} else if strings.Contains(flow, fmt.Sprintf("priority=550, in_port=%s, %s, %s_src=%s, %s_dst=%s, actions=ct(commit,zone=%d,table=2)",
+			ofPortHost, protoPrefix, protoPrefix, masqSubnet, protoPrefix, svcCIDR, config.Default.HostMasqConntrackZone)) {
+			nTable0UDNMasqFlows++
+		} else if strings.Contains(flow, fmt.Sprintf("priority=100, table=2, actions=set_field:%s->eth_dst,output:%s",
+			bridgeMAC, defaultConfig.ofPortPatch)) {
+			nTable2Flows++
+		}
+	}
+
+	Expect(nTable0DefaultFlows).To(Equal(1))
+	Expect(nTable0UDNMasqFlows).To(Equal(1))
+	Expect(nTable2Flows).To(Equal(1))
+}
+
+func checkUDNSvcIsolationOVSFlows(flows []string, netConfig *bridgeUDNConfiguration, netName, ofPortHost, bridgeMAC string, svcCIDR *net.IPNet, expectedNFlows int) {
+	By(fmt.Sprintf("Checking UDN %s service isolation flows for %s; expected %d flows",
+		netName, svcCIDR.String(), expectedNFlows))
+
+	var mgmtMasqIP string
+	var protoPrefix string
+	if utilnet.IsIPv4CIDR(svcCIDR) {
+		mgmtMasqIP = netConfig.v4MasqIPs.ManagementPort.IP.String()
+		protoPrefix = "ip"
+	} else {
+		mgmtMasqIP = netConfig.v6MasqIPs.ManagementPort.IP.String()
+		protoPrefix = "ip6"
+	}
+
+	var nFlows int
+	for _, flow := range flows {
+		if strings.Contains(flow, fmt.Sprintf("priority=200, table=2, %s, %s_src=%s, actions=set_field:%s->eth_dst,output:%s",
+			protoPrefix, protoPrefix, mgmtMasqIP, bridgeMAC, netConfig.ofPortPatch)) {
+			nFlows++
+		}
+	}
+
+	Expect(nFlows).To(Equal(expectedNFlows))
 }
 
 var _ = Describe("UserDefinedNetworkGateway", func() {
@@ -533,7 +597,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
 			localGw.openflowManager.syncFlows()
 			flowMap := udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(45))
+
+			Expect(len(flowMap["DEFAULT"])).To(Equal(46))
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
 			for _, flows := range flowMap {
@@ -550,25 +615,37 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(59))                                // 14 UDN Flows are added by default
+			Expect(len(flowMap["DEFAULT"])).To(Equal(62))                                // 16 UDN Flows are added by default
 			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(2)) // default network + UDN network
+			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["default"]
+			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["bluenet"]
+			bridgeMAC := udnGateway.openflowManager.defaultBridge.macAddress.String()
+			ofPortHost := udnGateway.openflowManager.defaultBridge.ofPortHost
 			for _, flows := range flowMap {
 				for _, flow := range flows {
 					if strings.Contains(flow, fmt.Sprintf("0x%x", udnGateway.masqCTMark)) {
 						// UDN Flow
 						udnFlows++
-					} else if strings.Contains(flow, fmt.Sprintf("in_port=%s", udnGateway.openflowManager.defaultBridge.netConfig["bluenet"].ofPortPatch)) {
+					} else if strings.Contains(flow, fmt.Sprintf("in_port=%s", bridgeUdnConfig.ofPortPatch)) {
 						udnFlows++
 					}
 				}
 			}
 			Expect(udnFlows).To(Equal(14))
 
+			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+				// Check flows for default network service CIDR.
+				checkDefaultSvcIsolationOVSFlows(flowMap["DEFAULT"], defaultUdnConfig, ofPortHost, bridgeMAC, svcCIDR)
+
+				// Expect exactly one flow per UDN for table 2 for service isolation.
+				checkUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", ofPortHost, bridgeMAC, svcCIDR, 1)
+			}
+
 			cnode := node.DeepCopy()
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(45))                                // only default network flows are present
+			Expect(len(flowMap["DEFAULT"])).To(Equal(46))                                // only default network flows are present
 			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
@@ -580,6 +657,14 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				}
 			}
 			Expect(udnFlows).To(Equal(0))
+
+			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+				// Check flows for default network service CIDR.
+				checkDefaultSvcIsolationOVSFlows(flowMap["DEFAULT"], defaultUdnConfig, ofPortHost, bridgeMAC, svcCIDR)
+
+				// Expect no more flows per UDN for table 2 for service isolation.
+				checkUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", ofPortHost, bridgeMAC, svcCIDR, 0)
+			}
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -709,7 +794,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
 			localGw.openflowManager.syncFlows()
 			flowMap := udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(45))
+			Expect(len(flowMap["DEFAULT"])).To(Equal(46))
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
 			for _, flows := range flowMap {
@@ -726,25 +811,37 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(59))                                // 14 UDN Flows are added by default
+			Expect(len(flowMap["DEFAULT"])).To(Equal(62))                                // 16 UDN Flows are added by default
 			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(2)) // default network + UDN network
+			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["default"]
+			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.netConfig["bluenet"]
+			bridgeMAC := udnGateway.openflowManager.defaultBridge.macAddress.String()
+			ofPortHost := udnGateway.openflowManager.defaultBridge.ofPortHost
 			for _, flows := range flowMap {
 				for _, flow := range flows {
 					if strings.Contains(flow, fmt.Sprintf("0x%x", udnGateway.masqCTMark)) {
 						// UDN Flow
 						udnFlows++
-					} else if strings.Contains(flow, fmt.Sprintf("in_port=%s", udnGateway.openflowManager.defaultBridge.netConfig["bluenet"].ofPortPatch)) {
+					} else if strings.Contains(flow, fmt.Sprintf("in_port=%s", bridgeUdnConfig.ofPortPatch)) {
 						udnFlows++
 					}
 				}
 			}
 			Expect(udnFlows).To(Equal(14))
 
+			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+				// Check flows for default network service CIDR.
+				checkDefaultSvcIsolationOVSFlows(flowMap["DEFAULT"], defaultUdnConfig, ofPortHost, bridgeMAC, svcCIDR)
+
+				// Expect exactly one flow per UDN for tables 0 and 2 for service isolation.
+				checkUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", ofPortHost, bridgeMAC, svcCIDR, 1)
+			}
+
 			cnode := node.DeepCopy()
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(len(flowMap["DEFAULT"])).To(Equal(45))                                // only default network flows are present
+			Expect(len(flowMap["DEFAULT"])).To(Equal(46))                                // only default network flows are present
 			Expect(len(udnGateway.openflowManager.defaultBridge.netConfig)).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
@@ -756,6 +853,14 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				}
 			}
 			Expect(udnFlows).To(Equal(0))
+
+			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+				// Check flows for default network service CIDR.
+				checkDefaultSvcIsolationOVSFlows(flowMap["DEFAULT"], defaultUdnConfig, ofPortHost, bridgeMAC, svcCIDR)
+
+				// Expect no more flows per UDN for tables 0 and 2 for service isolation.
+				checkUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", ofPortHost, bridgeMAC, svcCIDR, 0)
+			}
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/generator/udn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -39,10 +40,10 @@ func (c *openflowManager) getExGwBridgePortConfigurations() ([]bridgeUDNConfigur
 	return c.externalGatewayBridge.getBridgePortConfigurations()
 }
 
-func (c *openflowManager) addNetwork(nInfo util.NetInfo, masqCTMark uint, v4MasqIP, v6MasqIP *net.IPNet) {
-	c.defaultBridge.addNetworkBridgeConfig(nInfo, masqCTMark, v4MasqIP, v6MasqIP)
+func (c *openflowManager) addNetwork(nInfo util.NetInfo, masqCTMark uint, v4MasqIPs, v6MasqIPs *udn.MasqueradeIPs) {
+	c.defaultBridge.addNetworkBridgeConfig(nInfo, masqCTMark, v4MasqIPs, v6MasqIPs)
 	if c.externalGatewayBridge != nil {
-		c.externalGatewayBridge.addNetworkBridgeConfig(nInfo, masqCTMark, v4MasqIP, v6MasqIP)
+		c.externalGatewayBridge.addNetworkBridgeConfig(nInfo, masqCTMark, v4MasqIPs, v6MasqIPs)
 	}
 }
 

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -249,15 +249,9 @@ var _ = Describe("Network Segmentation: services", func() {
 
 				By("Verify the UDN client connection to the default network service")
 				checkConnectionToNodePort(f, udnClientPod2, defaultService, &nodes.Items[0], "server node", defaultServerPod.Name)
-				// TODO(kyrtapz): This doesn't work in L2, the condtion will change to checkNoConnectionToNodePort in https://github.com/ovn-org/ovn-kubernetes/pull/4705
-				if netConfigParams.topology != types.Layer2Topology {
-					checkConnectionToNodePort(f, udnClientPod2, defaultService, &nodes.Items[1], "local node", defaultServerPod.Name)
-				}
+				checkNoConnectionToNodePort(f, udnClientPod2, defaultService, &nodes.Items[1], "local node")
 				checkConnectionToNodePort(f, udnClientPod2, defaultService, &nodes.Items[2], "other node", defaultServerPod.Name)
-				// FIXME(tssurya): https://github.com/ovn-org/ovn-kubernetes/issues/4687
-				if !IsGatewayModeLocal() {
-					checkNoConnectionToClusterIPs(f, udnClientPod2, defaultService)
-				}
+				checkNoConnectionToClusterIPs(f, udnClientPod2, defaultService)
 			},
 
 			Entry(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
Ensures isolation between UDN pods and services from the default network.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4687

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
E2E tests covering this use case have been updated.
Unit tests added to check the correct openflows are added to br-ex.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->
N/A

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
NONE
```
