### PR TITLE
kind: Allow to install custom kubevirt versions

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -321,7 +321,13 @@ is_nested_virt_enabled() {
 }
 
 install_kubevirt() {
-    local kubevirt_version="$(curl -L https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)"
+    # possible values:
+    # stable - install newest stable (default)
+    # vX.Y.Z - install specific stable (i.e v1.3.1)
+    # nightly - install newest nightly
+    # nightly tag - install specific nightly (i.e 20240910)
+    KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-"stable"}
+
     for node in $(kubectl get node --no-headers  -o custom-columns=":metadata.name"); do
         $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_watches=1048576' >> /etc/sysctl.conf"
         $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_instances=512' >> /etc/sysctl.conf"
@@ -330,10 +336,10 @@ install_kubevirt() {
             kubectl label nodes $node node-role.kubernetes.io/worker="" --overwrite=true
         fi
     done
-    local kubevirt_release_url="https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}"
 
-    echo "Deploy latest nighly build Kubevirt"
     if [ "$(kubectl get kubevirts -n kubevirt kubevirt -ojsonpath='{.status.phase}')" != "Deployed" ]; then
+      local kubevirt_release_url=$(get_kubevirt_release_url "$KUBEVIRT_VERSION")
+      echo "Deploying Kubevirt from $kubevirt_release_url"
       kubectl apply -f "${kubevirt_release_url}/kubevirt-operator.yaml"
       kubectl apply -f "${kubevirt_release_url}/kubevirt-cr.yaml"
       if ! is_nested_virt_enabled; then
@@ -352,7 +358,8 @@ install_kubevirt() {
 
     kubectl -n kubevirt patch kubevirt kubevirt --type=json --patch '[{"op":"add","path":"/spec/configuration/developerConfiguration","value":{"featureGates":[]}},{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"NetworkBindingPlugins"}]'
     
-    local passt_binding_image="quay.io/kubevirt/network-passt-binding:${kubevirt_version}"
+    local kubevirt_stable_release_url=$(get_kubevirt_release_url "stable")
+    local passt_binding_image="quay.io/kubevirt/network-passt-binding:${kubevirt_stable_release_url##*/}"
     kubectl -n kubevirt patch kubevirt kubevirt --type=json --patch '[{"op":"add","path":"/spec/configuration/network","value":{}},{"op":"add","path":"/spec/configuration/network/binding","value":{"passt":{"computeResourceOverhead":{"requests":{"memory":"500Mi"}},"migration":{"method":"link-refresh"},"networkAttachmentDefinition":"default/primary-udn-kubevirt-binding","sidecarImage":"'"${passt_binding_image}"'"}}}]'
     
     if [ ! -d "./bin" ]
@@ -369,8 +376,9 @@ install_kubevirt() {
 
     pushd ./bin
        if [ ! -f ./virtctl ]; then
-           cli_name="virtctl-${kubevirt_version}-${OS_TYPE}-${ARCH}"
-           curl -LO "${kubevirt_release_url}/${cli_name}"
+           kubevirt_stable_release_url=$(get_kubevirt_release_url "stable")
+           cli_name="virtctl-${kubevirt_stable_release_url##*/}-${OS_TYPE}-${ARCH}"
+           curl -LO "${kubevirt_stable_release_url}/${cli_name}"
            mv ${cli_name} virtctl
            if_error_exit "Failed to download virtctl!"
        fi
@@ -614,4 +622,30 @@ deploy_passt_binary() {
   run_kubectl apply -f "$manifest"
 
   run_kubectl rollout status -n kube-system daemonset/passt-binding-cni --timeout 2m
+}
+
+get_kubevirt_release_url() {
+    local VERSION="$1"
+
+    local kubevirt_version
+    local kubevirt_release_url
+
+    if [[ "$VERSION" == "stable" ]]; then
+        kubevirt_version=$(curl -sL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
+        kubevirt_release_url="https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}"
+    elif [[ "$VERSION" == v* ]]; then
+        kubevirt_version="$VERSION"
+        kubevirt_release_url="https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}"
+    elif [[ "$VERSION" == "nightly" ]]; then
+        kubevirt_version=$(curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest)
+        kubevirt_release_url="https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${kubevirt_version}"
+    elif [[ "$VERSION" =~ ^[0-9]{8}$ ]]; then
+        kubevirt_version="$VERSION"
+        kubevirt_release_url="https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${kubevirt_version}"
+    else
+        echo "Unsupported KUBEVIRT_VERSION value $VERSION (use either stable, vX.Y.Z, nightly or nightly tag)"
+        exit 1
+    fi
+
+    echo "$kubevirt_release_url"
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
Allow to install custom Kubevirt releases.
Also allows to freeze specific version upon needs, for example if newest breaks stuff,
or if a feature is required before a stable release exists.

Default stays deploy last stable as it was.
Since nightly doesn't release virtctl binary, keep using the latest stable released virtctl.

Use by exporting optional env var `KUBEVIRT_VERSION` with the requested value.

Possible values of `KUBEVIRT_VERSION`:
```
stable - install newest stable (default)
vX.Y.Z - install specific stable (i.e v1.3.1)
nightly - install newest nightly
nightly tag - install specific nightly (i.e 20240910)
```

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
`quay.io/kubevirt/network-passt-binding` does have nightly,
in order to determine the tag, some more logic need to be added,
so for now only support stable

Note that the daemonset that deploys the passt binary use only stable releases,
but this is not due to this PR.

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
