### PR TITLE
kind, metallb: Remove customizating for ipv6

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -129,12 +129,6 @@ install_metallb() {
   pushd "${builddir}"
   git clone https://github.com/metallb/metallb.git
   cd metallb
-  # Use global IP next hops in IPv6
-  if  [ "$KIND_IPV6_SUPPORT" == true ]; then
-    sed -i '/address-family PROTOCOL unicast/a \
-  neighbor NODE0_IP route-map IPV6GLOBAL in\n  neighbor NODE1_IP route-map IPV6GLOBAL in\n  neighbor NODE2_IP route-map IPV6GLOBAL in' dev-env/bgp/frr/bgpd.conf.tmpl
-    printf "route-map IPV6GLOBAL permit 10\n set ipv6 next-hop prefer-global" >> dev-env/bgp/frr/bgpd.conf.tmpl
-  fi
   pip install -r dev-env/requirements.txt
 
   local ip_family ipv6_network


### PR DESCRIPTION
metallb dev-env is already using the global IPv6 addresses we should not need this cutomization.