### PR TITLE
Adds e2e test: conntrack flush after ovnkube delete + bumps OVN with fix

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-24.03.90-6.fc42
+ARG ovnver=ovn-24.03.90-7.fc42
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Test opens a TCP connection that simulates a GCP LB environment where the packet is redirected via iptables to a local server on a node. Note, in GCP the LB does not DNAT the VIP, so the packet arrives to the node with the GCP VIP on it. In OCP, we then redirect that packet to the local kapi server running on the node.

Once the test opens the TCP connection, it leaves it open for 2 minutes while ovnkube-node is then deleted. Post ovn-controller starting it should not flush the conntrack in zone 0, and the test ensures that the conntrack entry still exists.

Recent OVN regression that prompted this E2E: https://issues.redhat.com/browse/FDP-773

I tested this with OVN 24.03 and it passed. Testing with 24.09 will fail due to the above regression. We should wait until an OVN version is ready with the fix for FDP-773 and include it in this PR for OVN bump.

