### PR TITLE
Fix sudo perms when running tests

### DIFF
--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Healthcheck tests", func() {
 			Expect(testutils.UnmountNS(testNS)).To(Succeed())
 		})
 
-		It("check vrf devices are cleaned for deleted networks", func() {
+		ovntest.OnSupportedPlatformsIt("check vrf devices are cleaned for deleted networks", func() {
 			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 			config.OVNKubernetesFeature.EnableMultiNetwork = true
 

--- a/go-controller/pkg/node/secondary_node_network_controller_test.go
+++ b/go-controller/pkg/node/secondary_node_network_controller_test.go
@@ -35,22 +35,6 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 	var (
 		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
-		netName                 = "bluenet"
-		netID                   = 3
-		nodeName         string = "worker1"
-		mgtPortMAC       string = "00:00:00:55:66:77"
-		fexec            *ovntest.FakeExec
-		testNS           ns.NetNS
-		vrf              *vrfmanager.Controller
-		ipRulesManager   *iprulemanager.Controller
-		v4NodeSubnet     = "10.128.0.0/24"
-		v6NodeSubnet     = "ae70::66/112"
-		mgtPort          = fmt.Sprintf("%s%d", types.K8sMgmtIntfNamePrefix, netID)
-		gatewayInterface = "eth0"
-		gatewayBridge    = "breth0"
-		stopCh           chan struct{}
-		wg               *sync.WaitGroup
-		kubeMock         kubemocks.Interface
 	)
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -58,67 +42,6 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		// Use a larger masq subnet to allow OF manager to allocate IPs for UDNs.
 		config.Gateway.V6MasqueradeSubnet = "fd69::/112"
 		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/17"
-		// Set up a fake vsctl command mock interface
-		kubeMock = kubemocks.Interface{}
-		fexec = ovntest.NewFakeExec()
-		err := util.SetExec(fexec)
-		Expect(err).NotTo(HaveOccurred())
-		// Set up a fake k8sMgmt interface
-		testNS, err = testutils.NewNS()
-		Expect(err).NotTo(HaveOccurred())
-		err = testNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-			ovntest.AddLink(gatewayInterface)
-			link := ovntest.AddLink(gatewayBridge)
-			ovntest.AddLink(mgtPort)
-			addr, _ := netlink.ParseAddr("169.254.169.2/29")
-			err = netlink.AddrAdd(link, addr)
-			if err != nil {
-				return err
-			}
-			addr, _ = netlink.ParseAddr("10.0.0.5/24")
-			err = netlink.AddrAdd(link, addr)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-		Expect(err).NotTo(HaveOccurred())
-		wg = &sync.WaitGroup{}
-		stopCh = make(chan struct{})
-		routeManager := routemanager.NewController()
-		wg.Add(1)
-		go testNS.Do(func(netNS ns.NetNS) error {
-			defer wg.Done()
-			routeManager.Run(stopCh, 2*time.Minute)
-			return nil
-		})
-		ipRulesManager = iprulemanager.NewController(true, true)
-		wg.Add(1)
-		go testNS.Do(func(netNS ns.NetNS) error {
-			defer wg.Done()
-			ipRulesManager.Run(stopCh, 4*time.Minute)
-			return nil
-		})
-		vrf = vrfmanager.NewController(routeManager)
-		wg2 := &sync.WaitGroup{}
-		defer func() {
-			wg2.Wait()
-		}()
-		wg2.Add(1)
-		go testNS.Do(func(netNS ns.NetNS) error {
-			defer wg2.Done()
-			defer GinkgoRecover()
-			err = vrf.Run(stopCh, wg)
-			Expect(err).NotTo(HaveOccurred())
-			return nil
-		})
-	})
-	AfterEach(func() {
-		close(stopCh)
-		wg.Wait()
-		Expect(testNS.Close()).To(Succeed())
-		Expect(testutils.UnmountNS(testNS)).To(Succeed())
 	})
 
 	It("should return networkID from one of the nodes in the cluster", func() {
@@ -252,6 +175,98 @@ var _ = Describe("SecondaryNodeNetworkController", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(controller.gateway).To(BeNil())
 	})
+})
+
+var _ = Describe("SecondaryNodeNetworkController: UserDefinedPrimaryNetwork Gateway functionality", func() {
+	var (
+		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
+		netName                 = "bluenet"
+		netID                   = 3
+		nodeName         string = "worker1"
+		mgtPortMAC       string = "00:00:00:55:66:77"
+		fexec            *ovntest.FakeExec
+		testNS           ns.NetNS
+		vrf              *vrfmanager.Controller
+		ipRulesManager   *iprulemanager.Controller
+		v4NodeSubnet     = "10.128.0.0/24"
+		v6NodeSubnet     = "ae70::66/112"
+		mgtPort          = fmt.Sprintf("%s%d", types.K8sMgmtIntfNamePrefix, netID)
+		gatewayInterface = "eth0"
+		gatewayBridge    = "breth0"
+		stopCh           chan struct{}
+		wg               *sync.WaitGroup
+		kubeMock         kubemocks.Interface
+	)
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		// Use a larger masq subnet to allow OF manager to allocate IPs for UDNs.
+		config.Gateway.V6MasqueradeSubnet = "fd69::/112"
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/17"
+		// Set up a fake vsctl command mock interface
+		kubeMock = kubemocks.Interface{}
+		fexec = ovntest.NewFakeExec()
+		err := util.SetExec(fexec)
+		Expect(err).NotTo(HaveOccurred())
+		// Set up a fake k8sMgmt interface
+		testNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			ovntest.AddLink(gatewayInterface)
+			link := ovntest.AddLink(gatewayBridge)
+			ovntest.AddLink(mgtPort)
+			addr, _ := netlink.ParseAddr("169.254.169.2/29")
+			err = netlink.AddrAdd(link, addr)
+			if err != nil {
+				return err
+			}
+			addr, _ = netlink.ParseAddr("10.0.0.5/24")
+			err = netlink.AddrAdd(link, addr)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		wg = &sync.WaitGroup{}
+		stopCh = make(chan struct{})
+		routeManager := routemanager.NewController()
+		wg.Add(1)
+		go testNS.Do(func(netNS ns.NetNS) error {
+			defer wg.Done()
+			routeManager.Run(stopCh, 2*time.Minute)
+			return nil
+		})
+		ipRulesManager = iprulemanager.NewController(true, true)
+		wg.Add(1)
+		go testNS.Do(func(netNS ns.NetNS) error {
+			defer wg.Done()
+			ipRulesManager.Run(stopCh, 4*time.Minute)
+			return nil
+		})
+		vrf = vrfmanager.NewController(routeManager)
+		wg2 := &sync.WaitGroup{}
+		defer func() {
+			wg2.Wait()
+		}()
+		wg2.Add(1)
+		go testNS.Do(func(netNS ns.NetNS) error {
+			defer wg2.Done()
+			defer GinkgoRecover()
+			err = vrf.Run(stopCh, wg)
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+	})
+	AfterEach(func() {
+		close(stopCh)
+		wg.Wait()
+		Expect(testNS.Close()).To(Succeed())
+		Expect(testutils.UnmountNS(testNS)).To(Succeed())
+	})
+
 	ovntest.OnSupportedPlatformsIt("ensure UDNGateway and VRFManager and IPRulesManager are invoked for Primary UDNs when feature gate is ON", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true


### PR DESCRIPTION
#### What this PR does and why is it needed
`
mount --make-rshared /run/user/1000/netns failed: "operation not permitted"
`

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
Rather than making all the tests there go into sudo mode I moved out the test that requires the testNS framework into its own package so that we can run the other tests properly downstream.

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
