### PR TITLE
[release-1.0], kind: Pin metallb to v0.14.8

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -122,12 +122,13 @@ install_ingress() {
 
 METALLB_DIR="/tmp/metallb"
 install_metallb() {
+  local metallb_version=v0.14.8
   mkdir -p /tmp/metallb
   local builddir
   builddir=$(mktemp -d "${METALLB_DIR}/XXXXXX")
 
   pushd "${builddir}"
-  git clone https://github.com/metallb/metallb.git
+  git clone https://github.com/metallb/metallb.git -b $metallb_version
   cd metallb
   # Use global IP next hops in IPv6
   if  [ "$KIND_IPV6_SUPPORT" == true ]; then


### PR DESCRIPTION
#### What this PR does and why is it needed
There are some expectation at the dev-env interface at metallb that can change and break ovn-k CI, let's pin it so we can propertly consume those changes at a PR later on.

(cherry picked from commit b3ba566d043011be863a5cffce47918002fb3d72)

```release-note
[release-1.0], kind: Pin metallb to v0.14.8
```
