### PR TITLE
UDN: L3: Use nodesubnet annotations for L3; not clustersubnet from NAD

### DIFF
--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -297,10 +297,10 @@ var _ = Describe("OVN Multi-Homed pod operations for layer2 network", func() {
 
 func dummySecondaryLayer2UserDefinedNetwork(subnets string) secondaryNetInfo {
 	return secondaryNetInfo{
-		netName:  secondaryNetworkName,
-		nadName:  namespacedName(ns, nadName),
-		topology: ovntypes.Layer2Topology,
-		subnets:  subnets,
+		netName:        secondaryNetworkName,
+		nadName:        namespacedName(ns, nadName),
+		topology:       ovntypes.Layer2Topology,
+		clustersubnets: subnets,
 	}
 }
 
@@ -329,7 +329,7 @@ func dummyL2TestPod(nsName string, info secondaryNetInfo) testPod {
 		pod.addNetwork(
 			info.netName,
 			info.nadName,
-			info.subnets,
+			info.clustersubnets,
 			"",
 			"100.200.0.1",
 			"100.200.0.3/16",
@@ -353,7 +353,7 @@ func dummyL2TestPod(nsName string, info secondaryNetInfo) testPod {
 	pod.addNetwork(
 		info.netName,
 		info.nadName,
-		info.subnets,
+		info.clustersubnets,
 		"",
 		"",
 		"100.200.0.1/16",
@@ -459,10 +459,10 @@ func ipv4DefaultRoute() *net.IPNet {
 
 func dummyLayer2SecondaryUserDefinedNetwork(subnets string) secondaryNetInfo {
 	return secondaryNetInfo{
-		netName:  secondaryNetworkName,
-		nadName:  namespacedName(ns, nadName),
-		topology: ovntypes.Layer2Topology,
-		subnets:  subnets,
+		netName:        secondaryNetworkName,
+		nadName:        namespacedName(ns, nadName),
+		topology:       ovntypes.Layer2Topology,
+		clustersubnets: subnets,
 	}
 }
 

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -898,10 +898,10 @@ func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *kapi.Node) (
 		hostAddrs = append(hostAddrs, externalIP.String())
 	}
 
-	// Use the host subnets present in the network attachment definition.
-	hostSubnets := make([]*net.IPNet, 0, len(oc.Subnets()))
-	for _, subnet := range oc.Subnets() {
-		hostSubnets = append(hostSubnets, subnet.CIDR)
+	// Fetch the host subnets present in the node annotation for this network
+	hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, oc.GetNetworkName())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %q subnet annotation for network %q: %v", node.Name, oc.GetNetworkName(), err)
 	}
 
 	gwLRPIPs, err := util.ParseNodeGatewayRouterJoinAddrs(node, oc.GetNetworkName())

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -682,7 +682,7 @@ func (oc *SecondaryLayer3NetworkController) addUpdateLocalNodeEvent(node *kapi.N
 					gwConfig.config,
 					gwConfig.hostSubnets,
 					gwConfig.hostAddrs,
-					gwConfig.hostSubnets,
+					gwConfig.clusterSubnets,
 					gwConfig.gwLRPIPs,
 					oc.SCTPSupport,
 					oc.ovnClusterLRPToJoinIfAddrs,
@@ -858,11 +858,12 @@ func (oc *SecondaryLayer3NetworkController) gatherJoinSwitchIPs() error {
 }
 
 type SecondaryL3GatewayConfig struct {
-	config      *util.L3GatewayConfig
-	hostSubnets []*net.IPNet
-	gwLRPIPs    []*net.IPNet
-	hostAddrs   []string
-	externalIPs []net.IP
+	config         *util.L3GatewayConfig
+	hostSubnets    []*net.IPNet
+	clusterSubnets []*net.IPNet
+	gwLRPIPs       []*net.IPNet
+	hostAddrs      []string
+	externalIPs    []net.IP
 }
 
 func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *kapi.Node) (*SecondaryL3GatewayConfig, error) {
@@ -898,6 +899,12 @@ func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *kapi.Node) (
 		hostAddrs = append(hostAddrs, externalIP.String())
 	}
 
+	// Use the cluster subnets present in the network attachment definition.
+	clusterSubnets := make([]*net.IPNet, 0, len(oc.Subnets()))
+	for _, subnet := range oc.Subnets() {
+		clusterSubnets = append(clusterSubnets, subnet.CIDR)
+	}
+
 	// Fetch the host subnets present in the node annotation for this network
 	hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, oc.GetNetworkName())
 	if err != nil {
@@ -913,11 +920,12 @@ func (oc *SecondaryLayer3NetworkController) nodeGatewayConfig(node *kapi.Node) (
 	l3GatewayConfig.InterfaceID = oc.GetNetworkScopedExtPortName(l3GatewayConfig.BridgeID, node.Name)
 
 	return &SecondaryL3GatewayConfig{
-		config:      l3GatewayConfig,
-		hostSubnets: hostSubnets,
-		gwLRPIPs:    gwLRPIPs,
-		hostAddrs:   hostAddrs,
-		externalIPs: externalIPs,
+		config:         l3GatewayConfig,
+		hostSubnets:    hostSubnets,
+		clusterSubnets: clusterSubnets,
+		gwLRPIPs:       gwLRPIPs,
+		hostAddrs:      hostAddrs,
+		externalIPs:    externalIPs,
 	}, nil
 }
 


### PR DESCRIPTION
For UDN L3, it seems the local LRSR and LRPs are not getting created correctly.

SGW:
See a snippet of default network routes:
```
sh-5.2# ovn-nbctl lr-route-list ovn_cluster_router                                                                                                                          
IPv4 Routes
Route Table <main>:
               100.64.0.2                100.88.0.2 dst-ip
               100.64.0.3                100.64.0.3 dst-ip
               100.64.0.4                100.88.0.4 dst-ip
            10.244.0.0/24                100.88.0.2 dst-ip --> remote pod subnet re-route to other node's transit port
            10.244.2.0/24                100.88.0.4 dst-ip --> remote pod subnet re-route to other node's transit port
            10.244.1.0/24                100.64.0.3 src-ip --> local pod subnet re-route to GR of this node
            10.244.0.0/16                100.64.0.3 src-ip ----> USED FOR EGRESSIPs so that packets between egressIP pods don't get dropped.
```
versus:
UDN routes:
```
sh-5.2# ovn-nbctl lr-route-list xfrkk_tenant.red_ovn_cluster_router
IPv4 Routes
Route Table <main>:
               100.65.0.2                100.88.0.2 dst-ip
               100.65.0.3                100.65.0.3 dst-ip
               100.65.0.4                100.88.0.4 dst-ip
            10.128.0.0/24                100.88.0.2 dst-ip --> remote pod subnet re-route to other node's transit port
            10.128.2.0/24                100.88.0.4 dst-ip --> remote pod subnet re-route to other node's transit port
            10.128.0.0/16                100.65.0.3 src-ip --> supposed to be local pod subnet re-route to GR of this node but looks like we are using the entire cluster subnet which is causing issues. ACTUAL ROUTE SHOULD BE 10.128.1.0/24 which is the local pod subnet here for this node
```
we are having an incorrect one... the local pod subnet
and the /16 one is supposed to be added from EIP code here: `CreateDefaultRouteToExternal` that will come only when EIP support comes on UDN.

Also seems like:
```
      1004 inport == "rtos-xfrkk_tenant.red_ovn-worker" && ip4.dst == 172.18.0.3 /* xfrkk_tenant.red_ovn-worker */         reroute                10.128.0.2                 
````
is pulling info from cluster-subnet and not node-subnet for L3 which leads to issues like:
```
2024-09-12T18:41:19.353Z|00017|northd|WARN|No path for routing policy priority 1004; next hop 10.128.0.2                                                                     
```
so here the managementport is supposed to be 10.128.1.2 not 0.2 which leads to policy not translating well into SBDB flows.

Also fixes: https://github.com/ovn-org/ovn-kubernetes/issues/4723