### PR TITLE
Use fedora 41 instead of rawhide

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -9,13 +9,13 @@
 # are built locally and included in the image (instead of the rpm)
 #
 
-FROM fedora:rawhide
+FROM fedora:41
 
 USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-24.03.90-7.fc42
+ARG ovnver=ovn-24.03.90-7.fc41
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
We are running into issues with our CI:
```
13.52 >>> Librepo error: Cannot download repomd.xml: Cannot download repodata/repomd.xFailed to download metadata (metalink: "https://mirrors.fedoraproject.org/metalink?repo=rawhide&arch=x86_64") for repository "rawhide"
13.52  Librepo error: Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
------
```

@dceara helped us get unblocked by doing a build: https://koji.fedoraproject.org/koji/taskinfo?taskID=123480682 on fedora41 to make this rpm available, let's use that meanwhile waiting for https://bodhi.fedoraproject.org/updates/FEDORA-2024-91bf950011 to get karmas