### PR TITLE
Fix missing ICMP SNAT for L2 UDNs GR

### DIFF
--- a/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller_test.go
@@ -418,7 +418,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 
 	var nat []string
 	if config.Gateway.DisableSNATMultipleGWs {
-		nat = append(nat, nat1, perPodSNAT, masqSNATUUID1)
+		nat = append(nat, nat1, nat3, perPodSNAT, masqSNATUUID1)
 	} else {
 		nat = append(nat, nat1, nat2, nat3, masqSNATUUID1)
 	}
@@ -457,6 +457,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	expectedEntities = append(expectedEntities, expectedExternalSwitchAndLSPs(netInfo, gwConfig, nodeName)...)
 	if config.Gateway.DisableSNATMultipleGWs {
 		expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo)))
+		expectedEntities = append(expectedEntities, newNATEntry(nat3, dummyMasqueradeIP().IP.String(), layer2SubnetGWAddr().IP.String(), standardNonDefaultNetworkExtIDs(netInfo)))
 		expectedEntities = append(expectedEntities, newNATEntry(perPodSNAT, dummyMasqueradeIP().IP.String(), dummyL2TestPodAdditionalNetworkIP(), nil))
 	} else {
 		expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo)))


### PR DESCRIPTION
On GRs we have an SNAT from the join port IP address to the external IP address for ICMP needs frag sent by OVN to the external network.

In L2 UDNs, even though there is no join network, the internal port has two IPs, one for the pod subnet and another for the join subnet. The ICMP source address will be the first one in lexicographical order which might be the pod subnet one.

The proper SNAT for the GR pod subnet address gets created in the gateway initialization. But:
1 when DisableSNATMultipleGWs=false, it is redundant because there is
  already a SNAT for the whole pod subnet
2 when DisableSNATMultipleGWs=true we end up with no SNAT because
  cleanupStalePodSNATs cleans it up becaause it never expected that
  SNAT

This commit fixes (2)
