### PR TITLE
Skip cluster port group operations for UDN

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -680,11 +680,13 @@ func (bnc *BaseNetworkController) syncNodeManagementPort(node *kapi.Node, switch
 		return nil, err
 	}
 
-	// TODO(dceara): The cluster port group must be per network.
-	err = libovsdbops.AddPortsToPortGroup(bnc.nbClient, bnc.getClusterPortGroupName(types.ClusterPortGroupNameBase), logicalSwitchPort.UUID)
-	if err != nil {
-		klog.Errorf(err.Error())
-		return nil, err
+	// TODO(dceara): The cluster port group must be per network. So for now skip adding management port to the cluster port
+	// group for secondary network's because the cluster port group is not yet created for secondary networks.
+	if bnc.IsDefault() {
+		if err = libovsdbops.AddPortsToPortGroup(bnc.nbClient, bnc.getClusterPortGroupName(types.ClusterPortGroupNameBase), logicalSwitchPort.UUID); err != nil {
+			klog.Errorf(err.Error())
+			return nil, err
+		}
 	}
 
 	if v4Subnet != nil {

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -214,8 +214,15 @@ func (em *secondaryNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(is
 			var otherConfig map[string]string
 			if hasSubnets {
 				otherConfig = map[string]string{
-					"exclude_ips": managementPortIP(subnet).String(),
-					"subnet":      subnet.String(),
+					"subnet": subnet.String(),
+				}
+				if !ocInfo.bnc.IsPrimaryNetwork() {
+					// FIXME: This is weird that for secondary networks that don't have
+					// management ports these tests are expecting managementportIP to be
+					// excluded for no reason.
+					// FIXME2: Why are we setting exclude_ips on OVN switches when we don't
+					// even use OVN IPAMs.
+					otherConfig["exclude_ips"] = managementPortIP(subnet).String()
 				}
 			}
 


### PR DESCRIPTION
We kept trying to add the management port
for secondary networks into the cluster
port group of secondary networks.

But that port group doesn't exist yet.
It will exist once we get https://github.com/ovn-org/ovn-kubernetes/pull/4547 merged but until then this is causing
infinite retries from syncMgmtPort
erroring out. So let's skip this for now

PS: Not really infinite, only 15 times..