### PR TITLE
Return an error while adding nodes if duplicate chassis id is detected

### DIFF
--- a/go-controller/pkg/ovn/zone_interconnect/chassis_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/chassis_handler.go
@@ -133,6 +133,15 @@ func (zch *ZoneChassisHandler) createOrUpdateNodeChassis(node *corev1.Node, isRe
 			node.Name, parsedErr)
 	}
 
+	chassisList, err := libovsdbops.ListChassis(zch.sbClient)
+	if err != nil {
+		return fmt.Errorf("failed to get the list of chassis from OVN Southbound db : %w", err)
+	}
+	for _, ch := range chassisList {
+		if ch.Name == chassisID && ch.Hostname != node.Name {
+			return fmt.Errorf("duplicate chassis id has been detected for node %s and %s, consider recreating newly added node", ch.Hostname, node.Name)
+		}
+	}
 	nodePrimaryIp, err := util.GetNodePrimaryIP(node)
 	if err != nil {
 		return fmt.Errorf("failed to parse node %s primary IP %w", node.Name, err)


### PR DESCRIPTION
While multiple nodes gets same chassis id, POD to POD connectivity between newly added node and all other existing nodes gets impacted due to several missing OVN flows and OpenFlows.

Chassis ID is generally obtained from /etc/openvswitch/system-id.conf and this file gets created while starting up Opevswitch. While the chances of duplicate Openvswitch system ID created for multiple nodes is very thin but not impossible.

This commit returns an error if duplicate chassis id is detected while adding a new node.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
