### PR TITLE
Services NodePort E2Es: Reset shared variables before each test

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -708,11 +708,8 @@ var _ = ginkgo.Describe("Services", func() {
 		var nodes *v1.NodeList
 		var err error
 		nodeIPs := make(map[string]map[int]string)
-		var egressPod *v1.Pod
 		var egressNode string
-		targetSecondaryNode := node{
-			name: "egressSecondaryTargetNode-allowed",
-		}
+		var targetSecondaryNode node
 
 		const (
 			endpointHTTPPort    = 80
@@ -721,6 +718,14 @@ var _ = ginkgo.Describe("Services", func() {
 			clusterUDPPort      = 91
 			clientContainerName = "npclient"
 		)
+
+		ginkgo.BeforeEach(func() {
+			nodeIPs = make(map[string]map[int]string)
+			egressNode = ""
+			targetSecondaryNode = node{
+				name: "egressSecondaryTargetNode-allowed",
+			}
+		})
 
 		ginkgo.AfterEach(func() {
 			ginkgo.By("Cleaning up external container")
@@ -745,7 +750,6 @@ var _ = ginkgo.Describe("Services", func() {
 				e2ekubectl.RunKubectlOrDie("default", "delete", "eip", "egressip", "--ignore-not-found=true")
 				e2ekubectl.RunKubectlOrDie("default", "label", "node", egressNode, "k8s.ovn.org/egress-assignable-")
 				tearDownNetworkAndTargetForMultiNIC([]string{egressNode}, targetSecondaryNode)
-				targetSecondaryNode.nodeIP = ""
 			}
 		})
 
@@ -924,7 +928,7 @@ var _ = ginkgo.Describe("Services", func() {
 			}
 
 			ginkgo.By("Choosing egressIP pod")
-			egressPod = endPoints[0]
+			egressPod := endPoints[0]
 			framework.Logf("EgressIP pod is %s/%s", endPoints[0].Namespace, endPoints[0].Name)
 
 			ginkgo.By("Label egress node" + egressNode + " create external container to send egress traffic to via secondary MultiNIC EIP")


### PR DESCRIPTION
Reset shared variables before each test to avoid cleanup issues.
Fixes: https://github.com/ovn-org/ovn-kubernetes/issues/4733.