### PR TITLE
Fix egress gateway pod cleanup for remote zone pods.

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -277,12 +277,10 @@ func (oc *DefaultNetworkController) removeLocalZonePod(pod *kapi.Pod, portInfo *
 // It removes the remote pod ips from the namespace address set and if its an external gw pod, removes
 // its routes.
 func (oc *DefaultNetworkController) removeRemoteZonePod(pod *kapi.Pod) error {
-	if util.PodWantsHostNetwork(pod) {
-		// Delete the routes in the namespace associated with this remote pod if it was acting as an external GW
-		if err := oc.deletePodExternalGW(pod); err != nil {
-			return fmt.Errorf("unable to delete external gateway routes for remote pod %s: %w",
-				getPodNamespacedName(pod), err)
-		}
+	// Delete the routes in the namespace associated with this remote pod if it was acting as an external GW
+	if err := oc.deletePodExternalGW(pod); err != nil {
+		return fmt.Errorf("unable to delete external gateway routes for remote pod %s: %w",
+			getPodNamespacedName(pod), err)
 	}
 
 	// while this check is only intended for local pods, we also need it for

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -37,7 +37,7 @@ SKIPPED_TESTS=""
 if [ "$KIND_IPV4_SUPPORT" == true ]; then
     if  [ "$KIND_IPV6_SUPPORT" == true ]; then
 	# No support for these features in dual-stack yet
-	SKIPPED_TESTS="hybrid.overlay|external.gateway"
+	SKIPPED_TESTS="hybrid.overlay"
     else
 	# Skip sflow in IPv4 since it's a long test (~5 minutes)
 	# We're validating netflow v5 with an ipv4 cluster, sflow with an ipv6 cluster


### PR DESCRIPTION
Cleanup gateway pod for remote zone.
For local zone pods, deleteLogicalPort cleans this up, but before IC
this function was called for all non-host-network pods, hence this
logic. After IC, deleteLogicalPort won't be called for all remote zone
pods, so condition is not needed.

See test result without the fix here https://github.com/ovn-org/ovn-kubernetes/pull/4743