### PR TITLE
run update-codegen.sh to sync up with latest

### DIFF
--- a/dist/templates/k8s.cni.cncf.io_ipamclaims.yaml
+++ b/dist/templates/k8s.cni.cncf.io_ipamclaims.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: ipamclaims.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  names:
+    kind: IPAMClaim
+    listKind: IPAMClaimList
+    plural: ipamclaims
+    singular: ipamclaim
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAMClaim is the Schema for the IPAMClaim API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              interface:
+                description: The pod interface name for which this allocation was
+                  created
+                type: string
+              network:
+                description: The network name for which this persistent allocation
+                  was created
+                type: string
+            required:
+            - interface
+            - network
+            type: object
+          status:
+            properties:
+              ips:
+                description: The list of IP addresses (v4, v6) that were allocated
+                  for the pod interface
+                items:
+                  type: string
+                type: array
+            required:
+            - ips
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
+++ b/dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
@@ -85,11 +85,13 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - key
                           - operator
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       matchLabels:
                         additionalProperties:
                           type: string
@@ -154,11 +156,13 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - key
                                 - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string
@@ -205,11 +209,13 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - key
                                 - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string

--- a/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
@@ -93,13 +93,11 @@ spec:
                             be unset.
                           type: string
                         dnsName:
-                          description: dnsName is the domain name to allow/deny traffic
-                            to. If this is set, cidrSelector and nodeSelector must
-                            be unset. For a wildcard DNS name, the '*' will match
-                            only one label. Additionally, only a single '*' can be
-                            used at the beginning of the wildcard DNS name. For example,
-                            '*.example.com' will match 'sub1.example.com' but won't
-                            match 'sub2.sub1.example.com'.
+                          description: |-
+                            dnsName is the domain name to allow/deny traffic to. If this is set, cidrSelector and nodeSelector must be unset.
+                            For a wildcard DNS name, the '*' will match only one label. Additionally, only a single '*' can be
+                            used at the beginning of the wildcard DNS name. For example, '*.example.com' will match 'sub1.example.com'
+                            but won't match 'sub2.sub1.example.com'.
                           pattern: ^(\*\.)?([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
                           type: string
                         nodeSelector:
@@ -133,11 +131,13 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - key
                                 - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string

--- a/dist/templates/k8s.ovn.org_egressips.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressips.yaml.j2
@@ -92,11 +92,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
@@ -143,11 +145,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string

--- a/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
@@ -101,11 +101,13 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - key
                             - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string

--- a/dist/templates/k8s.ovn.org_egressservices.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressservices.yaml.j2
@@ -84,11 +84,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string


### PR DESCRIPTION
```
cd go-controller && ./hack/update-codegen.sh
```

The generated YAMLs for the CRDs were not reflecting the changes to IPAMClaims merged via: https://github.com/ovn-org/ovn-kubernetes/pull/4165

There were also changes in `DNSNameResolver` that were missing: https://github.com/ovn-org/ovn-kubernetes/pull/4045

Lastly, `x-kubernetes-list-type` was added as part of the generated CRDs.
