### PR TITLE
Add hybird overlay pod IPs to the namespace address_set

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -2528,5 +2528,56 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("should correctly handle a pod running on a no host subnet node", func() {
+			app.Action = func(ctx *cli.Context) error {
+				testNs := "namespace1"
+				testPodIP := "10.128.1.3"
+				namespaceT := *newNamespace(testNs)
+				myPod := newPod(testNs, "myPod", node2Name, testPodIP)
+				myPod.Status.Phase = v1.PodRunning
+				initialDB = libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{},
+				}
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							// Add a hybrid overlay node
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: nodeName,
+								},
+								Status: v1.NodeStatus{
+									Conditions: []v1.NodeCondition{
+										{
+											Type:   v1.NodeReady,
+											Status: v1.ConditionTrue,
+										},
+									},
+								},
+							},
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*myPod},
+					},
+				)
+				fakeOvn.controller.lsManager.AddOrUpdateSwitch(myPod.Spec.NodeName, nil)
+				err := fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// check that the pod IP is added to the namespace AS
+				fakeOvn.asf.ExpectAddressSetWithAddresses(testNs, []string{testPodIP})
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
#### What this PR does and why is it needed
The IPs of the pods that are on hybrid overlay nodes shall also be added to the namespace address_set.
#### Which issue(s) this PR fixes

Fixes https://issues.redhat.com//browse/OCPBUGS-42244, https://issues.redhat.com/browse/OCPBUGS-42605

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it

1. Create a hybrid overlay enabled cluster.
2. Create pods on hybrid overlay nodes.
3. check if the pod IPs are added to the namespace address_set.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
