### PR TITLE
VRF manager: reduce log chat for link updates

### DIFF
--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -96,7 +96,7 @@ func (vrfm *Controller) runInternal(stopChan <-chan struct{}, doneWg *sync.WaitG
 						continue
 					}
 					ifName := linkUpdateEvent.Link.Attrs().Name
-					klog.V(3).Infof("VRF Manager: link update received for interface %s", ifName)
+					klog.V(5).Infof("VRF Manager: link update received for interface %s", ifName)
 					err = vrfm.syncVRF(linkUpdateEvent.Link)
 					if err != nil {
 						klog.Errorf("VRF Manager: Error syncing link %s update event, err: %v", ifName, err)


### PR DESCRIPTION
Sample of logs from an active node:
```
2024-09-18T15:31:11.170275900Z I0918 15:31:11.170246    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:11.170952573Z I0918 15:31:11.170929    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:11.171235113Z I0918 15:31:11.171216    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:11.171632264Z I0918 15:31:11.171613    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:11.180630043Z I0918 15:31:11.180572    6743 helper_linux.go:442] ConfigureOVS: namespace: openshift-must-gather-m2dq9, podName: perf-node-gather-daemonset-pq5l4, hostIfaceName: 5ebc7f96ab4dfdd, network: default, NAD default, SandboxID: "5ebc7f96ab4dfdd389742189c0832b1d8a16534365dfb9f0e65411c9cf56a1bd", PCI device ID: , UID: "c1f4b74e-58ef-4c9b-95ba-4edd28bc44c6", MAC: 0a:58:0a:80:00:fe, IPs: [10.128.0.254/23]
2024-09-18T15:31:11.228917947Z I0918 15:31:11.228845    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:11.228995481Z I0918 15:31:11.228983    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:11.313175215Z I0918 15:31:11.313103    6743 cni.go:305] [openshift-must-gather-m2dq9/perf-node-gather-daemonset-pq5l4 5ebc7f96ab4dfdd389742189c0832b1d8a16534365dfb9f0e65411c9cf56a1bd network default NAD default] ADD finished CNI request [openshift-must-gather-m2dq9/perf-node-gather-daemonset-pq5l4 5ebc7f96ab4dfdd389742189c0832b1d8a16534365dfb9f0e65411c9cf56a1bd network default NAD default], result "{\"interfaces\":[{\"name\":\"5ebc7f96ab4dfdd\",\"mac\":\"3e:42:8b:4b:61:49\"},{\"name\":\"eth0\",\"mac\":\"0a:58:0a:80:00:fe\",\"sandbox\":\"/var/run/netns/94bf297c-0715-4cf8-b3fc-a6b44b927f3c\"}],\"ips\":[{\"interface\":1,\"address\":\"10.128.0.254/23\",\"gateway\":\"10.128.0.1\"}],\"dns\":{}}", err <nil>
2024-09-18T15:31:12.549237699Z I0918 15:31:12.549175    6743 route_manager.go:160] Route Manager: netlink route addition event: "{Ifindex: 2541 Dst: fe80::3c42:8bff:fe4b:6149/128 Src: <nil> Gw: <nil> Flags: [] Table: 255 Realm: 0}"
2024-09-18T15:31:12.863074755Z I0918 15:31:12.863019    6743 reflector.go:808] k8s.io/client-go/informers/factory.go:160: Watch close - *v1.NetworkPolicy total 6 items received
2024-09-18T15:31:19.698722839Z W0918 15:31:19.698658    6743 ovnkube_controller.go:1304] Config duration recorder: measurement expired for pod/e2e-test-cli-deployment-6b9lw/deployment-simple-1-9k7cd
2024-09-18T15:31:19.698722839Z W0918 15:31:19.698697    6743 ovnkube_controller.go:1304] Config duration recorder: measurement expired for pod/e2e-test-router-reencrypt-qf6dp/execpod
2024-09-18T15:31:33.759136673Z I0918 15:31:33.759069    6743 reflector.go:808] github.com/openshift/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/informers/externalversions/factory.go:140: Watch close - *v1.EgressService total 9 items received
2024-09-18T15:31:35.809741791Z I0918 15:31:35.809692    6743 pods.go:172] Deleting pod: openshift-must-gather-m2dq9/perf-node-gather-daemonset-pq5l4
2024-09-18T15:31:35.813159418Z I0918 15:31:35.813115    6743 pods.go:206] Attempting to release IPs for pod: openshift-must-gather-m2dq9/perf-node-gather-daemonset-pq5l4, ips: 10.128.0.254
2024-09-18T15:31:36.014053649Z I0918 15:31:36.013993    6743 cni.go:284] [openshift-must-gather-m2dq9/perf-node-gather-daemonset-pq5l4 5ebc7f96ab4dfdd389742189c0832b1d8a16534365dfb9f0e65411c9cf56a1bd network default NAD default] DEL starting CNI request [openshift-must-gather-m2dq9/perf-node-gather-daemonset-pq5l4 5ebc7f96ab4dfdd389742189c0832b1d8a16534365dfb9f0e65411c9cf56a1bd network default NAD default]
2024-09-18T15:31:36.045221086Z I0918 15:31:36.045176    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:36.045296698Z I0918 15:31:36.045286    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:36.049047110Z I0918 15:31:36.049001    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd
2024-09-18T15:31:36.052174596Z I0918 15:31:36.052138    6743 vrf_manager.go:99] VRF Manager: link update received for interface 5ebc7f96ab4dfdd

```