### PR TITLE
interconenct: Ask ovn-northd to bind the remote ports.

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -371,16 +371,6 @@ func (bsnc *BaseSecondaryNetworkController) addLogicalPortToNetworkForNAD(pod *k
 		_ = bsnc.logicalPortCache.add(pod, switchName, nadName, lsp.UUID, podAnnotation.MAC, podAnnotation.IPs)
 	}
 
-	// we need to create the binding ourselves for the remote ports we create on
-	// layer2 topologies with interconnect
-	isRemotePort := !isLocalPod && bsnc.isLayer2Interconnect()
-	if isRemotePort {
-		err := bsnc.zoneICHandler.BindTransitRemotePort(pod.Spec.NodeName, lsp.Name)
-		if err != nil {
-			return fmt.Errorf("failed to bind remote transit port: %w", err)
-		}
-	}
-
 	if isLocalPod {
 		bsnc.podRecorder.AddLSP(pod.UID, bsnc.NetInfo)
 		if newlyCreated {


### PR DESCRIPTION
Presently for each remote node, ovnkube after creating the remote port in the OVN Northbound db transit switch, binds the port to the remote chassis in the Southbound database.  In order to do this, we have to wait for the remote logical ports (for each of the remote zone nodes) to appear in the OVN Southbound database. This can lead to race conditions.  Instead ask ovn-northd to bind to the remote chassis.  OVN after this commit [1] already supports this.  We just need to set the requested-chassis option in the logical port.

[1] - https://github.com/ovn-org/ovn/commit/170d3e5f19f0fcd760db068cda29fc1b7f1d7ef5

Jira: https://issues.redhat.com/browse/OCPBUGS-42616

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
