### PR TITLE
[WIP] node annotations: add k8s.ovn.org/node-mgmt-port-info

### DIFF
--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -33,6 +33,7 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeMasqCIDR:                   nil,
 	util.OvnNodeGatewayMtuSupport:          nil,
 	util.OvnNodeManagementPort:             nil,
+	util.OvnNodeManagementPortInfo:         nil,
 	util.OvnNodeChassisID: func(v annotationChange, nodeName string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -270,6 +270,25 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "ovnkube-node can set util.OvnNodeManagementPortInfo",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: userName,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OvnNodeManagementPortInfo: `{"default":{"function-info":{"PfId":1,"FuncId":1}}}`},
+				},
+			},
+		},
+		{
 			name: "ovnkube-node can set util.OvnNodeGatewayMtuSupport",
 			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
 				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -65,7 +65,7 @@ func updateSubnetAnnotation(annotations map[string]string, annotationName, netNa
 	// if no host subnet left, just delete the host subnet annotation from node annotations.
 	if len(subnetsMap) == 0 {
 		delete(annotations, annotationName)
-		return nil
+		return updateNodeMgmtPortInfoIpAddresses(netName, hostSubnets, annotations)
 	}
 
 	// Marshal all host subnets of all networks back to annotations.
@@ -82,7 +82,7 @@ func updateSubnetAnnotation(annotations map[string]string, annotationName, netNa
 		return err
 	}
 	annotations[annotationName] = string(bytes)
-	return nil
+	return updateNodeMgmtPortInfoIpAddresses(netName, hostSubnets, annotations)
 }
 
 func setSubnetAnnotation(nodeAnnotator kube.Annotator, annotationName string, defaultSubnets []*net.IPNet) error {


### PR DESCRIPTION
Instead of making an assumption about the IP address on ovn-k8s-mp0, where it is expected to be the second IP of node-subnet for the default/primary network, it is better to provide this information through an annotation.

```
  k8s.ovn.org/node-mgmt-port-info: {
     "default": {
                "ip-addresses": [ "10.192.13.2/26" ],
                "mac-address": "0a:58:0a:c0:0d:02",
                "function-info": { "PfId": 0, "FuncId": 0 }
     }
  }
```

In addition to the IP addresses, include the following info:

```
  k8s.ovn.org/node-mgmt-port: '{"PfId":0,"FuncId":0}'
  k8s.ovn.org/node-mgmt-port-mac-addresses: '{"default":"0a:58:0a:c0:0d:02"}'
```