### PR TITLE
ANP: Use configured primary network pod ips and logical port name

### DIFF
--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
@@ -9,6 +9,7 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/observability"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -99,6 +100,9 @@ type Controller struct {
 	anpNodeQueue  workqueue.RateLimitingInterface
 
 	observManager *observability.Manager
+
+	// nadController used for getting network information for UDNs
+	nadController nad.NADController
 }
 
 // NewController returns a new *Controller.
@@ -115,7 +119,8 @@ func NewController(
 	isPodScheduledinLocalZone func(*v1.Pod) bool,
 	zone string,
 	recorder record.EventRecorder,
-	observManager *observability.Manager) (*Controller, error) {
+	observManager *observability.Manager,
+	nadController nad.NADController) (*Controller, error) {
 
 	c := &Controller{
 		controllerName:            controllerName,
@@ -128,6 +133,7 @@ func NewController(
 		anpPriorityMap:            make(map[int32]string),
 		banpCache:                 &adminNetworkPolicyState{}, // safe to initialise pointer to empty struct than nil
 		observManager:             observManager,
+		nadController:             nadController,
 	}
 
 	klog.V(5).Info("Setting up event handlers for Admin Network Policy")

--- a/go-controller/pkg/ovn/controller/admin_network_policy/status_test.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/status_test.go
@@ -128,6 +128,7 @@ func newANPControllerWithDBSetup(dbSetup libovsdbtest.TestSetup, initANPs anpapi
 		"targaryen",
 		recorder,
 		nil,
+		nil,
 	)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -517,6 +517,7 @@ func (oc *DefaultNetworkController) newANPController() error {
 		oc.zone,
 		oc.recorder,
 		oc.observManager,
+		oc.nadController,
 	)
 	return err
 }


### PR DESCRIPTION
The admin policy controller currently uses the default network to retrieve pod IPs and its logical port name. But this is not true when pod is configured with user defined network as its primary network. So this commit updates the controller to use appropriate netinfo object to retrieve those parameters. This way ANP can be supported for UDN though the ANP controller is initialized from the default network controller.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note

```
