### PR TITLE
WIP option 2

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -202,6 +202,10 @@ func (ncc *networkClusterController) init() error {
 	return nil
 }
 
+func (ncc *networkClusterController) PreStart(ctx context.Context) error {
+	return nil
+}
+
 // Start the network cluster controller. Depending on the cluster configuration
 // and type of network, it does the following:
 //   - initializes the node allocator and starts listening to node events

--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -61,6 +61,10 @@ func newSecondaryNetworkClusterManager(ovnClient *util.OVNClusterManagerClientse
 	return sncm, nil
 }
 
+func (sncm *secondaryNetworkClusterManager) PreStart() error {
+	return nil
+}
+
 // Start the secondary layer3 controller, handles all events and creates all
 // needed logical entities
 func (sncm *secondaryNetworkClusterManager) Start() error {

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -29,6 +29,7 @@ import (
 var ErrNetworkControllerTopologyNotManaged = errors.New("no cluster network controller to manage topology")
 
 type BaseNetworkController interface {
+	PreStart(ctx context.Context) error
 	Start(ctx context.Context) error
 	Stop()
 }
@@ -53,6 +54,7 @@ type watchFactory interface {
 }
 
 type NADController interface {
+	PreStart() error
 	Start() error
 	Stop()
 	GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error)
@@ -122,6 +124,10 @@ func NewNetAttachDefinitionController(
 	)
 
 	return nadController, nil
+}
+
+func (nadController *NetAttachDefinitionController) PreStart() error {
+	return nil
 }
 
 func (nadController *NetAttachDefinitionController) Start() error {

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller_test.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller_test.go
@@ -29,6 +29,10 @@ type testNetworkController struct {
 	tncm *testNetworkControllerManager
 }
 
+func (tnc *testNetworkController) PreStart(context.Context) error {
+	return nil
+}
+
 func (tnc *testNetworkController) Start(context.Context) error {
 	tnc.tncm.Lock()
 	defer tnc.tncm.Unlock()

--- a/go-controller/pkg/network-attach-def-controller/network_manager.go
+++ b/go-controller/pkg/network-attach-def-controller/network_manager.go
@@ -162,6 +162,8 @@ func (nm *networkManagerImpl) sync(network string) error {
 
 	if dispose {
 		if !have.stoppedAndDeleting {
+			klog.Infof("RICCARDO %s: sync network %s, dispose=%t, !have.stoppedAndDeleting", nm.name, network, dispose)
+
 			have.controller.Stop()
 		}
 		have.stoppedAndDeleting = true
@@ -183,13 +185,16 @@ func (nm *networkManagerImpl) sync(network string) error {
 		return nil
 	}
 
-	// setup & start the new network controller
-	nc, err := nm.ncm.NewNetworkController(util.CopyNetInfo(want))
+	// setup & start the new *secondary* network controller
+	klog.Infof("RICCARDO %s: sync network %s, creating new network controller", nm.name, network)
+
+	nc, err := nm.ncm.NewNetworkController(util.CopyNetInfo(want)) // ****creates SNNC**** // <--- fails here now
 	if err != nil {
 		return fmt.Errorf("%s: failed to create network %s: %w", nm.name, network, err)
 	}
+	klog.Infof("RICCARDO %s: sync network %s, starting new network controller", nm.name, network)
 
-	err = nc.Start(context.Background())
+	err = nc.Start(context.Background()) // **** starts SNNC****
 	if err != nil {
 		return fmt.Errorf("%s: failed to start network %s: %w", nm.name, network, err)
 	}

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -192,18 +192,23 @@ func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) 
 		ncm.routeManager.Run(ncm.stopChan, 2*time.Minute)
 	}()
 
+	err = ncm.initDefaultNodeNetworkController() // <--- init DNNC
+	if err != nil {
+		return fmt.Errorf("failed to init default node network controller: %v", err)
+	}
+	err = ncm.defaultNodeNetworkController.PreStart(ctx) // <--- pre start DNNC  (partial gateway init + OpenFlow Manager)
+	if err != nil {
+		return fmt.Errorf("failed to start default node network controller: %v", err)
+	}
+
 	if ncm.nadController != nil {
-		err = ncm.nadController.Start()
+		err = ncm.nadController.Start() // start NAD controller and SNNC controller <--- eventually initializes b.netConfig
 		if err != nil {
 			return fmt.Errorf("failed to start NAD controller: %w", err)
 		}
 	}
 
-	err = ncm.initDefaultNodeNetworkController()
-	if err != nil {
-		return fmt.Errorf("failed to init default node network controller: %v", err)
-	}
-	err = ncm.defaultNodeNetworkController.Start(ctx)
+	err = ncm.defaultNodeNetworkController.Start(ctx) // <--- start DNNC
 	if err != nil {
 		return fmt.Errorf("failed to start default node network controller: %v", err)
 	}

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -56,7 +56,7 @@ func (ncm *nodeNetworkControllerManager) NewNetworkController(nInfo util.NetInfo
 	case ovntypes.Layer3Topology, ovntypes.Layer2Topology, ovntypes.LocalnetTopology:
 		dnnc, ok := ncm.defaultNodeNetworkController.(*node.DefaultNodeNetworkController)
 		if !ok {
-			return nil, fmt.Errorf("unable to deference default node network controller object")
+			return nil, fmt.Errorf("unable to dereference default node network controller object")
 		}
 		return node.NewSecondaryNodeNetworkController(ncm.newCommonNetworkControllerInfo(),
 			nInfo, ncm.vrfManager, ncm.ruleManager, dnnc.Gateway)
@@ -172,6 +172,7 @@ func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) 
 	// make sure we clean up after ourselves on failure
 	defer func() {
 		if err != nil {
+			klog.Errorf("Stopping node network controller manager, err=%v", err)
 			ncm.Stop()
 		}
 	}()

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -118,6 +118,15 @@ type DefaultNodeNetworkController struct {
 	nadController *nad.NetAttachDefinitionController
 
 	cniServer *cni.Server
+
+	gatewaySetup *preStartSetup
+}
+
+type preStartSetup struct {
+	mgmtPorts      []managementPortEntry
+	mgmtPortConfig *managementPortConfig
+	nodeAddress    net.IP
+	sbZone         string
 }
 
 func newDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, stopChan chan struct{},
@@ -701,15 +710,15 @@ func portExists(namespace, name string) bool {
 
 /** HACK END **/
 
-// Start learns the subnets assigned to it by the master controller
-// and calls the SetupNode script which establishes the logical switch
-func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
-	klog.Infof("Starting the default node network controller")
+func (nc *DefaultNodeNetworkController) PreStart(ctx context.Context) error {
+	klog.Infof("RICCARDO DefaultNodeNetworkController: PreStart")
 
 	var err error
 	var node *kapi.Node
 	var subnets []*net.IPNet
 	var cniServer *cni.Server
+
+	gatewaySetup := &preStartSetup{}
 
 	// Setting debug log level during node bring up to expose bring up process.
 	// Log level is returned to configured value when bring up is complete.
@@ -718,17 +727,13 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
-		if err = configureGlobalForwarding(); err != nil {
-			return err
-		}
+	if err = configureGlobalForwarding(); err != nil {
+		return err
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
-		// Bootstrap flows in OVS if just normal flow is present
-		if err := bootstrapOVSFlows(nc.name); err != nil {
-			return fmt.Errorf("failed to bootstrap OVS flows: %w", err)
-		}
+	// Bootstrap flows in OVS if just normal flow is present
+	if err := bootstrapOVSFlows(nc.name); err != nil {
+		return fmt.Errorf("failed to bootstrap OVS flows: %w", err)
 	}
 
 	if node, err = nc.Kube.GetNode(nc.name); err != nil {
@@ -819,6 +824,86 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	nodeAnnotator := kube.NewNodeAnnotator(nc.Kube, node.Name)
 	waiter := newStartupWaiter()
 
+	// Setup management ports
+	mgmtPorts, mgmtPortConfig, err := createNodeManagementPorts(node, nc.watchFactory.NodeCoreInformer().Lister(), nodeAnnotator,
+		nc.Kube, waiter, subnets, nc.routeManager)
+	if err != nil {
+		return err
+	}
+	gatewaySetup.mgmtPorts = mgmtPorts
+	gatewaySetup.mgmtPortConfig = mgmtPortConfig
+
+	// CAREFUL: the zone was previously set /after/ gateway initialization
+	if err := util.SetNodeZone(nodeAnnotator, sbZone); err != nil {
+		return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
+	}
+	if err := nodeAnnotator.Run(); err != nil {
+		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
+	}
+
+	// Connect ovn-controller to SBDB
+	for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
+		if err := auth.SetDBAuth(); err != nil {
+			return fmt.Errorf("upgrade hack: Unable to set the authentication towards OVN local dbs")
+		}
+	}
+	// ******************************************************
+
+	// Initialize gateway
+	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+		err = nc.initGatewayDPUHost(nodeAddr)
+		if err != nil {
+			return err
+		}
+	} else {
+		// TODO phaseOne should be run BEFORE SNNC is started
+		// Initialize gateway for OVS internal port or representor management port
+		gw, err := nc.initGatewayPhaseOne(subnets, nodeAnnotator, mgmtPortConfig, nodeAddr)
+		if err != nil {
+			return err
+		}
+		nc.Gateway = gw
+	}
+
+	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {
+		klog.Errorf("Reset of initial klog \"loglevel\" failed, err: %v", err)
+	}
+	gatewaySetup.sbZone = sbZone
+
+	nc.gatewaySetup = gatewaySetup
+	klog.Infof("RICCARDO DefaultNodeNetworkController: PreStart DONE")
+
+	return nil
+
+}
+
+// Start learns the subnets assigned to it by the master controller
+// and calls the SetupNode script which establishes the logical switch
+func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
+	klog.Infof("RICCARDO DefaultNodeNetworkController: Start")
+	// klog.Infof("Starting the default node network controller")
+
+	var err error
+	var node *kapi.Node
+
+	if nc.gatewaySetup == nil {
+		return fmt.Errorf("default node network controller hasn't been pre-started")
+	}
+
+	// Setting debug log level during node bring up to expose bring up process.
+	// Log level is returned to configured value when bring up is complete.
+	var level klog.Level
+	if err := level.Set("5"); err != nil {
+		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
+	}
+
+	if node, err = nc.Kube.GetNode(nc.name); err != nil {
+		return fmt.Errorf("error retrieving node %s: %v", nc.name, err)
+	}
+
+	nodeAnnotator := kube.NewNodeAnnotator(nc.Kube, node.Name)
+	waiter := newStartupWaiter()
+
 	// Use the device from environment when the DP resource name is specified.
 	if config.OvnKubeNode.MgmtPortDPResourceName != "" {
 		if err := handleDevicePluginResources(); err != nil {
@@ -839,40 +924,14 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 			config.OvnKubeNode.MgmtPortNetdev, config.OvnKubeNode.MgmtPortDPResourceName)
 	}
 
-	// Setup management ports
-	mgmtPorts, mgmtPortConfig, err := createNodeManagementPorts(node, nc.watchFactory.NodeCoreInformer().Lister(), nodeAnnotator,
-		nc.Kube, waiter, subnets, nc.routeManager)
-	if err != nil {
-		return err
-	}
-
-	// CAREFUL: the zone was previously set /after/ gateway initialization
-	if err := util.SetNodeZone(nodeAnnotator, sbZone); err != nil {
-		return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
-	}
-	if err := nodeAnnotator.Run(); err != nil {
-		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
-	}
-
-	// Connect ovn-controller to SBDB
-	for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
-		if err := auth.SetDBAuth(); err != nil {
-			return fmt.Errorf("upgrade hack: Unable to set the authentication towards OVN local dbs")
-		}
-	}
-
 	// Initialize gateway
 	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
-		err = nc.initGatewayDPUHost(nodeAddr)
+		err = nc.initGatewayDPUHost(nc.gatewaySetup.nodeAddress)
 		if err != nil {
 			return err
 		}
 	} else {
-		// Initialize gateway for OVS internal port or representor management port
-		gw, err := nc.initGatewayPhaseOne(subnets, nodeAnnotator, mgmtPortConfig, nodeAddr)
-		if err != nil {
-			return err
-		}
+		gw := nc.Gateway.(*gateway)
 		if err := nc.initGatewayPhaseTwo(gw, waiter); err != nil {
 			return err
 		}
@@ -911,11 +970,12 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	//        plumbing (takes 80ms based on what we saw in CI runs so we might still have that small window of disruption).
 	// NOTE: ovnkube-node in DPU host mode doesn't go through upgrades for OVN-IC and has no SBDB to connect to. Thus this part shall be skipped.
 	var syncNodes, syncServices, syncPods bool
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && config.OVNKubernetesFeature.EnableInterconnect && sbZone != types.OvnDefaultZone && !util.HasNodeMigratedZone(node) { // so this should be done only once in phase2 (not in phase1)
+	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && config.OVNKubernetesFeature.EnableInterconnect && nc.gatewaySetup.sbZone != types.OvnDefaultZone && !util.HasNodeMigratedZone(node) {
 		klog.Info("Upgrade Hack: Interconnect is enabled")
 		var err1 error
 		start := time.Now()
 		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 300*time.Second, true, func(ctx context.Context) (bool, error) {
+			klog.Infof("RICCARDO Upgrade Hack: started to sync nodes")
 			// we loop through all the nodes in the cluster and ensure ovnkube-controller has finished creating the LRSR required for pod2pod overlay communication
 			if !syncNodes {
 				nodes, err := nc.Kube.GetNodes()
@@ -993,7 +1053,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("upgrade hack: failed while waiting for the remote ovnkube-controller to be ready: %v, %v", err, err1)
 		}
-		if err := util.SetNodeZoneMigrated(nodeAnnotator, sbZone); err != nil {
+		if err := util.SetNodeZoneMigrated(nodeAnnotator, nc.gatewaySetup.sbZone); err != nil {
 			return fmt.Errorf("upgrade hack: failed to set node zone annotation for node %s: %w", nc.name, err)
 		}
 		if err := nodeAnnotator.Run(); err != nil {
@@ -1069,7 +1129,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	}
 
 	// start management ports health check
-	for _, mgmtPort := range mgmtPorts {
+	for _, mgmtPort := range nc.gatewaySetup.mgmtPorts {
 		mgmtPort.port.CheckManagementPortHealth(nc.routeManager, mgmtPort.config, nc.stopChan)
 		if config.OVNKubernetesFeature.EnableEgressIP {
 			// Start the health checking server used by egressip, if EgressIPNodeHealthCheckPort is specified
@@ -1085,7 +1145,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		// "k8s.ovn.org/external-gw-pod-ips". In that case, we need ovnkube-node to flush
 		// conntrack on every node. In multi-zone-interconnect case, we will handle the flushing
 		// directly on the ovnkube-controller code to avoid an extra namespace annotation
-		if !config.OVNKubernetesFeature.EnableInterconnect || sbZone == types.OvnDefaultZone {
+		if !config.OVNKubernetesFeature.EnableInterconnect || nc.gatewaySetup.sbZone == types.OvnDefaultZone {
 			err := nc.WatchNamespaces()
 			if err != nil {
 				return fmt.Errorf("failed to watch namespaces: %w", err)
@@ -1165,7 +1225,8 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		ovspinning.Run(nc.stopChan)
 	}()
 
-	klog.Infof("Default node network controller initialized and ready.")
+	// klog.Infof("Default node network controller initialized and ready.")
+	klog.Infof("RICCARDO DefaultNodeNetworkController: Start DONE")
 	return nil
 }
 

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1075,7 +1075,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	if err := waiter.Wait(); err != nil {
 		return err
 	}
-	nc.Gateway.Start()
+	nc.Gateway.Start() // Will start a goroutine that runs the OnChange code that was registered before fo g.nodeIPManager and g.openflowManager
 	klog.Infof("Gateway and management port readiness took %v", time.Since(start))
 
 	// Note(adrianc): DPU deployments are expected to support the new shared gateway changes, upgrade flow

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"net"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -845,6 +846,21 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		return err
 	}
 
+	// CAREFUL: the zone was previously set /after/ gateway initialization
+	if err := util.SetNodeZone(nodeAnnotator, sbZone); err != nil {
+		return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
+	}
+	if err := nodeAnnotator.Run(); err != nil {
+		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
+	}
+
+	// Connect ovn-controller to SBDB
+	for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
+		if err := auth.SetDBAuth(); err != nil {
+			return fmt.Errorf("upgrade hack: Unable to set the authentication towards OVN local dbs")
+		}
+	}
+
 	// Initialize gateway
 	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
 		err = nc.initGatewayDPUHost(nodeAddr)
@@ -853,17 +869,13 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		}
 	} else {
 		// Initialize gateway for OVS internal port or representor management port
-		if err := nc.initGateway(subnets, nodeAnnotator, waiter, mgmtPortConfig, nodeAddr); err != nil {
+		gw, err := nc.initGatewayPhaseOne(subnets, nodeAnnotator, mgmtPortConfig, nodeAddr)
+		if err != nil {
 			return err
 		}
-	}
-
-	if err := util.SetNodeZone(nodeAnnotator, sbZone); err != nil {
-		return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
-	}
-
-	if err := nodeAnnotator.Run(); err != nil {
-		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
+		if err := nc.initGatewayPhaseTwo(gw, waiter); err != nil {
+			return err
+		}
 	}
 
 	// If EncapPort is not the default tell sbdb to use specified port.

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -54,6 +54,7 @@ type gateway struct {
 	servicesRetryFramework *retry.RetryFramework
 
 	gwBridge, exGwBridge *bridgeConfiguration
+	subnets []*net.IPNet
 
 	watchFactory *factory.WatchFactory // used for retry
 	stopChan     <-chan struct{}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -473,7 +473,9 @@ func interfaceForEXGW(intfName string) string {
 	return intfName
 }
 
-// TODO adapt this too
+// ***********************************
+// TODO split this too!
+// ***********************************
 func (nc *DefaultNodeNetworkController) initGatewayDPUHost(kubeNodeIP net.IP) error {
 	// A DPU host gateway is complementary to the shared gateway running
 	// on the DPU embedded CPU. it performs some initializations and

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -358,14 +358,10 @@ func (nc *DefaultNodeNetworkController) initGateway(subnets []*net.IPNet, nodeAn
 
 	var gw *gateway
 	switch config.Gateway.Mode {
-	case config.GatewayModeLocal:
-		klog.Info("Preparing Local Gateway")
-		gw, err = newLocalGateway(nc.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator,
-			managementPortConfig, nc.Kube, nc.watchFactory, nc.routeManager, nc.nadController)
-	case config.GatewayModeShared:
-		klog.Info("Preparing Shared Gateway")
-		gw, err = newSharedGateway(nc.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator, nc.Kube,
-			managementPortConfig, nc.watchFactory, nc.routeManager, nc.nadController)
+	case config.GatewayModeLocal, config.GatewayModeShared:
+		klog.Info("Preparing Gateway")
+		gw, err = newGateway(nc.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator,
+			managementPortConfig, nc.Kube, nc.watchFactory, nc.routeManager, nc.nadController, config.Gateway.Mode)
 	case config.GatewayModeDisabled:
 		var chassisID string
 		klog.Info("Gateway Mode is disabled")

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -305,8 +305,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
-			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs, nodeAnnotator, k,
-				&fakeMgmtPortConfig, wf, rm, nadController)
+			sharedGw, err := newGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs, nodeAnnotator,
+				&fakeMgmtPortConfig, k, wf, rm, nadController, config.GatewayModeShared)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())
@@ -701,8 +701,8 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
-			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
-				gatewayIntf, "", ifAddrs, nodeAnnotator, k, &fakeMgmtPortConfig, wf, rm, nadController)
+			sharedGw, err := newGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
+				gatewayIntf, "", ifAddrs, nodeAnnotator, &fakeMgmtPortConfig, k, wf, rm, nadController, config.GatewayModeShared)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())
@@ -1153,8 +1153,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
-			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs,
-				nodeAnnotator, &fakeMgmtPortConfig, k, wf, rm, nadController)
+			localGw, err := newGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", ifAddrs,
+				nodeAnnotator, &fakeMgmtPortConfig, k, wf, rm, nadController, config.GatewayModeLocal)
 			Expect(err).NotTo(HaveOccurred())
 			err = localGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -5,31 +5,20 @@ package node
 
 import (
 	"fmt"
-	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"net"
 	"strings"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	utilerrors "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/errors"
 
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
-func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string, gwIPs []*net.IPNet,
-	nodeAnnotator kube.Annotator, cfg *managementPortConfig, kube kube.Interface, watchFactory factory.NodeWatchFactory,
-	routeManager *routemanager.Controller, nadController *nad.NetAttachDefinitionController) (*gateway, error) {
-	klog.Info("Creating new local gateway")
-	gw := &gateway{}
-
+func initLocalGateway(hostSubnets []*net.IPNet, cfg *managementPortConfig) error {
+	klog.Info("Adding iptables masquerading rules for new local gateway")
 	if util.IsNetworkSegmentationSupportEnabled() {
 		if err := ensureChain("nat", iptableUDNMasqueradeChain); err != nil {
-			return nil, fmt.Errorf("failed to ensure chain %s in NAT table: %w", iptableUDNMasqueradeChain, err)
+			return fmt.Errorf("failed to ensure chain %s in NAT table: %w", iptableUDNMasqueradeChain, err)
 		}
 	}
 	for _, hostSubnet := range hostSubnets {
@@ -44,140 +33,11 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 		// add iptables masquerading for mp0 to exit the host for egress
 		cidr := nextHop.IP.Mask(nextHop.Mask)
 		cidrNet := &net.IPNet{IP: cidr, Mask: nextHop.Mask}
-		err := initLocalGatewayNATRules(cfg.ifName, cidrNet)
-		if err != nil {
-			return nil, fmt.Errorf("failed to add local NAT rules for: %s, err: %v", cfg.ifName, err)
+		if err := initLocalGatewayNATRules(cfg.ifName, cidrNet); err != nil {
+			return fmt.Errorf("failed to add local NAT rules for: %s, err: %v", cfg.ifName, err)
 		}
 	}
-
-	gwBridge, exGwBridge, err := gatewayInitInternal(
-		nodeName, gwIntf, egressGWIntf, gwNextHops, gwIPs, nodeAnnotator)
-	if err != nil {
-		return nil, err
-	}
-
-	if exGwBridge != nil {
-		gw.readyFunc = func() (bool, error) {
-			gwBridge.Lock()
-			for _, netConfig := range gwBridge.netConfig {
-				ready, err := gatewayReady(netConfig.patchPort)
-				if err != nil || !ready {
-					gwBridge.Unlock()
-					return false, err
-				}
-			}
-			gwBridge.Unlock()
-			exGwBridge.Lock()
-			for _, netConfig := range exGwBridge.netConfig {
-				exGWReady, err := gatewayReady(netConfig.patchPort)
-				if err != nil || !exGWReady {
-					exGwBridge.Unlock()
-					return false, err
-				}
-			}
-			exGwBridge.Unlock()
-			return true, nil
-		}
-	} else {
-		gw.readyFunc = func() (bool, error) {
-			gwBridge.Lock()
-			for _, netConfig := range gwBridge.netConfig {
-				ready, err := gatewayReady(netConfig.patchPort)
-				if err != nil || !ready {
-					gwBridge.Unlock()
-					return false, err
-				}
-			}
-			gwBridge.Unlock()
-			return true, nil
-		}
-	}
-
-	gw.initFunc = func() error {
-		klog.Info("Creating Local Gateway Openflow Manager")
-		err := setBridgeOfPorts(gwBridge)
-		if err != nil {
-			return err
-		}
-		if exGwBridge != nil {
-			err = setBridgeOfPorts(exGwBridge)
-			if err != nil {
-				return err
-			}
-
-		}
-
-		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory, gwBridge)
-
-		// Delete stale masquerade resources if there are any. This is to make sure that there
-		// are no Linux resouces with IP from old masquerade subnet when masquerade subnet
-		// gets changed as part of day2 operation.
-		if err := deleteStaleMasqueradeResources(gwBridge.bridgeName, nodeName, watchFactory); err != nil {
-			return fmt.Errorf("failed to remove stale masquerade resources: %w", err)
-		}
-
-		if err := setNodeMasqueradeIPOnExtBridge(gwBridge.bridgeName); err != nil {
-			return fmt.Errorf("failed to set the node masquerade IP on the ext bridge %s: %v", gwBridge.bridgeName, err)
-		}
-
-		if err := addMasqueradeRoute(routeManager, gwBridge.bridgeName, nodeName, gwIPs, watchFactory); err != nil {
-			return fmt.Errorf("failed to set the node masquerade route to OVN: %v", err)
-		}
-
-		// Masquerade config mostly done on node, update annotation
-		if err := updateMasqueradeAnnotation(nodeName, kube); err != nil {
-			return fmt.Errorf("failed to update masquerade subnet annotation on node: %s, error: %v", nodeName, err)
-		}
-
-		gw.openflowManager, err = newGatewayOpenFlowManager(gwBridge, exGwBridge, hostSubnets, gw.nodeIPManager.ListAddresses())
-		if err != nil {
-			return err
-		}
-		// resync flows on IP change
-		gw.nodeIPManager.OnChanged = func() {
-			klog.V(5).Info("Node addresses changed, re-syncing bridge flows")
-			if err := gw.openflowManager.updateBridgeFlowCache(hostSubnets, gw.nodeIPManager.ListAddresses()); err != nil {
-				// very unlikely - somehow node has lost its IP address
-				klog.Errorf("Failed to re-generate gateway flows after address change: %v", err)
-			}
-			// update gateway IPs for service openflows programmed by nodePortWatcher interface
-			npw, _ := gw.nodePortWatcher.(*nodePortWatcher)
-			npw.updateGatewayIPs(gw.nodeIPManager)
-			// Services create OpenFlow flows as well, need to update them all
-			if gw.servicesRetryFramework != nil {
-				if errs := gw.addAllServices(); errs != nil {
-					err := utilerrors.Join(errs...)
-					klog.Errorf("Failed to sync all services after node IP change: %v", err)
-				}
-			}
-			gw.openflowManager.requestFlowSync()
-		}
-
-		if config.Gateway.NodeportEnable {
-			if config.OvnKubeNode.Mode == types.NodeModeFull {
-				// (TODO): Internal Traffic Policy is not supported in DPU mode
-				if err := initSvcViaMgmPortRoutingRules(hostSubnets); err != nil {
-					return err
-				}
-			}
-			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge, gw.openflowManager, gw.nodeIPManager, watchFactory, nadController)
-			if err != nil {
-				return err
-			}
-		} else {
-			// no service OpenFlows, request to sync flows now.
-			gw.openflowManager.requestFlowSync()
-		}
-
-		if err := addHostMACBindings(gwBridge.bridgeName); err != nil {
-			return fmt.Errorf("failed to add MAC bindings for service routing")
-		}
-
-		return nil
-	}
-	gw.watchFactory = watchFactory.(*factory.WatchFactory)
-	klog.Info("Local Gateway Creation Complete")
-	return gw, nil
+	return nil
 }
 
 func getGatewayFamilyAddrs(gatewayIfAddrs []*net.IPNet) (string, string) {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"fmt"
-	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"hash/fnv"
 	"math"
 	"net"
@@ -16,6 +15,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	nad "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice"
 	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
@@ -1887,11 +1887,17 @@ func initSvcViaMgmPortRoutingRules(hostSubnets []*net.IPNet) error {
 	return nil
 }
 
-func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string,
-	gwIPs []*net.IPNet, nodeAnnotator kube.Annotator, kube kube.Interface, cfg *managementPortConfig,
-	watchFactory factory.NodeWatchFactory, routeManager *routemanager.Controller, nadController *nad.NetAttachDefinitionController) (*gateway, error) {
-	klog.Info("Creating new shared gateway")
+func newGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string,
+	gwIPs []*net.IPNet, nodeAnnotator kube.Annotator, cfg *managementPortConfig, kube kube.Interface,
+	watchFactory factory.NodeWatchFactory, routeManager *routemanager.Controller, nadController *nad.NetAttachDefinitionController, gatewayMode config.GatewayMode) (*gateway, error) {
+	klog.Info("Creating new gateway")
 	gw := &gateway{}
+
+	if gatewayMode == config.GatewayModeLocal {
+		if err := initLocalGateway(subnets, cfg); err != nil {
+			return nil, fmt.Errorf("failed to initialize new local gateway, err: %w", err)
+		}
+	}
 
 	gwBridge, exGwBridge, err := gatewayInitInternal(
 		nodeName, gwIntf, egressGWIntf, gwNextHops, gwIPs, nodeAnnotator)
@@ -1939,7 +1945,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 	gw.initFunc = func() error {
 		// Program cluster.GatewayIntf to let non-pod traffic to go to host
 		// stack
-		klog.Info("Creating Shared Gateway Openflow Manager")
+		klog.Info("Creating Gateway Openflow Manager")
 		err := setBridgeOfPorts(gwBridge)
 		if err != nil {
 			return err
@@ -2006,7 +2012,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 					return err
 				}
 			}
-			klog.Info("Creating Shared Gateway Node Port Watcher")
+			klog.Info("Creating Gateway Node Port Watcher")
 			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge, gw.openflowManager, gw.nodeIPManager, watchFactory, nadController)
 			if err != nil {
 				return err
@@ -2023,7 +2029,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		return nil
 	}
 	gw.watchFactory = watchFactory.(*factory.WatchFactory)
-	klog.Info("Shared Gateway Creation Complete")
+	klog.Info("Gateway Creation Complete")
 	return gw, nil
 }
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -141,7 +141,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, netInf
 	var actions string
 
 	if add {
-		netConfig = npw.ofm.getActiveNetwork(netInfo)
+		netConfig = npw.ofm.getActiveNetwork(netInfo) // TODO This is where the problem initially surfaced
 		if netConfig == nil {
 			return fmt.Errorf("failed to get active network config for network %s", netInfo.GetNetworkName())
 		}

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -199,7 +199,7 @@ func NewUserDefinedNetworkGateway(netInfo util.NetInfo, networkID int, node *v1.
 
 	gw, ok := defaultNetworkGateway.(*gateway)
 	if !ok {
-		return nil, fmt.Errorf("unable to deference default node network controller gateway object")
+		return nil, fmt.Errorf("unable to dereference default node network controller gateway object")
 	}
 
 	return &UserDefinedNetworkGateway{

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -580,8 +580,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// make preparations for creating openflow manager in DNCC which can be used for SNCC
-			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet), gatewayNextHops,
-				gatewayIntf, "", ifAddrs, nodeAnnotatorMock, &fakeMgmtPortConfig, &kubeMock, wf, rm, nadController)
+			localGw, err := newGateway(nodeName, ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet), gatewayNextHops,
+				gatewayIntf, "", ifAddrs, nodeAnnotatorMock, &fakeMgmtPortConfig, &kubeMock, wf, rm, nadController, config.GatewayModeLocal)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}
@@ -777,8 +777,8 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			nadController, err := networkAttachDefController.NewNetAttachDefinitionController("test", testNCM, wf, nil)
 			Expect(err).NotTo(HaveOccurred())
 			// make preparations for creating openflow manager in DNCC which can be used for SNCC
-			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet), gatewayNextHops,
-				gatewayIntf, "", ifAddrs, nodeAnnotatorMock, &fakeMgmtPortConfig, &kubeMock, wf, rm, nadController)
+			localGw, err := newGateway(nodeName, ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet), gatewayNextHops,
+				gatewayIntf, "", ifAddrs, nodeAnnotatorMock, &fakeMgmtPortConfig, &kubeMock, wf, rm, nadController, config.GatewayModeLocal)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -152,6 +152,10 @@ func (c *openflowManager) syncFlows() {
 // -- to handle external -> service(ExternalTrafficPolicy: Local) -> host access without SNAT
 func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration, subnets []*net.IPNet, extraIPs []net.IP) (*openflowManager, error) {
 	// add health check function to check default OpenFlow flows are on the shared gateway bridge
+	klog.Infof("RICCARDO newGatewayOpenFlowManager: gwBridge=%+v, exGWBridge=%+v",
+		gwBridge,
+		exGWBridge)
+
 	ofm := &openflowManager{
 		defaultBridge:         gwBridge,
 		externalGatewayBridge: exGWBridge,

--- a/go-controller/pkg/node/secondary_node_network_controller.go
+++ b/go-controller/pkg/node/secondary_node_network_controller.go
@@ -61,6 +61,10 @@ func NewSecondaryNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, n
 	return snnc, nil
 }
 
+func (nc *SecondaryNodeNetworkController) PreStart(ctx context.Context) error {
+	return nil
+}
+
 // Start starts the default controller; handles all events and creates all needed logical entities
 func (nc *SecondaryNodeNetworkController) Start(ctx context.Context) error {
 	klog.Infof("Start secondary node network controller of network %s", nc.GetNetworkName())

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -326,6 +326,10 @@ func (oc *DefaultNetworkController) syncDb() error {
 	return nil
 }
 
+func (oc *DefaultNetworkController) PreStart(ctx context.Context) error {
+	return nil
+}
+
 // Start starts the default controller; handles all events and creates all needed logical entities
 func (oc *DefaultNetworkController) Start(ctx context.Context) error {
 	klog.Infof("Starting the default network controller")

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -348,6 +348,10 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 	return oc, nil
 }
 
+func (oc *SecondaryLayer2NetworkController) PreStart(ctx context.Context) error {
+	return nil
+}
+
 // Start starts the secondary layer2 controller, handles all events and creates all needed logical entities
 func (oc *SecondaryLayer2NetworkController) Start(ctx context.Context) error {
 	klog.Infof("Starting controller for secondary network %s", oc.GetNetworkName())

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -417,6 +417,10 @@ func (oc *SecondaryLayer3NetworkController) newRetryFramework(
 	)
 }
 
+func (oc *SecondaryLayer3NetworkController) PreStart(ctx context.Context) error {
+	return nil
+}
+
 // Start starts the secondary layer3 controller, handles all events and creates all needed logical entities
 func (oc *SecondaryLayer3NetworkController) Start(ctx context.Context) error {
 	klog.Infof("Start secondary %s network controller of network %s", oc.TopologyType(), oc.GetNetworkName())

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -243,6 +243,10 @@ func NewSecondaryLocalnetNetworkController(cnci *CommonNetworkControllerInfo, ne
 	return oc
 }
 
+func (oc *SecondaryLocalnetNetworkController) PreStart(ctx context.Context) error {
+	return nil
+}
+
 // Start starts the secondary localnet controller, handles all events and creates all needed logical entities
 func (oc *SecondaryLocalnetNetworkController) Start(ctx context.Context) error {
 	klog.Infof("Starting controller for secondary network network %s", oc.GetNetworkName())

--- a/go-controller/pkg/testing/nad/netattach.go
+++ b/go-controller/pkg/testing/nad/netattach.go
@@ -2,6 +2,7 @@ package nad
 
 import (
 	"context"
+
 	networkAttachDefController "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-attach-def-controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -11,6 +12,10 @@ type FakeNetworkController struct {
 }
 
 func (nc *FakeNetworkController) Start(ctx context.Context) error {
+	return nil
+}
+
+func (nc *FakeNetworkController) PreStart(ctx context.Context) error {
 	return nil
 }
 
@@ -35,8 +40,9 @@ type FakeNADController struct {
 	PrimaryNetworks map[string]util.NetInfo
 }
 
-func (nc *FakeNADController) Start() error { return nil }
-func (nc *FakeNADController) Stop()        {}
+func (nc *FakeNADController) PreStart() error { return nil }
+func (nc *FakeNADController) Start() error    { return nil }
+func (nc *FakeNADController) Stop()           {}
 func (nc *FakeNADController) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
 	if primaryNetworks, ok := nc.PrimaryNetworks[namespace]; ok && primaryNetworks != nil {
 		return primaryNetworks, nil


### PR DESCRIPTION
Splitting newGateway(), initGateway() and gateway start.

(vs not splitting newGateway at all and running it in `preStart` as in https://github.com/ovn-org/ovn-kubernetes/pull/4734)