### PR TITLE
Fix incorrect removal of VRF device

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -72,7 +72,7 @@ function testrun {
 }
 
 # These packages requires root for network namespace manipulation in unit tests
-root_pkgs=("github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-controller-manager" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/rulemanager" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressip")
+root_pkgs=("github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-controller-manager" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/rulemanager" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/vrfmanager" "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressip")
 
 # These packages are big and require more than the 10m default to run the unit tests
 big_pkgs=("github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn")


### PR DESCRIPTION
This PR fixes repair method of VRF manager which is buggy and it incorrectly removes valid VRF device associated with a user defined network while running reconcile loop.