### PR TITLE
node_annotations: Make GetNodeHostAddrs() return stable results.

### DIFF
--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -1072,7 +1072,7 @@ func GetNodeHostAddrs(node *kapi.Node) ([]string, error) {
 	if err != nil && !IsAnnotationNotSetError(err) {
 		return nil, fmt.Errorf("failed to get node host CIDRs for %s: %s", node.Name, err.Error())
 	}
-	return hostAddresses.UnsortedList(), nil
+	return sets.List(hostAddresses), nil
 }
 
 func ParseNodeHostCIDRsExcludeOVNNetworks(node *kapi.Node) ([]string, error) {


### PR DESCRIPTION
#### What this PR does and why is it needed
The host address annotations were parsed as a set of strings and sets are unordered.  In consequence GetNodeHostAddrs() might return differently ordered host addresses when invoked on the same annotation.

In some cases this can cause DeepEqual() comparisons of objects that contain the parsed annotation results to fail even though the annotation itself didn't change.

One such example is with NodeTracker.updateNodeInfo() which compares two nodeInfo structures that contain parsed lists of host addresses.  The unstable parsing was causing unexpected full service resyncs when nothing relevant had actually changed on the node annotation.

This becomes more visible when testing with a larger number of UDNs because the NodeTracker objects are created per UDN.

Without this fix, on a 20 node kind cluster when creating 100 L3 user defined networks with one pod each, pprof CPU traces show Controller.syncService() -> Controller.configureUDNEnabledServiceRoute() taking up ~35% of the CPU time.  Some of the services were resynced thousands of times on some of the UDNs.

With the fix, no service resync happens on already configured UDNs in this case.
#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
To manually test this bring up a reasonably sized kind cluster (e.g., 20 nodes) and create a large number of L3 UDNs with one pod in each (e.g., 100 namespaces).  Make sure that resync-ing services doesn't happen on existing nodes when either new nodes are added or new UDNs are created.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->
N/A

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: TBD
-->
```release-note
NONE
```
