### PR TITLE
controller: make stop idempotent.

### DIFF
--- a/go-controller/pkg/controller/controller.go
+++ b/go-controller/pkg/controller/controller.go
@@ -139,7 +139,12 @@ func (c *controller[T]) startWorkers() error {
 }
 
 func (c *controller[T]) stop() {
+	// we assign stopChan to nil to signal that controller was already stopped.
+	if c.stopChan == nil {
+		return
+	}
 	close(c.stopChan)
+	c.stopChan = nil
 	c.cleanup()
 	c.wg.Wait()
 }

--- a/go-controller/pkg/controller/controller_test.go
+++ b/go-controller/pkg/controller/controller_test.go
@@ -91,6 +91,11 @@ var _ = Describe("Level-driven controller", func() {
 		Stop(controller)
 	})
 
+	It("has idempotent Stop", func() {
+		startController(getDefaultConfig(), nil)
+		Stop(controller)
+		Stop(controller)
+	})
 	It("handles initial objects once", func() {
 		namespace := util.NewNamespace(namespace1Name)
 		pod1 := &v1.Pod{


### PR DESCRIPTION
Usually controller should only be stopped once, but when it is a part of another controller that tries to cleanup, that may be complicated.
Currently `nodeNetworkControllerManager` on `Start` failure will call its own `Stop` method.
https://github.com/ovn-org/ovn-kubernetes/blob/715d5252f6c8ea62885d7da2c5c67970dedd65c3/go-controller/pkg/network-controller-manager/node_network_controller_manager.go#L173-L177
If it was `nadController` that failed to start https://github.com/ovn-org/ovn-kubernetes/blob/715d5252f6c8ea62885d7da2c5c67970dedd65c3/go-controller/pkg/network-controller-manager/node_network_controller_manager.go#L195 it doesn't not expect to be stopped (it actually already cleaned up its resources on failed start), but ncm `Stop` funciton doesn't track which part failed to start, and will try to `Stop` all controllers https://github.com/ovn-org/ovn-kubernetes/blob/715d5252f6c8ea62885d7da2c5c67970dedd65c3/go-controller/pkg/network-controller-manager/node_network_controller_manager.go#L244-L247. For `nadController` it will be a second cleanup.
