### PR TITLE
node: Relax check_ports() for UDN patch ports.

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1443,7 +1443,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 	// already been SNATed to the UDN's masq IP.
 	if config.IPv4Mode {
 		for _, netConfig := range bridge.patchedNetConfigs() {
-			if netConfig.masqCTMark == ctMarkOVN {
+			if netConfig.isDefaultNetwork() {
 				continue
 			}
 			dftFlows = append(dftFlows,
@@ -1456,7 +1456,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 
 	if config.IPv6Mode {
 		for _, netConfig := range bridge.patchedNetConfigs() {
-			if netConfig.masqCTMark == ctMarkOVN {
+			if netConfig.isDefaultNetwork() {
 				continue
 			}
 
@@ -1556,7 +1556,7 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 
 				// table 0, packets coming from pods headed externally. Commit connections with ct_mark ctMarkOVN
 				// so that reverse direction goes back to the pods.
-				if netConfig.masqCTMark == ctMarkOVN {
+				if netConfig.isDefaultNetwork() {
 					dftFlows = append(dftFlows,
 						fmt.Sprintf("cookie=%s, priority=100, in_port=%s, dl_src=%s, ip, "+
 							"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
@@ -1632,7 +1632,7 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 
 				// table 0, packets coming from pods headed externally. Commit connections with ct_mark ctMarkOVN
 				// so that reverse direction goes back to the pods.
-				if netConfig.masqCTMark == ctMarkOVN {
+				if netConfig.isDefaultNetwork() {
 					dftFlows = append(dftFlows,
 						fmt.Sprintf("cookie=%s, priority=100, in_port=%s, dl_src=%s, ipv6, "+
 							"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -153,6 +153,10 @@ type bridgeUDNConfiguration struct {
 	v6MasqIPs   *udn.MasqueradeIPs
 }
 
+func (netConfig *bridgeUDNConfiguration) isDefaultNetwork() bool {
+	return netConfig.masqCTMark == ctMarkOVN
+}
+
 func (netConfig *bridgeUDNConfiguration) setBridgeNetworkOfPortsInternal() error {
 	ofportPatch, stderr, err := util.GetOVSOfPort("get", "Interface", netConfig.patchPort, "ofport")
 	if err != nil {

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -179,6 +180,44 @@ func setUpUDNOpenflowManagerFakeOVSCommands(fexec *ovntest.FakeExec) {
 		Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_bluenet_worker1-to-br-int ofport",
 		Output: "15",
 	})
+}
+
+func setUpUDNOpenflowManagerCheckPortsFakeOVSCommands(fexec *ovntest.FakeExec) {
+	// Default and UDN patch port
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Interface patch-breth0_bluenet_worker1-to-br-int ofport",
+		Output: "15",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Interface patch-breth0_worker1-to-br-int ofport",
+		Output: "5",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 ofport",
+		Output: "7",
+	})
+
+	// After simulated deletion.
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Interface patch-breth0_bluenet_worker1-to-br-int ofport",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Interface patch-breth0_worker1-to-br-int ofport",
+		Output: "5",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 ofport",
+		Output: "7",
+	})
+}
+
+func openflowManagerCheckPorts(ofMgr *openflowManager) {
+	netConfigs, uplink, ofPortPhys := ofMgr.getDefaultBridgePortConfigurations()
+	sort.SliceStable(netConfigs, func(i, j int) bool {
+		return netConfigs[i].patchPort < netConfigs[j].patchPort
+	})
+	checkPorts(netConfigs, uplink, ofPortPhys)
 }
 
 func checkDefaultSvcIsolationOVSFlows(flows []string, defaultConfig *bridgeUDNConfiguration, ofPortHost, bridgeMAC string, svcCIDR *net.IPNet) {
@@ -502,6 +541,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		getVRFCreationFakeOVSCommands(fexec)
 		getRPFilterLooseModeFakeCommands(fexec)
 		setUpUDNOpenflowManagerFakeOVSCommands(fexec)
+		setUpUDNOpenflowManagerCheckPortsFakeOVSCommands(fexec)
 		getDeletionFakeOVSCommands(fexec, mgtPort)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
 		kubeFakeClient := fake.NewSimpleClientset(
@@ -632,6 +672,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				}
 			}
 			Expect(udnFlows).To(Equal(14))
+			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
 				// Check flows for default network service CIDR.
@@ -640,6 +681,11 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				// Expect exactly one flow per UDN for table 2 for service isolation.
 				checkUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", ofPortHost, bridgeMAC, svcCIDR, 1)
 			}
+
+			// The second call to checkPorts() will return no ofPort for the UDN - simulating a deletion that already was
+			// processed by ovn-northd/ovn-controller.  We should not be panicking on that.
+			// See setUpUDNOpenflowManagerCheckPortsFakeOVSCommands() for the order of ofPort query results.
+			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			cnode := node.DeepCopy()
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
@@ -698,6 +744,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		getVRFCreationFakeOVSCommands(fexec)
 		getRPFilterLooseModeFakeCommands(fexec)
 		setUpUDNOpenflowManagerFakeOVSCommands(fexec)
+		setUpUDNOpenflowManagerCheckPortsFakeOVSCommands(fexec)
 		getDeletionFakeOVSCommands(fexec, mgtPort)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
 		kubeFakeClient := fake.NewSimpleClientset(
@@ -828,6 +875,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				}
 			}
 			Expect(udnFlows).To(Equal(14))
+			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
 				// Check flows for default network service CIDR.
@@ -836,6 +884,11 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				// Expect exactly one flow per UDN for tables 0 and 2 for service isolation.
 				checkUDNSvcIsolationOVSFlows(flowMap["DEFAULT"], bridgeUdnConfig, "bluenet", ofPortHost, bridgeMAC, svcCIDR, 1)
 			}
+
+			// The second call to checkPorts() will return no ofPort for the UDN - simulating a deletion that already was
+			// processed by ovn-northd/ovn-controller.  We should not be panicking on that.
+			// See setUpUDNOpenflowManagerCheckPortsFakeOVSCommands() for the order of ofPort query results.
+			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			cnode := node.DeepCopy()
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -254,9 +254,13 @@ func checkPorts(netConfigs []bridgeUDNConfiguration, physIntf, ofPortPhys string
 
 		}
 		if netConfig.ofPortPatch != curOfportPatch {
-			klog.Errorf("Fatal error: patch port %s ofport changed from %s to %s",
-				netConfig.patchPort, netConfig.ofPortPatch, curOfportPatch)
-			os.Exit(1)
+			if netConfig.isDefaultNetwork() || curOfportPatch != "" {
+				klog.Errorf("Fatal error: patch port %s ofport changed from %s to %s",
+					netConfig.patchPort, netConfig.ofPortPatch, curOfportPatch)
+				os.Exit(1)
+			} else {
+				klog.Warningf("Patch port %s removed for existing network", netConfig.patchPort)
+			}
 		}
 	}
 


### PR DESCRIPTION
The UDN deletion process is asynchronous between ovn-kubernetes and ovn-controller.

Considering the following sequence of events:
1. UDN created
2. ovnkube's network controller creates the OVN external switch for the UDN (with a localnet port)
3. ovn-controller creates the patch port for the UDN localnet port
4. ovnkube's node controller updates netConfigs include the UDN network
5. ovnkube's node controller determines the ofPort of the newly created patch port
6. UDN deleted
7. ovnkube's network controller deletes the OVN external switch
8. ovn-controller removes the patch port
9. ovnkube's node controller finally gets the update about UDN being deleted and removes the corresponding netConfig.

Steps "8" and "9" are asynchronous and can happen in any order.  If "8" happens before "9" and if in between "8" and "9"
openflowManager.checkPorts() is called then the patch port was already deleted so ovnkube reports a fatal error and exits.

For the default network that behavior is probably OK because the patch port will never be deleted under normal circumstances.  However, for user defined networks, we eventually converge to a valid topology as soon as both "8" and "9" complete.

Relax the checkPorts() behavior for UDNs to allow for asynchronous deletion.

This was reported by Nadia as it was hit in one unrelated PR CI run: https://github.com/ovn-org/ovn-kubernetes/actions/runs/11384905304/job/31675052357?pr=4647

Fixes: #4783