### PR TITLE
Remove PreStart from NetworkController interface

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -222,10 +222,6 @@ func (ncc *networkClusterController) init() error {
 	return nil
 }
 
-func (ncc *networkClusterController) PreStart(ctx context.Context) error {
-	return nil
-}
-
 // updateNetworkStatus allows to report a status for networkClusterController's network via a UDN status condition
 // of type "NetworkAllocationSucceeded", if the network was created by UDN.
 // When at least one node reports an error, condition will be set to false and an event with node-specific error will be

--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -64,10 +64,6 @@ func newSecondaryNetworkClusterManager(ovnClient *util.OVNClusterManagerClientse
 	return sncm, nil
 }
 
-func (sncm *secondaryNetworkClusterManager) PreStart() error {
-	return nil
-}
-
 func (sncm *secondaryNetworkClusterManager) SetNetworkStatusReporter(errorReporter NetworkStatusReporter) {
 	sncm.errorReporter = errorReporter
 }

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -29,7 +29,6 @@ import (
 var ErrNetworkControllerTopologyNotManaged = errors.New("no cluster network controller to manage topology")
 
 type BaseNetworkController interface {
-	PreStart(ctx context.Context) error
 	Start(ctx context.Context) error
 	Stop()
 }
@@ -54,7 +53,6 @@ type watchFactory interface {
 }
 
 type NADController interface {
-	PreStart() error
 	Start() error
 	Stop()
 	GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error)
@@ -124,10 +122,6 @@ func NewNetAttachDefinitionController(
 	)
 
 	return nadController, nil
-}
-
-func (nadController *NetAttachDefinitionController) PreStart() error {
-	return nil
 }
 
 func (nadController *NetAttachDefinitionController) Start() error {

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller_test.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller_test.go
@@ -29,10 +29,6 @@ type testNetworkController struct {
 	tncm *testNetworkControllerManager
 }
 
-func (tnc *testNetworkController) PreStart(context.Context) error {
-	return nil
-}
-
 func (tnc *testNetworkController) Start(context.Context) error {
 	tnc.tncm.Lock()
 	defer tnc.tncm.Unlock()

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -36,7 +36,7 @@ type nodeNetworkControllerManager struct {
 	wg            *sync.WaitGroup
 	recorder      record.EventRecorder
 
-	defaultNodeNetworkController nad.BaseNetworkController
+	defaultNodeNetworkController *node.DefaultNodeNetworkController
 
 	// net-attach-def controller handle net-attach-def and create/delete secondary controllers
 	// nil in dpu-host mode
@@ -54,12 +54,8 @@ func (ncm *nodeNetworkControllerManager) NewNetworkController(nInfo util.NetInfo
 	topoType := nInfo.TopologyType()
 	switch topoType {
 	case ovntypes.Layer3Topology, ovntypes.Layer2Topology, ovntypes.LocalnetTopology:
-		dnnc, ok := ncm.defaultNodeNetworkController.(*node.DefaultNodeNetworkController)
-		if !ok {
-			return nil, fmt.Errorf("unable to dereference default node network controller object")
-		}
 		return node.NewSecondaryNodeNetworkController(ncm.newCommonNetworkControllerInfo(),
-			nInfo, ncm.vrfManager, ncm.ruleManager, dnnc.Gateway)
+			nInfo, ncm.vrfManager, ncm.ruleManager, ncm.defaultNodeNetworkController.Gateway)
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
 }

--- a/go-controller/pkg/node/secondary_node_network_controller.go
+++ b/go-controller/pkg/node/secondary_node_network_controller.go
@@ -61,10 +61,6 @@ func NewSecondaryNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, n
 	return snnc, nil
 }
 
-func (nc *SecondaryNodeNetworkController) PreStart(ctx context.Context) error {
-	return nil
-}
-
 // Start starts the default controller; handles all events and creates all needed logical entities
 func (nc *SecondaryNodeNetworkController) Start(ctx context.Context) error {
 	klog.Infof("Start secondary node network controller of network %s", nc.GetNetworkName())

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -326,10 +326,6 @@ func (oc *DefaultNetworkController) syncDb() error {
 	return nil
 }
 
-func (oc *DefaultNetworkController) PreStart(ctx context.Context) error {
-	return nil
-}
-
 // Start starts the default controller; handles all events and creates all needed logical entities
 func (oc *DefaultNetworkController) Start(ctx context.Context) error {
 	klog.Infof("Starting the default network controller")

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -344,10 +344,6 @@ func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netI
 	return oc, nil
 }
 
-func (oc *SecondaryLayer2NetworkController) PreStart(ctx context.Context) error {
-	return nil
-}
-
 // Start starts the secondary layer2 controller, handles all events and creates all needed logical entities
 func (oc *SecondaryLayer2NetworkController) Start(ctx context.Context) error {
 	klog.Infof("Starting controller for secondary network %s", oc.GetNetworkName())

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller.go
@@ -428,10 +428,6 @@ func (oc *SecondaryLayer3NetworkController) newRetryFramework(
 	)
 }
 
-func (oc *SecondaryLayer3NetworkController) PreStart(ctx context.Context) error {
-	return nil
-}
-
 // Start starts the secondary layer3 controller, handles all events and creates all needed logical entities
 func (oc *SecondaryLayer3NetworkController) Start(ctx context.Context) error {
 	klog.Infof("Start secondary %s network controller of network %s", oc.TopologyType(), oc.GetNetworkName())

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -243,10 +243,6 @@ func NewSecondaryLocalnetNetworkController(cnci *CommonNetworkControllerInfo, ne
 	return oc
 }
 
-func (oc *SecondaryLocalnetNetworkController) PreStart(ctx context.Context) error {
-	return nil
-}
-
 // Start starts the secondary localnet controller, handles all events and creates all needed logical entities
 func (oc *SecondaryLocalnetNetworkController) Start(ctx context.Context) error {
 	klog.Infof("Starting controller for secondary network network %s", oc.GetNetworkName())

--- a/go-controller/pkg/testing/nad/netattach.go
+++ b/go-controller/pkg/testing/nad/netattach.go
@@ -15,10 +15,6 @@ func (nc *FakeNetworkController) Start(ctx context.Context) error {
 	return nil
 }
 
-func (nc *FakeNetworkController) PreStart(ctx context.Context) error {
-	return nil
-}
-
 func (nc *FakeNetworkController) Stop() {}
 
 func (nc *FakeNetworkController) Cleanup() error {
@@ -40,9 +36,8 @@ type FakeNADController struct {
 	PrimaryNetworks map[string]util.NetInfo
 }
 
-func (nc *FakeNADController) PreStart() error { return nil }
-func (nc *FakeNADController) Start() error    { return nil }
-func (nc *FakeNADController) Stop()           {}
+func (nc *FakeNADController) Start() error { return nil }
+func (nc *FakeNADController) Stop()        {}
 func (nc *FakeNADController) GetActiveNetworkForNamespace(namespace string) (util.NetInfo, error) {
 	if primaryNetworks, ok := nc.PrimaryNetworks[namespace]; ok && primaryNetworks != nil {
 		return primaryNetworks, nil


### PR DESCRIPTION
As it is unused in any network controller except the node default network controller.

The future plan is to strip PreStart from the node default network controller as well and move that somewhere else.

The ultimate reason is we want to configure the management ports (SNAT) correctly depending on whether the network is advertised or not:
https://github.com/ovn-org/ovn-kubernetes/pull/4572
On that PR, commit `Don't SNAT to mgmt port if pod network advertised`:
https://github.com/ovn-org/ovn-kubernetes/pull/4572/commits/ec47746eac307caebd0172b02835f2cec610107c

For this we will depend on the NAD controller, even for the default network:
https://github.com/ovn-org/ovn-kubernetes/pull/4533
On that PR, commit `Provide NAD controller access to the default network controller`:
https://github.com/ovn-org/ovn-kubernetes/pull/4533/commits/0792356cc66c843f9cf7d91a7c862f7fbef9af73

So we need to start the NAD controller before the management port is initialized. So we need a way to make the gateway functionality available to network controllers independently of whether we have applied its configuration or not. So, basically, we need to be able to reconcile gateway configuration asynchronously.
