### PR TITLE
Only configure IPv6 RAs when ipv6 mode enabled

### DIFF
--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -403,7 +403,8 @@ func (gw *GatewayManager) GatewayInit(
 			types.NetworkExternalID:  gw.netInfo.GetNetworkName(),
 			types.TopologyExternalID: gw.netInfo.TopologyType(),
 		}
-		if gw.netInfo.IsPrimaryNetwork() && gw.netInfo.TopologyType() == types.Layer2Topology {
+		_, isNetIPv6 := gw.netInfo.IPMode()
+		if gw.netInfo.IsPrimaryNetwork() && gw.netInfo.TopologyType() == types.Layer2Topology && isNetIPv6 && config.IPv6Mode {
 			logicalRouterPort.Ipv6RaConfigs = map[string]string{
 				"address_mode":      "dhcpv6_stateful",
 				"send_periodic":     "true",

--- a/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
+++ b/go-controller/pkg/ovn/secondary_layer3_network_controller_test.go
@@ -16,6 +16,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -97,6 +98,11 @@ var _ = Describe("OVN Multi-Homed pod operations", func() {
 				}
 			}
 			config.Gateway.Mode = gwMode
+			if knet.IsIPv6CIDRString(netInfo.clustersubnets) {
+				config.IPv6Mode = true
+				// tests dont support dualstack yet
+				config.IPv4Mode = false
+			}
 			app.Action = func(ctx *cli.Context) error {
 				nad, err := newNetworkAttachmentDefinition(
 					ns,


### PR DESCRIPTION
Without this fix, ovn-controller would spam:
2024-10-28T16:58:44.283Z|04438|pinctrl|WARN|Invalid IPv6 prefixes:
