### PR TITLE
Adds startup probe to UDN e2e

### DIFF
--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -261,6 +261,17 @@ var _ = Describe("Network Segmentation", func() {
 								PeriodSeconds:       1,
 								FailureThreshold:    1,
 							}
+							pod.Spec.Containers[0].StartupProbe = &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									HTTPGet: &v1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.FromInt32(port),
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+								FailureThreshold:    3,
+							}
 							// add NET_ADMIN to change pod routes
 							pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
 								Capabilities: &v1.Capabilities{


### PR DESCRIPTION
It was seen in downstream that this container can take longer than a second for its http server to start sometimes:

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/2314/pull-ci-openshift-ovn-kubernetes-master-e2e-gcp-ovn-techpreview/1849904878739001344

Therefore add a startup probe to give it a few seconds to fully start, then run liveness probe. The test doesn't check for at least 8 seconds (claimed in the comments) that the container never restarted, so this should be fine to finish start up probe and get a few iterations of liveness probe in.

