### PR TITLE
OCPBUGS-43454: Ignore cluster manager `topology not managed` errors for localnet  with no subnets

### DIFF
--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -68,7 +68,7 @@ func (sncm *secondaryNetworkClusterManager) SetNetworkStatusReporter(errorReport
 	sncm.errorReporter = errorReporter
 }
 
-// Start the secondary layer3 controller, handles all events and creates all
+// Start the secondary network controller, handles all events and creates all
 // needed logical entities
 func (sncm *secondaryNetworkClusterManager) Start() error {
 	klog.Infof("Starting secondary network cluster manager")

--- a/go-controller/pkg/network-attach-def-controller/network_manager.go
+++ b/go-controller/pkg/network-attach-def-controller/network_manager.go
@@ -2,6 +2,7 @@ package networkAttachDefController
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -214,7 +215,13 @@ func (nm *networkManagerImpl) syncAll() error {
 	start := time.Now()
 	klog.Infof("%s: syncing all networks", nm.name)
 	for _, network := range validNetworks {
-		if err := nm.sync(network.GetNetworkName()); err != nil {
+		if err := nm.sync(network.GetNetworkName()); errors.Is(err, ErrNetworkControllerTopologyNotManaged) {
+			klog.V(5).Infof(
+				"ignoring network %q since %q does not manage it",
+				network.GetNetworkName(),
+				nm.name,
+			)
+		} else if err != nil {
 			return fmt.Errorf("failed to sync network %s: %w", network.GetNetworkName(), err)
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

#### What this PR does and why is it needed
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR ignores `topology net managed` errors on the initial all networks sync of the cluster manager controllers.

Only the `secondaryNetworkClusterManager` - which is created by the cluster controller manager, and executed in the control plane pods - actually returns this type of error.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

#### How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
1. Configure the bridge mappings for the localnet network
2. Create a localnet network without subnets.
3. Attach a pod to the localnet network.
4. Restart the ovnkube-control-plane pods

To configure the mappings for the localnet network you can (upstream):
```sh
for pod in $(kubectl get pods -novn-kubernetes -l "app=ovs-node" --no-headers -ocustom-columns=":metadata.name"); do 
    kubectl -n ovn-kubernetes exec $pod -- ovs-vsctl set open . external-ids:ovn-bridge-mappings="physnet:breth0,tenantblue:breth0"
done
```

The following manifests can be used to reproduce this upstream:
```yaml
---
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: tenantblue
spec:
    config: '{
        "cniVersion": "0.4.0",
        "name": "tenantblue",
        "netAttachDefName": "default/tenantblue",
        "topology": "localnet",
        "type": "ovn-k8s-cni-overlay",
        "logFile": "/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log",
        "logLevel": "5",
        "logfile-maxsize": 100,
        "logfile-maxbackups": 5,
        "logfile-maxage": 5
    }'
---
apiVersion: v1                
kind: Pod                        
metadata:
  namespace: default
  name: pod1
  annotations:
    k8s.v1.cni.cncf.io/networks: '[
      {
        "name": "tenantblue","ips": ["192.168.200.20/24"]
      }                                          
    ]'                         
spec:                                 
  containers:                                                        
  - name: centos        
    image: docker.io/centos/tools:latest
    command:                    
    - /sbin/init           
```

Without this PR, the control-plane pods will crash loop.

#### Details to documentation updates
<!--
Did you include good docs that explain to our end users/developers/contributors
how your code works?
-->


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Prevent a localnet network without subnets (typical virt use case) from crash-looping the control plane pods when they restart (for instance, during an upgrade).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
No.

For more information on release notes see: TBD
-->
```release-note
Prevent a localnet network without subnets from crash-looping the control plane pods upon restart (e.g. during an upgrade)
```
