### PR TITLE
go-controller: fix typo in test script

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -48,7 +48,7 @@ function testrun {
             go_test="sudo ${testfile}"
         fi
     fi
-    if [[ -n "$gingko_focus" ]]; then
+    if [[ -n "$ginkgo_focus" ]]; then
         local ginkgoargs=${ginkgo_focus:-}
     fi
     local path=${pkg#github.com/ovn-org/ovn-kubernetes/go-controller}


### PR DESCRIPTION
## 📑 Description

The variable ginkgo_focus is misspelled as gingko_focus.

As the latter var is not used anywhere else in this repo and is used to concatenate the var ginkgo_focus in the next line to ginkgoargs it seems to be a typo.

Fixes #4942
