### PR TITLE
Use accelerated device as Gateway interface

### DIFF
--- a/docs/design/gatway-accelerated-interface-configuration.md
+++ b/docs/design/gatway-accelerated-interface-configuration.md
@@ -1,0 +1,84 @@
+# Gateway Accelerated Interface Configuration
+
+## Description
+
+To provide hardware acceleration for traffic, both IN and OUT ports need to be a hardware 
+accelerated netdevice backed by the Network Interface Card hardware itself.
+In case of external traffic, when one such port is the external OVS bridge, which for example has the gateway IP, 
+such traffic (like host networking traffic) would not be accelerated.
+Using Switchdev VirtualFunction (VF) or SubFunction (SF) as a gateway interface allows to accelerate these too.
+
+
+## How it works?
+
+Instead of using the gateway interface as the external bridge itself, use a  switchdev VF or SF instead. 
+This is depicted as following:
+
+```
+                         +----------+
+                         |  br-ext  |
+                   +--------+       |
+                   | UPLINK |       |
+                   +--------+       |  patch  +----------+
+                         |          x---------x  br-int  |
+    +--------+     +--------+       |  port   +----------+
+    | NETDEV +-----+   REP  |       |
+    +--------+     +--------+       |
+                         +----------+
+```
+
+Where `UPLINK` is a port on an offloading capable network interface hardware, `NETDEV` is a switchdev function 
+of this port and `REP` is a representor netdevice of the switchdev function. 
+Node/Host IP assigned to `NETDEV` which make OVS to chose `REP` port for external flows instead of the bridge.
+
+
+## How to use?
+
+Gateway accelerated interface can be used in two steps:
+
+a) Creating and configuring the device. 
+See figure above.
+An `UPLINK` device is connected to the OVS external bridge. 
+An existing VF or SF `NETDEV` from the `UPLINK` is first selected as the the Gateway Interface. Its associated 
+representor `REP` is plugged into the OVS external bridge (br-ext). The gateway IP is assigned to this interface 
+instead of the OVS external bridge (br-ext). 
+
+b) Specify `NETDEV` as a gateway interface explicitly via `OVN_GATEWAY_OPTS` environment variable for
+  ovnkube-node container. Example:
+
+```yaml
+            - name: OVN_GATEWAY_OPTS
+              value: "--gateway-accelerated-interface=<<NETDEV>>"
+```
+
+Note that this is mutually exclusive to the `--gateway-interface` flag for GATEWAY_OPTIONS.
+
+c) Set the external-id on the bridge to detect the uplink device correctly. This is useful for instances where,
+the name of the bridge (eg: br-ext) does not use the uplink device (eg: p0) in its name. The uplink can also 
+be a bond device. 
+```bash
+ovs-vsctl br-set-external-id br-ext bridge-uplink p0
+```
+This gives more flexibility in detecting the uplink device in cases where the auto detection fails (like in case of 
+bonded uplinks etc.)
+
+## Verification
+
+Openflow rules added to the external bridge will use this port as the IN/OUT port instead.
+
+Example flows when pf0vf1 is the netdev and pf0vf1_r is the representor
+```bash
+ cookie=0xdeff105, duration=505314.637s, table=0, n_packets=0, n_bytes=0, priority=500,ip,in_port="pf0vf1_r",nw_dst=169.254.0.1 actions=ct(table=5,zone=64002,nat)
+ cookie=0xdeff105, duration=505314.637s, table=0, n_packets=655, n_bytes=129843, priority=500,ip,in_port="pf0vf1_r",nw_dst=10.96.0.0/16 actions=ct(commit,table=2,zone=64001,nat(src=169.254.0.2))
+ cookie=0xdeff105, duration=505314.637s, table=0, n_packets=359877855, n_bytes=531033264511, priority=205,udp,in_port=p0,dl_dst=42:0b:9a:f1:83:b2,tp_dst=6081 actions=output:"pf0vf1_r"
+ cookie=0xdeff105, duration=505314.637s, table=0, n_packets=6252796, n_bytes=775727815, priority=200,udp,in_port="pf0vf1_r",tp_dst=6081 actions=output:p0
+ cookie=0xdeff105, duration=505314.637s, table=0, n_packets=1867752, n_bytes=294547557, priority=100,ip,in_port="pf0vf1_r" actions=ct(commit,zone=64000,exec(load:0x2->NXM_NX_CT_MARK[])),output:p0
+ cookie=0xdeff105, duration=505314.637s, table=0, n_packets=22, n_bytes=1320, priority=10,in_port=p0,dl_dst=42:0b:9a:f1:83:b2 actions=output:"patch-brp0_c-23",output:"pf0vf1_r"
+ cookie=0xdeff105, duration=505314.637s, table=1, n_packets=1313364, n_bytes=669490616, priority=100,ct_state=+est+trk,ct_mark=0x2,ip actions=output:"pf0vf1_r"
+ cookie=0xdeff105, duration=505314.637s, table=1, n_packets=0, n_bytes=0, priority=100,ct_state=+rel+trk,ct_mark=0x2,ip actions=output:"pf0vf1_r"
+ cookie=0xdeff105, duration=505314.637s, table=1, n_packets=0, n_bytes=0, priority=13,udp,in_port=p0,tp_dst=3784 actions=output:"patch-brp0_c-23",output:"pf0vf1_r"
+ cookie=0xdeff105, duration=505314.637s, table=1, n_packets=493602, n_bytes=48384748, priority=10,dl_dst=42:0b:9a:f1:83:b2 actions=output:"pf0vf1_r"
+ cookie=0xdeff105, duration=505314.637s, table=3, n_packets=694, n_bytes=276779, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],mod_dl_dst:42:0b:9a:f1:83:b2,output:"pf0vf1_r"
+
+
+```

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -452,7 +452,12 @@ type GatewayConfig struct {
 	Mode GatewayMode `gcfg:"mode"`
 	// Interface is the network interface to use for the gateway in "shared" mode
 	Interface string `gcfg:"interface"`
-	// Exgress gateway interface is the optional network interface to use for external gw pods traffic.
+	// GatewayAcceleratedInterface is the optional network interface to use for gateway traffic acceleration.
+	// This is typically a VF or SF device. When specified it would be used as the in_port for Openflow rules
+	// on the external bridge. The Host IP would be on this device.
+	// Should be used mutually exclusive to the `--gateway-interface` flag.
+	GatewayAcceleratedInterface string `gcfg:"gateway-accelerated-interface"`
+	// Egress gateway interface is the optional network interface to use for external gw pods traffic.
 	EgressGWInterface string `gcfg:"egw-interface"`
 	// NextHop is the gateway IP address of Interface; will be autodetected if not given
 	NextHop string `gcfg:"next-hop"`
@@ -1405,6 +1410,13 @@ var OVNGatewayFlags = []cli.Flag{
 			"default gateway is configured will be used as the gateway " +
 			"interface. Only useful with \"init-gateways\"",
 		Destination: &cliConfig.Gateway.Interface,
+	},
+	&cli.StringFlag{
+		Name: "gateway-accelerated-interface",
+		Usage: "The optional network interface to use for gateway traffic acceleration. " +
+			"This is typically a VF or SF device. When specified it would be used as the in_port for Openflow rules " +
+			"on the external bridge. The Host IP would be on this device.",
+		Destination: &cliConfig.Gateway.GatewayAcceleratedInterface,
 	},
 	&cli.StringFlag{
 		Name: "exgw-interface",

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1180,9 +1180,8 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	// Note(adrianc): DPU deployments are expected to support the new shared gateway changes, upgrade flow
 	// is not needed. Future upgrade flows will need to take DPUs into account.
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
-		bridgeName := ""
 		if config.OvnKubeNode.Mode == types.NodeModeFull {
-			bridgeName = nc.Gateway.GetGatewayBridgeIface()
+			bridgeName := nc.Gateway.GetGatewayIface()
 			// Configure route for svc towards shared gw bridge
 			// Have to have the route to bridge for multi-NIC mode, where the default gateway may go to a non-OVS interface
 			if err := configureSvcRouteViaBridge(nc.routeManager, bridgeName); err != nil {

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -603,7 +603,7 @@ func (nc *DefaultNodeNetworkController) updateGatewayMAC(link netlink.Link) erro
 		return nil
 	}
 
-	if nc.Gateway.GetGatewayBridgeIface() != link.Attrs().Name {
+	if nc.Gateway.GetGatewayIface() != link.Attrs().Name {
 		return nil
 	}
 


### PR DESCRIPTION
For host networking, external bridge acts as the input/output port with Node IP configured on the bridge itself as a local port.

When hardware acceleration capable devices, like ConnectX or Bluefield2 cards are used, pods can use hardware accelerated Virtual Functions (VFs) or SubFunctions(SFs) as interfaces, and fully offload all kubernetes traffic flows.
But for host networking pods or when the host itself is the traffic endpoint, not all kubernetes flows are accelerated since current CT infrastructure cannot offload CT flows where external bridge is the in/out port.

To allow accelerated traffic flows for host networking, this patch allows specifying a gateway accelerated interface via the `--gateway-accelerated-interface` flag. This can either be a switchdev VF or SF, connected to the external bridge and holding the Node IP.

```
                        ┌──────────┐
                        │  br-ext  │
                  ┌─────┴──┐       │    ┌──────────┐
                  │  eth0  │       │    │  br-int  │
                  └─────┬──┘       │    │          │
                        │          X────X          │
   ┌────────┐     ┌─────┴──┐       │    │          │
   │ eth0v0 ├─────┤ eth0_0 │       │    │          │
   └────────┘     └─────┬──┘       │    └──────────┘
     NODE_IP            │          │
                        └──────────┘
```
where, eth0v0 and eth0_0 are, for ex., VF and VF representor of eth0 uplink. Note that used netdevice must be excluded from device plugin pools, so it won't be used for workload pods.

This flag should be used mutually exclusive to the existing `--gateway-interface` flag.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
Allows accelerating host networking kubernetes flows by specifying a accelerated netdev as the gateway interface.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


## Additional Information for reviewers

Note: It is possible to combine this functionality into the existing `--gateway-interface` flag and do auto detect if it is a accelerated device or not and configure accordingly. Though that would have been simpler from a user perspective, new flag was added from a feature gate perspective as well as to avoid any potential risks introduced by this feature. 
Open for suggestions in this regard.

<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
On a compute node:

Create switchdev VF or SF from the uplink device. Connect the representor to the external bridge.
Assign/Move the Node IP to this device (VF/SF).
Deploy a cluster, with OVN_GATEWAY_OPTS using this value of VF or SF netdevice. For the scheme above it is `--gateway-accelerated-interface=eth0v0`.
All openflows for the NodeIP should use the openflow port number of this port.
Deploy some workload pod to see if cluster work as expected.
