### PR TITLE
[SDN-3551] LB eps not updated correctly while target port changes

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -340,11 +340,10 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *corev1.Service, netI
 					if len(nodeportFlows) > 0 {
 						npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 						npw.ofm.updateGroupCacheEntry(key, nodeportGroups)
-						continue
+					} else {
+						npw.ofm.updateGroupCacheEntry(key, nil)
 					}
-					npw.ofm.updateGroupCacheEntry(key, nil)
-				}
-				if config.Gateway.Mode == config.GatewayModeShared {
+				} else if config.Gateway.Mode == config.GatewayModeShared {
 					// case2 (see function description for details)
 					npw.ofm.updateFlowCacheEntry(key, []string{
 						// table=0, matches on service traffic towards nodePort and sends it to OVN pipeline
@@ -524,7 +523,6 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *corev1.Service,
 		// And then ensure that return traffic is UnDNATed correctly back
 		// to the ingress / external IP
 		isServiceTypeETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
-		hostNetworkFlowsAdded := false
 		if isServiceTypeETPLocal && hasLocalHostNetworkEp {
 			// Get the target port (this is important for named ports).
 			svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
@@ -558,12 +556,10 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *corev1.Service,
 			externalIPFlows = append(externalIPFlows, hostNetworkFlows...)
 			if len(hostNetworkFlows) > 0 {
 				npw.ofm.updateGroupCacheEntry(key, hostNetworkGroups)
-				hostNetworkFlowsAdded = true
 			} else {
 				npw.ofm.updateGroupCacheEntry(key, nil)
 			}
-		}
-		if !hostNetworkFlowsAdded && config.Gateway.Mode == config.GatewayModeShared {
+		} else if config.Gateway.Mode == config.GatewayModeShared {
 			// add the ICMP Fragmentation flow for shared gateway mode.
 			icmpFlow := nodeutil.GenerateICMPFragmentationFlow(externalIPOrLBIngressIP, netConfig.OfPortPatch, npw.ofportPhys, cookie, 110)
 			externalIPFlows = append(externalIPFlows, icmpFlow)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1396,6 +1396,7 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 	}
 
 	if out.hasLocalHostNetworkEp != hasLocalHostNetworkEp ||
+		(hasLocalHostNetworkEp && !reflect.DeepEqual(out.localEndpoints, localEndpoints)) ||
 		(!util.LoadBalancerServiceHasNodePortAllocation(svc) && !reflect.DeepEqual(out.localEndpoints, localEndpoints)) {
 		klog.V(5).Infof("Endpointslice %s ADD event in namespace %s is updating rules", epSlice.Name, epSlice.Namespace)
 		if err = delServiceRules(svc, out.localEndpoints, npw); err != nil {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -316,24 +316,6 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *corev1.Service, netI
 						errors = append(errors, err)
 						continue
 					}
-					if len(lbe) > 1 {
-						klog.Warningf("Multiple target ports for service %s/%s port %s, using first",
-							service.Namespace, service.Name, svcPortKey)
-					}
-					// The return traffic, matches on the flowProtocol + targetPort. That's different from cookie which
-					// uses svcPort.NodePort.
-					targetPort := lbe[0].Port
-					targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
-					if err != nil {
-						klog.Warningf("Unable to generate target port cookie for svc: %s, %s, %d, error: %v",
-							service.Namespace, service.Name, targetPort, err)
-						targetPortCookie = "0"
-					}
-
-					// case1 (see function description for details)
-					var nodeportFlows []string
-					klog.V(5).Infof("Adding flows on breth0 for Nodeport Service %s with targetPort %d in "+
-						"Namespace: %s since ExternalTrafficPolicy=local", service.Name, targetPort, service.Namespace)
 					// table 0, This rule matches on all traffic with dst port == NodePort, DNAT's the nodePort to the svc targetPort
 					// If IPv6 make sure to choose the IPv6 node address for rule, otherwise send to the IPv4 node address.
 					gatewayAddress := npw.gatewayIPv4
@@ -349,25 +331,50 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *corev1.Service, netI
 						continue
 					}
 
-					nodeportFlows = append(nodeportFlows,
-						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, "+
-							"actions=ct(commit,zone=%d,nat(dst=%s:%d),table=6)",
-							cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort,
-							config.Default.HostNodePortConntrackZone, gatewayAddress, targetPort))
+					// case1 (see function description for details)
+					//
+					// DNAT, table 6, and table 7 flows have identical match criteria regardless of target
+					// port, so we only install them once (i==0). During rolling updates multiple target
+					// ports coexist transiently; conntrack preserves existing connections.
+					// Return flows (tp_src) differ per target port, so we install one for each entry.
+					var nodeportFlows []string
+					for i, entry := range lbe {
+						targetPort := entry.Port
+						// The return traffic, matches on the flowProtocol + targetPort. That's different from cookie which
+						// uses svcPort.NodePort.
+						targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
+						if err != nil {
+							klog.Warningf("Unable to generate target port cookie for svc: %s, %s, %d, error: %v",
+								service.Namespace, service.Name, targetPort, err)
+							targetPortCookie = "0"
+						}
 
-					nodeportFlows = append(nodeportFlows,
-						// table 6, Sends the packet to the host. Note that the constant etp svc cookie is used since this flow would be
-						// same for all such services.
-						fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
-							etpSvcOpenFlowCookie),
+						klog.V(5).Infof("Adding flows on breth0 for Nodeport Service %s with targetPort %d in "+
+							"Namespace: %s since ExternalTrafficPolicy=local", service.Name, targetPort, service.Namespace)
+						if i == 0 {
+							nodeportFlows = append(nodeportFlows,
+								fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, "+
+									"actions=ct(commit,zone=%d,nat(dst=%s:%d),table=6)",
+									cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort,
+									config.Default.HostNodePortConntrackZone, gatewayAddress, targetPort),
+								// table 6, Sends the packet to the host. Note that the constant etp svc cookie is used since this flow would be
+								// same for all such services.
+								fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+									etpSvcOpenFlowCookie))
+						}
 						// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
 						// Use targetPortCookie, as the flow will be the same if the target port + protocol are the same.
-						fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%d, actions=ct(zone=%d nat,table=7)",
-							targetPortCookie, flowProtocol, targetPort, config.Default.HostNodePortConntrackZone),
-						// table 7, Sends the packet back out eth0 to the external client. Note that the constant etp svc
-						// cookie is used since this would be same for all such services.
-						fmt.Sprintf("cookie=%s, priority=110, table=7, "+
-							"actions=output:%s", etpSvcOpenFlowCookie, npw.ofportPhys))
+						nodeportFlows = append(nodeportFlows,
+							fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%d, actions=ct(zone=%d nat,table=7)",
+								targetPortCookie, flowProtocol, targetPort, config.Default.HostNodePortConntrackZone))
+						if i == 0 {
+							nodeportFlows = append(nodeportFlows,
+								// table 7, Sends the packet back out eth0 to the external client. Note that the constant etp svc
+								// cookie is used since this would be same for all such services.
+								fmt.Sprintf("cookie=%s, priority=110, table=7, "+
+									"actions=output:%s", etpSvcOpenFlowCookie, npw.ofportPhys))
+						}
+					}
 					npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 				} else if config.Gateway.Mode == config.GatewayModeShared {
 					// case2 (see function description for details)
@@ -556,23 +563,6 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *corev1.Service,
 				errors = append(errors, err)
 				continue
 			}
-			if len(lbe) > 1 {
-				klog.Warningf("Multiple target ports for %s service %s/%s port %s, using first",
-					ipType, service.Namespace, service.Name, svcPortKey)
-			}
-			// cookie uses externalIPOrLBIngressIP and thus generates different cookies for each of the IP addresses.
-			// The return traffic, however, matches on the flowProtocol + src port only. Therefore, generate a stable
-			// cookie regardless of IP address and use this for the return flows.
-			targetPort := lbe[0].Port
-			targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
-			if err != nil {
-				klog.Warningf("Unable to generate target port cookie for %s svc: %s, %s, %d, error: %v",
-					ipType, service.Namespace, service.Name, targetPort, err)
-				targetPortCookie = "0"
-			}
-
-			// case1 (see function description for details)
-			klog.V(5).Infof("Adding flows on breth0 for %s Service %s in Namespace: %s since ExternalTrafficPolicy=local", ipType, service.Name, service.Namespace)
 			// table 0, This rule matches on all traffic with dst ip == LoadbalancerIP / externalIP, DNAT's the nodePort to the svc targetPort
 			// If IPv6 make sure to choose the IPv6 node address for rule, otherwise send to the IPv4 node address.
 			gatewayAddress := npw.gatewayIPv4
@@ -588,25 +578,46 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *corev1.Service,
 				continue
 			}
 
-			externalIPFlows = append(externalIPFlows,
-				fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
-					"actions=ct(commit,zone=%d,nat(dst=%s:%d),table=6)",
-					cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port,
-					config.Default.HostNodePortConntrackZone, gatewayAddress, targetPort))
+			// case1 (see function description for details)
+			// Same logic as the nodePort case: DNAT/table6/table7 installed once (i==0),
+			// return flows (tp_src) installed per target port entry.
+			klog.V(5).Infof("Adding flows on breth0 for %s Service %s in Namespace: %s since ExternalTrafficPolicy=local", ipType, service.Name, service.Namespace)
+			for i, entry := range lbe {
+				targetPort := entry.Port
+				// cookie uses externalIPOrLBIngressIP and thus generates different cookies for each of the IP addresses.
+				// The return traffic, however, matches on the flowProtocol + src port only. Therefore, generate a stable
+				// cookie regardless of IP address and use this for the return flows.
+				targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
+				if err != nil {
+					klog.Warningf("Unable to generate target port cookie for %s svc: %s, %s, %d, error: %v",
+						ipType, service.Namespace, service.Name, targetPort, err)
+					targetPortCookie = "0"
+				}
 
-			externalIPFlows = append(externalIPFlows,
-				// table 6, Sends the packet to Host. Note that the constant etp svc cookie is used since this flow would be
-				// same for all such services.
-				fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
-					etpSvcOpenFlowCookie),
+				if i == 0 {
+					externalIPFlows = append(externalIPFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
+							"actions=ct(commit,zone=%d,nat(dst=%s:%d),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port,
+							config.Default.HostNodePortConntrackZone, gatewayAddress, targetPort),
+						// table 6, Sends the packet to Host. Note that the constant etp svc cookie is used since this flow would be
+						// same for all such services.
+						fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+							etpSvcOpenFlowCookie))
+				}
 				// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs.
 				// Use targetPortCookie, as the flow will be the same for each ExternalIP / LB status IP.
-				fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%d, actions=ct(zone=%d nat,table=7)",
-					targetPortCookie, flowProtocol, targetPort, config.Default.HostNodePortConntrackZone),
-				// table 7, Sends the reply packet back out eth0 to the external client. Note that the constant etp svc
-				// cookie is used since this would be same for all such services.
-				fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s",
-					etpSvcOpenFlowCookie, npw.ofportPhys))
+				externalIPFlows = append(externalIPFlows,
+					fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%d, actions=ct(zone=%d nat,table=7)",
+						targetPortCookie, flowProtocol, targetPort, config.Default.HostNodePortConntrackZone))
+				if i == 0 {
+					externalIPFlows = append(externalIPFlows,
+						// table 7, Sends the reply packet back out eth0 to the external client. Note that the constant etp svc
+						// cookie is used since this would be same for all such services.
+						fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s",
+							etpSvcOpenFlowCookie, npw.ofportPhys))
+				}
+			}
 		} else if config.Gateway.Mode == config.GatewayModeShared {
 			// add the ICMP Fragmentation flow for shared gateway mode.
 			icmpFlow := nodeutil.GenerateICMPFragmentationFlow(externalIPOrLBIngressIP, netConfig.OfPortPatch, npw.ofportPhys, cookie, 110)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -332,51 +332,19 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *corev1.Service, netI
 					}
 
 					// case1 (see function description for details)
-					//
-					// DNAT, table 6, and table 7 flows have identical match criteria regardless of target
-					// port, so we only install them once (i==0). During rolling updates multiple target
-					// ports coexist transiently; conntrack preserves existing connections.
-					// Return flows (tp_src) differ per target port, so we install one for each entry.
-					var nodeportFlows []string
-					for i, entry := range lbe {
-						targetPort := entry.Port
-						// The return traffic, matches on the flowProtocol + targetPort. That's different from cookie which
-						// uses svcPort.NodePort.
-						targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
-						if err != nil {
-							klog.Warningf("Unable to generate target port cookie for svc: %s, %s, %d, error: %v",
-								service.Namespace, service.Name, targetPort, err)
-							targetPortCookie = "0"
-						}
-
-						klog.V(5).Infof("Adding flows on breth0 for Nodeport Service %s with targetPort %d in "+
-							"Namespace: %s since ExternalTrafficPolicy=local", service.Name, targetPort, service.Namespace)
-						if i == 0 {
-							nodeportFlows = append(nodeportFlows,
-								fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, "+
-									"actions=ct(commit,zone=%d,nat(dst=%s:%d),table=6)",
-									cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort,
-									config.Default.HostNodePortConntrackZone, gatewayAddress, targetPort),
-								// table 6, Sends the packet to the host. Note that the constant etp svc cookie is used since this flow would be
-								// same for all such services.
-								fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
-									etpSvcOpenFlowCookie))
-						}
-						// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
-						// Use targetPortCookie, as the flow will be the same if the target port + protocol are the same.
-						nodeportFlows = append(nodeportFlows,
-							fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%d, actions=ct(zone=%d nat,table=7)",
-								targetPortCookie, flowProtocol, targetPort, config.Default.HostNodePortConntrackZone))
-						if i == 0 {
-							nodeportFlows = append(nodeportFlows,
-								// table 7, Sends the packet back out eth0 to the external client. Note that the constant etp svc
-								// cookie is used since this would be same for all such services.
-								fmt.Sprintf("cookie=%s, priority=110, table=7, "+
-									"actions=output:%s", etpSvcOpenFlowCookie, npw.ofportPhys))
-						}
+					nodeIPs, _ := npw.nodeIPManager.ListAddresses()
+					nodeportFlows, nodeportGroups := npw.hostNetworkServiceOpenFlows(
+						service, key, cookie, flowProtocol,
+						fmt.Sprintf("in_port=%s, %s, tp_dst=%d", npw.ofportPhys, flowProtocol, svcPort.NodePort),
+						gatewayAddress, lbe, nodeIPs)
+					if len(nodeportFlows) > 0 {
+						npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
+						npw.ofm.updateGroupCacheEntry(key, nodeportGroups)
+						continue
 					}
-					npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
-				} else if config.Gateway.Mode == config.GatewayModeShared {
+					npw.ofm.updateGroupCacheEntry(key, nil)
+				}
+				if config.Gateway.Mode == config.GatewayModeShared {
 					// case2 (see function description for details)
 					npw.ofm.updateFlowCacheEntry(key, []string{
 						// table=0, matches on service traffic towards nodePort and sends it to OVN pipeline
@@ -387,6 +355,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *corev1.Service, netI
 						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, dl_src=%s, %s, tp_src=%d, "+
 							"actions=output:%s",
 							cookie, netConfig.OfPortPatch, npw.ofm.getDefaultBridgeMAC(), flowProtocol, svcPort.NodePort, npw.ofportPhys)})
+					npw.ofm.updateGroupCacheEntry(key, nil)
 				}
 			}
 		}
@@ -555,6 +524,7 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *corev1.Service,
 		// And then ensure that return traffic is UnDNATed correctly back
 		// to the ingress / external IP
 		isServiceTypeETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
+		hostNetworkFlowsAdded := false
 		if isServiceTypeETPLocal && hasLocalHostNetworkEp {
 			// Get the target port (this is important for named ports).
 			svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
@@ -579,46 +549,21 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *corev1.Service,
 			}
 
 			// case1 (see function description for details)
-			// Same logic as the nodePort case: DNAT/table6/table7 installed once (i==0),
-			// return flows (tp_src) installed per target port entry.
 			klog.V(5).Infof("Adding flows on breth0 for %s Service %s in Namespace: %s since ExternalTrafficPolicy=local", ipType, service.Name, service.Namespace)
-			for i, entry := range lbe {
-				targetPort := entry.Port
-				// cookie uses externalIPOrLBIngressIP and thus generates different cookies for each of the IP addresses.
-				// The return traffic, however, matches on the flowProtocol + src port only. Therefore, generate a stable
-				// cookie regardless of IP address and use this for the return flows.
-				targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
-				if err != nil {
-					klog.Warningf("Unable to generate target port cookie for %s svc: %s, %s, %d, error: %v",
-						ipType, service.Namespace, service.Name, targetPort, err)
-					targetPortCookie = "0"
-				}
-
-				if i == 0 {
-					externalIPFlows = append(externalIPFlows,
-						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
-							"actions=ct(commit,zone=%d,nat(dst=%s:%d),table=6)",
-							cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port,
-							config.Default.HostNodePortConntrackZone, gatewayAddress, targetPort),
-						// table 6, Sends the packet to Host. Note that the constant etp svc cookie is used since this flow would be
-						// same for all such services.
-						fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
-							etpSvcOpenFlowCookie))
-				}
-				// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs.
-				// Use targetPortCookie, as the flow will be the same for each ExternalIP / LB status IP.
-				externalIPFlows = append(externalIPFlows,
-					fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%d, actions=ct(zone=%d nat,table=7)",
-						targetPortCookie, flowProtocol, targetPort, config.Default.HostNodePortConntrackZone))
-				if i == 0 {
-					externalIPFlows = append(externalIPFlows,
-						// table 7, Sends the reply packet back out eth0 to the external client. Note that the constant etp svc
-						// cookie is used since this would be same for all such services.
-						fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s",
-							etpSvcOpenFlowCookie, npw.ofportPhys))
-				}
+			nodeIPs, _ := npw.nodeIPManager.ListAddresses()
+			hostNetworkFlows, hostNetworkGroups := npw.hostNetworkServiceOpenFlows(
+				service, key, cookie, flowProtocol,
+				fmt.Sprintf("in_port=%s, %s, %s=%s, tp_dst=%d", npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port),
+				gatewayAddress, lbe, nodeIPs)
+			externalIPFlows = append(externalIPFlows, hostNetworkFlows...)
+			if len(hostNetworkFlows) > 0 {
+				npw.ofm.updateGroupCacheEntry(key, hostNetworkGroups)
+				hostNetworkFlowsAdded = true
+			} else {
+				npw.ofm.updateGroupCacheEntry(key, nil)
 			}
-		} else if config.Gateway.Mode == config.GatewayModeShared {
+		}
+		if !hostNetworkFlowsAdded && config.Gateway.Mode == config.GatewayModeShared {
 			// add the ICMP Fragmentation flow for shared gateway mode.
 			icmpFlow := nodeutil.GenerateICMPFragmentationFlow(externalIPOrLBIngressIP, netConfig.OfPortPatch, npw.ofportPhys, cookie, 110)
 			externalIPFlows = append(externalIPFlows, icmpFlow)
@@ -632,11 +577,101 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *corev1.Service,
 				fmt.Sprintf("cookie=%s, priority=110, in_port=%s, dl_src=%s, %s, %s=%s, tp_src=%d, "+
 					"actions=output:%s",
 					cookie, netConfig.OfPortPatch, npw.ofm.getDefaultBridgeMAC(), flowProtocol, nwSrc, externalIPOrLBIngressIP, svcPort.Port, npw.ofportPhys))
+			npw.ofm.updateGroupCacheEntry(key, nil)
 		}
 		npw.ofm.updateFlowCacheEntry(key, externalIPFlows)
 	}
 
 	return utilerrors.Join(errors...)
+}
+
+func (npw *nodePortWatcher) hostNetworkServiceOpenFlows(service *corev1.Service, key, cookie, flowProtocol, match, gatewayAddress string,
+	lbe util.LBEndpoints, nodeIPs []net.IP) ([]string, []string) {
+	targetPorts := hostNetworkTargetPorts(lbe, nodeIPs, strings.Contains(flowProtocol, "6"))
+	if len(targetPorts) == 0 {
+		return nil, nil
+	}
+
+	flows := make([]string, 0, len(targetPorts)+3)
+	groups := []string(nil)
+	action := fmt.Sprintf("ct(commit,zone=%d,nat(dst=%s:%d),table=6)",
+		config.Default.HostNodePortConntrackZone, gatewayAddress, targetPorts[0])
+	if len(targetPorts) > 1 {
+		groupID := hostNetworkServiceGroupID(key)
+		buckets := make([]string, 0, len(targetPorts))
+		for _, targetPort := range targetPorts {
+			buckets = append(buckets, fmt.Sprintf("bucket=actions=ct(commit,zone=%d,nat(dst=%s:%d),table=6)",
+				config.Default.HostNodePortConntrackZone, gatewayAddress, targetPort))
+		}
+		groups = append(groups, fmt.Sprintf("group_id=%d,type=select,%s", groupID, strings.Join(buckets, ",")))
+		action = fmt.Sprintf("group:%d", groupID)
+	}
+
+	flows = append(flows,
+		fmt.Sprintf("cookie=%s, priority=110, %s, actions=%s", cookie, match, action),
+		// table 6 sends the packet to the host. The constant cookie is used because this flow is common to all ETP service traffic.
+		fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL", etpSvcOpenFlowCookie))
+
+	for _, targetPort := range targetPorts {
+		targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
+		if err != nil {
+			klog.Warningf("Unable to generate target port cookie for svc: %s, %s, %d, error: %v",
+				service.Namespace, service.Name, targetPort, err)
+			targetPortCookie = "0"
+		}
+
+		klog.V(5).Infof("Adding flows on breth0 for Service %s with targetPort %d in Namespace: %s since ExternalTrafficPolicy=local",
+			service.Name, targetPort, service.Namespace)
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%d, actions=ct(zone=%d nat,table=7)",
+				targetPortCookie, flowProtocol, targetPort, config.Default.HostNodePortConntrackZone))
+	}
+
+	flows = append(flows,
+		// table 7 sends the reply packet back out eth0 to the external client. The constant cookie is used because this flow is common to all ETP service traffic.
+		fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s", etpSvcOpenFlowCookie, npw.ofportPhys))
+	return flows, groups
+}
+
+func hostNetworkTargetPorts(lbe util.LBEndpoints, nodeIPs []net.IP, isIPv6 bool) []int32 {
+	if len(lbe) == 0 || len(nodeIPs) == 0 {
+		return nil
+	}
+
+	nodeIPSet := sets.New[string]()
+	for _, nodeIP := range nodeIPs {
+		if utilnet.IsIPv6(nodeIP) == isIPv6 {
+			nodeIPSet.Insert(nodeIP.String())
+		}
+	}
+	if len(nodeIPSet) == 0 {
+		return nil
+	}
+
+	targetPortSet := sets.New[int32]()
+	for _, entry := range lbe {
+		endpointIPs := entry.V4IPs
+		if isIPv6 {
+			endpointIPs = entry.V6IPs
+		}
+		for _, endpointIP := range endpointIPs {
+			if nodeIPSet.Has(endpointIP) {
+				targetPortSet.Insert(entry.Port)
+				break
+			}
+		}
+	}
+	return sets.List(targetPortSet)
+}
+
+func hostNetworkServiceGroupID(key string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte("hostNetworkService_" + key))
+	groupID := h.Sum32()
+	if groupID == 0 {
+		return 1
+	}
+	return groupID
 }
 
 // generate ARP/NS bypass flow which will send the ARP/NS request everywhere *but* to OVN

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -316,9 +316,13 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *corev1.Service, netI
 						errors = append(errors, err)
 						continue
 					}
+					if len(lbe) > 1 {
+						klog.Warningf("Multiple target ports for service %s/%s port %s, using first",
+							service.Namespace, service.Name, svcPortKey)
+					}
 					// The return traffic, matches on the flowProtocol + targetPort. That's different from cookie which
 					// uses svcPort.NodePort.
-					targetPort := lbe.Port
+					targetPort := lbe[0].Port
 					targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
 					if err != nil {
 						klog.Warningf("Unable to generate target port cookie for svc: %s, %s, %d, error: %v",
@@ -552,10 +556,14 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *corev1.Service,
 				errors = append(errors, err)
 				continue
 			}
+			if len(lbe) > 1 {
+				klog.Warningf("Multiple target ports for %s service %s/%s port %s, using first",
+					ipType, service.Namespace, service.Name, svcPortKey)
+			}
 			// cookie uses externalIPOrLBIngressIP and thus generates different cookies for each of the IP addresses.
 			// The return traffic, however, matches on the flowProtocol + src port only. Therefore, generate a stable
 			// cookie regardless of IP address and use this for the return flows.
-			targetPort := lbe.Port
+			targetPort := lbe[0].Port
 			targetPortCookie, err := svcToCookie(service.Namespace, service.Name, flowProtocol, targetPort)
 			if err != nil {
 				klog.Warningf("Unable to generate target port cookie for %s svc: %s, %s, %d, error: %v",

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -9,6 +9,8 @@ package node
 import (
 	"fmt"
 	"net"
+	"strings"
+	"testing"
 
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	"github.com/vishvananda/netlink"
@@ -36,6 +38,56 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func TestHostNetworkServiceOpenFlowsUsesGroupForMultipleHostNetworkTargetPorts(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "namespace1",
+			Name:      "service1",
+		},
+	}
+	npw := &nodePortWatcher{ofportPhys: "eth0"}
+	key := "NodePort_namespace1_service1_tcp_31111"
+
+	flows, groups := npw.hostNetworkServiceOpenFlows(
+		service,
+		key,
+		"0x123",
+		"tcp",
+		"in_port=eth0, tcp, tp_dst=31111",
+		"10.244.0.1",
+		util.LBEndpoints{
+			{Port: 8080, V4IPs: []string{"10.128.0.2"}},    // local OVN-networked endpoint, not a host DNAT target
+			{Port: 9090, V4IPs: []string{"192.168.18.15"}}, // local host-networked endpoint
+			{Port: 10090, V4IPs: []string{"192.168.18.15"}},
+		},
+		[]net.IP{net.ParseIP("192.168.18.15")},
+	)
+
+	groupID := hostNetworkServiceGroupID(key)
+	expectedGroup := fmt.Sprintf("group_id=%d,type=select,"+
+		"bucket=actions=ct(commit,zone=64003,nat(dst=10.244.0.1:9090),table=6),"+
+		"bucket=actions=ct(commit,zone=64003,nat(dst=10.244.0.1:10090),table=6)", groupID)
+	if len(groups) != 1 || groups[0] != expectedGroup {
+		t.Fatalf("unexpected groups: %#v", groups)
+	}
+	if len(flows) != 5 {
+		t.Fatalf("expected 5 flows, got %d: %#v", len(flows), flows)
+	}
+	expectedIngressFlow := fmt.Sprintf("cookie=0x123, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=group:%d", groupID)
+	if flows[0] != expectedIngressFlow {
+		t.Fatalf("unexpected ingress flow: %q", flows[0])
+	}
+	for _, line := range append(flows, groups...) {
+		if strings.Contains(line, "10.244.0.1:8080") || strings.Contains(line, "tp_src=8080") {
+			t.Fatalf("non-host endpoint target port was programmed: %q", line)
+		}
+	}
+}
 
 // Note: Local mocks are used instead of FakeNetworkManager to test specific error conditions
 // (NotFound, InvalidPrimaryNetworkError) from GetActiveNetworkForNamespace. FakeNetworkManager

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -25,13 +25,18 @@ type openflowManager struct {
 	defaultBridge         *bridgeconfig.BridgeConfiguration
 	externalGatewayBridge *bridgeconfig.BridgeConfiguration
 	// flow cache, use map instead of array for readability when debugging
-	flowCache     map[string][]string
-	flowMutex     sync.Mutex
-	exGWFlowCache map[string][]string
-	exGWFlowMutex sync.Mutex
+	flowCache       map[string][]string
+	flowMutex       sync.Mutex
+	groupCache      map[string][]string
+	groupMutex      sync.Mutex
+	installedGroups map[string]struct{}
+	exGWFlowCache   map[string][]string
+	exGWFlowMutex   sync.Mutex
 	// channel to indicate we need to update flows immediately
 	flowChan chan struct{}
 }
+
+var openFlowGroupIDRegexp = regexp.MustCompile(`(?:^|,)group_id=([^,]+)`)
 
 // UTILs Needed for UDN (also leveraged for default netInfo) in openflowmanager
 
@@ -89,19 +94,48 @@ func (c *openflowManager) setDefaultBridgeGARPDrop(isDropped bool) {
 func (c *openflowManager) updateFlowCacheEntry(key string, flows []string) {
 	c.flowMutex.Lock()
 	defer c.flowMutex.Unlock()
+	if c.flowCache == nil {
+		c.flowCache = make(map[string][]string)
+	}
 	c.flowCache[key] = flows
 }
 
 func (c *openflowManager) deleteFlowsByKey(key string) {
 	c.flowMutex.Lock()
-	defer c.flowMutex.Unlock()
 	delete(c.flowCache, key)
+	c.flowMutex.Unlock()
+	c.deleteGroupsByKey(key)
 }
 
 func (c *openflowManager) getFlowsByKey(key string) []string {
 	c.flowMutex.Lock()
 	defer c.flowMutex.Unlock()
 	return c.flowCache[key]
+}
+
+func (c *openflowManager) updateGroupCacheEntry(key string, groups []string) {
+	c.groupMutex.Lock()
+	defer c.groupMutex.Unlock()
+	if len(groups) == 0 {
+		delete(c.groupCache, key)
+		return
+	}
+	if c.groupCache == nil {
+		c.groupCache = make(map[string][]string)
+	}
+	c.groupCache[key] = groups
+}
+
+func (c *openflowManager) deleteGroupsByKey(key string) {
+	c.groupMutex.Lock()
+	defer c.groupMutex.Unlock()
+	delete(c.groupCache, key)
+}
+
+func (c *openflowManager) getGroupsByKey(key string) []string {
+	c.groupMutex.Lock()
+	defer c.groupMutex.Unlock()
+	return c.groupCache[key]
 }
 
 func (c *openflowManager) updateExBridgeFlowCacheEntry(key string, flows []string) {
@@ -120,14 +154,21 @@ func (c *openflowManager) requestFlowSync() {
 }
 
 func (c *openflowManager) syncFlows() {
-	c.flowMutex.Lock()
-	flows := flattenFlowCacheEntries(c.flowCache)
-	c.flowMutex.Unlock()
+	groupsSynced := c.syncGroups()
+	if !groupsSynced {
+		klog.Errorf("Skipping flow sync for bridge %s because OpenFlow group sync failed", c.defaultBridge.GetBridgeName())
+	} else {
+		c.flowMutex.Lock()
+		flows := flattenFlowCacheEntries(c.flowCache)
+		c.flowMutex.Unlock()
 
-	_, stderr, err := util.ReplaceOFFlows(c.defaultBridge.GetBridgeName(), flows)
-	if err != nil {
-		klog.Errorf("Failed to add flows for bridge %s, error: %v, stderr, %s, flow count: %d",
-			c.defaultBridge.GetBridgeName(), err, stderr, len(flows))
+		_, stderr, err := util.ReplaceOFFlows(c.defaultBridge.GetBridgeName(), flows)
+		if err != nil {
+			klog.Errorf("Failed to add flows for bridge %s, error: %v, stderr, %s, flow count: %d",
+				c.defaultBridge.GetBridgeName(), err, stderr, len(flows))
+		} else {
+			c.deleteStaleGroups()
+		}
 	}
 
 	if c.externalGatewayBridge != nil {
@@ -141,6 +182,84 @@ func (c *openflowManager) syncFlows() {
 				c.externalGatewayBridge.GetBridgeName(), err, stderr, len(exGWFlows))
 		}
 	}
+}
+
+func (c *openflowManager) syncGroups() bool {
+	c.groupMutex.Lock()
+	groups := flattenFlowCacheEntries(c.groupCache)
+	c.groupMutex.Unlock()
+
+	success := true
+	successfulGroupIDs := make([]string, 0, len(groups))
+	for _, group := range groups {
+		_, stderr, err := util.AddOrModOFGroup(c.defaultBridge.GetBridgeName(), group)
+		if err != nil {
+			klog.Errorf("Failed to add or modify OpenFlow group for bridge %s, error: %v, stderr: %s, group: %s",
+				c.defaultBridge.GetBridgeName(), err, stderr, group)
+			success = false
+			continue
+		}
+		if groupID, ok := parseOpenFlowGroupID(group); ok {
+			successfulGroupIDs = append(successfulGroupIDs, groupID)
+		}
+	}
+	if len(successfulGroupIDs) > 0 {
+		c.groupMutex.Lock()
+		if c.installedGroups == nil {
+			c.installedGroups = make(map[string]struct{})
+		}
+		for _, groupID := range successfulGroupIDs {
+			c.installedGroups[groupID] = struct{}{}
+		}
+		c.groupMutex.Unlock()
+	}
+	return success
+}
+
+func (c *openflowManager) deleteStaleGroups() {
+	c.groupMutex.Lock()
+	groups := flattenFlowCacheEntries(c.groupCache)
+	desiredGroupIDs := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		if groupID, ok := parseOpenFlowGroupID(group); ok {
+			desiredGroupIDs[groupID] = struct{}{}
+		}
+	}
+	if c.installedGroups == nil {
+		c.installedGroups = make(map[string]struct{})
+	}
+	staleGroupIDs := make([]string, 0, len(c.installedGroups))
+	for groupID := range c.installedGroups {
+		if _, ok := desiredGroupIDs[groupID]; !ok {
+			staleGroupIDs = append(staleGroupIDs, groupID)
+		}
+	}
+	c.groupMutex.Unlock()
+
+	failedGroupIDs := make([]string, 0)
+	for _, groupID := range staleGroupIDs {
+		_, stderr, err := util.DeleteOFGroup(c.defaultBridge.GetBridgeName(), groupID)
+		if err != nil {
+			klog.Errorf("Failed to delete stale OpenFlow group %s for bridge %s, error: %v, stderr: %s",
+				groupID, c.defaultBridge.GetBridgeName(), err, stderr)
+			failedGroupIDs = append(failedGroupIDs, groupID)
+		}
+	}
+
+	c.groupMutex.Lock()
+	c.installedGroups = desiredGroupIDs
+	for _, groupID := range failedGroupIDs {
+		c.installedGroups[groupID] = struct{}{}
+	}
+	c.groupMutex.Unlock()
+}
+
+func parseOpenFlowGroupID(group string) (string, bool) {
+	match := openFlowGroupIDRegexp.FindStringSubmatch(group)
+	if len(match) != 2 {
+		return "", false
+	}
+	return match[1], true
 }
 
 func flattenFlowCacheEntries(flowCache map[string][]string) []string {
@@ -170,6 +289,9 @@ func newGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeconfig.BridgeConfigur
 		externalGatewayBridge: exGWBridge,
 		flowCache:             make(map[string][]string),
 		flowMutex:             sync.Mutex{},
+		groupCache:            make(map[string][]string),
+		groupMutex:            sync.Mutex{},
+		installedGroups:       make(map[string]struct{}),
 		exGWFlowCache:         make(map[string][]string),
 		exGWFlowMutex:         sync.Mutex{},
 		flowChan:              make(chan struct{}, 1),

--- a/go-controller/pkg/node/openflow_manager_test.go
+++ b/go-controller/pkg/node/openflow_manager_test.go
@@ -5,6 +5,23 @@ package node
 
 import "testing"
 
+func TestOpenFlowManagerDeletesGroupCacheWithFlowCache(t *testing.T) {
+	ofm := &openflowManager{}
+	key := "NodePort_namespace1_service1_tcp_31111"
+
+	ofm.updateFlowCacheEntry(key, []string{"cookie=0x123, priority=110, actions=group:100"})
+	ofm.updateGroupCacheEntry(key, []string{"group_id=100,type=select,bucket=actions=output:LOCAL"})
+
+	ofm.deleteFlowsByKey(key)
+
+	if flows := ofm.getFlowsByKey(key); flows != nil {
+		t.Fatalf("expected flow cache entry to be deleted, got %#v", flows)
+	}
+	if groups := ofm.getGroupsByKey(key); groups != nil {
+		t.Fatalf("expected group cache entry to be deleted, got %#v", groups)
+	}
+}
+
 func TestOpenFlowManagerDefaultNetOVSBridgeFinder(t *testing.T) {
 	const nodeName = "multi-homing-worker-0.maiqueb.org"
 

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -46,9 +46,9 @@ type lbConfig struct {
 	hasNodePort bool
 }
 
-func makeNodeSwitchTargetIPs(node string, c *lbConfig) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
-	targetIPsV4 = c.clusterEndpoints.V4IPs
-	targetIPsV6 = c.clusterEndpoints.V6IPs
+func makeNodeSwitchTargetIPs(node string, clusterEntry util.LBEndpointEntry, c *lbConfig) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
+	targetIPsV4 = clusterEntry.V4IPs
+	targetIPsV6 = clusterEntry.V6IPs
 
 	if c.externalTrafficLocal || c.internalTrafficLocal {
 		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
@@ -57,23 +57,24 @@ func makeNodeSwitchTargetIPs(node string, c *lbConfig) (targetIPsV4, targetIPsV6
 		localIPsV4 := []string{}
 		localIPsV6 := []string{}
 		if localEndpoints, ok := c.nodeEndpoints[node]; ok {
-			localIPsV4 = localEndpoints.V4IPs
-			localIPsV6 = localEndpoints.V6IPs
+			localEntry := localEndpoints.GetEntryByPort(clusterEntry.Port)
+			localIPsV4 = localEntry.V4IPs
+			localIPsV6 = localEntry.V6IPs
 		}
 		targetIPsV4 = localIPsV4
 		targetIPsV6 = localIPsV6
 	}
 
 	// Local endpoints are a subset of cluster endpoints, so it is enough to compare their length
-	v4Changed = len(targetIPsV4) != len(c.clusterEndpoints.V4IPs)
-	v6Changed = len(targetIPsV6) != len(c.clusterEndpoints.V6IPs)
+	v4Changed = len(targetIPsV4) != len(clusterEntry.V4IPs)
+	v6Changed = len(targetIPsV6) != len(clusterEntry.V6IPs)
 
 	return
 }
 
-func makeNodeRouterTargetIPs(node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
-	targetIPsV4 = c.clusterEndpoints.V4IPs
-	targetIPsV6 = c.clusterEndpoints.V6IPs
+func makeNodeRouterTargetIPs(node *nodeInfo, clusterEntry util.LBEndpointEntry, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
+	targetIPsV4 = clusterEntry.V4IPs
+	targetIPsV6 = clusterEntry.V6IPs
 
 	if c.externalTrafficLocal {
 		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
@@ -81,8 +82,9 @@ func makeNodeRouterTargetIPs(node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, ho
 		localIPsV4 := []string{}
 		localIPsV6 := []string{}
 		if localEndpoints, ok := c.nodeEndpoints[node.name]; ok {
-			localIPsV4 = localEndpoints.V4IPs
-			localIPsV6 = localEndpoints.V6IPs
+			localEntry := localEndpoints.GetEntryByPort(clusterEntry.Port)
+			localIPsV4 = localEntry.V4IPs
+			localIPsV6 = localEntry.V6IPs
 		}
 		targetIPsV4 = localIPsV4
 		targetIPsV6 = localIPsV6
@@ -100,8 +102,8 @@ func makeNodeRouterTargetIPs(node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, ho
 	targetIPsV6, v6Updated := util.UpdateIPsSlice(targetIPsV6, lbAddresses, []string{hostMasqueradeIPV6})
 
 	// Local endpoints are a subset of cluster endpoints, so it is enough to compare their length
-	v4Changed = len(targetIPsV4) != len(c.clusterEndpoints.V4IPs) || v4Updated
-	v6Changed = len(targetIPsV6) != len(c.clusterEndpoints.V6IPs) || v6Updated
+	v4Changed = len(targetIPsV4) != len(clusterEntry.V4IPs) || v4Updated
+	v6Changed = len(targetIPsV6) != len(clusterEntry.V6IPs) || v6Updated
 
 	return
 }
@@ -146,11 +148,8 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 	needsLocalEndpoints := util.ServiceExternalTrafficPolicyLocal(service) || util.ServiceInternalTrafficPolicyLocal(service)
 	portToClusterEndpoints, portToNodeToEndpoints, err := util.GetEndpointsForService(endpointSlices, service, nodes, true, needsLocalEndpoints)
 	if err != nil {
-		if service != nil {
-			klog.Warningf("Failed to get endpoints for service %s/%s during LB config build: %v", service.Namespace, service.Name, err)
-		} else {
-			klog.Warningf("Failed to get endpoints for service during LB config build: %v", err)
-		}
+		klog.Warningf("Failed to get endpoints for service %s/%s during LB config build: %v",
+			service.Namespace, service.Name, err)
 	}
 	for _, svcPort := range service.Spec.Ports {
 		svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
@@ -228,7 +227,12 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 		// - ETP=local service backed by non-local-host-networked endpoints
 		//
 		// In that case, we need to create per-node LBs.
-		if hasHostEndpoints(clusterEndpoints.V4IPs, netInfo) || hasHostEndpoints(clusterEndpoints.V6IPs, netInfo) || internalTrafficLocal {
+		ips := []string{}
+		for _, ep := range clusterEndpoints {
+			ips = append(ips, ep.V4IPs...)
+			ips = append(ips, ep.V6IPs...)
+		}
+		if hasHostEndpoints(ips, netInfo) || internalTrafficLocal {
 			perNodeConfigs = append(perNodeConfigs, clusterIPConfig)
 		} else {
 			clusterConfigs = append(clusterConfigs, clusterIPConfig)
@@ -305,20 +309,22 @@ func buildClusterLBs(service *corev1.Service, configs []lbConfig, nodeInfos []no
 					service.Namespace, service.Name)
 			}
 
-			v4targets := make([]Addr, 0, len(config.clusterEndpoints.V4IPs))
-			for _, targetIP := range config.clusterEndpoints.V4IPs {
-				v4targets = append(v4targets, Addr{
-					IP:   targetIP,
-					Port: config.clusterEndpoints.Port,
-				})
-			}
+			v4targets := []Addr{}
+			v6targets := []Addr{}
+			for _, entry := range config.clusterEndpoints {
+				for _, targetIP := range entry.V4IPs {
+					v4targets = append(v4targets, Addr{
+						IP:   targetIP,
+						Port: entry.Port,
+					})
+				}
 
-			v6targets := make([]Addr, 0, len(config.clusterEndpoints.V6IPs))
-			for _, targetIP := range config.clusterEndpoints.V6IPs {
-				v6targets = append(v6targets, Addr{
-					IP:   targetIP,
-					Port: config.clusterEndpoints.Port,
-				})
+				for _, targetIP := range entry.V6IPs {
+					v6targets = append(v6targets, Addr{
+						IP:   targetIP,
+						Port: entry.Port,
+					})
+				}
 			}
 
 			rules := make([]LBRule, 0, len(config.vips))
@@ -406,63 +412,71 @@ func buildTemplateLBs(service *corev1.Service, configs []lbConfig, nodes []nodeI
 						service, proto, cfg.inport,
 						optsV6.AddressFamily, "node_router_template", netInfo))
 
-			allV4TargetIPs := cfg.clusterEndpoints.V4IPs
-			allV6TargetIPs := cfg.clusterEndpoints.V6IPs
+			// Phase 1: Accumulate template values and needsTemplate flags
+			// across all target port numbers. When multiple target ports
+			// coexist (e.g. during a rolling update), each port's targets
+			// must be appended into the template rather than overwriting.
+			switchV4TargetNeedsTemplate := false
+			switchV6TargetNeedsTemplate := false
+			routerV4TargetNeedsTemplate := false
+			routerV6TargetNeedsTemplate := false
+			allSharedV4Targets := []Addr{}
+			allSharedV6Targets := []Addr{}
 
-			for range cfg.vips {
-				klog.V(5).Infof("buildTemplateLBs() service %s/%s adding rules for network=%s",
-					service.Namespace, service.Name, netInfo.GetNetworkName())
-
-				// If all targets have exactly the same IPs on all nodes there's
-				// no need to use a template, just use the same list of explicit
-				// targets on all nodes.
-				switchV4TargetNeedsTemplate := false
-				switchV6TargetNeedsTemplate := false
-				routerV4TargetNeedsTemplate := false
-				routerV6TargetNeedsTemplate := false
+			for _, entry := range cfg.clusterEndpoints {
+				allSharedV4Targets = append(allSharedV4Targets, joinHostsPort(entry.V4IPs, entry.Port)...)
+				allSharedV6Targets = append(allSharedV6Targets, joinHostsPort(entry.V6IPs, entry.Port)...)
 
 				for _, node := range nodes {
-
-					switchV4TargetIPs, switchV6TargetIPs, v4Changed, v6Changed := makeNodeSwitchTargetIPs(node.name, &cfg)
-					if !switchV4TargetNeedsTemplate && v4Changed {
+					switchV4TargetIPs, switchV6TargetIPs, v4Changed, v6Changed := makeNodeSwitchTargetIPs(node.name, entry, &cfg)
+					if v4Changed {
 						switchV4TargetNeedsTemplate = true
 					}
-					if !switchV6TargetNeedsTemplate && v6Changed {
+					if v6Changed {
 						switchV6TargetNeedsTemplate = true
 					}
 
 					routerV4TargetIPs, routerV6TargetIPs, v4Changed, v6Changed := makeNodeRouterTargetIPs(
 						&node,
+						entry,
 						&cfg,
 						config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
 						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
 
-					if !routerV4TargetNeedsTemplate && v4Changed {
+					if v4Changed {
 						routerV4TargetNeedsTemplate = true
 					}
-					if !routerV6TargetNeedsTemplate && v6Changed {
+					if v6Changed {
 						routerV6TargetNeedsTemplate = true
 					}
 
-					switchV4TemplateTarget.Value[node.chassisID] = addrsToString(
-						joinHostsPort(switchV4TargetIPs, cfg.clusterEndpoints.Port))
-					switchV6TemplateTarget.Value[node.chassisID] = addrsToString(
-						joinHostsPort(switchV6TargetIPs, cfg.clusterEndpoints.Port))
+					appendTemplateValue(switchV4TemplateTarget, node.chassisID,
+						addrsToString(joinHostsPort(switchV4TargetIPs, entry.Port)))
+					appendTemplateValue(switchV6TemplateTarget, node.chassisID,
+						addrsToString(joinHostsPort(switchV6TargetIPs, entry.Port)))
+					appendTemplateValue(routerV4TemplateTarget, node.chassisID,
+						addrsToString(joinHostsPort(routerV4TargetIPs, entry.Port)))
+					appendTemplateValue(routerV6TemplateTarget, node.chassisID,
+						addrsToString(joinHostsPort(routerV6TargetIPs, entry.Port)))
+				}
+			}
 
-					routerV4TemplateTarget.Value[node.chassisID] = addrsToString(
-						joinHostsPort(routerV4TargetIPs, cfg.clusterEndpoints.Port))
-					routerV6TemplateTarget.Value[node.chassisID] = addrsToString(
-						joinHostsPort(routerV6TargetIPs, cfg.clusterEndpoints.Port))
-				}
+			// Phase 2: Create rules using fully-populated template values.
+			// If all targets have exactly the same IPs on all nodes there's
+			// no need to use a template, just use the same list of explicit
+			// targets on all nodes.
+			sharedV4Targets := []Addr{}
+			sharedV6Targets := []Addr{}
+			if !switchV4TargetNeedsTemplate || !routerV4TargetNeedsTemplate {
+				sharedV4Targets = allSharedV4Targets
+			}
+			if !switchV6TargetNeedsTemplate || !routerV6TargetNeedsTemplate {
+				sharedV6Targets = allSharedV6Targets
+			}
 
-				sharedV4Targets := []Addr{}
-				sharedV6Targets := []Addr{}
-				if !switchV4TargetNeedsTemplate || !routerV4TargetNeedsTemplate {
-					sharedV4Targets = joinHostsPort(allV4TargetIPs, cfg.clusterEndpoints.Port)
-				}
-				if !switchV6TargetNeedsTemplate || !routerV6TargetNeedsTemplate {
-					sharedV6Targets = joinHostsPort(allV6TargetIPs, cfg.clusterEndpoints.Port)
-				}
+			for range cfg.vips {
+				klog.V(5).Infof("buildTemplateLBs() service %s/%s adding rules for network=%s",
+					service.Namespace, service.Name, netInfo.GetNetworkName())
 
 				for _, nodeIPv4Template := range nodeIPv4Templates.AsTemplates() {
 
@@ -622,19 +636,36 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 
 			for _, cfg := range configs {
 
-				switchV4TargetIPs, switchV6TargetIPs, _, _ := makeNodeSwitchTargetIPs(node.name, &cfg)
+				// Accumulate targets across all port numbers. When
+				// clusterEndpoints is empty (e.g. pod deleted during
+				// cycling), these remain empty and we still create
+				// rules with empty targets so OVN cleans up conntrack.
+				switchV4targets := []Addr{}
+				switchV6targets := []Addr{}
+				routerV4targets := []Addr{}
+				routerV6targets := []Addr{}
+				switchV4LocalTargets := []Addr{}
+				switchV6LocalTargets := []Addr{}
 
-				routerV4TargetIPs, routerV6TargetIPs, _, _ := makeNodeRouterTargetIPs(
-					&node,
-					&cfg,
-					config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
-					config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
+				for _, entry := range cfg.clusterEndpoints {
+					switchV4TargetIPs, switchV6TargetIPs, _, _ := makeNodeSwitchTargetIPs(node.name, entry, &cfg)
 
-				routerV4targets := joinHostsPort(routerV4TargetIPs, cfg.clusterEndpoints.Port)
-				routerV6targets := joinHostsPort(routerV6TargetIPs, cfg.clusterEndpoints.Port)
+					routerV4TargetIPs, routerV6TargetIPs, _, _ := makeNodeRouterTargetIPs(
+						&node,
+						entry,
+						&cfg,
+						config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
+						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
 
-				switchV4targets := joinHostsPort(cfg.clusterEndpoints.V4IPs, cfg.clusterEndpoints.Port)
-				switchV6targets := joinHostsPort(cfg.clusterEndpoints.V6IPs, cfg.clusterEndpoints.Port)
+					routerV4targets = append(routerV4targets, joinHostsPort(routerV4TargetIPs, entry.Port)...)
+					routerV6targets = append(routerV6targets, joinHostsPort(routerV6TargetIPs, entry.Port)...)
+
+					switchV4targets = append(switchV4targets, joinHostsPort(entry.V4IPs, entry.Port)...)
+					switchV6targets = append(switchV6targets, joinHostsPort(entry.V6IPs, entry.Port)...)
+
+					switchV4LocalTargets = append(switchV4LocalTargets, joinHostsPort(switchV4TargetIPs, entry.Port)...)
+					switchV6LocalTargets = append(switchV6LocalTargets, joinHostsPort(switchV6TargetIPs, entry.Port)...)
+				}
 
 				// Substitute the special vip "node" for the node's physical ips
 				// This is used for nodeport
@@ -660,10 +691,10 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 					if cfg.externalTrafficLocal && cfg.hasNodePort {
 						// add special masqueradeIP as a vip if its nodePort svc with ETP=local
 						mvip := config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
-						targetsETP := joinHostsPort(switchV4TargetIPs, cfg.clusterEndpoints.Port)
+						targetsETP := switchV4LocalTargets
 						if isv6 {
 							mvip = config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
-							targetsETP = joinHostsPort(switchV6TargetIPs, cfg.clusterEndpoints.Port)
+							targetsETP = switchV6LocalTargets
 						}
 						switchRules = append(switchRules, LBRule{
 							Source:  Addr{IP: mvip, Port: cfg.inport},
@@ -671,9 +702,9 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 						})
 					}
 					if cfg.internalTrafficLocal && util.IsClusterIP(vip) { // ITP only applicable to CIP
-						targetsITP := joinHostsPort(switchV4TargetIPs, cfg.clusterEndpoints.Port)
+						targetsITP := switchV4LocalTargets
 						if isv6 {
-							targetsITP = joinHostsPort(switchV6TargetIPs, cfg.clusterEndpoints.Port)
+							targetsITP = switchV6LocalTargets
 						}
 						switchRules = append(switchRules, LBRule{
 							Source:  Addr{IP: vip, Port: cfg.inport},

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -48,6 +48,16 @@ var (
 	httpPortValue int32  = int32(80)
 )
 
+func newLBEndpointEntry(port int32, v4IPs, v6IPs []string) util.LBEndpointEntry {
+	if len(v4IPs) == 0 {
+		v4IPs = nil
+	}
+	if len(v6IPs) == 0 {
+		v6IPs = nil
+	}
+	return util.LBEndpointEntry{Port: port, V4IPs: v4IPs, V6IPs: v6IPs}
+}
+
 func getSampleService(publishNotReadyAddresses bool) *corev1.Service {
 	name := "service-test"
 	namespace := "test"
@@ -250,7 +260,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:             []string{"192.168.1.1"},
 				protocol:         corev1.ProtocolTCP,
 				inport:           80,
-				clusterEndpoints: util.LBEndpoints{},
+				clusterEndpoints: nil,
 				nodeEndpoints:    util.PortToLBEndpoints{},
 			}},
 			resultsSame: true,
@@ -275,14 +285,11 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				},
 			},
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:     []string{"192.168.1.1"},
-				protocol: corev1.ProtocolTCP,
-				inport:   inport,
-				clusterEndpoints: util.LBEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					Port:  outport,
-				},
-				nodeEndpoints: util.PortToLBEndpoints{}, // service is not ETP=local or ITP=local, so nodeEndpoints is not filled out
+				vips:             []string{"192.168.1.1"},
+				protocol:         corev1.ProtocolTCP,
+				inport:           inport,
+				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+				nodeEndpoints:    util.PortToLBEndpoints{}, // service is not ETP=local or ITP=local, so nodeEndpoints is not filled out
 			}},
 			resultsSame: true,
 		},
@@ -307,19 +314,12 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				},
 			},
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:     []string{"192.168.1.1"},
-				protocol: corev1.ProtocolTCP,
-				inport:   inport,
-				clusterEndpoints: util.LBEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					Port:  outport,
-				},
+				vips:             []string{"192.168.1.1"},
+				protocol:         corev1.ProtocolTCP,
+				inport:           inport,
+				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
 				nodeEndpoints: util.PortToLBEndpoints{ // service is ETP=local, so nodeEndpoints is filled out
-					nodeA: {
-						V4IPs: []string{"10.128.0.2"},
-						Port:  outport,
-					},
-				},
+					nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})}},
 			}},
 			resultsSame: true,
 		},
@@ -374,24 +374,18 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
+					vips:             []string{"192.168.1.1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
 				},
 				{
-					vips:     []string{"192.168.1.1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport1,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  outport1,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
+					vips:             []string{"192.168.1.1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport1,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport1, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
 				},
 			},
 		},
@@ -446,24 +440,18 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
+					vips:             []string{"192.168.1.1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
 				},
 				{
-					vips:     []string{"192.168.1.1"},
-					protocol: corev1.ProtocolUDP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
+					vips:             []string{"192.168.1.1"},
+					protocol:         corev1.ProtocolUDP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
 				},
 			},
 		},
@@ -488,15 +476,11 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			},
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:     []string{"192.168.1.1", "2002::1"},
-				protocol: corev1.ProtocolTCP,
-				inport:   inport,
-				clusterEndpoints: util.LBEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{"fe00::1:1"},
-					Port:  outport,
-				},
-				nodeEndpoints: util.PortToLBEndpoints{},
+				vips:             []string{"192.168.1.1", "2002::1"},
+				protocol:         corev1.ProtocolTCP,
+				inport:           inport,
+				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
+				nodeEndpoints:    util.PortToLBEndpoints{},
 			}},
 		},
 		{
@@ -528,15 +512,11 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			},
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:     []string{"192.168.1.1", "2002::1", "4.2.2.2", "42::42", "5.5.5.5"},
-				protocol: corev1.ProtocolTCP,
-				inport:   inport,
-				clusterEndpoints: util.LBEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{"fe00::1:1"},
-					Port:  outport,
-				},
-				nodeEndpoints: util.PortToLBEndpoints{}, // ETP=cluster (default), so nodeEndpoints is not filled out
+				vips:             []string{"192.168.1.1", "2002::1", "4.2.2.2", "42::42", "5.5.5.5"},
+				protocol:         corev1.ProtocolTCP,
+				inport:           inport,
+				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
+				nodeEndpoints:    util.PortToLBEndpoints{}, // ETP=cluster (default), so nodeEndpoints is not filled out
 			}},
 		},
 		{
@@ -570,21 +550,12 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1", "2002::1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						V6IPs: []string{"fe00::1:1"},
-						Port:  outport,
-					},
+					vips:             []string{"192.168.1.1", "2002::1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							V6IPs: []string{"fe00::1:1"},
-							Port:  outport,
-						},
-					},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})}},
 				},
 			},
 			resultSharedGatewayNode: []lbConfig{
@@ -593,18 +564,9 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol:             corev1.ProtocolTCP,
 					inport:               inport,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						V6IPs: []string{"fe00::1:1"},
-						Port:  outport,
-					},
+					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							V6IPs: []string{"fe00::1:1"},
-							Port:  outport,
-						},
-					},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})}},
 				},
 			},
 		},
@@ -630,27 +592,19 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			},
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:     []string{"192.168.1.1", "2002::1"},
-				protocol: corev1.ProtocolTCP,
-				inport:   inport,
-				clusterEndpoints: util.LBEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{"fe00::1:1"},
-					Port:  outport,
-				},
-				nodeEndpoints: util.PortToLBEndpoints{},
+				vips:             []string{"192.168.1.1", "2002::1"},
+				protocol:         corev1.ProtocolTCP,
+				inport:           inport,
+				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
+				nodeEndpoints:    util.PortToLBEndpoints{},
 			}},
 			resultSharedGatewayTemplate: []lbConfig{{
-				vips:     []string{"node"},
-				protocol: corev1.ProtocolTCP,
-				inport:   5,
-				clusterEndpoints: util.LBEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{"fe00::1:1"},
-					Port:  outport,
-				},
-				nodeEndpoints: util.PortToLBEndpoints{},
-				hasNodePort:   true,
+				vips:             []string{"node"},
+				protocol:         corev1.ProtocolTCP,
+				inport:           5,
+				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
+				nodeEndpoints:    util.PortToLBEndpoints{},
+				hasNodePort:      true,
 			}},
 		},
 		{
@@ -677,57 +631,41 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			// In shared and local gateway modes, nodeport and host-network-pods must be per-node
 			resultSharedGatewayNode: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1", "2002::1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
+					vips:             []string{"192.168.1.1", "2002::1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
 				},
 			},
 			resultSharedGatewayTemplate: []lbConfig{
 				{
-					vips:     []string{"node"},
-					protocol: corev1.ProtocolTCP,
-					inport:   5,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
-					hasNodePort:   true,
+					vips:             []string{"node"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           5,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
+					hasNodePort:      true,
 				},
 			},
 			// in local gateway mode, only nodePort is per-node
 			resultLocalGatewayNode: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1", "2002::1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
+					vips:             []string{"192.168.1.1", "2002::1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
 				},
 			},
 			resultLocalGatewayTemplate: []lbConfig{
 				{
-					vips:     []string{"node"},
-					protocol: corev1.ProtocolTCP,
-					inport:   5,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
-					hasNodePort:   true,
+					vips:             []string{"node"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           5,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
+					hasNodePort:      true,
 				},
 			},
 		},
@@ -756,78 +694,42 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			// In shared & local gateway modes, nodeport and host-network-pods must be per-node
 			resultSharedGatewayNode: []lbConfig{
 				{
-					vips:     []string{"node"},
-					protocol: corev1.ProtocolTCP,
-					inport:   5,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
+					vips:             []string{"node"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           5,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"192.168.0.1"},
-							V6IPs: []string{"2001::1"},
-							Port:  outport,
-						},
-					},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})}},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
 				},
 				{
-					vips:     []string{"192.168.1.1", "2002::1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
+					vips:             []string{"192.168.1.1", "2002::1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"192.168.0.1"},
-							V6IPs: []string{"2001::1"},
-							Port:  outport,
-						},
-					},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})}},
 				},
 			},
 			resultLocalGatewayNode: []lbConfig{
 				{
-					vips:     []string{"node"},
-					protocol: corev1.ProtocolTCP,
-					inport:   5,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
+					vips:             []string{"node"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           5,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"192.168.0.1"},
-							V6IPs: []string{"2001::1"},
-							Port:  outport,
-						},
-					},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})}},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
 				},
 				{
-					vips:     []string{"192.168.1.1", "2002::1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
+					vips:             []string{"192.168.1.1", "2002::1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"192.168.0.1"},
-							V6IPs: []string{"2001::1"},
-							Port:  outport,
-						},
-					},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})}},
 				},
 			},
 		},
@@ -854,28 +756,20 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			// In shared gateway mode, nodeport and host-network-pods must be per-node
 			resultSharedGatewayNode: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1", "2002::1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
+					vips:             []string{"192.168.1.1", "2002::1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
 				},
 			},
 			resultLocalGatewayNode: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1", "2002::1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{},
+					vips:             []string{"192.168.1.1", "2002::1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					nodeEndpoints:    util.PortToLBEndpoints{},
 				},
 			},
 		},
@@ -915,22 +809,13 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  outport,
-					},
+					vips:             []string{"192.168.1.1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.2"},
-							Port:  outport,
-						},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
 					},
 				},
 			},
@@ -941,19 +826,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               5,
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  outport,
-					},
+					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.2"},
-							Port:  outport,
-						},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
 					},
 				},
 				{
@@ -962,19 +838,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               inport,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  outport,
-					},
+					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.2"},
-							Port:  outport,
-						},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
 					},
 				},
 			},
@@ -1016,22 +883,13 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  outport,
-					},
+					vips:             []string{"192.168.1.1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
-							Port:  outport,
-						},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
 					},
 				},
 			},
@@ -1042,19 +900,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               5,
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  outport,
-					},
+					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
-							Port:  outport,
-						},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
 					},
 				},
 				{
@@ -1063,19 +912,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               inport,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  outport,
-					},
+					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
-							Port:  outport,
-						},
+						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
 					},
 				},
 			},
@@ -1115,19 +955,11 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:     []string{"192.168.1.1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   inport,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-					},
+					vips:             []string{"192.168.1.1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           inport,
+					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})}},
 				},
 			},
 			resultSharedGatewayNode: []lbConfig{
@@ -1137,16 +969,8 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               5,
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-					},
+					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+					nodeEndpoints:        util.PortToLBEndpoints{nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})}},
 				},
 				{
 					vips:                 []string{"4.2.2.2", "5.5.5.5"},
@@ -1154,16 +978,8 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               inport,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  outport,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  outport,
-						},
-					},
+					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+					nodeEndpoints:        util.PortToLBEndpoints{nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})}},
 				},
 			},
 		},
@@ -1239,34 +1055,18 @@ func Test_buildClusterLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:     []string{"1.2.3.4"},
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
-							Port:  8080,
-						},
-					},
+					vips:             []string{"1.2.3.4"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"192.168.0.1", "192.168.0.2"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1", "192.168.0.2"}}}},
 				},
 				{
-					vips:     []string{"1.2.3.4"},
-					protocol: corev1.ProtocolTCP,
-					inport:   443,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						Port:  8043,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"192.168.0.1"},
-							Port:  8043,
-						},
-					},
+					vips:             []string{"1.2.3.4"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           443,
+					clusterEndpoints: util.LBEndpoints{{Port: 8043, V4IPs: []string{"192.168.0.1"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8043, V4IPs: []string{"192.168.0.1"}}}},
 				},
 			},
 			nodeInfos: defaultNodes,
@@ -1298,34 +1098,18 @@ func Test_buildClusterLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:     []string{"1.2.3.4"},
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
-							Port:  8080,
-						},
-					},
+					vips:             []string{"1.2.3.4"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"192.168.0.1", "192.168.0.2"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1", "192.168.0.2"}}}},
 				},
 				{
-					vips:     []string{"1.2.3.4"},
-					protocol: corev1.ProtocolUDP,
-					inport:   443,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						Port:  8043,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"192.168.0.1"},
-							Port:  8043,
-						},
-					},
+					vips:             []string{"1.2.3.4"},
+					protocol:         corev1.ProtocolUDP,
+					inport:           443,
+					clusterEndpoints: util.LBEndpoints{{Port: 8043, V4IPs: []string{"192.168.0.1"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8043, V4IPs: []string{"192.168.0.1"}}}},
 				},
 			},
 			nodeInfos: defaultNodes,
@@ -1372,36 +1156,26 @@ func Test_buildClusterLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4", "fe80::1"},
 					protocol: corev1.ProtocolTCP,
 					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
+					clusterEndpoints: util.LBEndpoints{{Port: 8080,
 						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
-						V6IPs: []string{"fe90::1", "fe91::1"},
-
-						Port: 8080,
-					},
+						V6IPs: []string{"fe90::1", "fe91::1"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
+						nodeA: {{Port: 8080,
 							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
 							V6IPs: []string{"fe90::1", "fe91::1"},
-							Port:  8080,
-						},
+						}},
 					},
 				},
 				{
-					vips:     []string{"1.2.3.4", "fe80::1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   443,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"fe90::1"},
-
-						Port: 8043,
-					},
+					vips:             []string{"1.2.3.4", "fe80::1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           443,
+					clusterEndpoints: util.LBEndpoints{{Port: 8043, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe90::1"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
+						nodeA: {{Port: 8043,
 							V4IPs: []string{"192.168.0.1"},
 							V6IPs: []string{"fe90::1"},
-							Port:  8043,
-						},
+						}},
 					},
 				},
 			},
@@ -1554,18 +1328,14 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:     []string{"1.2.3.4"},
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1"},
-						Port:  8080,
-					},
+					vips:             []string{"1.2.3.4"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
+						nodeA: {{Port: 8080,
 							V4IPs: []string{"10.0.0.1"},
-							Port:  8080,
-						},
+						}},
 					},
 				},
 			},
@@ -1604,16 +1374,11 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:     []string{"node"},
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
-					},
+					vips:             []string{"node"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}}},
 				},
 			},
 			expectedShared: []LB{
@@ -1690,34 +1455,18 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:     []string{"192.168.0.1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.0.0.1"},
-							Port:  8080,
-						},
-					},
+					vips:             []string{"192.168.0.1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
 				},
 				{
-					vips:     []string{"node"},
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.0.0.1"},
-							Port:  8080,
-						},
-					},
+					vips:             []string{"node"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
 				},
 			},
 			expectedShared: []LB{
@@ -1851,19 +1600,11 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:     []string{"192.168.0.1"},
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.0.0.1"},
-							Port:  8080,
-						},
-					},
+					vips:             []string{"192.168.0.1"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
 				},
 				{
 					vips:                 []string{"node"},
@@ -1871,16 +1612,8 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					externalTrafficLocal: true,
 					hasNodePort:          true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.0.0.1"},
-							Port:  8080,
-						},
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+					nodeEndpoints:        util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
 				},
 			},
 			expectedShared: []LB{
@@ -2001,38 +1734,20 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					protocol:             corev1.ProtocolTCP,
 					inport:               80,
 					internalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
-						Port:  8080,
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.1", "10.128.1.1"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.1"},
-							Port:  8080,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.1"},
-							Port:  8080,
-						},
+						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.1"}}},
+						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.1"}}},
 					},
 				},
 				{
-					vips:     []string{"1.2.3.4"}, // externalIP config
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
-						Port:  8080,
-					},
+					vips:             []string{"1.2.3.4"}, // externalIP config
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.1", "10.128.1.1"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.1"},
-							Port:  8080,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.1"},
-							Port:  8080,
-						},
+						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.1"}}},
+						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.1"}}},
 					},
 				},
 			},
@@ -2152,38 +1867,20 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					protocol:             corev1.ProtocolTCP,
 					inport:               80,
 					internalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
-						Port:  8080,
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1", "10.0.0.2"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.0.0.1"},
-							Port:  8080,
-						},
-						nodeB: {
-							V4IPs: []string{"10.0.0.2"},
-							Port:  8080,
-						},
+						nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+						nodeB: {{Port: 8080, V4IPs: []string{"10.0.0.2"}}},
 					},
 				},
 				{
-					vips:     []string{"1.2.3.4"}, // externalIP config
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
-						Port:  8080,
-					},
+					vips:             []string{"1.2.3.4"}, // externalIP config
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1", "10.0.0.2"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.0.0.1"},
-							Port:  8080,
-						},
-						nodeB: {
-							V4IPs: []string{"10.0.0.2"},
-							Port:  8080,
-						},
+						nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+						nodeB: {{Port: 8080, V4IPs: []string{"10.0.0.2"}}},
 					},
 				},
 			},
@@ -2339,16 +2036,8 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					internalTrafficLocal: true,
 					externalTrafficLocal: false, // ETP is applicable only to nodePorts and LBs
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
-							Port:  8080,
-						},
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+					nodeEndpoints:        util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
 				},
 				{
 					vips:                 []string{"node"}, // nodePort config
@@ -2357,16 +2046,8 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					externalTrafficLocal: true,
 					internalTrafficLocal: false, // ITP is applicable only to clusterIPs
 					hasNodePort:          true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.0.0.1"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
-							Port:  8080,
-						},
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+					nodeEndpoints:        util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
 				},
 			},
 			expectedShared: []LB{
@@ -2579,19 +2260,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               5, // nodePort
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  8080,
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2", "10.128.1.2"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  8080,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.2"},
-							Port:  8080,
-						},
+						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
+						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.2"}}},
 					},
 				},
 				{
@@ -2600,19 +2272,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						Port:  8080,
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2", "10.128.1.2"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {
-							V4IPs: []string{"10.128.0.2"},
-							Port:  8080,
-						},
-						nodeB: {
-							V4IPs: []string{"10.128.1.2"},
-							Port:  8080,
-						},
+						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
+						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.2"}}},
 					},
 				},
 			},
@@ -2734,13 +2397,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               5, // nodePort
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  8080,
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
-						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: 8080},
+						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
+						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.2"}}},
 					},
 				},
 				{
@@ -2749,13 +2409,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						Port:  8080,
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
-						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: 8080},
+						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
+						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.2"}}},
 					},
 				},
 			},
@@ -2883,16 +2540,11 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:     []string{"node"},
-					protocol: corev1.ProtocolTCP,
-					inport:   80,
-					clusterEndpoints: util.LBEndpoints{
-						V6IPs: []string{"fe00:0:0:0:1::2"},
-						Port:  8080,
-					},
-					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
-					},
+					vips:             []string{"node"},
+					protocol:         corev1.ProtocolTCP,
+					inport:           80,
+					clusterEndpoints: util.LBEndpoints{{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}}},
 				},
 			},
 			expectedShared: []LB{
@@ -2975,13 +2627,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               5, // nodePort
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V6IPs: []string{"fe00:0:0:0:1::2"},
-						Port:  8080,
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
-						nodeB: {V6IPs: []string{"fe00:0:0:0:2::2"}, Port: 8080},
+						nodeA: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+						nodeB: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:2::2"}}},
 					},
 				},
 				{
@@ -2990,13 +2639,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints: util.LBEndpoints{
-						V6IPs: []string{"fe00:0:0:0:1::2"},
-						Port:  8080,
-					},
+					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
-						nodeB: {V6IPs: []string{"fe00:0:0:0:2::2"}, Port: 8080},
+						nodeA: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+						nodeB: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:2::2"}}},
 					},
 				},
 			},
@@ -3277,7 +2923,7 @@ func Test_idledServices(t *testing.T) {
 	}
 }
 
-func Test_GetEndpointsForService(t *testing.T) {
+func Test_getEndpointsForService(t *testing.T) {
 	type args struct {
 		slices []*discovery.EndpointSlice
 		svc    *corev1.Service
@@ -3289,7 +2935,6 @@ func Test_GetEndpointsForService(t *testing.T) {
 		args                 args
 		wantClusterEndpoints util.PortToLBEndpoints
 		wantNodeEndpoints    util.PortToNodeToLBEndpoints
-		wantError            error
 	}{
 		{
 			name: "empty slices",
@@ -3325,7 +2970,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // no need for local endpoints, service is not ETP or ITP local
 		},
 		{
@@ -3353,9 +2998,9 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 80}}}, // ETP=local, one local endpoint
+				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}}, // ETP=local, one local endpoint
 		},
 		{
 			name: "slice with one non-local endpoint, ETP=local",
@@ -3382,7 +3027,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // ETP=local but no local endpoint
 		},
 		{
@@ -3437,9 +3082,9 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA, nodeB), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeB: util.LBEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 80}}}, // endpoint on nodeB
+				getServicePortKey(tcp, "tcp-example"): {nodeB: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}}, // endpoint on nodeB
 		},
 		{
 			name: "slice with different port name than the service",
@@ -3493,9 +3138,9 @@ func Test_GetEndpointsForService(t *testing.T) {
 
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, ""): {V4IPs: []string{"10.0.0.2"}, Port: 8080}}, // one cluster-wide endpoint
+				getServicePortKey(tcp, ""): util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, ""): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 8080}}}, // one local endpoint
+				getServicePortKey(tcp, ""): {nodeA: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.2"}, []string{})}}}, // one local endpoint
 		},
 		{
 			name: "slice with an IPv6 endpoint",
@@ -3522,7 +3167,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V6IPs: []string{"2001:db2::2"}, Port: 80}}, // one cluster-wide endpoint
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::2"})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, //  local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3566,9 +3211,9 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}}},
+				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}}},
 		},
 		{
 			name: "one slice with a duplicate address in the same endpoint",
@@ -3595,7 +3240,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3623,7 +3268,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3667,7 +3312,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3711,11 +3356,11 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80},
-				util.GetServicePortKey(tcp, "other-port"):  {V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})},
+				getServicePortKey(tcp, "other-port"):  util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
-				util.GetServicePortKey(tcp, "other-port"):  {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}}},
+				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
+				getServicePortKey(tcp, "other-port"):  {nodeA: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}}},
 		},
 		{
 			name: "multiples slices with different ports, OVN zone with two nodes, ETP=local",
@@ -3758,11 +3403,11 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA, nodeB), // zone with two nodes
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80},
-				util.GetServicePortKey(tcp, "other-port"):  {V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})},
+				getServicePortKey(tcp, "other-port"):  util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
-				util.GetServicePortKey(tcp, "other-port"):  {nodeB: util.LBEndpoints{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}}},
+				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
+				getServicePortKey(tcp, "other-port"):  {nodeB: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}}},
 		},
 		{
 			name: "slice with a mix of ready and terminating (serving and non-serving) endpoints",
@@ -3796,7 +3441,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V6IPs: []string{"2001:db2::2", "2001:db2::3"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::2", "2001:db2::3"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3829,7 +3474,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V6IPs: []string{"2001:db2::4", "2001:db2::5"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::4", "2001:db2::5"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3910,7 +3555,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V6IPs: []string{"2001:db2::3", "2001:db2::4"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::3", "2001:db2::4"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -4010,7 +3655,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -4060,7 +3705,7 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.3"}, V6IPs: []string{"2001:db2::3"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.3"}, []string{"2001:db2::3"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -4160,14 +3805,13 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA),                                                                // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {
-					V4IPs: []string{"10.0.0.2", "10.0.0.3", "10.0.0.4"},
-					V6IPs: []string{"2001:db2::2", "2001:db2::3", "2001:db2::4"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.0.0.3", "10.0.0.4"},
+					[]string{"2001:db2::2", "2001:db2::3", "2001:db2::4"})}},
 
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
-		// According to https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports, the following
-		// should be supported. However, in OVNK, this was never implemented.
+		// Multiple slices with same port name but different port numbers.
+		// SDN-3551: both target ports are now supported during rolling updates.
 		{
 			name: "multiple slices with same port name, different ports, ETP=local",
 			args: args{
@@ -4209,11 +3853,15 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): {
+					newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{}),
+					newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{}),
+				}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}}},
-			wantError: fmt.Errorf("OVN Kubernetes does not support more than one target port per service port for " +
-				"service \"test/service-test\": servicePortKey \"TCP/tcp-example\" portNumbers [80 8080]"),
+				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{
+					newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{}),
+					newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{}),
+				}}},
 		},
 		// The following is not supported by Kubernetes - OVNK will just ignore this and look up the matching
 		// protocol (TCP) only.
@@ -4258,9 +3906,9 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
+				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}}},
+				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}}},
 		},
 		// The following should never happen in k8s - endpoints should not be empty.
 		{
@@ -4303,96 +3951,10 @@ func Test_GetEndpointsForService(t *testing.T) {
 				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
 				nodes: sets.New(nodeA), // one-node zone
 			},
-			wantClusterEndpoints: util.PortToLBEndpoints{"TCP/tcp-example": util.LBEndpoints{Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)}},
+			wantClusterEndpoints: util.PortToLBEndpoints{"TCP/tcp-example": util.LBEndpoints{newLBEndpointEntry(80, []string{"10.1.1.2"}, []string{})}},
 			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
 		},
-		// The following should never happen in k8s - invalid port number.
-		{
-			name: "single slices, invalid port number, ETP=local",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     ptr.To("tcp-example"),
-								Protocol: ptr.To(corev1.ProtocolTCP),
-								Port:     ptr.To(int32(-2)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints:   []discovery.Endpoint{kubetest.MakeUnassignedEndpoint("10.1.1.2")},
-					},
-				},
-				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
-				nodes: sets.New(nodeA), // one-node zone
-			},
-			wantClusterEndpoints: util.PortToLBEndpoints{},
-			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
-		},
-		{
-			name: "nil service without endpoints, ETP=local",
-			args: args{
-				slices: []*discovery.EndpointSlice{},
-				svc:    nil,
-				nodes:  sets.New(nodeA),
-			},
-			wantClusterEndpoints: util.PortToLBEndpoints{},
-			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
-		},
-		{
-			name: "multiple slices, nil service with endpoints, ETP=local",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     ptr.To("tcp-example"),
-								Protocol: ptr.To(corev1.ProtocolTCP),
-								Port:     ptr.To(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.1.1.2"),
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     ptr.To("tcp-example2"),
-								Protocol: ptr.To(corev1.ProtocolTCP),
-								Port:     ptr.To(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.1.1.3"),
-					},
-				},
-				svc:   nil,
-				nodes: sets.New(nodeA),
-			},
-			wantClusterEndpoints: util.PortToLBEndpoints{
-				"TCP/tcp-example":  util.LBEndpoints{Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)},
-				"TCP/tcp-example2": util.LBEndpoints{Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)},
-			},
-			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				"TCP/tcp-example":  map[string]util.LBEndpoints{"node-a": {Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)}},
-				"TCP/tcp-example2": map[string]util.LBEndpoints{"node-a": {Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)}},
-			},
-		},
+
 		{
 			name: "multiple slices, service selects correct slice, ETP=local",
 			args: args{
@@ -4434,10 +3996,178 @@ func Test_GetEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA),
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				"TCP/tcp-example2": util.LBEndpoints{Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)},
+				"TCP/tcp-example2": util.LBEndpoints{newLBEndpointEntry(80, []string{"10.1.1.3"}, []string{})},
 			},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				"TCP/tcp-example2": map[string]util.LBEndpoints{"node-a": {Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)}},
+				"TCP/tcp-example2": {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.1.1.3"}, []string{})}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			needsLocal := util.ServiceExternalTrafficPolicyLocal(tt.args.svc) || util.ServiceInternalTrafficPolicyLocal(tt.args.svc)
+			portToClusterEndpoints, portToNodeToEndpoints, err := util.GetEndpointsForService(
+				tt.args.slices, tt.args.svc, tt.args.nodes, true, needsLocal)
+			if err != nil {
+				t.Logf("GetEndpointsForService returned non-fatal error: %v", err)
+			}
+			assert.Equal(t, tt.wantClusterEndpoints, portToClusterEndpoints)
+			assert.Equal(t, tt.wantNodeEndpoints, portToNodeToEndpoints)
+		})
+	}
+}
+
+// Test_utilGetEndpointsForService tests util.GetEndpointsForService for additional scenarios.
+// These include nil service handling, port validation, and multi-port error reporting.
+func Test_utilGetEndpointsForService(t *testing.T) {
+	type args struct {
+		slices []*discovery.EndpointSlice
+		svc    *corev1.Service
+		nodes  sets.Set[string]
+	}
+
+	tests := []struct {
+		name                 string
+		args                 args
+		wantClusterEndpoints util.PortToLBEndpoints
+		wantNodeEndpoints    util.PortToNodeToLBEndpoints
+		wantError            error
+	}{
+		{
+			name: "multiple slices with same port name, different ports, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     ptr.To("tcp-example"),
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     ptr.To(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab24",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     ptr.To("tcp-example"),
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     ptr.To(int32(8080)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.0.0.3", "10.2.2.3"),
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
+				nodes: sets.New(nodeA),
+			},
+			wantClusterEndpoints: util.PortToLBEndpoints{
+				util.GetServicePortKey(tcp, "tcp-example"): {
+					{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, V6IPs: []string(nil), Port: 80},
+					{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, V6IPs: []string(nil), Port: 8080},
+				}},
+			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{
+					{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, V6IPs: []string(nil), Port: 80},
+					{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, V6IPs: []string(nil), Port: 8080},
+				}}},
+		},
+		{
+			name: "single slices, invalid port number, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     ptr.To("tcp-example"),
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     ptr.To(int32(-2)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   []discovery.Endpoint{kubetest.MakeUnassignedEndpoint("10.1.1.2")},
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
+				nodes: sets.New(nodeA),
+			},
+			wantClusterEndpoints: util.PortToLBEndpoints{},
+			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
+		},
+		{
+			name: "nil service without endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{},
+				svc:    nil,
+				nodes:  sets.New(nodeA),
+			},
+			wantClusterEndpoints: util.PortToLBEndpoints{},
+			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
+		},
+		{
+			name: "multiple slices, nil service with endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     ptr.To("tcp-example"),
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     ptr.To(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     ptr.To("tcp-example2"),
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     ptr.To(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.1.1.3"),
+					},
+				},
+				svc:   nil,
+				nodes: sets.New(nodeA),
+			},
+			wantClusterEndpoints: util.PortToLBEndpoints{
+				"TCP/tcp-example":  util.LBEndpoints{{Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)}},
+				"TCP/tcp-example2": util.LBEndpoints{{Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)}},
+			},
+			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
+				"TCP/tcp-example":  util.PortToLBEndpoints{"node-a": {{Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)}}},
+				"TCP/tcp-example2": util.PortToLBEndpoints{"node-a": {{Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)}}},
 			},
 		},
 	}
@@ -4470,20 +4200,12 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 		{
 			name: "cluster ip service", //ETP=cluster by default on all services
 			config: &lbConfig{
-				vips:     []string{"1.2.3.4", "fe10::1"},
-				protocol: corev1.ProtocolTCP,
-				inport:   80,
-				clusterEndpoints: util.LBEndpoints{
-					V4IPs: []string{"192.168.0.1"},
-					V6IPs: []string{"fe00:0:0:0:1::2"},
-					Port:  8080,
-				},
+				vips:             []string{"1.2.3.4", "fe10::1"},
+				protocol:         corev1.ProtocolTCP,
+				inport:           80,
+				clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe00:0:0:0:1::2"}}},
 				nodeEndpoints: util.PortToLBEndpoints{
-					nodeA: {
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"fe00:0:0:0:1::2"},
-						Port:  8080,
-					},
+					nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe00:0:0:0:1::2"}}},
 				},
 			},
 			node:                nodeA,
@@ -4498,18 +4220,11 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 				vips:     []string{"1.2.3.4", "fe10::1"},
 				protocol: corev1.ProtocolTCP,
 				inport:   80,
-				clusterEndpoints: util.LBEndpoints{
+				clusterEndpoints: util.LBEndpoints{{Port: 8080,
 					V4IPs: []string{"192.168.0.1", "192.168.1.1"},
-					V6IPs: []string{"fe00:0:0:0:1::2", "fe00:0:0:0:2::2"},
-
-					Port: 8080,
-				},
+					V6IPs: []string{"fe00:0:0:0:1::2", "fe00:0:0:0:2::2"}}},
 				nodeEndpoints: util.PortToLBEndpoints{
-					nodeA: {
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"fe00:0:0:0:1::2"},
-						Port:  8080,
-					},
+					nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe00:0:0:0:1::2"}}},
 				},
 				externalTrafficLocal: true,
 			},
@@ -4525,18 +4240,12 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 				vips:     []string{"1.2.3.4", "fe10::1"},
 				protocol: corev1.ProtocolTCP,
 				inport:   80,
-				clusterEndpoints: util.LBEndpoints{
+				clusterEndpoints: util.LBEndpoints{{Port: 8080,
 					V4IPs: []string{"192.168.0.1"},
 					V6IPs: []string{"fe00:0:0:0:1::2"},
-
-					Port: 8080,
-				},
+				}},
 				nodeEndpoints: util.PortToLBEndpoints{
-					nodeA: {
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"fe00:0:0:0:1::2"},
-						Port:  8080,
-					},
+					nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe00:0:0:0:1::2"}}},
 				},
 				externalTrafficLocal: true,
 			},
@@ -4551,11 +4260,10 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 				vips:     []string{"1.2.3.4", "fe10::1"},
 				protocol: corev1.ProtocolTCP,
 				inport:   80,
-				clusterEndpoints: util.LBEndpoints{
+				clusterEndpoints: util.LBEndpoints{{Port: 8080,
 					V4IPs: []string{"192.168.1.1"},     // on nodeB
 					V6IPs: []string{"fe00:0:0:0:2::2"}, // on nodeB
-					Port:  8080,
-				},
+				}},
 				// nothing on nodeA
 				externalTrafficLocal: true,
 			},
@@ -4568,7 +4276,7 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 	}
 	for i, tt := range tc {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
-			actualTargetIPsV4, actualTargetIPsV6, actualV4Changed, actualV6Changed := makeNodeSwitchTargetIPs(tt.node, tt.config)
+			actualTargetIPsV4, actualTargetIPsV6, actualV4Changed, actualV6Changed := makeNodeSwitchTargetIPs(tt.node, tt.config.clusterEndpoints.GetEntryByPort(8080), tt.config)
 			assert.Equal(t, tt.expectedTargetIPsV4, actualTargetIPsV4)
 			assert.Equal(t, tt.expectedTargetIPsV6, actualTargetIPsV6)
 			assert.Equal(t, tt.expectedV4Changed, actualV4Changed)

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -6,6 +6,8 @@ package services
 import (
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -2851,6 +2853,125 @@ func Test_buildPerNodeLBs(t *testing.T) {
 
 }
 
+// Test_buildTemplateLBs_multipleTargetPorts verifies that when multiple target
+// ports coexist (e.g. during a rolling update), buildTemplateLBs produces
+// template values that include targets for ALL port numbers, not just the last
+// one processed.
+func Test_buildTemplateLBs_multipleTargetPorts(t *testing.T) {
+	oldGwMode := globalconfig.Gateway.Mode
+	oldClusterSubnet := globalconfig.Default.ClusterSubnets
+	oldIPv4Mode := globalconfig.IPv4Mode
+	defer func() {
+		globalconfig.Gateway.Mode = oldGwMode
+		globalconfig.Default.ClusterSubnets = oldClusterSubnet
+		globalconfig.IPv4Mode = oldIPv4Mode
+	}()
+
+	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
+	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 26}}
+	globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
+	globalconfig.IPv4Mode = true
+
+	name := "foo"
+	namespace := "testns"
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+		},
+	}
+
+	// Two nodes are needed so that ETP=local creates per-node differences,
+	// which forces the template path (needsTemplate=true).
+	nodes := []nodeInfo{
+		{
+			name:               nodeA,
+			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.1")},
+			hostAddresses:      []net.IP{net.ParseIP("10.0.0.1")},
+			chassisID:          "chassis-a",
+			gatewayRouterName:  "gr-node-a",
+			switchName:         "switch-node-a",
+			podSubnets:         []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+		{
+			name:               nodeB,
+			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.2")},
+			hostAddresses:      []net.IP{net.ParseIP("10.0.0.2")},
+			chassisID:          "chassis-b",
+			gatewayRouterName:  "gr-node-b",
+			switchName:         "switch-node-b",
+			podSubnets:         []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+		},
+	}
+
+	nodeIPv4Templates := NewNodeIPsTemplates(corev1.IPv4Protocol)
+	nodeIPv4Templates.AddIP("chassis-a", net.ParseIP("10.0.0.1"))
+	nodeIPv4Templates.AddIP("chassis-b", net.ParseIP("10.0.0.2"))
+	nodeIPv6Templates := NewNodeIPsTemplates(corev1.IPv6Protocol)
+
+	// Simulate a rolling update with ETP=local: port 8080 endpoints are on
+	// nodeA, port 9090 endpoints are on nodeB. This creates per-node
+	// differences that force the template code path.
+	configs := []lbConfig{
+		{
+			vips:     []string{placeholderNodeIPs},
+			protocol: corev1.ProtocolTCP,
+			inport:   80,
+			clusterEndpoints: util.LBEndpoints{
+				{Port: 8080, V4IPs: []string{"192.168.0.1"}},
+				{Port: 9090, V4IPs: []string{"192.168.0.2"}},
+			},
+			nodeEndpoints: util.PortToLBEndpoints{
+				nodeA: {
+					{Port: 8080, V4IPs: []string{"192.168.0.1"}},
+				},
+				nodeB: {
+					{Port: 9090, V4IPs: []string{"192.168.0.2"}},
+				},
+			},
+			externalTrafficLocal: true,
+			hasNodePort:          true,
+		},
+	}
+
+	result := buildTemplateLBs(service, configs, nodes, nodeIPv4Templates, nodeIPv6Templates, &util.DefaultNetInfo{})
+	require.NotEmpty(t, result, "expected at least one template LB")
+
+	// For each LB, collect all target ports from all rules. With templates,
+	// the per-chassis values are strings like "192.168.0.1:8080,192.168.0.2:9090".
+	// Before the fix, the template value would only contain one port's
+	// targets because the second portno iteration overwrote the first.
+	for _, lb := range result {
+		allTargetPorts := sets.New[int32]()
+		for _, rule := range lb.Rules {
+			for _, tgt := range rule.Targets {
+				if tgt.Template != nil {
+					for _, value := range tgt.Template.Value {
+						for _, addr := range strings.Split(value, ",") {
+							if addr == "" {
+								continue
+							}
+							parts := strings.Split(addr, ":")
+							if len(parts) == 2 {
+								port, err := strconv.Atoi(parts[1])
+								if err == nil {
+									allTargetPorts.Insert(int32(port))
+								}
+							}
+						}
+					}
+				} else if tgt.Port != 0 {
+					allTargetPorts.Insert(tgt.Port)
+				}
+			}
+		}
+		assert.True(t, allTargetPorts.Has(8080),
+			"LB %q should have targets with port 8080, got ports: %v", lb.Name, allTargetPorts.UnsortedList())
+		assert.True(t, allTargetPorts.Has(9090),
+			"LB %q should have targets with port 9090, got ports: %v", lb.Name, allTargetPorts.UnsortedList())
+	}
+}
+
 func Test_idledServices(t *testing.T) {
 	serviceName := "foo"
 	ns := "testns"
@@ -2970,7 +3091,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // no need for local endpoints, service is not ETP or ITP local
 		},
 		{
@@ -2998,9 +3119,9 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}}, // ETP=local, one local endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}}, // ETP=local, one local endpoint
 		},
 		{
 			name: "slice with one non-local endpoint, ETP=local",
@@ -3027,7 +3148,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // ETP=local but no local endpoint
 		},
 		{
@@ -3082,9 +3203,9 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA, nodeB), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): {nodeB: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}}, // endpoint on nodeB
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeB: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}}, // endpoint on nodeB
 		},
 		{
 			name: "slice with different port name than the service",
@@ -3138,9 +3259,9 @@ func Test_getEndpointsForService(t *testing.T) {
 
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, ""): util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, ""): util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				getServicePortKey(tcp, ""): {nodeA: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.2"}, []string{})}}}, // one local endpoint
+				util.GetServicePortKey(tcp, ""): {nodeA: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.2"}, []string{})}}}, // one local endpoint
 		},
 		{
 			name: "slice with an IPv6 endpoint",
@@ -3167,7 +3288,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::2"})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::2"})}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, //  local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3211,9 +3332,9 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}}},
 		},
 		{
 			name: "one slice with a duplicate address in the same endpoint",
@@ -3240,7 +3361,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3268,7 +3389,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3312,7 +3433,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3356,11 +3477,11 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})},
-				getServicePortKey(tcp, "other-port"):  util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})},
+				util.GetServicePortKey(tcp, "other-port"):  util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
-				getServicePortKey(tcp, "other-port"):  {nodeA: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "other-port"):  {nodeA: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}}},
 		},
 		{
 			name: "multiples slices with different ports, OVN zone with two nodes, ETP=local",
@@ -3403,11 +3524,11 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA, nodeB), // zone with two nodes
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})},
-				getServicePortKey(tcp, "other-port"):  util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})},
+				util.GetServicePortKey(tcp, "other-port"):  util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
-				getServicePortKey(tcp, "other-port"):  {nodeB: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "other-port"):  {nodeB: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}}},
 		},
 		{
 			name: "slice with a mix of ready and terminating (serving and non-serving) endpoints",
@@ -3441,7 +3562,7 @@ func Test_getEndpointsForService(t *testing.T) {
 
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::2", "2001:db2::3"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::2", "2001:db2::3"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3474,7 +3595,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::4", "2001:db2::5"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::4", "2001:db2::5"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3555,7 +3676,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::3", "2001:db2::4"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::3", "2001:db2::4"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3655,7 +3776,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3705,7 +3826,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.3"}, []string{"2001:db2::3"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.3"}, []string{"2001:db2::3"})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3805,7 +3926,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA),                                                                // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.0.0.3", "10.0.0.4"},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.0.0.3", "10.0.0.4"},
 					[]string{"2001:db2::2", "2001:db2::3", "2001:db2::4"})}},
 
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
@@ -3853,12 +3974,12 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): {
+				util.GetServicePortKey(tcp, "tcp-example"): {
 					newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{}),
 					newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{}),
 				}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{
 					newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{}),
 					newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{}),
 				}}},
@@ -3906,9 +4027,9 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				getServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}}},
 		},
 		// The following should never happen in k8s - endpoints should not be empty.
 		{

--- a/go-controller/pkg/ovn/controller/services/loadbalancer.go
+++ b/go-controller/pkg/ovn/controller/services/loadbalancer.go
@@ -397,13 +397,19 @@ func buildLB(lb *LB) *templateLoadBalancer {
 
 // buildVipMap returns a viups map from a set of rules
 func buildVipMap(rules []LBRule) map[string]string {
+	// the same rule source could have multiple rules each owns different target port number,
+	// consolidate all the targets of different target port number.
+	vipTgts := make(map[string][]string)
 	vipMap := make(map[string]string, len(rules))
 	for _, r := range rules {
 		tgts := make([]string, 0, len(r.Targets))
 		for _, tgt := range r.Targets {
 			tgts = append(tgts, tgt.String())
 		}
-		vipMap[r.Source.String()] = strings.Join(tgts, ",")
+		vipTgts[r.Source.String()] = append(vipTgts[r.Source.String()], tgts...)
+	}
+	for source, tgts := range vipTgts {
+		vipMap[source] = strings.Join(tgts, ",")
 	}
 
 	return vipMap

--- a/go-controller/pkg/ovn/controller/services/svc_template_var.go
+++ b/go-controller/pkg/ovn/controller/services/svc_template_var.go
@@ -73,6 +73,20 @@ func makeTemplate(name string) *Template {
 	return &Template{Name: name, Value: map[string]string{}}
 }
 
+// appendTemplateValue appends a comma-separated value to a template's
+// per-chassis entry. This is used when accumulating targets across
+// multiple port numbers into a single template.
+func appendTemplateValue(t *Template, chassisID, value string) {
+	if value == "" {
+		return
+	}
+	if existing := t.Value[chassisID]; existing != "" {
+		t.Value[chassisID] = existing + "," + value
+	} else {
+		t.Value[chassisID] = value
+	}
+}
+
 func forEachNBTemplateInMaps(templateMaps []TemplateMap, callback func(nbTemplate *nbdb.ChassisTemplateVar) bool) {
 	// First flatten the maps into *nbdb.ChassisTemplateVar records:
 	flattened := ChassisTemplateVarMap{}

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -618,14 +618,14 @@ func TestHasLocalHostNetworkEndpoints(t *testing.T) {
 		{
 			"Tests with local endpoints that include the node address",
 			PortToLBEndpoints{"test": LBEndpoints{
-				V4IPs: []string{ep1Address, ep2Address},
+				{V4IPs: []string{ep1Address, ep2Address}},
 			}},
 			true,
 		},
 		{
 			"Tests against a different local endpoint than the node address",
 			PortToLBEndpoints{"test": LBEndpoints{
-				V4IPs: []string{ep2Address},
+				{V4IPs: []string{ep2Address}},
 			}},
 			false,
 		},

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -743,6 +743,16 @@ func ReplaceOFFlows(bridgeName string, flows []string) (string, string, error) {
 	return strings.Trim(stdout.String(), "\" \n"), stderr.String(), err
 }
 
+// AddOrModOFGroup creates or modifies an OpenFlow group on the bridge.
+func AddOrModOFGroup(bridgeName, group string) (string, string, error) {
+	return RunOVSOfctl("-O", "OpenFlow13", "--may-create", "mod-group", bridgeName, group)
+}
+
+// DeleteOFGroup deletes an OpenFlow group from the bridge by group ID.
+func DeleteOFGroup(bridgeName, groupID string) (string, string, error) {
+	return RunOVSOfctl("-O", "OpenFlow13", "del-groups", bridgeName, fmt.Sprintf("group_id=%s", groupID))
+}
+
 // GetOFFlows gets all the flows from a bridge
 func GetOFFlows(bridgeName string) ([]string, error) {
 	stdout, stderr, err := RunOVSOfctl("dump-flows", bridgeName)

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -691,36 +691,54 @@ type IPPort struct {
 	Port int32
 }
 
-// LBEndpoints contains load balancer endpoint information with IPv4 and IPv6 addresses.
+// LBEndpointEntry contains load balancer endpoint information for a single target port
+// with IPv4 and IPv6 addresses.
 // Port is the endpoint port (the one exposed by the pod) and IPs are the IP addresses of the backend pods.
-// e.g. LBEndpoints{Port: 8080, V4IPs: []string{"192.168.1.10", "192.168.1.11"}, V6IPs: []string{"2001:db8::1"}}.
-// TBD: currently, OVNK only supports a single backend port per named port.
-type LBEndpoints struct {
+// e.g. LBEndpointEntry{Port: 8080, V4IPs: []string{"192.168.1.10", "192.168.1.11"}, V6IPs: []string{"2001:db8::1"}}.
+type LBEndpointEntry struct {
 	Port  int32
 	V4IPs []string
 	V6IPs []string
 }
 
-// GetV4Destinations builds IPv4 destination mappings from endpoint addresses to ports.
-// e.g. for V4IPs ["192.168.1.10", "192.168.1.11"] and Port 8080, returns
-// []IPPort{{IP: "192.168.1.10", Port: 8080}, {IP: "192.168.1.11", Port: 8080}}.
+// LBEndpoints holds endpoint entries for one or more target ports.
+// During a rolling update that changes a service's target port, a single service port
+// may temporarily map to multiple target ports (e.g., both 8080 and 9090).
+type LBEndpoints []LBEndpointEntry
+
+// GetV4Destinations builds IPv4 destination mappings from all endpoint entries.
+// e.g. for entries [{Port: 8080, V4IPs: ["10.0.0.1"]}, {Port: 9090, V4IPs: ["10.0.0.2"]}], returns
+// []IPPort{{IP: "10.0.0.1", Port: 8080}, {IP: "10.0.0.2", Port: 9090}}.
 func (le LBEndpoints) GetV4Destinations() []IPPort {
 	destinations := []IPPort{}
-	for _, ip := range le.V4IPs {
-		destinations = append(destinations, IPPort{IP: ip, Port: le.Port})
+	for _, entry := range le {
+		for _, ip := range entry.V4IPs {
+			destinations = append(destinations, IPPort{IP: ip, Port: entry.Port})
+		}
 	}
 	return destinations
 }
 
-// GetV6Destinations builds IPv6 destination mappings from endpoint addresses to ports.
-// e.g. for V6IPs ["2001:db8::1", "2001:db8::2"] and Port 8080, returns
-// []IPPort{{IP: "2001:db8::1", Port: 8080}, {IP: "2001:db8::2", Port: 8080}}.
+// GetV6Destinations builds IPv6 destination mappings from all endpoint entries.
 func (le LBEndpoints) GetV6Destinations() []IPPort {
 	destinations := []IPPort{}
-	for _, ip := range le.V6IPs {
-		destinations = append(destinations, IPPort{IP: ip, Port: le.Port})
+	for _, entry := range le {
+		for _, ip := range entry.V6IPs {
+			destinations = append(destinations, IPPort{IP: ip, Port: entry.Port})
+		}
 	}
 	return destinations
+}
+
+// GetEntryByPort returns the LBEndpointEntry for the given target port number,
+// or an empty entry if not found.
+func (le LBEndpoints) GetEntryByPort(port int32) LBEndpointEntry {
+	for _, entry := range le {
+		if entry.Port == port {
+			return entry
+		}
+	}
+	return LBEndpointEntry{}
 }
 
 // PortToLBEndpoints maps service port keys (protocol + service port name) to load balancer endpoints.
@@ -742,8 +760,10 @@ func (p PortToLBEndpoints) GetLBEndpoints(key string) (LBEndpoints, error) {
 func (p PortToLBEndpoints) GetAddresses() sets.Set[string] {
 	s := sets.New[string]()
 	for _, lbEndpoints := range p {
-		s.Insert(lbEndpoints.V4IPs...)
-		s.Insert(lbEndpoints.V6IPs...)
+		for _, entry := range lbEndpoints {
+			s.Insert(entry.V4IPs...)
+			s.Insert(entry.V6IPs...)
+		}
 	}
 	return s
 }
@@ -803,7 +823,7 @@ func (p PortToNodeToLBEndpoints) GetNode(node string) PortToLBEndpoints {
 // Validation requirements:
 //   - EndpointSlice port names must match Service port names (when service is not nil)
 //   - Only one protocol per port name is supported (Kubernetes requirement).
-//   - Only one target port number per protocol/port combination is supported (OVNKubernetes limitation).
+//   - Multiple target port numbers per protocol/port combination are supported (e.g., during rolling updates).
 func GetEndpointsForService(endpointSlices []*discoveryv1.EndpointSlice, service *corev1.Service,
 	nodes sets.Set[string], needsGlobalEndpoints, needsLocalEndpoints bool) (PortToLBEndpoints, PortToNodeToLBEndpoints, error) {
 
@@ -848,30 +868,32 @@ func GetEndpointsForService(endpointSlices []*discoveryv1.EndpointSlice, service
 				continue
 			}
 
-			// Process the first (and typically only) target port number.
-			// OVN currently does not support multiple target port numbers for the same service name.
+			// Process all target port numbers for this service port key.
+			// During rolling updates, a service port may temporarily map to multiple target ports
+			// (e.g., old pods on port 8080 and new pods on port 9090).
 			portNumbers := maps.Keys(portNumberMap)
 			slices.Sort(portNumbers)
-			if len(portNumbers) > 1 {
-				addValidationError("OVN Kubernetes does not support more than one target port per service port",
-					fmt.Sprintf("servicePortKey %q portNumbers %v",
-						slicePortKey, portNumbers))
-			}
-			targetPortNumber := portNumbers[0]
-			endpointList := portNumberMap[targetPortNumber]
-			// Build global endpoint mapping.
-			if needsGlobalEndpoints {
-				lbe, err := buildLBEndpoints(service, targetPortNumber, endpointList)
-				if err != nil {
-					klog.Warningf("Failed to build global endpoints for port %s: %v", slicePortKey, err)
-					continue
+			for _, targetPortNumber := range portNumbers {
+				endpointList := portNumberMap[targetPortNumber]
+				if needsGlobalEndpoints {
+					entry, err := buildLBEndpointEntry(service, targetPortNumber, endpointList)
+					if err != nil {
+						klog.Warningf("Failed to build global endpoints for port %s/%d: %v", slicePortKey, targetPortNumber, err)
+						continue
+					}
+					globalEndpoints[slicePortKey] = append(globalEndpoints[slicePortKey], entry)
 				}
-				globalEndpoints[slicePortKey] = lbe
-			}
-			// Build per-node endpoint mapping if needed for traffic policies.
-			if needsLocalEndpoints {
-				if lbe, err := buildNodeLBEndpoints(service, targetPortNumber, endpointList, nodes); err == nil {
-					localEndpoints[slicePortKey] = lbe
+				if needsLocalEndpoints {
+					nodeEntries, err := buildNodeLBEndpointEntry(service, targetPortNumber, endpointList, nodes)
+					if err != nil {
+						continue
+					}
+					for node, entry := range nodeEntries {
+						if localEndpoints[slicePortKey] == nil {
+							localEndpoints[slicePortKey] = map[string]LBEndpoints{}
+						}
+						localEndpoints[slicePortKey][node] = append(localEndpoints[slicePortKey][node], entry)
+					}
 				}
 			}
 		}
@@ -930,7 +952,7 @@ func groupEndpointsByNode(endpoints []discoveryv1.Endpoint) map[string][]discove
 	return nodeEndpoints
 }
 
-// buildNodeLBEndpoints creates a per-node mapping of load balancer endpoints.
+// buildNodeLBEndpointEntry creates a per-node mapping of load balancer endpoint entries for a single target port.
 // Only nodes present in the provided node set are included in the result.
 // This is used for services with local traffic policies that require per-node endpoint tracking.
 //
@@ -941,16 +963,16 @@ func groupEndpointsByNode(endpoints []discoveryv1.Endpoint) map[string][]discove
 //   - nodes: Set of valid node names to include
 //
 // Returns:
-//   - map[string]LBEndpoints: Node name to LBEndpoints mapping
-func buildNodeLBEndpoints(service *corev1.Service, portNumber int32, endpoints []discoveryv1.Endpoint, nodes sets.Set[string]) (map[string]LBEndpoints, error) {
-	nodeLBEndpoints := map[string]LBEndpoints{}
+//   - map[string]LBEndpointEntry: Node name to LBEndpointEntry mapping
+func buildNodeLBEndpointEntry(service *corev1.Service, portNumber int32, endpoints []discoveryv1.Endpoint, nodes sets.Set[string]) (map[string]LBEndpointEntry, error) {
+	nodeLBEndpoints := map[string]LBEndpointEntry{}
 
 	nodeEndpoints := groupEndpointsByNode(endpoints)
 	for node, nodeEndpoints := range nodeEndpoints {
 		if !nodes.Has(node) {
 			continue
 		}
-		lbe, err := buildLBEndpoints(service, portNumber, nodeEndpoints)
+		lbe, err := buildLBEndpointEntry(service, portNumber, nodeEndpoints)
 		if err != nil {
 			klog.Warningf("Failed to build node endpoints for node %s port %d: %v", node, portNumber, err)
 			continue
@@ -964,9 +986,9 @@ func buildNodeLBEndpoints(service *corev1.Service, portNumber int32, endpoints [
 	return nodeLBEndpoints, nil
 }
 
-// buildLBEndpoints constructs an LBEndpoints structure from a list of discovery endpoints.
+// buildLBEndpointEntry constructs an LBEndpointEntry from a list of discovery endpoints.
 // It filters endpoints for eligibility, separates IPv4 and IPv6 addresses, and returns
-// an empty LBEndpoints if no valid addresses are found.
+// an empty LBEndpointEntry if no valid addresses are found.
 //
 // Parameters:
 //   - service: The Kubernetes Service object (used for endpoint eligibility filtering)
@@ -975,30 +997,30 @@ func buildNodeLBEndpoints(service *corev1.Service, portNumber int32, endpoints [
 //   - endpoints: List of discovery endpoints to process
 //
 // Returns:
-//   - LBEndpoints: Structure containing IPv4/IPv6 addresses and port number
-func buildLBEndpoints(service *corev1.Service, port int32, endpoints []discoveryv1.Endpoint) (LBEndpoints, error) {
+//   - LBEndpointEntry: Structure containing IPv4/IPv6 addresses and port number
+func buildLBEndpointEntry(service *corev1.Service, port int32, endpoints []discoveryv1.Endpoint) (LBEndpointEntry, error) {
 	addresses := GetEligibleEndpointAddresses(endpoints, service)
 	v4IPs, v4ErrorNoIP := MatchAllIPStringFamily(false, addresses)
 	v6IPs, v6ErrorNoIP := MatchAllIPStringFamily(true, addresses)
 
 	if v4ErrorNoIP != nil && v6ErrorNoIP != nil {
 		if service != nil {
-			return LBEndpoints{}, fmt.Errorf("empty IP address endpoints for service %s/%s", service.Namespace, service.Name)
+			return LBEndpointEntry{}, fmt.Errorf("empty IP address endpoints for service %s/%s", service.Namespace, service.Name)
 		} else {
-			return LBEndpoints{}, fmt.Errorf("empty IP address endpoints")
+			return LBEndpointEntry{}, fmt.Errorf("empty IP address endpoints")
 		}
 	}
 
 	if port <= 0 || port > 65535 {
 		if service != nil {
-			return LBEndpoints{}, fmt.Errorf("invalid endpoint port %d for service %s/%s: port must be between 1-65535",
+			return LBEndpointEntry{}, fmt.Errorf("invalid endpoint port %d for service %s/%s: port must be between 1-65535",
 				port, service.Namespace, service.Name)
 		} else {
-			return LBEndpoints{}, fmt.Errorf("invalid endpoint port %d: port must be between 1-65535", port)
+			return LBEndpointEntry{}, fmt.Errorf("invalid endpoint port %d: port must be between 1-65535", port)
 		}
 	}
 
-	return LBEndpoints{
+	return LBEndpointEntry{
 		V4IPs: v4IPs,
 		V6IPs: v6IPs,
 		Port:  port,

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/ipalloc"
 	e2eendpointslice "k8s.io/kubernetes/test/e2e/framework/endpointslice"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -1615,7 +1617,882 @@ spec:
 			}
 		})
 	})
+
+	// This test verifies that a ClusterIP service remains reachable during a
+	// rolling update that changes the container's target port. During the
+	// rolling update, endpoint slices will contain endpoints with different
+	// target port numbers for the same named port. OVN-K must program LB
+	// rules for all distinct target ports so that both old and new pods
+	// remain reachable.
+	//
+	// The test pauses the rollout once both target ports are observed in the
+	// endpoint slices. While paused, no pods are being terminated, so every
+	// request must succeed -- any failure indicates that OVN-K failed to
+	// program LB rules for both target ports (the SDN-3551 bug).
+	ginkgo.It("Maintains service connectivity during rolling update when target port changes", func() {
+		namespace := f.Namespace.Name
+		ctx := context.TODO()
+
+		const (
+			deploymentName = "rolling-update-backend"
+			svcName        = "rolling-update-svc"
+			portName       = "http"
+			svcPort        = int32(80)
+			oldTargetPort  = int32(8080)
+			newTargetPort  = int32(9090)
+		)
+		replicas := int32(4)
+
+		ginkgo.By(fmt.Sprintf("Creating a deployment with %d replicas listening on port %d", replicas, oldTargetPort))
+		labels := map[string]string{"app": "rolling-update-test"}
+		maxUnavailable := intstr.FromInt(0)
+		maxSurge := intstr.FromInt(1)
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentName,
+				Namespace: namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &maxUnavailable,
+						MaxSurge:       &maxSurge,
+					},
+				},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:    "agnhost",
+								Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+								Command: []string{"/agnhost", "serve-hostname", fmt.Sprintf("--port=%d", oldTargetPort)},
+								Ports: []v1.ContainerPort{
+									{
+										Name:          portName,
+										ContainerPort: oldTargetPort,
+										Protocol:      v1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := cs.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for deployment to become ready")
+		err = wait.PollImmediate(framework.Poll, 2*time.Minute, func() (bool, error) {
+			dp, err := cs.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return dp.Status.ReadyReplicas == replicas, nil
+		})
+		framework.ExpectNoError(err, "deployment did not become ready in time")
+
+		ginkgo.By("Creating a ClusterIP service with named target port")
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcName,
+				Namespace: namespace,
+			},
+			Spec: v1.ServiceSpec{
+				Selector: labels,
+				Type:     v1.ServiceTypeClusterIP,
+				Ports: []v1.ServicePort{
+					{
+						Name:       portName,
+						Protocol:   v1.ProtocolTCP,
+						Port:       svcPort,
+						TargetPort: intstr.FromString(portName),
+					},
+				},
+			},
+		}
+		svc, err = cs.CoreV1().Services(namespace).Create(ctx, svc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Creating an exec pod for connectivity checks")
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, namespace, "exec-pod-rolling-update", nil)
+
+		serviceAddr := net.JoinHostPort(svc.Spec.ClusterIP, fmt.Sprintf("%d", svcPort))
+		curlCmd := fmt.Sprintf("curl -q -s --connect-timeout 3 http://%s/", serviceAddr)
+
+		ginkgo.By("Verifying initial service connectivity")
+		gomega.Eventually(func() error {
+			stdout, err := e2epodoutput.RunHostCmd(namespace, execPod.Name, curlCmd)
+			if err != nil {
+				return fmt.Errorf("connection failed: %v", err)
+			}
+			if strings.TrimSpace(stdout) == "" {
+				return fmt.Errorf("empty response from service")
+			}
+			framework.Logf("Initial connectivity check succeeded, got response: %s", strings.TrimSpace(stdout))
+			return nil
+		}, 30*time.Second, framework.Poll).Should(gomega.Succeed())
+
+		ginkgo.By("Recording initial (old) pod names before rolling update")
+		oldPodNames := sets.New[string]()
+		podList, err := cs.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=rolling-update-test",
+		})
+		framework.ExpectNoError(err)
+		for _, pod := range podList.Items {
+			oldPodNames.Insert(pod.Name)
+		}
+		framework.Logf("Old pod names: %v", oldPodNames.UnsortedList())
+
+		ginkgo.By(fmt.Sprintf("Triggering rolling update: changing target port from %d to %d", oldTargetPort, newTargetPort))
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			deployment, err = cs.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			deployment.Spec.Template.Spec.Containers[0].Command = []string{
+				"/agnhost", "serve-hostname", fmt.Sprintf("--port=%d", newTargetPort),
+			}
+			deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = newTargetPort
+			_, err = cs.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+			return err
+		})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for endpoint slices to contain both old and new target ports")
+		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
+			ports, err := getReadyEndpointSlicePorts(cs, namespace, svcName)
+			if err != nil {
+				framework.Logf("Transient error listing endpoint slices: %v", err)
+				return false, nil
+			}
+			if ports.Has(oldTargetPort) && ports.Has(newTargetPort) {
+				framework.Logf("Detected both target ports in endpoint slices: %v", ports.UnsortedList())
+				return true, nil
+			}
+			framework.Logf("Current target ports in endpoint slices: %v (waiting for both %d and %d)",
+				ports.UnsortedList(), oldTargetPort, newTargetPort)
+			return false, nil
+		})
+		framework.ExpectNoError(err, "timed out waiting for both target ports to appear in endpoint slices")
+
+		ginkgo.By("Pausing the rolling update to freeze the multi-port state")
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			deployment, err = cs.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			deployment.Spec.Paused = true
+			_, err = cs.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+			return err
+		})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for all backend pods to be running and ready (no in-flight terminations)")
+		err = wait.PollImmediate(framework.Poll, 1*time.Minute, func() (bool, error) {
+			pods, err := cs.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=rolling-update-test",
+			})
+			if err != nil {
+				return false, err
+			}
+			for _, pod := range pods.Items {
+				if pod.DeletionTimestamp != nil {
+					framework.Logf("Pod %s is still terminating", pod.Name)
+					return false, nil
+				}
+				if pod.Status.Phase != v1.PodRunning {
+					framework.Logf("Pod %s is in phase %s", pod.Name, pod.Status.Phase)
+					return false, nil
+				}
+				ready := false
+				for _, cond := range pod.Status.Conditions {
+					if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+						ready = true
+						break
+					}
+				}
+				if !ready {
+					framework.Logf("Pod %s is not ready", pod.Name)
+					return false, nil
+				}
+			}
+			framework.Logf("All %d backend pods are running and ready", len(pods.Items))
+			return true, nil
+		})
+		framework.ExpectNoError(err, "timed out waiting for all pods to be running and ready after pause")
+
+		ginkgo.By("Verifying endpoint slices still contain both target ports while paused")
+		var portNumbers sets.Set[int32]
+		gomega.Eventually(func() error {
+			var err error
+			portNumbers, err = getReadyEndpointSlicePorts(cs, namespace, svcName)
+			return err
+		}, 30*time.Second, framework.Poll).Should(gomega.Succeed())
+		framework.Logf("Target ports in endpoint slices while paused: %v", portNumbers.UnsortedList())
+		gomega.Expect(portNumbers.Has(oldTargetPort) && portNumbers.Has(newTargetPort)).To(gomega.BeTrue(),
+			"expected both target ports %d and %d in endpoint slices while paused, got: %v",
+			oldTargetPort, newTargetPort, portNumbers.UnsortedList())
+
+		ginkgo.By("Identifying new pods created by the rolling update")
+		newPodNames := sets.New[string]()
+		podList, err = cs.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=rolling-update-test",
+		})
+		framework.ExpectNoError(err)
+		for _, pod := range podList.Items {
+			if pod.DeletionTimestamp == nil && !oldPodNames.Has(pod.Name) {
+				newPodNames.Insert(pod.Name)
+			}
+		}
+		framework.Logf("New pod names (listening on port %d): %v", newTargetPort, newPodNames.UnsortedList())
+		gomega.Expect(newPodNames.Len()).To(gomega.BeNumerically(">", 0),
+			"expected at least one new pod after rolling update pause")
+
+		ginkgo.By("Verifying service traffic reaches both old and new pods (validates SDN-3551 fix)")
+		// Without the SDN-3551 fix, OVN-K programs LB backends with only
+		// one target port, so traffic never reaches pods on the other port.
+		// We verify that responses come from both old pods (port 8080) and
+		// new pods (port 9090), proving the LB has correct entries for both.
+		hitOld := sets.New[string]()
+		hitNew := sets.New[string]()
+		gomega.Eventually(func() error {
+			stdout, err := e2epodoutput.RunHostCmd(namespace, execPod.Name, curlCmd)
+			if err != nil {
+				return fmt.Errorf("connection failed: %v", err)
+			}
+			hostname := strings.TrimSpace(stdout)
+			if hostname == "" {
+				return fmt.Errorf("empty response from service")
+			}
+			if oldPodNames.Has(hostname) {
+				hitOld.Insert(hostname)
+			} else if newPodNames.Has(hostname) {
+				hitNew.Insert(hostname)
+			}
+			if hitOld.Len() > 0 && hitNew.Len() > 0 {
+				return nil
+			}
+			return fmt.Errorf("have not yet hit both old and new pods: hitOld=%v, hitNew=%v",
+				hitOld.UnsortedList(), hitNew.UnsortedList())
+		}, 30*time.Second, 500*time.Millisecond).Should(gomega.Succeed(),
+			"traffic must reach both old pods (port %d) and new pods (port %d) to confirm LB has rules for both target ports",
+			oldTargetPort, newTargetPort)
+		framework.Logf("Confirmed traffic reached old pods %v and new pods %v", hitOld.UnsortedList(), hitNew.UnsortedList())
+
+		ginkgo.By("Resuming the rolling update")
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			deployment, err = cs.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			deployment.Spec.Paused = false
+			_, err = cs.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+			return err
+		})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for the rolling update to complete")
+		err = wait.PollImmediate(framework.Poll, 3*time.Minute, func() (bool, error) {
+			dp, err := cs.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return dp.Status.UpdatedReplicas == replicas &&
+				dp.Status.ReadyReplicas == replicas &&
+				dp.Status.AvailableReplicas == replicas, nil
+		})
+		framework.ExpectNoError(err, "rolling update did not complete in time")
+
+		ginkgo.By("Verifying service connectivity after the rolling update completes")
+		gomega.Eventually(func() error {
+			stdout, err := e2epodoutput.RunHostCmd(namespace, execPod.Name, curlCmd)
+			if err != nil {
+				return fmt.Errorf("connection failed: %v", err)
+			}
+			if strings.TrimSpace(stdout) == "" {
+				return fmt.Errorf("empty response from service")
+			}
+			framework.Logf("Post-rollout connectivity check succeeded, got response: %s", strings.TrimSpace(stdout))
+			return nil
+		}, 30*time.Second, framework.Poll).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying all endpoint slices with ready endpoints now use only the new target port")
+		gomega.Eventually(func() error {
+			ports, err := getReadyEndpointSlicePorts(cs, namespace, svcName)
+			if err != nil {
+				return fmt.Errorf("listing endpoint slices: %v", err)
+			}
+			if ports.Has(oldTargetPort) {
+				return fmt.Errorf("old target port %d still present in endpoint slices: %v", oldTargetPort, ports.UnsortedList())
+			}
+			if !ports.Has(newTargetPort) {
+				return fmt.Errorf("new target port %d not found in endpoint slices: %v", newTargetPort, ports.UnsortedList())
+			}
+			return nil
+		}, 2*time.Minute, framework.Poll).Should(gomega.Succeed(),
+			"after rolling update completes, all endpoint slices should use the new target port")
+	})
+
+	// This test verifies that a ClusterIP service with multiple endpoints
+	// using different numerical values for the same named port correctly
+	// load-balances across all target ports. This can occur in steady state
+	// when pods with different container images resolve a named port to
+	// different numbers, or transiently during rolling updates.
+	ginkgo.It("Distributes traffic to multiple endpoints with different named target ports", func() {
+		namespace := f.Namespace.Name
+		ctx := context.TODO()
+
+		const (
+			svcName  = "multi-target-port-svc"
+			portName = "http"
+			svcPort  = int32(80)
+			port1    = int32(8080)
+			port2    = int32(9090)
+		)
+
+		labels := map[string]string{"app": "multi-target-port"}
+
+		ginkgo.By(fmt.Sprintf("Creating first pod listening on port %d", port1))
+		pod1 := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backend-port-1",
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "agnhost",
+						Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+						Command: []string{"/agnhost", "serve-hostname", fmt.Sprintf("--port=%d", port1)},
+						Ports: []v1.ContainerPort{
+							{
+								Name:          portName,
+								ContainerPort: port1,
+								Protocol:      v1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := cs.CoreV1().Pods(namespace).Create(ctx, pod1, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By(fmt.Sprintf("Creating second pod listening on port %d", port2))
+		pod2 := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backend-port-2",
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "agnhost",
+						Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+						Command: []string{"/agnhost", "serve-hostname", fmt.Sprintf("--port=%d", port2)},
+						Ports: []v1.ContainerPort{
+							{
+								Name:          portName,
+								ContainerPort: port2,
+								Protocol:      v1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err = cs.CoreV1().Pods(namespace).Create(ctx, pod2, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for both pods to be running and ready")
+		err = e2epod.WaitForPodsRunningReady(ctx, cs, namespace, 2, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Creating a ClusterIP service with a named target port")
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcName,
+				Namespace: namespace,
+			},
+			Spec: v1.ServiceSpec{
+				Selector: labels,
+				Type:     v1.ServiceTypeClusterIP,
+				Ports: []v1.ServicePort{
+					{
+						Name:       portName,
+						Protocol:   v1.ProtocolTCP,
+						Port:       svcPort,
+						TargetPort: intstr.FromString(portName),
+					},
+				},
+			},
+		}
+		svc, err = cs.CoreV1().Services(namespace).Create(ctx, svc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for endpoint slices to contain both target ports")
+		err = wait.PollImmediate(framework.Poll, 1*time.Minute, func() (bool, error) {
+			ports, err := getReadyEndpointSlicePorts(cs, namespace, svcName)
+			if err != nil {
+				return false, nil
+			}
+			if ports.Has(port1) && ports.Has(port2) {
+				framework.Logf("Endpoint slices contain both ports: %v", ports.UnsortedList())
+				return true, nil
+			}
+			framework.Logf("Current endpoint slice ports: %v (waiting for both %d and %d)", ports.UnsortedList(), port1, port2)
+			return false, nil
+		})
+		framework.ExpectNoError(err, "timed out waiting for both target ports in endpoint slices")
+
+		ginkgo.By("Creating a client pod to curl the service")
+		clientPod := e2epod.NewAgnhostPod(namespace, "curl-client", nil, nil, nil)
+		clientPod.Spec.Containers[0].Command = []string{"sleep", "infinity"}
+		clientPod = e2epod.NewPodClient(f).CreateSync(ctx, clientPod)
+
+		ginkgo.By("Verifying service traffic reaches both backends (different target ports)")
+		clusterIP := svc.Spec.ClusterIP
+		curlCmd := fmt.Sprintf("curl -q -s --connect-timeout 2 http://%s/",
+			net.JoinHostPort(clusterIP, fmt.Sprintf("%d", svcPort)))
+
+		hitPod1 := false
+		hitPod2 := false
+		gomega.Eventually(func() error {
+			stdout, err := e2epodoutput.RunHostCmd(namespace, clientPod.Name, curlCmd)
+			if err != nil {
+				return fmt.Errorf("connection failed: %v", err)
+			}
+			hostname := strings.TrimSpace(stdout)
+			if hostname == "" {
+				return fmt.Errorf("empty response from service")
+			}
+			framework.Logf("Got response from: %s", hostname)
+			if hostname == pod1.Name {
+				hitPod1 = true
+			} else if hostname == pod2.Name {
+				hitPod2 = true
+			}
+			if hitPod1 && hitPod2 {
+				return nil
+			}
+			return fmt.Errorf("have not yet hit both pods: hitPod1=%v, hitPod2=%v", hitPod1, hitPod2)
+		}, 30*time.Second, 500*time.Millisecond).Should(gomega.Succeed(),
+			"traffic must reach both endpoints (ports %d and %d) to confirm LB has rules for all target ports",
+			port1, port2)
+		framework.Logf("Confirmed traffic reached both pods: %s (port %d) and %s (port %d)",
+			pod1.Name, port1, pod2.Name, port2)
+	})
+
+	// This test verifies that ETP=Local NodePort services with host-networked
+	// endpoints correctly load-balance across multiple target ports when
+	// using named ports. Two host-network pods on the same node listen on
+	// different ports but share the same named port in their container spec.
+	// The OpenFlow group installed on breth0 must select between both target
+	// ports for new incoming connections.
+	ginkgo.It("Distributes traffic to multiple host-network endpoints with different named target ports", func() {
+		namespace := f.Namespace.Name
+		ctx := context.TODO()
+
+		const (
+			svcName  = "host-net-multi-port-svc"
+			portName = "http"
+			svcPort  = int32(80)
+		)
+		port1 := int32(infraprovider.Get().GetK8HostPort())
+		port2 := int32(infraprovider.Get().GetK8HostPort())
+		gomega.Expect(port1).ToNot(gomega.Equal(port2),
+			"allocated host ports must differ")
+
+		ginkgo.By("Selecting a schedulable node for host-network pods")
+		nodeList, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 1)
+		framework.ExpectNoError(err)
+		gomega.Expect(nodeList.Items).ToNot(gomega.BeEmpty())
+		nodeName := nodeList.Items[0].Name
+
+		labels := map[string]string{"app": "host-net-multi-port"}
+
+		ginkgo.By(fmt.Sprintf("Creating first host-network pod listening on port %d", port1))
+		pod1 := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "host-net-pod-1",
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: v1.PodSpec{
+				NodeName:    nodeName,
+				HostNetwork: true,
+				Containers: []v1.Container{
+					{
+						Name:    "agnhost",
+						Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+						Command: []string{"/agnhost", "netexec", fmt.Sprintf("--http-port=%d", port1), "--udp-port=-1"},
+						Ports: []v1.ContainerPort{
+							{
+								Name:          portName,
+								ContainerPort: port1,
+								Protocol:      v1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err = cs.CoreV1().Pods(namespace).Create(ctx, pod1, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By(fmt.Sprintf("Creating second host-network pod listening on port %d", port2))
+		pod2 := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "host-net-pod-2",
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: v1.PodSpec{
+				NodeName:    nodeName,
+				HostNetwork: true,
+				Containers: []v1.Container{
+					{
+						Name:    "agnhost",
+						Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+						Command: []string{"/agnhost", "netexec", fmt.Sprintf("--http-port=%d", port2), "--udp-port=-1"},
+						Ports: []v1.ContainerPort{
+							{
+								Name:          portName,
+								ContainerPort: port2,
+								Protocol:      v1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err = cs.CoreV1().Pods(namespace).Create(ctx, pod2, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for both pods to be running and ready")
+		err = e2epod.WaitForPodsRunningReady(ctx, cs, namespace, 2, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Creating an ETP=Local NodePort service with a named target port")
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcName,
+				Namespace: namespace,
+			},
+			Spec: v1.ServiceSpec{
+				Selector: labels,
+				Type:     v1.ServiceTypeNodePort,
+				IPFamilyPolicy:        ptr.To(v1.IPFamilyPolicyPreferDualStack),
+				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
+				Ports: []v1.ServicePort{
+					{
+						Name:       portName,
+						Protocol:   v1.ProtocolTCP,
+						Port:       svcPort,
+						TargetPort: intstr.FromString(portName),
+					},
+				},
+			},
+		}
+		svc, err = cs.CoreV1().Services(namespace).Create(ctx, svc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		nodePort := svc.Spec.Ports[0].NodePort
+
+		ginkgo.By("Waiting for endpoint slices to contain both target ports")
+		err = wait.PollImmediate(framework.Poll, 1*time.Minute, func() (bool, error) {
+			ports, err := getReadyEndpointSlicePorts(cs, namespace, svcName)
+			if err != nil {
+				return false, nil
+			}
+			if ports.Has(port1) && ports.Has(port2) {
+				framework.Logf("Endpoint slices contain both ports: %v", ports.UnsortedList())
+				return true, nil
+			}
+			framework.Logf("Current endpoint slice ports: %v (waiting for both %d and %d)", ports.UnsortedList(), port1, port2)
+			return false, nil
+		})
+		framework.ExpectNoError(err, "timed out waiting for both target ports in endpoint slices")
+
+		ginkgo.By("Creating a client pod on a different node to send external traffic")
+		clientNodeName := nodeName
+		if len(nodeList.Items) > 1 {
+			clientNodeName = nodeList.Items[1].Name
+		}
+		clientPod := e2epod.NewAgnhostPod(namespace, "curl-client", nil, nil, nil)
+		clientPod.Spec.NodeName = clientNodeName
+		clientPod.Spec.Containers[0].Command = []string{"sleep", "infinity"}
+		clientPod = e2epod.NewPodClient(f).CreateSync(ctx, clientPod)
+
+		ginkgo.By(fmt.Sprintf("Curling NodePort %d on node %s to verify traffic reaches both target ports", nodePort, nodeName))
+		nodeIP := nodeList.Items[0].Status.Addresses[0].Address
+		curlCmd := fmt.Sprintf("curl -q -s --max-time 2 --connect-timeout 1 http://%s/serverport",
+			net.JoinHostPort(nodeIP, fmt.Sprintf("%d", nodePort)))
+
+		hitPort1 := false
+		hitPort2 := false
+		gomega.Eventually(func() error {
+			stdout, err := e2epodoutput.RunHostCmd(namespace, clientPod.Name, curlCmd)
+			if err != nil {
+				return fmt.Errorf("connection failed: %v", err)
+			}
+			resp := strings.TrimSpace(stdout)
+			if resp == "" {
+				return fmt.Errorf("empty response from service")
+			}
+			framework.Logf("Got response from server port: %s", resp)
+			if resp == fmt.Sprintf("%d", port1) {
+				hitPort1 = true
+			} else if resp == fmt.Sprintf("%d", port2) {
+				hitPort2 = true
+			}
+			if hitPort1 && hitPort2 {
+				return nil
+			}
+			return fmt.Errorf("have not yet hit both ports: hitPort1=%v, hitPort2=%v", hitPort1, hitPort2)
+		}, 30*time.Second, 500*time.Millisecond).Should(gomega.Succeed(),
+			"traffic must reach both host-network endpoints (ports %d and %d) via the OpenFlow select group",
+			port1, port2)
+		framework.Logf("Confirmed traffic reached both target ports %d and %d", port1, port2)
+	})
+
+	// This test verifies that external NodePort traffic arriving at breth0
+	// (in_port=physical) is load-balanced across multiple host-network target
+	// ports via the OpenFlow select group. A host-network client on a
+	// different node ensures traffic traverses the physical network and
+	// enters the target node's OVS bridge from the external port, exercising
+	// the breth0 ETP=Local DNAT path rather than the OVN LB pipeline.
+	ginkgo.It("Distributes external traffic to multiple host-network endpoints with different named target ports", func() {
+		namespace := f.Namespace.Name
+		ctx := context.TODO()
+
+		const (
+			svcName  = "host-ext-multi-port-svc"
+			portName = "http"
+			svcPort  = int32(80)
+		)
+		port1 := int32(infraprovider.Get().GetK8HostPort())
+		port2 := int32(infraprovider.Get().GetK8HostPort())
+		gomega.Expect(port1).ToNot(gomega.Equal(port2),
+			"allocated host ports must differ")
+
+		ginkgo.By("Selecting 2 schedulable nodes")
+		nodeList, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 2)
+		framework.ExpectNoError(err)
+		gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">", 1),
+			"need at least 2 nodes so the client sends traffic via the physical network")
+		serverNodeName := nodeList.Items[0].Name
+		clientNodeName := nodeList.Items[1].Name
+
+		labels := map[string]string{"app": "host-ext-multi-port"}
+
+		ginkgo.By(fmt.Sprintf("Creating first host-network pod on %s listening on port %d", serverNodeName, port1))
+		pod1 := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "host-net-pod-1",
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: v1.PodSpec{
+				NodeName:    serverNodeName,
+				HostNetwork: true,
+				Containers: []v1.Container{
+					{
+						Name:    "agnhost",
+						Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+						Command: []string{"/agnhost", "netexec", fmt.Sprintf("--http-port=%d", port1), "--udp-port=-1"},
+						Ports: []v1.ContainerPort{
+							{
+								Name:          portName,
+								ContainerPort: port1,
+								Protocol:      v1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err = cs.CoreV1().Pods(namespace).Create(ctx, pod1, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By(fmt.Sprintf("Creating second host-network pod on %s listening on port %d", serverNodeName, port2))
+		pod2 := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "host-net-pod-2",
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			Spec: v1.PodSpec{
+				NodeName:    serverNodeName,
+				HostNetwork: true,
+				Containers: []v1.Container{
+					{
+						Name:    "agnhost",
+						Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+						Command: []string{"/agnhost", "netexec", fmt.Sprintf("--http-port=%d", port2), "--udp-port=-1"},
+						Ports: []v1.ContainerPort{
+							{
+								Name:          portName,
+								ContainerPort: port2,
+								Protocol:      v1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err = cs.CoreV1().Pods(namespace).Create(ctx, pod2, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for both pods to be running and ready")
+		err = e2epod.WaitForPodsRunningReady(ctx, cs, namespace, 2, 2*time.Minute)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Creating an ETP=Local NodePort service with a named target port")
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcName,
+				Namespace: namespace,
+			},
+			Spec: v1.ServiceSpec{
+				Selector: labels,
+				Type:     v1.ServiceTypeNodePort,
+				IPFamilyPolicy:        ptr.To(v1.IPFamilyPolicyPreferDualStack),
+				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
+				Ports: []v1.ServicePort{
+					{
+						Name:       portName,
+						Protocol:   v1.ProtocolTCP,
+						Port:       svcPort,
+						TargetPort: intstr.FromString(portName),
+					},
+				},
+			},
+		}
+		svc, err = cs.CoreV1().Services(namespace).Create(ctx, svc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		nodePort := svc.Spec.Ports[0].NodePort
+
+		ginkgo.By("Waiting for endpoint slices to contain both target ports")
+		err = wait.PollImmediate(framework.Poll, 1*time.Minute, func() (bool, error) {
+			ports, err := getReadyEndpointSlicePorts(cs, namespace, svcName)
+			if err != nil {
+				return false, nil
+			}
+			if ports.Has(port1) && ports.Has(port2) {
+				framework.Logf("Endpoint slices contain both ports: %v", ports.UnsortedList())
+				return true, nil
+			}
+			framework.Logf("Current endpoint slice ports: %v (waiting for both %d and %d)", ports.UnsortedList(), port1, port2)
+			return false, nil
+		})
+		framework.ExpectNoError(err, "timed out waiting for both target ports in endpoint slices")
+
+		ginkgo.By(fmt.Sprintf("Creating a host-network client pod on %s", clientNodeName))
+		clientPod := e2epod.NewAgnhostPod(namespace, "curl-host-client", nil, nil, nil)
+		clientPod.Spec.NodeName = clientNodeName
+		clientPod.Spec.HostNetwork = true
+		for k := range clientPod.Spec.Containers {
+			if clientPod.Spec.Containers[k].Name == "agnhost-container" {
+				clientPod.Spec.Containers[k].Command = []string{"sleep", "infinity"}
+				clientPod.Spec.Containers[k].SecurityContext.Privileged = pointer.Bool(true)
+			}
+		}
+		clientPod = e2epod.NewPodClient(f).CreateSync(ctx, clientPod)
+
+		serverNode := nodeList.Items[0]
+		serverNodeIPs := e2enode.GetAddresses(&serverNode, v1.NodeInternalIP)
+		gomega.Expect(serverNodeIPs).ToNot(gomega.BeEmpty())
+
+		for _, serverNodeIP := range serverNodeIPs {
+			addrLabel := "IPv4"
+			if utilnet.IsIPv6String(serverNodeIP) {
+				addrLabel = "IPv6"
+			}
+
+			ginkgo.By(fmt.Sprintf("Curling %s NodePort %d on %s (%s) to verify traffic reaches both target ports",
+				addrLabel, nodePort, serverNodeName, serverNodeIP))
+			curlCmd := fmt.Sprintf("curl -q -s --max-time 2 --connect-timeout 1 http://%s/serverport",
+				net.JoinHostPort(serverNodeIP, fmt.Sprintf("%d", nodePort)))
+
+			hitPort1 := false
+			hitPort2 := false
+			gomega.Eventually(func() error {
+				stdout, err := e2epodoutput.RunHostCmd(namespace, clientPod.Name, curlCmd)
+				if err != nil {
+					return fmt.Errorf("connection failed: %v", err)
+				}
+				resp := strings.TrimSpace(stdout)
+				if resp == "" {
+					return fmt.Errorf("empty response from service")
+				}
+				framework.Logf("[%s] Got response from server port: %s", addrLabel, resp)
+				if resp == fmt.Sprintf("%d", port1) {
+					hitPort1 = true
+				} else if resp == fmt.Sprintf("%d", port2) {
+					hitPort2 = true
+				}
+				if hitPort1 && hitPort2 {
+					return nil
+				}
+				return fmt.Errorf("have not yet hit both ports via %s: hitPort1=%v, hitPort2=%v", addrLabel, hitPort1, hitPort2)
+			}, 30*time.Second, 500*time.Millisecond).Should(gomega.Succeed(),
+				"external traffic via %s must reach both host-network endpoints (ports %d and %d) via breth0 OpenFlow group",
+				addrLabel, port1, port2)
+			framework.Logf("[%s] Confirmed traffic reached both target ports %d and %d", addrLabel, port1, port2)
+		}
+	})
+
 })
+
+// getReadyEndpointSlicePorts returns the set of target port numbers from endpoint
+// slices that have at least one ready endpoint. Slices with no endpoints or no
+// ready endpoints are excluded.
+func getReadyEndpointSlicePorts(cs clientset.Interface, namespace, svcName string) (sets.Set[int32], error) {
+	slices, err := cs.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("kubernetes.io/service-name=%s", svcName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	ports := sets.New[int32]()
+	for _, slice := range slices.Items {
+		if len(slice.Endpoints) == 0 {
+			continue
+		}
+		hasReady := false
+		for _, ep := range slice.Endpoints {
+			cond := ep.Conditions
+			ready := cond.Ready == nil || *cond.Ready
+			serving := cond.Serving == nil || *cond.Serving
+			terminating := cond.Terminating != nil && *cond.Terminating
+			if ready && serving && !terminating {
+				hasReady = true
+				break
+			}
+		}
+		if !hasReady {
+			continue
+		}
+		for _, port := range slice.Ports {
+			if port.Port != nil {
+				ports.Insert(*port.Port)
+			}
+		}
+	}
+	return ports, nil
+}
 
 func getServiceBackendsFromPod(execPod *v1.Pod, serviceIP string, servicePort int) []string {
 	connectionAttempts := 15


### PR DESCRIPTION
When service endpoint target port updated to a different value, at the time during rolling update, old target port and new target port are both used but associated with different set of target IPs. Current ovn-k8s does not support it. It randomly chose one port to associted with all the current target IPs.

This commit fixes that.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated load‑balancer targets so multiple rules aggregate backends; made endpoint detection port‑aware to prevent overwritten or missing backends and ensure correct per-port return traffic.

* **New Features**
  * Per‑port endpoint aggregation and per‑port LB handling for NodePort/Local flows, including per‑port masquerade and template value aggregation.
  * Consistent port-key generation for service ports.

* **Tests**
  * Added unit and e2e tests for multi‑port backends and rolling updates that change target ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->