### PR TITLE
Fix ovnkube-node startup when UDN runs out of host subnet

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -3,6 +3,7 @@ package node
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"sync"
 	"time"
 
@@ -39,6 +40,10 @@ type Gateway interface {
 	SetDefaultPodNetworkAdvertised(bool)
 	SetDefaultBridgeGARPDropFlows(bool)
 	Reconcile() error
+	AreResourcesEqual(reflect.Type, any, any) (bool, error)
+	AddResource(reflect.Type, any, bool) error
+	UpdateResource(reflect.Type, any, any, bool) error
+	DeleteResource(reflect.Type, any) error
 }
 
 type gateway struct {
@@ -336,6 +341,22 @@ func (g *gateway) Start() error {
 	}
 
 	return nil
+}
+
+func (g *gateway) AreResourcesEqual(objType reflect.Type, _, _ any) (bool, error) {
+	return false, fmt.Errorf("no object comparison for type %s", objType)
+}
+
+func (g *gateway) AddResource(objType reflect.Type, _ any, _ bool) error {
+	return fmt.Errorf("no add function for object type %s", objType)
+}
+
+func (g *gateway) UpdateResource(objType reflect.Type, _ any, _ any, _ bool) error {
+	return fmt.Errorf("no update function for object type %s", objType)
+}
+
+func (g *gateway) DeleteResource(objType reflect.Type, _ any) error {
+	return fmt.Errorf("no delete function for object type %s", objType)
 }
 
 // sets up an uplink interface for UDP Generic Receive Offload forwarding as part of

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1151,7 +1151,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(udnFlows).To(Equal(0))
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // only default network
 
-			Expect(udnGateway.AddNetwork()).To(Succeed())
+			Expect(udnGateway.syncNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(80))                                      // 18 UDN Flows, 5 advertisedUDN flows, and 2 packet mark flows (IPv4+IPv6) are added by default
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network

--- a/go-controller/pkg/node/user_defined_node_network_controller.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller.go
@@ -77,8 +77,9 @@ func (nc *UserDefinedNodeNetworkController) Start(_ context.Context) error {
 	}
 	if util.IsNetworkSegmentationSupportEnabled() && nc.IsPrimaryNetwork() {
 		if err := nc.gateway.AddNetwork(); err != nil {
-			return fmt.Errorf("failed to add network to node gateway for network %s at node %s: %w",
+			klog.Warningf("Failed to add network %s to node gateway at %s: %v. Will attempt to reconcile",
 				nc.GetNetworkName(), nc.name, err)
+			nc.gateway.Reconcile()
 		}
 	}
 	return nil

--- a/go-controller/pkg/node/user_defined_node_network_controller.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller.go
@@ -76,6 +76,10 @@ func (nc *UserDefinedNodeNetworkController) Start(_ context.Context) error {
 		nc.podHandler = handler
 	}
 	if util.IsNetworkSegmentationSupportEnabled() && nc.IsPrimaryNetwork() {
+		err := nc.gateway.Init()
+		if err != nil {
+			return fmt.Errorf("failed to init UDN gateway for network %s, at %s: %w", nc.GetNetworkName(), nc.name, err)
+		}
 		if err := nc.gateway.AddNetwork(); err != nil {
 			klog.Warningf("Failed to add network %s to node gateway at %s: %v. Will attempt to reconcile",
 				nc.GetNetworkName(), nc.name, err)

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -119,8 +119,7 @@ var _ = Describe("UserDefinedNodeNetworkController", func() {
 		controller, err := NewUserDefinedNodeNetworkController(&cnnci, NetInfo, nil, nil, nil, &gateway{openflowManager: ofm})
 		Expect(err).NotTo(HaveOccurred())
 		err = controller.Start(context.Background())
-		Expect(err).To(HaveOccurred()) // we don't have the gateway pieces setup so its expected to fail here
-		Expect(err.Error()).To(ContainSubstring("could not create management port"), err.Error())
+		Expect(err).NotTo(HaveOccurred())
 		Expect(controller.gateway).To(Not(BeNil()))
 	})
 	It("ensure UDNGateway is not invoked for Primary UDNs when feature gate is ON but network is not Primary", func() {

--- a/test/e2e/network_segmentation_endpointslices_mirror.go
+++ b/test/e2e/network_segmentation_endpointslices_mirror.go
@@ -169,7 +169,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c networkAttachmentConfigParams) error {
-				udnManifest := generateUserDefinedNetworkManifest(&c, f.ClientSet)
+				udnManifest := generateUserDefinedNetworkManifestWithSupportedNetworkConfig(&c, f.ClientSet)
 				cleanup, err := createManifest(f.Namespace.Name, udnManifest)
 				DeferCleanup(cleanup)
 				Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, f.Namespace.Name, c.name), 5*time.Second, time.Second).Should(Succeed())
@@ -255,7 +255,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c networkAttachmentConfigParams) error {
-				udnManifest := generateUserDefinedNetworkManifest(&c, f.ClientSet)
+				udnManifest := generateUserDefinedNetworkManifestWithSupportedNetworkConfig(&c, f.ClientSet)
 				cleanup, err := createManifest(fmt.Sprintf("%s-default", f.Namespace.Name), udnManifest)
 				DeferCleanup(cleanup)
 				Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, fmt.Sprintf("%s-default", f.Namespace.Name), c.name), 5*time.Second, time.Second).Should(Succeed())

--- a/test/e2e/network_segmentation_preconfigured_layer2.go
+++ b/test/e2e/network_segmentation_preconfigured_layer2.go
@@ -59,7 +59,7 @@ var _ = Describe("Network Segmentation: Preconfigured Layer2 UDN", feature.Netwo
 			By("creating the L2 network")
 
 			netConfig.namespace = f.Namespace.Name
-			udnManifest := generateUserDefinedNetworkManifest(netConfig, f.ClientSet)
+			udnManifest := generateUserDefinedNetworkManifestWithSupportedNetworkConfig(netConfig, f.ClientSet)
 			cleanup, err := createManifest(netConfig.namespace, udnManifest)
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(cleanup)


### PR DESCRIPTION
When L3 Primary UDN host subnet is exhausted, host subnet may not be allocated for the node(s) by cluster manager, then node is not annotated with subnet on the k8s.ovn.org/node-subnets. When ovnkube-node is restarted, then it goes into CLBO because subnet is not found for the network on the annotation, but it okay UDN to fail on the node, but ovnkube-node should come up and continue to work for other networks. So this PR relaxes subnet annotation check for the UDN network on network controller's syncAll method and makes ovnkube-controller to come up without an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Event-driven reconciliation for User Defined Networks (UDN), improving responsiveness to node changes.
  - Cluster-aware CIDR selection with support for limited host-subnet configurations.

- Bug Fixes
  - More reliable UDN startup and reconciliation; falls back to self-recovery instead of failing.
  - Reduced unnecessary reconciliations for non-applicable topologies.
  - De-duplication and safe merging of VRF routes to avoid conflicts.
  - Consistent host-subnet manifest formatting.

- Tests
  - Expanded end-to-end coverage for UDN (limited host-subnet, EndpointSlice mirroring, preconfigured L2).
  - Manifest generation updated to honor supported network configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->