### PR TITLE
dnm: Use underlay for frr external cluster

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -465,7 +465,7 @@ docker_create_second_disconnected_interface() {
   fi
 
   # Create the network without subnets; ignore if already exists.
-  "$OCI_BIN" network create --driver=bridge ${podman_params-} "$bridge_name" || true
+  "$OCI_BIN" network create --ipv6 --driver=bridge ${podman_params-} "$bridge_name" || true
 
   KIND_NODES=$(kind_get_nodes)
   for n in $KIND_NODES; do
@@ -663,6 +663,8 @@ clone_frr() {
     # Change into the cloned repo directory before applying patches
     pushd frr-k8s
     git apply ../patches/*
+    sed -r -i 's#^NODE_IPS_V4=(.*)#NODE_IPS_V4=${NODE_IPS_V4:-\1}#' hack/demo/demo.sh
+    sed -r -i 's#^NODE_IPS_V6=(.*)#NODE_IPS_V6=${NODE_IPS_V6:-\1}#' hack/demo/demo.sh
     popd
 
     popd || exit 1
@@ -704,6 +706,10 @@ deploy_frr_external_container() {
     # Add route-reflector-client for IPv6 neighbors
     sed -i '/neighbor fc00.*remote-as 64512/a \ neighbor {{ . }} route-reflector-client' frr/frr.conf.tmpl
   fi
+
+  export NODE_IPS_V4=$(docker network inspect underlay |jq -r '.[0].Containers[] | select(.Name!="frr") | .IPv4Address' | sed s#/.*## | tr '\n' ' ')
+  export NODE_IPS_V6=$(docker network inspect underlay |jq -r '.[0].Containers[] | select(.Name!="frr") | .IPv6Address' | sed s#/.*## | tr '\n' ' ')
+
   ./demo.sh
   popd || exit 1
   if  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -867,8 +867,7 @@ func (bsnc *BaseSecondaryNetworkController) requireDHCP(pod *corev1.Pod) bool {
 	// Configure DHCP only for kubevirt VMs layer2 primary udn with subnets
 	return kubevirt.IsPodOwnedByVirtualMachine(pod) &&
 		util.IsNetworkSegmentationSupportEnabled() &&
-		bsnc.IsPrimaryNetwork() &&
-		bsnc.TopologyType() == types.Layer2Topology
+		bsnc.IsPrimaryNetwork()
 }
 
 func (bsnc *BaseSecondaryNetworkController) setPodLogicalSwitchPortAddressesAndEnabledField(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

```yaml
---
apiVersion: v1
kind: Namespace
metadata:
  name: test12
  labels:
    k8s.ovn.org/primary-user-defined-network: ""
---
apiVersion: k8s.ovn.org/v1
kind: ClusterUserDefinedNetwork
metadata:
  name: test-bgp
  labels:
    namespace: test12
spec:
  namespaceSelector:
    matchExpressions:
    - key: "kubernetes.io/metadata.name"
      operator: In
      values:
        - test12
  network:
    topology: Layer3
    layer3:
      role: Primary
      subnets:
        - cidr: 203.203.0.0/16
          hostSubnet: 24
---
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  labels:
    app: iperf-server
  name: vm-a
  namespace: test12
spec:
  runStrategy: Always
  template:
    metadata:
      name: vm-a
      namespace: test12
      labels:
        app: iperf-server
    spec:
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: containerdisk
          - disk:
              bus: virtio
            name: cloudinitdisk
          interfaces:
          - name: isolated-namespace
            binding:
              name: l2bridge
          rng: {}
        resources:
          requests:
            memory: 2048M
      networks:
      - pod: {}
        name: isolated-namespace
      terminationGracePeriodSeconds: 0
      volumes:
      - containerDisk:
          image: quay.io/kubevirtci/fedora-with-test-tooling:v20241128-4d4c8fe
        name: containerdisk
      - cloudInitNoCloud:
          userData: |-
            #cloud-config
            password: fedora
            chpasswd: { expire: False }
            runcmd:
              - ["iperf3", "-s", "-D", "--logfile", "/tmp/iperf3.log"]
          networkData: |-
            version: 2
            ethernets:
              eth0:
                dhcp4: true
                dhcp6: true
        name: cloudinitdisk
---
apiVersion: v1
kind: Service
metadata:
  name: iperf3-server-vm-a
  namespace: test12
spec:
  ports:
  - port: 5201
  ipFamilyPolicy: PreferDualStack
  selector:
    app: iperf-server
  sessionAffinity: None
  type: NodePort
---
apiVersion: k8s.ovn.org/v1
kind: RouteAdvertisements
metadata:
  name: test-bgp
spec:
  nodeSelector: {}
  frrConfigurationSelector:
    matchLabels:
      namespace: test12
  advertisements:
  - PodNetwork
  networkSelectors:
    - networkSelectionType: ClusterUserDefinedNetworks
      clusterUserDefinedNetworkSelector:
        networkSelector:
          matchLabels:
            namespace: test12
---
apiVersion: frrk8s.metallb.io/v1beta1
kind: FRRConfiguration
metadata:
  name: receive-filtered-test-bgp
  namespace: frr-k8s-system
  labels:
    namespace: test12
spec:
  bgp:
    routers:
    - asn: 64512
      neighbors:
      - address: 172.19.0.5
        asn: 64512
        disableMP: true
        toReceive:
          allowed:
            mode: filtered
            prefixes:
            - prefix: 172.26.0.0/16
            - prefix: fc00:f853:ccd:e796::/64
```

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
