### PR TITLE
ovnkube.sh: Add new overwriting options for the gateway options and kubernetes node name

### DIFF
--- a/docs/features/hardware-offload/dpu-support.md
+++ b/docs/features/hardware-offload/dpu-support.md
@@ -17,3 +17,39 @@ on the embedded CPU.
 Any vendor that manufactures a DPU which supports the above model should work with current design.
 
 Design document can be found [here](https://docs.google.com/document/d/11IoMKiohK7hIyIE36FJmwJv46DEBx52a4fqvrpCBBcg/edit?usp=sharing).
+
+## OVN Kubernetes in a DPU-Accelerated Environment
+
+The **ovn-kubernetes** deployment will have two parts one on the host and another on the DPU side.
+
+
+These aforementioned parts are expected to be deployed also on two different Kubernetes clusters, one for the host and another for the DPUs.
+
+
+### Host Cluster
+---
+
+#### OVN Kubernetes control plane related component
+- ovn-cluster-manager
+
+#### OVN Kubernetes components on a Standard Host (Non-DPU)
+- local-nb-ovsdb
+- local-sb-ovsdb
+- run-ovn-northd
+- ovnkube-controller-with-node
+- ovn-controller
+- ovs-metrics
+
+#### OVN Kubernetes component on a DPU-Enabled Host
+- ovn-node
+
+### DPU Cluster
+---
+
+#### OVN Kubernetes components
+- local-nb-ovsdb 
+- local-sb-ovsdb
+- run-ovn-northd
+- ovnkube-controller-with-node
+- ovn-controller
+- ovs-metrics


### PR DESCRIPTION

This commit adds:
  a) options to change ovn_gateway_opts and ovn_gateway_router_subnet by a container inside the same POD.
     the idea is that a init container can do an IP allocation write the output to a file and we will
     consume those values from the file.
  b) in case of ovnkube in DPU mode, we are running ovnkube on behalf of a different host, however the
     way we identify that is using the DPU hostname. to bypass the latter we will use the OVS metadata
     external_ids:host-k8s-nodename. This is already used by the ovn-node (OVN central where we have a single
     global zone).
  c) extend stateless network policies for ovnkube running in different mode types: ovn-master, ovnkube-controller
     and ovnkube-controller-with-node. this is useful for offloading RDMA traffic.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
