### PR TITLE
NodeTracker: Only update the node if the subnet changed for the specific network

### DIFF
--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -119,7 +119,7 @@ func (nt *nodeTracker) Start(nodeInformer coreinformers.NodeInformer) (cache.Res
 			// - node changes its zone
 			// - node becomes a hybrid overlay node from a ovn node or vice verse
 			// . No need to trigger update for any other field change.
-			if util.NodeSubnetAnnotationChanged(oldObj, newObj) ||
+			if util.NodeSubnetAnnotationChangedForNetwork(oldObj, newObj, nt.netInfo.GetNetworkName()) ||
 				util.NodeL3GatewayAnnotationChanged(oldObj, newObj) ||
 				oldObj.Name != newObj.Name ||
 				util.NodeHostCIDRsAnnotationChanged(oldObj, newObj) ||
@@ -169,7 +169,7 @@ func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName, chassisI
 		ni.podSubnets = append(ni.podSubnets, *podSubnets[i]) // de-pointer
 	}
 
-	klog.Infof("Node %s switch + router changed, syncing services", nodeName)
+	klog.Infof("Node %s switch + router changed, syncing services in network %q", nodeName, nt.netInfo.GetNetworkName())
 
 	nt.Lock()
 	defer nt.Unlock()
@@ -208,7 +208,7 @@ func (nt *nodeTracker) removeNode(nodeName string) {
 // The switch exists when the HostSubnet annotation is set.
 // The gateway router will exist sometime after the L3Gateway annotation is set.
 func (nt *nodeTracker) updateNode(node *corev1.Node) {
-	klog.V(2).Infof("Processing possible switch / router updates for node %s", node.Name)
+	klog.V(2).Infof("Processing possible switch / router updates for node %s in network %q", node.Name, nt.netInfo.GetNetworkName())
 	var hsn []*net.IPNet
 	var err error
 	if nt.netInfo.TopologyType() == types.Layer2Topology {


### PR DESCRIPTION
Previously every update `k8s.ovn.org/node-subnets` caused a call to `nt.updateNode` on every network.
