### PR TITLE
persistentIPs: Deprecate primary UDN IPAMClaim annotation - 'k8s.ovn.org/primary-udn-ipamclaim'

### DIFF
--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -1543,7 +1543,6 @@ func overrideActiveNSEWithDefaultNSE(defaultNSE, activeNSE *nettypes.NetworkSele
 	}
 	activeNSE.IPRequest = defaultNSE.IPRequest
 	activeNSE.MacRequest = defaultNSE.MacRequest
-	activeNSE.IPAMClaimReference = defaultNSE.IPAMClaimReference
 	return nil
 }
 
@@ -1586,29 +1585,38 @@ func GetPodNADToNetworkMappingWithActiveNetwork(pod *corev1.Pod, nInfo NetInfo, 
 		Name:      activeNADKey.Name,
 	}
 
+	isPersistentIPsPrimaryNetwork := nInfo.IsPrimaryNetwork() && AllowsPersistentIPs(nInfo)
+	var defaultNSE *nettypes.NetworkSelectionElement
+	if isPersistentIPsPrimaryNetwork || IsPreconfiguredUDNAddressesEnabled() {
+		defaultNSE, err = GetK8sPodDefaultNetworkSelection(pod)
+		if err != nil {
+			return false, nil, fmt.Errorf("failed getting default-network annotation for pod %q: %w", pod.Namespace+"/"+pod.Name, err)
+		}
+	}
+
+	if isPersistentIPsPrimaryNetwork {
+		// 'k8s.ovn.org/primary-udn-ipamclaim' annotation has been deprecated. Maintain backward compatibility by
+		// using it as a fallback; when defaultNSE.IPAMClaimReference is set, it takes precedence.
+		if ipamClaimName, wasPersistentIPRequested := pod.Annotations[DeprecatedOvnUDNIPAMClaimName]; wasPersistentIPRequested {
+			activeNSE.IPAMClaimReference = ipamClaimName
+		}
+		if defaultNSE != nil && defaultNSE.IPAMClaimReference != "" {
+			activeNSE.IPAMClaimReference = defaultNSE.IPAMClaimReference
+		}
+	}
+
 	// Feature gate integration: EnablePreconfiguredUDNAddresses controls default network IP/MAC transfer to active network
 	if IsPreconfiguredUDNAddressesEnabled() {
 		// Limit the static ip and mac requests to the layer2 primary UDN when EnablePreconfiguredUDNAddresses is enabled, we
 		// don't need to explicitly check this is primary UDN since
 		// the "active network" concept is exactly that.
 		if activeNetwork.TopologyType() == types.Layer2Topology {
-			defaultNSE, err := GetK8sPodDefaultNetworkSelection(pod)
-			if err != nil {
-				return false, nil, fmt.Errorf("failed getting default-network annotation for pod %q: %w", pod.Namespace+"/"+pod.Name, err)
-			}
 			// If there are static IPs and MACs at the default NSE, override the active NSE with them
 			if defaultNSE != nil {
 				if err := overrideActiveNSEWithDefaultNSE(defaultNSE, activeNSE); err != nil {
 					return false, nil, err
 				}
 			}
-		}
-	}
-
-	if nInfo.IsPrimaryNetwork() && AllowsPersistentIPs(nInfo) && activeNSE.IPAMClaimReference == "" {
-		ipamClaimName, wasPersistentIPRequested := pod.Annotations[OvnUDNIPAMClaimName]
-		if wasPersistentIPRequested {
-			activeNSE.IPAMClaimReference = ipamClaimName
 		}
 	}
 

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -54,11 +54,13 @@ const (
 	OvnPodAnnotationName = "k8s.ovn.org/pod-networks"
 	// DefNetworkAnnotation is the pod annotation for the cluster-wide active network
 	DefNetworkAnnotation = "v1.multus-cni.io/default-network"
-	// OvnUDNIPAMClaimName is used for workload owners to instruct OVN-K which
-	// IPAMClaim will hold the allocation for the workload
-	OvnUDNIPAMClaimName = "k8s.ovn.org/primary-udn-ipamclaim"
 	// UDNOpenPortsAnnotationName is the pod annotation to open default network pods on UDN pods.
 	UDNOpenPortsAnnotationName = "k8s.ovn.org/open-default-ports"
+
+	// DeprecatedOvnUDNIPAMClaimName is used for workload owners to instruct OVN-K which
+	// IPAMClaim will hold the allocation for the workload.
+	// Deprecated: Use 'v1.multus-cni.io/default-network' annotation instead, specifying the 'ipam-claim-reference' attribute.
+	DeprecatedOvnUDNIPAMClaimName = "k8s.ovn.org/primary-udn-ipamclaim"
 )
 
 var ErrNoPodIPFound = errors.New("no pod IPs found")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR implements the part of deprecating the UDN IPAMClaim annotation in favor of the default NSE extension for IPAMClaim https://github.com/kyrtapz/ovn-kubernetes/blob/master/docs/okeps/okep-5233-preconfigured-udn-addresses.md#pod-network-identity

The NetworkSelectionElement (NSE) API has been extended and features IPAM claim
reference attribute enabling associating pod with IPAMClaim CR.

Deprecate the UDN IPAMClaim annotation - `k8s.ovn.org/primary-udn-ipamclaim`.

The defaullt NSE `v1.multus-cni.io/default-network` should be used on
order to associate pod with IPAM claim CR.

When default NSE doesn't specify IPAMClaim reference, falling back to
UDN IPAMClaim annotation

In next release the UDN IPAMClaim annotation can be removed altogether.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Errors resolving a pod's default-network selection are now propagated earlier; persistent pod IP handling is more reliable.

* **Refactor**
  * Primary-network persistent-IP selection now prefers the default-network annotation (ipam-claim-reference) and falls back to the legacy annotation for compatibility; default-network static IP/MAC values can override active network requests.

* **Tests**
  * Expanded coverage for annotation precedence, default-network sourcing, primary-network behaviors, and legacy-annotation interactions.

* **Chores**
  * Legacy primary-IP annotation marked deprecated; guidance moved to using the standard default-network annotation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->