### PR TITLE
always() run the diags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -387,6 +387,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Runner Diagnostics
+      if: always()
       uses: ./.github/actions/diagnostics
 
     - name: ovn upgrade
@@ -395,6 +396,7 @@ jobs:
         make -C test upgrade-ovn
 
     - name: Runner Diagnostics
+      if: always()
       uses: ./.github/actions/diagnostics
 
     - name: Run E2E shard-conformance
@@ -402,6 +404,7 @@ jobs:
         make -C test shard-conformance
 
     - name: Runner Diagnostics
+      if: always()
       uses: ./.github/actions/diagnostics
 
     - name: Export kind logs
@@ -634,6 +637,7 @@ jobs:
       run: make -C test traffic-flow-tests WHAT="setup"
 
     - name: Runner Diagnostics
+      if: always()
       uses: ./.github/actions/diagnostics
 
     - name: Run Tests
@@ -687,6 +691,7 @@ jobs:
         fi
 
     - name: Runner Diagnostics
+      if: always()
       uses: ./.github/actions/diagnostics
 
     - name: Export kind logs
@@ -799,6 +804,7 @@ jobs:
         ./contrib/kind-dual-stack-conversion.sh
 
     - name: Runner Diagnostics
+      if: always()
       uses: ./.github/actions/diagnostics
 
     - name: Run Dual-Stack Tests
@@ -806,6 +812,7 @@ jobs:
         make -C test shard-test WHAT="Networking Granular Checks\|DualStack"
 
     - name: Runner Diagnostics
+      if: always()
       uses: ./.github/actions/diagnostics
 
     - name: Run Dual-Stack Control-Plane Tests
@@ -813,6 +820,7 @@ jobs:
         make -C test control-plane WHAT="DualStack"
 
     - name: Runner Diagnostics
+      if: always()
       uses: ./.github/actions/diagnostics
 
     - name: Export kind logs


### PR DESCRIPTION
when a step fails (e.g., e2e testing) the rest of the workflow will not run unless it's tagged with always(). and when something fails is exactly when we want to get some diags. move all references to "Runner Diagnostics" to use always()

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to ensure diagnostics always run, regardless of previous step outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->