### PR TITLE
fix ovspinning test error

### DIFF
--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -246,10 +246,12 @@ func assertPIDHasSchedAffinity(t *testing.T, pid int, expectedCPUSet unix.CPUSet
 	require.NoError(t, err)
 
 	for _, task := range tasks {
-		err := unix.SchedGetaffinity(task, &actual)
-		require.NoError(t, err)
-		assert.Equal(t, expectedCPUSet, actual,
-			"task[%d] of process[%d] Expected CPUSet %0x != Actual CPUSet %0x", task, pid, expectedCPUSet, actual)
+		assert.Eventually(t, func() bool {
+			err := unix.SchedGetaffinity(task, &actual)
+			assert.NoError(t, err)
+
+			return actual == expectedCPUSet
+		}, time.Second, 10*time.Millisecond, "task[%d] of process[%d]  Expected CPUSet %0x != Actual CPUSet %0x", task, pid, expectedCPUSet, actual)
 	}
 }
 


### PR DESCRIPTION
in our cicd, sometimes we noticed ovspinning unit testing error:

=== RUN   TestAlignCPUAffinity
I0715 18:20:46.441374   13095 ovspinning_linux_test.go:65] Test CPU Affinity [1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
I0715 18:20:46.441595   13095 ovspinning_linux.go:46] Starting OVS daemon CPU pinning
I0715 18:20:46.464072   13095 ovspinning_linux.go:196] Setting CPU affinity of PID(13108) (ntasks=15) to 0, was 0-7
I0715 18:20:46.465325   13095 ovspinning_linux.go:196] Setting CPU affinity of PID(13107) (ntasks=1) to 0, was 0-7
I0715 18:20:46.484089   13095 ovspinning_linux_test.go:65] Test CPU Affinity [2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
I0715 18:20:46.502727   13095 ovspinning_linux.go:196] Setting CPU affinity of PID(13108) (ntasks=15) to 1, was 0
I0715 18:20:46.502910   13095 ovspinning_linux.go:196] Setting CPU affinity of PID(13107) (ntasks=1) to 1, was 0
...
I0715 18:20:46.602398   13095 ovspinning_linux.go:196] Setting CPU affinity of PID(13108) (ntasks=15) to 5, was 4
I0715 18:20:46.602929   13095 ovspinning_linux.go:196] Setting CPU affinity of PID(13107) (ntasks=1) to 5, was 4
I0715 18:20:46.626233   13095 ovspinning_linux_test.go:65] Test CPU Affinity [40 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
I0715 18:20:46.642720   13095 ovspinning_linux.go:196] Setting CPU affinity of PID(13108) (ntasks=15) to 6, was 5
    ovspinning_linux_test.go:67:
        	Error Trace:	/builds/sdn/ovn-kubernetes/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go:251
        	            				/builds/sdn/ovn-kubernetes/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go:67
        	Error:      	Not equal:
        	            	expected: unix.CPUSet{0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
        	            	actual  : unix.CPUSet{0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,3 @@
        	            	 (unix.CPUSet) (len=16) {
        	            	- (unix.cpuMask) 64,
        	            	+ (unix.cpuMask) 32,
        	            	  (unix.cpuMask) 0,
        	Test:       	TestAlignCPUAffinity
        	Messages:   	task[13219] of process[13108] Expected CPUSet [40 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] != Actual CPUSet [20 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of CPU affinity validation in tests by adding a wait-and-retry mechanism for thread affinity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->