### PR TITLE
*.sh: use /usr/bin/env to locate bash

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -x
 
 #Always exit on errors

--- a/dist/images/ovn-config.sh
+++ b/dist/images/ovn-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # run on master to configure ovn-kubernetes
 # The /etc/openvswitch/ovn_k8s.conf and /etc/sysconfig/ovn-kubernetes

--- a/dist/images/ovn-run.sh
+++ b/dist/images/ovn-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # run the ovs-vswitchd daemon from a container
 

--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -euo pipefail
 
 verify-ovsdb-raft() {

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -euo pipefail
 
 # Enable verbose shell output if OVNKUBE_SH_VERBOSE is set to 'true'

--- a/dist/images/push_manifest.sh
+++ b/dist/images/push_manifest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Currently supported platforms of multi-arch images are: amd64 arm64
 LINUX_ARCH=(amd64 arm64)

--- a/dist/install-ovn-k8s.sh
+++ b/dist/install-ovn-k8s.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash -ex
 # shellcheck disable=SC2016
 
 SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]}")

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 GO=${GO:-go}

--- a/go-controller/hack/init.sh
+++ b/go-controller/hack/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OUT_DIR=${OUT_DIR:-_output}
 

--- a/go-controller/hack/regenerate_vendor_mocks.sh
+++ b/go-controller/hack/regenerate_vendor_mocks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 workdir=$(cd ../ && pwd)
 substitute_string='pkg/testing/mocks'

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 source "$(dirname "${BASH_SOURCE}")/init.sh"

--- a/go-controller/hack/verify-go-mod-vendor.sh
+++ b/go-controller/hack/verify-go-mod-vendor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit # Nozero exit code of any of the commands below will fail the test.
 set -o nounset
 set -o pipefail

--- a/go-controller/hack/verify-gofmt.sh
+++ b/go-controller/hack/verify-gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

On some unconventional systems like NixOS, bash is not installed in
/bin/bash and should instead be located via `env`. (Only `/bin/sh` is
guaranteed to be present on a POSIX system under `/bin`.)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved script portability by updating interpreter lookup to use a more environment-agnostic approach in various utility scripts. No changes to script functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->