### PR TITLE
test: Introduce and apply golangci-lint for e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,20 @@ jobs:
         cache: false
       id: go
 
-    - name: Verify
+    - name: Verify go-controller
       uses: golangci/golangci-lint-action@v6
       with:
         version: v1.64.8
         working-directory: go-controller
         args: --modules-download-mode=vendor --timeout=15m0s --verbose
+
+- name: Verify e2e tests
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: v1.64.8
+        working-directory: test/e2e
+        args: --timeout=15m0s --verbose
+
 
   build-base:
     name: Build-base

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,6 @@
 E2E_REPORT_DIR:=$(CURDIR)/_artifacts
 JOB_NAME?="$@"
+export GOLANGCI_LINT_VERSION ?= v1.60.3
 
 # Make no assumptions about network, so run all tests. If on IPv4 or
 # IPv6 only network, set appropriately to skip related tests.
@@ -50,3 +51,11 @@ tools:
 traffic-flow-tests:
 	TRAFFIC_FLOW_TESTS=$(TRAFFIC_FLOW_TESTS) \
 	./scripts/traffic-flow-tests.sh $(WHAT)
+
+.PHONY: lint
+lint:
+	./scripts/lint.sh $(WHAT)
+
+.PHONY: lint-fix
+lint-fix:
+	./scripts/lint.sh --fix $(WHAT)

--- a/test/e2e/.golangci.yml
+++ b/test/e2e/.golangci.yml
@@ -1,0 +1,68 @@
+issues:
+  exclude-dirs:
+    - vendor
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+#    - gci
+#    - ginkgolinter
+#    - gofmt
+#    - gosimple
+#    - govet
+#    - importas
+#    - ineffassign
+#    - nosprintfhostport
+#    - revive
+#    - staticcheck
+#    - testifylint
+#    - thelper
+#    - typecheck
+#    - unused
+
+linters-settings:
+  gci:
+    # default ordering except:
+    # - prefix sections ordered as stated
+    # - dot section at the very end
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(k8s.io,sigs.k8s.io)
+      - prefix(github.com/ovn-org)
+      - localmodule
+      - dot
+
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
+      - printf
+
+  importas:
+    no-unaliased: true
+    alias:
+      # Kubernetes
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: apierrors
+      - pkg: k8s.io/apimachinery/pkg/util/errors
+        alias: kerrors
+      - pkg: sigs.k8s.io/controller-runtime
+        alias: ctrl
+      # Other frequently used deps
+      - pkg: github.com/ovn-org/libovsdb/ovsdb
+        alias: ""
+
+  revive:
+    rules:
+      # TODO: enable recommended (default) revive rules
+      - name: duplicated-imports
+      - name: error-naming
+      - name: unused-parameter

--- a/test/e2e/acl_logging.go
+++ b/test/e2e/acl_logging.go
@@ -1111,8 +1111,10 @@ func isCountUpdatedAfterPokePod(fr *framework.Framework, clientPod, pokedPod *v1
 	if err != nil {
 		return false, err
 	}
-	pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)
-	endCount, _ := countACLLogs(
+	if err := pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP); err != nil {
+		return false, err
+	}
+	endCount, err := countACLLogs(
 		clientPod.Spec.NodeName,
 		regex,
 		aclVerdict,
@@ -1137,7 +1139,7 @@ func pokeExternalHost(fr *framework.Framework, pokePod *v1.Pod, dstIP string, ds
 		pokePod.GetName(),
 		pokePod.Spec.NodeName,
 	)
-	pokeExternalHostFromPod(fr, pokePod.Namespace, pokePod.GetName(), dstIP, dstPort)
+	framework.ExpectNoError(pokeExternalHostFromPod(fr, pokePod.Namespace, pokePod.GetName(), dstIP, dstPort))
 }
 
 const (

--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -638,7 +638,8 @@ spec:
 			for _, node := range nodes.Items {
 				patchData, err := json.Marshal(&patch)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				f.ClientSet.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+				_, err = f.ClientSet.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
 			ginkgo.By("Should be able to reach each host networked pod via node selector")

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -3052,7 +3052,9 @@ func setupGatewayContainers(f *framework.Framework, providerCtx infraapi.Context
 				_, err = infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "address", "add", address + "/32", "dev", "lo"})
 				framework.ExpectNoError(err, "failed to add the loopback ip to dev lo on the test container %s", gwContainer.Name)
 				providerCtx.AddCleanUpFn(func() error {
-					infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "address", "del", address + "/32", "dev", "lo"})
+					if _, err := infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "address", "del", address + "/32", "dev", "lo"}); err != nil {
+					framework.Logf("Warning: failed to delete address during cleanup: %v", err)
+				}
 					return nil
 				})
 			}
@@ -3061,7 +3063,9 @@ func setupGatewayContainers(f *framework.Framework, providerCtx infraapi.Context
 			_, err = infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "route", "add", addressesv4.srcPodIP, "via", addressesv4.nodeIP})
 			framework.ExpectNoError(err, "failed to add the pod host route on the test container %s", gwContainer.Name)
 			providerCtx.AddCleanUpFn(func() error {
-				infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "route", "del", addressesv4.srcPodIP, "via", addressesv4.nodeIP})
+				if _, err := infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "route", "del", addressesv4.srcPodIP, "via", addressesv4.nodeIP}); err != nil {
+				framework.Logf("Warning: failed to delete route during cleanup: %v", err)
+			}
 				return nil
 			})
 
@@ -3083,7 +3087,9 @@ func setupGatewayContainers(f *framework.Framework, providerCtx infraapi.Context
 				_, err = infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "address", "add", address + "/128", "dev", "lo"})
 				framework.ExpectNoError(err, "ipv6: failed to add the loopback ip to dev lo on the test container %s", gwContainer.Name)
 				providerCtx.AddCleanUpFn(func() error {
-					infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "address", "del", address + "/128", "dev", "lo"})
+					if _, err := infraprovider.Get().ExecExternalContainerCommand(gwContainer, []string{"ip", "address", "del", address + "/128", "dev", "lo"}); err != nil {
+					framework.Logf("Warning: failed to delete IPv6 address during cleanup: %v", err)
+				}
 					return nil
 				})
 			}
@@ -3452,7 +3458,9 @@ spec:
 }
 
 func deleteAPBExternalRouteCR(policyName string) {
-	e2ekubectl.RunKubectl("", "delete", "apbexternalroute", policyName)
+	if _, err := e2ekubectl.RunKubectl("", "delete", "apbexternalroute", policyName); err != nil {
+		framework.Logf("Warning: failed to delete apbexternalroute %s: %v", policyName, err)
+	}
 }
 func formatStaticHops(bfd bool, gateways ...string) string {
 	b := strings.Builder{}

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1310,7 +1310,9 @@ fi
 			Expect(crClient.Create(context.Background(), cudn)).To(Succeed())
 			DeferCleanup(func() {
 				if e2eframework.TestContext.DeleteNamespace && (e2eframework.TestContext.DeleteNamespaceOnFailure || !CurrentSpecReport().Failed()) {
-					crClient.Delete(context.Background(), cudn)
+					if err := crClient.Delete(context.Background(), cudn); err != nil {
+				e2eframework.Logf("Warning: failed to delete CUDN during cleanup: %v", err)
+			}
 				}
 			})
 			Eventually(clusterUserDefinedNetworkReadyFunc(fr.DynamicClient, cudn.Name), 5*time.Second, time.Second).Should(Succeed())
@@ -1322,7 +1324,9 @@ fi
 			Expect(crClient.Create(context.Background(), ra)).To(Succeed())
 			DeferCleanup(func() {
 				if e2eframework.TestContext.DeleteNamespace && (e2eframework.TestContext.DeleteNamespaceOnFailure || !CurrentSpecReport().Failed()) {
-					crClient.Delete(context.Background(), ra)
+					if err := crClient.Delete(context.Background(), ra); err != nil {
+				e2eframework.Logf("Warning: failed to delete RouteAdvertisements during cleanup: %v", err)
+			}
 				}
 			})
 

--- a/test/e2e/network_segmentation_api_validations.go
+++ b/test/e2e/network_segmentation_api_validations.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/feature"
@@ -59,7 +60,9 @@ func runKubectlInputWithFullOutput(namespace string, data string, args ...string
 
 func cleanupValidateCRsTest(scenarios []testscenario.ValidateCRScenario) {
 	for _, s := range scenarios {
-		e2ekubectl.RunKubectlInput("", s.Manifest, "delete", "-f", "-")
+		if _, err := e2ekubectl.RunKubectlInput("", s.Manifest, "delete", "-f", "-"); err != nil {
+			framework.Logf("Warning: failed to delete resource during cleanup: %v", err)
+		}
 	}
 	_, stderr, err := e2ekubectl.RunKubectlWithFullOutput("", "get", "clusteruserdefinednetworks")
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/node_ip_mac_migration.go
+++ b/test/e2e/node_ip_mac_migration.go
@@ -344,10 +344,14 @@ spec:
 
 				JustAfterEach(func() {
 					By("Deleting the gressip service")
-					e2ekubectl.RunKubectl("default", "delete", "eip", podLabels["app"])
+					if _, err := e2ekubectl.RunKubectl("default", "delete", "eip", podLabels["app"]); err != nil {
+					framework.Logf("Warning: failed to delete eip during cleanup: %v", err)
+				}
 
 					By(fmt.Sprintf("Removing the egress assignable label from node %s", workerNode.Name))
-					e2ekubectl.RunKubectl("default", "label", "node", workerNode.Name, "k8s.ovn.org/egress-assignable-")
+					if _, err := e2ekubectl.RunKubectl("default", "label", "node", workerNode.Name, "k8s.ovn.org/egress-assignable-"); err != nil {
+					framework.Logf("Warning: failed to remove label during cleanup: %v", err)
+				}
 				})
 
 				for _, updateKubeletFirst := range []bool{true, false} {
@@ -476,10 +480,14 @@ spec:
 
 				JustAfterEach(func() {
 					By("Deleting the service")
-					e2ekubectl.RunKubectl(f.Namespace.Name, "delete", "service", serviceName)
+					if _, err := e2ekubectl.RunKubectl(f.Namespace.Name, "delete", "service", serviceName); err != nil {
+					framework.Logf("Warning: failed to delete service during cleanup: %v", err)
+				}
 
 					By("Deleting host network backend pod")
-					e2ekubectl.RunKubectl(f.Namespace.Name, "delete", "pod", podName)
+					if _, err := e2ekubectl.RunKubectl(f.Namespace.Name, "delete", "pod", podName); err != nil {
+					framework.Logf("Warning: failed to delete pod during cleanup: %v", err)
+				}
 				})
 
 				for _, updateKubeletFirst := range []bool{true, false} {
@@ -590,7 +598,9 @@ spec:
 
 			JustAfterEach(func() {
 				By("Deleting the service")
-				e2ekubectl.RunKubectl(f.Namespace.Name, "delete", "service", serviceName)
+				if _, err := e2ekubectl.RunKubectl(f.Namespace.Name, "delete", "service", serviceName); err != nil {
+					framework.Logf("Warning: failed to delete service during cleanup: %v", err)
+				}
 			})
 
 			It(fmt.Sprintf("Ensures flows are updated when MAC address changes"), func() {

--- a/test/scripts/lint.sh
+++ b/test/scripts/lint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default values
+GOLANGCI_LINT_VERSION=${GOLANGCI_LINT_VERSION:-v1.64.8}
+
+# Change to e2e directory
+cd "$(dirname "$0")/../e2e"
+
+# Instead of building a single string with $@, collect the sub-command and flags in an array:
+LINT_ARGS=(run \
+  --verbose \
+  --print-resources-usage \
+  --timeout=15m0s \
+  --path-prefix=e2e/ \
+  "$@"
+)
+
+echo "Running golangci-lint in $(pwd)..."
+go run "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \
+  "${LINT_ARGS[@]}"


### PR DESCRIPTION
## 📑 Description
  
This PR introduces golangci-lint to the e2e test suite to improve
code quality, enforce consistency, and catch potential issues early.
    
Key changes include:
- A new `golangci-lint` configuration (`test/e2e/.golangci.yml`) has been
   added, enabling a curated set of linters (e.g., gci, importas, revive).
- A `make lint` target and a corresponding CI job have been added to
  run the linter automatically.
- The existing e2e test code has been updated to comply with the new
   linting rules.
- Fix multiple linting issues at code   

## Additional Information for reviewers

This the linting issues has being fixed assisted by AI 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
Call `make -C test lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added comprehensive linting for end-to-end tests with strict code quality rules.
  * Enhanced test infrastructure with improved error handling and context-aware polling mechanisms.
  * Standardized Kubernetes API references throughout test suite for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->