### PR TITLE
Revert "e2e: Use ovnk allocator and reserve IPs"

### DIFF
--- a/test/e2e/ipalloc/ipalloc.go
+++ b/test/e2e/ipalloc/ipalloc.go
@@ -1,0 +1,47 @@
+package ipalloc
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+type ipAllocator struct {
+	net *net.IPNet
+	// base is a cached version of the start IP in the CIDR range as a *big.Int
+	base *big.Int
+	// max is the maximum size of the usable addresses in the range
+	max   int
+	count int
+}
+
+func newIPAllocator(cidr *net.IPNet) *ipAllocator {
+	return &ipAllocator{net: cidr, base: getBaseInt(cidr.IP), max: limit(cidr)}
+}
+
+func (n *ipAllocator) AllocateNextIP() (net.IP, error) {
+	if n.count >= n.max {
+		return net.IP{}, fmt.Errorf("limit of %d reached", n.max)
+	}
+	n.base.Add(n.base, big.NewInt(1))
+	n.count += 1
+	b := n.base.Bytes()
+	b = append(make([]byte, 16), b...)
+	return b[len(b)-16:], nil
+}
+
+func getBaseInt(ip net.IP) *big.Int {
+	return big.NewInt(0).SetBytes(ip.To16())
+}
+
+func limit(subnet *net.IPNet) int {
+	ones, bits := subnet.Mask.Size()
+	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
+		return 0
+	}
+	// limit to 2^8 (256) IPs for e2es
+	if bits == 128 && (bits-ones) >= 8 {
+		return int(1) << uint(8)
+	}
+	return int(1) << uint(bits-ones)
+}

--- a/test/e2e/ipalloc/primaryipalloc.go
+++ b/test/e2e/ipalloc/primaryipalloc.go
@@ -3,20 +3,19 @@ package ipalloc
 import (
 	"context"
 	"fmt"
-	"net"
-	"sync"
-
-	ipallocator "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/allocator/ip"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"net"
+	"sync"
 )
 
 // primaryIPAllocator attempts to allocate an IP in the same subnet as a nodes primary network
 type primaryIPAllocator struct {
 	mu         *sync.Mutex
-	v4         *ipallocator.Range
-	v6         *ipallocator.Range
+	v4         *ipAllocator
+	v6         *ipAllocator
 	nodeClient v1.NodeInterface
 }
 
@@ -48,37 +47,91 @@ func newPrimaryIPAllocator(nodeClient v1.NodeInterface) (*primaryIPAllocator, er
 	if len(nodes.Items) == 0 {
 		return ipa, fmt.Errorf("expected at least one node but found zero")
 	}
+	// FIXME: the approach taken here to find the first node IP+mask and then to increment the second last octet wont work in
+	// all scenarios (node with /24). We should generate an EgressIP compatible with a Node providers primary network and then take care its unique globally.
 
-	for _, node := range nodes.Items {
+	// The approach here is to grab initial starting IP from first node found, increment the second last octet.
+	// Approach taken here won't work for Nodes handed /24 subnets.
+	nodePrimaryIPs, err := util.ParseNodePrimaryIfAddr(&nodes.Items[0])
+	if err != nil {
+		return ipa, fmt.Errorf("failed to parse node primary interface address from Node object: %v", err)
+	}
+	if nodePrimaryIPs.V4.IP != nil {
+		// should be ok with /16 and /64 node primary provider subnets
+		// TODO; fixme; what about /24 subnet Nodes like GCP
+		nodePrimaryIPs.V4.IP[len(nodePrimaryIPs.V4.IP)-2]++
+		ipa.v4 = newIPAllocator(&net.IPNet{IP: nodePrimaryIPs.V4.IP, Mask: nodePrimaryIPs.V4.Net.Mask})
+	}
+	if nodePrimaryIPs.V6.IP != nil {
+		nodePrimaryIPs.V6.IP[len(nodePrimaryIPs.V6.IP)-2]++
+		ipa.v6 = newIPAllocator(&net.IPNet{IP: nodePrimaryIPs.V6.IP, Mask: nodePrimaryIPs.V6.Net.Mask})
+	}
+	// verify the new starting base IP is within all Nodes subnets
+	if nodePrimaryIPs.V4.IP != nil {
+		ipNets, err := getNodePrimaryProviderIPs(nodes.Items, false)
+		if err != nil {
+			return ipa, err
+		}
+		nextIP, err := ipa.v4.AllocateNextIP()
+		if err != nil {
+			return ipa, err
+		}
+		if !isIPWithinAllSubnets(ipNets, nextIP) {
+			return ipa, fmt.Errorf("IP %s is not within all Node subnets", nextIP)
+		}
+	}
+	if nodePrimaryIPs.V6.IP != nil {
+		ipNets, err := getNodePrimaryProviderIPs(nodes.Items, true)
+		if err != nil {
+			return ipa, err
+		}
+		nextIP, err := ipa.v6.AllocateNextIP()
+		if err != nil {
+			return ipa, err
+		}
+		if !isIPWithinAllSubnets(ipNets, nextIP) {
+			return ipa, fmt.Errorf("IP %s is not within all Node subnets", nextIP)
+		}
+	}
+
+	return ipa, nil
+}
+
+func getNodePrimaryProviderIPs(nodes []corev1.Node, isIPv6 bool) ([]*net.IPNet, error) {
+	ipNets := make([]*net.IPNet, 0, len(nodes))
+	for _, node := range nodes {
 		nodePrimaryIPs, err := util.ParseNodePrimaryIfAddr(&node)
 		if err != nil {
-			return ipa, fmt.Errorf("failed to parse node primary interface address from Node %s object: %v", node.Name, err)
+			return nil, fmt.Errorf("failed to parse node primary interface address from Node %s object: %v", node.Name, err)
 		}
-		if nodePrimaryIPs.V4.IP != nil {
-			if ipa.v4 == nil {
-				ipa.v4, err = ipallocator.NewCIDRRange(nodePrimaryIPs.V4.Net)
-				if err != nil {
-					return ipa, fmt.Errorf("failed to create new CIDR range for IPv4: %v", err)
-				}
-			}
-			if err := ipa.v4.Allocate(nodePrimaryIPs.V4.IP); err != nil {
-				return ipa, fmt.Errorf("failed to allocate IPv4 %s: %v", nodePrimaryIPs.V4.IP, err)
-			}
-		}
-		if nodePrimaryIPs.V6.IP != nil {
-			if ipa.v6 == nil {
-				ipa.v6, err = ipallocator.NewCIDRRange(nodePrimaryIPs.V6.Net)
-				if err != nil {
-					return ipa, fmt.Errorf("failed to create new CIDR range for IPv6: %v", err)
-				}
-			}
-			if err := ipa.v6.Allocate(nodePrimaryIPs.V6.IP); err != nil {
-				return ipa, fmt.Errorf("failed to allocate IPv6 %s: %v", nodePrimaryIPs.V6.IP, err)
-			}
-		}
+		var mask net.IPMask
+		var ip net.IP
 
+		if isIPv6 {
+			ip = nodePrimaryIPs.V6.IP
+			mask = nodePrimaryIPs.V6.Net.Mask
+		} else {
+			ip = nodePrimaryIPs.V4.IP
+			mask = nodePrimaryIPs.V4.Net.Mask
+		}
+		if len(ip) == 0 || len(mask) == 0 {
+			return nil, fmt.Errorf("failed to find Node %s primary Node IP and/or mask", node.Name)
+		}
+		ipNets = append(ipNets, &net.IPNet{IP: ip, Mask: mask})
 	}
-	return ipa, nil
+	return ipNets, nil
+}
+
+func isIPWithinAllSubnets(ipNets []*net.IPNet, ip net.IP) bool {
+	if len(ipNets) == 0 {
+		return false
+	}
+	for _, ipNet := range ipNets {
+		if !ipNet.Contains(ip) {
+			return false
+		}
+	}
+	return true
 }
 
 func (pia *primaryIPAllocator) IncrementAndGetNextV4(times int) (net.IP, error) {
@@ -95,9 +148,12 @@ func (pia *primaryIPAllocator) AllocateNextV4() (net.IP, error) {
 	if pia.v4 == nil {
 		return nil, fmt.Errorf("IPv4 is not enable ")
 	}
+	if pia.v4.net == nil {
+		return nil, fmt.Errorf("IPv4 is not enabled but Allocation request was called")
+	}
 	pia.mu.Lock()
 	defer pia.mu.Unlock()
-	return pia.v4.AllocateNext()
+	return allocateIP(pia.nodeClient, pia.v4.AllocateNextIP)
 }
 
 func (pia *primaryIPAllocator) IncrementAndGetNextV6(times int) (net.IP, error) {
@@ -114,7 +170,51 @@ func (pia primaryIPAllocator) AllocateNextV6() (net.IP, error) {
 	if pia.v6 == nil {
 		return nil, fmt.Errorf("IPv6 is not enabled but Allocation request was called")
 	}
+	if pia.v6.net == nil {
+		return nil, fmt.Errorf("ipv6 network is not set")
+	}
 	pia.mu.Lock()
 	defer pia.mu.Unlock()
-	return pia.v6.AllocateNext()
+	return allocateIP(pia.nodeClient, pia.v6.AllocateNextIP)
+}
+
+type allocNextFn func() (net.IP, error)
+
+func allocateIP(nodeClient v1.NodeInterface, allocateFn allocNextFn) (net.IP, error) {
+	nodeList, err := nodeClient.List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %v", err)
+	}
+	for {
+		nextIP, err := allocateFn()
+		if err != nil {
+			return nil, fmt.Errorf("failed to allocated next IP address: %v", err)
+		}
+		firstOctet := nextIP[len(nextIP)-1]
+		// skip 0 and 1
+		if firstOctet == 0 || firstOctet == 1 {
+			continue
+		}
+		isConflict, err := isConflictWithExistingHostIPs(nodeList.Items, nextIP)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine if IP conflicts with existing IPs: %v", err)
+		}
+		if !isConflict {
+			return nextIP, nil
+		}
+	}
+}
+
+func isConflictWithExistingHostIPs(nodes []corev1.Node, ip net.IP) (bool, error) {
+	ipStr := ip.String()
+	for _, node := range nodes {
+		nodeIPsSet, err := util.ParseNodeHostCIDRsDropNetMask(&node)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse node %s primary annotation info: %v", node.Name, err)
+		}
+		if nodeIPsSet.Has(ipStr) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/test/e2e/ipalloc/primaryipalloc_test.go
+++ b/test/e2e/ipalloc/primaryipalloc_test.go
@@ -15,11 +15,46 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	utilsnet "k8s.io/utils/net"
 )
 
 func TestUtilSuite(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "node ip alloc suite")
+}
+
+func TestAllocateNext(t *testing.T) {
+	tests := []struct {
+		desc   string
+		input  *net.IPNet
+		output []net.IP
+	}{
+		{
+			desc:   "increments IPv4 address",
+			input:  mustParseCIDRIncIP("192.168.1.5/16"), // mask /24 would fail
+			output: []net.IP{net.ParseIP("192.168.1.6"), net.ParseIP("192.168.1.7"), net.ParseIP("192.168.1.8")},
+		},
+		{
+			desc:   "increments IPv6 address",
+			input:  mustParseCIDRIncIP("fc00:f853:ccd:e793::6/64"),
+			output: []net.IP{net.ParseIP("fc00:f853:ccd:e793::7"), net.ParseIP("fc00:f853:ccd:e793::8"), net.ParseIP("fc00:f853:ccd:e793::9")},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			nodeIPAlloc := newIPAllocator(tc.input)
+			for _, expectedIP := range tc.output {
+				allocatedIP, err := nodeIPAlloc.AllocateNextIP()
+				if err != nil {
+					t.Errorf("failed to allocated next IP: %v", err)
+				}
+				if !allocatedIP.Equal(expectedIP) {
+					t.Errorf("Expected IP %q, but got %q", expectedIP.String(), allocatedIP.String())
+				}
+			}
+		})
+	}
 }
 
 // mustParseCIDRIncIP parses the IP and CIDR. It adds the IP to the returned IPNet.
@@ -43,19 +78,20 @@ type node struct {
 }
 
 func TestIPAlloc(t *testing.T) {
-	g := gomega.NewWithT(t)
-
 	tests := []struct {
-		desc                   string
-		existingPrimaryNodeIPs []node
+		desc                     string
+		existingPrimaryNodeIPs   []node
+		expectedFromAllocateNext []string
 	}{
 		{
-			desc:                   "IPv4",
-			existingPrimaryNodeIPs: []node{{v4: network{ip: "192.168.1.1", mask: "16"}}, {v4: network{ip: "192.168.1.2", mask: "16"}}},
+			desc:                     "IPv4",
+			existingPrimaryNodeIPs:   []node{{v4: network{ip: "192.168.1.1", mask: "16"}}, {v4: network{ip: "192.168.1.2", mask: "16"}}},
+			expectedFromAllocateNext: []string{"192.168.2.3", "192.168.2.4"},
 		},
 		{
-			desc:                   "IPv6",
-			existingPrimaryNodeIPs: []node{{v6: network{ip: "fc00:f853:ccd:e793::5", mask: "64"}}, {v6: network{ip: "fc00:f853:ccd:e793::6", mask: "64"}}},
+			desc:                     "IPv6",
+			existingPrimaryNodeIPs:   []node{{v4: network{ip: "fc00:f853:ccd:e793::5", mask: "64"}}, {v4: network{ip: "fc00:f853:ccd:e793::6", mask: "64"}}},
+			expectedFromAllocateNext: []string{"fc00:f853:ccd:e793::8", "fc00:f853:ccd:e793::9"},
 		},
 	}
 
@@ -67,32 +103,22 @@ func TestIPAlloc(t *testing.T) {
 				t.Errorf(err.Error())
 				return
 			}
-			existingIPv4IPs := []string{}
-			existingIPv6IPs := []string{}
-			allocatedIPv4IPs := []string{}
-			allocatedIPv6IPs := []string{}
-			for _, existingPrimaryNodeIP := range tc.existingPrimaryNodeIPs {
-				if existingPrimaryNodeIP.v4.ip != "" {
-					existingIPv4IPs = append(existingIPv4IPs, existingPrimaryNodeIP.v4.ip)
-					nextIPv4, err := pipa.AllocateNextV4()
-					g.Expect(err).ToNot(gomega.HaveOccurred(), "should succeed in allocating the next IPv4 address")
-					g.Expect(nextIPv4).ToNot(gomega.BeNil(), "should allocate next IPv4 address")
-					allocatedIPv4IPs = append(allocatedIPv4IPs, nextIPv4.String())
+			for _, expectedIPStr := range tc.expectedFromAllocateNext {
+				expectedIP := net.ParseIP(expectedIPStr)
+				var nextIP net.IP
+				var err error
+				if utilsnet.IsIPv6(expectedIP) {
+					nextIP, err = pipa.AllocateNextV6()
+				} else {
+					nextIP, err = pipa.AllocateNextV4()
 				}
-
-				if existingPrimaryNodeIP.v6.ip != "" {
-					existingIPv6IPs = append(existingIPv6IPs, existingPrimaryNodeIP.v6.ip)
-					nextIPv6, err := pipa.AllocateNextV6()
-					g.Expect(err).ToNot(gomega.HaveOccurred(), "should succeed in allocating the next IPv6 address")
-					g.Expect(nextIPv6).ToNot(gomega.BeNil(), "should allocate next IPv6 address")
-					allocatedIPv6IPs = append(allocatedIPv6IPs, nextIPv6.String())
+				if err != nil || nextIP == nil {
+					t.Errorf("failed to allocated next IPv4 or IPv6 address. err %v", err)
+					return
 				}
-			}
-			if len(existingIPv4IPs) > 0 {
-				g.Expect(allocatedIPv4IPs).NotTo(gomega.ContainElements(existingIPv4IPs))
-			}
-			if len(existingIPv6IPs) > 0 {
-				g.Expect(allocatedIPv6IPs).NotTo(gomega.ContainElements(existingIPv6IPs))
+				if !nextIP.Equal(expectedIP) {
+					t.Errorf("expected IP %q, but found %q", expectedIP, nextIP)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR reverts commit 9fed90c790221bd4b925ba2a4ad57784a1cbea3f. We should not use production code as a testing utility, since production code is the stuff we are testing.

Fixes #

## Additional Information for reviewers
This reverts commit 9fed90c790221bd4b925ba2a4ad57784a1cbea3f, which introduced the usage of the ovnk IP allocator in e2e tests.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
This is a revert. CI should pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an IP address allocator supporting both IPv4 and IPv6 within a specified CIDR range.
  * Enhanced IP allocation logic to avoid conflicts and validate against all node subnets.

* **Bug Fixes**
  * Improved conflict detection to prevent allocation of IPs already used by node hosts.

* **Tests**
  * Introduced new and updated tests to verify correct IP allocation for both IPv4 and IPv6 scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->