### PR TITLE
WIP: OCPBUGS-45118: Fix ovnkube-node pods crashes with panic when invalid namespace selector provided for EgressIP

### DIFF
--- a/dist/templates/k8s.ovn.org_egressips.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressips.yaml.j2
@@ -109,6 +109,27 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: label keys must be valid qualified names (DNS subdomain
+                    + '/' + name)
+                  rule: self.matchLabels.all(key, key.matches(r'^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/)?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$'))
+                - message: label keys must be no more than 253 characters
+                  rule: self.matchLabels.all(key, key.size() <= 253)
+                - message: label key prefix must be ≤ 253 characters
+                  rule: self.matchLabels.all(key, !key.contains('/') || key.split('/')[0].size()
+                    <= 253)
+                - message: label key name must be ≤ 63 characters
+                  rule: self.matchLabels.all(key, !key.contains('/') || key.split('/')[1].size()
+                    <= 63)
+                - message: label key name-only must be ≤ 63 characters
+                  rule: self.matchLabels.all(key, key.contains('/') || key.size()
+                    <= 63)
+                - message: label values must be empty or valid strings that start
+                    and end with alphanumeric characters
+                  rule: self.matchLabels.all(key, self.matchLabels[key].matches(r'^([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?$'))
+                - message: label values must be no more than 63 characters
+                  rule: self.matchLabels.all(key, self.matchLabels[key].size() <=
+                    63)
               podSelector:
                 description: |-
                   PodSelector applies the egress IP only to the pods whose label

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -489,6 +489,10 @@ func (e *EgressIPController) reconcileEgressIP(old, new *egressipv1.EgressIP) (e
 // based on received namespace objects.
 // NOTE: we only care about namespace label updates
 func (e *EgressIPController) reconcileEgressIPNamespace(old, new *corev1.Namespace) error {
+	// Add nil checks to prevent panic on dereference
+	if old == nil && new == nil {
+		return nil // Nothing to reconcile
+	}
 	// Same as for reconcileEgressIP: labels play nicely with empty object, not
 	// nil ones.
 	var namespaceName string


### PR DESCRIPTION
 Fix ovnkube-node pods crashes with panic when invalid namespace selector provided for EgressIP

`pkg/crd/egressip/v1/types.go`: This commit fixes the CRD to check namespace selector key and value by checking against REGEX to ensure that label values in the selector follow Kubernetes namespace naming conventions (DNS-1123)

`pkg/ovn/egressip.go`: If the namespace list fails (due to the invalid key), the reconciler may be invoked with both parameters as nil, bypassing partial checks and causing a dereference. This early exit condition handles that gracefully.

`/dist/templates/k8s.ovn.org_egressips.yaml.j2`: Generated CRDs after adding CEL for checking REGEX to namespace selector field.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added detailed validation rules for label keys and values in NamespaceSelector to ensure proper formatting with clear error messages.
* **Bug Fixes**
  * Improved stability by preventing errors during namespace update processing when no relevant data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->