### PR TITLE
P-UDN: support multiple cluster-subnets for Layer3 topology

### DIFF
--- a/docs/okeps/okep-5377-extend-udn-to-support-multiple-cluster-subnets-in-layer3-topology.md
+++ b/docs/okeps/okep-5377-extend-udn-to-support-multiple-cluster-subnets-in-layer3-topology.md
@@ -157,10 +157,10 @@ is updated with a subnet that would overlap, and ensure that the Egress Firewall
 
 #### BGP RouteAdvertisement (RA)
 
-Whenever a BGP RA is configured to advertise the pod subnet, it generates an FRR-K8S configuration that includes the subnet.
-When a NAD changes today, we reconcile all BGP RAs. However, in the reconciliation, we check raNeedsUpdate, which only checks
-if the RA changed. We will need to fix this code and add a unit test to make sure that when an RA exists, with pod subnet
-advertisement, that adding a subnet updates the FRR-K8S configuration with the new subnet.
+No code change is required for Layer3 topology. When a BGP RA advertises pod subnets, the FRR-K8S configuration uses the
+node subnets allocated from the NAD and stored in the node subnet annotation, rather than the NAD cluster subnet list
+directly. If a node receives a subnet from a newly added NAD subnet range, the node subnet annotation changes and already
+triggers RA reconciliation.
 
 #### BGP Route Importing
 

--- a/go-controller/pkg/clustermanager/clustermanager_suite_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_suite_test.go
@@ -20,6 +20,11 @@ func init() {
 }
 
 func TestClusterManager(t *testing.T) {
+	// Disable WatchListClient for this suite. Fake NAD clients used in tests
+	// don't provide watchlist bookmarks and informer sync may time out.
+	if err := os.Setenv("KUBE_FEATURE_WatchListClient", "false"); err != nil {
+		t.Fatalf("Failed to set KUBE_FEATURE_WatchListClient: %v", err)
+	}
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Cluster Manager Operations Suite")
 }

--- a/go-controller/pkg/clustermanager/clustermanager_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"sync"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
@@ -17,12 +18,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	utilnet "k8s.io/utils/net"
 
 	hotypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	udncontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/userdefinednetwork"
+	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	networkconnect "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1"
 	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
@@ -411,6 +415,170 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("Add subnet to primary layer3 UDN", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				testNADName := "test/primary"
+				oneSubnetNetwork := &ovncnitypes.NetConf{
+					Topology: ovntypes.Layer3Topology,
+					NADName:  testNADName,
+					NetConf: cnitypes.NetConf{
+						Name: "primary",
+						Type: "ovn-k8s-cni-overlay",
+					},
+					Subnets: "10.10.0.0/16/17",
+					Role:    ovntypes.NetworkRolePrimary,
+					MTU:     1400,
+				}
+				twoSubnetNetwork := &ovncnitypes.NetConf{
+					Topology: ovntypes.Layer3Topology,
+					NADName:  testNADName,
+					NetConf: cnitypes.NetConf{
+						Name: "primary",
+						Type: "ovn-k8s-cni-overlay",
+					},
+					Subnets: "10.10.0.0/16/17, 10.20.0.0/16/17",
+					Role:    ovntypes.NetworkRolePrimary,
+					MTU:     1400,
+				}
+
+				nodes := []corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node2",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node3",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node4",
+						},
+					},
+				}
+
+				objs := []runtime.Object{
+					&corev1.NodeList{
+						Items: nodes,
+					},
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				config.Kubernetes.HostNetworkNamespace = ""
+				config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+				fakeClient := util.GetOVNClientset(objs...).GetClusterManagerClientset()
+
+				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = f.Start()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				c, cancel := context.WithCancel(ctx.Context)
+				defer cancel()
+				clusterManager, err := NewClusterManager(fakeClient, f, "identity", nil)
+				gomega.Expect(clusterManager).NotTo(gomega.BeNil())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = clusterManager.Start(c)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				defer clusterManager.Stop()
+
+				meetsExpectations := func(g gomega.Gomega, netName string,
+					expectedSubnetCount int, expectedSubnets []string, expectedNodeSubnetMap map[string]string) {
+					// Check subnet allocations
+					nodes, err := fakeClient.KubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+					g.Expect(err).ToNot(gomega.HaveOccurred())
+
+					nodesWithSubnets := 0
+					actualSubnets := []string{}
+					actualNodeSubnetMap := map[string]string{}
+					for _, node := range nodes.Items {
+						ipnets, err := util.ParseNodeHostSubnetAnnotation(&node, netName)
+						if err == nil {
+							nodesWithSubnets++
+							g.Expect(ipnets).To(gomega.HaveLen(1))
+							actualSubnets = append(actualSubnets, ipnets[0].String())
+							actualNodeSubnetMap[node.Name] = ipnets[0].String()
+						}
+					}
+					g.Expect(nodesWithSubnets).To(gomega.Equal(expectedSubnetCount))
+					if expectedSubnets != nil {
+						g.Expect(actualSubnets).To(gomega.ConsistOf(expectedSubnets))
+					}
+
+					for k, v := range expectedNodeSubnetMap {
+
+						g.Expect(actualNodeSubnetMap[k]).To(gomega.Equal(v))
+					}
+				}
+
+				// Wait for nodes to be allocated a default network subnet.
+				// Only the number of allocated subnets is checked here; the actual subnet values are not validated.
+				gomega.Eventually(func(g gomega.Gomega) {
+					meetsExpectations(g, ovntypes.DefaultNetworkName, 4, nil, nil)
+				}, "10s", "250ms").Should(gomega.Succeed())
+
+				// create NAD with one subnet
+				namespace, nadName, err := cache.SplitMetaNamespaceKey(testNADName)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				nad, err := testing.BuildNAD(nadName, namespace, oneSubnetNetwork)
+				nad.ResourceVersion = "2" // apparently changing the actual config isn't enough
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(context.Background(), nad, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				// Check that only 2 nodes get subnet due to subnet shortage
+				gomega.Eventually(func(g gomega.Gomega) {
+					meetsExpectations(g, nadName, 2, []string{"10.10.0.0/17", "10.10.128.0/17"}, nil)
+				}, "10s", "250ms").Should(gomega.Succeed())
+
+				getNodeSubnetMap := func(netName string) map[string]string {
+					nodes, err := fakeClient.KubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+					ret := map[string]string{}
+					for _, node := range nodes.Items {
+						ipnets, _ := util.ParseNodeHostSubnetAnnotation(&node, netName)
+						if len(ipnets) > 0 {
+							ret[node.Name] = ipnets[0].String()
+						}
+					}
+					return ret
+				}
+
+				expectedNodeSubnetMap := getNodeSubnetMap(nadName)
+
+				// Update NAD to add one more subnet
+				nad, err = testing.BuildNAD(nadName, namespace, twoSubnetNetwork)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Update(context.Background(), nad, metav1.UpdateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				// Verify that all nodes have been allocated subnets after adding the new subnet.
+				gomega.Eventually(func(g gomega.Gomega) {
+					meetsExpectations(g, nadName, 4, []string{"10.10.0.0/17", "10.10.128.0/17", "10.20.0.0/17", "10.20.128.0/17"}, expectedNodeSubnetMap)
+				}, "10s", "250ms").Should(gomega.Succeed())
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 	})
 
 	ginkgo.Context("Node Id allocations", func() {

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -814,8 +814,54 @@ func (ncc *networkClusterController) Cleanup() error {
 	return nil
 }
 
+// getNewSubnets returns subnets that are in new but not in old
+func getNewSubnets(old, new []config.CIDRNetworkEntry) []config.CIDRNetworkEntry {
+	if len(old) == 0 {
+		return new
+	}
+
+	oldSubnetMap := make(map[string]bool)
+	for _, subnet := range old {
+		oldSubnetMap[subnet.CIDR.String()] = true
+	}
+
+	var ret []config.CIDRNetworkEntry
+	for _, newSubnet := range new {
+		if !oldSubnetMap[newSubnet.CIDR.String()] {
+			ret = append(ret, newSubnet)
+		}
+	}
+
+	return ret
+}
+
 func (ncc *networkClusterController) Reconcile(netInfo util.NetInfo) error {
 	nadKeys := ncc.networkManager.GetNADKeysForNetwork(netInfo.GetNetworkName())
+	if ncc.nodeAllocator != nil {
+		oldSubnets := ncc.GetNetInfo().Subnets()
+		newSubnets := netInfo.Subnets()
+
+		// Find subnets that are in newSubnets but not in oldSubnets
+		addedSubnets := getNewSubnets(oldSubnets, newSubnets)
+		if len(addedSubnets) > 0 {
+			if err := ncc.nodeAllocator.AddSubnets(addedSubnets); err != nil {
+				return fmt.Errorf("failed to add new subnets to node allocator for network %s: %w", ncc.GetNetworkName(), err)
+			}
+
+			// Trigger a full reconcile for all allocatable nodes so any previous
+			// allocation failures are retried after subnet pool expansion.
+			nodes, err := ncc.watchFactory.GetNodes()
+			if err != nil {
+				klog.Errorf("Failed to list nodes for network %s: %v", ncc.GetNetworkName(), err)
+			} else {
+				for _, node := range nodes {
+					if !util.NoHostSubnet(node) {
+						ncc.nodeReconciler.ReconcileNetwork(node.Name, netInfo.GetNetworkName())
+					}
+				}
+			}
+		}
+	}
 	reconcilePendingPods := ncc.updateNADKeysChanged(nadKeys)
 	// update network information, point of no return
 	err := util.ReconcileNetInfo(ncc.ReconcilableNetInfo, netInfo)

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -126,6 +126,25 @@ func (na *NodeAllocator) CleanupStaleAnnotation() {
 	}
 }
 
+// AddSubnets adds new subnet ranges to the node allocator
+// It is used when a new subnet is added to a secondary layer3 network by updating UDN or NAD
+func (na *NodeAllocator) AddSubnets(subnets []config.CIDRNetworkEntry) error {
+	if !na.hasNodeSubnetAllocation() {
+		return nil
+	}
+
+	for _, subnet := range subnets {
+		if err := na.clusterSubnetAllocator.AddNetworkRange(subnet.CIDR, subnet.HostSubnetLength); err != nil {
+			return fmt.Errorf("failed to add network range %s/%d: %w", subnet.CIDR.String(), subnet.HostSubnetLength, err)
+		}
+		klog.V(5).Infof("Added new network range %s/%d to cluster subnet allocator for network %s",
+			subnet.CIDR.String(), subnet.HostSubnetLength, na.netInfo.GetNetworkName())
+	}
+	na.recordSubnetCount()
+
+	return nil
+}
+
 func (na *NodeAllocator) hasHybridOverlayAllocation() bool {
 	// When config.HybridOverlay.ClusterSubnets is empty, assume the subnet allocation will be managed by an external component.
 	return config.HybridOverlay.Enabled && !na.netInfo.IsUserDefinedNetwork() && len(config.HybridOverlay.ClusterSubnets) > 0
@@ -693,7 +712,7 @@ func (na *NodeAllocator) allocateNodeSubnets(allocator SubnetAllocator, nodeName
 }
 
 func (na *NodeAllocator) hasNodeSubnetAllocation() bool {
-	// we only allocate subnets for L3 secondary network or default network
+	// we only allocate subnets for L3 user-defined network or default network
 	return na.netInfo.TopologyType() == types.Layer3Topology || !na.netInfo.IsUserDefinedNetwork()
 }
 

--- a/go-controller/pkg/crd/userdefinednetwork/v1/apis/applyconfiguration/userdefinednetwork/v1/layer3config.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/apis/applyconfiguration/userdefinednetwork/v1/layer3config.go
@@ -24,8 +24,8 @@ type Layer3ConfigApplyConfiguration struct {
 	MTU *int32 `json:"mtu,omitempty"`
 	// Subnets are used for the pod network across the cluster.
 	//
-	// Dual-stack clusters may set 2 subnets (one for each IP family), otherwise only 1 subnet is allowed.
-	// Given subnet is split into smaller subnets for every node.
+	// Each IP family can have multiple subnets.
+	// For each IP family, every node allocates a smaller subnet from the provided subnets.
 	Subnets []Layer3SubnetApplyConfiguration `json:"subnets,omitempty"`
 	// JoinSubnets are used inside the OVN network topology.
 	//

--- a/go-controller/pkg/crd/userdefinednetwork/v1/cudn.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/cudn.go
@@ -45,7 +45,6 @@ type ClusterUserDefinedNetworkSpec struct {
 	// +kubebuilder:validation:XValidation:rule="!has(self.transport) || self.transport != 'EVPN' || self.topology != 'Layer2' || (has(self.evpn) && has(self.evpn.macVRF))", message="spec.evpn.macVRF field is required for Layer2 topology when transport is 'EVPN'"
 	// +kubebuilder:validation:XValidation:rule="!has(self.transport) || self.transport != 'EVPN' || self.topology != 'Layer3' || (has(self.evpn) && has(self.evpn.ipVRF))", message="spec.evpn.ipVRF field is required for Layer3 topology when transport is 'EVPN'"
 	// +kubebuilder:validation:XValidation:rule="!has(self.transport) || self.transport != 'EVPN' || self.topology != 'Layer3' || !has(self.evpn) || !has(self.evpn.macVRF)", message="spec.evpn.macVRF field is forbidden for Layer3 topology when transport is 'EVPN'"
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Network spec is immutable"
 	// +required
 	Network NetworkSpec `json:"network"`
 }
@@ -62,6 +61,7 @@ type NetworkSpec struct {
 	//
 	// +kubebuilder:validation:Enum=Layer2;Layer3;Localnet
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Topology is immutable"
 	// +required
 	// +unionDiscriminator
 	Topology NetworkTopology `json:"topology"`
@@ -71,10 +71,12 @@ type NetworkSpec struct {
 	Layer3 *Layer3Config `json:"layer3,omitempty"`
 
 	// Layer2 is the Layer2 topology configuration.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Layer2 is immutable"
 	// +optional
 	Layer2 *Layer2Config `json:"layer2,omitempty"`
 
 	// Localnet is the Localnet topology configuration.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Localnet is immutable"
 	// +optional
 	Localnet *LocalnetConfig `json:"localnet,omitempty"`
 
@@ -85,10 +87,12 @@ type NetworkSpec struct {
 	// When omitted, the network uses the default OVN overlay transport (e.g. Geneve, VXLAN)
 	// as configured by ovn-encap-type.
 	// +kubebuilder:validation:Enum=NoOverlay;EVPN
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Transport is immutable"
 	// +optional
 	Transport TransportOption `json:"transport,omitempty"`
 	// NoOverlay contains configuration for no-overlay mode.
 	// This is only allowed when Transport is "NoOverlay".
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="NoOverlay is immutable"
 	// +optional
 	NoOverlay *NoOverlayConfig `json:"noOverlay,omitempty"`
 	// EVPN contains configuration for EVPN mode.

--- a/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/shared.go
@@ -26,8 +26,17 @@ const (
 	NetworkTopologyLayer3 NetworkTopology = "Layer3"
 )
 
+// +kubebuilder:validation:XValidation:rule="self.role != 'Secondary' || self.subnets == oldSelf.subnets", message="Subnets is immutable for Secondary role"
+// +kubebuilder:validation:XValidation:rule="self.role != 'Secondary' || !has(self.subnets) || self.subnets.size() <= 2", message="Secondary networks may define at most 2 subnets"
+// +kubebuilder:validation:XValidation:rule="self.role != 'Secondary' || size(self.subnets) != 2 || !isCIDR(self.subnets[0].cidr) || !isCIDR(self.subnets[1].cidr) || cidr(self.subnets[0].cidr).ip().family() != cidr(self.subnets[1].cidr).ip().family()", message="When 2 CIDRs are set for Secondary networks, they must be from different IP families"
 // +kubebuilder:validation:XValidation:rule="!has(self.joinSubnets) || has(self.role) && self.role == 'Primary'", message="JoinSubnets is only supported for Primary network"
 // +kubebuilder:validation:XValidation:rule="!has(self.subnets) || !has(self.mtu) || !self.subnets.exists_one(i, isCIDR(i.cidr) && cidr(i.cidr).ip().family() == 6) || self.mtu >= 1280", message="MTU should be greater than or equal to 1280 when IPv6 subnet is used"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.subnets) || oldSelf.subnets.all(old, self.subnets.exists(new, new.cidr == old.cidr))", message="Removing existing subnets is not allowed"
+// +kubebuilder:validation:XValidation:rule="!has(self.subnets) || self.subnets.size() == 1 || !self.subnets.exists(i, self.subnets.exists(j, i != j && cidr(i.cidr).containsCIDR(j.cidr)))", message="Subnets must not overlap or contain each other"
+// +kubebuilder:validation:XValidation:rule="!has(self.subnets) || self.subnets.size() == 1 || !self.subnets.exists(i, self.subnets.filter(j, j.cidr == i.cidr).size() > 1)", message="Subnets with same CIDR are not allowed"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.subnets) || oldSelf.subnets.all(old, self.subnets.exists(new, new.cidr == old.cidr && (!has(old.hostSubnet) && !has(new.hostSubnet) || has(old.hostSubnet) && has(new.hostSubnet) && old.hostSubnet == new.hostSubnet)))", message="hostSubnet is immutable"
+// +kubebuilder:validation:XValidation:rule="!has(self.subnets) || self.subnets.size() == 1 || self.subnets.all(i, self.subnets.all(j, cidr(i.cidr).ip().family() != cidr(j.cidr).ip().family() || (has(i.hostSubnet) == has(j.hostSubnet) && (!has(i.hostSubnet) || i.hostSubnet == j.hostSubnet))))", message="Subnets from the same IP family must use the same hostSubnet value"
+
 type Layer3Config struct {
 	// Role describes the network role in the pod.
 	//
@@ -37,6 +46,7 @@ type Layer3Config struct {
 	//
 	// +kubebuilder:validation:Enum=Primary;Secondary
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="role is immutable"
 	// +required
 	Role NetworkRole `json:"role"`
 
@@ -46,18 +56,18 @@ type Layer3Config struct {
 	//
 	// +kubebuilder:validation:Minimum=576
 	// +kubebuilder:validation:Maximum=65536
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="mtu is immutable"
 	// +optional
 	MTU int32 `json:"mtu,omitempty"`
 
 	// Subnets are used for the pod network across the cluster.
 	//
-	// Dual-stack clusters may set 2 subnets (one for each IP family), otherwise only 1 subnet is allowed.
-	// Given subnet is split into smaller subnets for every node.
+	// Each IP family can have multiple subnets.
+	// For each IP family, every node allocates a smaller subnet from the provided subnets.
 	//
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:MaxItems=400
 	// +required
-	// +kubebuilder:validation:XValidation:rule="size(self) != 2 || !isCIDR(self[0].cidr) || !isCIDR(self[1].cidr) || cidr(self[0].cidr).ip().family() != cidr(self[1].cidr).ip().family()", message="When 2 CIDRs are set, they must be from different IP families"
 	Subnets []Layer3Subnet `json:"subnets,omitempty"`
 
 	// JoinSubnets are used inside the OVN network topology.
@@ -67,6 +77,7 @@ type Layer3Config struct {
 	// It is not recommended to set this field without explicit need and understanding of the OVN network topology.
 	// When omitted, the platform will choose a reasonable default which is subject to change over time.
 	//
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="joinSubnets is immutable"
 	// +optional
 	JoinSubnets DualStackCIDRs `json:"joinSubnets,omitempty"`
 }

--- a/go-controller/pkg/crd/userdefinednetwork/v1/udn.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/udn.go
@@ -17,7 +17,6 @@ type UserDefinedNetwork struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Spec is immutable"
 	// +kubebuilder:validation:XValidation:rule="has(self.topology) && self.topology == 'Layer3' ? has(self.layer3): !has(self.layer3)", message="spec.layer3 is required when topology is Layer3 and forbidden otherwise"
 	// +kubebuilder:validation:XValidation:rule="has(self.topology) && self.topology == 'Layer2' ? has(self.layer2): !has(self.layer2)", message="spec.layer2 is required when topology is Layer2 and forbidden otherwise"
 	// +required
@@ -37,6 +36,7 @@ type UserDefinedNetworkSpec struct {
 	//
 	// +kubebuilder:validation:Enum=Layer2;Layer3
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Topology is immutable"
 	// +required
 	// +unionDiscriminator
 	Topology NetworkTopology `json:"topology"`
@@ -46,6 +46,7 @@ type UserDefinedNetworkSpec struct {
 	Layer3 *Layer3Config `json:"layer3,omitempty"`
 
 	// Layer2 is the Layer2 topology configuration.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Layer2 is immutable"
 	// +optional
 	Layer2 *Layer2Config `json:"layer2,omitempty"`
 }

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -1150,8 +1150,12 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 		ensureNetwork = util.NewMutableNetInfo(nadNetwork)
 	case util.AreNetworksCompatible(currentNetwork, nadNetwork):
 		// the NAD refers to an existing compatible network, ensure that
-		// existing network holds a reference to this NAD
-		ensureNetwork = currentNetwork
+		// existing network holds references to all NADs while still allowing
+		// dynamic fields from the latest NAD config to reconcile.
+		ensureNetwork = util.NewMutableNetInfo(nadNetwork)
+		if nadSet := c.nadsByNetwork[nadNetworkName]; len(nadSet) > 0 {
+			ensureNetwork.AddNADs(nadSet.UnsortedList()...)
+		}
 	case func() bool {
 		nadSet := c.nadsByNetwork[nadNetworkName]
 		return len(nadSet) == 1 && nadSet.Has(key)

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	networkconnectv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	ovntesting "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -153,7 +154,7 @@ func TestSyncNAD_NotifiesReconcilers(t *testing.T) {
 		MTU:     1400,
 		NADName: nadKey,
 	}
-	nad, err := buildNAD(nadName, nadNS, networkAPrimary)
+	nad, err := ovntesting.BuildNAD(nadName, nadNS, networkAPrimary)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// The NAD has no network ID annotation so syncNAD will not ensure the network,
@@ -923,7 +924,7 @@ func TestNADController(t *testing.T) {
 				var nad *nettypes.NetworkAttachmentDefinition
 				if args.network != nil {
 					args.network.NADName = args.nad
-					nad, err = buildNAD(name, namespace, args.network)
+					nad, err = ovntesting.BuildNAD(name, namespace, args.network)
 					g.Expect(err).ToNot(gomega.HaveOccurred())
 					_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(context.Background(), nad, metav1.CreateOptions{})
 					g.Expect(err).To(gomega.Or(gomega.Not(gomega.HaveOccurred()), gomega.MatchError(apierrors.IsAlreadyExists, "AlreadyExists")))
@@ -1844,7 +1845,7 @@ func TestResourceCleanup(t *testing.T) {
 		MTU:     1400,
 		NADName: nadKey,
 	}
-	nad, err := buildNAD(nadName, nadNs, networkAPrimary)
+	nad, err := ovntesting.BuildNAD(nadName, nadNs, networkAPrimary)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// make annotation update fail (nad doesn't exist), make sure networkID and tunnel keys are released
@@ -1857,6 +1858,15 @@ func TestResourceCleanup(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	err = nadController.tunnelKeysAllocator.ReserveKeys("networkB", []int{16711684, 16715779})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
+}
+
+func buildNADWithAnnotations(name, namespace string, network *ovncnitypes.NetConf, annotations map[string]string) (*nettypes.NetworkAttachmentDefinition, error) {
+	nad, err := ovntesting.BuildNAD(name, namespace, network)
+	if err != nil {
+		return nil, err
+	}
+	nad.Annotations = annotations
+	return nad, nil
 }
 
 func buildNAD(name, namespace string, network *ovncnitypes.NetConf) (*nettypes.NetworkAttachmentDefinition, error) {
@@ -1873,15 +1883,6 @@ func buildNAD(name, namespace string, network *ovncnitypes.NetConf) (*nettypes.N
 			Config: string(config),
 		},
 	}
-	return nad, nil
-}
-
-func buildNADWithAnnotations(name, namespace string, network *ovncnitypes.NetConf, annotations map[string]string) (*nettypes.NetworkAttachmentDefinition, error) {
-	nad, err := buildNAD(name, namespace, network)
-	if err != nil {
-		return nil, err
-	}
-	nad.Annotations = annotations
 	return nad, nil
 }
 
@@ -3154,7 +3155,7 @@ func TestOnNetworkRefChangeNotifiesNetworkController(t *testing.T) {
 				Role:     types.NetworkRolePrimary,
 				NADName:  "ns1/primary",
 			}
-			nad, err := buildNAD("primary", "ns1", netConf)
+			nad, err := ovntesting.BuildNAD("primary", "ns1", netConf)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			nad.OwnerReferences = []metav1.OwnerReference{{
 				Kind:       "UserDefinedNetwork",

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig_testutil.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig_testutil.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func TestDefaultBridgeConfig() *BridgeConfiguration {
@@ -71,32 +70,31 @@ func CheckAdvertisedUDNSvcIsolationOVSFlows(flows []string, netConfig *BridgeUDN
 	ginkgo.By(fmt.Sprintf("Checking advertised UDN %s service isolation flows for %s; expected %d flows",
 		netName, svcCIDR.String(), expectedNFlows))
 
-	var matchingIPFamilySubnet *net.IPNet
 	var protoPrefix string
-	var udnAdvertisedSubnets []*net.IPNet
-	var err error
-	for _, clusterEntry := range netConfig.Subnets {
-		udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
-	}
+	var matchingIPFamilySubnets []*net.IPNet
 	if net2.IsIPv4CIDR(svcCIDR) {
-		matchingIPFamilySubnet, err = util.MatchFirstIPNetFamily(false, udnAdvertisedSubnets)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		protoPrefix = protoPrefixV4
 	} else {
-		matchingIPFamilySubnet, err = util.MatchFirstIPNetFamily(true, udnAdvertisedSubnets)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		protoPrefix = protoPrefixV6
 	}
+	for _, clusterEntry := range netConfig.Subnets {
+		if net2.IsIPv6CIDR(clusterEntry.CIDR) == net2.IsIPv6CIDR(svcCIDR) {
+			matchingIPFamilySubnets = append(matchingIPFamilySubnets, clusterEntry.CIDR)
+		}
+	}
+	gomega.Expect(matchingIPFamilySubnets).NotTo(gomega.BeEmpty())
 
 	var nFlows int
 	for _, flow := range flows {
-		if strings.Contains(flow, fmt.Sprintf("priority=200, table=2, %s, %s_src=%s, actions=drop",
-			protoPrefix, protoPrefix, matchingIPFamilySubnet)) {
-			nFlows++
-		}
-		if strings.Contains(flow, fmt.Sprintf("priority=550, in_port=LOCAL, %s, %s_src=%s, %s_dst=%s, actions=ct(commit,zone=64001,table=2)",
-			protoPrefix, protoPrefix, matchingIPFamilySubnet, protoPrefix, svcCIDR)) {
-			nFlows++
+		for _, matchingIPFamilySubnet := range matchingIPFamilySubnets {
+			if strings.Contains(flow, fmt.Sprintf("priority=200, table=2, %s, %s_src=%s, actions=drop",
+				protoPrefix, protoPrefix, matchingIPFamilySubnet)) {
+				nFlows++
+			}
+			if strings.Contains(flow, fmt.Sprintf("priority=550, in_port=LOCAL, %s, %s_src=%s, %s_dst=%s, actions=ct(commit,zone=64001,table=2)",
+				protoPrefix, protoPrefix, matchingIPFamilySubnet, protoPrefix, svcCIDR)) {
+				nFlows++
+			}
 		}
 	}
 

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -22,6 +22,16 @@ const (
 	protoPrefixV6 = "ipv6"
 )
 
+func matchIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) []*net.IPNet {
+	var matches []*net.IPNet
+	for _, ipnet := range ipnets {
+		if utilnet.IsIPv6CIDR(ipnet) == isIPv6 {
+			matches = append(matches, ipnet)
+		}
+	}
+	return matches
+}
+
 func (b *BridgeConfiguration) DefaultBridgeFlows(hostSubnets []*net.IPNet, extraIPs []net.IP) ([]string, error) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
@@ -252,20 +262,20 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 						for _, clusterEntry := range netConfig.Subnets {
 							udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
 						}
-						// Filter subnets based on the clusterIP service family
-						// NOTE: We don't support more than 1 subnet CIDR of same family type; we only pick the first one
-						matchingIPFamilySubnet, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(svcCIDR), udnAdvertisedSubnets)
-						if err != nil {
-							klog.Infof("Unable to determine UDN subnet for the provided family isIPV6: %t, %v", utilnet.IsIPv6CIDR(svcCIDR), err)
+						matchingIPFamilySubnets := matchIPNetFamily(utilnet.IsIPv6CIDR(svcCIDR), udnAdvertisedSubnets)
+						if len(matchingIPFamilySubnets) == 0 {
+							klog.Infof("Unable to determine UDN subnet for the provided family isIPV6: %t", utilnet.IsIPv6CIDR(svcCIDR))
 							continue
 						}
 
-						// Use the filtered subnet for the flow compute instead of the masqueradeIP
-						dftFlows = append(dftFlows,
-							fmt.Sprintf("cookie=%s, priority=550, in_port=%s, %s, %s_src=%s, %s_dst=%s, "+
-								"actions=ct(commit,zone=%d,table=2)",
-								nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefix, protoPrefix,
-								matchingIPFamilySubnet.String(), protoPrefix, svcCIDR, config.Default.HostMasqConntrackZone))
+						for _, matchingIPFamilySubnet := range matchingIPFamilySubnets {
+							// Use the filtered subnet for the flow compute instead of the masqueradeIP
+							dftFlows = append(dftFlows,
+								fmt.Sprintf("cookie=%s, priority=550, in_port=%s, %s, %s_src=%s, %s_dst=%s, "+
+									"actions=ct(commit,zone=%d,table=2)",
+									nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefix, protoPrefix,
+									matchingIPFamilySubnet.String(), protoPrefix, svcCIDR, config.Default.HostMasqConntrackZone))
+						}
 					}
 				}
 			}
@@ -387,21 +397,21 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 				for _, clusterEntry := range netConfig.Subnets {
 					udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
 				}
-				// Filter subnets based on the clusterIP service family
-				// NOTE: We don't support more than 1 subnet CIDR of same family type; we only pick the first one
-				matchingIPFamilySubnet, err := util.MatchFirstIPNetFamily(false, udnAdvertisedSubnets)
-				if err != nil {
-					klog.Infof("Unable to determine IPV4 UDN subnet for the provided family isIPV6: %v", err)
+				matchingIPFamilySubnets := matchIPNetFamily(false, udnAdvertisedSubnets)
+				if len(matchingIPFamilySubnets) == 0 {
+					klog.Infof("Unable to determine IPV4 UDN subnet")
 					continue
 				}
 				// In addition to the masqueradeIP based flows, we also need the podsubnet based flows for
 				// advertised networks since UDN pod to clusterIP is unSNATed and we need this traffic to be taken into
 				// the correct patch port of it's own network where it's a deadend if the clusterIP is not part of
 				// that UDN network and works if it is part of the UDN network.
-				dftFlows = append(dftFlows,
-					fmt.Sprintf("cookie=%s, priority=200, table=2, %s, %s_src=%s, "+
-						"actions=drop",
-						nodetypes.DefaultOpenFlowCookie, protoPrefixV4, protoPrefixV4, matchingIPFamilySubnet.String()))
+				for _, matchingIPFamilySubnet := range matchingIPFamilySubnets {
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=200, table=2, %s, %s_src=%s, "+
+							"actions=drop",
+							nodetypes.DefaultOpenFlowCookie, protoPrefixV4, protoPrefixV4, matchingIPFamilySubnet.String()))
+				}
 			}
 			// Drop traffic coming from the masquerade IP or the UDN subnet(for advertised UDNs) to ensure that
 			// isolation between networks is enforced. This handles the case where a pod on the UDN subnet is sending traffic to
@@ -430,19 +440,19 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 				for _, clusterEntry := range netConfig.Subnets {
 					udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
 				}
-				// Filter subnets based on the clusterIP service family
-				// NOTE: We don't support more than 1 subnet CIDR of same family type; we only pick the first one
-				matchingIPFamilySubnet, err := util.MatchFirstIPNetFamily(true, udnAdvertisedSubnets)
-				if err != nil {
-					klog.Infof("Unable to determine IPV6 UDN subnet for the provided family isIPV6: %v", err)
+				matchingIPFamilySubnets := matchIPNetFamily(true, udnAdvertisedSubnets)
+				if len(matchingIPFamilySubnets) == 0 {
+					klog.Infof("Unable to determine IPV6 UDN subnet")
 					continue
 				}
 
-				dftFlows = append(dftFlows,
-					fmt.Sprintf("cookie=%s, priority=200, table=2, %s, %s_src=%s, "+
-						"actions=drop",
-						nodetypes.DefaultOpenFlowCookie, protoPrefixV6, protoPrefixV6,
-						matchingIPFamilySubnet.String()))
+				for _, matchingIPFamilySubnet := range matchingIPFamilySubnets {
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=200, table=2, %s, %s_src=%s, "+
+							"actions=drop",
+							nodetypes.DefaultOpenFlowCookie, protoPrefixV6, protoPrefixV6,
+							matchingIPFamilySubnet.String()))
+				}
 			}
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=200, table=2, %s, %s_src=%s, "+

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -205,7 +205,8 @@ func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed f
 		nodeName := key.(string)
 		wasAdvertised := util.IsPodNetworkAdvertisedAtNode(oc, nodeName)
 		isAdvertised := util.IsPodNetworkAdvertisedAtNode(netInfo, nodeName)
-		if wasAdvertised == isAdvertised && !(isAdvertised && subnetsChanged) {
+		reconcileSubnetChange := subnetsChanged && (isAdvertised || config.OVNKubernetesFeature.EnableEgressIP)
+		if wasAdvertised == isAdvertised && !reconcileSubnetChange {
 			// noop
 			return true
 		}

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -200,11 +200,12 @@ type BaseNetworkController struct {
 func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed func(string)) error {
 	// gather some information first
 	var reconcileNodes []string
+	subnetsChanged := clusterSubnetsChanged(oc, netInfo)
 	oc.localZoneNodes.Range(func(key, _ any) bool {
 		nodeName := key.(string)
 		wasAdvertised := util.IsPodNetworkAdvertisedAtNode(oc, nodeName)
 		isAdvertised := util.IsPodNetworkAdvertisedAtNode(netInfo, nodeName)
-		if wasAdvertised == isAdvertised {
+		if wasAdvertised == isAdvertised && !(isAdvertised && subnetsChanged) {
 			// noop
 			return true
 		}
@@ -229,6 +230,20 @@ func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed f
 		return fmt.Errorf("failed to reconcile network information for network %s: %v", oc.GetNetworkName(), err)
 	}
 	return oc.doReconcile(reconcileRoutes, reconcilePendingPods, reconcileNodes, setNodeFailed, reconcileNamespaces.List())
+}
+
+func clusterSubnetsChanged(old, new util.NetInfo) bool {
+	oldSubnets := sets.New[string]()
+	for _, subnet := range old.Subnets() {
+		oldSubnets.Insert(subnet.CIDR.String())
+	}
+
+	newSubnets := sets.New[string]()
+	for _, subnet := range new.Subnets() {
+		newSubnets.Insert(subnet.CIDR.String())
+	}
+
+	return !oldSubnets.Equal(newSubnets)
 }
 
 func (oc *BaseNetworkController) updateNADKeysChanged(nadKeys []string) bool {

--- a/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall_sync_test.go
+++ b/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall_sync_test.go
@@ -192,3 +192,115 @@ func TestEFControllerSync_UpdatesOnSubnetChangeAndSkipsWhenUnchanged(t *testing.
 	require.Equal(t, pgName, entry.pgName)
 	require.True(t, util.IsIPNetsEqual(subnetsForNetInfo(netInfo2), entry.subnets))
 }
+
+func TestEFControllerSync_AddsCIDRExclusionWhenPrimaryNetworkAddsOverlappingSubnet(t *testing.T) {
+	require.NoError(t, config.PrepareTestConfig())
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+
+	const (
+		namespace = "namespace1"
+		udnName   = "udn-test"
+		zone      = "global"
+	)
+
+	netInfoBefore := mustNetInfo(t, udnName, "10.128.0.0/16")
+	netInfoAfter := mustNetInfo(t, udnName, "10.128.0.0/16,10.129.0.0/16")
+
+	networkManager := &fakenetworkmanager.FakeNetworkManager{
+		PrimaryNetworks: map[string]util.NetInfo{
+			namespace: netInfoBefore,
+		},
+	}
+
+	ownerController := udnName + "-network-controller"
+	pgName := libovsdbutil.GetPortGroupName(getNamespacePortGroupDbIDs(namespace, ownerController))
+
+	initialDB := libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			&nbdb.PortGroup{
+				Name: pgName,
+				ExternalIDs: map[string]string{
+					libovsdbops.OwnerTypeKey.String():       libovsdbops.NamespaceOwnerType,
+					libovsdbops.OwnerControllerKey.String(): ownerController,
+					libovsdbops.ObjectNameKey.String():      namespace,
+				},
+			},
+		},
+	}
+	nbClient, _, cleanup, err := libovsdbtest.NewNBSBTestHarness(initialDB)
+	require.NoError(t, err)
+	t.Cleanup(cleanup.Cleanup)
+
+	nsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, nsIndexer.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}))
+	namespaceLister := corelisters.NewNamespaceLister(nsIndexer)
+
+	efIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	ef := &egressfirewallapi.EgressFirewall{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            egressFirewallName,
+			Namespace:       namespace,
+			ResourceVersion: "1",
+		},
+		Spec: egressfirewallapi.EgressFirewallSpec{
+			Egress: []egressfirewallapi.EgressFirewallRule{
+				{
+					Type: egressfirewallapi.EgressFirewallRuleAllow,
+					To: egressfirewallapi.EgressFirewallDestination{
+						CIDRSelector: "10.129.1.0/24",
+					},
+				},
+			},
+		},
+		Status: egressfirewallapi.EgressFirewallStatus{
+			Messages: []string{types.GetZoneStatus(zone, EgressFirewallAppliedCorrectly)},
+		},
+	}
+	require.NoError(t, efIndexer.Add(ef))
+	efLister := egressfirewalllisters.NewEgressFirewallLister(efIndexer)
+
+	oc := &EFController{
+		name:            "test",
+		zone:            zone,
+		cache:           syncmap.NewSyncMap[*cacheEntry](),
+		nbClient:        nbClient,
+		kube:            nil, // status updates are no-op in this test due to pre-seeded status message
+		namespaceLister: namespaceLister,
+		efLister:        efLister,
+		networkManager:  networkManager,
+		ruleCounter:     sync.Map{},
+		dnsNameResolver: noopDNSNameResolver{},
+	}
+
+	// Pre-seed rule counter so status updates don't affect global metrics.
+	oc.ruleCounter.Store(namespace+"/"+egressFirewallName, uint32(len(ef.Spec.Egress)))
+
+	err = oc.sync(namespace + "/" + egressFirewallName)
+	require.NoError(t, err)
+
+	p := libovsdbops.GetPredicate[*nbdb.ACL](oc.GetEgressFirewallACLDbIDs(namespace, 0), nil)
+	acls, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
+	require.NoError(t, err)
+	require.Len(t, acls, 1)
+	require.Contains(t, acls[0].Match, "ip4.dst == 10.129.1.0/24")
+	require.NotContains(t, acls[0].Match, "ip4.dst != 10.129.0.0/16")
+
+	networkManager.Lock()
+	networkManager.PrimaryNetworks[namespace] = netInfoAfter
+	networkManager.Unlock()
+
+	err = oc.sync(namespace + "/" + egressFirewallName)
+	require.NoError(t, err)
+
+	acls, err = libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
+	require.NoError(t, err)
+	require.Len(t, acls, 1)
+	require.Contains(t, acls[0].Match, "ip4.dst == 10.129.1.0/24")
+	require.Contains(t, acls[0].Match, "ip4.dst != 10.129.0.0/16")
+
+	entry, ok := oc.cache.Load(namespace)
+	require.True(t, ok)
+	require.Equal(t, pgName, entry.pgName)
+	require.True(t, util.IsIPNetsEqual(subnetsForNetInfo(netInfoAfter), entry.subnets))
+}

--- a/go-controller/pkg/ovn/controller/networkconnect/controller_suite_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller_suite_test.go
@@ -4,20 +4,26 @@
 package networkconnect
 
 import (
-	"os"
 	"testing"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	_ "k8s.io/kubernetes/pkg/features"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-func TestMain(m *testing.M) {
+func init() {
 	// Disable WatchListClient feature gate for tests.
 	// Fake clientsets from third-party libraries don't yet support WatchList semantics
 	// introduced in K8s 1.35, causing informers to hang waiting for bookmark events.
+	// The KUBE_FEATURE_WatchListClient env var alone is insufficient because
+	// k8s.io/kubernetes/pkg/features replaces client-go's env-var-based feature gates
+	// with utilfeature.DefaultMutableFeatureGate.
 	// See: https://github.com/kubernetes/kubernetes/issues/135895
-	os.Setenv("KUBE_FEATURE_WatchListClient", "false")
-	os.Exit(m.Run())
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{"WatchListClient": false}); err != nil {
+		panic(err)
+	}
 }
 
 func TestNetworkConnectController(t *testing.T) {

--- a/go-controller/pkg/ovn/controller/networkconnect/controller_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller_test.go
@@ -61,6 +61,7 @@ type testNetwork struct {
 	name         string
 	id           int
 	topologyType string
+	role         string
 	subnets      []string // Pod subnets for the network (optional, defaults based on IP mode)
 }
 
@@ -298,11 +299,15 @@ func createNetInfo(net testNetwork) (util.NetInfo, error) {
 	// Use DefaultSubnets which handles IP mode
 	subnets := net.DefaultSubnets()
 	subnetsStr := strings.Join(subnets, ",")
+	role := net.role
+	if role == "" {
+		role = ovntypes.NetworkRoleSecondary
+	}
 
 	netConf := &ovncnitypes.NetConf{
 		NetConf:  cnitypes.NetConf{Name: net.name},
 		Topology: net.topologyType,
-		Role:     ovntypes.NetworkRoleSecondary,
+		Role:     role,
 		Subnets:  subnetsStr,
 	}
 	netInfo, err := util.NewNetInfo(netConf)
@@ -550,6 +555,33 @@ func verifyRouterPolicyCount(nbClient libovsdbclient.Client, routerName, cncName
 	if len(policies) != expectedCount {
 		return fmt.Errorf("expected %d policies on %s for CNC %s, got %d",
 			expectedCount, routerName, cncName, len(policies))
+	}
+	return nil
+}
+
+// verifyRouterPolicyMatch verifies the routing policy for an IP family has the expected match.
+// Returns error for use in Eventually.
+func verifyRouterPolicyMatch(nbClient libovsdbclient.Client, routerName, cncName string,
+	srcNetworkID, dstNetworkID int, ipFamily, expectedMatch string) error {
+	policies, err := libovsdbops.FindALogicalRouterPoliciesWithPredicate(nbClient, routerName,
+		func(policy *nbdb.LogicalRouterPolicy) bool {
+			return policy.ExternalIDs != nil &&
+				policy.ExternalIDs[libovsdbops.ObjectNameKey.String()] == cncName &&
+				policy.ExternalIDs[libovsdbops.SourceNetworkIDKey.String()] == strconv.Itoa(srcNetworkID) &&
+				policy.ExternalIDs[libovsdbops.DestinationNetworkIDKey.String()] == strconv.Itoa(dstNetworkID) &&
+				policy.ExternalIDs[libovsdbops.IPFamilyKey.String()] == ipFamily
+		})
+	if err != nil {
+		return fmt.Errorf("failed to get policies from %s: %v", routerName, err)
+	}
+
+	if len(policies) != 1 {
+		return fmt.Errorf("expected 1 %s policy on %s for CNC %s, got %d",
+			ipFamily, routerName, cncName, len(policies))
+	}
+	if policies[0].Match != expectedMatch {
+		return fmt.Errorf("expected %s policy match %q on %s for CNC %s, got %q",
+			ipFamily, expectedMatch, routerName, cncName, policies[0].Match)
 	}
 	return nil
 }
@@ -1482,6 +1514,85 @@ var _ = Describe("OVNKube Network Connect Controller Integration Tests", func() 
 						return verifyRouterPolicyCount(nbClient, networks[1].RouterName(),
 							"update-cnc", networks[1].id, networks[0].id, expectedRouteCount)
 					}).WithTimeout(5 * time.Second).Should(Succeed())
+				})
+
+				It("should update router policies when a connected primary Layer3 network adds a subnet", func() {
+					networks := []testNetwork{
+						{name: "subnet-net1", id: 1, topologyType: ovntypes.Layer3Topology, role: ovntypes.NetworkRolePrimary,
+							subnets: []string{"10.128.0.0/14/23", "fd00:10:128::/48/64"}},
+						{name: "subnet-net2", id: 2, topologyType: ovntypes.Layer3Topology, role: ovntypes.NetworkRolePrimary,
+							subnets: []string{"10.132.0.0/14/23", "fd00:10:132::/48/64"}},
+					}
+					nodes := []testNode{
+						{name: "node1", id: 1, zone: "node1", nodeSubnets: map[string]subnetPair{
+							"subnet-net1": {"10.128.1.0/24", "fd00:10:128:1::/64"},
+							"subnet-net2": {"10.132.1.0/24", "fd00:10:132:1::/64"},
+						}},
+					}
+					initialDB := createInitialDBWithRouters(networks)
+					nad1 := ovntest.GenerateNAD(networks[0].name, networks[0].name, "ns1",
+						networks[0].topologyType, strings.Join(networks[0].DefaultSubnets(), ","), networks[0].role)
+					nad2 := ovntest.GenerateNAD(networks[1].name, networks[1].name, "ns2",
+						networks[1].topologyType, strings.Join(networks[1].DefaultSubnets(), ","), networks[1].role)
+					start(initialDB, nodes, map[string]testNetwork{"ns1": networks[0], "ns2": networks[1]}, nad1, nad2)
+
+					subnetAnnotation := buildConnectSubnetAnnotation(map[string]subnetPair{
+						"layer3_1": {"192.168.0.0/24", "fd00:192:168::/64"},
+						"layer3_2": {"192.168.1.0/24", "fd00:192:168:1::/64"},
+					})
+					cnc := createTestCNC("subnet-update-cnc", 450, defaultConnectSubnets(), subnetAnnotation)
+
+					_, err := fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Create(
+						context.Background(), cnc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					expectedPerIPFamily := 0
+					if config.IPv4Mode {
+						expectedPerIPFamily++
+					}
+					if config.IPv6Mode {
+						expectedPerIPFamily++
+					}
+
+					Eventually(func() error {
+						return verifyRouterPolicyCount(nbClient, networks[0].RouterName(),
+							"subnet-update-cnc", networks[0].id, networks[1].id, expectedPerIPFamily)
+					}).WithTimeout(5 * time.Second).Should(Succeed())
+
+					updatedNetwork := networks[1]
+					updatedNetwork.subnets = []string{
+						"10.132.0.0/14/23",
+						"10.136.0.0/14/23",
+						"fd00:10:132::/48/64",
+						"fd00:10:136::/48/64",
+					}
+					updatedNetInfo, err := createNetInfo(updatedNetwork)
+					Expect(err).NotTo(HaveOccurred())
+
+					fakeNM.Lock()
+					fakeNM.PrimaryNetworks["ns2"] = updatedNetInfo
+					if fakeNM.NADNetworks == nil {
+						fakeNM.NADNetworks = make(map[string]util.NetInfo)
+					}
+					fakeNM.NADNetworks["ns2/subnet-net2"] = updatedNetInfo
+					fakeNM.Unlock()
+					fakeNM.TriggerHandlers("ns2/subnet-net2", updatedNetInfo, false)
+
+					expectedInport := ovntypes.RouterToSwitchPrefix + util.GetUserDefinedNetworkPrefix(networks[0].name) + "node1"
+					if config.IPv4Mode {
+						Eventually(func() error {
+							return verifyRouterPolicyMatch(nbClient, networks[0].RouterName(),
+								"subnet-update-cnc", networks[0].id, networks[1].id, "v4",
+								fmt.Sprintf(`inport == "%s" && (ip4.dst == 10.132.0.0/14 || ip4.dst == 10.136.0.0/14)`, expectedInport))
+						}).WithTimeout(5 * time.Second).Should(Succeed())
+					}
+					if config.IPv6Mode {
+						Eventually(func() error {
+							return verifyRouterPolicyMatch(nbClient, networks[0].RouterName(),
+								"subnet-update-cnc", networks[0].id, networks[1].id, "v6",
+								fmt.Sprintf(`inport == "%s" && (ip6.dst == fd00:10:132::/48 || ip6.dst == fd00:10:136::/48)`, expectedInport))
+						}).WithTimeout(5 * time.Second).Should(Succeed())
+					}
 				})
 
 				It("should remove ports, policies and routes when network is disconnected via annotation update", func() {

--- a/go-controller/pkg/ovn/controller/networkconnect/topology.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/topology.go
@@ -1003,36 +1003,57 @@ func (c *Controller) ensureRoutingPoliciesOps(ops []ovsdb.Operation, cncName str
 // createRoutingPoliciesOps returns ops to create logical router policies.
 func (c *Controller) createRoutingPoliciesOps(ops []ovsdb.Operation, dstNetworkID int, routerName, inportName string,
 	dstSubnets []config.CIDRNetworkEntry, srcNetworkID int, nexthops []net.IP, cncName string) ([]ovsdb.Operation, error) {
-	for _, dstSubnet := range dstSubnets {
-		// Determine IP version and get appropriate nexthop
-		var nexthop string
-		for _, nh := range nexthops {
-			isIPv4Subnet := utilnet.IsIPv4(dstSubnet.CIDR.IP)
-			isIPv4Nexthop := utilnet.IsIPv4(nh)
-			if isIPv4Subnet == isIPv4Nexthop {
-				nexthop = nh.String()
-				break
-			}
+	type policyConfig struct {
+		ipVersion string
+		nexthop   string
+		subnets   []string
+	}
+
+	policyByFamily := map[string]*policyConfig{
+		"v4": {ipVersion: "ip4"},
+		"v6": {ipVersion: "ip6"},
+	}
+
+	for _, nexthop := range nexthops {
+		ipFamily := "v4"
+		if utilnet.IsIPv6(nexthop) {
+			ipFamily = "v6"
 		}
-		if nexthop == "" {
+		if policyByFamily[ipFamily].nexthop == "" {
+			policyByFamily[ipFamily].nexthop = nexthop.String()
+		}
+	}
+
+	for _, dstSubnet := range dstSubnets {
+		ipFamily := "v4"
+		if utilnet.IsIPv6(dstSubnet.CIDR.IP) {
+			ipFamily = "v6"
+		}
+		policyByFamily[ipFamily].subnets = append(policyByFamily[ipFamily].subnets, dstSubnet.CIDR.String())
+	}
+
+	for _, ipFamily := range []string{"v4", "v6"} {
+		policyConfig := policyByFamily[ipFamily]
+		if policyConfig.nexthop == "" || len(policyConfig.subnets) == 0 {
 			continue
 		}
 
-		// Build the match string
-		ipVersion := "ip4"
-		ipFamily := "v4"
-		if utilnet.IsIPv6(dstSubnet.CIDR.IP) {
-			ipVersion = "ip6"
-			ipFamily = "v6"
+		var dstMatches []string
+		for _, dstSubnet := range policyConfig.subnets {
+			dstMatches = append(dstMatches, fmt.Sprintf("%s.dst == %s", policyConfig.ipVersion, dstSubnet))
 		}
-		match := fmt.Sprintf(`inport == "%s" && %s.dst == %s`, inportName, ipVersion, dstSubnet.CIDR.String())
+		dstMatch := dstMatches[0]
+		if len(dstMatches) > 1 {
+			dstMatch = fmt.Sprintf("(%s)", strings.Join(dstMatches, " || "))
+		}
+		match := fmt.Sprintf(`inport == "%s" && %s`, inportName, dstMatch)
 
 		dbIndexes := buildLRPolicyDBIDs(cncName, strconv.Itoa(srcNetworkID), strconv.Itoa(dstNetworkID), ipFamily, routerName)
 		policy := &nbdb.LogicalRouterPolicy{
 			Priority:    ovntypes.NetworkConnectPolicyPriority,
 			Match:       match,
 			Action:      nbdb.LogicalRouterPolicyActionReroute,
-			Nexthops:    []string{nexthop},
+			Nexthops:    []string{policyConfig.nexthop},
 			ExternalIDs: dbIndexes.GetExternalIDs(),
 		}
 
@@ -1043,7 +1064,7 @@ func (c *Controller) createRoutingPoliciesOps(ops []ovsdb.Operation, dstNetworkI
 			return nil, fmt.Errorf("failed to create routing policy ops on %s: %v", routerName, err)
 		}
 
-		klog.V(5).Infof("Created/updated routing policy ops on %s: %s -> %s", routerName, match, nexthop)
+		klog.V(5).Infof("Created/updated routing policy ops on %s: %s -> %s", routerName, match, policyConfig.nexthop)
 	}
 
 	return ops, nil

--- a/go-controller/pkg/ovn/controller/networkconnect/topology_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/topology_test.go
@@ -1274,6 +1274,32 @@ func TestCreateRoutingPoliciesOps(t *testing.T) {
 			},
 		},
 		{
+			name:         "create single IPv4 routing policy for multiple same-family destination subnets",
+			dstNetworkID: 2,
+			routerName:   "network-router-1",
+			inportName:   "switch-to-router-port",
+			nexthops: []net.IP{
+				net.ParseIP("192.168.0.0"),
+			},
+			cncName:      "test-cnc",
+			srcNetworkID: 1,
+			dstSubnets:   []string{"10.200.0.0/24", "10.201.0.0/24"},
+			initialDB: []libovsdbtest.TestData{
+				&nbdb.LogicalRouter{
+					UUID: "router-uuid",
+					Name: "network-router-1",
+				},
+			},
+			expectError: false,
+			expectedPolicies: []expectedPolicy{
+				{
+					match:    `inport == "switch-to-router-port" && (ip4.dst == 10.200.0.0/24 || ip4.dst == 10.201.0.0/24)`,
+					nexthop:  "192.168.0.0",
+					ipFamily: "v4",
+				},
+			},
+		},
+		{
 			name:         "create dual-stack routing policies",
 			dstNetworkID: 2,
 			routerName:   "network-router-1",

--- a/go-controller/pkg/ovn/egressip_udn_l3_test.go
+++ b/go-controller/pkg/ovn/egressip_udn_l3_test.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -25,6 +26,7 @@ import (
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	udngenerator "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -123,6 +125,118 @@ var _ = ginkgo.Describe("EgressIP Operations for user defined network with topol
 	})
 
 	ginkgo.Context("sync", func() {
+		ginkgo.It("queues local nodes when EgressIP primary Layer3 UDN adds a subnet", func() {
+			netInfoBefore := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
+			nadBefore, err := newNetworkAttachmentDefinition(ns, nadName, *netInfoBefore.netconf())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			node, err := newNodeWithUserDefinedNetworks(node1Name, "192.168.126.202/24", netInfoBefore)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{},
+				node,
+				&nadv1.NetworkAttachmentDefinitionList{Items: []nadv1.NetworkAttachmentDefinition{*nadBefore}},
+			)
+
+			l3Controller, ok := fakeOvn.fullL3UDNControllers[netInfoBefore.netName]
+			gomega.Expect(ok).To(gomega.BeTrue())
+			l3Controller.lastNADKeys = sets.New[string](ns + "/" + nadName)
+
+			netInfoAfter := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16,192.169.0.0/16", "192.168.1.0/24")
+			nadAfter, err := newNetworkAttachmentDefinition(ns, nadName, *netInfoAfter.netconf())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			parsedNetInfoAfter, err := util.ParseNADInfo(nadAfter)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			mutableNetInfoAfter := util.NewMutableNetInfo(parsedNetInfoAfter)
+			mutableNetInfoAfter.SetNetworkID(2)
+
+			reconciledNodes := sets.New[string]()
+			gomega.Expect(l3Controller.reconcile(mutableNetInfoAfter, func(node string) {
+				reconciledNodes.Insert(node)
+			})).To(gomega.Succeed())
+			gomega.Expect(reconciledNodes.Has(node1Name)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("creates EgressIP routes and no-reroute policies for each primary Layer3 UDN subnet", func() {
+			netInfo := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16,192.169.0.0/16", "192.168.1.0/24")
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netInfo.netconf())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			node, err := newNodeWithUserDefinedNetworks(node1Name, "192.168.126.202/24", netInfo)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			parsedNetInfo, err := util.ParseNADInfo(nad)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			mutableNetInfo := util.NewMutableNetInfo(parsedNetInfo)
+			mutableNetInfo.SetNetworkID(2)
+			routerName := mutableNetInfo.GetNetworkScopedClusterRouterName()
+			udnEnabledSvcV4, _ := addressset.GetTestDbAddrSets(udnenabledsvc.GetAddressSetDBIDs(), []string{})
+
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalRouter{
+							Name:        routerName,
+							UUID:        routerName + "-UUID",
+							ExternalIDs: util.GenerateExternalIDsForSwitchOrRouter(mutableNetInfo),
+						},
+						udnEnabledSvcV4,
+					},
+				},
+				node,
+				&nadv1.NetworkAttachmentDefinitionList{Items: []nadv1.NetworkAttachmentDefinition{*nad}},
+			)
+			fakeOvn.eIPController.nodeZoneState.Store(node1Name, true)
+
+			gomega.Expect(fakeOvn.eIPController.ensureRouterPoliciesForNetwork(mutableNetInfo, node)).To(gomega.Succeed())
+
+			gatewayIPs, err := udngenerator.GetGWRouterIPs(node, mutableNetInfo)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(gatewayIPs).To(gomega.HaveLen(1))
+			expectedNextHop := gatewayIPs[0].IP.String()
+			routes, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(
+				fakeOvn.nbClient,
+				&nbdb.LogicalRouter{Name: routerName},
+				func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.Policy != nil &&
+						*route.Policy == nbdb.LogicalRouterStaticRoutePolicySrcIP &&
+						route.Nexthop == expectedNextHop
+				},
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			routePrefixes := sets.New[string]()
+			for _, route := range routes {
+				routePrefixes.Insert(route.IPPrefix)
+			}
+			gomega.Expect(routePrefixes.HasAll("192.168.0.0/16", "192.169.0.0/16")).To(gomega.BeTrue())
+
+			findNoRerouteMatches := func(policyName egressIPNoReroutePolicyName) []string {
+				policies, err := libovsdbops.FindALogicalRouterPoliciesWithPredicate(
+					fakeOvn.nbClient,
+					routerName,
+					func(policy *nbdb.LogicalRouterPolicy) bool {
+						return policy.Priority == ovntypes.DefaultNoRereoutePriority &&
+							policy.ExternalIDs[libovsdbops.ObjectNameKey.String()] == string(policyName) &&
+							policy.ExternalIDs[libovsdbops.NetworkKey.String()] == mutableNetInfo.GetNetworkName()
+					},
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				matches := make([]string, 0, len(policies))
+				for _, policy := range policies {
+					matches = append(matches, policy.Match)
+				}
+				return matches
+			}
+			gomega.Expect(findNoRerouteMatches(NoReRoutePodToJoin)).To(gomega.ContainElements(
+				fmt.Sprintf("ip4.src == %s && ip4.dst == %s", "192.168.0.0/16", config.Gateway.V4JoinSubnet),
+				fmt.Sprintf("ip4.src == %s && ip4.dst == %s", "192.169.0.0/16", config.Gateway.V4JoinSubnet),
+			))
+			gomega.Expect(findNoRerouteMatches(NoReRoutePodToPod)).To(gomega.ContainElements(
+				"ip4.src == 192.168.0.0/16 && ip4.dst == 192.168.0.0/16",
+				"ip4.src == 192.168.0.0/16 && ip4.dst == 192.169.0.0/16",
+				"ip4.src == 192.169.0.0/16 && ip4.dst == 192.168.0.0/16",
+				"ip4.src == 192.169.0.0/16 && ip4.dst == 192.169.0.0/16",
+			))
+		})
+
 		ginkgo.It("should remove stale LRPs for marks and configures missing LRP marks", func() {
 			app.Action = func(ctx *cli.Context) error {
 				// Node 1 is local, Node 2 is remote

--- a/go-controller/pkg/ovn/routeimport/route_import_test.go
+++ b/go-controller/pkg/ovn/routeimport/route_import_test.go
@@ -105,6 +105,56 @@ func Test_controller_syncNetwork(t *testing.T) {
 	cudnNoOverlayRouter := cudnNoOverlay.GetNetworkScopedGWRouterName(node)
 	cudnNoOverlayRouterPort := types.GWRouterToExtSwitchPrefix + cudnNoOverlayRouter
 
+	primaryUDNMultiSubnet := &multinetworkmocks.NetInfo{}
+	primaryUDNMultiSubnet.On("IsDefault").Return(false)
+	primaryUDNMultiSubnet.On("GetNetworkName").Return("primary-udn")
+	primaryUDNMultiSubnet.On("GetNetworkID").Return(5)
+	primaryUDNMultiSubnet.On("Subnets").Return([]config.CIDRNetworkEntry{
+		{
+			CIDR: &net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 0),
+				Mask: net.CIDRMask(16, 32),
+			},
+			HostSubnetLength: 24,
+		},
+		{
+			CIDR: &net.IPNet{
+				IP:   net.IPv4(192, 169, 0, 0),
+				Mask: net.CIDRMask(16, 32),
+			},
+			HostSubnetLength: 24,
+		},
+	})
+	primaryUDNMultiSubnet.On("GetNetworkScopedGWRouterName", node).Return("primary-udn-router")
+	primaryUDNMultiSubnet.On("Transport").Return("")
+	primaryUDNMultiSubnetRouter := primaryUDNMultiSubnet.GetNetworkScopedGWRouterName(node)
+	primaryUDNMultiSubnetRouterPort := types.GWRouterToExtSwitchPrefix + primaryUDNMultiSubnetRouter
+
+	primaryUDNMultiSubnetNoOverlay := &multinetworkmocks.NetInfo{}
+	primaryUDNMultiSubnetNoOverlay.On("IsDefault").Return(false)
+	primaryUDNMultiSubnetNoOverlay.On("GetNetworkName").Return("primary-udn-nooverlay")
+	primaryUDNMultiSubnetNoOverlay.On("GetNetworkID").Return(6)
+	primaryUDNMultiSubnetNoOverlay.On("Subnets").Return([]config.CIDRNetworkEntry{
+		{
+			CIDR: &net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 0),
+				Mask: net.CIDRMask(16, 32),
+			},
+			HostSubnetLength: 24,
+		},
+		{
+			CIDR: &net.IPNet{
+				IP:   net.IPv4(192, 169, 0, 0),
+				Mask: net.CIDRMask(16, 32),
+			},
+			HostSubnetLength: 24,
+		},
+	})
+	primaryUDNMultiSubnetNoOverlay.On("GetNetworkScopedGWRouterName", node).Return("primary-udn-nooverlay-router")
+	primaryUDNMultiSubnetNoOverlay.On("Transport").Return(types.NetworkTransportNoOverlay)
+	primaryUDNMultiSubnetNoOverlayRouter := primaryUDNMultiSubnetNoOverlay.GetNetworkScopedGWRouterName(node)
+	primaryUDNMultiSubnetNoOverlayRouterPort := types.GWRouterToExtSwitchPrefix + primaryUDNMultiSubnetNoOverlayRouter
+
 	type fields struct {
 		networkIDs map[int]string
 		networks   map[string]util.NetInfo
@@ -293,6 +343,49 @@ func Test_controller_syncNetwork(t *testing.T) {
 			expected: []libovsdb.TestData{
 				&nbdb.LogicalRouter{UUID: "router", Name: cudnOverlayRouter, StaticRoutes: []string{"keep-1"}},
 				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &cudnOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+		},
+		{
+			name: "ignores primary UDN pod subnet routes from additional subnet in overlay mode",
+			args: args{"primary-udn"},
+			fields: fields{
+				networkIDs: map[int]string{5: "primary-udn"},
+				networks:   map[string]util.NetInfo{"primary-udn": primaryUDNMultiSubnet},
+			},
+			link: &netlink.Vrf{Table: 5},
+			initial: []libovsdb.TestData{
+				&nbdb.LogicalRouter{Name: primaryUDNMultiSubnetRouter, StaticRoutes: []string{"keep-1"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &primaryUDNMultiSubnetRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+			routes: []netlink.Route{
+				{Dst: ovntesting.MustParseIPNet("1.1.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
+				{Dst: ovntesting.MustParseIPNet("192.169.1.0/24"), Gw: ovntesting.MustParseIP("2.2.2.1")},
+			},
+			expected: []libovsdb.TestData{
+				&nbdb.LogicalRouter{UUID: "router", Name: primaryUDNMultiSubnetRouter, StaticRoutes: []string{"keep-1"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &primaryUDNMultiSubnetRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+		},
+		{
+			name: "adds primary UDN pod subnet routes from additional subnet in no-overlay mode",
+			args: args{"primary-udn-nooverlay"},
+			fields: fields{
+				networkIDs: map[int]string{6: "primary-udn-nooverlay"},
+				networks:   map[string]util.NetInfo{"primary-udn-nooverlay": primaryUDNMultiSubnetNoOverlay},
+			},
+			link: &netlink.Vrf{Table: 6},
+			initial: []libovsdb.TestData{
+				&nbdb.LogicalRouter{Name: primaryUDNMultiSubnetNoOverlayRouter, StaticRoutes: []string{"keep-1"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &primaryUDNMultiSubnetNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+			routes: []netlink.Route{
+				{Dst: ovntesting.MustParseIPNet("1.1.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
+				{Dst: ovntesting.MustParseIPNet("192.169.1.0/24"), Gw: ovntesting.MustParseIP("2.2.2.1")},
+			},
+			expected: []libovsdb.TestData{
+				&nbdb.LogicalRouter{UUID: "router", Name: primaryUDNMultiSubnetNoOverlayRouter, StaticRoutes: []string{"keep-1", "add-1"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &primaryUDNMultiSubnetNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "192.169.1.0/24", Nexthop: "2.2.2.1", OutputPort: &primaryUDNMultiSubnetNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
 			},
 		},
 		{

--- a/go-controller/pkg/ovn/udn_isolation_test.go
+++ b/go-controller/pkg/ovn/udn_isolation_test.go
@@ -4,12 +4,19 @@
 package ovn
 
 import (
+	"strings"
+
+	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -91,5 +98,119 @@ var _ = Describe("UDN Isolation", func() {
 		Expect(acls[0].ExternalIDs).To(Equal(fakeController.getUDNACLDbIDs(denyPrimaryUDNACL, libovsdbutil.ACLEgress).GetExternalIDs()))
 		By("expect updated ACL with proper name")
 		Expect(*acls[0].Name).To(BeEmpty())
+	})
+
+	It("queues advertised local nodes when a primary Layer3 UDN adds a subnet", func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+		config.OVNKubernetesFeature.AdvertisedUDNIsolationMode = config.AdvertisedUDNIsolationModeStrict
+		config.IPv4Mode = true
+		config.IPv6Mode = false
+
+		fakeOVN := NewFakeOVN(true)
+
+		netInfoBefore := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
+		nadBefore, err := newNetworkAttachmentDefinition(ns, nadName, *netInfoBefore.netconf())
+		Expect(err).NotTo(HaveOccurred())
+		node, err := newNodeWithUserDefinedNetworks(nodeName, "192.168.126.202/24", netInfoBefore)
+		Expect(err).NotTo(HaveOccurred())
+
+		fakeOVN.startWithDBSetup(
+			libovsdbtest.TestSetup{},
+			node,
+			&nettypes.NetworkAttachmentDefinitionList{Items: []nettypes.NetworkAttachmentDefinition{*nadBefore}},
+		)
+		defer fakeOVN.shutdown()
+
+		l3Controller, ok := fakeOVN.fullL3UDNControllers[netInfoBefore.netName]
+		Expect(ok).To(BeTrue())
+		mutableNetInfo := util.NewMutableNetInfo(l3Controller.GetNetInfo())
+		mutableNetInfo.SetNetworkID(2)
+		mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{nodeName: {"vrf"}})
+		Expect(util.ReconcileNetInfo(l3Controller.ReconcilableNetInfo, mutableNetInfo)).To(Succeed())
+		l3Controller.lastNADKeys = sets.New[string](ns + "/" + nadName)
+
+		netInfoAfter := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16,192.169.0.0/16", "192.168.1.0/24")
+		nadAfter, err := newNetworkAttachmentDefinition(ns, nadName, *netInfoAfter.netconf())
+		Expect(err).NotTo(HaveOccurred())
+		parsedNetInfoAfter, err := util.ParseNADInfo(nadAfter)
+		Expect(err).NotTo(HaveOccurred())
+		mutableNetInfoAfter := util.NewMutableNetInfo(parsedNetInfoAfter)
+		mutableNetInfoAfter.SetNetworkID(2)
+		mutableNetInfoAfter.SetPodNetworkAdvertisedVRFs(map[string][]string{nodeName: {"vrf"}})
+
+		reconciledNodes := sets.New[string]()
+		Expect(l3Controller.reconcile(mutableNetInfoAfter, func(node string) {
+			reconciledNodes.Insert(node)
+		})).To(Succeed())
+		Expect(reconciledNodes.Has(nodeName)).To(BeTrue())
+	})
+
+	It("updates advertised network isolation ACLs when a primary Layer3 UDN adds a subnet", func() {
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+		config.OVNKubernetesFeature.AdvertisedUDNIsolationMode = config.AdvertisedUDNIsolationModeStrict
+		config.IPv4Mode = true
+		config.IPv6Mode = false
+
+		fakeOVN := NewFakeOVN(true)
+
+		netInfoBefore := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24")
+		nadBefore, err := newNetworkAttachmentDefinition(ns, nadName, *netInfoBefore.netconf())
+		Expect(err).NotTo(HaveOccurred())
+		node, err := newNodeWithUserDefinedNetworks(nodeName, "192.168.126.202/24", netInfoBefore)
+		Expect(err).NotTo(HaveOccurred())
+
+		fakeOVN.startWithDBSetup(
+			libovsdbtest.TestSetup{},
+			node,
+			&nettypes.NetworkAttachmentDefinitionList{Items: []nettypes.NetworkAttachmentDefinition{*nadBefore}},
+		)
+		defer fakeOVN.shutdown()
+
+		l3Controller, ok := fakeOVN.fullL3UDNControllers[netInfoBefore.netName]
+		Expect(ok).To(BeTrue())
+		mutableNetInfo := util.NewMutableNetInfo(l3Controller.GetNetInfo())
+		mutableNetInfo.SetNetworkID(2)
+		mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{nodeName: {"vrf"}})
+		Expect(util.ReconcileNetInfo(l3Controller.ReconcilableNetInfo, mutableNetInfo)).To(Succeed())
+
+		_, err = l3Controller.addressSetFactory.EnsureAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(libovsdbops.CreateOrUpdateLogicalSwitch(fakeOVN.nbClient, &nbdb.LogicalSwitch{
+			Name: l3Controller.GetNetworkScopedSwitchName(nodeName),
+		})).To(Succeed())
+
+		Expect(l3Controller.addAdvertisedNetworkIsolation(nodeName)).To(Succeed())
+		getPassACL := func() *nbdb.ACL {
+			acls, err := libovsdbops.FindACLsWithPredicate(fakeOVN.nbClient, func(acl *nbdb.ACL) bool {
+				return acl.Action == nbdb.ACLActionPass &&
+					acl.ExternalIDs[libovsdbops.ObjectNameKey.String()] == netInfoBefore.netName
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(acls).To(HaveLen(1))
+			return acls[0]
+		}
+		Expect(getPassACL().Match).To(ContainSubstring("192.168.0.0/16"))
+		Expect(getPassACL().Match).NotTo(ContainSubstring("192.169.0.0/16"))
+
+		netInfoAfter := dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16,192.169.0.0/16", "192.168.1.0/24")
+		nadAfter, err := newNetworkAttachmentDefinition(ns, nadName, *netInfoAfter.netconf())
+		Expect(err).NotTo(HaveOccurred())
+		parsedNetInfoAfter, err := util.ParseNADInfo(nadAfter)
+		Expect(err).NotTo(HaveOccurred())
+		mutableNetInfoAfter := util.NewMutableNetInfo(parsedNetInfoAfter)
+		mutableNetInfoAfter.SetNetworkID(2)
+		mutableNetInfoAfter.SetPodNetworkAdvertisedVRFs(map[string][]string{nodeName: {"vrf"}})
+		Expect(util.ReconcileNetInfo(l3Controller.ReconcilableNetInfo, mutableNetInfoAfter)).To(Succeed())
+
+		Expect(l3Controller.addAdvertisedNetworkIsolation(nodeName)).To(Succeed())
+		passACLMatch := getPassACL().Match
+		Expect(passACLMatch).To(ContainSubstring("192.168.0.0/16"))
+		Expect(passACLMatch).To(ContainSubstring("192.169.0.0/16"))
+		Expect(strings.Count(passACLMatch, "ip4.src ==")).To(Equal(2))
+		Expect(strings.Count(passACLMatch, "ip4.dst ==")).To(Equal(2))
 	})
 })

--- a/go-controller/pkg/testing/util.go
+++ b/go-controller/pkg/testing/util.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
 
+	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	networkconnectv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1"
 	networkconnectfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1/apis/clientset/versioned/fake"
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
@@ -190,4 +191,12 @@ func AddVTEPApplyReactor(fakeClient *vtepfake.Clientset) {
 		}
 		return true, vtep, nil
 	})
+}
+
+func BuildNAD(name, namespace string, network *ovncnitypes.NetConf) (*nadapi.NetworkAttachmentDefinition, error) {
+	config, err := json.Marshal(network)
+	if err != nil {
+		return nil, err
+	}
+	return GenerateNADWithConfig(name, namespace, string(config)), nil
 }

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -246,8 +246,10 @@ type mutableNetInfo struct {
 	podNetworkAdvertisements map[string][]string
 	eipAdvertisements        map[string][]string
 
-	// information generated from previous fields, not used in comparisons
+	// subnets can be added for Layer3 networks
+	subnets []config.CIDRNetworkEntry
 
+	// information generated from previous fields, not used in comparisons
 	// namespaces from nads
 	namespaces sets.Set[string]
 }
@@ -282,11 +284,14 @@ func (l *mutableNetInfo) equals(r *mutableNetInfo) bool {
 	defer l.RUnlock()
 	r.RLock()
 	defer r.RUnlock()
+
+	lessCIDR := func(a, b config.CIDRNetworkEntry) bool { return a.String() < b.String() }
 	return reflect.DeepEqual(l.id, r.id) &&
 		reflect.DeepEqual(l.tunnelKeys, r.tunnelKeys) &&
 		reflect.DeepEqual(l.nads, r.nads) &&
 		reflect.DeepEqual(l.podNetworkAdvertisements, r.podNetworkAdvertisements) &&
-		reflect.DeepEqual(l.eipAdvertisements, r.eipAdvertisements)
+		reflect.DeepEqual(l.eipAdvertisements, r.eipAdvertisements) &&
+		cmp.Equal(l.subnets, r.subnets, cmpopts.SortSlices(lessCIDR))
 }
 
 func (l *mutableNetInfo) copyFrom(r *mutableNetInfo) {
@@ -300,6 +305,7 @@ func (l *mutableNetInfo) copyFrom(r *mutableNetInfo) {
 	aux.nads = r.nads.Clone()
 	aux.setPodNetworkAdvertisedOnVRFs(r.podNetworkAdvertisements)
 	aux.setEgressIPAdvertisedAtNodes(r.eipAdvertisements)
+	aux.subnets = append([]config.CIDRNetworkEntry(nil), r.subnets...)
 	aux.namespaces = r.namespaces.Clone()
 	r.RUnlock()
 	l.Lock()
@@ -309,6 +315,7 @@ func (l *mutableNetInfo) copyFrom(r *mutableNetInfo) {
 	l.nads = aux.nads
 	l.podNetworkAdvertisements = aux.podNetworkAdvertisements
 	l.eipAdvertisements = aux.eipAdvertisements
+	l.subnets = aux.subnets
 	l.namespaces = aux.namespaces
 }
 
@@ -731,7 +738,6 @@ type userDefinedNetInfo struct {
 	allowPersistentIPs bool
 
 	ipv4mode, ipv6mode    bool
-	subnets               []config.CIDRNetworkEntry
 	excludeSubnets        []*net.IPNet
 	reservedSubnets       []*net.IPNet
 	infrastructureSubnets []*net.IPNet
@@ -972,7 +978,9 @@ func (nInfo *userDefinedNetInfo) IPMode() (bool, bool) {
 
 // Subnets returns the Subnets value
 func (nInfo *userDefinedNetInfo) Subnets() []config.CIDRNetworkEntry {
-	return nInfo.subnets
+	nInfo.RLock()
+	defer nInfo.RUnlock()
+	return append([]config.CIDRNetworkEntry(nil), nInfo.mutableNetInfo.subnets...)
 }
 
 // ExcludeSubnets returns the ExcludeSubnets value
@@ -1019,6 +1027,10 @@ func (nInfo *userDefinedNetInfo) JoinSubnets() []*net.IPNet {
 // For now it is only set for Primary Layer2 UDNs, otherwise is empty
 func (nInfo *userDefinedNetInfo) TransitSubnets() []*net.IPNet {
 	return nInfo.transitSubnets
+}
+
+func (nInfo *userDefinedNetInfo) reconcile(other NetInfo) {
+	nInfo.mutableNetInfo.reconcile(other)
 }
 
 func (nInfo *userDefinedNetInfo) canReconcile(other NetInfo) bool {
@@ -1074,8 +1086,12 @@ func (nInfo *userDefinedNetInfo) canReconcile(other NetInfo) bool {
 	}
 
 	lessCIDRNetworkEntry := func(a, b config.CIDRNetworkEntry) bool { return a.String() < b.String() }
-	if !cmp.Equal(nInfo.subnets, other.Subnets(), cmpopts.SortSlices(lessCIDRNetworkEntry)) {
-		return false
+	if !cmp.Equal(nInfo.Subnets(), other.Subnets(), cmpopts.SortSlices(lessCIDRNetworkEntry)) {
+		// For Layer3 topology, adding subnets is considered compatible and reconcilable
+		// CRD validation ensures only subnet additions are allowed
+		if nInfo.topology != types.Layer3Topology {
+			return false
+		}
 	}
 
 	lessIPNet := func(a, b net.IPNet) bool { return a.String() < b.String() }
@@ -1105,7 +1121,6 @@ func (nInfo *userDefinedNetInfo) copy() *userDefinedNetInfo {
 		allowPersistentIPs:    nInfo.allowPersistentIPs,
 		ipv4mode:              nInfo.ipv4mode,
 		ipv6mode:              nInfo.ipv6mode,
-		subnets:               nInfo.subnets,
 		excludeSubnets:        nInfo.excludeSubnets,
 		reservedSubnets:       nInfo.reservedSubnets,
 		infrastructureSubnets: nInfo.infrastructureSubnets,
@@ -1136,14 +1151,14 @@ func newLayer3NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		netName:        netconf.Name,
 		primaryNetwork: netconf.Role == types.NetworkRolePrimary,
 		topology:       types.Layer3Topology,
-		subnets:        subnets,
 		joinSubnets:    joinSubnets,
 		mtu:            netconf.MTU,
 		transport:      netconf.Transport,
 		evpn:           netconf.EVPN,
 		mutableNetInfo: mutableNetInfo{
-			id:   types.InvalidID,
-			nads: sets.Set[string]{},
+			id:      types.InvalidID,
+			nads:    sets.Set[string]{},
+			subnets: append([]config.CIDRNetworkEntry(nil), subnets...),
 		},
 	}
 	ni.ipv4mode, ni.ipv6mode = getIPMode(subnets)
@@ -1206,7 +1221,6 @@ func newLayer2NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		netName:               netconf.Name,
 		primaryNetwork:        netconf.Role == types.NetworkRolePrimary,
 		topology:              types.Layer2Topology,
-		subnets:               subnets,
 		joinSubnets:           joinSubnets,
 		transitSubnets:        transitSubnets,
 		excludeSubnets:        excludes,
@@ -1219,8 +1233,9 @@ func newLayer2NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		transport:             netconf.Transport,
 		evpn:                  netconf.EVPN,
 		mutableNetInfo: mutableNetInfo{
-			id:   types.InvalidID,
-			nads: sets.Set[string]{},
+			id:      types.InvalidID,
+			nads:    sets.Set[string]{},
+			subnets: append([]config.CIDRNetworkEntry(nil), subnets...),
 		},
 	}
 	ni.ipv4mode, ni.ipv6mode = getIPMode(subnets)
@@ -1245,15 +1260,15 @@ func newLocalnetNetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error
 	ni := &userDefinedNetInfo{
 		netName:             netconf.Name,
 		topology:            types.LocalnetTopology,
-		subnets:             subnets,
 		excludeSubnets:      excludes,
 		mtu:                 netconf.MTU,
 		vlan:                uint(netconf.VLANID),
 		allowPersistentIPs:  netconf.AllowPersistentIPs,
 		physicalNetworkName: netconf.PhysicalNetworkName,
 		mutableNetInfo: mutableNetInfo{
-			id:   types.InvalidID,
-			nads: sets.Set[string]{},
+			id:      types.InvalidID,
+			nads:    sets.Set[string]{},
+			subnets: append([]config.CIDRNetworkEntry(nil), subnets...),
 		},
 	}
 	ni.ipv4mode, ni.ipv6mode = getIPMode(subnets)

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -46,6 +46,36 @@ func TestParseNetworkSubnets(t *testing.T) {
 			},
 		},
 		{
+			desc:     "multiple ipv4 subnets layer3 topology",
+			topology: ovntypes.Layer3Topology,
+			subnets:  "192.168.1.0/24/28, 192.168.2.0/24/28",
+			expectedSubnets: []config.CIDRNetworkEntry{
+				{
+					CIDR:             ovntest.MustParseIPNet("192.168.1.0/24"),
+					HostSubnetLength: 28,
+				},
+				{
+					CIDR:             ovntest.MustParseIPNet("192.168.2.0/24"),
+					HostSubnetLength: 28,
+				},
+			},
+		},
+		{
+			desc:     "multiple ipv6 subnets layer3 topology",
+			topology: ovntypes.Layer3Topology,
+			subnets:  "fda6::/48, fda7::/48",
+			expectedSubnets: []config.CIDRNetworkEntry{
+				{
+					CIDR:             ovntest.MustParseIPNet("fda6::/48"),
+					HostSubnetLength: 64,
+				},
+				{
+					CIDR:             ovntest.MustParseIPNet("fda7::/48"),
+					HostSubnetLength: 64,
+				},
+			},
+		},
+		{
 			desc:     "empty subnets layer 3 topology",
 			topology: ovntypes.Layer3Topology,
 		},

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_clusteruserdefinednetworks.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_clusteruserdefinednetworks.yaml
@@ -410,6 +410,8 @@ spec:
                     - role
                     type: object
                     x-kubernetes-validations:
+                    - message: Layer2 is immutable
+                      rule: self == oldSelf
                     - message: Subnets is required with ipam.mode is Enabled or unset
                       rule: has(self.ipam) && has(self.ipam.mode) && self.ipam.mode
                         != 'Enabled' || has(self.subnets)
@@ -497,6 +499,8 @@ spec:
                         minItems: 1
                         type: array
                         x-kubernetes-validations:
+                        - message: joinSubnets is immutable
+                          rule: self == oldSelf
                         - message: When 2 CIDRs are set, they must be from different
                             IP families
                           rule: size(self) != 2 || !isCIDR(self[0]) || !isCIDR(self[1])
@@ -510,6 +514,9 @@ spec:
                         maximum: 65536
                         minimum: 576
                         type: integer
+                        x-kubernetes-validations:
+                        - message: mtu is immutable
+                          rule: self == oldSelf
                       role:
                         description: |-
                           Role describes the network role in the pod.
@@ -521,12 +528,15 @@ spec:
                         - Primary
                         - Secondary
                         type: string
+                        x-kubernetes-validations:
+                        - message: role is immutable
+                          rule: self == oldSelf
                       subnets:
                         description: |-
                           Subnets are used for the pod network across the cluster.
 
-                          Dual-stack clusters may set 2 subnets (one for each IP family), otherwise only 1 subnet is allowed.
-                          Given subnet is split into smaller subnets for every node.
+                          Each IP family can have multiple subnets.
+                          For each IP family, every node allocates a smaller subnet from the provided subnets.
                         items:
                           properties:
                             cidr:
@@ -557,19 +567,24 @@ spec:
                             rule: '!has(self.hostSubnet) || !isCIDR(self.cidr) ||
                               (cidr(self.cidr).ip().family() != 4 || self.hostSubnet
                               < 32)'
-                        maxItems: 2
+                        maxItems: 400
                         minItems: 1
                         type: array
-                        x-kubernetes-validations:
-                        - message: When 2 CIDRs are set, they must be from different
-                            IP families
-                          rule: size(self) != 2 || !isCIDR(self[0].cidr) || !isCIDR(self[1].cidr)
-                            || cidr(self[0].cidr).ip().family() != cidr(self[1].cidr).ip().family()
                     required:
                     - role
                     - subnets
                     type: object
                     x-kubernetes-validations:
+                    - message: Subnets is immutable for Secondary role
+                      rule: self.role != 'Secondary' || self.subnets == oldSelf.subnets
+                    - message: Secondary networks may define at most 2 subnets
+                      rule: self.role != 'Secondary' || !has(self.subnets) || self.subnets.size()
+                        <= 2
+                    - message: When 2 CIDRs are set for Secondary networks, they must
+                        be from different IP families
+                      rule: self.role != 'Secondary' || size(self.subnets) != 2 ||
+                        !isCIDR(self.subnets[0].cidr) || !isCIDR(self.subnets[1].cidr)
+                        || cidr(self.subnets[0].cidr).ip().family() != cidr(self.subnets[1].cidr).ip().family()
                     - message: JoinSubnets is only supported for Primary network
                       rule: '!has(self.joinSubnets) || has(self.role) && self.role
                         == ''Primary'''
@@ -578,6 +593,26 @@ spec:
                       rule: '!has(self.subnets) || !has(self.mtu) || !self.subnets.exists_one(i,
                         isCIDR(i.cidr) && cidr(i.cidr).ip().family() == 6) || self.mtu
                         >= 1280'
+                    - message: Removing existing subnets is not allowed
+                      rule: '!has(oldSelf.subnets) || oldSelf.subnets.all(old, self.subnets.exists(new,
+                        new.cidr == old.cidr))'
+                    - message: Subnets must not overlap or contain each other
+                      rule: '!has(self.subnets) || self.subnets.size() == 1 || !self.subnets.exists(i,
+                        self.subnets.exists(j, i != j && cidr(i.cidr).containsCIDR(j.cidr)))'
+                    - message: Subnets with same CIDR are not allowed
+                      rule: '!has(self.subnets) || self.subnets.size() == 1 || !self.subnets.exists(i,
+                        self.subnets.filter(j, j.cidr == i.cidr).size() > 1)'
+                    - message: hostSubnet is immutable
+                      rule: '!has(oldSelf.subnets) || oldSelf.subnets.all(old, self.subnets.exists(new,
+                        new.cidr == old.cidr && (!has(old.hostSubnet) && !has(new.hostSubnet)
+                        || has(old.hostSubnet) && has(new.hostSubnet) && old.hostSubnet
+                        == new.hostSubnet)))'
+                    - message: Subnets from the same IP family must use the same hostSubnet
+                        value
+                      rule: '!has(self.subnets) || self.subnets.size() == 1 || self.subnets.all(i,
+                        self.subnets.all(j, cidr(i.cidr).ip().family() != cidr(j.cidr).ip().family()
+                        || (has(i.hostSubnet) == has(j.hostSubnet) && (!has(i.hostSubnet)
+                        || i.hostSubnet == j.hostSubnet))))'
                   localnet:
                     description: Localnet is the Localnet topology configuration.
                     properties:
@@ -759,6 +794,8 @@ spec:
                     - role
                     type: object
                     x-kubernetes-validations:
+                    - message: Localnet is immutable
+                      rule: self == oldSelf
                     - message: Subnets is required with ipam.mode is Enabled or unset,
                         and forbidden otherwise
                       rule: '!has(self.ipam) || !has(self.ipam.mode) || self.ipam.mode
@@ -792,6 +829,9 @@ spec:
                     - outboundSNAT
                     - routing
                     type: object
+                    x-kubernetes-validations:
+                    - message: NoOverlay is immutable
+                      rule: self == oldSelf
                   topology:
                     description: |-
                       Topology describes network configuration.
@@ -805,6 +845,9 @@ spec:
                     - Layer3
                     - Localnet
                     type: string
+                    x-kubernetes-validations:
+                    - message: Topology is immutable
+                      rule: self == oldSelf
                   transport:
                     description: |-
                       Transport describes the transport technology for pod-to-pod traffic.
@@ -817,6 +860,9 @@ spec:
                     - NoOverlay
                     - EVPN
                     type: string
+                    x-kubernetes-validations:
+                    - message: Transport is immutable
+                      rule: self == oldSelf
                 required:
                 - topology
                 type: object
@@ -867,8 +913,6 @@ spec:
                     when transport is 'EVPN'
                   rule: '!has(self.transport) || self.transport != ''EVPN'' || self.topology
                     != ''Layer3'' || !has(self.evpn) || !has(self.evpn.macVRF)'
-                - message: Network spec is immutable
-                  rule: self == oldSelf
             required:
             - namespaceSelector
             - network

--- a/helm/ovn-kubernetes/crds/k8s.ovn.org_userdefinednetworks.yaml
+++ b/helm/ovn-kubernetes/crds/k8s.ovn.org_userdefinednetworks.yaml
@@ -205,6 +205,8 @@ spec:
                 - role
                 type: object
                 x-kubernetes-validations:
+                - message: Layer2 is immutable
+                  rule: self == oldSelf
                 - message: Subnets is required with ipam.mode is Enabled or unset
                   rule: has(self.ipam) && has(self.ipam.mode) && self.ipam.mode !=
                     'Enabled' || has(self.subnets)
@@ -288,6 +290,8 @@ spec:
                     minItems: 1
                     type: array
                     x-kubernetes-validations:
+                    - message: joinSubnets is immutable
+                      rule: self == oldSelf
                     - message: When 2 CIDRs are set, they must be from different IP
                         families
                       rule: size(self) != 2 || !isCIDR(self[0]) || !isCIDR(self[1])
@@ -301,6 +305,9 @@ spec:
                     maximum: 65536
                     minimum: 576
                     type: integer
+                    x-kubernetes-validations:
+                    - message: mtu is immutable
+                      rule: self == oldSelf
                   role:
                     description: |-
                       Role describes the network role in the pod.
@@ -312,12 +319,15 @@ spec:
                     - Primary
                     - Secondary
                     type: string
+                    x-kubernetes-validations:
+                    - message: role is immutable
+                      rule: self == oldSelf
                   subnets:
                     description: |-
                       Subnets are used for the pod network across the cluster.
 
-                      Dual-stack clusters may set 2 subnets (one for each IP family), otherwise only 1 subnet is allowed.
-                      Given subnet is split into smaller subnets for every node.
+                      Each IP family can have multiple subnets.
+                      For each IP family, every node allocates a smaller subnet from the provided subnets.
                     items:
                       properties:
                         cidr:
@@ -347,19 +357,24 @@ spec:
                       - message: HostSubnet must < 32 for ipv4 CIDR
                         rule: '!has(self.hostSubnet) || !isCIDR(self.cidr) || (cidr(self.cidr).ip().family()
                           != 4 || self.hostSubnet < 32)'
-                    maxItems: 2
+                    maxItems: 400
                     minItems: 1
                     type: array
-                    x-kubernetes-validations:
-                    - message: When 2 CIDRs are set, they must be from different IP
-                        families
-                      rule: size(self) != 2 || !isCIDR(self[0].cidr) || !isCIDR(self[1].cidr)
-                        || cidr(self[0].cidr).ip().family() != cidr(self[1].cidr).ip().family()
                 required:
                 - role
                 - subnets
                 type: object
                 x-kubernetes-validations:
+                - message: Subnets is immutable for Secondary role
+                  rule: self.role != 'Secondary' || self.subnets == oldSelf.subnets
+                - message: Secondary networks may define at most 2 subnets
+                  rule: self.role != 'Secondary' || !has(self.subnets) || self.subnets.size()
+                    <= 2
+                - message: When 2 CIDRs are set for Secondary networks, they must
+                    be from different IP families
+                  rule: self.role != 'Secondary' || size(self.subnets) != 2 || !isCIDR(self.subnets[0].cidr)
+                    || !isCIDR(self.subnets[1].cidr) || cidr(self.subnets[0].cidr).ip().family()
+                    != cidr(self.subnets[1].cidr).ip().family()
                 - message: JoinSubnets is only supported for Primary network
                   rule: '!has(self.joinSubnets) || has(self.role) && self.role ==
                     ''Primary'''
@@ -368,6 +383,26 @@ spec:
                   rule: '!has(self.subnets) || !has(self.mtu) || !self.subnets.exists_one(i,
                     isCIDR(i.cidr) && cidr(i.cidr).ip().family() == 6) || self.mtu
                     >= 1280'
+                - message: Removing existing subnets is not allowed
+                  rule: '!has(oldSelf.subnets) || oldSelf.subnets.all(old, self.subnets.exists(new,
+                    new.cidr == old.cidr))'
+                - message: Subnets must not overlap or contain each other
+                  rule: '!has(self.subnets) || self.subnets.size() == 1 || !self.subnets.exists(i,
+                    self.subnets.exists(j, i != j && cidr(i.cidr).containsCIDR(j.cidr)))'
+                - message: Subnets with same CIDR are not allowed
+                  rule: '!has(self.subnets) || self.subnets.size() == 1 || !self.subnets.exists(i,
+                    self.subnets.filter(j, j.cidr == i.cidr).size() > 1)'
+                - message: hostSubnet is immutable
+                  rule: '!has(oldSelf.subnets) || oldSelf.subnets.all(old, self.subnets.exists(new,
+                    new.cidr == old.cidr && (!has(old.hostSubnet) && !has(new.hostSubnet)
+                    || has(old.hostSubnet) && has(new.hostSubnet) && old.hostSubnet
+                    == new.hostSubnet)))'
+                - message: Subnets from the same IP family must use the same hostSubnet
+                    value
+                  rule: '!has(self.subnets) || self.subnets.size() == 1 || self.subnets.all(i,
+                    self.subnets.all(j, cidr(i.cidr).ip().family() != cidr(j.cidr).ip().family()
+                    || (has(i.hostSubnet) == has(j.hostSubnet) && (!has(i.hostSubnet)
+                    || i.hostSubnet == j.hostSubnet))))'
               topology:
                 description: |-
                   Topology describes network configuration.
@@ -379,12 +414,13 @@ spec:
                 - Layer2
                 - Layer3
                 type: string
+                x-kubernetes-validations:
+                - message: Topology is immutable
+                  rule: self == oldSelf
             required:
             - topology
             type: object
             x-kubernetes-validations:
-            - message: Spec is immutable
-              rule: self == oldSelf
             - message: spec.layer3 is required when topology is Layer3 and forbidden
                 otherwise
               rule: 'has(self.topology) && self.topology == ''Layer3'' ? has(self.layer3):

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -91,57 +91,113 @@ func generateConnectSubnetsWithCIDRs(cs clientset.Interface, v4CIDR string, v4Pr
 	return strings.Join(subnets, "\n")
 }
 
-// generateNetworkSubnets generates subnets YAML with custom CIDRs
-// Pass empty strings to use defaults
-func generateNetworkSubnets(cs clientset.Interface, topology, v4Subnet, v6Subnet string) string {
+// generateNetworkSubnets generates subnets YAML with custom CIDRs.
+// Pass empty slices to use defaults.
+func generateNetworkSubnets(cs clientset.Interface, topology string, v4Subnets, v6Subnets []string) string {
 	// Use custom subnets if provided, otherwise fall back to defaults
-	l3v4CIDR := layer3UserDefinedNetworkIPv4CIDR
-	l3v6CIDR := layer3UserDefinedNetworkIPv6CIDR
-	l2v4CIDR := layer2UserDefinedNetworkIPv4CIDR
-	l2v6CIDR := layer2UserDefinedNetworkIPv6CIDR
+	l3v4Subnets := []string{layer3UserDefinedNetworkIPv4CIDR}
+	l3v6Subnets := []string{layer3UserDefinedNetworkIPv6CIDR}
+	l2v4Subnets := []string{layer2UserDefinedNetworkIPv4CIDR}
+	l2v6Subnets := []string{layer2UserDefinedNetworkIPv6CIDR}
 
-	if v4Subnet != "" {
-		l3v4CIDR = v4Subnet
-		l2v4CIDR = v4Subnet
+	if len(v4Subnets) > 0 {
+		l3v4Subnets = v4Subnets
+		l2v4Subnets = v4Subnets
 	}
-	if v6Subnet != "" {
-		l3v6CIDR = v6Subnet
-		l2v6CIDR = v6Subnet
+	if len(v6Subnets) > 0 {
+		l3v6Subnets = v6Subnets
+		l2v6Subnets = v6Subnets
 	}
 
 	if topology == "Layer3" {
 		var subnets []string
 		if isIPv4Supported(cs) {
-			subnets = append(subnets, fmt.Sprintf(`{cidr: "%s", hostSubnet: %d}`, l3v4CIDR, layer3UserDefinedNetworkIPv4HostSubnet))
+			for _, cidr := range l3v4Subnets {
+				if len(strings.Split(cidr, "/")) == 2 {
+					subnets = append(subnets, fmt.Sprintf(`{cidr: "%s", hostSubnet: %d}`, cidr, layer3UserDefinedNetworkIPv4HostSubnet))
+				} else {
+					subnets = append(subnets, generateLayer3Subnets(cidr)[0])
+				}
+			}
 		}
 		if isIPv6Supported(cs) {
-			subnets = append(subnets, fmt.Sprintf(`{cidr: "%s", hostSubnet: %d}`, l3v6CIDR, layer3UserDefinedNetworkIPv6HostSubnet))
+			for _, cidr := range l3v6Subnets {
+				if len(strings.Split(cidr, "/")) == 2 {
+					subnets = append(subnets, fmt.Sprintf(`{cidr: "%s", hostSubnet: %d}`, cidr, layer3UserDefinedNetworkIPv6HostSubnet))
+				} else {
+					subnets = append(subnets, generateLayer3Subnets(cidr)[0])
+				}
+			}
 		}
 		return fmt.Sprintf("[%s]", strings.Join(subnets, ","))
 	}
 	// Layer2 format
 	var quotedCidrs []string
 	if isIPv4Supported(cs) {
-		quotedCidrs = append(quotedCidrs, fmt.Sprintf(`"%s"`, l2v4CIDR))
+		for _, cidr := range l2v4Subnets {
+			quotedCidrs = append(quotedCidrs, fmt.Sprintf(`"%s"`, cidr))
+		}
 	}
 	if isIPv6Supported(cs) {
-		quotedCidrs = append(quotedCidrs, fmt.Sprintf(`"%s"`, l2v6CIDR))
+		for _, cidr := range l2v6Subnets {
+			quotedCidrs = append(quotedCidrs, fmt.Sprintf(`"%s"`, cidr))
+		}
 	}
 	return fmt.Sprintf("[%s]", strings.Join(quotedCidrs, ","))
+}
+
+func generateLayer3NetworkSubnets(cs clientset.Interface, cidrs ...string) string {
+	subnets := generateLayer3Subnets(joinStrings(filterCIDRs(cs, cidrs...)...))
+	return fmt.Sprintf("[%s]", strings.Join(subnets, ","))
+}
+
+func generatePrimaryUDNSubnets(cs clientset.Interface, topology string, subnets []string) string {
+	if len(subnets) == 0 {
+		if topology == "Layer3" {
+			subnets = []string{layer3UserDefinedNetworkIPv4CIDR, layer3UserDefinedNetworkIPv6CIDR}
+		} else {
+			subnets = []string{layer2UserDefinedNetworkIPv4CIDR, layer2UserDefinedNetworkIPv6CIDR}
+		}
+	}
+
+	if topology == "Layer3" {
+		return generateLayer3NetworkSubnets(cs, subnets...)
+	}
+
+	var quotedCidrs []string
+	for _, cidr := range filterCIDRs(cs, subnets...) {
+		quotedCidrs = append(quotedCidrs, fmt.Sprintf(`"%s"`, cidr))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(quotedCidrs, ","))
+}
+
+func subnetList(subnets ...string) []string {
+	return subnets
 }
 
 // newTestNetworkSubnetsAllocator returns a function that yields unique (v4CIDR, v6CIDR) pairs
 // for UDN/CUDN creation within a single test.
 //
 // This prevents multiple networks in the same test from accidentally sharing the same CIDRs.
-func newTestNetworkSubnetsAllocator() func() (string, string) {
+func newTestNetworkSubnetsAllocator() func(bool) ([]string, []string) {
 	i := 0
-	return func() (string, string) {
+	return func(multiSubnet bool) ([]string, []string) {
 		i++
 		// Allocated networks for ipv4 are 172.31.0.0/16, 172.32.0.0/16, ... (non-overlapping /16s)
-		v4 := fmt.Sprintf("172.%d.0.0/16", 30+i)
+		v4 := []string{fmt.Sprintf("172.%d.0.0/16", 30+i)}
 		// Allocated networks for ipv6 are 2014:100:201::0/60, 2014:100:202::0/60, ... (non-overlapping /60s)
-		v6 := fmt.Sprintf("2014:100:%d::0/60", 200+i)
+		v6 := []string{fmt.Sprintf("2014:100:%d::0/60", 200+i)}
+		if multiSubnet {
+			v4 = []string{
+				fmt.Sprintf("172.%d.0.0/23/24", 30+i),
+				fmt.Sprintf("172.%d.0.0/16/24", 31+i),
+			}
+			v6 = []string{
+				fmt.Sprintf("2014:100:%d::0/63/64", 200+i),
+				fmt.Sprintf("2014:100:%d::0/48/64", 201+i),
+			}
+			i++
+		}
 		return v4, v6
 	}
 }
@@ -290,8 +346,8 @@ func deleteCNC(cncName string) {
 }
 
 // createPrimaryCUDNWithSubnets creates a primary CUDN with specified topology and custom subnets.
-// Pass empty strings for v4Subnet/v6Subnet to use defaults.
-func createPrimaryCUDNWithSubnets(cs clientset.Interface, cudnName, topology string, labels map[string]string, v4Subnet, v6Subnet string, targetNamespaces ...string) {
+// Pass empty slices for v4Subnets/v6Subnets to use defaults.
+func createPrimaryCUDNWithSubnets(cs clientset.Interface, cudnName, topology string, labels map[string]string, v4Subnets, v6Subnets []string, targetNamespaces ...string) {
 	targetNs := strings.Join(targetNamespaces, ",")
 	labelAnnotations := ""
 	for k, v := range labels {
@@ -319,7 +375,7 @@ spec:
     %s:
       role: Primary
       subnets: %s
-`, cudnName, labelAnnotations, targetNs, topology, topologyLower, generateNetworkSubnets(cs, topology, v4Subnet, v6Subnet))
+`, cudnName, labelAnnotations, targetNs, topology, topologyLower, generateNetworkSubnets(cs, topology, v4Subnets, v6Subnets))
 	_, err := e2ekubectl.RunKubectlInput("", manifest, "apply", "-f", "-")
 	Expect(err).NotTo(HaveOccurred())
 }
@@ -330,9 +386,10 @@ func deleteCUDN(cudnName string) {
 }
 
 // createPrimaryUDNWithSubnets creates a primary UDN with specified topology and custom subnets.
-// Pass empty strings for v4Subnet/v6Subnet to use defaults.
-func createPrimaryUDNWithSubnets(cs clientset.Interface, namespace, udnName, topology, v4Subnet, v6Subnet string) {
+// Pass empty slices for v4Subnets/v6Subnets to use defaults.
+func createPrimaryUDNWithSubnets(cs clientset.Interface, namespace, udnName, topology string, v4Subnets, v6Subnets []string) {
 	topologyLower := strings.ToLower(topology)
+	subnets := append(append([]string{}, v4Subnets...), v6Subnets...)
 	manifest := fmt.Sprintf(`
 apiVersion: k8s.ovn.org/v1
 kind: UserDefinedNetwork
@@ -343,7 +400,7 @@ spec:
   %s:
     role: Primary
     subnets: %s
-`, udnName, topology, topologyLower, generateNetworkSubnets(cs, topology, v4Subnet, v6Subnet))
+`, udnName, topology, topologyLower, generatePrimaryUDNSubnets(cs, topology, subnets))
 	_, err := e2ekubectl.RunKubectlInput(namespace, manifest, "apply", "-f", "-")
 	Expect(err).NotTo(HaveOccurred())
 }
@@ -354,23 +411,23 @@ func deleteUDN(namespace, udnName string) {
 }
 
 // createLayer3PrimaryCUDNWithSubnets creates a Layer3 primary CUDN with custom subnets
-func createLayer3PrimaryCUDNWithSubnets(cs clientset.Interface, cudnName string, labels map[string]string, v4Subnet, v6Subnet string, targetNamespaces ...string) {
-	createPrimaryCUDNWithSubnets(cs, cudnName, "Layer3", labels, v4Subnet, v6Subnet, targetNamespaces...)
+func createLayer3PrimaryCUDNWithSubnets(cs clientset.Interface, cudnName string, labels map[string]string, v4Subnets, v6Subnets []string, targetNamespaces ...string) {
+	createPrimaryCUDNWithSubnets(cs, cudnName, "Layer3", labels, v4Subnets, v6Subnets, targetNamespaces...)
 }
 
 // createLayer2PrimaryCUDNWithSubnets creates a Layer2 primary CUDN with custom subnets
-func createLayer2PrimaryCUDNWithSubnets(cs clientset.Interface, cudnName string, labels map[string]string, v4Subnet, v6Subnet string, targetNamespaces ...string) {
-	createPrimaryCUDNWithSubnets(cs, cudnName, "Layer2", labels, v4Subnet, v6Subnet, targetNamespaces...)
+func createLayer2PrimaryCUDNWithSubnets(cs clientset.Interface, cudnName string, labels map[string]string, v4Subnets, v6Subnets []string, targetNamespaces ...string) {
+	createPrimaryCUDNWithSubnets(cs, cudnName, "Layer2", labels, v4Subnets, v6Subnets, targetNamespaces...)
 }
 
 // createLayer3PrimaryUDNWithSubnets creates a Layer3 primary UDN with custom subnets
-func createLayer3PrimaryUDNWithSubnets(cs clientset.Interface, namespace, udnName, v4Subnet, v6Subnet string) {
-	createPrimaryUDNWithSubnets(cs, namespace, udnName, "Layer3", v4Subnet, v6Subnet)
+func createLayer3PrimaryUDNWithSubnets(cs clientset.Interface, namespace, udnName string, v4Subnets, v6Subnets []string) {
+	createPrimaryUDNWithSubnets(cs, namespace, udnName, "Layer3", v4Subnets, v6Subnets)
 }
 
 // createLayer2PrimaryUDNWithSubnets creates a Layer2 primary UDN with custom subnets
-func createLayer2PrimaryUDNWithSubnets(cs clientset.Interface, namespace, udnName, v4Subnet, v6Subnet string) {
-	createPrimaryUDNWithSubnets(cs, namespace, udnName, "Layer2", v4Subnet, v6Subnet)
+func createLayer2PrimaryUDNWithSubnets(cs clientset.Interface, namespace, udnName string, v4Subnets, v6Subnets []string) {
+	createPrimaryUDNWithSubnets(cs, namespace, udnName, "Layer2", v4Subnets, v6Subnets)
 }
 
 // getCNCAnnotations gets CNC annotations
@@ -686,7 +743,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					})
 
 					By(fmt.Sprintf("creating a %s primary UDN", topology))
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(topology == "Layer3")
 					createPrimaryUDNWithSubnets(cs, ns.Name, networkName, topology, v4, v6)
 
 					By("waiting for UDN to be ready")
@@ -703,7 +760,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					})
 
 					By(fmt.Sprintf("creating a %s primary CUDN", topology))
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(topology == "Layer3")
 					createPrimaryCUDNWithSubnets(cs, networkName, topology, testLabel, v4, v6, ns.Name)
 
 					By("waiting for CUDN to be ready")
@@ -750,16 +807,16 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					})
 
 					By("creating 2 Layer3 and 2 Layer2 primary UDNs")
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(true)
 					createLayer3PrimaryUDNWithSubnets(cs, namespaces[0].Name, networkNames[0], v4, v6)
 					expectedTopologies = append(expectedTopologies, "Layer3")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(true)
 					createLayer3PrimaryUDNWithSubnets(cs, namespaces[1].Name, networkNames[1], v4, v6)
 					expectedTopologies = append(expectedTopologies, "Layer3")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(false)
 					createLayer2PrimaryUDNWithSubnets(cs, namespaces[2].Name, networkNames[2], v4, v6)
 					expectedTopologies = append(expectedTopologies, "Layer2")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(false)
 					createLayer2PrimaryUDNWithSubnets(cs, namespaces[3].Name, networkNames[3], v4, v6)
 					expectedTopologies = append(expectedTopologies, "Layer2")
 
@@ -788,16 +845,16 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					})
 
 					By("creating 2 Layer3 and 2 Layer2 primary CUDNs (one L3 targets multiple namespaces)")
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(true)
 					createPrimaryCUDNWithSubnets(cs, networkNames[0], "Layer3", testLabel, v4, v6, namespaces[0].Name)
 					expectedTopologies = append(expectedTopologies, "Layer3")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(true)
 					createPrimaryCUDNWithSubnets(cs, networkNames[1], "Layer3", testLabel, v4, v6, namespaces[1].Name, namespaces[4].Name) // multi-ns
 					expectedTopologies = append(expectedTopologies, "Layer3")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(false)
 					createPrimaryCUDNWithSubnets(cs, networkNames[2], "Layer2", testLabel, v4, v6, namespaces[2].Name)
 					expectedTopologies = append(expectedTopologies, "Layer2")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(false)
 					createPrimaryCUDNWithSubnets(cs, networkNames[3], "Layer2", testLabel, v4, v6, namespaces[3].Name)
 					expectedTopologies = append(expectedTopologies, "Layer2")
 
@@ -856,30 +913,30 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 			})
 
 			By("creating 4 CUDNs (2xL3 + 2xL2)")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnNames[0], cudnLabel, v4, v6, cudnNamespaces[0].Name)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnNames[1], cudnLabel, v4, v6, cudnNamespaces[1].Name)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnNames[2], cudnLabel, v4, v6, cudnNamespaces[2].Name)
 			expectedTopologies = append(expectedTopologies, "Layer2")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnNames[3], cudnLabel, v4, v6, cudnNamespaces[3].Name)
 			expectedTopologies = append(expectedTopologies, "Layer2")
 
 			By("creating 4 UDNs (2xL3 + 2xL2)")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, udnNamespaces[0].Name, udnNames[0], v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, udnNamespaces[1].Name, udnNames[1], v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, udnNamespaces[2].Name, udnNames[2], v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer2")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, udnNamespaces[3].Name, udnNames[3], v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer2")
 
@@ -929,7 +986,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					verifyCNCHasOnlyTunnelIDAnnotation(cncName)
 
 					By(fmt.Sprintf("creating a %s primary UDN", topology))
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(topology == "Layer3")
 					createPrimaryUDNWithSubnets(cs, ns.Name, networkName, topology, v4, v6)
 					expectedTopologies = append(expectedTopologies, topology)
 
@@ -951,7 +1008,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					verifyCNCHasOnlyTunnelIDAnnotation(cncName)
 
 					By(fmt.Sprintf("creating a %s primary CUDN", topology))
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(topology == "Layer3")
 					createPrimaryCUDNWithSubnets(cs, networkName, topology, testLabel, v4, v6, ns.Name)
 					expectedTopologies = append(expectedTopologies, topology)
 
@@ -1002,16 +1059,16 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					verifyCNCHasOnlyTunnelIDAnnotation(cncName)
 
 					By("creating 2 Layer3 and 2 Layer2 primary UDNs")
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(true)
 					createLayer3PrimaryUDNWithSubnets(cs, namespaces[0].Name, networkNames[0], v4, v6)
 					expectedTopologies = append(expectedTopologies, "Layer3")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(true)
 					createLayer3PrimaryUDNWithSubnets(cs, namespaces[1].Name, networkNames[1], v4, v6)
 					expectedTopologies = append(expectedTopologies, "Layer3")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(false)
 					createLayer2PrimaryUDNWithSubnets(cs, namespaces[2].Name, networkNames[2], v4, v6)
 					expectedTopologies = append(expectedTopologies, "Layer2")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(false)
 					createLayer2PrimaryUDNWithSubnets(cs, namespaces[3].Name, networkNames[3], v4, v6)
 					expectedTopologies = append(expectedTopologies, "Layer2")
 
@@ -1043,16 +1100,16 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					verifyCNCHasOnlyTunnelIDAnnotation(cncName)
 
 					By("creating 2 Layer3 and 2 Layer2 primary CUDNs (one L3 targets multiple namespaces)")
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(true)
 					createPrimaryCUDNWithSubnets(cs, networkNames[0], "Layer3", testLabel, v4, v6, namespaces[0].Name)
 					expectedTopologies = append(expectedTopologies, "Layer3")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(true)
 					createPrimaryCUDNWithSubnets(cs, networkNames[1], "Layer3", testLabel, v4, v6, namespaces[1].Name, namespaces[4].Name)
 					expectedTopologies = append(expectedTopologies, "Layer3")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(false)
 					createPrimaryCUDNWithSubnets(cs, networkNames[2], "Layer2", testLabel, v4, v6, namespaces[2].Name)
 					expectedTopologies = append(expectedTopologies, "Layer2")
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(false)
 					createPrimaryCUDNWithSubnets(cs, networkNames[3], "Layer2", testLabel, v4, v6, namespaces[3].Name)
 					expectedTopologies = append(expectedTopologies, "Layer2")
 
@@ -1114,30 +1171,30 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			By("creating 4 CUDNs (2xL3 + 2xL2)")
 			nextSubnets := newTestNetworkSubnetsAllocator()
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnNames[0], cudnLabel, v4, v6, cudnNamespaces[0].Name)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnNames[1], cudnLabel, v4, v6, cudnNamespaces[1].Name)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnNames[2], cudnLabel, v4, v6, cudnNamespaces[2].Name)
 			expectedTopologies = append(expectedTopologies, "Layer2")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnNames[3], cudnLabel, v4, v6, cudnNamespaces[3].Name)
 			expectedTopologies = append(expectedTopologies, "Layer2")
 
 			By("creating 4 UDNs (2xL3 + 2xL2)")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, udnNamespaces[0].Name, udnNames[0], v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, udnNamespaces[1].Name, udnNames[1], v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, udnNamespaces[2].Name, udnNames[2], v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer2")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, udnNamespaces[3].Name, udnNames[3], v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer2")
 
@@ -1186,7 +1243,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 					By(fmt.Sprintf("creating initial %s primary UDN", initialTopology))
 					nextSubnets := newTestNetworkSubnetsAllocator()
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(initialTopology == "Layer3")
 					createPrimaryUDNWithSubnets(cs, namespaces[0].Name, networkNames[0], initialTopology, v4, v6)
 					expectedTopologies = append(expectedTopologies, initialTopology)
 					Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, namespaces[0].Name, networkNames[0]), 30*time.Second, time.Second).Should(Succeed())
@@ -1200,7 +1257,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					verifyCNCSubnetAnnotationContent(cncName, expectedTopologies)
 
 					By(fmt.Sprintf("adding a %s primary UDN", addedTopology))
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(addedTopology == "Layer3")
 					createPrimaryUDNWithSubnets(cs, namespaces[1].Name, networkNames[1], addedTopology, v4, v6)
 					expectedTopologies = append(expectedTopologies, addedTopology)
 					Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, namespaces[1].Name, networkNames[1]), 30*time.Second, time.Second).Should(Succeed())
@@ -1223,7 +1280,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 					By(fmt.Sprintf("creating initial %s primary CUDN", initialTopology))
 					nextSubnets := newTestNetworkSubnetsAllocator()
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(initialTopology == "Layer3")
 					createPrimaryCUDNWithSubnets(cs, networkNames[0], initialTopology, testLabel, v4, v6, namespaces[0].Name)
 					expectedTopologies = append(expectedTopologies, initialTopology)
 					Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, networkNames[0]), 30*time.Second, time.Second).Should(Succeed())
@@ -1237,7 +1294,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 					verifyCNCSubnetAnnotationContent(cncName, expectedTopologies)
 
 					By(fmt.Sprintf("adding a %s primary CUDN", addedTopology))
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(addedTopology == "Layer3")
 					createPrimaryCUDNWithSubnets(cs, networkNames[1], addedTopology, testLabel, v4, v6, namespaces[1].Name)
 					expectedTopologies = append(expectedTopologies, addedTopology)
 					Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, networkNames[1]), 30*time.Second, time.Second).Should(Succeed())
@@ -1284,10 +1341,10 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 			})
 
 			By("creating initial L3 CUDN and L3 UDN")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, initialCudnName, cudnLabel, v4, v6, cudnNs.Name)
 			expectedTopologies = append(expectedTopologies, "Layer3")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, udnNs.Name, initialUdnName, v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer3")
 
@@ -1303,10 +1360,10 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 			verifyCNCSubnetAnnotationContent(cncName, expectedTopologies)
 
 			By("adding L2 CUDN and L2 UDN")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, addedCudnName, cudnLabel, v4, v6, addedCudnNs.Name)
 			expectedTopologies = append(expectedTopologies, "Layer2")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, addedUdnNs.Name, addedUdnName, v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer2")
 
@@ -1348,9 +1405,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 					By("creating 2 primary UDNs (L3 + topology)")
 					nextSubnets := newTestNetworkSubnetsAllocator()
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(true)
 					createLayer3PrimaryUDNWithSubnets(cs, namespaces[0].Name, networkNames[0], v4, v6)
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(topology == "Layer3")
 					createPrimaryUDNWithSubnets(cs, namespaces[1].Name, networkNames[1], topology, v4, v6)
 					for i, ns := range namespaces {
 						Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, ns.Name, networkNames[i]), 30*time.Second, time.Second).Should(Succeed())
@@ -1390,9 +1447,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 					By("creating 2 primary CUDNs (L3 + topology)")
 					nextSubnets := newTestNetworkSubnetsAllocator()
-					v4, v6 := nextSubnets()
+					v4, v6 := nextSubnets(true)
 					createLayer3PrimaryCUDNWithSubnets(cs, networkNames[0], testLabel, v4, v6, namespaces[0].Name)
-					v4, v6 = nextSubnets()
+					v4, v6 = nextSubnets(topology == "Layer3")
 					createPrimaryCUDNWithSubnets(cs, networkNames[1], topology, testLabel, v4, v6, namespaces[1].Name)
 					for i := 0; i < 2; i++ {
 						Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, networkNames[i]), 30*time.Second, time.Second).Should(Succeed())
@@ -1454,13 +1511,13 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			By("creating 2 CUDNs (L3 + L2) and 2 UDNs (L3 + L2)")
 			nextSubnets := newTestNetworkSubnetsAllocator()
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName1, cudnLabel, v4, v6, cudnNs1.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnName2, cudnLabel, v4, v6, cudnNs2.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, udnNs1.Name, udnName1, v4, v6)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, udnNs2.Name, udnName2, v4, v6)
 
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName1), 30*time.Second, time.Second).Should(Succeed())
@@ -1518,9 +1575,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			By("creating 2 CUDNs - both with common label, second also has specific label")
 			nextSubnets := newTestNetworkSubnetsAllocator()
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName1, commonLabel, v4, v6, ns1.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnName2, specificLabel, v4, v6, ns2.Name)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName1), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -1568,9 +1625,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			By("creating 2 UDNs in namespaces - both with common label, second also has specific")
 			nextSubnets := newTestNetworkSubnetsAllocator()
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, ns1.Name, udnName1, v4, v6)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, ns2.Name, udnName2, v4, v6)
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, ns1.Name, udnName1), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, ns2.Name, udnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -1618,9 +1675,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			By("creating L3 CUDN and L2 UDN")
 			nextSubnets := newTestNetworkSubnetsAllocator()
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName, cudnLabel, v4, v6, cudnNs.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, udnNs.Name, udnName, v4, v6)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, udnNs.Name, udnName), 30*time.Second, time.Second).Should(Succeed())
@@ -1670,9 +1727,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			By("creating L3 CUDN and L2 UDN")
 			nextSubnets := newTestNetworkSubnetsAllocator()
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName, cudnLabel, v4, v6, cudnNs.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, udnNs.Name, udnName, v4, v6)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, udnNs.Name, udnName), 30*time.Second, time.Second).Should(Succeed())
@@ -1733,9 +1790,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			By("creating 2 CUDNs - first with matching label, second without")
 			nextSubnets := newTestNetworkSubnetsAllocator()
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName1, cncLabel, v4, v6, ns1.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnName2, map[string]string{"other": "label"}, v4, v6, ns2.Name)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName1), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -1792,9 +1849,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			By("creating 2 UDNs - first in namespace with matching label, second without")
 			nextSubnets := newTestNetworkSubnetsAllocator()
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, ns1.Name, udnName1, v4, v6)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, ns2.Name, udnName2, v4, v6)
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, ns1.Name, udnName1), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, ns2.Name, udnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -1876,9 +1933,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 			})
 
 			By("creating 2 CUDNs with different labels")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName1, label1, v4, v6, ns1.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnName2, label2, v4, v6, ns2.Name)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName1), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -1925,7 +1982,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 			})
 
 			By("creating a CUDN with shared label")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName, sharedLabel, v4, v6, ns.Name)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 30*time.Second, time.Second).Should(Succeed())
 
@@ -1974,9 +2031,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 			})
 
 			By("creating 2 CUDNs with different labels")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName1, label1, v4, v6, ns1.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnName2, label2, v4, v6, ns2.Name)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName1), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -2020,7 +2077,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 			})
 
 			By("creating a CUDN")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName, cncLabel, v4, v6, ns.Name)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 30*time.Second, time.Second).Should(Succeed())
 
@@ -2075,9 +2132,9 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 			})
 
 			By("creating 2 CUDNs with different labels")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName1, label1, v4, v6, ns1.Name)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnName2, label2, v4, v6, ns2.Name)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName1), 30*time.Second, time.Second).Should(Succeed())
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -2160,7 +2217,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			// Phase 2: Create first L3 CUDN - count goes to 1
 			By("Phase 2: Creating first L3 CUDN")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, cudnName1, cudnLabel, v4, v6, cudnNs1.Name)
 			expectedTopologies = append(expectedTopologies, "Layer3")
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName1), 30*time.Second, time.Second).Should(Succeed())
@@ -2169,7 +2226,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			// Phase 3: Create first L2 UDN - count goes to 2
 			By("Phase 3: Creating first L2 UDN")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, udnNs1.Name, udnName1, v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer2")
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, udnNs1.Name, udnName1), 30*time.Second, time.Second).Should(Succeed())
@@ -2178,7 +2235,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			// Phase 4: Create second L2 CUDN - count goes to 3
 			By("Phase 4: Creating second L2 CUDN")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, cudnName2, cudnLabel, v4, v6, cudnNs2.Name)
 			expectedTopologies = append(expectedTopologies, "Layer2")
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -2187,7 +2244,7 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 			// Phase 5: Create second L3 UDN - count goes to 4
 			By("Phase 5: Creating second L3 UDN")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, udnNs2.Name, udnName2, v4, v6)
 			expectedTopologies = append(expectedTopologies, "Layer3")
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, udnNs2.Name, udnName2), 30*time.Second, time.Second).Should(Succeed())
@@ -2276,8 +2333,8 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 		})
 
 		By(fmt.Sprintf("creating 2 %s primary UDNs with overlapping subnets", topology))
-		createPrimaryUDNWithSubnets(cs, ns1.Name, udnName1, topology, overlapV4Subnet, overlapV6Subnet)
-		createPrimaryUDNWithSubnets(cs, ns2.Name, udnName2, topology, overlapV4Subnet, overlapV6Subnet)
+		createPrimaryUDNWithSubnets(cs, ns1.Name, udnName1, topology, subnetList(overlapV4Subnet), subnetList(overlapV6Subnet))
+		createPrimaryUDNWithSubnets(cs, ns2.Name, udnName2, topology, subnetList(overlapV4Subnet), subnetList(overlapV6Subnet))
 
 		By("waiting for UDNs to be ready")
 		Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, ns1.Name, udnName1), 30*time.Second, time.Second).Should(Succeed())
@@ -2409,7 +2466,7 @@ var _ = Describe("ClusterNetworkConnect ValidatingAdmissionPolicy", feature.Netw
 		})
 
 		By("creating a CUDN and CNC so cluster-manager sets both annotations")
-		v4, v6 := nextSubnets()
+		v4, v6 := nextSubnets(true)
 		createLayer3PrimaryCUDNWithSubnets(cs, cudnName, cncLabel, v4, v6, ns.Name)
 		Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 30*time.Second, time.Second).Should(Succeed())
 
@@ -2457,7 +2514,7 @@ var _ = Describe("ClusterNetworkConnect ValidatingAdmissionPolicy", feature.Netw
 		})
 
 		By("creating a CUDN and CNC so cluster-manager sets both annotations")
-		v4, v6 := nextSubnets()
+		v4, v6 := nextSubnets(true)
 		createLayer3PrimaryCUDNWithSubnets(cs, cudnName, cncLabel, v4, v6, ns.Name)
 		Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 30*time.Second, time.Second).Should(Succeed())
 
@@ -2767,14 +2824,14 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			createUDNNamespaceWithName(cs, whiteNs1, nil)
 
 			By("1. Creating black CUDN targeting black-ns-0 and black-ns-1")
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, blackCUDN, cudnLabel, v4, v6, blackNs0, blackNs1)
 
 			By("1. Waiting for black CUDN to be ready")
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, blackCUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			By("1. Creating white CUDN targeting white-ns-0 and white-ns-1")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryCUDNWithSubnets(cs, whiteCUDN, cudnLabel, v4, v6, whiteNs0, whiteNs1)
 
 			By("1. Waiting for white CUDN to be ready")
@@ -2808,14 +2865,14 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			createUDNNamespaceWithName(cs, greenNs, udnLabel)
 
 			By("2. Creating blue UDN (L3)")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, blueNs, blueUDN, v4, v6)
 
 			By("2. Waiting for blue UDN to be ready")
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, blueNs, blueUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			By("2. Creating green UDN (L2)")
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, greenNs, greenUDN, v4, v6)
 
 			By("2. Waiting for green UDN to be ready")
@@ -3133,8 +3190,8 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			createUDNNamespaceWithName(cs, l2Namespace, udnLabel)
 
 			By("Creating the L3 and L2 UDNs")
-			createLayer3PrimaryUDNWithSubnets(cs, l3Namespace, l3UDNName, "10.140.0.0/16", "2014:100:600::0/60")
-			createLayer2PrimaryUDNWithSubnets(cs, l2Namespace, l2UDNName, "10.141.0.0/16", "2014:100:700::0/60")
+			createLayer3PrimaryUDNWithSubnets(cs, l3Namespace, l3UDNName, []string{"10.140.0.0/16"}, []string{"2014:100:600::0/60"})
+			createLayer2PrimaryUDNWithSubnets(cs, l2Namespace, l2UDNName, []string{"10.141.0.0/16"}, []string{"2014:100:700::0/60"})
 
 			By("Waiting for both UDNs to be ready")
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, l3Namespace, l3UDNName), 60*time.Second, time.Second).Should(Succeed())
@@ -3324,7 +3381,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			// =====================================================================
 			By("3. Creating blue namespace and L2 UDN")
 			createUDNNamespaceWithName(cs, blueNs, blueLabel)
-			v4, v6 := nextSubnets()
+			v4, v6 := nextSubnets(false)
 			createLayer2PrimaryUDNWithSubnets(cs, blueNs, blueUDN, v4, v6)
 
 			By("3. Waiting for blue UDN to be ready")
@@ -3351,7 +3408,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			// =====================================================================
 			By("4. Creating red namespace and L3 CUDN")
 			createUDNNamespaceWithName(cs, redNs, nil)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryCUDNWithSubnets(cs, redCUDN, redLabel, v4, v6, redNs)
 
 			By("4. Waiting for red CUDN to be ready")
@@ -3378,7 +3435,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			// =====================================================================
 			By("5. Creating green namespace and L3 UDN")
 			createUDNNamespaceWithName(cs, greenNs, greenLabel)
-			v4, v6 = nextSubnets()
+			v4, v6 = nextSubnets(true)
 			createLayer3PrimaryUDNWithSubnets(cs, greenNs, greenUDN, v4, v6)
 
 			By("5. Waiting for green UDN to be ready")
@@ -3560,7 +3617,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			// =====================================================================
 			By("2. Creating blue namespace, L2 UDN, and pods")
 			createUDNNamespaceWithName(cs, blueNs, blueLabel)
-			createLayer2PrimaryUDNWithSubnets(cs, blueNs, blueUDN, "10.128.0.0/16", "2014:100:200::0/60")
+			createLayer2PrimaryUDNWithSubnets(cs, blueNs, blueUDN, subnetList("10.128.0.0/16"), subnetList("2014:100:200::0/60"))
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, blueNs, blueUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			bluePodConfig0 := httpServerPodConfig("blue-pod-0", blueNs)
@@ -3574,7 +3631,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 
 			By("2. Creating red namespace, L3 CUDN, and pods")
 			createUDNNamespaceWithName(cs, redNs, nil)
-			createLayer3PrimaryCUDNWithSubnets(cs, redCUDN, redLabel, "10.129.0.0/16", "2014:100:300::0/60", redNs)
+			createLayer3PrimaryCUDNWithSubnets(cs, redCUDN, redLabel, subnetList("10.129.0.0/16"), subnetList("2014:100:300::0/60"), redNs)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, redCUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			redPodConfig0 := httpServerPodConfig("red-pod-0", redNs)
@@ -3584,7 +3641,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 
 			By("2. Creating green namespace, L3 UDN, and pods")
 			createUDNNamespaceWithName(cs, greenNs, greenLabel)
-			createLayer3PrimaryUDNWithSubnets(cs, greenNs, greenUDN, "10.130.0.0/16", "2014:100:400::0/60")
+			createLayer3PrimaryUDNWithSubnets(cs, greenNs, greenUDN, subnetList("10.130.0.0/16"), subnetList("2014:100:400::0/60"))
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, greenNs, greenUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			greenPodConfig0 := httpServerPodConfig("green-pod-0", greenNs)
@@ -3790,7 +3847,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			// =====================================================================
 			By("2. Creating net-A namespace, L3 CUDN, and pods")
 			createUDNNamespaceWithName(cs, netANs, nil)
-			createLayer3PrimaryCUDNWithSubnets(cs, netACUDN, sharedCUDNLabel, "10.128.0.0/16", "2014:100:200::0/60", netANs)
+			createLayer3PrimaryCUDNWithSubnets(cs, netACUDN, sharedCUDNLabel, subnetList("10.128.0.0/16"), subnetList("2014:100:200::0/60"), netANs)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, netACUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			netAPodConfig := httpServerPodConfig("net-a-pod-0", netANs)
@@ -3800,7 +3857,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 
 			By("2. Creating net-B namespace, L2 UDN, and pods")
 			createUDNNamespaceWithName(cs, netBNs, sharedUDNLabel)
-			createLayer2PrimaryUDNWithSubnets(cs, netBNs, netBUDN, "10.129.0.0/16", "2014:100:300::0/60")
+			createLayer2PrimaryUDNWithSubnets(cs, netBNs, netBUDN, subnetList("10.129.0.0/16"), subnetList("2014:100:300::0/60"))
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, netBNs, netBUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			netBPodConfig := httpServerPodConfig("net-b-pod-0", netBNs)
@@ -4047,11 +4104,11 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			createUDNNamespaceWithName(cs, whiteNs1, nil)
 
 			By("Setup: Creating black CUDN (L3)")
-			createLayer3PrimaryCUDNWithSubnets(cs, blackCUDN, cudnLabel, "10.128.0.0/16", "2014:100:200::0/60", blackNs0, blackNs1)
+			createLayer3PrimaryCUDNWithSubnets(cs, blackCUDN, cudnLabel, subnetList("10.128.0.0/16"), subnetList("2014:100:200::0/60"), blackNs0, blackNs1)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, blackCUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			By("Setup: Creating white CUDN (L2)")
-			createLayer2PrimaryCUDNWithSubnets(cs, whiteCUDN, cudnLabel, "10.129.0.0/16", "2014:100:300::0/60", whiteNs0, whiteNs1)
+			createLayer2PrimaryCUDNWithSubnets(cs, whiteCUDN, cudnLabel, subnetList("10.129.0.0/16"), subnetList("2014:100:300::0/60"), whiteNs0, whiteNs1)
 			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, whiteCUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			By("Setup: Creating pods in black CUDN namespaces")
@@ -4086,11 +4143,11 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			createUDNNamespaceWithName(cs, greenNs, pudnLabel)
 
 			By("Setup: Creating blue UDN (L3)")
-			createLayer3PrimaryUDNWithSubnets(cs, blueNs, blueUDN, "10.130.0.0/16", "2014:100:400::0/60")
+			createLayer3PrimaryUDNWithSubnets(cs, blueNs, blueUDN, subnetList("10.130.0.0/16"), subnetList("2014:100:400::0/60"))
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, blueNs, blueUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			By("Setup: Creating green UDN (L2)")
-			createLayer2PrimaryUDNWithSubnets(cs, greenNs, greenUDN, "10.131.0.0/16", "2014:100:500::0/60")
+			createLayer2PrimaryUDNWithSubnets(cs, greenNs, greenUDN, subnetList("10.131.0.0/16"), subnetList("2014:100:500::0/60"))
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, greenNs, greenUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			By("Setup: Creating pods in blue UDN namespace")
@@ -4511,7 +4568,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			// Step 31: Re-create blue PUDN network and pods (service was not deleted)
 			// =====================================================================
 			By("31. Recreating blue PUDN network")
-			createLayer3PrimaryUDNWithSubnets(cs, blueNs, blueUDN, "103.103.0.0/16", "2014:100:400::0/60")
+			createLayer3PrimaryUDNWithSubnets(cs, blueNs, blueUDN, subnetList("103.103.0.0/16"), subnetList("2014:100:400::0/60"))
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, blueNs, blueUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			By("31. Recreating blue pods")
@@ -4528,7 +4585,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			// Step 32: Re-create green PUDN network and pods (service was not deleted)
 			// =====================================================================
 			By("32. Recreating green PUDN network")
-			createLayer2PrimaryUDNWithSubnets(cs, greenNs, greenUDN, "104.104.0.0/16", "2014:100:500::0/60")
+			createLayer2PrimaryUDNWithSubnets(cs, greenNs, greenUDN, subnetList("104.104.0.0/16"), subnetList("2014:100:500::0/60"))
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, greenNs, greenUDN), 60*time.Second, time.Second).Should(Succeed())
 
 			By("32. Recreating green pods")

--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -152,13 +152,18 @@ func egressFirewallPolicyValidationTests(useUDN bool, udnTopology string) {
 				f.Namespace = namespace
 				framework.ExpectNoError(err)
 
-				userDefinedNetworkIPv4Subnet := "172.31.0.0/16"
-				userDefinedNetworkIPv6Subnet := "2014:100:200::0/60"
+				userDefinedNetworkIPv4Subnets := []string{"172.31.0.0/16"}
+				userDefinedNetworkIPv6Subnets := []string{"2014:100:200::0/60"}
+				if udnTopology == "layer3" {
+					userDefinedNetworkIPv4Subnets = []string{"172.31.0.0/23/24", "172.30.0.0/16/24"}
+					userDefinedNetworkIPv6Subnets = []string{"2014:100:200::0/63/64", "2014:100:100::0/48/64"}
+				}
+				userDefinedNetworkSubnets := append(append([]string{}, userDefinedNetworkIPv4Subnets...), userDefinedNetworkIPv6Subnets...)
 
 				nadCfg := networkAttachmentConfigParams{
 					name:     "tenant-red",
 					topology: udnTopology,
-					cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     joinStrings(userDefinedNetworkSubnets...),
 					role:     "primary",
 				}
 
@@ -167,10 +172,10 @@ func egressFirewallPolicyValidationTests(useUDN bool, udnTopology string) {
 				switch strings.ToLower(udnTopology) {
 				case "layer2":
 					createLayer2PrimaryUDNWithSubnets(f.ClientSet, f.Namespace.Name, netConfig.name,
-						userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet)
+						userDefinedNetworkIPv4Subnets, userDefinedNetworkIPv6Subnets)
 				case "layer3":
-					createLayer3PrimaryUDNWithSubnets(f.ClientSet, f.Namespace.Name, netConfig.name,
-						userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet)
+					createPrimaryUDNWithSubnets(f.ClientSet, f.Namespace.Name, netConfig.name, "Layer3",
+						userDefinedNetworkIPv4Subnets, userDefinedNetworkIPv6Subnets)
 				default:
 					framework.Failf("unsupported UDN topology %q", udnTopology)
 				}

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -637,10 +637,10 @@ var _ = ginkgo.DescribeTableSubtree("e2e egress IP validation", feature.EgressIP
 		if netConfigParams.cidr == "" {
 			return false, "UDN network must have subnet specified"
 		}
-		if utilnet.IsIPv4CIDRString(netConfigParams.cidr) && !isNodeInternalAddressesPresentForIPFamily(nodes, corev1.IPv4Protocol) {
+		if cidrsContainIPFamily(netConfigParams.cidr, false) && !isNodeInternalAddressesPresentForIPFamily(nodes, corev1.IPv4Protocol) {
 			return false, "cluster must have IPv4 Node internal address"
 		}
-		if utilnet.IsIPv6CIDRString(netConfigParams.cidr) && !isNodeInternalAddressesPresentForIPFamily(nodes, corev1.IPv6Protocol) {
+		if cidrsContainIPFamily(netConfigParams.cidr, true) && !isNodeInternalAddressesPresentForIPFamily(nodes, corev1.IPv6Protocol) {
 			return false, "cluster must have IPv6 Node internal address"
 		}
 		return true, "network is supported"
@@ -666,11 +666,11 @@ var _ = ginkgo.DescribeTableSubtree("e2e egress IP validation", feature.EgressIP
 			if netConfigParams.cidr == "" {
 				framework.Failf("network config must have subnet defined")
 			}
-			if utilnet.IsIPv4CIDRString(netConfigParams.cidr) && isIPv4Cluster {
-				ipFamily = corev1.IPv4Protocol
-			}
-			if utilnet.IsIPv6CIDRString(netConfigParams.cidr) && isIPv6Cluster {
+			if cidrsContainIPFamily(netConfigParams.cidr, true) && isIPv6Cluster {
 				ipFamily = corev1.IPv6Protocol
+			}
+			if cidrsContainIPFamily(netConfigParams.cidr, false) && isIPv4Cluster {
+				ipFamily = corev1.IPv4Protocol
 			}
 		}
 		if ipFamily == corev1.IPFamilyUnknown {
@@ -3528,10 +3528,9 @@ spec:
 		var otherNetworkNamespace *corev1.Namespace
 		var err error
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-		isOtherNetworkIPv6 := utilnet.IsIPv6CIDRString(otherNetworkAttachParms.cidr)
 		// The EgressIP IP must match both networks IP family
-		if isOtherNetworkIPv6 != isIPv6TestRun {
-			ginkgo.Skip(fmt.Sprintf("Test run IP family (is IPv6: %v) doesn't match other networks IP family (is IPv6: %v)", isIPv6TestRun, isOtherNetworkIPv6))
+		if !cidrsContainIPFamily(otherNetworkAttachParms.cidr, isIPv6TestRun) {
+			ginkgo.Skip(fmt.Sprintf("Test run IP family (is IPv6: %v) isn't supported by other network", isIPv6TestRun))
 		}
 		// is the test namespace a CDN? If so create the UDN namespace
 		if isClusterDefaultNetwork(netConfigParams) {
@@ -3642,7 +3641,7 @@ spec:
 		ginkgo.Entry("L3 Primary UDN", networkAttachmentConfigParams{
 			name:     "l3primary",
 			topology: types.Layer3Topology,
-			cidr:     joinStrings("30.10.0.0/16", "2014:100:200::0/60"),
+			cidr:     primaryLayer3MultiCIDRs(),
 			role:     "primary",
 		}),
 		ginkgo.Entry("L2 Primary UDN", networkAttachmentConfigParams{
@@ -3666,7 +3665,7 @@ spec:
 		networkAttachmentConfigParams{
 			name:     "l3primaryv4",
 			topology: types.Layer3Topology,
-			cidr:     "10.10.0.0/16",
+			cidr:     primaryLayer3MultiIPv4CIDRs(),
 			role:     "primary",
 		},
 	),
@@ -3675,7 +3674,7 @@ spec:
 		networkAttachmentConfigParams{
 			name:     "l3primaryv6",
 			topology: types.Layer3Topology,
-			cidr:     "2014:100:200::0/60",
+			cidr:     primaryLayer3MultiIPv6CIDRs(),
 			role:     "primary",
 		},
 	),

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -39,6 +39,24 @@ func joinStrings(vals ...string) string {
 	return strings.Join(vals, ",")
 }
 
+func primaryLayer3MultiCIDRs() string {
+	return joinStrings(primaryLayer3MultiIPv4CIDRs(), primaryLayer3MultiIPv6CIDRs())
+}
+
+func primaryLayer3MultiIPv4CIDRs() string {
+	return joinStrings(
+		"172.31.0.0/23/24",
+		"172.30.0.0/16/24",
+	)
+}
+
+func primaryLayer3MultiIPv6CIDRs() string {
+	return joinStrings(
+		"2014:100:200::0/63/64",
+		"2014:100:100::0/48/64",
+	)
+}
+
 func filterCIDRsAndJoin(cs clientset.Interface, cidrs string) string {
 	if cidrs == "" {
 		return "" // we may not always set CIDR - i.e. CDN
@@ -49,6 +67,9 @@ func filterCIDRsAndJoin(cs clientset.Interface, cidrs string) string {
 func filterCIDRs(cs clientset.Interface, cidrs ...string) []string {
 	var supportedCIDRs []string
 	for _, cidr := range cidrs {
+		if strings.TrimSpace(cidr) == "" {
+			continue
+		}
 		if !isCIDRIPFamilySupported(cs, cidr) {
 			continue
 		}
@@ -202,7 +223,7 @@ type podConfiguration struct {
 	nodeSelector           map[string]string
 	isPrivileged           bool
 	labels                 map[string]string
-	annotations                  map[string]string
+	annotations            map[string]string
 	requiresExtraNamespace bool
 	hostNetwork            bool
 	ipRequestFromSubnet    string
@@ -309,6 +330,58 @@ func inRange(cidr string, ip string) error {
 	}
 
 	return fmt.Errorf("ip [%s] is NOT in range %s", ip, cidr)
+}
+
+func inAnyConfiguredSubnet(cidrs string, ip string) error {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return fmt.Errorf("invalid IP %q", ip)
+	}
+	ipv4 := parsedIP.To4() != nil
+
+	var sameFamilyCIDRs []string
+	for _, cidr := range strings.Split(cidrs, ",") {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		subnet, err := getNetCIDRSubnet(cidr)
+		if err != nil {
+			return err
+		}
+		_, ipnet, err := net.ParseCIDR(subnet)
+		if err != nil {
+			return err
+		}
+		if (ipnet.IP.To4() != nil) != ipv4 {
+			continue
+		}
+		sameFamilyCIDRs = append(sameFamilyCIDRs, subnet)
+		if ipnet.Contains(parsedIP) {
+			return nil
+		}
+	}
+	if len(sameFamilyCIDRs) == 0 {
+		return fmt.Errorf("no configured subnet for IP %q", ip)
+	}
+	return fmt.Errorf("ip [%s] is NOT in any configured subnet %s", ip, strings.Join(sameFamilyCIDRs, ","))
+}
+
+func cidrsContainIPFamily(cidrs string, ipv6 bool) bool {
+	for _, cidr := range strings.Split(cidrs, ",") {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		subnet, err := getNetCIDRSubnet(cidr)
+		if err != nil {
+			continue
+		}
+		if utilnet.IsIPv6CIDRString(subnet) == ipv6 {
+			return true
+		}
+	}
+	return false
 }
 
 func connectToServer(clientPodConfig podConfiguration, serverIP string, port uint16, args ...string) error {

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	ovnkubeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
@@ -77,6 +79,13 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 		customL2IPv6InfraCIDR               = "2014:100:200::/122"
 		userDefinedNetworkName              = "hogwarts"
 		nadName                             = "gryffindor"
+
+		// each subnet can support 2 nodes; when cluster has more than 2 nodes,
+		// both subnets will be utilized.
+		userDefinedNetworkIPv4Subnet1 = "172.31.0.0/24/25"
+		userDefinedNetworkIPv4Subnet2 = "172.30.0.0/16/25"
+		userDefinedNetworkIPv6Subnet1 = "2014:100:200::0/63/64"
+		userDefinedNetworkIPv6Subnet2 = "2014:100:100::0/48/64"
 	)
 
 	BeforeEach(func() {
@@ -961,6 +970,345 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 				//}),
 			)
 		})
+	})
+
+	Context("layer3 primary network with multi-subnets", func() {
+		DescribeTableSubtree("created using",
+			func(createNetworkFn func(netConfig *networkAttachmentConfigParams) error) {
+
+				BeforeEach(func() {
+					nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+					framework.ExpectNoError(err)
+					if len(nodeList.Items) < 3 {
+						e2eskipper.Skipf("need at least 3 ready schedulable nodes to run this test")
+					}
+				})
+
+				DescribeTable(
+					"can perform east/west traffic between nodes on different CIDR",
+					func(netConfig *networkAttachmentConfigParams) {
+						By("validate test config")
+						cidr2nodev4 := make(map[string]*v1.Node)
+						cidr2nodev6 := make(map[string]*v1.Node)
+						netConfig.cidr = filterCIDRsAndJoin(f.ClientSet, netConfig.cidr)
+						for _, cidr := range strings.Split(netConfig.cidr, ",") {
+							c, err := getNetCIDRSubnet(cidr)
+							Expect(err).NotTo(HaveOccurred())
+							if utilnet.IsIPv4CIDRString(c) {
+								cidr2nodev4[c] = nil
+							} else {
+								cidr2nodev6[c] = nil
+							}
+						}
+
+						ipv4, ipv6 := getSupportedIPFamilies(cs)
+						if ipv4 {
+							Expect(len(cidr2nodev4)).To(BeNumerically(">=", 2), "need at least 2 different IPv4 CIDRs")
+						}
+						if ipv6 {
+							Expect(len(cidr2nodev6)).To(BeNumerically(">=", 2), "need at least 2 different IPv6 CIDRs")
+						}
+						By("creating the network with multiple CIDRs")
+						netConfig.namespace = f.Namespace.Name
+						Expect(createNetworkFn(netConfig)).To(Succeed())
+
+						By("ensure have 2 scheduable Nodes on different CIDR")
+						nad, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Get(context.TODO(), netConfig.name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						networkName := nad.Annotations["k8s.ovn.org/network-name"]
+
+						if isDynamicUDNEnabled() {
+							nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+							Expect(err).NotTo(HaveOccurred())
+							for i := range nodeList.Items {
+								node := &nodeList.Items[i]
+								runUDNPod(cs, f.Namespace.Name, podConfiguration{
+									name:         fmt.Sprintf("subnet-allocator-%d", i),
+									namespace:    f.Namespace.Name,
+									containerCmd: []string{"/agnhost", "pause"},
+									nodeSelector: map[string]string{nodeHostnameKey: node.Name},
+								}, nil)
+							}
+						}
+
+						node2cidrv4 := map[string]string{}
+						node2cidrv6 := map[string]string{}
+						clientNodeName, serverNodeName := "", ""
+						Eventually(func() error {
+							nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+							if err != nil {
+								return err
+							}
+
+							node2cidrv4 = map[string]string{}
+							node2cidrv6 = map[string]string{}
+							nodes := []*v1.Node{}
+							for i := range nodeList.Items {
+								node := &nodeList.Items[i]
+								ipnets, err := ovnkubeutil.ParseNodeHostSubnetAnnotation(node, networkName)
+								if err != nil {
+									if ovnkubeutil.IsAnnotationNotSetError(err) {
+										continue
+									}
+									return err
+								}
+								nodes = append(nodes, node)
+								for _, ipnet := range ipnets {
+									if utilnet.IsIPv4CIDR(ipnet) {
+										node2cidrv4[node.Name] = ipnet.String()
+									} else {
+										node2cidrv6[node.Name] = ipnet.String()
+									}
+								}
+							}
+
+							// find a pair of nodes with different IPv4 and IPv6 CIDRs
+							clientNodeName, serverNodeName = "", ""
+							for i := 0; i < len(nodes)-1; i++ {
+								for j := i + 1; j < len(nodes); j++ {
+									ni, nj := nodes[i].Name, nodes[j].Name
+									if (!ipv4 || node2cidrv4[ni] != "" && node2cidrv4[nj] != "" && node2cidrv4[ni] != node2cidrv4[nj]) &&
+										(!ipv6 || node2cidrv6[ni] != "" && node2cidrv6[nj] != "" && node2cidrv6[ni] != node2cidrv6[nj]) {
+										clientNodeName, serverNodeName = ni, nj
+										return nil
+									}
+								}
+							}
+							return fmt.Errorf("can not find a pair of nodes with different IPv4 and IPv6 CIDRs")
+						}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+						Expect(clientNodeName != "" && serverNodeName != "").To(BeTrue(), "can not find a pair of nodes with different IPv4 and IPv6 CIDRs")
+						By("creating pods on nodes")
+						clientPodConfig := podConfiguration{
+							name:         "client-pod",
+							namespace:    f.Namespace.Name,
+							nodeSelector: map[string]string{nodeHostnameKey: clientNodeName},
+						}
+						serverPodConfig := podConfiguration{
+							name:         "server-pod",
+							namespace:    f.Namespace.Name,
+							containerCmd: httpServerContainerCmd(podClusterNetPort),
+							nodeSelector: map[string]string{nodeHostnameKey: serverNodeName},
+						}
+						runUDNPod(cs, f.Namespace.Name, clientPodConfig, nil)
+						runUDNPod(cs, f.Namespace.Name, serverPodConfig, nil)
+
+						clientIPs, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, clientPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
+						Expect(err).NotTo(HaveOccurred())
+						for _, clientIP := range clientIPs {
+							if utilnet.IsIPv4CIDR(clientIP) {
+								Expect(inRange(node2cidrv4[clientNodeName], clientIP.IP.String())).To(Succeed())
+							} else {
+								Expect(inRange(node2cidrv6[clientNodeName], clientIP.IP.String())).To(Succeed())
+							}
+						}
+
+						serverIPs, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, serverPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
+						Expect(err).NotTo(HaveOccurred())
+						for _, serverIP := range serverIPs {
+							if utilnet.IsIPv4CIDR(serverIP) {
+								Expect(inRange(node2cidrv4[serverNodeName], serverIP.IP.String())).To(Succeed())
+							} else {
+								Expect(inRange(node2cidrv6[serverNodeName], serverIP.IP.String())).To(Succeed())
+							}
+						}
+
+						By("asserting the *client* pod can contact the server pod exposed endpoint")
+						for _, serverIP := range serverIPs {
+							Eventually(func() error {
+								return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP.IP.String(), podClusterNetPort)
+							}, 6*time.Minute, 6*time.Second).Should(Succeed())
+						}
+					},
+					Entry("L3 primary network",
+						&networkAttachmentConfigParams{
+							name:     nadName,
+							topology: "layer3",
+							cidr: joinStrings(
+								// the 1st set of CIDR can only allocate subnet for 2 nodes
+								userDefinedNetworkIPv4Subnet1, userDefinedNetworkIPv4Subnet2,
+								// the 2nd set of CIDR can allocate subnet for remaining nodes
+								userDefinedNetworkIPv6Subnet1, userDefinedNetworkIPv6Subnet2,
+							),
+							role: "primary",
+						},
+					),
+				)
+
+			},
+			Entry("UserDefinedNetwork", func(c *networkAttachmentConfigParams) error {
+				udnManifest := generateUserDefinedNetworkManifest(c, f.ClientSet)
+				cleanup, err := createManifest(c.namespace, udnManifest)
+				DeferCleanup(cleanup)
+				Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, c.namespace, c.name), 10*time.Second, time.Second).Should(Succeed())
+				return err
+			}),
+			Entry("ClusterUserDefinedNetwork", func(c *networkAttachmentConfigParams) error {
+				cudnName := randomNetworkMetaName()
+				c.name = cudnName
+				cudnManifest := generateClusterUserDefinedNetworkManifest(c, f.ClientSet)
+				cleanup, err := createManifest("", cudnManifest)
+				DeferCleanup(func() {
+					cleanup()
+					By(fmt.Sprintf("delete pods in %s namespace to unblock CUDN CR & associate NAD deletion", c.namespace))
+					Expect(cs.CoreV1().Pods(c.namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(Succeed())
+					_, err := e2ekubectl.RunKubectl("", "delete", "clusteruserdefinednetwork", cudnName, "--wait", fmt.Sprintf("--timeout=%ds", 120))
+					Expect(err).NotTo(HaveOccurred())
+				})
+				Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, c.name), 10*time.Second, time.Second).Should(Succeed())
+				return err
+			}),
+		)
+
+		DescribeTableSubtree("created using",
+			func(createNetworkFn func(netConfig *networkAttachmentConfigParams) error,
+				updateNetworkFn func(netConfig *networkAttachmentConfigParams) error,
+				getDynamicClient func(netConfig *networkAttachmentConfigParams) dynamic.ResourceInterface) {
+
+				It("add subnet not affecting existing node subnet assignment", func() {
+					nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+					framework.ExpectNoError(err)
+					if len(nodeList.Items) < 3 {
+						e2eskipper.Skipf("need at least 3 ready schedulable nodes to run this test")
+					}
+
+					By("creating the intial network with one CIDR")
+					netConfig := &networkAttachmentConfigParams{
+						name:      randomNetworkMetaName(),
+						namespace: f.Namespace.Name,
+						topology:  "layer3",
+						cidr: joinStrings(
+							userDefinedNetworkIPv4Subnet1, userDefinedNetworkIPv6Subnet1,
+						),
+						role: "primary",
+					}
+					netConfig.cidr = filterCIDRsAndJoin(f.ClientSet, netConfig.cidr)
+					Expect(createNetworkFn(netConfig)).To(Succeed())
+
+					nad, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Get(context.TODO(), netConfig.name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					networkName := nad.Annotations["k8s.ovn.org/network-name"]
+
+					By("getting the node subnet assignment")
+					nodeList, err = e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+					framework.ExpectNoError(err)
+
+					oldv4, oldv6, err := getNodeSubnetAssignments(cs, networkName)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(oldv4) == 0 || len(oldv4) < len(nodeList.Items)).To(BeTrue(), "expect some nodes do not have subnet assigned")
+					Expect(len(oldv6) == 0 || len(oldv6) < len(nodeList.Items)).To(BeTrue(), "expect some nodes do not have subnet assigned")
+
+					By("Add subnets to the network")
+					cirds := []string{
+						userDefinedNetworkIPv4Subnet1, userDefinedNetworkIPv6Subnet1,
+						userDefinedNetworkIPv4Subnet2, userDefinedNetworkIPv6Subnet2,
+					}
+					netConfig.cidr = joinStrings(cirds...)
+					Expect(updateNetworkFn(netConfig)).To(Succeed())
+
+					By("wait all nodes to have subnet assigned")
+					newv4, newv6 := map[string]string{}, map[string]string{}
+					Eventually(func() error {
+						newv4, newv6, err = getNodeSubnetAssignments(cs, networkName)
+						Expect(err).NotTo(HaveOccurred())
+						if (len(newv4) == 0 || len(newv4) == len(nodeList.Items)) &&
+							(len(newv6) == 0 || len(newv6) == len(nodeList.Items)) {
+							return nil
+						}
+						return fmt.Errorf("expect all nodes have subnet")
+					}, 60*time.Second, 3*time.Second).Should(Succeed())
+
+					By("Check node subnet assignment after adding subnets")
+					for nodeName, subnet := range oldv4 {
+						Expect(newv4[nodeName]).To(Equal(subnet), "node %s IPv4 subnet changed from %s to %s", nodeName, subnet, newv4[nodeName])
+					}
+					for nodeName, subnet := range oldv6 {
+						Expect(newv6[nodeName]).To(Equal(subnet), "node %s IPv6 subnet changed from %s to %s", nodeName, subnet, newv6[nodeName])
+					}
+				})
+
+				It("add bad subnet should not cause change on existing NAD", func() {
+					By("creating the intial network with one CIDR")
+					netConfig := &networkAttachmentConfigParams{
+						name:      randomNetworkMetaName(),
+						namespace: f.Namespace.Name,
+						topology:  "layer3",
+						cidr: joinStrings(
+							userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet,
+						),
+						role: "primary",
+					}
+					netConfig.cidr = filterCIDRsAndJoin(f.ClientSet, netConfig.cidr)
+					Expect(createNetworkFn(netConfig)).To(Succeed())
+
+					nad, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Get(context.TODO(), netConfig.name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Add Join subnets to the network")
+					cirds := []string{
+						userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet,
+						config.Gateway.V4JoinSubnet, config.Gateway.V6JoinSubnet,
+					}
+					netConfig.cidr = joinStrings(cirds...)
+					Expect(updateNetworkFn(netConfig)).To(Succeed())
+
+					By("check status NetworkCreated is changed to false")
+					client := getDynamicClient(netConfig)
+					Eventually(checkStatusFunc(client, netConfig.name, "NetworkCreated", metav1.ConditionFalse),
+						30*time.Second, 2*time.Second).Should(Succeed())
+
+					By("Check NAD is intacted after adding bad subnet")
+					curNad, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Get(context.TODO(), netConfig.name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(curNad.Spec.Config).To(Equal(nad.Spec.Config))
+				})
+
+			},
+			Entry("UserDefinedNetwork",
+				func(c *networkAttachmentConfigParams) error {
+					udnManifest := generateUserDefinedNetworkManifest(c, f.ClientSet)
+					cleanup, err := createManifest(c.namespace, udnManifest)
+					DeferCleanup(cleanup)
+					Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, c.namespace, c.name), 10*time.Second, time.Second).Should(Succeed())
+					return err
+				},
+				func(c *networkAttachmentConfigParams) error {
+					udnManifest := generateUserDefinedNetworkManifest(c, f.ClientSet)
+					cleanup, err := applyManifest(c.namespace, udnManifest)
+					DeferCleanup(cleanup)
+					return err
+				},
+				func(c *networkAttachmentConfigParams) dynamic.ResourceInterface {
+					return f.DynamicClient.Resource(udnGVR).Namespace(c.namespace)
+				},
+			),
+			Entry("ClusterUserDefinedNetwork",
+				func(c *networkAttachmentConfigParams) error {
+					cudnManifest := generateClusterUserDefinedNetworkManifest(c, f.ClientSet)
+					cleanup, err := createManifest("", cudnManifest)
+					DeferCleanup(func() {
+						cleanup()
+						By(fmt.Sprintf("delete pods in %s namespace to unblock CUDN CR & associate NAD deletion", c.namespace))
+						Expect(cs.CoreV1().Pods(c.namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(Succeed())
+						_, err := e2ekubectl.RunKubectl("", "delete", "clusteruserdefinednetwork", c.name, "--wait", fmt.Sprintf("--timeout=%ds", 120))
+						Expect(err).NotTo(HaveOccurred())
+					})
+					Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, c.name), 10*time.Second, time.Second).Should(Succeed())
+					return err
+				},
+				func(c *networkAttachmentConfigParams) error {
+					cudnManifest := generateClusterUserDefinedNetworkManifest(c, f.ClientSet)
+					cleanup, err := applyManifest("", cudnManifest)
+					DeferCleanup(func() {
+						cleanup()
+					})
+					return err
+				},
+				func(c *networkAttachmentConfigParams) dynamic.ResourceInterface {
+					return f.DynamicClient.Resource(clusterUDNGVR)
+				},
+			),
+		)
 	})
 
 	Context("UserDefinedNetwork CRD Controller", func() {
@@ -2132,7 +2480,7 @@ func generateLayer3Subnets(cidrs string) []string {
 		case 2:
 			subnets = append(subnets, fmt.Sprintf(`{cidr: "%s/%s"}`, cidrSplit[0], cidrSplit[1]))
 		case 3:
-			subnets = append(subnets, fmt.Sprintf(`{cidr: "%s/%s", hostSubnet: %q }`, cidrSplit[0], cidrSplit[1], cidrSplit[2]))
+			subnets = append(subnets, fmt.Sprintf(`{cidr: "%s/%s", hostSubnet: %s }`, cidrSplit[0], cidrSplit[1], cidrSplit[2]))
 		default:
 			panic(fmt.Sprintf("invalid layer3 subnet: %v", cidr))
 		}
@@ -2172,6 +2520,31 @@ func networkReadyFunc(client dynamic.ResourceInterface, name string) func() erro
 	}
 }
 
+func checkStatusFunc(client dynamic.ResourceInterface, name string, condType string, condStatus metav1.ConditionStatus) func() error {
+	return func() error {
+		obj, err := client.Get(context.Background(), name, metav1.GetOptions{}, "status")
+		if err != nil {
+			return err
+		}
+		conditions, err := getConditions(obj)
+		if err != nil {
+			return err
+		}
+		if len(conditions) == 0 {
+			return fmt.Errorf("no conditions found in: %v", obj)
+		}
+		for _, condition := range conditions {
+			if condition.Type == condType {
+				if condition.Status == condStatus {
+					return nil
+				}
+				return fmt.Errorf("unexpected condition status: %s", condition.Status)
+			}
+		}
+		return fmt.Errorf("no %s condition found in: %v", condType, obj)
+	}
+}
+
 func createManifest(namespace, manifest string) (func(), error) {
 	tmpDir, err := os.MkdirTemp("", "udn-test")
 	if err != nil {
@@ -2189,6 +2562,23 @@ func createManifest(namespace, manifest string) (func(), error) {
 	}
 
 	_, err = e2ekubectl.RunKubectl(namespace, "create", "-f", path)
+	if err != nil {
+		return cleanup, err
+	}
+	return cleanup, nil
+}
+
+func applyManifest(namespace, manifest string) (func(), error) {
+	path := "test-" + randString(5) + ".yaml"
+	if err := os.WriteFile(path, []byte(manifest), 0644); err != nil {
+		framework.Failf("Unable to write yaml to disk: %v", err)
+	}
+	cleanup := func() {
+		if err := os.Remove(path); err != nil {
+			framework.Logf("Unable to remove yaml from disk: %v", err)
+		}
+	}
+	_, err := e2ekubectl.RunKubectl(namespace, "apply", "-f", path)
 	if err != nil {
 		return cleanup, err
 	}
@@ -2689,4 +3079,28 @@ func getNetworkSubnetsFromSpec(networkSpec *udnv1.NetworkSpec) []string {
 		panic("unsupported network type")
 	}
 	return subnets
+}
+
+func getNodeSubnetAssignments(cs clientset.Interface, networkName string) (map[string]string, map[string]string, error) {
+	nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+	if err != nil {
+		return nil, nil, err
+	}
+	nodeSubnetMapV4 := map[string]string{}
+	nodeSubnetMapV6 := map[string]string{}
+	for _, node := range nodeList.Items {
+		ipnets, err := ovnkubeutil.ParseNodeHostSubnetAnnotation(&node, networkName)
+		if err != nil && !ovnkubeutil.IsAnnotationNotSetError(err) {
+			return nil, nil, err
+		}
+
+		for _, ipnet := range ipnets {
+			if utilnet.IsIPv4CIDR(ipnet) {
+				nodeSubnetMapV4[node.Name] = ipnet.String()
+			} else {
+				nodeSubnetMapV6[node.Name] = ipnet.String()
+			}
+		}
+	}
+	return nodeSubnetMapV4, nodeSubnetMapV6, nil
 }

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -80,10 +80,10 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 		userDefinedNetworkName              = "hogwarts"
 		nadName                             = "gryffindor"
 
-		// each subnet can support 2 nodes; when cluster has more than 2 nodes,
+		// The first subnet can support 2 nodes; when the cluster has more than 2 nodes,
 		// both subnets will be utilized.
-		userDefinedNetworkIPv4Subnet1 = "172.31.0.0/24/25"
-		userDefinedNetworkIPv4Subnet2 = "172.30.0.0/16/25"
+		userDefinedNetworkIPv4Subnet1 = "172.31.0.0/23/24"
+		userDefinedNetworkIPv4Subnet2 = "172.30.0.0/16/24"
 		userDefinedNetworkIPv6Subnet1 = "2014:100:200::0/63/64"
 		userDefinedNetworkIPv6Subnet2 = "2014:100:100::0/48/64"
 	)
@@ -132,17 +132,9 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						Expect(udnNetStat).To(HaveLen(expectedDefaultNetStatusLen))
 						Expect(udnNetStat[0].Interface).To(Equal(ovnUDNInterface))
 
-						cidrs := strings.Split(netConfig.cidr, ",")
-						for i, serverIP := range udnNetStat[0].IPs {
-							cidr := cidrs[i]
-							if cidr != "" {
-								By("asserting the server pod has an IP from the configured range")
-								const netPrefixLengthPerNode = 24
-								By(fmt.Sprintf("asserting the pod IP %s is from the configured range %s/%d", serverIP, cidr, netPrefixLengthPerNode))
-								subnet, err := getNetCIDRSubnet(cidr)
-								Expect(err).NotTo(HaveOccurred())
-								Expect(inRange(subnet, serverIP)).To(Succeed())
-							}
+						for _, serverIP := range udnNetStat[0].IPs {
+							By("asserting the server pod has an IP from the configured range")
+							Expect(inAnyConfiguredSubnet(netConfig.cidr, serverIP)).To(Succeed())
 						}
 					},
 					Entry("L2 primary UDN",
@@ -168,7 +160,7 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						&networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     primaryLayer3MultiCIDRs(),
 							role:     "primary",
 						},
 					),
@@ -203,28 +195,15 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						runUDNPod(cs, f.Namespace.Name, serverPodConfig, nil)
 						runUDNPod(cs, f.Namespace.Name, clientPodConfig, nil)
 
-						var serverIP string
-						for i, cidr := range strings.Split(netConfig.cidr, ",") {
-							if cidr != "" {
-								By("asserting the server pod has an IP from the configured range")
-								serverIP, err = getPodAnnotationIPsForAttachmentByIndex(
-									cs,
-									f.Namespace.Name,
-									serverPodConfig.name,
-									namespacedName(f.Namespace.Name, netConfig.name),
-									i,
-								)
-								Expect(err).NotTo(HaveOccurred())
-								const netPrefixLengthPerNode = 24
-								By(fmt.Sprintf("asserting the server pod IP %v is from the configured range %v/%v", serverIP, cidr, netPrefixLengthPerNode))
-								subnet, err := getNetCIDRSubnet(cidr)
-								Expect(err).NotTo(HaveOccurred())
-								Expect(inRange(subnet, serverIP)).To(Succeed())
-							}
+						serverIPs, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, serverPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
+						Expect(err).NotTo(HaveOccurred())
+						for _, serverIP := range serverIPs {
+							By("asserting the server pod has an IP from the configured range")
+							Expect(inAnyConfiguredSubnet(netConfig.cidr, serverIP.IP.String())).To(Succeed())
 
 							By("asserting the *client* pod can contact the server pod exposed endpoint")
 							Eventually(func() error {
-								return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, podClusterNetPort)
+								return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP.IP.String(), podClusterNetPort)
 							}, 2*time.Minute, 6*time.Second).Should(Succeed())
 						}
 					},
@@ -272,7 +251,7 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						&networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     primaryLayer3MultiCIDRs(),
 							role:     "primary",
 						},
 						*podConfig(
@@ -576,7 +555,7 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						&networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     primaryLayer3MultiCIDRs(),
 							role:     "primary",
 						},
 						*podConfig(
@@ -736,8 +715,8 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						"with L3 primary UDN",
 						"layer3",
 						10,
-						userDefinedNetworkIPv4Subnet,
-						userDefinedNetworkIPv6Subnet,
+						primaryLayer3MultiIPv4CIDRs(),
+						primaryLayer3MultiIPv6CIDRs(),
 					),
 				)
 			},
@@ -914,7 +893,7 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 				ginkgo.Entry("with primary layer3 UDN", networkAttachmentConfigParams{
 					name:     nadName,
 					topology: "layer3",
-					cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     primaryLayer3MultiCIDRs(),
 					role:     "primary",
 				}),
 				ginkgo.Entry("with primary layer2 UDN", networkAttachmentConfigParams{
@@ -949,7 +928,7 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 				ginkgo.Entry("with primary layer3 UDN", networkAttachmentConfigParams{
 					name:     nadName,
 					topology: "layer3",
-					cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     primaryLayer3MultiCIDRs(),
 					role:     "primary",
 				}),
 				// TODO: this test is broken, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5309
@@ -1565,7 +1544,7 @@ spec:
 			topology:    "layer3",
 			name:        primaryNadName,
 			networkName: primaryNadName,
-			cidr:        joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+			cidr:        primaryLayer3MultiCIDRs(),
 		}), f.ClientSet)
 		_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(context.Background(), primaryNetNad, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -1982,7 +1961,7 @@ spec:
 			topology:    "layer3",
 			name:        primaryNadName,
 			networkName: primaryNadName,
-			cidr:        joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+			cidr:        primaryLayer3MultiCIDRs(),
 		}), f.ClientSet)
 		_, err := nadClient.NetworkAttachmentDefinitions(primaryNetTenantNs).Create(context.Background(), primaryNetNad, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -2101,7 +2080,7 @@ spec:
 						&networkAttachmentConfigParams{
 							name:     userDefinedNetworkName,
 							topology: "layer3",
-							cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     primaryLayer3MultiCIDRs(),
 							role:     "primary",
 						},
 						*podConfig("client-pod"),
@@ -2323,7 +2302,7 @@ spec:
 				networkAttachmentConfigParams{
 					name:     nadName,
 					topology: "layer3",
-					cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     primaryLayer3MultiCIDRs(),
 					role:     "primary",
 				},
 				*podConfig(
@@ -2832,7 +2811,7 @@ spec:
     topology: Layer3
     layer3:
       role: Primary
-      subnets: ` + generateCIDRforClusterUDN(cs, "10.20.100.0/16", "2014:100:200::0/60")
+      subnets: ` + generateCIDRforClusterUDN(cs, primaryLayer3MultiCIDRs(), "")
 }
 
 func newL2SecondaryUDNManifest(name string) string {
@@ -2859,24 +2838,17 @@ spec:
   topology: Layer3
   layer3:
     role: Primary
-    subnets: ` + generateCIDRforUDN(cs, "10.20.100.0/16", "2014:100:200::0/60")
+    subnets: ` + generateCIDRforUDN(cs, primaryLayer3MultiCIDRs())
 }
 
-func generateCIDRforUDN(cs clientset.Interface, v4, v6 string) string {
-	cidr := `
-    - cidr: ` + v4 + `
-`
-	if isIPv6Supported(cs) && isIPv4Supported(cs) {
-		cidr = `
-    - cidr: ` + v4 + `
-    - cidr: ` + v6 + `
-`
-	} else if isIPv6Supported(cs) {
-		cidr = `
-    - cidr: ` + v6 + `
-`
+func generateCIDRforUDN(cs clientset.Interface, cidrs string) string {
+	cidrItems := generateLayer3Subnets(filterCIDRsAndJoin(cs, cidrs))
+	var subnets strings.Builder
+	for _, cidr := range cidrItems {
+		subnets.WriteString("\n    - ")
+		subnets.WriteString(cidr)
 	}
-	return cidr
+	return subnets.String()
 }
 
 func filterDualStackCIDRs(cs clientset.Interface, cidrs udnv1.DualStackCIDRs) udnv1.DualStackCIDRs {
@@ -2920,13 +2892,8 @@ func matchL2SubnetsByIPFamilies(families sets.Set[utilnet.IPFamily], in ...udnv1
 }
 
 func generateCIDRforClusterUDN(cs clientset.Interface, v4, v6 string) string {
-	cidr := `[{cidr: ` + v4 + `}]`
-	if isIPv6Supported(cs) && isIPv4Supported(cs) {
-		cidr = `[{cidr: ` + v4 + `},{cidr: ` + v6 + `}]`
-	} else if isIPv6Supported(cs) {
-		cidr = `[{cidr: ` + v6 + `}]`
-	}
-	return cidr
+	cidrItems := generateLayer3Subnets(filterCIDRsAndJoin(cs, joinStrings(v4, v6)))
+	return fmt.Sprintf("[%s]", strings.Join(cidrItems, ","))
 }
 
 type podOption func(*podConfiguration)
@@ -3046,10 +3013,15 @@ func expectedNumberOfRoutes(cs clientset.Interface, netConfig networkAttachmentC
 			return 2 //one family supported
 		}
 	}
-	if isIPv6Supported(cs) && isIPv4Supported(cs) {
-		return 6 // 3 v4 routes + 3 v6 routes for UDN
+
+	routes := len(filterCIDRs(cs, strings.Split(netConfig.cidr, ",")...))
+	if isIPv4Supported(cs) {
+		routes += 2
 	}
-	return 3 //only one family, each has 3 routes
+	if isIPv6Supported(cs) {
+		routes += 2
+	}
+	return routes
 }
 
 func unmarshalPodAnnotationAllNetworks(annotations map[string]string) (map[string]podAnnotation, error) {

--- a/test/e2e/network_segmentation_api_validations.go
+++ b/test/e2e/network_segmentation_api_validations.go
@@ -22,7 +22,7 @@ var _ = Describe("Network Segmentation: API validations", feature.NetworkSegment
 			})
 			for _, s := range scenarios {
 				By(s.Description)
-				_, stderr, err := runKubectlInputWithFullOutput("", s.Manifest, "create", "-f", "-")
+				_, stderr, err := runKubectlInputWithFullOutput("", s.Manifest, "apply", "-f", "-")
 				Expect(err).To(HaveOccurred(), "should fail to create invalid CR")
 				Expect(stderr).To(ContainSubstring(s.ExpectedErr))
 			}
@@ -37,6 +37,7 @@ var _ = Describe("Network Segmentation: API validations", feature.NetworkSegment
 		Entry("ClusterUserDefinedNetwork, evpn", testscenariocudn.EVPNCUDNInvalid),
 		Entry("UserDefinedNetwork, layer2", testscenariocudn.Layer2UDNInvalid),
 		Entry("ClusterUserDefinedNetwork, no-overlay, invalid", testscenariocudn.NoOverlayInvalid),
+		Entry("ClusterUserDefinedNetwork, layer3, multi-subnets", testscenariocudn.Layer3InvalidSubnets),
 	)
 
 	DescribeTable("api-server should accept valid CRs",
@@ -55,6 +56,7 @@ var _ = Describe("Network Segmentation: API validations", feature.NetworkSegment
 		Entry("ClusterUserDefinedNetwork, evpn", testscenariocudn.EVPNCUDNValid),
 		Entry("UserDefinedNetwork, layer2", testscenariocudn.Layer2UDNValid),
 		Entry("ClusterUserDefinedNetwork, no-overlay, valid", testscenariocudn.NoOverlayValid),
+		Entry("ClusterUserDefinedNetwork, layer3, multi-subnets", testscenariocudn.Layer3ValidSubnets),
 	)
 })
 

--- a/test/e2e/network_segmentation_endpointslices_mirror.go
+++ b/test/e2e/network_segmentation_endpointslices_mirror.go
@@ -96,7 +96,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 
 						By("asserting the mirrored EndpointSlice exists and contains PODs primary IPs")
 						Eventually(func() error {
-							return validateMirroredEndpointSlices(cs, f.Namespace.Name, svc.Name, userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet, hostSubnets, int(replicas), isDualStack, isHostNetwork)
+							return validateMirroredEndpointSlices(cs, f.Namespace.Name, svc.Name, netConfig.cidr, hostSubnets, int(replicas), isDualStack, isHostNetwork)
 
 						}, 2*time.Minute, 6*time.Second).ShouldNot(HaveOccurred())
 
@@ -104,7 +104,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 						err = cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", "k8s.ovn.org/service-name", svc.Name)})
 						framework.ExpectNoError(err, "Failed removing the mirrored EndpointSlice %v", err)
 						Eventually(func() error {
-							return validateMirroredEndpointSlices(cs, f.Namespace.Name, svc.Name, userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet, hostSubnets, int(replicas), isDualStack, isHostNetwork)
+							return validateMirroredEndpointSlices(cs, f.Namespace.Name, svc.Name, netConfig.cidr, hostSubnets, int(replicas), isDualStack, isHostNetwork)
 						}, 2*time.Minute, 6*time.Second).ShouldNot(HaveOccurred())
 
 						By("removing the service so both EndpointSlices get removed")
@@ -138,7 +138,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     primaryLayer3MultiCIDRs(),
 							role:     "primary",
 						},
 						false,
@@ -158,7 +158,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+							cidr:     primaryLayer3MultiCIDRs(),
 							role:     "primary",
 						},
 						true,
@@ -268,7 +268,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 	})
 })
 
-func validateMirroredEndpointSlices(cs clientset.Interface, namespace, svcName, expectedV4Subnet, expectedV6Subnet string, hostSubnet *util.ParsedNodeEgressIPConfiguration, expectedEndpoints int, isDualStack, isHostNetwork bool) error {
+func validateMirroredEndpointSlices(cs clientset.Interface, namespace, svcName, expectedSubnets string, hostSubnet *util.ParsedNodeEgressIPConfiguration, expectedEndpoints int, isDualStack, isHostNetwork bool) error {
 	esList, err := cs.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", "k8s.ovn.org/service-name", svcName)})
 	if err != nil {
 		return err
@@ -287,13 +287,12 @@ func validateMirroredEndpointSlices(cs clientset.Interface, namespace, svcName, 
 			return fmt.Errorf("expected %d endpoints, got: %d", expectedEndpoints, len(esList.Items))
 		}
 
-		subnet := expectedV4Subnet
+		subnet := expectedSubnets
 		if isHostNetwork {
 			subnet = hostSubnet.V4.Net.String()
 		}
 
 		if endpointSlice.AddressType == discoveryv1.AddressTypeIPv6 {
-			subnet = expectedV6Subnet
 			if isHostNetwork {
 				subnet = hostSubnet.V6.Net.String()
 			}
@@ -302,7 +301,7 @@ func validateMirroredEndpointSlices(cs clientset.Interface, namespace, svcName, 
 			if len(endpoint.Addresses) != 1 {
 				return fmt.Errorf("expected 1 endpoint, got: %d", len(endpoint.Addresses))
 			}
-			if err := inRange(subnet, endpoint.Addresses[0]); err != nil {
+			if err := inAnyConfiguredSubnet(subnet, endpoint.Addresses[0]); err != nil {
 				return err
 			}
 		}

--- a/test/e2e/network_segmentation_policy.go
+++ b/test/e2e/network_segmentation_policy.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
@@ -117,24 +116,17 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				runUDNPod(cs, f.Namespace.Name, serverPodConfig, nil)
 				runUDNPod(cs, f.Namespace.Name, clientPodConfig, nil)
 
-				var serverIP string
-				for i, cidr := range strings.Split(netConfig.cidr, ",") {
-					if cidr != "" {
-						ginkgo.By("asserting the server pod has an IP from the configured range")
-						serverIP, err = getPodAnnotationIPsForAttachmentByIndex(
-							cs,
-							f.Namespace.Name,
-							serverPodConfig.name,
-							namespacedName(f.Namespace.Name, netConfig.name),
-							i,
-						)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						ginkgo.By(fmt.Sprintf("asserting the server pod IP %v is from the configured range %v", serverIP, cidr))
-						subnet, err := getNetCIDRSubnet(cidr)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						gomega.Expect(inRange(subnet, serverIP)).To(gomega.Succeed())
-					}
+				serverIPNets, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, serverPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				var serverIPs []string
+				for _, serverIP := range serverIPNets {
+					ginkgo.By("asserting the server pod has an IP from the configured range")
+					gomega.Expect(inAnyConfiguredSubnet(netConfig.cidr, serverIP.IP.String())).To(gomega.Succeed())
+					serverIPs = append(serverIPs, serverIP.IP.String())
+				}
+				gomega.Expect(serverIPs).NotTo(gomega.BeEmpty())
 
+				for _, serverIP := range serverIPs {
 					ginkgo.By("asserting the *client* pod can contact the server pod exposed endpoint")
 					gomega.Eventually(func() error {
 						return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
@@ -146,9 +138,11 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ginkgo.By("asserting the *client* pod can not contact the server pod exposed endpoint")
-				gomega.Eventually(func() error {
-					return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
-				}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+				for _, serverIP := range serverIPs {
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP, port)
+					}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+				}
 
 			},
 			ginkgo.Entry(
@@ -195,7 +189,7 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				networkAttachmentConfigParams{
 					name:     nadName,
 					topology: "layer3",
-					cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     primaryLayer3MultiCIDRs(),
 					role:     "primary",
 				},
 				*podConfig(
@@ -249,20 +243,12 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				_, err = makeDenyAllPolicy(f, f.Namespace.Name, "deny-all")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+				serverIPNets, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, serverPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				var serverIPs []string
-				for i, cidr := range strings.Split(netConfig.cidr, ",") {
-					if cidr == "" {
-						continue
-					}
-					serverIP, err := getPodAnnotationIPsForAttachmentByIndex(
-						cs,
-						f.Namespace.Name,
-						serverPodConfig.name,
-						namespacedName(f.Namespace.Name, netConfig.name),
-						i,
-					)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					serverIPs = append(serverIPs, serverIP)
+				for _, serverIP := range serverIPNets {
+					gomega.Expect(inAnyConfiguredSubnet(netConfig.cidr, serverIP.IP.String())).To(gomega.Succeed())
+					serverIPs = append(serverIPs, serverIP.IP.String())
 				}
 				gomega.Expect(serverIPs).NotTo(gomega.BeEmpty())
 
@@ -309,7 +295,7 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				networkAttachmentConfigParams{
 					name:     nadName,
 					topology: "layer3",
-					cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     primaryLayer3MultiCIDRs(),
 					role:     "primary",
 				},
 				*podConfig(
@@ -349,6 +335,9 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					networkName: fmt.Sprintf("%s-%s", "green", rand.String(randomStringLength)),
 					role:        "primary",
 				}
+				if topology == "layer3" {
+					nad.cidr = primaryLayer3MultiCIDRs()
+				}
 				filterSupportedNetworkConfig(f.ClientSet, &nad)
 
 				// Use random suffix in net conf name to avoid race between tests.
@@ -376,24 +365,16 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				runUDNPod(cs, namespaceBlue, clientPodConfig, nil)
 
 				ginkgo.By("asserting the server pods have an IP from the configured range")
-				var allowServerPodIP, denyServerPodIP string
-				for i, cidr := range strings.Split(nad.cidr, ",") {
-					if cidr == "" {
-						continue
-					}
-					subnet, err := getNetCIDRSubnet(cidr)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					allowServerPodIP, err = getPodAnnotationIPsForAttachmentByIndex(cs, namespaceYellow, allowServerPodConfig.name,
-						namespacedName(namespaceYellow, netConfName), i)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					ginkgo.By(fmt.Sprintf("asserting the allow server pod IP %v is from the configured range %v", allowServerPodIP, cidr))
-					gomega.Expect(inRange(subnet, allowServerPodIP)).To(gomega.Succeed())
-					denyServerPodIP, err = getPodAnnotationIPsForAttachmentByIndex(cs, namespaceYellow, denyServerPodConfig.name,
-						namespacedName(namespaceYellow, netConfName), i)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					ginkgo.By(fmt.Sprintf("asserting the deny server pod IP %v is from the configured range %v", denyServerPodIP, cidr))
-					gomega.Expect(inRange(subnet, denyServerPodIP)).To(gomega.Succeed())
-				}
+				allowServerPodIPs, err := getPodAnnotationIPsForAttachment(cs, namespaceYellow, allowServerPodConfig.name, namespacedName(namespaceYellow, netConfName))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				denyServerPodIPs, err := getPodAnnotationIPsForAttachment(cs, namespaceYellow, denyServerPodConfig.name, namespacedName(namespaceYellow, netConfName))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(allowServerPodIPs).NotTo(gomega.BeEmpty())
+				gomega.Expect(denyServerPodIPs).NotTo(gomega.BeEmpty())
+				allowServerPodIP := allowServerPodIPs[0].IP.String()
+				denyServerPodIP := denyServerPodIPs[0].IP.String()
+				gomega.Expect(inAnyConfiguredSubnet(nad.cidr, allowServerPodIP)).To(gomega.Succeed())
+				gomega.Expect(inAnyConfiguredSubnet(nad.cidr, denyServerPodIP)).To(gomega.Succeed())
 
 				ginkgo.By("asserting the *client* pod can contact the allow server pod exposed endpoint")
 				gomega.Eventually(func() error {
@@ -406,7 +387,7 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				}, 2*time.Minute, 6*time.Second).Should(gomega.Succeed())
 
 				ginkgo.By("creating a \"default deny\" network policy")
-				_, err := makeDenyAllPolicy(f, namespaceYellow, "deny-all")
+				_, err = makeDenyAllPolicy(f, namespaceYellow, "deny-all")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ginkgo.By("asserting the *client* pod can not contact the allow server pod exposed endpoint")

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -280,7 +280,7 @@ ips=$(ip -o addr show dev $iface| grep global |awk '{print $4}' | cut -d/ -f1 | 
 				networkAttachmentConfigParams{
 					name:     nadName,
 					topology: "layer3",
-					cidr:     joinStrings(userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
+					cidr:     primaryLayer3MultiCIDRs(),
 					role:     "primary",
 				},
 			),

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -929,10 +929,16 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 						Layer3: &udnv1.Layer3Config{
 							Role: "Primary",
 							Subnets: []udnv1.Layer3Subnet{{
-								CIDR:       "103.103.0.0/16",
+								CIDR:       "103.103.0.0/23",
 								HostSubnet: 24,
 							}, {
-								CIDR:       "2014:100:200::0/60",
+								CIDR:       "103.104.0.0/16",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "2014:100:200::0/63",
+								HostSubnet: 64,
+							}, {
+								CIDR:       "2014:100:201::0/48",
 								HostSubnet: 64,
 							}},
 						},
@@ -1931,10 +1937,16 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					Layer3: &udnv1.Layer3Config{
 						Role: "Primary",
 						Subnets: []udnv1.Layer3Subnet{{
-							CIDR:       "102.102.0.0/16",
+							CIDR:       "102.102.0.0/23",
 							HostSubnet: 24,
 						}, {
-							CIDR:       "2013:100:200::0/60",
+							CIDR:       "102.104.0.0/16",
+							HostSubnet: 24,
+						}, {
+							CIDR:       "2013:100:200::0/63",
+							HostSubnet: 64,
+						}, {
+							CIDR:       "2013:100:201::0/48",
 							HostSubnet: 64,
 						}},
 					},
@@ -1951,10 +1963,16 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					Layer3: &udnv1.Layer3Config{
 						Role: "Primary",
 						Subnets: []udnv1.Layer3Subnet{{
-							CIDR:       "103.103.0.0/16",
+							CIDR:       "103.103.0.0/23",
 							HostSubnet: 24,
 						}, {
-							CIDR:       "2014:100:200::0/60",
+							CIDR:       "103.104.0.0/16",
+							HostSubnet: 24,
+						}, {
+							CIDR:       "2014:100:200::0/63",
+							HostSubnet: 64,
+						}, {
+							CIDR:       "2014:100:201::0/48",
 							HostSubnet: 64,
 						}},
 					},

--- a/test/e2e/testscenario/cudn/invalid-scenarios-layer3.go
+++ b/test/e2e/testscenario/cudn/invalid-scenarios-layer3.go
@@ -1,0 +1,350 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cudn
+
+import "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/testscenario"
+
+var Layer3InvalidSubnets = []testscenario.ValidateCRScenario{
+	{
+		Description: "modifying Secondary network's subnets is not allowed",
+		ExpectedErr: `Subnets is immutable for Secondary role`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: secondary-modify-subnet-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Secondary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+---
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: secondary-modify-subnet-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Secondary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.2.0.0/16
+        hostSubnet: 24
+`,
+	},
+	{
+		Description: "Secondary network with more than 2 subnets is not allowed",
+		ExpectedErr: `Secondary networks may define at most 2 subnets`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: secondary-more-than-two-subnets
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Secondary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+      - cidr: 10.2.0.0/16
+        hostSubnet: 24
+`,
+	},
+	{
+		Description: "Secondary network with 2 same-family subnets is not allowed",
+		ExpectedErr: `When 2 CIDRs are set for Secondary networks, they must be from different IP families`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: secondary-same-family-subnets
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Secondary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.2.0.0/16
+        hostSubnet: 24
+`,
+	},
+	{
+		Description: "IPv4: remove subnet is not allowed",
+		ExpectedErr: `Removing existing subnets is not allowed`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-remove-subnet-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.2.0.0/16
+        hostSubnet: 24
+---
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-remove-subnet-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+`,
+	},
+	{
+		Description: "IPv4: overlap subnets are not allowed",
+		ExpectedErr: `Subnets must not overlap or contain each other`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-overlap-subnets-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.1.128.0/17
+        hostSubnet: 24
+`,
+	},
+	{
+		Description: "IPv4: same subnets are not allowed",
+		ExpectedErr: `Subnets with same CIDR are not allowed`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-same-subnets-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+`,
+	},
+	{
+		Description: "IPv4: mutate hostSubnet is not allowed",
+		ExpectedErr: `hostSubnet is immutable`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-mutate-host-subnet-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+---
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-mutate-host-subnet-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 18
+`,
+	},
+	{
+		Description: "IPv4: subnets with different hostSubnet is not allowed",
+		ExpectedErr: `Subnets from the same IP family must use the same hostSubnet value`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-different-host-subnet-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.2.0.0/16
+        hostSubnet: 27
+`,
+	},
+	{
+		Description: "IPv6: remove subnet is not allowed",
+		ExpectedErr: `Removing existing subnets is not allowed`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-remove-subnet-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+      - cidr: 2001:db8:2::/48
+        hostSubnet: 64
+---
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-remove-subnet-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+`,
+	},
+	{
+		Description: "IPv6: overlap subnets are not allowed",
+		ExpectedErr: `Subnets must not overlap or contain each other`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-overlap-subnets-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+      - cidr: 2001:db8:1:8000::/49
+        hostSubnet: 64
+`,
+	},
+	{
+		Description: "IPv6: same subnets are not allowed",
+		ExpectedErr: `Subnets with same CIDR are not allowed`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-same-subnets-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+`,
+	},
+	{
+		Description: "IPv6: mutate hostSubnet is not allowed",
+		ExpectedErr: `hostSubnet is immutable`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-mutate-host-subnet-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+---
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-mutate-host-subnet-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 60
+`,
+	},
+	{
+		Description: "IPv6: subnets with different hostSubnet is not allowed",
+		ExpectedErr: `Subnets from the same IP family must use the same hostSubnet value`,
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-different-host-subnet-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+      - cidr: 2001:db8:2::/48
+        hostSubnet: 60
+`,
+	},
+}

--- a/test/e2e/testscenario/cudn/valid-scenarios-layer3.go
+++ b/test/e2e/testscenario/cudn/valid-scenarios-layer3.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cudn
+
+import "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/testscenario"
+
+var Layer3ValidSubnets = []testscenario.ValidateCRScenario{
+	{
+		Description: "IPv4: valid Primary network with multiple subnets",
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-with-multiple-subnets-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.2.0.0/16
+        hostSubnet: 24
+`,
+	},
+	{
+		Description: "IPv4: valid Primary network with multiple subnets - add subnet",
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-with-multiple-subnets-ipv4
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.2.0.0/16
+        hostSubnet: 24
+      - cidr: 10.3.0.0/16
+        hostSubnet: 24
+`,
+	},
+	{
+		Description: "IPv6: valid Primary network with multiple subnets",
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-with-multiple-subnets-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+      - cidr: 2001:db8:2::/48
+        hostSubnet: 64
+`,
+	},
+	{
+		Description: "IPv6: valid Primary network with multiple subnets - add subnet",
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-with-multiple-subnets-ipv6
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+      - cidr: 2001:db8:2::/48
+        hostSubnet: 64
+      - cidr: 2001:db8:3::/48
+        hostSubnet: 64
+`,
+	},
+	{
+		Description: "dual-stack: valid Primary network with multiple subnets",
+		Manifest: `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: primary-with-multiple-subnets-dual-stack
+spec:
+  namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: red}}
+  network:
+    topology: Layer3
+    layer3:
+      role: Primary
+      subnets:
+      - cidr: 10.1.0.0/16
+        hostSubnet: 24
+      - cidr: 10.2.0.0/16
+        hostSubnet: 24
+      - cidr: 2001:db8:1::/48
+        hostSubnet: 64
+      - cidr: 2001:db8:2::/48
+        hostSubnet: 64
+`,
+	},
+}


### PR DESCRIPTION
## 📑 Description

Changes:
- Modify UDN/CUDN CRD schemas to allow adding multiple cluster-subents of
  the same IP family in Layer3 topology
- Reconcile network controllers to add new subnets to NodeAllocator.


Fixes #5377

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [X] My code requires tests
- [X] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layer3 user-defined networks support many subnets (limit raised, per-IP-family multi-subnet) with dynamic subnet additions and automatic per-node allocation and reconciliation.

* **Validation**
  * Per-field immutability added and stricter subnet rules enforced (no overlaps/duplicates, hostSubnet constraints, removal restrictions).

* **Reliability**
  * Nodes are requeued/reconciled when subnets expand so allocations propagate promptly.

* **Tests**
  * Extensive unit and e2e coverage for NAD lifecycle, allocation, updates, multi-subnet and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->