### PR TITLE
fix: GWAcceleratedInterface - use gwInterfaceRep port instead of LOCAL

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -236,6 +236,10 @@ func (b *BridgeConfiguration) GetGatewayIface() string {
 	return b.gwIface
 }
 
+func (b *BridgeConfiguration) GetGatewayIfaceRep() string {
+	return b.gwIfaceRep
+}
+
 // UpdateInterfaceIPAddresses sets and returns the bridge's current ips
 func (b *BridgeConfiguration) UpdateInterfaceIPAddresses(node *corev1.Node) ([]*net.IPNet, error) {
 	b.mutex.Lock()

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -428,8 +428,14 @@ func gatewayInitInternal(nodeName, gwIntf, egressGatewayIntf string, gwNextHops 
 		}
 	}
 
-	// Set static FDB entry for LOCAL port
-	if err := util.SetStaticFDBEntry(gatewayBridge.GetBridgeName(), gatewayBridge.GetBridgeName(), gatewayBridge.GetMAC()); err != nil {
+	// Set static FDB entry for sharedGW MAC.
+	// If `GatewayIfaceRep` port is present, use it instead of LOCAL (bridge name).
+	gwport := gatewayBridge.GetBridgeName()                           // Default is LOCAL port for the bridge.
+	if repPort := gatewayBridge.GetGatewayIfaceRep(); repPort != "" { // We have an accelerated switchdev device for GW.
+		gwport = repPort
+	}
+
+	if err := util.SetStaticFDBEntry(gatewayBridge.GetBridgeName(), gwport, gatewayBridge.GetMAC()); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
…LOCAL)

When GatewayAcceleratedInterface is set, use the gwInterfaceRep instead of LOCAL.

Fixes: #5478

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the gateway’s forwarding entry is attached to the correct network interface for accelerated/shared gateway setups, preventing misrouting and improving connectivity.
  * Preserves previous behavior for standard gateway configurations; no user configuration changes required.

* **Refactor**
  * Internal interface-selection logic streamlined to improve reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->