### PR TITLE
E2E: add EIP TCP disruption test where client pushes externally while we restart CP

### DIFF
--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -25,10 +25,12 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider"
 	infraapi "github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/ipalloc"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/iperf3helper"
 
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -691,6 +693,31 @@ var _ = ginkgo.DescribeTableSubtree("e2e egress IP validation", feature.EgressIP
 		return false
 	}
 
+	getOVNKubeNodePodNameOnNode := func(ctx context.Context, client clientset.Interface, nodeName string) (string, error) {
+		// get the egress nodes ovnkube-node and restart it
+		var ovnKubeNodePodName string
+		timeout := 5 * time.Second
+		err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, timeout, true, func(ctx context.Context) (done bool, err error) {
+			ovnkubeNodePods, err := client.CoreV1().Pods(deploymentconfig.Get().OVNKubernetesNamespace()).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=ovnkube-node",
+				FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+			})
+			if err != nil {
+				return false, fmt.Errorf("failed to list ovnkube node pods in namespace %q and selecting node %q: %w",
+					deploymentconfig.Get().OVNKubernetesNamespace(), nodeName, err)
+			}
+			if len(ovnkubeNodePods.Items) == 0 {
+				return false, nil
+			}
+			ovnKubeNodePodName = ovnkubeNodePods.Items[0].GetName()
+			return true, nil
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to find ovnkube node pod on node %q after %s", nodeName, timeout.String())
+		}
+		return ovnKubeNodePodName, nil
+	}
+
 	f := wrappedTestFramework(egressIPName)
 	f.SkipNamespaceCreation = true
 
@@ -1057,6 +1084,222 @@ spec:
 			ginkgo.Entry("disabling egress nodes impeding GRCP health check", &egressNodeAvailabilityHandlerViaHealthCheck{F: f, Legacy: false}),
 			ginkgo.Entry("disabling egress nodes impeding Legacy health check", &egressNodeAvailabilityHandlerViaHealthCheck{F: f, Legacy: true}),
 		)
+	})
+
+	ginkgo.It("should maintain tcp network connectivity without packet loss while ovnkube-node is restarted", func() {
+		// Goal of the test is to test an EIP selected Pod traffic while we restart ovnkube control plane on the egress node
+		// and the pod node. Test will fail if there's tcp disruption (packet data lost).
+
+		// FIXME when [1] lands: this test cannot work currently with the gRPC implementation of EIP Healthcheck because the EIP is prone
+		// to move to a different Node and therefore that will interrupt the tcp connection
+		// The gRPC server which helps implement the Egress IP healthcheck is removed when ovnkube node is shutdown / restarted,
+		// and there's a possibility the node is no longer assigned as an egress node by cluster manager, and today that will break
+		// the tcp connection if the eip is unassigned or reassigned to another node
+		// switch back to gRPC when https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4286 [1] is merged
+		eNodeHandler := &egressNodeAvailabilityHandlerViaHealthCheck{F: f, Legacy: true} // discard port 9 health check implementation
+
+		ginkgo.By("0. enable node as an egress node and use legacy healthcheck")
+		ginkgo.DeferCleanup(func() {
+			eNodeHandler.Restore(egress1Node.name)
+		})
+		eNodeHandler.Enable(egress1Node.name)
+		framework.Logf("Added egress-assignable label to node %s", egress1Node.name)
+		labels := map[string]string{
+			"name": f.Namespace.Name,
+		}
+		updateNamespaceLabels(f, f.Namespace, labels)
+
+		ginkgo.By("1. Create an external container to act as a server attached to the primary infra network")
+		network, err := infraprovider.Get().PrimaryNetwork()
+		framework.ExpectNoError(err, "failed to get primary network information")
+		externalServerContainerPort := infraprovider.Get().GetExternalContainerPort()
+		externalServerContainerPortStr := fmt.Sprintf("%d", externalServerContainerPort)
+		externalServerContainer := infraapi.ExternalContainer{Name: getContainerName("e2e-eip-connectivity-%d", externalServerContainerPort),
+			Image: images.IPerf3(), Network: network, RuntimeArgs: []string{}, ExtPort: externalServerContainerPort}
+		externalServerContainer, err = providerCtx.CreateExternalContainer(externalServerContainer)
+		framework.ExpectNoError(err, "failed to create external container (%s)", externalServerContainer)
+
+		framework.Logf("Start external containers iperf daemon")
+		logFilePath := "/tmp/iperf-results.json"
+		out, err := infraprovider.Get().ExecExternalContainerCommand(externalServerContainer, []string{
+			"iperf3",
+			"--daemon",
+			"--server",
+			"--verbose",
+			"--port", externalServerContainerPortStr,
+			"--logfile", logFilePath,
+		})
+		framework.ExpectNoError(err, "must start iperf daemon on external container, stdout/stderr:\n%q", out)
+
+		ginkgo.By("2. Create an EgressIP object1 with a single egress IP")
+		var egressIPIP net.IP
+		var externalContainerIP string
+		if utilnet.IsIPv6String(egress1Node.nodeIP) {
+			egressIPIP, err = ipalloc.NewPrimaryIPv6()
+			externalContainerIP = externalServerContainer.GetIPv6()
+		} else {
+			egressIPIP, err = ipalloc.NewPrimaryIPv4()
+			externalContainerIP = externalServerContainer.GetIPv4()
+		}
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "must allocate new IP Node IP")
+		gomega.Expect(net.ParseIP(externalContainerIP)).ShouldNot(gomega.BeNil())
+
+		var egressIPConfig = `apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: ` + egressIPName + `
+spec:
+    egressIPs:
+    - ` + egressIPIP.String() + `
+    podSelector:
+        matchLabels:
+            wants: egress
+    namespaceSelector:
+        matchLabels:
+            name: ` + f.Namespace.Name + `
+`
+		if err := os.WriteFile(egressIPYaml, []byte(egressIPConfig), 0644); err != nil {
+			framework.Failf("Unable to write CRD config to disk: %v", err)
+		}
+		defer func() {
+			if err := os.Remove(egressIPYaml); err != nil {
+				framework.Logf("Unable to remove the CRD config from disk: %v", err)
+			}
+		}()
+
+		framework.Logf("Create the EgressIP configuration")
+		e2ekubectl.RunKubectlOrDie("default", "create", "-f", egressIPYaml)
+
+		ginkgo.By("3. Check that the status is of length one and that one of them is assigned to the correct node")
+		statuses := verifyEgressIPStatusLengthEquals(1, nil)
+		assignedEIPNode := statuses[0].Node
+		// unusedEIPNode is the node that is egress-able but currently no EgressIP is assigned to it. The pod will be
+		// created on this node.
+		unusedEIPNode := egress1Node.name
+		if assignedEIPNode == egress1Node.name {
+			unusedEIPNode = egress2Node.name
+		}
+		framework.Logf("EgressIP %s is assigned to Node %q", egressIPIP.String(), assignedEIPNode)
+
+		framework.Logf("Get baseline network performance with no disruption")
+		clientPodName := "iperfclient-baseline-" + f.Namespace.Name
+		clientPod, err := createPod(f, clientPodName, unusedEIPNode, f.Namespace.Name, []string{"iperf3",
+			"--client", externalContainerIP,
+			"--port", externalServerContainerPortStr,
+			"--time", "2",
+			"--interval", ".1",
+			"--bitrate", "50M",
+			"--parallel", "1",
+			"--json",
+		}, podEgressLabel, func(pod *corev1.Pod) {
+			pod.Spec.Containers[0].Image = images.IPerf3()
+		})
+		framework.ExpectNoError(err, "Create one client pod matching the EgressIP, failed, err: %v", err)
+		framework.Logf("Fetch the baseline pods logs to get the test results")
+		clientPodContainerName := clientPodName + "-container"
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			testResultsStr, err := pod.GetPodLogs(ctx, f.ClientSet, clientPod.Namespace, clientPod.Name, clientPodContainerName)
+			if err != nil {
+				framework.Logf("Failed to get pod %s/%s logs (will retry) from container %q: %v",
+					clientPod.Namespace, clientPod.Name, clientPodContainerName, err)
+				return false, nil
+			}
+			if testResultsStr == "" {
+				return false, nil
+			}
+			testResults, err := iperf3helper.ParseIperf3JSON(testResultsStr)
+			if err != nil {
+				framework.Logf("Failed to parse JSON from pod %s/%s and container %s: %v", clientPod.Namespace, clientPod.Name, clientPodContainerName, err)
+				return false, nil
+			}
+			if testResults.SumReceived.Bytes == 0 || testResults.SumSent.Bytes == 0 {
+				framework.Failf("No bytes send / received when we expect at least one byte or more sent or received")
+			}
+			framework.Logf("Baseline results for 2 seconds and interval .1 seconds are:\ndata loss: %d\nretransmissions: %d",
+				testResults.GetSendReceivedBytesDifference(), testResults.GetRetransmissions())
+			return true, nil
+		})
+		// FIXME: replace with a test "monitor" for EgressIP feature instead of a specific serial and disruptive test
+		clientTestDuration := 200 * time.Second // changes to 200s
+		ginkgo.By("4. Create one client pod located on the unused egress node matching the EgressIP and testing connectivity for " + clientTestDuration.String())
+		clientPodName = "iperfclient-" + f.Namespace.Name
+		clientPod, err = createPod(f, clientPodName, unusedEIPNode, f.Namespace.Name, []string{"iperf3",
+			"--client", externalContainerIP,
+			"--port", externalServerContainerPortStr,
+			"--time", fmt.Sprintf("%d", int(clientTestDuration.Seconds())),
+			"--interval", ".1",
+			"--bitrate", "50M",
+			"--parallel", "1",
+			"--json",
+		}, podEgressLabel, func(pod *corev1.Pod) {
+			pod.Spec.Containers[0].Image = images.IPerf3()
+		})
+		framework.ExpectNoError(err, "Step 4. Create one client pod matching the EgressIP, failed, err: %v", err)
+		framework.Logf("Created pod %s/%s on node %s", clientPod.Namespace, clientPod.Name, unusedEIPNode)
+
+		ovnKubeNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+		// expected total mac time for ovnkube node to come back up
+		ovnKubeNodeRestartDuration := 200 * time.Second
+
+		for _, node := range sets.New(assignedEIPNode, clientPod.Spec.NodeName).UnsortedList() {
+			framework.Logf("Starting on Node %s and deleting ovnkube node pod on this node", node)
+			// get the egress nodes ovnkube-node and restart it
+			ovnKubeNodePodName, err := getOVNKubeNodePodNameOnNode(context.Background(), f.ClientSet, node)
+			framework.ExpectNoError(err, "must get ovnkube node pod on Node %q", node)
+			framework.Logf("Ensuring pod %s/%s is Running", ovnKubeNamespace, ovnKubeNodePodName)
+			err = waitForPodRunningInNamespaceTimeout(f.ClientSet, ovnKubeNodePodName, ovnKubeNamespace, ovnKubeNodeRestartDuration)
+			framework.ExpectNoError(err, "ovnkube Node pod %s must be Running", ovnKubeNodePodName)
+			err = waitForAllContainersReadyInNamespaceTimeout(f.ClientSet, ovnKubeNodePodName, ovnKubeNamespace, ovnKubeNodeRestartDuration)
+			framework.ExpectNoError(err, "all container(s) for pod %s/%s must Ready on Node %s", ovnKubeNamespace, ovnKubeNodePodName, node)
+			framework.Logf("Deleting ovnkube node pod %s/%s", ovnKubeNamespace, ovnKubeNodePodName)
+			err = deletePodWithWaitByName(context.Background(), f.ClientSet, ovnKubeNodePodName, ovnKubeNamespace)
+			framework.ExpectNoError(err, "failed to delete ovnkube node pod %s", ovnKubeNodePodName)
+			framework.Logf("Waiting for new ovnkube node pod %s/%s to come up", ovnKubeNamespace, ovnKubeNodePodName)
+			ovnKubeNodePodName, err = getOVNKubeNodePodNameOnNode(context.Background(), f.ClientSet, node)
+			framework.ExpectNoError(err, "must get newly created ovnkube node pod %s/%s on Node %s", ovnKubeNamespace, ovnKubeNodePodName, node)
+			err = waitForPodRunningInNamespaceTimeout(f.ClientSet, ovnKubeNodePodName, ovnKubeNamespace, ovnKubeNodeRestartDuration)
+			framework.ExpectNoError(err, "failed waiting for new ovnkube node pod %s/%s to be Running", ovnKubeNamespace, ovnKubeNodePodName)
+			framework.Logf("Waiting for all containers for pod %s/%s to become Ready", ovnKubeNamespace, ovnKubeNodePodName)
+			err = waitForAllContainersReadyInNamespaceTimeout(f.ClientSet, ovnKubeNodePodName, ovnKubeNamespace, ovnKubeNodeRestartDuration)
+			framework.ExpectNoError(err, "all container(s) for pod %s/%s must be ready on Node %s", ovnKubeNamespace, ovnKubeNodePodName, node)
+			framework.Logf("Finished Node %s", node)
+		}
+		framework.Logf("Waiting for client pod to complete testing..")
+		err = waitForPodSucceededOrFailedInNamespaceTimeout(f.ClientSet, clientPod.Name, clientPod.Namespace, clientTestDuration*2)
+		framework.ExpectNoError(err, "expected client pod to terminate (completed)")
+
+		framework.Logf("Client pod completed - get test results from client pod logs")
+		var testResults *iperf3helper.Iperf3Result
+		clientPodContainerName = fmt.Sprintf("%s-container", clientPodName)
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 20*time.Second,
+			true, func(ctx context.Context) (done bool, err error) {
+
+				testResultsStr, err := pod.GetPodLogs(ctx, f.ClientSet, clientPod.Namespace, clientPod.Name, clientPodContainerName)
+				if err != nil {
+					framework.Logf("Failed to get pod %s/%s logs (will retry) from container %q: %v",
+						clientPod.Namespace, clientPod.Name, clientPodContainerName, err)
+					return false, nil
+				}
+				if testResultsStr == "" {
+					return false, nil
+				}
+				testResults, err = iperf3helper.ParseIperf3JSON(testResultsStr)
+				if err != nil {
+					framework.Logf("Failed to parse JSON from pod %s/%s and container %s, err: %v, output iperf: %q",
+						clientPod.Namespace, clientPod.Name, clientPodContainerName, err, testResultsStr)
+					return false, nil
+				}
+				return true, nil
+			})
+		framework.ExpectNoError(err, "must get logs which contain only JSON from client iperf container %s/%s", clientPod.Namespace, clientPod.Name)
+		gomega.Expect(testResults).NotTo(gomega.BeNil(), "programming error: testResults should have been set")
+		ginkgo.By("Analysing test results from iperf")
+		gomega.Expect(testResults.SumSent.Bytes).NotTo(gomega.BeZero(), "no bytes sent during test run, iperf test result: %q", testResults)
+		gomega.Expect(testResults.SumReceived.Bytes).NotTo(gomega.BeZero(), "no bytes received during test run, iperf test result: %q", testResults)
+		gomega.Expect(testResults.IsSendReceivedBytesEqual()).Should(gomega.BeTrue(), "%d lost bytes occurred during test run\nPod logs:\n%s",
+			testResults.GetSendReceivedBytesDifference(), testResults)
+		framework.Logf("Results for %s and interval .1 seconds are:\ndata loss: %d\nretransmissions: %d",
+			clientTestDuration.String(), testResults.GetSendReceivedBytesDifference(), testResults.GetRetransmissions())
 	})
 
 	// Validate the egress IP by creating a httpd container on the kind

--- a/test/e2e/iperf3helper/iper3_test.go
+++ b/test/e2e/iperf3helper/iper3_test.go
@@ -1,0 +1,261 @@
+package iperf3helper
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestIperf3(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Iperf3 helper Suite")
+}
+
+var _ = Describe("Iperf3 JSON Parser", func() {
+	var (
+		validFullJSON string
+		result        *Iperf3Result
+		err           error
+	)
+
+	BeforeEach(func() {
+		validFullJSON = `{
+      "start":    {
+          "connected":    [{
+                  "socket":    5,
+                  "local_host":    "10.244.2.14",
+                  "local_port":    51708,
+                  "remote_host":    "172.18.0.7",
+                  "remote_port":    12003
+              }],
+          "version":    "iperf 3.5",
+          "system_info":    "Linux iperfclient-2660 6.2.15-100.fc36.x86_64 #1 SMP PREEMPT_DYNAMIC Thu May 11 16:51:53 UTC 2023 x86_64",
+          "timestamp":    {
+              "time":    "Wed, 23 Jul 2025 10:17:26 GMT",
+              "timesecs":    1753265846
+          },
+          "connecting_to":    {
+              "host":    "172.18.0.7",
+              "port":    12003
+          },
+          "cookie":    "b2xebq6iqaaqnjylix2i3wjeeqmevdwyaisl",
+          "tcp_mss_default":    1348,
+          "sock_bufsize":    0,
+          "sndbuf_actual":    16384,
+          "rcvbuf_actual":    131072,
+          "test_start":    {
+              "protocol":    "TCP",
+              "num_streams":    1,
+              "blksize":    131072,
+              "omit":    0,
+              "duration":    50,
+              "bytes":    0,
+              "blocks":    0,
+              "reverse":    0,
+              "tos":    0
+          }
+      },
+      "intervals":    [{
+              "streams":    [{
+                      "socket":    5,
+                      "start":    0,
+                      "end":    1.0001890659332275,
+                      "seconds":    1.0001890659332275,
+                      "bytes":    1321205760,
+                      "bits_per_second":    10567648097.750378,
+                      "retransmits":    0,
+                      "snd_cwnd":    311388,
+                      "rtt":    86,
+                      "rttvar":    16,
+                      "pmtu":    1400,
+                      "omitted":    false
+                  }]
+          }],
+      "end":    {
+          "streams":    [{
+                  "sender":    {
+                      "socket":    5,
+                      "start":    0,
+                      "end":    50.000158071517944,
+                      "seconds":    50.000158071517944,
+                      "bytes":    83334095492,
+                      "bits_per_second":    13333413126.062956,
+                      "retransmits":    889,
+                      "max_snd_cwnd":    2601640,
+                      "max_rtt":    117,
+                      "min_rtt":    62,
+                      "mean_rtt":    71
+                  },
+                  "receiver":    {
+                      "socket":    5,
+                      "start":    0,
+                      "end":    50.040286064147949,
+                      "seconds":    50.000158071517944,
+                      "bytes":    83334095492,
+                      "bits_per_second":    13322720878.9609
+                  }
+              }],
+          "sum_sent":    {
+              "start":    0,
+              "end":    50.000158071517944,
+              "seconds":    50.000158071517944,
+              "bytes":    83334095492,
+              "bits_per_second":    13333413126.062956,
+              "retransmits":    889
+          },
+          "sum_received":    {
+              "start":    0,
+              "end":    50.040286064147949,
+              "seconds":    50.040286064147949,
+              "bytes":    83334095492,
+              "bits_per_second":    13322720878.9609
+          },
+          "cpu_utilization_percent":    {
+              "host_total":    26.731040083439794,
+              "host_user":    0.13144291414072176,
+              "host_system":    26.599599166001397,
+              "remote_total":    25.095665001689387,
+              "remote_user":    0.44855781527332539,
+              "remote_system":    24.647107186416061
+          },
+          "sender_tcp_congestion":    "cubic",
+          "receiver_tcp_congestion":    "cubic"
+      }
+  }`
+	})
+
+	Describe("Parse output when --json flag enable", func() {
+		Context("with normal test run", func() {
+			BeforeEach(func() {
+				result, err = ParseIperf3JSON(validFullJSON)
+			})
+
+			It("should parse successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+			})
+
+			It("should extract sum_sent data correctly", func() {
+				Expect(result.SumSent.Start).To(Equal(0.0))
+				Expect(result.SumSent.End).To(Equal(50.000158071517944))
+				Expect(result.SumSent.Seconds).To(Equal(50.000158071517944))
+				Expect(result.SumSent.Bytes).To(Equal(int64(83334095492)))
+				Expect(result.SumSent.BitsPerSecond).To(Equal(13333413126.062956))
+				Expect(result.SumSent.Retransmits).To(Equal(889))
+			})
+
+			It("should extract sum_received data correctly", func() {
+				Expect(result.SumReceived.Start).To(Equal(0.0))
+				Expect(result.SumReceived.End).To(Equal(50.040286064147949))
+				Expect(result.SumReceived.Seconds).To(Equal(50.040286064147949))
+				Expect(result.SumReceived.Bytes).To(Equal(int64(83334095492)))
+				Expect(result.SumReceived.BitsPerSecond).To(Equal(13322720878.9609))
+				Expect(result.SumReceived.Retransmits).To(Equal(0)) // receiver doesn't have retransmits
+			})
+
+			It("should correctly determine bytes difference between send and receive", func() {
+				// Both sent and received have same byte count: 83334095492
+				Expect(result.IsBytesEqual).To(BeTrue())
+				Expect(result.GetSendReceivedBytesDifference()).To(Equal(int64(0)))
+			})
+		})
+
+		Context("with unequal sent/received bytes", func() {
+			BeforeEach(func() {
+				unequalJSON := `{
+					"end": {
+						"sum_sent": {
+							"start": 0,
+							"end": 10.0,
+							"seconds": 10.0,
+							"bytes": 1000000,
+							"bits_per_second": 800000,
+							"retransmits": 10
+						},
+						"sum_received": {
+							"start": 0,
+							"end": 10.0,
+							"seconds": 10.0,
+							"bytes": 950000,
+							"bits_per_second": 760000
+						}
+					}
+				}`
+				result, err = ParseIperf3JSON(unequalJSON)
+			})
+
+			It("should parse successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+			})
+
+			It("should detect bytes inequality", func() {
+				Expect(result.IsBytesEqual).To(BeFalse())
+			})
+
+			It("should calculate correct bytes difference", func() {
+				Expect(result.GetSendReceivedBytesDifference()).To(Equal(int64(50000)))
+			})
+		})
+
+		Context("with zero sent bytes", func() {
+			BeforeEach(func() {
+				zeroSentJSON := `{
+					"end": {
+						"sum_sent": {
+							"start": 0,
+							"end": 10.0,
+							"seconds": 10.0,
+							"bytes": 0,
+							"bits_per_second": 0,
+							"retransmits": 0
+						},
+						"sum_received": {
+							"start": 0,
+							"end": 10.0,
+							"seconds": 10.0,
+							"bytes": 0,
+							"bits_per_second": 0
+						}
+					}
+				}`
+				result, err = ParseIperf3JSON(zeroSentJSON)
+			})
+
+			It("should parse successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should handle zero bytes correctly", func() {
+				Expect(result.SumSent.Bytes).To(Equal(int64(0)))
+				Expect(result.SumReceived.Bytes).To(Equal(int64(0)))
+				Expect(result.IsBytesEqual).To(BeTrue())
+			})
+		})
+
+		Context("with invalid JSON input", func() {
+			It("should return known error for malformed JSON", func() {
+				invalidJSON := `{"end": {"sum_sent": invalid json`
+				result, err = ParseIperf3JSON(invalidJSON)
+
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+			})
+
+			It("should return error for empty JSON", func() {
+				result, err = ParseIperf3JSON("")
+
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+			})
+
+			It("should return error for non-JSON string", func() {
+				result, err = ParseIperf3JSON("not json at all")
+
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+})

--- a/test/e2e/iperf3helper/iperf3.go
+++ b/test/e2e/iperf3helper/iperf3.go
@@ -1,0 +1,86 @@
+package iperf3helper
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Iperf3Result represents the parsed iperf3 JSON output when using --json flag
+type Iperf3Result struct {
+	SumSent           Iperf3TestRun `json:"sum_sent"`
+	SumReceived       Iperf3TestRun `json:"sum_received"`
+	IsBytesEqual      bool
+	IsZeroRetransmits bool
+}
+
+func (i Iperf3Result) String() string {
+	res, err := json.Marshal(i)
+	if err != nil {
+		panic(fmt.Sprintf("failed to unmarshall Iperf3 test run result: %+v", i))
+	}
+	return string(res)
+}
+
+// Iperf3TestRun represents the sum data from iperf3 output when using --json flag
+type Iperf3TestRun struct {
+	Start         float64 `json:"start"`
+	End           float64 `json:"end"`
+	Seconds       float64 `json:"seconds"`
+	Bytes         int64   `json:"bytes"`
+	BitsPerSecond float64 `json:"bits_per_second"`
+	Retransmits   int     `json:"retransmits,omitempty"` // retransmits is only available from sum_sent therefore add omitempty
+}
+
+func (i Iperf3TestRun) String() string {
+	res, err := json.Marshal(i)
+	if err != nil {
+		panic(fmt.Sprintf("failed to unmarshall Iperf3 test run: %+v", i))
+	}
+	return string(res)
+}
+
+// iperf3Output represents the iperf3 JSON structure specifically for parsing json output "end" key. "end" map contains
+// "sum_sent" and "sum_received" which contain data about the data send and received during test time.
+type iperf3Output struct {
+	End struct {
+		SumSent     Iperf3TestRun `json:"sum_sent"`
+		SumReceived Iperf3TestRun `json:"sum_received"`
+	} `json:"end"`
+}
+
+// ParseIperf3JSON parses iperf3 JSON output and extracts sum_sent and sum_received from the "end" key. Arg jsonOutput must be
+// supplied from an iperf3 client with the --json flag specified.
+func ParseIperf3JSON(jsonOutput string) (*Iperf3Result, error) {
+	var output iperf3Output
+
+	if err := json.Unmarshal([]byte(jsonOutput), &output); err != nil {
+		return nil, fmt.Errorf("failed to parse iperf3 JSON, JSON input:\n%q\n,err: %w", jsonOutput, err)
+	}
+
+	result := &Iperf3Result{
+		SumSent:     output.End.SumSent,
+		SumReceived: output.End.SumReceived,
+	}
+
+	// Check if bytes sent equals bytes received
+	result.IsBytesEqual = result.SumSent.Bytes == result.SumReceived.Bytes
+	// Check if there were retransmissions (tcp only)
+	result.IsZeroRetransmits = result.SumSent.Retransmits == 0
+
+	return result, nil
+}
+
+// IsSendReceivedBytesEqual returns true if bytes sent equals bytes received
+func (r *Iperf3Result) IsSendReceivedBytesEqual() bool {
+	return r.IsBytesEqual
+}
+
+// GetSendReceivedBytesDifference returns the difference between sent and received bytes during the test run
+func (r *Iperf3Result) GetSendReceivedBytesDifference() int64 {
+	return r.SumSent.Bytes - r.SumReceived.Bytes
+}
+
+// GetRetransmissions returns the total amount of re-transmissions seen over the test run
+func (r *Iperf3Result) GetRetransmissions() int {
+	return r.SumSent.Retransmits
+}

--- a/test/e2e/static_pods.go
+++ b/test/e2e/static_pods.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,18 +21,85 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
+// waitForAllContainersReadyInNamespaceTimeout waits until timeout for all of a pod containers to become Ready. Will return
+// error if a container status is terminated. It is expected that no container will restart with an exit code of 0, otherwise error
+// is returned immediately.
+func waitForAllContainersReadyInNamespaceTimeout(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
+	return e2epod.WaitForPodCondition(context.TODO(), c, namespace, podName, fmt.Sprintf("%s", v1.PodRunning), timeout, func(pod *v1.Pod) (bool, error) {
+		var (
+			errs     []error
+			allReady = true
+		)
+		for _, cs := range pod.Status.ContainerStatuses {
+			if !cs.Ready {
+				allReady = false
+			}
+			// if container has terminated with non-zero exit, surface the error(s) to aid debug
+			if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
+				errs = append(errs, fmt.Errorf("container terminated non-zero: %s", cs.State.Terminated.String()))
+			}
+		}
+		if len(errs) > 0 {
+			return false, errors.Join(errs...)
+		}
+		if allReady {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
 // pulled from https://github.com/kubernetes/kubernetes/blob/v1.26.2/test/e2e/framework/pod/wait.go#L468
 // had to modify function due to restart policy on static pods being set to always, which caused function to fail
+// Will return error if pod phase is failed or unknown.
 func waitForPodRunningInNamespaceTimeout(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
 	return e2epod.WaitForPodCondition(context.TODO(), c, namespace, podName, fmt.Sprintf("%s", v1.PodRunning), timeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
 		case v1.PodRunning:
-			ginkgo.By("Saw pod running")
+			return true, nil
+		case v1.PodFailed, v1.PodUnknown:
+			return false, fmt.Errorf("pod %s/%s is in state Failed/Unknown: %q",
+				namespace, podName, getNonZeroTerminatedStatus(pod))
+		default:
+			return false, nil
+		}
+	})
+}
+
+// waitForPodSucceededOrFailedInNamespaceTimeout waits until timeout for a pod to become phase Succeeded. Will return error if pod failed or unknown.
+// FIXME: remove failed as a condition when we fix the EIP healthcheck and ensure it doesn't move an EIP when the ovnkube control plane is restarted.
+func waitForPodSucceededOrFailedInNamespaceTimeout(c clientset.Interface, podName, namespace string, timeout time.Duration) error {
+	return e2epod.WaitForPodCondition(context.TODO(), c, namespace, podName, fmt.Sprintf("%s", v1.PodSucceeded), timeout, func(pod *v1.Pod) (bool, error) {
+		switch pod.Status.Phase {
+		case v1.PodSucceeded, v1.PodFailed:
 			return true, nil
 		default:
 			return false, nil
 		}
 	})
+}
+
+// getNonZeroTerminatedStatus returns all status's of containers that exited with non zero exit code. Should only be used
+// for logging and to aid debugging of failed pods.
+func getNonZeroTerminatedStatus(pod *v1.Pod) string {
+	if pod == nil {
+		return "pod object is nil"
+	}
+	var containerStatuses []string
+	for _, cs := range pod.Status.ContainerStatuses {
+		// skip containers that are not terminated (may happen for PodFailed/PodUnknown)
+		if cs.State.Terminated == nil {
+			continue
+		}
+		if cs.State.Terminated.ExitCode == 0 {
+			continue
+		}
+		containerStatuses = append(containerStatuses, cs.State.Terminated.String())
+	}
+	if len(containerStatuses) == 0 {
+		return "no terminated containers with non-zero exit codes"
+	}
+	return strings.Join(containerStatuses, "\n")
 }
 
 func createStaticPod(nodeName string, podYaml string) {


### PR DESCRIPTION
Help give us confidence for restarting our control plane when eip is active for CDN,UDN (v4 & v6).
A few bugs recently could have been caught with something like this.

Client sets up tcp test with external server and performs an iperf test while we restart control plane.
Client contineously pushes data externally.

Fails on dataloss.
Logs retransmissions.
Restarts ovnkube node on egress node and client pod node.

This test cannot work currently with the gRPC
implementation of EIP Healthcheck because the EIP is prone to move to a different Node and therefore that
will interrupt the tcp connection.
The gRPC server which helps implement the Egress IP healthcheck is removed when ovnkube node is shutdown / restarted, and there's a possibility the node is no longer assigned as an egress node by cluster manager, and today that will break the TCP connection if the eip is unassigned or reassigned to another node switch back to gRPC when [1] is merged.

[1] https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4286

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.
- Tests
  - Added e2e tests validating TCP connectivity during ovnkube-node restarts (iperf3-based), including long-run throughput and packet-loss checks (note: test duplicated in diff).
  - Added an iperf3 JSON parser test suite covering normal, edge and invalid inputs.
  - Added iperf3 parsing utility to produce consistent send/receive/retransmit metrics.
- Chores
  - Improved test helpers to better wait for pod readiness/success and aggregate container termination errors for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->