### PR TITLE
fix: multiarch fedora build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,7 +84,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         builder: ${{ steps.buildx.outputs.name }}
-        context: ./dist/images
+        context: .
         file: ./dist/images/Dockerfile.fedora
         push: true
         platforms: linux/amd64,linux/arm64

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -287,22 +287,9 @@ build_ovn_image() {
       return
     fi
 
-    # Build ovn image
-    pushd ${DIR}/../go-controller
-    make
-    popd
-
     # Build ovn kube image
     pushd ${DIR}/../dist/images
-    # Find all built executables, but ignore the 'windows' directory if it exists
-    find ../../go-controller/_output/go/bin/ -maxdepth 1 -type f -exec cp -f {} . \;
-    echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
-    $OCI_BIN build \
-      --build-arg http_proxy="$http_proxy" \
-      --build-arg https_proxy="$https_proxy" \
-      --network=host \
-      -t "${OVN_IMAGE}" \
-      -f Dockerfile.fedora .
+    make fedora-image
     popd
 }
 

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -8,14 +8,30 @@
 # This is for a development build where the ovn-kubernetes utilities
 # are built locally and included in the image (instead of the rpm)
 #
-
 ARG OVN_FROM=koji
+ARG BUILDER_IMAGE
+ARG OVN_KUBERNETES_DIR=.
+
+#############################################
+# Stage to build OVN Kubernetes from Source #
+#############################################
+
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS ovnkube-builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+RUN apt-get update && apt-get install -y -qq make git
+COPY ${OVN_KUBERNETES_DIR} ovn-kubernetes
+RUN cd ovn-kubernetes/dist/images && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} make bld
+
 
 #############################################
 # Stage to get OVN and OVS RPMs from source #
 #############################################
 FROM quay.io/fedora/fedora:42 AS ovnbuilder
-
 USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
@@ -138,24 +154,22 @@ RUN rpm -Uhv --nodeps --force /*.rpm
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg
 RUN mkdir -p /usr/libexec/cni/
-COPY ovnkube ovn-kube-util ovndbchecker hybrid-overlay-node ovnkube-identity ovnkube-observ /usr/bin/
-COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/ovnkube /workspace/ovn-kubernetes/dist/images/ovn-kube-util /workspace/ovn-kubernetes/dist/images/ovndbchecker /workspace/ovn-kubernetes/dist/images/hybrid-overlay-node /workspace/ovn-kubernetes/dist/images/ovnkube-identity /workspace/ovn-kubernetes/dist/images/ovnkube-observ /usr/bin/
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/git_info /root
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
-COPY ovnkube.sh /root/
-COPY ovndb-raft-functions.sh /root/
-
-# copy git commit number into image
-COPY git_info /root
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/ovnkube.sh /root/
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/ovndb-raft-functions.sh /root/
 
 # iptables wrappers
-COPY ./iptables-scripts/iptables /usr/sbin/
-COPY ./iptables-scripts/iptables-save /usr/sbin/
-COPY ./iptables-scripts/iptables-restore /usr/sbin/
-COPY ./iptables-scripts/ip6tables /usr/sbin/
-COPY ./iptables-scripts/ip6tables-save /usr/sbin/
-COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/iptables-scripts/iptables /usr/sbin/
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/iptables-scripts/iptables-save /usr/sbin/
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/iptables-scripts/iptables-restore /usr/sbin/
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/iptables-scripts/ip6tables /usr/sbin/
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/iptables-scripts/ip6tables-save /usr/sbin/
+COPY --from=ovnkube-builder /workspace/ovn-kubernetes/dist/images/iptables-scripts/ip6tables-restore /usr/sbin/
 
 LABEL io.k8s.display-name="ovn-kubernetes" \
       io.k8s.description="This is a Kubernetes network plugin that provides an overlay network using OVN." \

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -11,7 +11,7 @@
 all: ubuntu fedora
 
 SLASH = -
-ARCH = $(subst aarch64,arm64,$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))))
+ARCH ?= $(subst aarch64,arm64,$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))))
 IMAGE_ARCH = $(SLASH)$(ARCH)
 DOCKERFILE_ARCH =
 ifeq ($(ARCH),arm64)
@@ -27,7 +27,8 @@ else
 OVN_FROM := source
 OVN_GITSHA := $(shell git ls-remote "${OVN_REPO}" "${OVN_GITREF}" | sort -k2  -V  |tail -1 | awk '{ print $$1 }')
 endif
-
+GO_VERSION ?= 1.24
+GO_IMAGE = quay.io/lib/golang:${GO_VERSION}
 
 OCI_BIN ?= docker
 
@@ -45,13 +46,16 @@ ubuntu-shared-gw-deployment: ubuntu-image
 	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-ubuntu:latest
 	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-ubuntu:latest
 
-fedora-image: bld
+fedora-image:
 	${OCI_BIN} build \
 		--build-arg OVN_FROM=${OVN_FROM} \
 		--build-arg OVN_REPO=${OVN_REPO} \
 		--build-arg OVN_GITREF=${OVN_GITSHA} \
+		--build-arg OVN_KUBERNETES_DIR=${OVN_KUBERNETES_DIR} \
+		--build-arg BUILDER_IMAGE=${GO_IMAGE} \
+		--platform=linux/${ARCH} \
 		-t ${IMAGE} \
-		-f Dockerfile.fedora .
+		-f Dockerfile.fedora ./../..
 
 fedora-shared-gw-deployment: fedora-image
 	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube


### PR DESCRIPTION
enable proper multi-arch fedora builds by building ovn-kubernetes inside the container build

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Build the ovn-kubernetes binaries inside the Fedora image build. This wil build truly multi-arch containers as part of the Fedora build and release. With the current github workflow the resulting arm64 images contain amd64 binaries. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #5504 

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Streamlined image build via a single Make target, making local builds faster and simpler.
- Refactor
  - Simplified the OVN image build process by removing manual binary collection and metadata steps.
- Chores
  - Updated CI workflow to adjust Docker build context for Fedora images; no impact on functionality or release artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->