### PR TITLE
rm /mnt/disk0.img to help with disk full faiulres

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -38,6 +38,10 @@ runs:
         echo "=== Remove potential leftover PV setup image ==="
         sudo rm -f /mnt/tmp-pv.img
 
+        echo "=== Remove potential leftover runner disk image ==="
+        # if /mnt/disk0.img exists, detach any loop using it, delete it to reclaim space (avoids rare disk-full)
+        sudo losetup -j /mnt/disk0.img | cut -d: -f1 | xargs -r -n1 sudo losetup -d; sudo rm -f /mnt/disk0.img || true
+
         echo "=== Disk usage after cleanup ==="
         df -h
 


### PR DESCRIPTION
seems that something in the github runner setup will sometimes leave this very large (60GB+) file on the runner which consumes so much space that we fail to install Kind. This will take care of that if it exists.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Mitigates rare CI failures caused by lingering temporary disk images exhausting runner space.

- Chores
  - Enhanced CI cleanup to reclaim disk space more reliably by removing leftover runner disk images and detaching associated mounts.
  - Improves stability and reduces intermittent build failures/timeouts due to low disk space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->