### PR TITLE
Fetch agnhost image from k8s upstream

### DIFF
--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -1,10 +1,21 @@
 package images
 
-import "os"
+import (
+	"os"
+
+	"k8s.io/kubernetes/test/utils/image"
+)
 
 var (
-	agnHost = "registry.k8s.io/e2e-test-images/agnhost:2.53"
-	iperf3  = "quay.io/sronanrh/iperf:latest"
+	// We limit the set of images used by e2e to reduce duplication and to allow us to provide offline mirroring of images
+	// for customers and restricted test environments.
+	// Ideally, every image used in e2e must be part of this package.
+	// New test images should ideally be sourced from the upstream k8s.io/kubernetes/test/utils/image package.
+	// Failing to find an image from upstream k8s, please get community approval because downstream consumers must
+	// pre-approve new images.
+	agnHost = image.GetE2EImage(image.Agnhost)
+	// FIXME: iperf3 image should not be retrieved from a users repo and should not have latest tag
+	iperf3 = "quay.io/sronanrh/iperf:latest"
 )
 
 func init() {


### PR DESCRIPTION
Lets fetch agnhost image from upstream
and pin it to the k8s release we consume.

Downstream, we approve k8 images. It eases adoption of E2Es.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test image resolution using an upstream utility; environment variable overrides remain supported. No user-facing behavior changes.

* **Documentation**
  * Expanded comments clarifying image sourcing, offline mirroring, and guidance for introducing new test images.

* **Chores**
  * Added dependency to support centralized image resolution.
  * Retained current iperf3 image reference with a note to revisit the “latest” tag.

* **Note**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->