### PR TITLE
Brings factory handling inline with level driven controllers

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -1287,20 +1287,39 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel l
 	intInf := inf.internalInformers[wf.internalInformerIndex]
 
 	intInf.Lock()
-	defer intInf.Unlock()
 
 	// we are going to add a handler, we need to update the atomic signal that handlers exist now
 	// so that we do not miss events after we list current items.
 	// We need to do this after we get internal informer lock, to preserve that we can be the only one updating
 	// the atomic and preserve known state of the atomic while the handler is going to be added in the future
-	hadZeroHandlers := atomic.CompareAndSwapUint32(&intInf.hasHandlers, hasNoHandler, hasHandler)
+	atomic.CompareAndSwapUint32(&intInf.hasHandlers, hasNoHandler, hasHandler)
 
-	items := make([]interface{}, 0)
+	// get list of items to use for initial add
+	infItems := inf.inf.GetStore().List()
+	items := make([]interface{}, 0, len(infItems))
+	for _, obj := range infItems {
+		if filterFunc(obj) {
+			items = append(items, obj)
+		}
+	}
+
+	// add handler with initial add, keeping informer locked
+	handlerID := atomic.AddUint64(&wf.handlerCounter.counter, 1)
+	handler := inf.addHandler(wf.internalInformerIndex, handlerID, priority, filterFunc, funcs, items)
+	klog.V(5).Infof("Added %v event handler %d", objType, handler.id)
+
+	// unlock informer, the workers (queuemap goroutines) can now resume processing. The handler we added
+	// is disabled, so it will be buffering events for now
+	intInf.Unlock()
+
+	// re-list items during informer lock to get accurate information to sync with
+	items = make([]interface{}, 0, len(items))
 	for _, obj := range inf.inf.GetStore().List() {
 		if filterFunc(obj) {
 			items = append(items, obj)
 		}
 	}
+
 	if processExisting != nil {
 		// Process existing items as a set so the caller can clean up
 		// after a restart or whatever. We will wrap it with retries to ensure it succeeds.
@@ -1313,17 +1332,14 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel l
 			return true, nil
 		})
 		if err != nil {
-			// handler is not going to be added, restore previous value if needed
-			if hadZeroHandlers {
-				atomic.StoreUint32(&intInf.hasHandlers, hasNoHandler)
-			}
+			wf.removeHandler(objType, handler)
 			return nil, err
 		}
 	}
 
-	handlerID := atomic.AddUint64(&wf.handlerCounter.counter, 1)
-	handler := inf.addHandler(wf.internalInformerIndex, handlerID, priority, filterFunc, funcs, items)
-	klog.V(5).Infof("Added %v event handler %d", objType, handler.id)
+	// sync is done, turn on the handler
+	handler.Enable()
+
 	return handler, nil
 }
 


### PR DESCRIPTION
Our watchFactory addHandler would take informer lock during sync. However, real level driven controllers do not. In level driven controllers the process is:
1. lock informer
2. handler is added to informer
3. initial add list is queued
4. informer is unlocked
5. informer now continues to enqueue events
6. handler re-lists existing objects, runs sync method
7. handler now starts workers to process enqueued events

Our watch factory today:
1. lock informer
2. informer still enqueing events, but workers are paused
3. run sync
4. initial adds are processed
5. handler added to informer
6. informer unlocked
7. workers now resume

The core difference here is in our watch factory, we share workers (queuemap) across all handlers/controllers, where as level driven creates worker threads specific to its handler/controller. Therefore the level-driven controller can afford to continously allow events to be enqueued by the informer, and eventually starting workers will start processing them. In our case, we pause workers, which stops handling for all controllers while we sync+process initial add for the handler. This is really bad for performance.

This patch modifies watch factory behavior to act the same way that level-driven controllers do. Since we are bound to sharing workers across all controllers, a new mechanism is used to avoid pausing workers when handlers are added. It works like this:

1. lock informer
2. informer still enqueuing events, but workers are paused
3. get initial add list
4. initial add now enqueues items to the handler's buffer
5. handler is added to informer, but in a disabled state
6. informer is unlocked, workers resume, but this handler is disabled, so events for this handler are enqueued to the buffer
7. handler re-lists existing objects, runs sync method
8. handler is now enabled, which causes handler to process all events in the buffer, while not blocking informer

This allows watch factory to do its sync and initial add events without any disruption to other handlers that are using the same informers and workers.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added buffered event handling with explicit enable step to ensure smooth activation of new handlers.
  - Introduced informative logging when event handlers are added.

- Bug Fixes
  - Prevented missed events during startup and restarts by buffering and then enabling handlers after syncing existing items.
  - Reduced race conditions and improved error handling with retries and safe rollback on failures.

- Refactor
  - Centralized event dispatch logic and streamlined handler lifecycle for more reliable and predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->