### PR TITLE
pod-allocation-annotator: Drop IPAMReconciler argument 

### DIFF
--- a/go-controller/pkg/allocator/pod/pod_annotation.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation.go
@@ -41,19 +41,23 @@ func NewPodAnnotationAllocator(
 	netInfo util.NetInfo,
 	podLister listers.PodLister,
 	kube kube.InterfaceOVN,
-	claimsReconciler persistentips.PersistentAllocations,
 	opts ...AllocatorOption,
 ) *PodAnnotationAllocator {
 	p := &PodAnnotationAllocator{
-		podLister:            podLister,
-		kube:                 kube,
-		netInfo:              netInfo,
-		ipamClaimsReconciler: claimsReconciler,
+		podLister: podLister,
+		kube:      kube,
+		netInfo:   netInfo,
 	}
 	for _, opt := range opts {
 		opt(p)
 	}
 	return p
+}
+
+func WithIPAMClaimReconciler(ipam persistentips.PersistentAllocations) AllocatorOption {
+	return func(p *PodAnnotationAllocator) {
+		p.ipamClaimsReconciler = ipam
+	}
 }
 
 func WithMACRegistry(m mac.Register) AllocatorOption {

--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -847,11 +847,13 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 			mutableNetInfo.AddNADs("namespace/nad")
 			netInfo = mutableNetInfo
 
+			var opts []pod.AllocatorOption
 			var ipamClaimsReconciler persistentips.PersistentAllocations
 			if tt.ipam && tt.args.ipamClaim != nil {
 				ctx, cancel := context.WithCancel(context.Background())
 				ipamClaimsLister, teardownFn := generateIPAMClaimsListerAndTeardownFunc(ctx.Done(), tt.args.ipamClaim)
 				ipamClaimsReconciler = persistentips.NewIPAMClaimReconciler(kubeMock, netInfo, ipamClaimsLister)
+				opts = append(opts, pod.WithIPAMClaimReconciler(ipamClaimsReconciler))
 
 				t.Cleanup(func() {
 					cancel()
@@ -859,7 +861,6 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 				})
 			}
 
-			var opts []pod.AllocatorOption
 			if tt.macRegistry != nil {
 				opts = append(opts, pod.WithMACRegistry(tt.macRegistry))
 			}
@@ -867,7 +868,6 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 				netInfo,
 				podListerMock,
 				kubeMock,
-				ipamClaimsReconciler,
 				opts...,
 			)
 

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -380,7 +380,7 @@ func NewLayer2UserDefinedNetworkController(
 	}
 
 	if oc.allocatesPodAnnotation() {
-		var claimsReconciler persistentips.PersistentAllocations
+		var opts []pod.AllocatorOption
 		if oc.allowPersistentIPs() {
 			ipamClaimsReconciler := persistentips.NewIPAMClaimReconciler(
 				oc.kube,
@@ -388,13 +388,14 @@ func NewLayer2UserDefinedNetworkController(
 				oc.watchFactory.IPAMClaimsInformer().Lister(),
 			)
 			oc.ipamClaimsReconciler = ipamClaimsReconciler
-			claimsReconciler = ipamClaimsReconciler
+			opts = append(opts, pod.WithIPAMClaimReconciler(ipamClaimsReconciler))
 		}
 		oc.podAnnotationAllocator = pod.NewPodAnnotationAllocator(
 			oc.GetNetInfo(),
 			cnci.watchFactory.PodCoreInformer().Lister(),
 			cnci.kube,
-			claimsReconciler)
+			opts...,
+		)
 	}
 
 	// enable multicast support for UDN only for primaries + multicast enabled

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -393,7 +393,7 @@ func NewLayer3UserDefinedNetworkController(
 			oc.GetNetInfo(),
 			cnci.watchFactory.PodCoreInformer().Lister(),
 			cnci.kube,
-			nil)
+		)
 		oc.podAnnotationAllocator = podAnnotationAllocator
 	}
 

--- a/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
@@ -225,7 +225,7 @@ func NewLocalnetUserDefinedNetworkController(
 	}
 
 	if oc.allocatesPodAnnotation() {
-		var claimsReconciler persistentips.PersistentAllocations
+		var opts []pod.AllocatorOption
 		if oc.allowPersistentIPs() {
 			ipamClaimsReconciler := persistentips.NewIPAMClaimReconciler(
 				oc.kube,
@@ -233,13 +233,14 @@ func NewLocalnetUserDefinedNetworkController(
 				oc.watchFactory.IPAMClaimsInformer().Lister(),
 			)
 			oc.ipamClaimsReconciler = ipamClaimsReconciler
-			claimsReconciler = ipamClaimsReconciler
+			opts = append(opts, pod.WithIPAMClaimReconciler(ipamClaimsReconciler))
 		}
 		oc.podAnnotationAllocator = pod.NewPodAnnotationAllocator(
 			netInfo,
 			cnci.watchFactory.PodCoreInformer().Lister(),
 			cnci.kube,
-			claimsReconciler)
+			opts...,
+		)
 	}
 
 	// disable multicast support for UDNs


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

This is a followup PR for https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5492 address this [review comment](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5492#discussion_r2332341740) 

The PR drop the pod-allocation-annotator IPAMClaimReconcilder argument in favor of option function for composing the IPAMClaimReconcilder instance.

Why we need this
There are quite few examples in the code base where functions has just too many arguments (e.g.: pod allocation functions), this PR eliminates one of them around the pod allocation annotator code.
Applying builder pattern (factory function reviving option functions) we encourage the next dev to avoid adding yet another parameter for a specific use case. Hopefully keeping this function with sane number of parameters.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers

Rebased on top  https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5492, please see the last commit.
This PR should merge once  https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5492 is merged.
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched pod annotation allocator to an option-based configuration. Persistent IP handling is now supplied via allocator options rather than a dedicated constructor parameter; runtime behavior remains unchanged.
* **Tests**
  * Updated tests to construct and exercise the allocator using the new options pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->