### PR TITLE
kv, e2e: Add --wait to killall

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -2330,7 +2330,7 @@ chpasswd: { expire: False }
 			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
 
 			By("Stop iperf3 traffic before force killing vm, so iperf3 server do not get stuck")
-			output, err = virtClient.RunCommand(vmi, "killall iperf3", 5*time.Second)
+			output, err = virtClient.RunCommand(vmi, "killall --wait iperf3", 5*time.Second)
 			Expect(err).ToNot(HaveOccurred(), output)
 
 			step = by(vmi.Name, fmt.Sprintf("Force kill qemu at node %q where VM is running on", vmi.Status.NodeName))


### PR DESCRIPTION
## 📑 Description
Not waiting for `killall` to terminate can cause the Kubevirt console expecter/matcher to incorrectly match the negative case. This occurs because the "Exit 1" string may prematurely appear in the output.

Fixes #5629 

## Additional Information for reviewers
NONE

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by ensuring network performance processes fully terminate before virtual machine force-stop scenarios proceed.
  * Reduced timing-related flakiness in VM shutdown paths, leading to more consistent CI outcomes and fewer intermittent failures.
  * Tightened error reporting when process termination does not complete as expected, making test failures easier to diagnose and triage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->