### PR TITLE
udn: Skip join subnet assignment for secondary Layer2 networks

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
@@ -174,12 +174,14 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter) (map[s
 			netConfSpec.DefaultGatewayIPs = ipString(cfg.DefaultGatewayIPs)
 		}
 		netConfSpec.JoinSubnet = cidrString(renderJoinSubnets(cfg.Role, cfg.JoinSubnets))
-		// now generate transit subnet for layer2 topology
 		if cfg.Role == userdefinednetworkv1.NetworkRolePrimary {
+			// now generate transit subnet for layer2 topology
 			err := util.SetTransitSubnets(netConfSpec)
 			if err != nil {
 				return nil, err
 			}
+			// Only set join subnet for primary networks; secondary Layer2 networks don't need join subnets
+			netConfSpec.JoinSubnet = cidrString(renderJoinSubnets(cfg.Role, cfg.JoinSubnets))
 		}
 	case userdefinednetworkv1.NetworkTopologyLocalnet:
 		cfg := spec.GetLocalnet()


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
Secondary Layer2 networks don't require join subnets, but were incorrectly being assigned the default UDN join subnet (100.65.0.0/16). This caused failures when the cluster join subnet matched the UDN default, as overlap validation would incorrectly flag a conflict.

Fix by only assigning join subnets to primary networks in the Layer2 topology case. Add regression test verifying secondary Layer2 networks can be created successfully even when cluster join subnet matches UDN default join subnet.

## Additional Information for reviewers
N/A

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
It already include unit tests 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secondary Layer2 user-defined networks no longer receive a join subnet, preventing subnet overlap errors and improving network stability when multiple networks share defaults.

* **Tests**
  * Added a regression test to verify secondary Layer2 networks omit join subnets when cluster join subnets match defaults.
  * Test setup now initializes IPv4/IPv6 cluster join subnets to avoid conflicts across UDN scenarios and ensure reliable test isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->