### PR TITLE
add nft rule for service in the dpu-host mode

### DIFF
--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -78,10 +77,10 @@ func getNoSNATLoadBalancerIPRules(svcPort corev1.ServicePort, localEndpoints []s
 // getUDNNodePortMarkNFTRule returns a verdict map element (nftablesUDNMarkNodePortsMap)
 // with a key composed of the svcPort protocol and port.
 // The value is a jump to the UDN chain mark if netInfo is provided, or nil that is useful for map entry removal.
-func getUDNNodePortMarkNFTRule(svcPort corev1.ServicePort, netInfo *bridgeconfig.BridgeUDNConfiguration) *knftables.Element {
+func getUDNNodePortMarkNFTRule(svcPort corev1.ServicePort, pktMark string) *knftables.Element {
 	var val []string
-	if netInfo != nil {
-		val = []string{fmt.Sprintf("jump %s", GetUDNMarkChain(netInfo.PktMark))}
+	if pktMark != "" {
+		val = []string{fmt.Sprintf("jump %s", GetUDNMarkChain(pktMark))}
 	}
 	return &knftables.Element{
 		Map:   nftablesUDNMarkNodePortsMap,
@@ -94,12 +93,12 @@ func getUDNNodePortMarkNFTRule(svcPort corev1.ServicePort, netInfo *bridgeconfig
 // getUDNExternalIPsMarkNFTRules returns a verdict map elements (nftablesUDNMarkExternalIPsV4Map or nftablesUDNMarkExternalIPsV6Map)
 // with a key composed of the external IP, svcPort protocol and port.
 // The value is a jump to the UDN chain mark if netInfo is provided,  or nil that is useful for map entry removal.
-func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []string, netInfo *bridgeconfig.BridgeUDNConfiguration) []*knftables.Element {
+func getUDNExternalIPsMarkNFTRules(svcPort corev1.ServicePort, externalIPs []string, pktMark string) []*knftables.Element {
 	var nftRules []*knftables.Element
 	var val []string
 
-	if netInfo != nil {
-		val = []string{fmt.Sprintf("jump %s", GetUDNMarkChain(netInfo.PktMark))}
+	if pktMark != "" {
+		val = []string{fmt.Sprintf("jump %s", GetUDNMarkChain(pktMark))}
 	}
 	for _, externalIP := range externalIPs {
 		mapName := nftablesUDNMarkExternalIPsV4Map
@@ -185,13 +184,13 @@ func getGatewayNFTRules(service *corev1.Service, localEndpoints []string, svcHas
 // getUDNNFTRules generates nftables rules for a UDN service.
 // If netConfig is nil, the resulting map elements will have empty values,
 // suitable only for entry removal.
-func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNConfiguration) []*knftables.Element {
+func getUDNNFTRules(service *corev1.Service, pktMark string) []*knftables.Element {
 	rules := make([]*knftables.Element, 0)
 	for _, svcPort := range service.Spec.Ports {
 		if util.ServiceTypeHasNodePort(service) {
-			rules = append(rules, getUDNNodePortMarkNFTRule(svcPort, netConfig))
+			rules = append(rules, getUDNNodePortMarkNFTRule(svcPort, pktMark))
 		}
-		rules = append(rules, getUDNExternalIPsMarkNFTRules(svcPort, util.GetExternalAndLBIPs(service), netConfig)...)
+		rules = append(rules, getUDNExternalIPsMarkNFTRules(svcPort, util.GetExternalAndLBIPs(service), pktMark)...)
 	}
 	return rules
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved support for network segmentation in gateway rules, applying per‑network packet marks and ensuring rules only apply on the primary network when segmentation is enabled.

- Bug Fixes
  - Enhanced robustness when the active network cannot be determined, gracefully skipping rule updates instead of failing.
  - More reliable add/remove of service rules for NodePort and ExternalIPs under segmented networks.

- Refactor
  - Streamlined NFT rule generation to reduce coupling and improve maintainability, aligning rule application across watchers and code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->