### PR TITLE
RunOVSAppctl() doesn't work when ovs is run on host and hostPID is false

### DIFF
--- a/go-controller/pkg/metrics/ovs.go
+++ b/go-controller/pkg/metrics/ovs.go
@@ -907,7 +907,7 @@ func registerOvsMetrics(ovsDBClient libovsdbclient.Client, metricsScrapeInterval
 		}
 
 		// OVS datapath metrics updater
-		go ovsDatapathMetricsUpdater(util.RunOVSAppctl, metricsScrapeInterval, stopChan)
+		go ovsDatapathMetricsUpdater(util.RunOvsVswitchdAppCtl, metricsScrapeInterval, stopChan)
 		// OVS bridge metrics updater
 		go ovsBridgeMetricsUpdater(ovsDBClient, util.RunOVSOfctl, metricsScrapeInterval, stopChan)
 		// OVS interface metrics updater

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -511,13 +511,7 @@ func setEncapPort(ctx context.Context) error {
 
 func isOVNControllerReady() (bool, error) {
 	// check node's connection status
-	runDir := util.GetOvnRunDir()
-	pid, err := os.ReadFile(runDir + "ovn-controller.pid")
-	if err != nil {
-		return false, fmt.Errorf("unknown pid for ovn-controller process: %v", err)
-	}
-	ctlFile := runDir + fmt.Sprintf("ovn-controller.%s.ctl", strings.TrimSuffix(string(pid), "\n"))
-	ret, _, err := util.RunOVSAppctl("-t", ctlFile, "connection-status")
+	ret, _, err := util.RunOVNControllerAppCtl("connection-status")
 	if err != nil {
 		return false, fmt.Errorf("could not get connection status: %w", err)
 	}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -362,11 +362,6 @@ func RunOVSAppctlWithTimeout(timeout int, args ...string) (string, string, error
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
-// RunOVSAppctl runs a command via ovs-appctl.
-func RunOVSAppctl(args ...string) (string, string, error) {
-	return RunOVSAppctlWithTimeout(ovsCommandTimeout, args...)
-}
-
 // RunOVNAppctlWithTimeout runs a command via ovn-appctl. If ovn-appctl is not present, then it
 // falls back to using ovs-appctl.
 func RunOVNAppctlWithTimeout(timeout int, args ...string) (string, string, error) {
@@ -802,7 +797,7 @@ func DetectSCTPSupport() (bool, error) {
 
 // DetectCheckPktLengthSupport checks if OVN supports check packet length action in OVS kernel datapath
 func DetectCheckPktLengthSupport(bridge string) (bool, error) {
-	stdout, stderr, err := RunOVSAppctl("dpif/show-dp-features", bridge)
+	stdout, stderr, err := RunOvsVswitchdAppCtl("dpif/show-dp-features", bridge)
 	if err != nil {
 		klog.Errorf("Failed to query OVS for check packet length support, "+
 			"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
@@ -824,7 +819,7 @@ func DetectCheckPktLengthSupport(bridge string) (bool, error) {
 func SetStaticFDBEntry(bridge, port string, mac net.HardwareAddr) error {
 	// Assume default VLAN for local port
 	vlan := "0"
-	stdout, stderr, err := RunOVSAppctl("fdb/add", bridge, port, vlan, mac.String())
+	stdout, stderr, err := RunOvsVswitchdAppCtl("fdb/add", bridge, port, vlan, mac.String())
 	if err != nil {
 		return fmt.Errorf("failed to add FDB entry to OVS for LOCAL port, "+
 			"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -1092,47 +1092,6 @@ func TestRunOVSAppctlWithTimeout(t *testing.T) {
 	}
 }
 
-func TestRunOVSAppctl(t *testing.T) {
-	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
-	mockExecRunner := new(mocks.ExecRunner)
-	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
-	// below is defined in ovs.go
-	runCmdExecRunner = mockExecRunner
-	// note runner is defined in ovs.go file
-	runner = &execHelper{exec: mockKexecIface}
-	tests := []struct {
-		desc                    string
-		expectedErr             error
-		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
-		onRetArgsKexecIface     *ovntest.TestifyMockHelper
-	}{
-		{
-			desc:                    "negative: run `ovs-appctl` command",
-			expectedErr:             fmt.Errorf("failed to execute ovs-appctl command"),
-			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-appctl command")}},
-			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
-		},
-		{
-			desc:                    "positive: run `ovs-appctl` command",
-			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
-		},
-	}
-	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
-			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
-
-			_, _, e := RunOVSAppctl()
-
-			assert.Equal(t, tc.expectedErr, e)
-			mockExecRunner.AssertExpectations(t)
-			mockKexecIface.AssertExpectations(t)
-		})
-	}
-}
-
 func TestRunOVNAppctlWithTimeout(t *testing.T) {
 	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
 	mockExecRunner := new(mocks.ExecRunner)


### PR DESCRIPTION
When OVS is run as system service on node, the /run/openvswitch/ovs-vswitchd.pid is locked by
ovs-vswitchd with its PID in host process ID namespace: 

```
$ lslocks  | grep ovs-vswitchd.pid 
COMMAND             PID   TYPE SIZE MODE  M      START        END PATH
ovs-vswitchd       1615  POSIX     5B WRITE 0          0          0 /run/openvswitch/ovs-vswitchd.pid

$ stat -Lc '%d:%i %n' /run/openvswitch/ovs-vswitchd.pid
25:5398 /run/openvswitch/ovs-vswitchd.pid
```

In ovnkube-node Pod, if hostPID is false, the ovs-vswitchd's PID is not visible inside the Pod's process
ID namespace, so the file lock becomes invisible as well, that causes ovs-appctl fail to run:

```
# kubectl  -n ovn-kubernetes exec -it -c ovnkube-controller  ovnkube-node-xyz -- bash

$ ovs-appctl fdb/show br-int
2025-10-14T19:18:36Z|00001|daemon_unix|WARN|/var/run/openvswitch/ovs-vswitchd.pid: stale pidfile for pid 1615
 being deleted by pid 0
ovs-appctl: cannot read pidfile "/var/run/openvswitch/ovs-vswitchd.pid" (No such process)
command terminated with exit code 1

$ stat -Lc '%d:%i %n' /run/openvswitch/ovs-vswitchd.pid
25:5398 /run/openvswitch/ovs-vswitchd.pid
```

Please refer to `read_pidfile__()` function in [ovs/lib/daemon-unix.c](https://github.com/openvswitch/ovs/blob/main/lib/daemon-unix.c#L670-L678)  

This change replaces RunOVSAppctl() with RunOvsVswitchdAppCtl(), which use `-t /var/run/openvswitch/ovs-vswitchd.1234.ctl` option to skip reading pid file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of datapath metrics collection and controller readiness checks to reduce false negatives.

* **Refactor**
  * Unified OVS/OVN control command execution to use a single appctl pathway, removing an older wrapper.

* **Tests**
  * Removed an obsolete test for the previous command wrapper and updated tests to use a mocked filesystem and fixed control-socket invocations for OVS interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->