### PR TITLE
chore: Remove SetTaintOnNode

### DIFF
--- a/go-controller/pkg/kube/kube_test.go
+++ b/go-controller/pkg/kube/kube_test.go
@@ -16,7 +16,6 @@ var _ = Describe("Kube", func() {
 	Describe("Taint node operations", func() {
 		var kube Kube
 		var existingNodeTaints []corev1.Taint
-		var taint corev1.Taint
 		var node *corev1.Node
 
 		BeforeEach(func() {
@@ -24,7 +23,6 @@ var _ = Describe("Kube", func() {
 			kube = Kube{
 				KClient: fakeClient,
 			}
-			taint = corev1.Taint{Key: "my-taint-key", Value: "my-taint-value", Effect: corev1.TaintEffectNoSchedule}
 		})
 
 		JustBeforeEach(func() {
@@ -42,90 +40,6 @@ var _ = Describe("Kube", func() {
 			node, err = kube.KClient.CoreV1().Nodes().Create(context.TODO(), newNode, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(node).NotTo(BeZero())
-		})
-
-		Context("with a node not having the taint", func() {
-
-			BeforeEach(func() {
-				existingNodeTaints = make([]corev1.Taint, 0)
-			})
-
-			Context("SetTaintOnNode", func() {
-				It("should add the taint to the node", func() {
-					err := kube.SetTaintOnNode(node.Name, &taint)
-					Expect(err).ToNot(HaveOccurred())
-
-					loadedNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(loadedNode.Spec.Taints).To(ContainElement(taint))
-				})
-			})
-
-			Context("RemoveTaintFromNode", func() {
-				It("should remove nothing from the node", func() {
-					err := kube.RemoveTaintFromNode(node.Name, &taint)
-					Expect(err).ToNot(HaveOccurred())
-
-					loadedNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(loadedNode.Spec.Taints).To(HaveLen(len(node.Spec.Taints)))
-				})
-			})
-		})
-
-		Context("with a node having the same taint already", func() {
-
-			BeforeEach(func() {
-				existingNodeTaints = []corev1.Taint{taint}
-			})
-
-			Context("SetTaintOnNode", func() {
-				It("should update the taint of the node if effect differs", func() {
-					updatedTaint := taint.DeepCopy()
-					updatedTaint.Effect = corev1.TaintEffectPreferNoSchedule
-
-					err := kube.SetTaintOnNode(node.Name, updatedTaint)
-					Expect(err).ToNot(HaveOccurred())
-
-					loadedNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(loadedNode.Spec.Taints).To(ContainElement(*updatedTaint))
-				})
-
-				It("should update nothing if taint is the same", func() {
-					err := kube.SetTaintOnNode(node.Name, &taint)
-					Expect(err).ToNot(HaveOccurred())
-
-					updatedNode, err := kube.GetNodeForWindows(node.Name)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(updatedNode.Spec.Taints).To(Equal([]corev1.Taint{taint}))
-				})
-			})
-
-			Context("RemoveTaintFromNode", func() {
-				It("should remove the taint from the node", func() {
-					err := kube.RemoveTaintFromNode(node.Name, &taint)
-					Expect(err).ToNot(HaveOccurred())
-
-					loadedNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(loadedNode.Spec.Taints).NotTo(ContainElement(taint))
-					Expect(loadedNode.Spec.Taints).To(HaveLen(len(node.Spec.Taints) - 1))
-				})
-			})
-		})
-
-		Context("with references to a node which doesn't exist", func() {
-
-			Context("SetTaintOnNode", func() {
-
-				It("should return an error, if node doesn't exist", func() {
-					nodeName := "targaryen"
-					err := kube.SetTaintOnNode(nodeName, &taint)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("nodes \"targaryen\" not found"))
-				})
-			})
 		})
 	})
 

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -145,24 +145,6 @@ func (_m *Interface) PatchNode(old *corev1.Node, new *corev1.Node) error {
 	return r0
 }
 
-// RemoveTaintFromNode provides a mock function with given fields: nodeName, taint
-func (_m *Interface) RemoveTaintFromNode(nodeName string, taint *corev1.Taint) error {
-	ret := _m.Called(nodeName, taint)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RemoveTaintFromNode")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *corev1.Taint) error); ok {
-		r0 = rf(nodeName, taint)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // SetAnnotationsOnNamespace provides a mock function with given fields: namespaceName, annotations
 func (_m *Interface) SetAnnotationsOnNamespace(namespaceName string, annotations map[string]interface{}) error {
 	ret := _m.Called(namespaceName, annotations)
@@ -246,24 +228,6 @@ func (_m *Interface) SetLabelsOnNode(nodeName string, labels map[string]interfac
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, map[string]interface{}) error); ok {
 		r0 = rf(nodeName, labels)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SetTaintOnNode provides a mock function with given fields: nodeName, taint
-func (_m *Interface) SetTaintOnNode(nodeName string, taint *corev1.Taint) error {
-	ret := _m.Called(nodeName, taint)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetTaintOnNode")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *corev1.Taint) error); ok {
-		r0 = rf(nodeName, taint)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/kube/mocks/InterfaceOVN.go
+++ b/go-controller/pkg/kube/mocks/InterfaceOVN.go
@@ -415,24 +415,6 @@ func (_m *InterfaceOVN) SetLabelsOnNode(nodeName string, labels map[string]inter
 	return r0
 }
 
-// SetTaintOnNode provides a mock function with given fields: nodeName, taint
-func (_m *InterfaceOVN) SetTaintOnNode(nodeName string, taint *apicorev1.Taint) error {
-	ret := _m.Called(nodeName, taint)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetTaintOnNode")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *apicorev1.Taint) error); ok {
-		r0 = rf(nodeName, taint)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // UpdateCloudPrivateIPConfig provides a mock function with given fields: cloudPrivateIPConfig
 func (_m *InterfaceOVN) UpdateCloudPrivateIPConfig(cloudPrivateIPConfig *v1.CloudPrivateIPConfig) (*v1.CloudPrivateIPConfig, error) {
 	ret := _m.Called(cloudPrivateIPConfig)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

Node-taints for too-small MTU were removed in #3004. Taints for NoSchedule were removed in #2459.
In general, it's not the CNI plugins responsibility to set node taints. This is for the kubelet/container runtime to figure out.

Therefore, it's safe to remove this unused code since it won't be required in future.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed node taint management operations from the public API, simplifying the interface and reducing surface area.
* **Tests**
  * Removed taint-related test suites and scenarios to align with the updated capabilities.
* **Chores**
  * Updated mocks to reflect the removal of taint operations and ensure consistency across tests and integrations.

These changes streamline the codebase and eliminate unsupported taint operations, with no impact on remaining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->