### PR TITLE
External Gateway E2E: Increase single target attempts

### DIFF
--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -93,6 +93,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 		podTCPPort          = 80
 		podUDPPort          = 90
 		singleTargetRetries = 50 // enough attempts to avoid hashing to the same gateway
+		bfdTimeout          = 4 * time.Second
 	)
 
 	// Validate pods can reach a network running in a container's loopback address via
@@ -1111,7 +1112,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 							ginkgo.By("Deleting one container")
 							err := providerCtx.DeleteExternalContainer(gwContainers[1])
 							framework.ExpectNoError(err, "failed to delete external container %s", gwContainers[1].Name)
-							time.Sleep(3 * time.Second) // bfd timeout
+							time.Sleep(bfdTimeout)
 
 							tcpDumpSync = sync.WaitGroup{}
 							tcpDumpSync.Add(1)
@@ -1189,7 +1190,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 							err := providerCtx.DeleteExternalContainer(gwContainers[1])
 							framework.ExpectNoError(err, "failed to delete external container %s", gwContainers[1].Name)
 							ginkgo.By("Waiting for BFD to sync")
-							time.Sleep(3 * time.Second) // bfd timeout
+							time.Sleep(bfdTimeout)
 
 							// ECMP should direct all the traffic to the only container
 							expectedHostName := hostNameForExternalContainer(gwContainers[0])
@@ -1328,7 +1329,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 					ginkgo.By("Deleting one container")
 					err := providerCtx.DeleteExternalContainer(gwContainers[1])
 					framework.ExpectNoError(err, "failed to delete external container %s", gwContainers[1].Name)
-					time.Sleep(3 * time.Second) // bfd timeout
+					time.Sleep(bfdTimeout)
 
 					pingSync = sync.WaitGroup{}
 					tcpDumpSync = sync.WaitGroup{}
@@ -1409,7 +1410,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 					err := providerCtx.DeleteExternalContainer(gwContainers[1])
 					framework.ExpectNoError(err, "failed to delete external container %s", gwContainers[1].Name)
 					ginkgo.By("Waiting for BFD to sync")
-					time.Sleep(3 * time.Second) // bfd timeout
+					time.Sleep(bfdTimeout)
 
 					// ECMP should direct all the traffic to the only container
 					expectedHostName := hostNameForExternalContainer(gwContainers[0])
@@ -2216,7 +2217,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 							err := providerCtx.DeleteExternalContainer(gwContainers[1])
 							framework.ExpectNoError(err, "failed to delete external container %s", gwContainers[1].Name)
 
-							time.Sleep(3 * time.Second) // bfd timeout
+							time.Sleep(bfdTimeout)
 
 							tcpDumpSync = sync.WaitGroup{}
 							tcpDumpSync.Add(1)
@@ -2296,7 +2297,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 							err := providerCtx.DeleteExternalContainer(gwContainers[1])
 							framework.ExpectNoError(err, "failed to delete external container %s", gwContainers[1].Name)
 							ginkgo.By("Waiting for BFD to sync")
-							time.Sleep(3 * time.Second) // bfd timeout
+							time.Sleep(bfdTimeout)
 
 							// ECMP should direct all the traffic to the only container
 							expectedHostName := hostNameForExternalContainer(gwContainers[0])
@@ -2433,7 +2434,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 					ginkgo.By("Deleting one container")
 					err := providerCtx.DeleteExternalContainer(gwContainers[1])
 					framework.ExpectNoError(err, "failed to delete external container %s", gwContainers[1].Name)
-					time.Sleep(3 * time.Second) // bfd timeout
+					time.Sleep(bfdTimeout)
 
 					pingSync = sync.WaitGroup{}
 					tcpDumpSync = sync.WaitGroup{}
@@ -2513,7 +2514,7 @@ var _ = ginkgo.Describe("External Gateway", feature.ExternalGateway, func() {
 					err := providerCtx.DeleteExternalContainer(gwContainers[1])
 					framework.ExpectNoError(err, "failed to delete external container %s", gwContainers[1].Name)
 					ginkgo.By("Waiting for BFD to sync")
-					time.Sleep(3 * time.Second) // bfd timeout
+					time.Sleep(bfdTimeout)
 
 					// ECMP should direct all the traffic to the only container
 					expectedHostName := hostNameForExternalContainer(gwContainers[0])


### PR DESCRIPTION
While trying to reproduce flakes with these tests, this is the thing I could reproduce easily. In the tests we add 20 target IPs to each gateway, then we ping them to make sure they go to each gateway and get resolved. However, for TCP/UDP tests, we only run a listener on one of the target IPs. Then we would attempt to contact the listenter from a source pod 20 times, and check that it hit both gateways.

In my testing, I can easily run these tests in a loop and see it fail, due to all 20 of the attempts hashing to the same gateway, and never hitting the other gateway. I bumped it to 50, and ran it all night and do not see the issue anymore.

Not sure if this fixes all of the flakes we see with these tests, as the logs have gone stale for other runs, but will consider this closed for now and then if we see more flakes reopen it.

Closes: #4432

*Update* - Also hit the BFD CI flake and although I cannot reproduce it, I found that the BFD sleep in the test is too low, fixed it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased retry threshold in external gateway end-to-end tests to improve stability under variable timing and hashing behavior.
  * Replaced scattered hard-coded limits with a single test constant for consistency.
  * Reduced flakiness when probing reachability and hostnames by allowing more attempts before failing.
  * No impact to production behavior. Helps standardize test expectations across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->