### PR TITLE
Reintroduce completed pod check in shouldReleaseDeletedPod

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -1045,6 +1045,12 @@ func (bnc *BaseNetworkController) shouldReleaseDeletedPod(pod *corev1.Pod, switc
 		}
 	}
 
+	// this pod is being deleted before completion so there is no risk (and no
+	// need to check) that its IPs are being used by other pod
+	if !util.PodCompleted(pod) {
+		return true, nil
+	}
+
 	if bnc.wasPodReleasedBeforeStartup(string(pod.UID), nad) {
 		klog.Infof("Completed pod %s/%s was already released for nad %s before startup",
 			pod.Namespace,

--- a/go-controller/pkg/ovn/base_network_controller_pods_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods_test.go
@@ -234,3 +234,41 @@ func TestBaseNetworkController_trackPodsReleasedBeforeStartup(t *testing.T) {
 		})
 	}
 }
+
+func TestBaseNetworkController_shouldReleaseDeletedPod(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		pod        *corev1.Pod
+		switchName string
+		nad        string
+		podIfAddrs []*net.IPNet
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name: "should release a running pod",
+			pod:  &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bnc BaseNetworkController
+			bnc.ReconcilableNetInfo = &util.DefaultNetInfo{}
+			got, gotErr := bnc.shouldReleaseDeletedPod(tt.pod, tt.switchName, tt.nad, tt.podIfAddrs)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("shouldReleaseDeletedPod() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("shouldReleaseDeletedPod() succeeded unexpectedly")
+			}
+			if got != tt.want {
+				t.Errorf("shouldReleaseDeletedPod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I accidentally removed the check in recent PR [1] which could have performance consequences as checking against other pods has a cost. Reintroduce the check with a hopefully useful comment to prevent it form happening again.

[1] https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod deletion handling improved: IPs for pods deleted before completion are now released immediately, reducing stale allocations and scheduling delays.
  * Lowers risk of IP exhaustion during high churn and speeds network cleanup for better cluster stability and responsiveness.

* **Tests**
  * Added unit tests covering the pod deletion IP-release behavior to ensure correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->