### PR TITLE
UT: set up fake OVS pid file for appctl commands in UDN controller tests

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/testutils"
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	"github.com/k8snetworkplumbingwg/sriovnet"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
@@ -260,10 +259,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		// syncServices()
 
 		// Setup mock filesystem for ovs-vswitchd.pid file needed by ovs-appctl commands
-		err := util.AppFs.MkdirAll("/var/run/openvswitch/", 0o755)
-		Expect(err).NotTo(HaveOccurred())
-		err = afero.WriteFile(util.AppFs, "/var/run/openvswitch/ovs-vswitchd.pid", []byte("1234"), 0o644)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(util.SetupMockOVSPidFile()).To(Succeed())
 
 		err = util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
@@ -715,12 +711,9 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		// syncServices()
 
 		// Setup mock filesystem for ovs-vswitchd.pid file needed by ovs-appctl commands
-		err := util.AppFs.MkdirAll("/var/run/openvswitch/", 0o755)
-		Expect(err).NotTo(HaveOccurred())
-		err = afero.WriteFile(util.AppFs, "/var/run/openvswitch/ovs-vswitchd.pid", []byte("1234"), 0o644)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(util.SetupMockOVSPidFile()).To(Succeed())
 
-		err = util.SetExec(fexec)
+		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = config.InitConfig(ctx, fexec, nil)
@@ -1185,12 +1178,9 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		// syncServices()
 
 		// Setup mock filesystem for ovs-vswitchd.pid file needed by ovs-appctl commands
-		err := util.AppFs.MkdirAll("/var/run/openvswitch/", 0o755)
-		Expect(err).NotTo(HaveOccurred())
-		err = afero.WriteFile(util.AppFs, "/var/run/openvswitch/ovs-vswitchd.pid", []byte("1234"), 0o644)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(util.SetupMockOVSPidFile()).To(Succeed())
 
-		err = util.SetExec(fexec)
+		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = config.InitConfig(ctx, fexec, nil)

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/testutils"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -295,8 +294,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		// Set up a fake vsctl command mock interface
 		fexec = ovntest.NewFakeExec()
 		// Setup mock filesystem for ovs-vswitchd.pid file needed by ovs-appctl commands
-		Expect(util.AppFs.MkdirAll("/var/run/openvswitch/", 0o755)).To(Succeed())
-		Expect(afero.WriteFile(util.AppFs, "/var/run/openvswitch/ovs-vswitchd.pid", []byte("1234"), 0o644)).To(Succeed())
+		Expect(util.SetupMockOVSPidFile()).To(Succeed())
 		Expect(util.SetExec(fexec)).To(Succeed())
 		// Set up a fake k8sMgmt interface
 		testNS, err = testutils.NewNS()

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -57,6 +57,8 @@ var _ = Describe("UserDefinedNodeNetworkController", func() {
 		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/17"
 		// Set up a fake vsctl command mock interface
 		fexec = ovntest.NewFakeExec()
+		// Setup mock filesystem for ovs-vswitchd.pid file needed by ovs-appctl commands
+		Expect(util.SetupMockOVSPidFile()).To(Succeed())
 		Expect(util.SetExec(fexec)).To(Succeed())
 		ovntest.AnnotateNADWithNetworkID(networkID, nad)
 		ovntest.AddLink("breth0")
@@ -185,6 +187,8 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 		// Set up a fake vsctl command mock interface
 		kubeMock = kubemocks.Interface{}
 		fexec = ovntest.NewFakeExec()
+		// Setup mock filesystem for ovs-vswitchd.pid file needed by ovs-appctl commands
+		Expect(util.SetupMockOVSPidFile()).To(Succeed())
 		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
 		// Set up a fake k8sMgmt interface

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -73,6 +73,15 @@ func PrepareTestConfig() {
 	ovnRunDir = savedOVNRunDir
 }
 
+// SetupMockOVSPidFile setup mock filesystem for ovs-vswitchd.pid file.
+func SetupMockOVSPidFile() error {
+	err := AppFs.MkdirAll("/var/run/openvswitch/", 0o755)
+	if err != nil {
+		return err
+	}
+	return afero.WriteFile(AppFs, "/var/run/openvswitch/ovs-vswitchd.pid", []byte("1234"), 0o644)
+}
+
 func runningPlatform() (string, error) {
 	if runtime.GOOS == windowsOS {
 		return windowsOS, nil


### PR DESCRIPTION
The UDN node network controller unit tests did not create an `ovs-vswitchd.pid` file required by ovs-appctl commands. Instead, they reused the file from other node tests. This caused failures when the UDN tests ran first, before those other tests created the pid file.

This PR fixes the issue by setting up a fake `ovs-vswitchd.pid` file within the UDN node network controller tests as well.

Failure Link: https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/18724028091/job/53403865435?pr=5606

```
2025-10-22T17:20:45.1380178Z E1022 17:20:45.136232   41666 ovs.go:802] Failed to query OVS for check packet length support, stdout: "", stderr: "", error: failed to get ovs-vswitch pid : open /var/run/openvswitch/ovs-vswitchd.pid: no such file or directory
2025-10-22T17:20:45.1453717Z I1022 17:20:45.142120   41666 watch.go:218] "Stopping fake watcher"
2025-10-22T17:20:45.1454611Z I1022 17:20:45.142151   41666 watch.go:218] "Stopping fake watcher"
2025-10-22T17:20:45.1455732Z I1022 17:20:45.142222   41666 watch.go:218] "Stopping fake watcher"
2025-10-22T17:20:45.1456607Z I1022 17:20:45.142250   41666 watch.go:218] "Stopping fake watcher"
2025-10-22T17:20:45.1457339Z I1022 17:20:45.142336   41666 watch.go:218] "Stopping fake watcher"
2025-10-22T17:20:45.1458057Z I1022 17:20:45.142435   41666 watch.go:218] "Stopping fake watcher"
2025-10-22T17:20:45.1458954Z I1022 17:20:45.142441   41666 watch.go:218] "Stopping fake watcher"
2025-10-22T17:20:45.1460499Z I1022 17:20:45.142506   41666 reflector.go:363] "Stopping reflector" type="*v1.ClusterUserDefinedNetwork" resyncPeriod="0s" reflector="pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:140"
2025-10-22T17:20:45.1462946Z I1022 17:20:45.142507   41666 watch.go:218] "Stopping fake watcher"
2025-10-22T17:20:45.1464003Z I1022 17:20:45.142549   41666 reflector.go:363] "Stopping reflector" type="*v1.Namespace" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:160"
2025-10-22T17:20:45.1465789Z I1022 17:20:45.142580   41666 reflector.go:363] "Stopping reflector" type="*v1.UserDefinedNetwork" resyncPeriod="0s" reflector="pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:140"
2025-10-22T17:20:45.1467788Z I1022 17:20:45.142596   41666 reflector.go:363] "Stopping reflector" type="*v1.Pod" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:160"
2025-10-22T17:20:45.1469491Z I1022 17:20:45.142721   41666 reflector.go:363] "Stopping reflector" type="*v1.Node" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:160"
2025-10-22T17:20:45.1470918Z I1022 17:20:45.143101   41666 reflector.go:363] "Stopping reflector" type="*v1.Service" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:160"
2025-10-22T17:20:45.1473062Z I1022 17:20:45.143248   41666 reflector.go:363] "Stopping reflector" type="*v1.NetworkAttachmentDefinition" resyncPeriod="0s" reflector="github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/factory.go:117"
2025-10-22T17:20:45.1475203Z I1022 17:20:45.144244   41666 reflector.go:363] "Stopping reflector" type="*v1.EndpointSlice" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:160"
2025-10-22T17:20:45.1570715Z I1022 17:20:45.156859   41666 factory.go:642] Stopping watch factory
2025-10-22T17:20:45.1588475Z   [38;5;9m[FAILED][0m in [It] - /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/user_defined_node_network_controller_test.go:406 [38;5;243m@ 10/22/25 17:20:45.158[0m
2025-10-22T17:20:45.1594737Z E1022 17:20:45.158811   41666 vrf_manager.go:52] Failed during LinkSubscribe callback: Receive failed: resource temporarily unavailable
2025-10-22T17:20:45.1597123Z [38;5;9m• [FAILED] [0.322 seconds][0m
2025-10-22T17:20:45.1600286Z [0mUserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Gateway functionality [38;5;9m[1m[It] ensure UDNGateway and VRFManager and IPRulesManager are invoked for Primary UDNs when feature gate is ON[0m
2025-10-22T17:20:45.1602379Z [38;5;243m/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/testing.go:16[0m
2025-10-22T17:20:45.1603049Z 
2025-10-22T17:20:45.1603410Z   [38;5;9m[FAILED] Unexpected error:
2025-10-22T17:20:45.1604002Z       <*errors.errorString | 0xc0081de010>: 
2025-10-22T17:20:45.1605062Z       failed to get ovs-vswitch pid : open /var/run/openvswitch/ovs-vswitchd.pid: no such file or directory
2025-10-22T17:20:45.1605836Z       {
2025-10-22T17:20:45.1606987Z           s: "failed to get ovs-vswitch pid : open /var/run/openvswitch/ovs-vswitchd.pid: no such file or directory",
2025-10-22T17:20:45.1607729Z       }
2025-10-22T17:20:45.1608093Z   occurred[0m
2025-10-22T17:20:45.1609997Z   [38;5;9mIn [1m[It][0m[38;5;9m at: [1m/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/user_defined_node_network_controller_test.go:406[0m [38;5;243m@ 10/22/25 17:20:45.158[0m
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test environment setup to make tests more reliable by ensuring required runtime artifacts are present for command interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->