### PR TITLE
Skip IPv6 UDP tests affected by GH Runner issue

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -18,6 +18,8 @@ export KUBECONFIG=${KUBECONFIG:-${HOME}/ovn.conf}
 # https://github.com/ovn-org/ovn-kubernetes/issues/4131 for details.
 # TODO: Fix EIP tests. See https://github.com/ovn-org/ovn-kubernetes/issues/4130 for details.
 # TODO: Fix MTU tests. See https://github.com/ovn-org/ovn-kubernetes/issues/4160 for details.
+# "be able to send multicast UDP traffic between nodes" broken by https://github.com/actions/runner-images/issues/13190
+# "Services of type NodePort.*should handle IP fragments" broken by https://github.com/actions/runner-images/issues/13190
 IPV6_SKIPPED_TESTS="Should be allowed by externalip services|\
 should provide connection to external host by DNS name from a pod|\
 should provide Internet connection continuously when ovnkube-node pod is killed|\
@@ -30,7 +32,9 @@ test node readiness according to its defaults interface MTU size|\
 Pod to pod TCP with low MTU|\
 queries to the hostNetworked server pod on another node shall work for TCP|\
 queries to the hostNetworked server pod on another node shall work for UDP|\
-ipv4 pod"
+ipv4 pod|\
+be able to send multicast UDP traffic between nodes|\
+Services of type NodePort.*should handle IP fragments"
 
 SKIPPED_TESTS=""
 skip() {

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -127,13 +127,19 @@ RA_SKIPPED_TESTS="
 \[sig-network\] Services should fallback to local terminating endpoints when there are no ready endpoints with externalTrafficPolicy=Local
 "
 
+# REMOVE when https://github.com/actions/runner-images/issues/13190 is fixed
+GH_RUNNER_IPv6_SKIPPED="
+Granular Checks.*Services.*should be able to handle large requests.*udp
+Granular Checks.*Services.*should function for service endpoints using hostNetwork
+"
+
 # Github CI doesn´t offer IPv6 connectivity, so always skip IPv6 only tests.
 #  See: https://github.com/ovn-org/ovn-kubernetes/issues/1522
 SKIPPED_TESTS=$SKIPPED_TESTS$IPV6_ONLY_TESTS
 
 # Either single stack IPV6 or dualstack
 if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-  SKIPPED_TESTS=$SKIPPED_TESTS$SINGLESTACK_IPV4_ONLY_TESTS
+  SKIPPED_TESTS=$SKIPPED_TESTS$SINGLESTACK_IPV4_ONLY_TESTS$GH_RUNNER_IPv6_SKIPPED
 fi
 
 # IPv6 Only, skip any IPv4 Only Tests


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/13190



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consistently skip multicast UDP and related flaky NodePort/IP-fragment scenarios across IPv4 and IPv6 test paths; added runner-specific IPv6 skip patterns and extended the IPv4 pod skip list to match.
* **Documentation**
  * Added a DPU Healthcheck enhancement proposal covering goals, design, user stories, testing, and risks.
  * Added the DPU Healthcheck entry to the site navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->