### PR TITLE
EIP: Change capacity storage to pointers

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1313,20 +1313,20 @@ func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []
 			if egressIPNetwork == "" {
 				continue
 			}
-			if eNode.egressIPConfig.Capacity.IP < util.UnlimitedNodeCapacity {
-				if eNode.egressIPConfig.Capacity.IP-len(eNode.allocations) <= 0 {
+			if eNode.egressIPConfig.Capacity.IP != nil && *eNode.egressIPConfig.Capacity.IP < util.UnlimitedNodeCapacity {
+				if *eNode.egressIPConfig.Capacity.IP-len(eNode.allocations) <= 0 {
 					klog.V(5).Infof("Additional allocation on Node: %s exhausts it's IP capacity, trying another node", eNode.name)
 					continue
 				}
 			}
-			if eNode.egressIPConfig.Capacity.IPv4 < util.UnlimitedNodeCapacity && utilnet.IsIPv4(eIP) {
-				if eNode.egressIPConfig.Capacity.IPv4-getIPFamilyAllocationCount(eNode.allocations, false) <= 0 {
+			if eNode.egressIPConfig.Capacity.IPv4 != nil && *eNode.egressIPConfig.Capacity.IPv4 < util.UnlimitedNodeCapacity && utilnet.IsIPv4(eIP) {
+				if *eNode.egressIPConfig.Capacity.IPv4-getIPFamilyAllocationCount(eNode.allocations, false) <= 0 {
 					klog.V(5).Infof("Additional allocation on Node: %s exhausts it's IPv4 capacity, trying another node", eNode.name)
 					continue
 				}
 			}
-			if eNode.egressIPConfig.Capacity.IPv6 < util.UnlimitedNodeCapacity && utilnet.IsIPv6(eIP) {
-				if eNode.egressIPConfig.Capacity.IPv6-getIPFamilyAllocationCount(eNode.allocations, true) <= 0 {
+			if eNode.egressIPConfig.Capacity.IPv6 != nil && *eNode.egressIPConfig.Capacity.IPv6 < util.UnlimitedNodeCapacity && utilnet.IsIPv6(eIP) {
+				if *eNode.egressIPConfig.Capacity.IPv6-getIPFamilyAllocationCount(eNode.allocations, true) <= 0 {
 					klog.V(5).Infof("Additional allocation on Node: %s exhausts it's IPv6 capacity, trying another node", eNode.name)
 					continue
 				}

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -142,10 +142,11 @@ func newCloudPrivateIPConfigMeta(egressIP string) metav1.ObjectMeta {
 }
 
 func setupNode(nodeName string, ipNets []string, mockAllocationIPs map[string]string) egressNode {
+	unlimited := util.UnlimitedNodeCapacity
 	var config = &util.ParsedNodeEgressIPConfiguration{Capacity: util.Capacity{
-		IP:   util.UnlimitedNodeCapacity,
-		IPv4: util.UnlimitedNodeCapacity,
-		IPv6: util.UnlimitedNodeCapacity,
+		IP:   &unlimited,
+		IPv4: &unlimited,
+		IPv6: &unlimited,
 	}}
 	for _, ipNetStr := range ipNets {
 		ip, ipNet, _ := net.ParseCIDR(ipNetStr)

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -580,9 +580,9 @@ type ifAddr struct {
 }
 
 type Capacity struct {
-	IPv4 int `json:"ipv4,omitempty"`
-	IPv6 int `json:"ipv6,omitempty"`
-	IP   int `json:"ip,omitempty"`
+	IPv4 *int `json:"ipv4,omitempty"`
+	IPv6 *int `json:"ipv6,omitempty"`
+	IP   *int `json:"ip,omitempty"`
 }
 
 type nodeEgressIPConfiguration struct {
@@ -623,12 +623,13 @@ func ParseNodePrimaryIfAddr(node *corev1.Node) (*ParsedNodeEgressIPConfiguration
 	if err != nil {
 		return nil, err
 	}
+	unlimited := UnlimitedNodeCapacity
 	nodeEgressIPConfig := nodeEgressIPConfiguration{
 		IFAddr: ifAddr(*nodeIfAddr),
 		Capacity: Capacity{
-			IP:   UnlimitedNodeCapacity,
-			IPv4: UnlimitedNodeCapacity,
-			IPv6: UnlimitedNodeCapacity,
+			IP:   &unlimited,
+			IPv4: &unlimited,
+			IPv6: &unlimited,
 		},
 	}
 	parsedEgressIPConfig, err := parseNodeEgressIPConfig(&nodeEgressIPConfig)
@@ -742,12 +743,13 @@ func ParseCloudEgressIPConfig(node *corev1.Node) (*ParsedNodeEgressIPConfigurati
 	if !ok {
 		return nil, newAnnotationNotSetError("%s annotation not found for node %q", cloudEgressIPConfigAnnotationKey, node.Name)
 	}
+	unlimited := UnlimitedNodeCapacity
 	nodeEgressIPConfig := []nodeEgressIPConfiguration{
 		{
 			Capacity: Capacity{
-				IP:   UnlimitedNodeCapacity,
-				IPv4: UnlimitedNodeCapacity,
-				IPv6: UnlimitedNodeCapacity,
+				IP:   &unlimited,
+				IPv4: &unlimited,
+				IPv6: &unlimited,
 			},
 		},
 	}


### PR DESCRIPTION
We need to differentiate between
the field not being set and field
being set to 0 which means no
available capacity on that node.

## 📑 Description
<!-- Add a brief description of the pr -->

See https://github.com/openshift/cloud-network-config-controller/pull/183 for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node capacity handling in egress IP allocation to better support edge cases where capacity metrics are unavailable or incomplete, enhancing system stability and preventing potential allocation failures during node selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->