### PR TITLE
[layer2] Add tunnel key for local port connecting TR with L2 switch.

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -437,6 +437,14 @@ func (bnc *BaseNetworkController) syncNodeClusterRouterPort(node *corev1.Node, h
 			libovsdbops.GatewayMTU: strconv.Itoa(config.Default.MTU),
 		}
 	}
+	if bnc.TopologyType() == types.Layer2Topology {
+		// In layer2 topology transit router is a distributed router, so even local ports need to have a tunnel key.
+		// we reserve the same tunnel key for all transit router to l2 switch ports on all nodes.
+		if lrpOptions == nil {
+			lrpOptions = make(map[string]string)
+		}
+		lrpOptions[libovsdbops.RequestedTnlKey] = strconv.Itoa(transitRouterToSwitchTunnelKey)
+	}
 	logicalRouterPort := nbdb.LogicalRouterPort{
 		Name:     lrpName,
 		MAC:      nodeLRPMAC.String(),

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -395,7 +395,7 @@ func (gw *GatewayManager) createGWRouterPeerRouterPort() error {
 		MAC:      util.IPAddrToHWAddr(gw.transitRouterInfo.transitRouterNets[0].IP).String(),
 		Networks: util.IPNetsToStringSlice(gw.transitRouterInfo.transitRouterNets),
 		Options: map[string]string{
-			libovsdbops.RequestedTnlKey: fmt.Sprintf("%d", gw.transitRouterInfo.nodeID),
+			libovsdbops.RequestedTnlKey: getTransitRouterPortTunnelKey(gw.transitRouterInfo.nodeID),
 		},
 		Peer: ptr.To(gwRouterPortName),
 		ExternalIDs: map[string]string{

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -870,7 +870,7 @@ func (oc *Layer2UserDefinedNetworkController) addRouterSetupForRemoteNodeGR(node
 		MAC:      util.IPAddrToHWAddr(transitRouterInfo.transitRouterNets[0].IP).String(),
 		Networks: util.IPNetsToStringSlice(transitRouterInfo.transitRouterNets),
 		Options: map[string]string{
-			libovsdbops.RequestedTnlKey:  strconv.Itoa(transitRouterInfo.nodeID),
+			libovsdbops.RequestedTnlKey:  getTransitRouterPortTunnelKey(transitRouterInfo.nodeID),
 			libovsdbops.RequestedChassis: node.Name,
 		},
 		ExternalIDs: map[string]string{

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -768,14 +768,17 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 			Networks:       []string{"100.200.0.1/16"},
 			MAC:            "0a:58:64:c8:00:01",
 			GatewayChassis: []string{gatewayChassisUUID},
-			Options:        map[string]string{libovsdbops.GatewayMTU: "1400"},
+			Options: map[string]string{
+				libovsdbops.GatewayMTU:      "1400",
+				libovsdbops.RequestedTnlKey: "1", // as defined by getTransitRouterPortTunnelKey(nodeID)
+			},
 		},
 		&nbdb.LogicalRouterPort{
 			UUID:        rtorLRPUUID,
 			Name:        rtorLRPName,
 			Networks:    []string{trInfo.transitRouterNets[0].String()},
 			MAC:         util.IPAddrToHWAddr(trInfo.transitRouterNets[0].IP).String(),
-			Options:     map[string]string{libovsdbops.RequestedTnlKey: "4"},
+			Options:     map[string]string{libovsdbops.RequestedTnlKey: "14"},
 			Peer:        ptr.To(fmt.Sprintf("%s%s", ovntypes.RouterToTransitRouterPrefix, gwRouterName)),
 			ExternalIDs: standardNonDefaultNetworkExtIDs(netInfo),
 		},
@@ -800,7 +803,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 			Networks: []string{remoteTRInfo.transitRouterNets[0].String()},
 			MAC:      util.IPAddrToHWAddr(remoteTRInfo.transitRouterNets[0].IP).String(),
 			Options: map[string]string{
-				libovsdbops.RequestedTnlKey:  "5",
+				libovsdbops.RequestedTnlKey:  "15", // as defined by getTransitRouterPortTunnelKey(nodeID)
 				libovsdbops.RequestedChassis: staleNodeName},
 			ExternalIDs: externalIDs,
 		}

--- a/go-controller/pkg/ovn/transit_router.go
+++ b/go-controller/pkg/ovn/transit_router.go
@@ -11,6 +11,18 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
+const (
+	// reserve 1-9 keys for any future local ports that may be needed.
+	// currently we only use 1 local port to connect transit router to the layer2 switch
+	transitRouterPortFirstTunnelKey = 10
+	// reserve tunnel key = 1 for transitRouterToSwitch port
+	transitRouterToSwitchTunnelKey = 1
+)
+
+func getTransitRouterPortTunnelKey(nodeID int) string {
+	return fmt.Sprintf("%d", transitRouterPortFirstTunnelKey+nodeID)
+}
+
 type transitRouterInfo struct {
 	gatewayRouterNets, transitRouterNets []*net.IPNet
 	nodeID                               int


### PR DESCRIPTION
Use key 1 for transit router to switch port, reserve keys 1-9 for potential local ports in the future.

Based on discussion here https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5246#discussion_r2448010535.
It is safe to change tunnel keys now before the next release
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tunnel key assignment for transit router ports in Layer2 topology configurations
  * Enhanced gateway port tunnel key handling to ensure consistent port identification across multi-node deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->