### PR TITLE
Properly clean up OVSDB clients in both shutdown and error paths

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -149,6 +149,7 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 	go func() {
 		<-stopCh
 		cancel()
+		c.Close()
 	}()
 
 	// Only Monitor Required SBDB tables to reduce memory overhead
@@ -173,6 +174,7 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		),
 	)
 	if err != nil {
+		cancel()
 		c.Close()
 		return nil, err
 	}
@@ -214,10 +216,12 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 	go func() {
 		<-stopCh
 		cancel()
+		c.Close()
 	}()
 
 	_, err = c.MonitorAll(ctx)
 	if err != nil {
+		cancel()
 		c.Close()
 		return nil, err
 	}
@@ -248,6 +252,7 @@ func NewOVSClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (c
 	go func() {
 		<-stopCh
 		cancel()
+		c.Close()
 	}()
 
 	_, err = c.Monitor(ctx,
@@ -259,6 +264,7 @@ func NewOVSClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (c
 		),
 	)
 	if err != nil {
+		cancel()
 		c.Close()
 		return nil, err
 	}


### PR DESCRIPTION
Changes:
- Add c.Close() in shutdown goroutines to release client resources (connections, file descriptors, readLoop goroutines) when stopCh is signaled
- Add cancel() in error paths to stop context timeout timers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved connection resource cleanup to prevent leaks during shutdown and error handling, enhancing system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->