### PR TITLE
Fix MultiNetworkPolicy blocking reply packets on secondary Layer3 UDNs

### DIFF
--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -742,7 +742,7 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 		}
 	}
 
-	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
+	if util.IsNetworkSegmentationSupportEnabled() {
 		if nSyncs.syncMgmtPort {
 			hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, oc.GetNetworkName())
 			if err != nil {

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -118,6 +118,16 @@ func withClusterPortGroup() option {
 	}
 }
 
+func (em *userDefinedNetworkExpectationMachine) shouldExpectManagementPort(topology string) bool {
+	if topology == ovntypes.Layer3Topology {
+		return true
+	}
+	if topology == ovntypes.Layer2Topology {
+		return em.gatewayConfig != nil
+	}
+	return false
+}
+
 func (em *userDefinedNetworkExpectationMachine) expectedLogicalSwitchesAndPorts(isPrimary bool) []libovsdbtest.TestData {
 	return em.expectedLogicalSwitchesAndPortsWithLspEnabled(isPrimary, nil)
 }
@@ -181,7 +191,7 @@ func (em *userDefinedNetworkExpectationMachine) expectedLogicalSwitchesAndPortsW
 					nodeslsps[switchName] = append(nodeslsps[switchName], switchToRouterPortUUID)
 
 					if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&
-						em.gatewayConfig != nil {
+						em.shouldExpectManagementPort(ovntypes.Layer3Topology) {
 						mgmtPortName := managementPortName(switchName)
 						mgmtPortUUID := mgmtPortName + "-UUID"
 						mgmtPort := expectedManagementPort(mgmtPortName, managementIP)
@@ -199,7 +209,7 @@ func (em *userDefinedNetworkExpectationMachine) expectedLogicalSwitchesAndPortsW
 					managementIP := managementPortIP(subnet)
 
 					if _, alreadyAdded := alreadyAddedManagementElements[pod.nodeName]; !alreadyAdded &&
-						em.gatewayConfig != nil {
+						em.shouldExpectManagementPort(ovntypes.Layer2Topology) {
 						// there are multiple mgmt ports in the cluster, thus the ports must be scoped with the node name
 						mgmtPortName := managementPortName(ocInfo.bnc.GetNetworkScopedName(nodeName))
 						mgmtPortUUID := mgmtPortName + "-UUID"


### PR DESCRIPTION
  ---
  ## 📑 Description

 MultiNetworkPolicy on secondary UDN incorrectly blocks egress reply packets from pods
  when only ingress is denied. This occurs because reply packets from connections initiated by the pod are treated
   as new ingress traffic and blocked by the deny policy.

  Root Cause:
  Secondary UDNs were not getting management ports created, without management ports, the NetpolNode ACL (with action=allow-related) was never attached  to UDN logical switches, preventing OVN connection tracking from working properly.

  This PR allows secondary UDNs to get management ports created.

  Fixes #5667

  ## Additional Information for reviewers


  ## ✅ Checks
  - [ ] My code requires changes to the documentation
  - [ ] if so, I have updated the documentation as required
  - [x] My code requires tests
  - [x] if so, I have added and/or updated the tests as required
  - [] All the tests have passed in the CI

  ## How to verify it
  **Unit tests:**

  **Manual verification (optional):**
   Check details in reported issue


  ---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**

* **Tests**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->