### PR TITLE
[WIP] docs: how to add openvswitch bridge

### DIFF
--- a/docs/getting-started/ovs-bridge-config.md
+++ b/docs/getting-started/ovs-bridge-config.md
@@ -1,0 +1,26 @@
+# Configure OpenvSwitch Bridge
+
+Configure OpenvSwitch Bridge
+
+##  Netplan (Debian/Ubuntu)
+Here is example netplan config which configures OpenvSwitch bridge
+```
+network:
+  version: 2
+  ethernets:
+    enp0s3:
+      dhcp4: no
+  bridges:
+    brext:
+      dhcp4: no
+      addresses:
+      - 192.168.122.11/24
+      gateway4: 192.168.122.1
+      nameservers:
+        addresses:
+        - 8.8.8.8
+      interfaces:
+      - enp0s3
+      openvswitch: {}
+```
+Run `netplan try` or `netplan apply` to apply the config


### PR DESCRIPTION
This commit briefly documents how to create openvswitch bridge on major linux distributions if you intend to maintain the bridge by yourself.

Fixes: #5662
Document how to add openvswitch bridge br-ex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New documentation guide added for configuring OpenvSwitch bridges using Netplan on Debian and Ubuntu systems. Includes comprehensive examples covering static IP address configuration, gateway routing, DNS server settings, and physical interface connection to network bridges. Guide provides step-by-step instructions and practical configuration examples for deploying network changes using netplan commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->