### PR TITLE
Bump OVN to 25.09.

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -79,7 +79,7 @@ RUN git log -n 1
 # Stage to download OVN RPMs from koji #
 ########################################
 FROM quay.io/fedora/fedora:42 AS kojidownloader
-ARG ovnver=ovn-25.03.1-42.fc42
+ARG ovnver=ovn-25.09.0-42.fc42
 
 USER root
 


### PR DESCRIPTION
OVN 25.09 is the most recent OVN release.  Start using it to ensure CI catches any potential issues early.