### PR TITLE
Fixes NAD Controller syncAll for networkID upgrade from node->NAD

### DIFF
--- a/go-controller/pkg/allocator/id/allocator.go
+++ b/go-controller/pkg/allocator/id/allocator.go
@@ -18,6 +18,7 @@ type Allocator interface {
 	ReserveID(name string, id int) error
 	ReleaseID(name string)
 	ForName(name string) NamedAllocator
+	GetID(name string) int
 }
 
 // NamedAllocator of IDs for a specific resource
@@ -105,6 +106,14 @@ func (idAllocator *idAllocator) ForName(name string) NamedAllocator {
 		name:      name,
 		allocator: idAllocator,
 	}
+}
+
+func (idAllocator *idAllocator) GetID(name string) int {
+	v, ok := idAllocator.nameIdMap.Load(name)
+	if !ok {
+		return invalidID
+	}
+	return v
 }
 
 type namedAllocator struct {

--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -138,6 +138,10 @@ func (a *idAllocatorStub) AllocateID(string) (int, error) {
 	panic("not implemented") // TODO: Implement
 }
 
+func (a *idAllocatorStub) GetID(string) int {
+	panic("not implemented") // TODO: Implement
+}
+
 func (a *idAllocatorStub) ReserveID(string, int) error {
 	panic("not implemented") // TODO: Implement
 }

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -143,9 +143,9 @@ const (
 	// InvalidNodeID indicates an invalid node id
 	InvalidNodeID = -1
 
-	// ovnNetworkIDs is the constant string representing the ids allocated for the
+	// OvnNetworkIDs is the constant string representing the ids allocated for the
 	// default network and other layer3 secondary networks by cluster manager.
-	ovnNetworkIDs = "k8s.ovn.org/network-ids"
+	OvnNetworkIDs = "k8s.ovn.org/network-ids"
 
 	// ovnUDNLayer2NodeGRLRPTunnelIDs is the constant string representing the tunnel id allocated for the
 	// UDN L2 network for this node's GR LRP by cluster manager. This is used to create the remote tunnel
@@ -1225,17 +1225,17 @@ func parseNetworkMapAnnotation(nodeAnnotations map[string]string, annotationName
 	return idsStrMap, nil
 }
 
-// ParseNetworkIDAnnotation parses the 'ovnNetworkIDs' annotation for the specified
+// ParseNetworkIDAnnotation parses the 'OvnNetworkIDs' annotation for the specified
 // network in 'netName' and returns the network id.
 func ParseNetworkIDAnnotation(node *corev1.Node, netName string) (int, error) {
-	networkIDsMap, err := parseNetworkMapAnnotation(node.Annotations, ovnNetworkIDs)
+	networkIDsMap, err := parseNetworkMapAnnotation(node.Annotations, OvnNetworkIDs)
 	if err != nil {
 		return types.InvalidID, err
 	}
 
 	networkID, ok := networkIDsMap[netName]
 	if !ok {
-		return types.InvalidID, newAnnotationNotSetError("node %q has no %q annotation for network %s", node.Name, ovnNetworkIDs, netName)
+		return types.InvalidID, newAnnotationNotSetError("node %q has no %q annotation for network %s", node.Name, OvnNetworkIDs, netName)
 	}
 
 	return strconv.Atoi(networkID)
@@ -1244,7 +1244,7 @@ func ParseNetworkIDAnnotation(node *corev1.Node, netName string) (int, error) {
 // updateNetworkAnnotation updates the provided annotationName in the 'annotations' map
 // with the provided ID in 'annotationName's value.  If 'id' is InvalidID (-1)
 // it deletes the annotationName annotation from the map.
-// It is currently used for ovnNetworkIDs annotation updates
+// It is currently used for OvnNetworkIDs annotation updates
 func updateNetworkAnnotation(annotations map[string]string, netName string, id int, annotationName string) error {
 	var bytes []byte
 
@@ -1285,13 +1285,13 @@ func updateNetworkAnnotation(annotations map[string]string, netName string, id i
 	return nil
 }
 
-// UpdateNetworkIDAnnotation updates the ovnNetworkIDs annotation for the network name 'netName' with the network id 'networkID'.
+// UpdateNetworkIDAnnotation updates the OvnNetworkIDs annotation for the network name 'netName' with the network id 'networkID'.
 // If 'networkID' is invalid network ID (-1), then it deletes that network from the network ids annotation.
 func UpdateNetworkIDAnnotation(annotations map[string]string, netName string, networkID int) (map[string]string, error) {
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	err := updateNetworkAnnotation(annotations, netName, networkID, ovnNetworkIDs)
+	err := updateNetworkAnnotation(annotations, netName, networkID, OvnNetworkIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1301,7 +1301,7 @@ func UpdateNetworkIDAnnotation(annotations map[string]string, netName string, ne
 // GetNodeNetworkIDsAnnotationNetworkIDs parses the "k8s.ovn.org/network-ids" annotation
 // on a node and returns the map of network name and ids.
 func GetNodeNetworkIDsAnnotationNetworkIDs(node *corev1.Node) (map[string]int, error) {
-	networkIDsStrMap, err := parseNetworkMapAnnotation(node.Annotations, ovnNetworkIDs)
+	networkIDsStrMap, err := parseNetworkMapAnnotation(node.Annotations, OvnNetworkIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1317,7 +1317,7 @@ func GetNodeNetworkIDsAnnotationNetworkIDs(node *corev1.Node) (map[string]int, e
 	return networkIDsMap, nil
 }
 
-// NodeNetworkIDAnnotationChanged returns true if the ovnNetworkIDs annotation in the corev1.Nodes doesn't match
+// NodeNetworkIDAnnotationChanged returns true if the OvnNetworkIDs annotation in the corev1.Nodes doesn't match
 func NodeNetworkIDAnnotationChanged(oldNode, newNode *corev1.Node, netName string) bool {
 	oldNodeNetID, _ := ParseNetworkIDAnnotation(oldNode, netName)
 	newNodeNetID, _ := ParseNetworkIDAnnotation(newNode, netName)


### PR DESCRIPTION
There are several issues with NAD Controller start up. Some of the
issues were introduced by https://github.com/ovn-kubernetes/ovn-kubernetes/commit/adb1fc8b5f9506e28375d042c691fe456aeb6b72

The core problem is that with the change to move the networkID from
nodes to NADs, the upgrade logic left a gap in time where pods could not
start. This because cluster-manager was responsible for migrating the
networkID from the node->NAD, and in our upgrade strategy, workers
upgrade before control plane nodes. This would leave worker nodes in a
state where new OVNK code was running that was only looking for the
networkID on the NAD, but it had not yet been migrated.

This patch changes the behavior so that any NAD Controller (zone, node,
or cluster manager) will attempt at start up to find NADs that are
missing networkIDs and search nodes for the legacy values. The NAD
Controller will then attempt to reserve the ID for the entire cluster by
updating the NAD itself.

Unit tests added to cover the different scenarios.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NADs without explicit network IDs can deterministically inherit IDs from node annotations; per-NAD node lookup improves ID resolution across modes.
  * Controller now supports centralized network ID allocation with mode-aware behavior (cluster-manager vs non-cluster-manager).

* **Public API**
  * Network ID annotation key made public.
  * Allocator interface gained a non-allocating GetID(name) to read existing mappings.

* **Tests**
  * Expanded scenarios covering ID generation, inheritance, conflicts, and mode-specific behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->