### PR TITLE
make retryFramework log message clearer with specific caller

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -447,7 +447,7 @@ func (eIPC *egressIPClusterController) newRetryFramework(objectType reflect.Type
 		ObjType:                objectType,
 		EventHandler:           eventHandler,
 	}
-	return objretry.NewRetryFramework(eIPC.stopChan, eIPC.wg, eIPC.watchFactory, resourceHandler)
+	return objretry.NewRetryFramework("EgressIPClusterController", eIPC.stopChan, eIPC.wg, eIPC.watchFactory, resourceHandler)
 }
 
 func (eIPC *egressIPClusterController) Start() error {

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -542,7 +542,7 @@ func (ncc *networkClusterController) newRetryFramework(objectType reflect.Type, 
 			syncFunc: nil,
 		},
 	}
-	return objretry.NewRetryFramework(ncc.stopChan, ncc.wg, ncc.watchFactory, resourceHandler)
+	return objretry.NewRetryFramework(ncc.GetNetworkName()+"/clustermanager", ncc.stopChan, ncc.wg, ncc.watchFactory, resourceHandler)
 }
 
 // Cleanup the subnet annotations from the node for the User Defined Networks

--- a/go-controller/pkg/clustermanager/zone_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/zone_cluster_controller.go
@@ -107,7 +107,7 @@ func (zcc *zoneClusterController) initRetryFramework() {
 		},
 	}
 
-	zcc.retryNodes = objretry.NewRetryFramework(zcc.stopChan, zcc.wg, zcc.watchFactory, resourceHandler)
+	zcc.retryNodes = objretry.NewRetryFramework("zoneClusterController", zcc.stopChan, zcc.wg, zcc.watchFactory, resourceHandler)
 }
 
 // Start starts the zone cluster controller to watch the kubernetes nodes

--- a/go-controller/pkg/node/obj_retry_gateway.go
+++ b/go-controller/pkg/node/obj_retry_gateway.go
@@ -41,7 +41,7 @@ func (g *gateway) newRetryFrameworkNodeWithParameters(
 			syncFunc: syncFunc,
 		},
 	}
-	r := retry.NewRetryFramework(g.stopChan, g.wg, g.watchFactory, resourceHandler)
+	r := retry.NewRetryFramework("nodeGateway", g.stopChan, g.wg, g.watchFactory, resourceHandler)
 
 	return r
 }

--- a/go-controller/pkg/node/obj_retry_node.go
+++ b/go-controller/pkg/node/obj_retry_node.go
@@ -53,7 +53,7 @@ func (nc *DefaultNodeNetworkController) newRetryFrameworkNodeWithParameters(
 		},
 	}
 
-	r := retry.NewRetryFramework(nc.stopChan, nc.wg, nc.watchFactory.(*factory.WatchFactory), resourceHandler)
+	r := retry.NewRetryFramework("Default/NodeController", nc.stopChan, nc.wg, nc.watchFactory.(*factory.WatchFactory), resourceHandler)
 
 	return r
 }

--- a/go-controller/pkg/node/obj_retry_test_helper.go
+++ b/go-controller/pkg/node/obj_retry_test_helper.go
@@ -36,7 +36,7 @@ func (n *nodePortWatcher) newRetryFrameworkForTests(objectType reflect.Type, sto
 			n:       n,
 		},
 	}
-	r := retry.NewRetryFramework(stopChan, wg, n.watchFactory.(*factory.WatchFactory), resourceHandler)
+	r := retry.NewRetryFramework("nodePortWatcher", stopChan, wg, n.watchFactory.(*factory.WatchFactory), resourceHandler)
 
 	return r
 }

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -288,6 +288,7 @@ func (oc *DefaultNetworkController) newRetryFramework(
 		EventHandler:           eventHandler,
 	}
 	r := retry.NewRetryFramework(
+		oc.GetNetworkName()+"/networkController",
 		oc.stopChan,
 		oc.wg,
 		oc.watchFactory,

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -653,6 +653,7 @@ func (oc *Layer2UserDefinedNetworkController) newRetryFramework(
 		EventHandler:           eventHandler,
 	}
 	return retry.NewRetryFramework(
+		oc.GetNetworkName()+"/networkController",
 		oc.stopChan,
 		oc.wg,
 		oc.watchFactory,

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -465,6 +465,7 @@ func (oc *Layer3UserDefinedNetworkController) newRetryFramework(
 		EventHandler:           eventHandler,
 	}
 	return retry.NewRetryFramework(
+		oc.GetNetworkName()+"/networkController",
 		oc.stopChan,
 		oc.wg,
 		oc.watchFactory,

--- a/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
@@ -352,6 +352,7 @@ func (oc *LocalnetUserDefinedNetworkController) newRetryFramework(
 		EventHandler:           eventHandler,
 	}
 	return retry.NewRetryFramework(
+		oc.GetNetworkName()+"/networkController",
 		oc.stopChan,
 		oc.wg,
 		oc.watchFactory,

--- a/go-controller/pkg/ovn/network_controller_policy_event_handler.go
+++ b/go-controller/pkg/ovn/network_controller_policy_event_handler.go
@@ -43,6 +43,7 @@ func (bnc *BaseNetworkController) newNetpolRetryFramework(
 		EventHandler:           eventHandler,
 	}
 	return retry.NewRetryFramework(
+		bnc.GetNetworkName()+"/netPolController",
 		stopChan,
 		bnc.wg,
 		bnc.watchFactory,

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -105,6 +105,7 @@ type ResourceHandler struct {
 }
 
 type RetryFramework struct {
+	name string
 	// cache to hold object needs retry to successfully complete processing
 	retryEntries *syncmap.SyncMap[*retryObjEntry]
 	// channel to indicate we need to retry objs immediately
@@ -123,11 +124,12 @@ type RetryFramework struct {
 // with its function attributes pre-filled with default code. Clients of this pkg (ovnk master,
 // ovnk node) will have to override the functions in the returned struct with the desired
 // per-resource logic.
-func NewRetryFramework(
+func NewRetryFramework(name string,
 	stopChan <-chan struct{}, doneWg *sync.WaitGroup,
 	watchFactory *factory.WatchFactory,
 	resourceHandler *ResourceHandler) *RetryFramework {
 	return &RetryFramework{
+		name:              name,
 		retryEntries:      syncmap.NewSyncMap[*retryObjEntry](),
 		retryChan:         make(chan struct{}, 1),
 		watchFactory:      watchFactory,
@@ -225,7 +227,7 @@ func (r *RetryFramework) AddRetryObjWithDeleteNoBackoff(obj interface{}) error {
 func (r *RetryFramework) AddRetryObjWithAddNoBackoff(obj interface{}) error {
 	key, err := GetResourceKey(obj)
 	if err != nil {
-		return fmt.Errorf("could not get the key of %s %v: %v", r.ResourceHandler.ObjType, obj, err)
+		return fmt.Errorf("%s: could not get the key of %s %v: %v", r.name, r.ResourceHandler.ObjType, obj, err)
 	}
 	r.DoWithLock(key, func(key string) {
 		r.initRetryObjWithAddBackoff(obj, key, noBackoff)
@@ -268,9 +270,9 @@ func (r *RetryFramework) increaseFailedAttemptsCounter(entry *retryObjEntry) {
 func (r *RetryFramework) RequestRetryObjs() {
 	select {
 	case r.retryChan <- struct{}{}:
-		klog.V(5).Infof("Iterate retry objects requested (resource %s)", r.ResourceHandler.ObjType)
+		klog.V(5).Infof("%s: iterate retry objects requested (resource %s)", r.name, r.ResourceHandler.ObjType)
 	default:
-		klog.V(5).Infof("Iterate retry objects already requested (resource %s)", r.ResourceHandler.ObjType)
+		klog.V(5).Infof("%s: iterate retry objects already requested (resource %s)", r.name, r.ResourceHandler.ObjType)
 	}
 }
 
@@ -289,18 +291,18 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 	r.DoWithLock(objKey, func(key string) {
 		entry, loaded := r.getRetryObj(key)
 		if !loaded {
-			klog.V(5).Infof("%v resource %s was not found in the iterateRetryResources map while retrying resource setup", r.ResourceHandler.ObjType, objKey)
+			klog.V(5).Infof("%s: %v resource %s was not found in the iterateRetryResources map while retrying resource setup", r.name, r.ResourceHandler.ObjType, objKey)
 			return
 		}
 
 		if entry.failedAttempts >= MaxFailedAttempts && !entry.infiniteRetry {
-			klog.Warningf("Dropping retry entry for %s %s: exceeded number of failed attempts",
-				r.ResourceHandler.ObjType, objKey)
+			klog.Warningf("%s: dropping retry entry for %s %s: exceeded number of failed attempts",
+				r.name, r.ResourceHandler.ObjType, objKey)
 			r.DeleteRetryObj(key)
 			metrics.MetricResourceRetryFailuresCount.Inc()
 			if entry.newObj != nil {
 				r.ResourceHandler.RecordErrorEvent(entry.newObj, "RetryFailed",
-					fmt.Errorf("failed to reconcile and retried %d times for object: %v", MaxFailedAttempts, entry.newObj))
+					fmt.Errorf("%s: failed to reconcile and retried %d times for object: %v", r.name, MaxFailedAttempts, entry.newObj))
 			}
 			return
 		}
@@ -313,7 +315,7 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 		backoff := entry.backoff + (time.Duration(rand.Intn(500)) * time.Millisecond)
 		objTimer := entry.timeStamp.Add(backoff)
 		if !forceRetry && now.Before(objTimer) {
-			klog.V(5).Infof("Attempting retry of %s %s before timer (time: %s): skip", r.ResourceHandler.ObjType, objKey, objTimer)
+			klog.V(5).Infof("%s: attempting retry of %s %s before timer (time: %s): skip", r.name, r.ResourceHandler.ObjType, objKey, objTimer)
 			return
 		}
 
@@ -331,7 +333,7 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 			initObj = entry.oldObj
 		}
 
-		klog.Infof("Retry object setup: %s %s", r.ResourceHandler.ObjType, objKey)
+		klog.Infof("%s: retry object setup: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
 
 		if entry.newObj != nil {
 			// get the latest version of the object from the informer;
@@ -339,30 +341,30 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 			kObj, err := r.ResourceHandler.GetResourceFromInformerCache(objKey)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					klog.Infof("%s %s not found in the informers cache,"+
-						" not going to retry object create", r.ResourceHandler.ObjType, objKey)
+					klog.Infof("%s: %s %s not found in the informers cache,"+
+						" not going to retry object create", r.name, r.ResourceHandler.ObjType, objKey)
 					kObj = nil
 				} else {
-					klog.Errorf("Failed to look up %s %s in the informers cache,"+
-						" will retry later: %v", r.ResourceHandler.ObjType, objKey, err)
+					klog.Errorf("%s: failed to look up %s %s in the informers cache,"+
+						" will retry later: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
 					return
 				}
 			}
 			entry.newObj = kObj
 		}
 		if r.ResourceHandler.NeedsUpdateDuringRetry && entry.config != nil && entry.newObj != nil {
-			klog.Infof("%v retry: updating object %s", r.ResourceHandler.ObjType, objKey)
+			klog.Infof("%s: %v retry: updating object %s", r.name, r.ResourceHandler.ObjType, objKey)
 			if !r.ResourceHandler.IsResourceScheduled(entry.newObj) {
 				// unscheduled resources (pods) will be retried again later we do not track these as failures, and should not retry.
 				// we should avoid queuing objects to the retry handler that are not scheduled. Thus treat this as an error.
-				klog.Errorf("%v retry: cannot update object that is not scheduled: %s", r.ResourceHandler.ObjType, objKey)
+				klog.Errorf("%s: %v retry: cannot update object that is not scheduled: %s", r.name, r.ResourceHandler.ObjType, objKey)
 			} else if err := r.ResourceHandler.UpdateResource(entry.config, entry.newObj, true); err != nil {
 				entry.timeStamp = time.Now()
 				r.increaseFailedAttemptsCounter(entry)
 				if entry.failedAttempts >= MaxFailedAttempts && !entry.infiniteRetry {
-					klog.Errorf("Retry update failed final attempt for %s %s: error: %v", r.ResourceHandler.ObjType, objKey, err)
+					klog.Errorf("%s: retry update failed final attempt for %s %s: error: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
 				} else {
-					klog.Infof("%v retry update failed for %s, will try again later: %v", r.ResourceHandler.ObjType, objKey, err)
+					klog.Infof("%s: %v retry update failed for %s, will try again later: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
 				}
 				return
 			}
@@ -372,19 +374,19 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 		} else {
 			// delete old object if needed
 			if entry.oldObj != nil {
-				klog.Infof("Removing old object: %s %s (failed: %v)", r.ResourceHandler.ObjType, objKey, entry.failedAttempts)
+				klog.Infof("%s: removing old object: %s %s (failed: %v)", r.name, r.ResourceHandler.ObjType, objKey, entry.failedAttempts)
 				if !r.ResourceHandler.IsResourceScheduled(entry.oldObj) {
 					// unscheduled resources (pods) will be retried again later we do not track these as failures, and should not retry.
 					// we should avoid queuing objects to the retry handler that are not scheduled. Thus treat this as an error.
-					klog.Errorf("%v retry: cannot delete object that was not scheduled %s", r.ResourceHandler.ObjType, objKey)
+					klog.Errorf("%s: %v retry: cannot delete object that was not scheduled %s", r.name, r.ResourceHandler.ObjType, objKey)
 				} else if err := r.ResourceHandler.DeleteResource(entry.oldObj, entry.config); err != nil {
 					entry.timeStamp = time.Now()
 					r.increaseFailedAttemptsCounter(entry)
 					if entry.failedAttempts >= MaxFailedAttempts && !entry.infiniteRetry {
-						klog.Errorf("Retry delete failed final attempt for %s %s: error: %v", r.ResourceHandler.ObjType, objKey, err)
+						klog.Errorf("%s: retry delete failed final attempt for %s %s: error: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
 					} else {
-						klog.Infof("Retry delete failed for %s %s, will try again later: %v",
-							r.ResourceHandler.ObjType, objKey, err)
+						klog.Infof("%s: retry delete failed for %s %s, will try again later: %v",
+							r.name, r.ResourceHandler.ObjType, objKey, err)
 					}
 
 					return
@@ -395,18 +397,18 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 
 			// create new object if needed
 			if entry.newObj != nil {
-				klog.Infof("Adding new object: %s %s", r.ResourceHandler.ObjType, objKey)
+				klog.Infof("%s: adding new object: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
 				if !r.ResourceHandler.IsResourceScheduled(entry.newObj) {
 					// unscheduled resources (pods) will be retried again later we do not track these as failures, and should not retry.
 					// we should avoid queuing objects to the retry handler that are not scheduled. Thus treat this as an error.
-					klog.Errorf("%v retry: cannot create object that is not scheduled %s", r.ResourceHandler.ObjType, objKey)
+					klog.Errorf("%s: %v retry: cannot create object that is not scheduled %s", r.name, r.ResourceHandler.ObjType, objKey)
 				} else if err := r.ResourceHandler.AddResource(entry.newObj, true); err != nil {
 					entry.timeStamp = time.Now()
 					r.increaseFailedAttemptsCounter(entry)
 					if entry.failedAttempts >= MaxFailedAttempts && !entry.infiniteRetry {
-						klog.Errorf("Retry add failed final attempt for %s %s: error: %v", r.ResourceHandler.ObjType, objKey, err)
+						klog.Errorf("%s: retry add failed final attempt for %s %s: error: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
 					} else {
-						klog.Infof("Retry add failed for %s %s, will try again later: %v", r.ResourceHandler.ObjType, objKey, err)
+						klog.Infof("%s: retry add failed for %s %s, will try again later: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
 					}
 					return
 				}
@@ -416,7 +418,7 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 		}
 
 		if entry.failedAttempts > 0 {
-			klog.Infof("Retry successful for %s %s after %d failed attempt(s)", r.ResourceHandler.ObjType, objKey, entry.failedAttempts)
+			klog.Infof("%s: retry successful for %s %s after %d failed attempt(s)", r.name, r.ResourceHandler.ObjType, objKey, entry.failedAttempts)
 		}
 		if initObj != nil {
 			r.ResourceHandler.RecordSuccessEvent(initObj)
@@ -440,7 +442,7 @@ func (r *RetryFramework) iterateRetryResources() {
 	wg := &sync.WaitGroup{}
 
 	// Process the above list of objects that need retry by holding the lock for each one of them.
-	klog.V(5).Infof("Going to retry %v resource setup for %d objects: %s", r.ResourceHandler.ObjType, len(entriesKeys), entriesKeys)
+	klog.V(5).Infof("%s: going to retry %v resource setup for %d objects: %s", r.name, r.ResourceHandler.ObjType, len(entriesKeys), entriesKeys)
 
 	for _, entryKey := range entriesKeys {
 		wg.Add(1)
@@ -449,9 +451,9 @@ func (r *RetryFramework) iterateRetryResources() {
 			r.resourceRetry(entryKey, now)
 		}(entryKey)
 	}
-	klog.V(5).Infof("Waiting for all the %s retry setup to complete in iterateRetryResources", r.ResourceHandler.ObjType)
+	klog.V(5).Infof("%s: waiting for all the %s retry setup to complete in iterateRetryResources", r.name, r.ResourceHandler.ObjType)
 	wg.Wait()
-	klog.V(5).Infof("Function iterateRetryResources for %s ended (in %v)", r.ResourceHandler.ObjType, time.Since(now))
+	klog.V(5).Infof("%s: function iterateRetryResources for %s ended (in %v)", r.name, r.ResourceHandler.ObjType, time.Since(now))
 }
 
 // periodicallyRetryResources tracks RetryFramework and checks if any object needs to be retried for add or delete every
@@ -465,12 +467,12 @@ func (r *RetryFramework) periodicallyRetryResources() {
 			r.iterateRetryResources()
 
 		case <-r.retryChan:
-			klog.V(5).Infof("periodicallyRetryResources: Retry channel got triggered: retrying failed objects of type %s", r.ResourceHandler.ObjType)
+			klog.V(5).Infof("%s: periodicallyRetryResources: Retry channel got triggered: retrying failed objects of type %s", r.name, r.ResourceHandler.ObjType)
 			r.iterateRetryResources()
 			timer.Reset(RetryObjInterval)
 
 		case <-r.stopChan:
-			klog.V(5).Infof("Stop channel got triggered: will stop retrying failed objects of type %s", r.ResourceHandler.ObjType)
+			klog.V(5).Infof("%s: stop channel got triggered: will stop retrying failed objects of type %s", r.name, r.ResourceHandler.ObjType)
 			return
 		}
 	}
@@ -491,19 +493,19 @@ func (r *RetryFramework) processObjectInTerminalState(obj interface{}, lockedKey
 	_, loaded := r.terminatedObjects.LoadOrStore(lockedKey, true)
 	if loaded {
 		// object was already terminated
-		klog.V(5).Infof("Detected object %s of type %s in terminal state (e.g. completed) will be "+
-			"ignored as it has already been processed", lockedKey, r.ResourceHandler.ObjType)
+		klog.V(5).Infof("%s: detected object %s of type %s in terminal state (e.g. completed) will be "+
+			"ignored as it has already been processed", r.name, lockedKey, r.ResourceHandler.ObjType)
 		return
 	}
 
 	// The object is in a terminal state: delete it from the cluster, delete its retry entry and return.
-	klog.V(5).Infof("Detected object %s of type %s in terminal state (e.g. completed)"+
-		" during %s event: will remove it", lockedKey, r.ResourceHandler.ObjType, event)
+	klog.V(5).Infof("%s: detected object %s of type %s in terminal state (e.g. completed)"+
+		" during %s event: will remove it", r.name, lockedKey, r.ResourceHandler.ObjType, event)
 	internalCacheEntry := r.ResourceHandler.GetInternalCacheEntry(obj)
 	retryEntry := r.initRetryObjWithDelete(obj, lockedKey, internalCacheEntry, true) // set up the retry obj for deletion
 	if err := r.ResourceHandler.DeleteResource(obj, internalCacheEntry); err != nil {
-		klog.Errorf("Failed to delete object %s of type %s in terminal state, during %s event: %v",
-			lockedKey, r.ResourceHandler.ObjType, event, err)
+		klog.Errorf("%s: failed to delete object %s of type %s in terminal state, during %s event: %v",
+			r.name, lockedKey, r.ResourceHandler.ObjType, event, err)
 		r.ResourceHandler.RecordErrorEvent(obj, "ErrorDeletingResource", err)
 		r.increaseFailedAttemptsCounter(retryEntry)
 		return
@@ -523,8 +525,8 @@ func (r *RetryFramework) WatchResource() (*factory.Handler, error) {
 func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler string, labelSelectorForFilteredHandler labels.Selector) (*factory.Handler, error) {
 	addHandlerFunc, err := r.watchFactory.GetResourceHandlerFunc(r.ResourceHandler.ObjType)
 	if err != nil {
-		return nil, fmt.Errorf("no resource handler function found for resource %v. "+
-			"Cannot watch this resource", r.ResourceHandler.ObjType)
+		return nil, fmt.Errorf("%s: no resource handler function found for resource %v. "+
+			"Cannot watch this resource", r.name, r.ResourceHandler.ObjType)
 	}
 
 	// create the actual watcher
@@ -540,10 +542,10 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 
 				key, err := GetResourceKey(obj)
 				if err != nil {
-					klog.Errorf("Upon add event: %v", err)
+					klog.Errorf("%s: upon add event for %s: %v", r.name, r.ResourceHandler.ObjType, err)
 					return
 				}
-				klog.V(5).Infof("Add event received for %s %s", r.ResourceHandler.ObjType, key)
+				klog.V(5).Infof("%s: add event received for %s %s", r.name, r.ResourceHandler.ObjType, key)
 
 				r.DoWithLock(key, func(key string) {
 					// This only applies to pod watchers (pods + dynamic network policy handlers watching pods):
@@ -558,13 +560,13 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					// with the same name as a previous object that failed deletion.
 					// Destroy the old object before we add the new one.
 					if retryObj.oldObj != nil {
-						klog.Infof("Detected stale object during new object"+
-							" add of type %s with the same key: %s",
+						klog.Infof("%s: detected stale object during new object"+
+							" add of type %s with the same key: %s", r.name,
 							r.ResourceHandler.ObjType, key)
 						internalCacheEntry := r.ResourceHandler.GetInternalCacheEntry(obj)
 						if err := r.ResourceHandler.DeleteResource(retryObj.oldObj, internalCacheEntry); err != nil {
-							klog.Errorf("Failed to delete old object %s of type %s,"+
-								" during add event: %v", key, r.ResourceHandler.ObjType, err)
+							klog.Errorf("%s: failed to delete old object %s of type %s,"+
+								" during add event: %v", r.name, key, r.ResourceHandler.ObjType, err)
 							r.ResourceHandler.RecordErrorEvent(obj, "ErrorDeletingResource", err)
 							r.increaseFailedAttemptsCounter(retryObj)
 							return
@@ -574,15 +576,15 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					start := time.Now()
 					if err := r.ResourceHandler.AddResource(obj, false); err != nil {
 						if !ovntypes.IsSuppressedError(err) {
-							klog.Errorf("Failed to create %s %s, error: %v", r.ResourceHandler.ObjType, key, err)
+							klog.Errorf("%s: failed to create %s %s, error: %v", r.name, r.ResourceHandler.ObjType, key, err)
 							r.ResourceHandler.RecordErrorEvent(obj, "ErrorAddingResource", err)
 						} else {
-							klog.Infof("Failed to create %s %s, error: %v", r.ResourceHandler.ObjType, key, err)
+							klog.Infof("%s: failed to create %s %s, error: %v", r.name, r.ResourceHandler.ObjType, key, err)
 						}
 						r.increaseFailedAttemptsCounter(retryObj)
 						return
 					}
-					klog.V(5).Infof("Creating %s %s took: %v", r.ResourceHandler.ObjType, key, time.Since(start))
+					klog.V(5).Infof("%s: creating %s %s took: %v", r.name, r.ResourceHandler.ObjType, key, time.Since(start))
 					// delete retryObj if handling was successful
 					r.DeleteRetryObj(key)
 					r.ResourceHandler.RecordSuccessEvent(obj)
@@ -595,8 +597,8 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 				// skip the whole update if old and newer are equal
 				areEqual, err := r.ResourceHandler.AreResourcesEqual(old, newer)
 				if err != nil {
-					klog.Errorf("Could not compare old and newer resource objects of type %s: %v",
-						r.ResourceHandler.ObjType, err)
+					klog.Errorf("%s: could not compare old and newer resource objects of type %s: %v",
+						r.name, r.ResourceHandler.ObjType, err)
 					return
 				}
 				if areEqual {
@@ -607,19 +609,19 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 				// get the object keys for newer and old (expected to be the same)
 				newKey, err := GetResourceKey(newer)
 				if err != nil {
-					klog.Errorf("Update of %s failed when looking up key of new obj: %v",
-						r.ResourceHandler.ObjType, err)
+					klog.Errorf("%s: update of %s failed when looking up key of new obj: %v",
+						r.name, r.ResourceHandler.ObjType, err)
 					return
 				}
 				oldKey, err := GetResourceKey(old)
 				if err != nil {
-					klog.Errorf("Update of %s failed when looking up key of old obj: %v",
-						r.ResourceHandler.ObjType, err)
+					klog.Errorf("%s: update of %s failed when looking up key of old obj: %v",
+						r.name, r.ResourceHandler.ObjType, err)
 					return
 				}
 				if newKey != oldKey {
-					klog.Errorf("Could not update resource object of type %s: the key was changed from %s to %s",
-						r.ResourceHandler.ObjType, oldKey, newKey)
+					klog.Errorf("%s: could not update resource object of type %s: the key was changed from %s to %s",
+						r.name, r.ResourceHandler.ObjType, oldKey, newKey)
 					return
 				}
 
@@ -631,25 +633,25 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					// This only applies to pod watchers (pods + dynamic network policy handlers watching pods).
 					if apierrors.IsNotFound(err) {
 						if r.ResourceHandler.IsObjectInTerminalState(newer) {
-							klog.V(5).Infof("%s %s is in terminal state but no longer exists in informer cache, removing",
-								r.ResourceHandler.ObjType, newKey)
+							klog.V(5).Infof("%s: %s %s is in terminal state but no longer exists in informer cache, removing",
+								r.name, r.ResourceHandler.ObjType, newKey)
 							r.DoWithLock(newKey, func(_ string) {
 								r.processObjectInTerminalState(newer, newKey, resourceEventUpdate)
 							})
 						} else {
-							klog.V(5).Infof("Ignoring update event for %s %s as it was not found in"+
-								" informer cache and is not in a terminal state", r.ResourceHandler.ObjType, newKey)
+							klog.V(5).Infof("%s: ignoring update event for %s %s as it was not found in"+
+								" informer cache and is not in a terminal state", r.name, r.ResourceHandler.ObjType, newKey)
 						}
 					} else {
 						// This should never happen. The cache storage backend type cannot return any error
 						// other than not found
-						klog.Errorf("Unhandled error while trying to retrieve %s %s from informer cache: %v",
-							r.ResourceHandler.ObjType, newKey, err)
+						klog.Errorf("%s: unhandled error while trying to retrieve %s %s from informer cache: %v",
+							r.name, r.ResourceHandler.ObjType, newKey, err)
 					}
 					return
 				}
 
-				klog.V(5).Infof("Update event received for %s %s", r.ResourceHandler.ObjType, newKey)
+				klog.V(5).Infof("%s: update event received for %s %s", r.name, r.ResourceHandler.ObjType, newKey)
 				r.DoWithLock(newKey, func(key string) {
 					// STEP 1:
 					// Delete existing (old) object if:
@@ -662,11 +664,11 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 
 					if found && retryEntryOrNil.oldObj != nil {
 						// [step 1a] there is a retry entry marked for deletion
-						klog.Infof("Found retry entry for %s %s marked for deletion: will delete the object",
-							r.ResourceHandler.ObjType, oldKey)
+						klog.Infof("%s: found retry entry for %s %s marked for deletion: will delete the object",
+							r.name, r.ResourceHandler.ObjType, oldKey)
 						if err := r.ResourceHandler.DeleteResource(retryEntryOrNil.oldObj,
 							retryEntryOrNil.config); err != nil {
-							klog.Errorf("Failed to delete stale object %s, during update: %v", oldKey, err)
+							klog.Errorf("%s: failed to delete stale object %s, during update: %v", r.name, oldKey, err)
 							r.ResourceHandler.RecordErrorEvent(retryEntryOrNil.oldObj, "ErrorDeletingResource", err)
 							retryEntry := r.initRetryObjWithAdd(latest, key)
 							r.increaseFailedAttemptsCounter(retryEntry)
@@ -690,10 +692,10 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 						if found {
 							existingCacheEntry = retryEntryOrNil.config
 						}
-						klog.V(5).Infof("Deleting old %s of type %s during update", oldKey, r.ResourceHandler.ObjType)
+						klog.V(5).Infof("%s: deleting old %s of type %s during update", r.name, oldKey, r.ResourceHandler.ObjType)
 						if err := r.ResourceHandler.DeleteResource(old, existingCacheEntry); err != nil {
-							klog.Errorf("Failed to delete %s %s, during update: %v",
-								r.ResourceHandler.ObjType, oldKey, err)
+							klog.Errorf("%s: failed to delete %s %s, during update: %v",
+								r.name, r.ResourceHandler.ObjType, oldKey, err)
 							r.ResourceHandler.RecordErrorEvent(old, "ErrorDeletingResource", err)
 							retryEntry := r.initRetryObjWithDelete(old, key, nil, false)
 							r.initRetryObjWithAdd(latest, key)
@@ -712,12 +714,12 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 						// if this resource type has an update func, just call the update function
 						if err := r.ResourceHandler.UpdateResource(old, latest, found); err != nil {
 							if !ovntypes.IsSuppressedError(err) {
-								klog.Errorf("Failed to update %s, old=%s, new=%s, error: %v",
-									r.ResourceHandler.ObjType, oldKey, newKey, err)
+								klog.Errorf("%s: failed to update %s, old=%s, new=%s, error: %v",
+									r.name, r.ResourceHandler.ObjType, oldKey, newKey, err)
 								r.ResourceHandler.RecordErrorEvent(latest, "ErrorUpdatingResource", err)
 							} else {
-								klog.V(5).Infof("Failed to update %s, old=%s, new=%s, error: %v",
-									r.ResourceHandler.ObjType, oldKey, newKey, err)
+								klog.V(5).Infof("%s: failed to update %s, old=%s, new=%s, error: %v",
+									r.name, r.ResourceHandler.ObjType, oldKey, newKey, err)
 							}
 							var retryEntry *retryObjEntry
 							if r.ResourceHandler.NeedsUpdateDuringRetry {
@@ -733,12 +735,12 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 							retryEntry := r.initRetryObjWithAdd(latest, key)
 							r.increaseFailedAttemptsCounter(retryEntry)
 							if !ovntypes.IsSuppressedError(err) {
-								klog.Errorf("Failed to add %s %s, during update: %v",
-									r.ResourceHandler.ObjType, newKey, err)
+								klog.Errorf("%s: failed to add %s %s, during update: %v",
+									r.name, r.ResourceHandler.ObjType, newKey, err)
 								r.ResourceHandler.RecordErrorEvent(latest, "ErrorAddingResource", err)
 							} else {
-								klog.Infof("Failed to add %s %s, during update: %v",
-									r.ResourceHandler.ObjType, newKey, err)
+								klog.Infof("%s: failed to add %s %s, during update: %v",
+									r.name, r.ResourceHandler.ObjType, newKey, err)
 							}
 							return
 						}
@@ -754,10 +756,10 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 				r.ResourceHandler.RecordDeleteEvent(obj)
 				key, err := GetResourceKey(obj)
 				if err != nil {
-					klog.Errorf("Delete of %s failed: %v", r.ResourceHandler.ObjType, err)
+					klog.Errorf("%s: delete of %s failed: %v", r.name, r.ResourceHandler.ObjType, err)
 					return
 				}
-				klog.V(5).Infof("Delete event received for %s %s", r.ResourceHandler.ObjType, key)
+				klog.V(5).Infof("%s: delete event received for %s %s", r.name, r.ResourceHandler.ObjType, key)
 				// If object is in terminal state, we would have already deleted it during update.
 				// No reason to attempt to delete it here again.
 				if r.ResourceHandler.IsObjectInTerminalState(obj) {
@@ -767,8 +769,8 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					// See: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/3318#issuecomment-1349804450
 					if _, loaded := r.terminatedObjects.LoadAndDelete(key); loaded {
 						// object was already terminated
-						klog.Infof("Ignoring delete event for resource in terminal state %s %s",
-							r.ResourceHandler.ObjType, key)
+						klog.Infof("%s: ignoring delete event for resource in terminal state %s %s",
+							r.name, r.ResourceHandler.ObjType, key)
 						return
 					}
 				}
@@ -777,7 +779,7 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					retryEntry := r.initRetryObjWithDelete(obj, key, internalCacheEntry, false) // set up the retry obj for deletion
 					if err = r.ResourceHandler.DeleteResource(obj, internalCacheEntry); err != nil {
 						r.increaseFailedAttemptsCounter(retryEntry)
-						klog.Errorf("Failed to delete %s %s, error: %v", r.ResourceHandler.ObjType, key, err)
+						klog.Errorf("%s: failed to delete %s %s, error: %v", r.name, r.ResourceHandler.ObjType, key, err)
 						return
 					}
 					r.DeleteRetryObj(key)
@@ -788,8 +790,8 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 		r.ResourceHandler.SyncFunc) // processes all existing objects at startup
 
 	if err != nil {
-		return nil, fmt.Errorf("watchResource for resource %v. "+
-			"Failed addHandlerFunc: %v", r.ResourceHandler.ObjType, err)
+		return nil, fmt.Errorf("%s: watchResource for resource %v. "+
+			"Failed addHandlerFunc: %v", r.name, r.ResourceHandler.ObjType, err)
 	}
 
 	// track the retry entries and every 30 seconds (or upon explicit request) check if any objects


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Retry framework instances are now named; logs and error messages include instance identifiers for clearer diagnostics across controllers and node components.
  * Call sites updated to supply these identifiers so retry behavior and control flow remain unchanged while observability is improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->