### PR TITLE
Add iptables FORWARD rules for DPU-host mode to fix NodePort connectivity

### DIFF
--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -364,6 +364,39 @@ func delExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
 	return deleteIptRules(getGatewayForwardRules(cidrs))
 }
 
+// configureForwardingRules sets up or removes iptables FORWARD rules for cluster and service CIDRs
+// based on config.Gateway.DisableForwarding setting.
+//
+// This function creates bidirectional FORWARD rules for:
+//   - Cluster subnets (pod CIDRs)
+//   - Service CIDRs
+//   - Masquerade IPs used by OVN
+//
+// These rules are essential in both standard gateway modes and DPU-host mode to allow
+// traffic forwarding for cluster resources. Without these rules, packets would be dropped
+// by the default iptables FORWARD policy, breaking external connectivity to services.
+//
+// When config.Gateway.DisableForwarding is true, rules are added.
+// When config.Gateway.DisableForwarding is false, rules are removed.
+func configureForwardingRules() error {
+	var subnets []*net.IPNet
+	for _, subnet := range config.Default.ClusterSubnets {
+		subnets = append(subnets, subnet.CIDR)
+	}
+	subnets = append(subnets, config.Kubernetes.ServiceCIDRs...)
+
+	if config.Gateway.DisableForwarding {
+		if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
+			return fmt.Errorf("failed to add iptables FORWARD rules: %v", err)
+		}
+	} else {
+		if err := delExternalBridgeServiceForwardingRules(subnets); err != nil {
+			return fmt.Errorf("failed to delete iptables FORWARD rules: %v", err)
+		}
+	}
+	return nil
+}
+
 func getLocalGatewayFilterRules(ifname string, cidr *net.IPNet) []nodeipt.Rule {
 	// Allow packets to/from the gateway interface in case defaults deny
 	protocol := getIPTablesProtocol(cidr.IP.String())

--- a/go-controller/pkg/node/gateway_iptables_test.go
+++ b/go-controller/pkg/node/gateway_iptables_test.go
@@ -1,0 +1,318 @@
+package node
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+	"github.com/coreos/go-iptables/iptables"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gateway IPTables", func() {
+	var testNS ns.NetNS
+	var iptCtrl *nodeipt.Controller
+
+	BeforeEach(func() {
+		if ovntest.NoRoot() {
+			Skip("Test requires root privileges")
+		}
+
+		var err error
+		runtime.LockOSThread()
+		testNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Start iptables controller
+		iptCtrl = nodeipt.NewController()
+		stopCh := make(chan struct{})
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = testNS.Do(func(ns.NetNS) error {
+				iptCtrl.Run(stopCh, 50*time.Millisecond)
+				return nil
+			})
+		}()
+
+		DeferCleanup(func() {
+			close(stopCh)
+			wg.Wait()
+			Expect(testNS.Close()).To(Succeed())
+			Expect(testutils.UnmountNS(testNS)).To(Succeed())
+			runtime.UnlockOSThread()
+		})
+	})
+
+	Context("configureForwardingRules", func() {
+		var originalDisableForwarding bool
+		var originalClusterSubnets []config.CIDRNetworkEntry
+		var originalServiceCIDRs []*net.IPNet
+		var originalIPv4Mode bool
+		var originalIPv6Mode bool
+		var originalMasqueradeIP net.IP
+
+		BeforeEach(func() {
+			// Save original config
+			originalDisableForwarding = config.Gateway.DisableForwarding
+			originalClusterSubnets = config.Default.ClusterSubnets
+			originalServiceCIDRs = config.Kubernetes.ServiceCIDRs
+			originalIPv4Mode = config.IPv4Mode
+			originalIPv6Mode = config.IPv6Mode
+			if config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP != nil {
+				originalMasqueradeIP = append(net.IP(nil), config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP...)
+			} else {
+				originalMasqueradeIP = nil
+			}
+
+			// Setup test config
+			config.IPv4Mode = true
+			config.IPv6Mode = false
+		})
+
+		AfterEach(func() {
+			// Restore original config
+			config.Gateway.DisableForwarding = originalDisableForwarding
+			config.Default.ClusterSubnets = originalClusterSubnets
+			config.Kubernetes.ServiceCIDRs = originalServiceCIDRs
+			config.IPv4Mode = originalIPv4Mode
+			config.IPv6Mode = originalIPv6Mode
+			config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP = append(net.IP(nil), originalMasqueradeIP...)
+		})
+
+		It("should add FORWARD rules when DisableForwarding is true", func() {
+			// Setup test configuration
+			config.Gateway.DisableForwarding = true
+			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
+				{CIDR: ovntest.MustParseIPNet("10.128.0.0/14")},
+			}
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{
+				ovntest.MustParseIPNet("172.30.0.0/16"),
+			}
+			config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP = net.ParseIP("169.254.0.1")
+
+			err := testNS.Do(func(ns.NetNS) error {
+				return configureForwardingRules()
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify rules were added
+			Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+					if err != nil {
+						return err
+					}
+
+					// Check cluster subnet rules
+					exists, err := ipt.Exists("filter", "FORWARD", "-s", "10.128.0.0/14", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if !exists {
+						return fmt.Errorf("cluster subnet source rule not found")
+					}
+
+					exists, err = ipt.Exists("filter", "FORWARD", "-d", "10.128.0.0/14", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if !exists {
+						return fmt.Errorf("cluster subnet dest rule not found")
+					}
+
+					// Check service CIDR rules
+					exists, err = ipt.Exists("filter", "FORWARD", "-s", "172.30.0.0/16", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if !exists {
+						return fmt.Errorf("service CIDR source rule not found")
+					}
+
+					exists, err = ipt.Exists("filter", "FORWARD", "-d", "172.30.0.0/16", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if !exists {
+						return fmt.Errorf("service CIDR dest rule not found")
+					}
+
+					// Check masquerade IP rules
+					exists, err = ipt.Exists("filter", "FORWARD", "-s", "169.254.0.1", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if !exists {
+						return fmt.Errorf("masquerade IP source rule not found")
+					}
+
+					exists, err = ipt.Exists("filter", "FORWARD", "-d", "169.254.0.1", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if !exists {
+						return fmt.Errorf("masquerade IP dest rule not found")
+					}
+
+					return nil
+				})
+			}, 2*time.Second).Should(Succeed())
+		})
+
+		It("should remove FORWARD rules when DisableForwarding is false", func() {
+			// Setup test configuration
+			config.Gateway.DisableForwarding = true
+			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
+				{CIDR: ovntest.MustParseIPNet("10.128.0.0/14")},
+			}
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{
+				ovntest.MustParseIPNet("172.30.0.0/16"),
+			}
+			config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP = net.ParseIP("169.254.0.1")
+
+			// First add the rules
+			err := testNS.Do(func(ns.NetNS) error {
+				return configureForwardingRules()
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for rules to be added
+			Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+					if err != nil {
+						return err
+					}
+
+					// Verify at least one rule exists
+					exists, err := ipt.Exists("filter", "FORWARD", "-s", "10.128.0.0/14", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if !exists {
+						return fmt.Errorf("waiting for rules to be added")
+					}
+					return nil
+				})
+			}, 2*time.Second).Should(Succeed())
+
+			// Now change config to remove rules
+			config.Gateway.DisableForwarding = false
+
+			err = testNS.Do(func(ns.NetNS) error {
+				return configureForwardingRules()
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify rules were removed
+			Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+					if err != nil {
+						return err
+					}
+
+					// Check that cluster subnet rules are removed
+					exists, err := ipt.Exists("filter", "FORWARD", "-s", "10.128.0.0/14", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if exists {
+						return fmt.Errorf("cluster subnet source rule should be removed")
+					}
+
+					exists, err = ipt.Exists("filter", "FORWARD", "-d", "10.128.0.0/14", "-j", "ACCEPT")
+					if err != nil {
+						return err
+					}
+					if exists {
+						return fmt.Errorf("cluster subnet dest rule should be removed")
+					}
+
+					return nil
+				})
+			}, 2*time.Second).Should(Succeed())
+		})
+
+		It("should handle multiple cluster subnets and service CIDRs", func() {
+			// Setup test configuration with multiple CIDRs
+			config.Gateway.DisableForwarding = true
+			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
+				{CIDR: ovntest.MustParseIPNet("10.128.0.0/14")},
+				{CIDR: ovntest.MustParseIPNet("10.132.0.0/14")},
+			}
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{
+				ovntest.MustParseIPNet("172.30.0.0/16"),
+				ovntest.MustParseIPNet("172.31.0.0/16"),
+			}
+			config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP = net.ParseIP("169.254.0.1")
+
+			err := testNS.Do(func(ns.NetNS) error {
+				return configureForwardingRules()
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify all rules were added
+			Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+					if err != nil {
+						return err
+					}
+
+					// Check all cluster subnet rules
+					for _, subnet := range []string{"10.128.0.0/14", "10.132.0.0/14"} {
+						exists, err := ipt.Exists("filter", "FORWARD", "-s", subnet, "-j", "ACCEPT")
+						if err != nil {
+							return err
+						}
+						if !exists {
+							return fmt.Errorf("cluster subnet source rule for %s not found", subnet)
+						}
+
+						exists, err = ipt.Exists("filter", "FORWARD", "-d", subnet, "-j", "ACCEPT")
+						if err != nil {
+							return err
+						}
+						if !exists {
+							return fmt.Errorf("cluster subnet dest rule for %s not found", subnet)
+						}
+					}
+
+					// Check all service CIDR rules
+					for _, cidr := range []string{"172.30.0.0/16", "172.31.0.0/16"} {
+						exists, err := ipt.Exists("filter", "FORWARD", "-s", cidr, "-j", "ACCEPT")
+						if err != nil {
+							return err
+						}
+						if !exists {
+							return fmt.Errorf("service CIDR source rule for %s not found", cidr)
+						}
+
+						exists, err = ipt.Exists("filter", "FORWARD", "-d", cidr, "-j", "ACCEPT")
+						if err != nil {
+							return err
+						}
+						if !exists {
+							return fmt.Errorf("service CIDR dest rule for %s not found", cidr)
+						}
+					}
+
+					return nil
+				})
+			}, 2*time.Second).Should(Succeed())
+		})
+	})
+})

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1618,21 +1618,10 @@ func newNodePortWatcher(
 				return nil, fmt.Errorf("unable to configure UDN isolation nftables: %w", err)
 			}
 		}
+		if err := configureForwardingRules(); err != nil {
+			return nil, fmt.Errorf("failed to configure forwarding rules for bridge %s: %v", gwBridge.GetGatewayIface(), err)
+		}
 
-		var subnets []*net.IPNet
-		for _, subnet := range config.Default.ClusterSubnets {
-			subnets = append(subnets, subnet.CIDR)
-		}
-		subnets = append(subnets, config.Kubernetes.ServiceCIDRs...)
-		if config.Gateway.DisableForwarding {
-			if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
-				return nil, fmt.Errorf("failed to add accept rules in forwarding table for bridge %s: err %v", gwBridge.GetGatewayIface(), err)
-			}
-		} else {
-			if err := delExternalBridgeServiceForwardingRules(subnets); err != nil {
-				return nil, fmt.Errorf("failed to delete accept rules in forwarding table for bridge %s: err %v", gwBridge.GetGatewayIface(), err)
-			}
-		}
 	}
 
 	// used to tell addServiceRules which rules to add


### PR DESCRIPTION
Add iptables FORWARD rules for DPU-host mode to fix NodePort connectivity
Currently, DPU-host mode fails to apply iptables FORWARD rules for cluster and service CIDRs, causing packets to be dropped by the default FORWARD policy. This breaks external connectivity to NodePort services and other cluster resources.

Problem:
--------
The gateway initialization code path for DPU-host mode (initGatewayDPUHostPreStart) was missing the iptables FORWARD rules that are applied in normal (full) mode. While DPU-host mode doesn't have an OVS bridge like full mode, the host still needs iptables FORWARD rules to allow traffic for:
- Cluster subnets (pod CIDRs, e.g., 10.128.0.0/14)
- Service CIDRs (e.g., 172.30.0.0/16)
- Masquerade IPs (e.g., 169.254.0.1/32)

Without these rules, packets are dropped by the default iptables FORWARD policy, preventing external sources from reaching NodePort services and other cluster endpoints via the DPU-host node.

Solution:
---------
1. Created a new configureForwardingRules() function in gateway_iptables.go that centralizes the logic for adding/removing iptables FORWARD rules based on the config.Gateway.DisableForwarding setting.

2. Updated initGatewayDPUHostPreStart() to call configureForwardingRules(), ensuring DPU-host mode applies the same FORWARD rules as full mode.

3. Refactored gateway_shared_intf.go to use the new configureForwardingRules() function, eliminating code duplication between the two code paths.

4. Added Linux build constraints (//go:build linux) to gateway_init.go and gateway_shared_intf.go to resolve compiler errors, as these files now depend on Linux-specific iptables functionality.

The configureForwardingRules() function handles:
- Creating bidirectional rules (-s and -d) for all configured CIDRs
- Adding rules for masquerade IPs used by OVN
- Removing rules when DisableForwarding is false
- Supporting multiple cluster subnets and service CIDRs

Testing:
--------
Added comprehensive unit tests in gateway_iptables_test.go covering:
- FORWARD rule creation when DisableForwarding=true
- FORWARD rule removal when DisableForwarding=false
- Handling of multiple cluster subnets and service CIDRs
- Verification of all rule types (cluster, service, masquerade)

Tests run in isolated network namespaces to avoid affecting the host system.

Impact:
-------
This fix ensures that DPU-host mode nodes can properly forward traffic to cluster resources, enabling external connectivity to NodePort services and other cluster endpoints. The refactoring also improves code maintainability by eliminating duplication between the two gateway initialization paths.

Signed-off-by: Igal Tsoiref itsoiref@redhat.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Initialization now always applies network forwarding configuration and honors the DisableForwarding setting to add or remove IPv4 FORWARD rules for cluster and service CIDRs.

* **Tests**
  * Added isolated network-namespace tests that verify creation/removal of FORWARD rules (including multiple subnets/CIDRs) with robust async waits and cleanup.

* **Documentation**
  * Added DPU-host docs describing forwarding rules, examples, and impact on external connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->