### PR TITLE
[kind] Set containerd port to workaround ANP conformance issue.

### DIFF
--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -14,12 +14,14 @@ networking:
 {%- if ovn_ip_family %}
   ipFamily: {{ ovn_ip_family }}
 {%- endif %}
-{%- if use_local_registy == "true"%}
 containerdConfigPatches:
   - |-
+{%- if use_local_registy == "true"%}
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:{{ kind_local_registry_port }}"]
       endpoint = ["http://{{ kind_local_registry_name }}:5000"]
 {%- endif %}
+    [plugins."io.containerd.grpc.v1.cri"]
+      stream_server_port = '33333'
 kubeadmConfigPatches:
 - |
   kind: ClusterConfiguration


### PR DESCRIPTION
https://github.com/kubernetes-sigs/network-policy-api/issues/341 (B)ANP conformance uses ports in range 34345-36366. containerd binds a random port, which can end up in conflict and cause flake. As a workaround (until ANP issue is resolved) set a pre-defined port for containerd outside of this range.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4348

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced local registry configuration with stream server port setup for the container runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->