### PR TITLE
node: fix conntrack deletion to use service port instead of endpoint port

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1340,9 +1340,15 @@ func (nc *DefaultNodeNetworkController) reconcileConntrackUponEndpointSliceEvent
 		return fmt.Errorf("cannot reconcile conntrack: %v", err)
 	}
 	svc, err := nc.watchFactory.GetService(namespacedName.Namespace, namespacedName.Name)
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(5).Infof("Service %s/%s not found (might have been deleted) when reconciling conntrack for endpointslice %s",
+				namespacedName.Namespace, namespacedName.Name, oldEndpointSlice.Name)
+			// service is not found, likely deleted, flushing service conntrack entries will be handled at service reconciliation. No-op here.
+			return nil
+		}
 		return fmt.Errorf("error while retrieving service for endpointslice %s/%s when reconciling conntrack: %v",
-			newEndpointSlice.Namespace, newEndpointSlice.Name, err)
+			oldEndpointSlice.Namespace, oldEndpointSlice.Name, err)
 	}
 	for _, oldPort := range oldEndpointSlice.Ports {
 		if *oldPort.Protocol != corev1.ProtocolUDP { // flush conntrack only for UDP
@@ -1356,10 +1362,21 @@ func (nc *DefaultNodeNetworkController) reconcileConntrackUponEndpointSliceEvent
 				if newEndpointSlice != nil && util.DoesEndpointSliceContainEligibleEndpoint(newEndpointSlice, oldIPStr, *oldPort.Port, *oldPort.Protocol, svc) {
 					continue
 				}
+				portName := ""
+				if oldPort.Name != nil {
+					portName = *oldPort.Name
+				}
+				servicePort, err := util.FindServicePortForEndpointSlicePort(svc, portName, *oldPort.Protocol)
+				if err != nil {
+					klog.Errorf("Failed to get service port for endpoint %s: %v", oldIPStr, err)
+					continue
+				}
 				// upon update and delete events, flush conntrack only for UDP
-				if err := util.DeleteConntrackServicePort(oldIPStr, *oldPort.Port, *oldPort.Protocol,
+				klog.V(5).Infof("Deleting conntrack entry for endpoint %s, port %d, protocol %s", oldIPStr, servicePort.Port, *oldPort.Protocol)
+				if err := util.DeleteConntrackServicePort(oldIPStr, servicePort.Port, *oldPort.Protocol,
 					netlink.ConntrackReplyAnyIP, nil); err != nil {
-					klog.Errorf("Failed to delete conntrack entry for %s: %v", oldIPStr, err)
+					klog.Errorf("Failed to delete conntrack entry for %s port %d: %v", oldIPStr, servicePort.Port, err)
+					errors = append(errors, err)
 				}
 			}
 		}

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -259,6 +261,153 @@ func TestGenerateId(t *testing.T) {
 func TestGetNetworkScopedK8sMgmtHostIntfName(t *testing.T) {
 	intfName := GetNetworkScopedK8sMgmtHostIntfName(1245678)
 	assert.Equal(t, "ovn-k8s-mp12456", intfName)
+}
+
+func TestFindServicePortForEndpointSlicePort(t *testing.T) {
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+
+	tests := []struct {
+		name                      string
+		service                   *corev1.Service
+		endpointslicePortName     string
+		endpointslicePortProtocol corev1.Protocol
+		wantPort                  *corev1.ServicePort
+		wantErr                   bool
+	}{
+		{
+			name: "Match named port with TCP protocol",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-svc",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "http", Protocol: tcp, Port: 80, TargetPort: intstr.FromInt(8080)},
+						{Name: "https", Protocol: tcp, Port: 443, TargetPort: intstr.FromInt(8443)},
+					},
+				},
+			},
+			endpointslicePortName:     "http",
+			endpointslicePortProtocol: tcp,
+			wantPort:                  &corev1.ServicePort{Name: "http", Protocol: tcp, Port: 80, TargetPort: intstr.FromInt(8080)},
+			wantErr:                   false,
+		},
+		{
+			name: "Match unnamed port (empty string)",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-svc",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "", Protocol: tcp, Port: 80, TargetPort: intstr.FromInt(8080)},
+					},
+				},
+			},
+			endpointslicePortName:     "",
+			endpointslicePortProtocol: tcp,
+			wantPort:                  &corev1.ServicePort{Name: "", Protocol: tcp, Port: 80, TargetPort: intstr.FromInt(8080)},
+			wantErr:                   false,
+		},
+		{
+			name: "Protocol mismatch",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-svc",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "dns", Protocol: tcp, Port: 53, TargetPort: intstr.FromInt(5353)},
+					},
+				},
+			},
+			endpointslicePortName:     "dns",
+			endpointslicePortProtocol: udp,
+			wantPort:                  nil,
+			wantErr:                   true,
+		},
+		{
+			name: "Port name not found",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-svc",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "http", Protocol: tcp, Port: 80, TargetPort: intstr.FromInt(8080)},
+					},
+				},
+			},
+			endpointslicePortName:     "https",
+			endpointslicePortProtocol: tcp,
+			wantPort:                  nil,
+			wantErr:                   true,
+		},
+		{
+			name: "Multiple ports, match second one",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-svc",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "http", Protocol: tcp, Port: 80, TargetPort: intstr.FromInt(8080)},
+						{Name: "grpc", Protocol: tcp, Port: 9090, TargetPort: intstr.FromInt(9091)},
+						{Name: "metrics", Protocol: tcp, Port: 8080, TargetPort: intstr.FromInt(8081)},
+					},
+				},
+			},
+			endpointslicePortName:     "grpc",
+			endpointslicePortProtocol: tcp,
+			wantPort:                  &corev1.ServicePort{Name: "grpc", Protocol: tcp, Port: 9090, TargetPort: intstr.FromInt(9091)},
+			wantErr:                   false,
+		},
+		{
+			name: "Named target port (not numeric)",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-svc",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "web", Protocol: tcp, Port: 80, TargetPort: intstr.FromString("http")},
+					},
+				},
+			},
+			endpointslicePortName:     "web",
+			endpointslicePortProtocol: tcp,
+			wantPort:                  &corev1.ServicePort{Name: "web", Protocol: tcp, Port: 80, TargetPort: intstr.FromString("http")},
+			wantErr:                   false,
+		},
+		{
+			name:                      "Nil service input",
+			service:                   nil,
+			endpointslicePortName:     "web",
+			endpointslicePortProtocol: tcp,
+			wantPort:                  nil,
+			wantErr:                   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FindServicePortForEndpointSlicePort(tt.service, tt.endpointslicePortName, tt.endpointslicePortProtocol)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantPort, got)
+			}
+		})
+	}
 }
 
 func TestServiceFromEndpointSlice(t *testing.T) {


### PR DESCRIPTION
When reconciling conntrack entries for endpoint changes, we need to use
the service port (the externally exposed port) rather than the endpoint
port (the target port on the pod). This ensures conntrack entries are
properly flushed for the actual service port that clients connect to.

Changes:
- Add FindServicePortForEndpointSlicePort helper to map endpoint ports to service ports
- Update reconcileConntrackUponEndpointSliceEvents to use service port for conntrack deletion
- Handle service not found error explicitly (return early, service deletion is handled separately)

All tests pass successfully.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities and types to improve service-port resolution and load‑balancer endpoint construction.

* **Bug Fixes**
  * Treat missing/deleted Services referenced by EndpointSlices as non-fatal to avoid reconciliation failures.
  * Resolve endpoint-slice port names to concrete service ports before conntrack deletion; preserve aggregated error reporting.
  * Emit finer-grained per-event diagnostic logs for conntrack operations.

* **Tests**
  * Expanded table-driven and unit tests covering IPv4/IPv6, dual-stack, named/unnamed ports, multi-endpoint and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->