### PR TITLE
add eip e2e cases on ns/pod labels update

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -201,6 +201,7 @@ else
     skip "e2e egress IP validation Cluster Default Network Should validate egress IP logic when one pod is managed by more than one egressIP object"
     skip "e2e egress IP validation Cluster Default Network Should re-assign egress IPs when node readiness / reachability goes down/up"
     skip "Pod to external server PMTUD when a client ovnk pod targeting an external server is created when tests are run towards the agnhost echo server queries to the hostNetworked server pod on another node shall work for UDP"
+    skip "e2e egress IP validation Cluster Default Network Should handle EIP reassignment correctly on namespace and pod label updates, and EIP object updates"
 
     # https://issues.redhat.com/browse/OCPBUGS-55028
     skip "e2e egress IP validation Cluster Default Network \[secondary-host-eip\]"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
This is one e2e test coverage for end user bug https://issues.redhat.com/browse/OCPBUGS-61742
The scenarios is:

1. Two EIPs exist:

- eip1 matches namespace label test: qe
- eip2 matches namespace label test: dev

2. There is a pod in test namespace
3.  change the label from the namespace from test=qe to test=dev or from test=dev to test=qe for a couple of times
4. Verify the source IP, the reported issue was that srcIP was nodeIP instead of egressIP.


And this case covers below scenarios: 
should handle EIP reassignment correctly on namespace label update 
should handle EIP reassignment correctly on pod label update 
should handle EIP reassignment correctly on EgressIP object update
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test validating EgressIP reassignment across repeated namespace, pod, and EgressIP selector updates. Verifies correct IP assignment, SNAT behavior, connectivity to external endpoints and node IPs, status length checks after changes, cleanup of CRD configuration, and deterministic reassignment across multiple iterations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->