### PR TITLE
Fixes regression with ecabc89

### DIFF
--- a/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go
+++ b/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go
@@ -558,7 +558,6 @@ func (oc *EFController) validateAndGetEgressFirewallDestination(namespace string
 		for _, clusterSubnet := range subnets {
 			if clusterSubnet.CIDR.Contains(ipNet.IP) || ipNet.Contains(clusterSubnet.CIDR.IP) {
 				clusterSubnetIntersection = append(clusterSubnetIntersection, clusterSubnet.CIDR)
-				break
 			}
 		}
 	} else {


### PR DESCRIPTION
With multiple subnets for a network, only the first one was being used for cluster subnet exclusion.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded egress firewall test coverage to validate CIDR selector with multiple cluster subnets
  * Added test case verifying proper handling of multiple cluster subnets intersection
  * Updated test setup to include additional cluster subnet scenarios

* **Bug Fixes**
  * Fixed egress firewall destination logic to evaluate all matching cluster subnets during CIDR intersection analysis, previously only processing the first match

<!-- end of auto-generated comment: release notes by coderabbit.ai -->