### PR TITLE
egressip: skip bridge configuration for secondary network IPs

### DIFF
--- a/go-controller/pkg/node/egressip/gateway_egressip_test.go
+++ b/go-controller/pkg/node/egressip/gateway_egressip_test.go
@@ -1,6 +1,7 @@
 package egressip
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -127,6 +128,25 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 		})
+
+		ginkgo.It("doesn't configure when EgressIP is on a secondary host network", func() {
+			// Setup a node with host-cidrs annotation containing a secondary network subnet
+			secondarySubnet := "10.10.10.0/24"
+			secondaryIP := "10.10.10.5"
+
+			nlMock.On("AddrAdd", nlLinkMock, egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex)).Return(nil)
+			addrMgr, stopFn := initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName, emptyAnnotation, []string{secondarySubnet})
+			defer stopFn()
+			eip := getEIPAssignedToNode(nodeName, mark, secondaryIP)
+			isUpdated, err := addrMgr.AddEgressIP(eip)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should not error for secondary network IP")
+			gomega.Expect(isUpdated).Should(gomega.BeFalse(), "should not update for secondary network IP")
+			node, err := addrMgr.nodeLister.Get(nodeName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+			gomega.Expect(parseEIPsFromAnnotation(node)).ShouldNot(gomega.ConsistOf(secondaryIP), "secondary IP should not be in annotation")
+			gomega.Expect(nlMock.AssertNotCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
+				egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex))).Should(gomega.BeTrue(), "should not add IP to bridge")
+		})
 	})
 
 	ginkgo.Context("update EgressIP", func() {
@@ -198,9 +218,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			isUpdated, err = addrMgr.UpdateEgressIP(assignedEIP1, assignedEIP2)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process a valid EgressIP")
 			gomega.Expect(isUpdated).Should(gomega.BeTrue())
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr2))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr2))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
@@ -292,9 +314,11 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			eipAssigned2 := getEIPAssignedToNode(nodeName, mark2, ipV4Addr2)
 			err := addrMgr.SyncEgressIP([]interface{}{eipAssigned1, eipAssigned2})
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should process valid EgressIPs")
-			node, err := addrMgr.nodeLister.Get(nodeName)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
-			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr, ipV4Addr2))
+			gomega.Eventually(func() []string {
+				node, err := addrMgr.nodeLister.Get(nodeName)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
+				return parseEIPsFromAnnotation(node)
+			}).Should(gomega.ConsistOf(ipV4Addr, ipV4Addr2))
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
 				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue())
 			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
@@ -313,15 +337,74 @@ var _ = ginkgo.Describe("Gateway EgressIP", func() {
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "node should be present within kapi")
 			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.BeEmpty())
 		})
+
+		ginkgo.It("cleans up mistakenly configured secondary network EgressIP", func() {
+			// Setup: secondary network IP that was mistakenly configured by old buggy code
+			secondaryIP := "10.10.10.5"
+			secondarySubnet := "10.10.10.0/24"
+
+			nlLinkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: bridgeName, Index: bridgeLinkIndex}, nil)
+			nlMock.On("LinkByName", bridgeName).Return(nlLinkMock, nil)
+			nlMock.On("LinkByIndex", bridgeLinkIndex).Return(nlLinkMock, nil)
+			nlMock.On("LinkList").Return([]netlink.Link{nlLinkMock}, nil)
+			nlMock.On("AddrList", nlLinkMock, 0).Return([]netlink.Addr{}, nil)
+			nlMock.On("AddrDel", nlLinkMock, egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex)).Return(nil)
+			nlMock.On("AddrAdd", nlLinkMock, egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex)).Return(nil)
+
+			// Initialize with host-cidrs that includes the secondary network and mistakenly configured secondary IP
+			addrMgr, stopFn := initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName, generateAnnotFromIPs(secondaryIP), []string{secondarySubnet})
+			defer stopFn()
+
+			// Simulate mistaken configuration by old buggy code: IP is in cache
+			secondaryEIP := getEIPAssignedToNode(nodeName, mark, secondaryIP)
+			pktMark, err := util.ParseEgressIPMark(secondaryEIP.Annotations)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			addrMgr.cache.insertMarkIP(pktMark, net.ParseIP(secondaryIP))
+
+			// Verify mistaken state exists
+			gomega.Expect(addrMgr.cache.IsIPPresent(net.ParseIP(secondaryIP))).Should(gomega.BeTrue(), "IP should be in cache (mistaken state)")
+			node, err := addrMgr.nodeLister.Get(nodeName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(secondaryIP), "IP should be in annotation (mistaken state)")
+
+			// Sync with a valid OVN network EgressIP - should clean up the secondary IP and add the new one
+			validEIP := getEIPAssignedToNode(nodeName, mark2, ipV4Addr)
+			err = addrMgr.SyncEgressIP([]interface{}{validEIP})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should sync and clean up mistaken secondary network EgressIP")
+
+			// Verify cleanup: secondary IP removed from cache, annotation, and bridge
+			gomega.Expect(addrMgr.cache.IsIPPresent(net.ParseIP(secondaryIP))).Should(gomega.BeFalse(), "secondary IP should be removed from cache")
+			node, err = addrMgr.nodeLister.Get(nodeName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(parseEIPsFromAnnotation(node)).Should(gomega.ConsistOf(ipV4Addr), "only valid OVN IP should be in annotation")
+			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrDel", nlLinkMock,
+				egressip.GetNetlinkAddress(net.ParseIP(secondaryIP), bridgeLinkIndex))).Should(gomega.BeTrue(), "should delete secondary IP from bridge")
+			gomega.Expect(nlMock.AssertCalled(ginkgo.GinkgoT(), "AddrAdd", nlLinkMock,
+				egressip.GetNetlinkAddress(net.ParseIP(ipV4Addr), bridgeLinkIndex))).Should(gomega.BeTrue(), "should add valid OVN IP to bridge")
+		})
 	})
 })
 
 func initBridgeEIPAddrManager(nodeName, bridgeName string, bridgeEIPAnnot string) (*BridgeEIPAddrManager, func()) {
+	return initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName, bridgeEIPAnnot, nil)
+}
+
+// initBridgeEIPAddrManagerWithHostCIDRs is a variant of initBridgeEIPAddrManager that sets the host-cidrs annotation
+func initBridgeEIPAddrManagerWithHostCIDRs(nodeName, bridgeName string, bridgeEIPAnnot string, hostCIDRs []string) (*BridgeEIPAddrManager, func()) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: nodeName, Annotations: map[string]string{}},
 	}
 	if bridgeEIPAnnot != "" {
 		node.Annotations[util.OVNNodeBridgeEgressIPs] = bridgeEIPAnnot
+	}
+	// Add OVN network annotation - required for isOVNNetworkIP to work
+	node.Annotations[util.OvnNodeIfAddr] = `{"ipv4":"192.168.1.10/24"}`
+	if len(hostCIDRs) > 0 {
+		// Add OVN (primary) network to host-cidrs
+		hostCIDRs = append(hostCIDRs, "192.168.1.0/24")
+		cidrsJSON, err := json.Marshal(hostCIDRs)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		node.Annotations[util.OVNNodeHostCIDRs] = string(cidrsJSON)
 	}
 	client := fake.NewSimpleClientset(node)
 	watchFactory, err := factory.NewNodeWatchFactory(&util.OVNNodeClientset{KubeClient: client}, nodeName)

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -1,11 +1,13 @@
 package linkmanager
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -152,7 +154,7 @@ func (c *Controller) DelAddress(address netlink.Addr) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if err := util.GetNetLinkOps().AddrDel(link, &address); err != nil {
-		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+		if !util.GetNetLinkOps().IsLinkNotFoundError(err) && !errors.Is(err, unix.EADDRNOTAVAIL) {
 			return fmt.Errorf("failed to delete address %s: %v", address.String(), err)
 		}
 	}


### PR DESCRIPTION
Skip configuring EgressIPs on the bridge when they don't belong to the OVN (primary) network. This prevents conflicts when EgressIPs are assigned to secondary host networks.

Uses util.IsOVNNetwork() to check network membership and adds a helper function parseAndValidateEIP() to consolidate validation logic and fix missing packet mark validation.


## 📑 Description

Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
1. Deploy a cluster with nodes that have multiple interfaces.
2. Create an EgreseIP for a node's secondary interface.
3. Check if the egress IP is only assigned to the secondary interface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Egress IP handling now skips secondary (non-primary) host-network IPs during add/update/delete/sync to prevent incorrect bridge/annotation changes and noisy logs.
  * Mistaken secondary-network Egress IPs are cleaned from annotations, bridge, and cache during updates/sync.
  * Address removal treats "address not available" (EADDRNOTAVAIL) as non-fatal to avoid spurious errors.

* **Refactor**
  * Centralized Egress IP parsing/validation and OVN/primary-network detection for consistent behavior and skip semantics.

* **Tests**
  * Added tests for secondary-network Egress IP scenarios, cleanup flows, host CIDR/annotation helpers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->