### PR TITLE
Bump back to go 1.24

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -11,7 +11,7 @@ PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
 export TEST_REPORT_DIR
-GO_VERSION ?= 1.25
+GO_VERSION ?= 1.24
 GO_DOCKER_IMG = quay.io/projectquay/golang:${GO_VERSION}
 # CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
 # podman/docker is installed on the system.

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -1,8 +1,8 @@
 module github.com/ovn-org/ovn-kubernetes/go-controller
 
-go 1.25.0
+go 1.24.0
 
-toolchain go1.25.1
+toolchain go1.24.5
 
 require (
 	github.com/Microsoft/hcsshim v0.9.6

--- a/test/conformance/go.mod
+++ b/test/conformance/go.mod
@@ -1,8 +1,8 @@
 module github.com/ovn-org/ovn-kubernetes/test/conformance
 
-go 1.25.0
+go 1.24.0
 
-toolchain go1.25.1
+toolchain go1.24.5
 
 require (
 	gopkg.in/yaml.v3 v3.0.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,8 +1,8 @@
 module github.com/ovn-org/ovn-kubernetes/test/e2e
 
-go 1.25.0
+go 1.24.0
 
-toolchain go1.25.1
+toolchain go1.24.5
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
go was bumped to 1.25 with the k8s bump to 1.34. This was a mistake as
k8s did not bump golang and stayed on 1.24 this time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go language and toolchain pins across the project and test suites (downgraded from 1.25 to 1.24).
  * Updated default Go version used by build/CI tooling.
  * No functional, API, or behavioral changes introduced; tooling adjustment only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->