### PR TITLE
Fixes gateway interface VLAN tag settings

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -123,6 +123,22 @@ Chain FORWARD (policy DROP 0 packets, 0 bytes)
     0     0 ACCEPT     0    --  *      ovn-k8s-mp0  ::/0                 ::/0          
 ```
 
+### VLAN Config
+
+OVN-Kubernetes supports using VLAN tagging for underlay connectivity. To enable VLAN tagging, specify the `vlan-id`
+gateway configuration option with the desired VLAN tag. This tag will be used for traffic ingressing and egressing
+OVN as well as the host. When `vlan-id` is configured:
+
+* OVN will be configured to accept the VLAN tag specified by `vlan-id`
+* The external gateway bridge will be configured to add/strip the VLAN tag specified by `vlan-id` for packets destined to
+and coming from the host
+* The physical interface attached to the external gateway bridge will act as a VLAN trunk
+
+Note, it is not required to configure a VLAN sub-interface (802.1q interface) on the host, OVN-Kubernetes will automatically
+handle VLAN tagging in the OVS external bridge. It is also supported to have additional interfaces attached to the external
+gateway bridge that use different VLAN tags than VLANID. These interfaces will operate in their own VLAN, and share the
+physical interface as a trunk.
+
 ## Logging Config
 
 ## Monitoring Config

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1491,12 +1491,12 @@ func newGateway(
 		// Program cluster.GatewayIntf to let non-pod traffic to go to host
 		// stack
 		klog.Info("Creating Gateway Openflow Manager")
-		err := gwBridge.SetOfPorts()
+		err := gwBridge.ConfigureBridgePorts()
 		if err != nil {
 			return err
 		}
 		if exGwBridge != nil {
-			err = exGwBridge.SetOfPorts()
+			err = exGwBridge.ConfigureBridgePorts()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
In OVNK we allow setting a VLANID. This VLANID works via:

 - The patch port to OVN should be a tagged VLAN interface. OVN expects a VLAN tag.
 - The physical port connected to the br-ex bridge is a trunk port by default carrying the VLAN tags.
 - The gateway interface (host interface) port should be an untagged VLAN interface.

We have flows that will strip the VLAN tag as OVN is communicating with the host. We also have flows that will push the VLAN tag as the host is communicating with OVN. However, we also use a NORMAL action as a fallback for unknown traffic to the shared gateway MAC, as well as traffic ingressing from the physical interface, and destined to the shared GW MAC. This NORMAL action needs to execute in the correct VLAN.

Since the physical interface is acting as a trunk already, NORMAL will work correctly there. However, the gateway/host interface was not set as an untagged access port in OVS, which would result in the interface not being a member of the VLAN, and packets being dropped with NORMAL action.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VLAN tagging support for gateway bridges and host interfaces with automatic detection of the appropriate host interface and guarded apply/remove behavior.

* **Refactor**
  * Reorganized VLAN flow variable names and bridge port configuration logic for clearer flow generation and maintainability without changing runtime behavior.

* **Tests**
  * Integration tests extended to cover both tagged and untagged gateway scenarios.

* **Documentation**
  * Added VLAN configuration guidance explaining vlan-id effects and trunking behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->