### PR TITLE
egressip: fix duplicate IP assignment on control-plane restart

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -531,7 +531,26 @@ func (eIPC *egressIPClusterController) getSortedEgressData() ([]*egressNode, map
 	return assignableNodes, allAllocations
 }
 
-func (eIPC *egressIPClusterController) initEgressNodeReachability(_ []interface{}) error {
+func (eIPC *egressIPClusterController) initEgressNodeReachability(objs []interface{}) error {
+	for _, obj := range objs {
+		node := obj.(*corev1.Node)
+		if err := eIPC.initEgressIPAllocator(node); err != nil {
+			klog.Warningf("Egress node initialization error: %v", err)
+		}
+	}
+
+	// Before reconciling unassigned EgressIPs, ensure the allocator cache is populated
+	// with existing assignments from EgressIP statuses. This prevents duplicate IP
+	// assignments when two EgressIPs have the same IP in their specs but only one has
+	// it assigned in status (e.g., after control-plane restart or during initial sync).
+	egressIPs, err := eIPC.kube.GetEgressIPs()
+	if err != nil {
+		return fmt.Errorf("unable to list EgressIPs, err: %v", err)
+	}
+	for _, egressIP := range egressIPs {
+		eIPC.ensureAllocatorEgressIPAssignments(egressIP)
+	}
+
 	go eIPC.checkEgressNodesReachability()
 	return nil
 }
@@ -1825,10 +1844,21 @@ func generateStatusPatchOp(statusItems []egressipv1.EgressIPStatusItem) jsonPatc
 	}
 }
 
+// ensureAllocatorEgressIPAssignments adds EgressIP assignments to the allocator cache
+// if the EgressIP has status items. This is critical to prevent duplicate IP assignments
+// during restart when EgressIPs are processed in arbitrary order.
+func (eIPC *egressIPClusterController) ensureAllocatorEgressIPAssignments(egressIP *egressipv1.EgressIP) {
+	if len(egressIP.Status.Items) > 0 {
+		eIPC.addAllocatorEgressIPAssignments(egressIP.Name, egressIP.Status.Items)
+	}
+}
+
 // syncEgressIPMarkAllocator iterates over all existing EgressIPs. It builds a mark cache of existing marks stored on each
-// EgressIP annotation or allocates and adds a new mark to an EgressIP if it doesn't exist
+// EgressIP annotation or allocates and adds a new mark to an EgressIP if it doesn't exist.
 func (eIPC *egressIPClusterController) syncEgressIPMarkAllocator(egressIPs []interface{}) error {
-	// reserve previously assigned marks
+	// Reserve previously assigned marks. Note: the allocator cache is pre-populated with
+	// existing assignments from EgressIP statuses in initEgressNodeReachability, which runs
+	// before this sync function.
 	for _, object := range egressIPs {
 		egressIP, ok := object.(*egressipv1.EgressIP)
 		if !ok {

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -4218,6 +4218,122 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		// This test validates that when two EgressIP CRs have the same IP in their specs,
+		// and one already has the IP assigned in status (from before restart), the sync
+		// function properly pre-populates the allocator cache to prevent duplicate assignment.
+		// This is a regression test for the bug where duplicate IPs were assigned during
+		// control-plane pod restart because the allocator cache wasn't populated from
+		// existing EgressIP statuses before processing individual ADD events.
+		ginkgo.It("should not assign duplicate IP during restart when two EgressIPs have same IP in spec", func() {
+			app.Action = func(*cli.Context) error {
+				duplicateIP := "192.168.126.101"
+				node1IPv4 := "192.168.126.12/24"
+				node2IPv4 := "192.168.126.51/24"
+
+				node1 := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\", \"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node1IPv4),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\": [\"%s\",\"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf("[\"%s\"]", node2IPv4),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				// eIP1 has the IP assigned in status (simulating state from before restart)
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta("egressip-1"),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{duplicateIP},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: duplicateIP,
+								Node:     node1Name,
+							},
+						},
+					},
+				}
+
+				// eIP2 has the same IP in spec but NOT in status (unassigned, but was created
+				// with duplicate IP - which should have been rejected but wasn't due to a bug
+				// or manual API manipulation)
+				eIP2 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta("egressip-2"),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{duplicateIP},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&corev1.NodeList{Items: []corev1.Node{node1, node2}},
+					// Both EgressIPs exist at startup - simulating restart scenario
+					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP1, eIP2}},
+				)
+
+				// Use WatchEgressNodes to properly initialize the allocator cache
+				// (simulating real startup behavior rather than manually setting up cache)
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// eIP1 should keep its assignment (the IP was already assigned)
+				gomega.Eventually(getEgressIPStatusLen("egressip-1")).Should(gomega.Equal(1))
+				egressIPs1, nodes1 := getEgressIPStatus("egressip-1")
+				gomega.Expect(nodes1[0]).To(gomega.Equal(node1Name))
+				gomega.Expect(egressIPs1[0]).To(gomega.Equal(duplicateIP))
+
+				// eIP2 should NOT get the duplicate IP assigned (not even to node2) -
+				// it should remain unassigned because initEgressNodeReachability pre-populated the
+				// cache with eIP1's assignment
+				gomega.Eventually(getEgressIPStatusLen("egressip-2")).Should(gomega.Equal(0))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("AddEgressIP for IPv4", func() {


### PR DESCRIPTION
When the ovn-k control-plane pods restart, two EgressIP CRs with the same IP in their specs could both get the IP assigned to nodes if one already had the IP assigned in status and the other didn't.


```console
$ kubectl get eip
NAME                     EGRESSIPS        ASSIGNED NODE                           ASSIGNED EGRESSIPS
egressip-dual-vlan94-1   192.168.118.30   cnfdc6.t5g-dev.eng.rdu2.dc.redhat.com   192.168.118.30
egressip-dual-vlan94-2   192.168.118.30                                           

$ kubectl -n openshift-ovn-kubernetes delete pods -l app=ovnkube-control-plane
pod "ovnkube-control-plane-6579d7875f-6v6zc" deleted
pod "ovnkube-control-plane-6579d7875f-7nggg" deleted

$ kubectl get eip
NAME                     EGRESSIPS        ASSIGNED NODE                           ASSIGNED EGRESSIPS
egressip-dual-vlan94-1   192.168.118.30   cnfdc6.t5g-dev.eng.rdu2.dc.redhat.com   192.168.118.30
egressip-dual-vlan94-2   192.168.118.30   cnfdc6.t5g-dev.eng.rdu2.dc.redhat.com   192.168.118.30
```

When WatchEgressNodes() processes node ADD events and calls addEgressNode(), it triggers reconcileEgressIP() for unassigned EgressIPs. At this point, the node allocator cache was empty and hadn't been populated with existing EgressIP assignments from their statuses. This allowed an unassigned EgressIP to get a duplicate IP assigned before the allocator cache knew about existing assignments.

Populate the node allocator cache with existing EgressIP status assignments in addEgressNode() BEFORE reconciling unassigned EgressIPs. Also add syncEgressIPAllocator() which is called from syncEgressIPMarkAllocator() to ensure the cache is populated when WatchEgressIP() processes ADD events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved allocator initialization to pre-populate assignments from status, preventing duplicate EgressIP assignments during restarts and concurrent reconciliations.

* **Tests**
  * Added a regression test that verifies duplicate IPs are not reassigned when multiple EgressIP resources share the same spec during restart (test included repeated block).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->