### PR TITLE
contrib: fix IPv6 address handling in frr-k8s webhook check

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -857,7 +857,10 @@ install_ffr_k8s() {
 echo "Attempting to reach frr-k8s webhook"
 kind export kubeconfig --name ovn
 while true; do
-$OCI_BIN exec ovn-control-plane curl -ksS --connect-timeout 0.1 https://$(kubectl get svc -n frr-k8s-system frr-k8s-webhook-service -o jsonpath='{.spec.clusterIP}')
+CLUSTER_IP=\$(kubectl get svc -n frr-k8s-system frr-k8s-webhook-service -o jsonpath='{.spec.clusterIP}')
+# Wrap IPv6 addresses in brackets for URL syntax
+[[ \${CLUSTER_IP} =~ : ]] && CLUSTER_IP="[\${CLUSTER_IP}]"
+$OCI_BIN exec ovn-control-plane curl -ksS --connect-timeout 0.1 https://\${CLUSTER_IP}
 [ \$? -eq 0 ] && exit 0
 echo "Couldn't reach frr-k8s webhook, trying in 1s..."
 sleep 1s


### PR DESCRIPTION
Wrap IPv6 addresses in brackets when constructing curl URLs, as IPv6 addresses with colons require bracket notation in URL syntax.

## 📑 Description

When deploying the FRR pods at an IPv6 cluster, the curl command with an IPv6 Address cannot return success.

Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

Use kind.sh to deploy an IPv6 cluster with route advertisement enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook probe to reliably contact cluster endpoints over HTTPS, including proper IPv6 address handling.
  * Continues automatic retry loop with backoff until successful.
  * Preserves existing failure diagnostics and logging on probe failures.
  * Ensures apply and cleanup proceed after a successful probe.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->