### PR TITLE
remove forced V(5) logging during startup

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -767,13 +767,6 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	var subnets []*net.IPNet
 	var cniServer *cni.Server
 
-	// Setting debug log level during node bring up to expose bring up process.
-	// Log level is returned to configured value when bring up is complete.
-	var level klog.Level
-	if err := level.Set("5"); err != nil {
-		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
-	}
-
 	if config.OvnKubeNode.Mode != types.NodeModeDPU {
 		if err = configureGlobalForwarding(); err != nil {
 			return err
@@ -951,9 +944,6 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		}
 	}
 
-	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {
-		klog.Errorf("Reset of initial klog \"loglevel\" failed, err: %v", err)
-	}
 	nc.sbZone = sbZone
 
 	return nil
@@ -969,13 +959,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 
 	if nc.mgmtPortController == nil {
 		return fmt.Errorf("default node network controller hasn't been pre-started")
-	}
-
-	// Setting debug log level during node bring up to expose bring up process.
-	// Log level is returned to configured value when bring up is complete.
-	var level klog.Level
-	if err := level.Set("5"); err != nil {
-		klog.Errorf("Setting klog \"loglevel\" to 5 failed, err: %v", err)
 	}
 
 	if node, err = nc.watchFactory.GetNode(nc.name); err != nil {
@@ -1181,10 +1164,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		if err != nil {
 			klog.Errorf("Deletion of port int on  br-int failed: %v (%v)", err, stderr)
 		}
-	}
-
-	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {
-		klog.Errorf("Reset of initial klog \"loglevel\" failed, err: %v", err)
 	}
 
 	// start management port controller


### PR DESCRIPTION
## 📑 Description

This PR removes the hardcoded log level override during ovnkube-node startup. Previously, the Init() and Start() functions forced log level to V(5) regardless of user configuration, then reset it after initialization completed.

This forced logging was originally added to help debug startup issues, but it overrides the user's `--loglevel` configuration, causing confusion when users set a lower log level but still see verbose V(5) logs during node initialization.

The startup process now respects the log level configured via the `--loglevel` flag or `OVN_KUBE_LOG_LEVEL` environment variable throughout execution.

## Additional Information for reviewers

Removed 4 code blocks (21 lines total) from `default_node_network_controller.go`:
- Init() function: Removed level.Set("5") at start and reset at end
- Start() function: Removed level.Set("5") at start and reset at end

## ✅ Checks

- [ ] My code requires changes to the documentation
- [x] All the tests have passed in the CI

## How to verify it

1. Deploy ovnkube-node with `--loglevel=2`
2. Observe startup logs
3. Verify no V(5) debug logs appear during initialization
4. Confirm the configured log level is respected throughout startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed dynamic logging level adjustments that occurred during node initialization and bring-up processes. Log levels now remain consistent throughout startup and initialization cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->