### PR TITLE
fix(kubevirt): Use pod network subnet gateway IP for DHCP router option

### DIFF
--- a/go-controller/pkg/kubevirt/dhcp.go
+++ b/go-controller/pkg/kubevirt/dhcp.go
@@ -71,19 +71,6 @@ func WithIPv6DNSServer(dnsServer string) func(*dhcpConfigs) {
 	}
 }
 
-func EnsureDHCPOptionsForMigratablePod(controllerName string, nbClient libovsdbclient.Client, watchFactory *factory.WatchFactory, pod *corev1.Pod, ips []*net.IPNet, lsp *nbdb.LogicalSwitchPort) error {
-	dnsServerIPv4, dnsServerIPv6, err := RetrieveDNSServiceClusterIPs(watchFactory)
-	if err != nil {
-		return fmt.Errorf("failed retrieving dns service cluster ip: %v", err)
-	}
-
-	return EnsureDHCPOptionsForLSP(controllerName, nbClient, pod, ips, lsp,
-		WithIPv4Router(ARPProxyIPv4),
-		WithIPv4DNSServer(dnsServerIPv4),
-		WithIPv6DNSServer(dnsServerIPv6),
-	)
-}
-
 func EnsureDHCPOptionsForLSP(controllerName string, nbClient libovsdbclient.Client, pod *corev1.Pod, ips []*net.IPNet, lsp *nbdb.LogicalSwitchPort, opts ...DHCPConfigsOpt) error {
 	vmKey := ExtractVMNameFromPod(pod)
 	if vmKey == nil {

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -230,7 +230,8 @@ func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed f
 // provided on the arguments of the method. This method returns no error and logs them
 // instead since once the controller NetInfo has been updated there is no point in retrying.
 func (oc *BaseNetworkController) doReconcile(reconcileRoutes, reconcilePendingPods bool,
-	reconcileNodes []string, setNodeFailed func(string), reconcileNamespaces []string) {
+	reconcileNodes []string, setNodeFailed func(string), reconcileNamespaces []string,
+) {
 	if reconcileRoutes {
 		err := oc.routeImportManager.ReconcileNetwork(oc.GetNetworkName())
 		if err != nil {
@@ -322,7 +323,8 @@ func getNetworkControllerName(netName string) string {
 // NewCommonNetworkControllerInfo creates CommonNetworkControllerInfo shared by controllers
 func NewCommonNetworkControllerInfo(client clientset.Interface, kube *kube.KubeOVN, wf *factory.WatchFactory,
 	recorder record.EventRecorder, nbClient libovsdbclient.Client, sbClient libovsdbclient.Client,
-	podRecorder *metrics.PodRecorder, SCTPSupport, multicastSupport, svcTemplateSupport bool) (*CommonNetworkControllerInfo, error) {
+	podRecorder *metrics.PodRecorder, SCTPSupport, multicastSupport, svcTemplateSupport bool,
+) (*CommonNetworkControllerInfo, error) {
 	zone, err := libovsdbutil.GetNBZone(nbClient)
 	if err != nil {
 		return nil, fmt.Errorf("error getting NB zone name : err - %w", err)
@@ -351,7 +353,8 @@ func (bnc *BaseNetworkController) GetLogicalPortName(pod *corev1.Pod, nadName st
 }
 
 func (bnc *BaseNetworkController) AddConfigDurationRecord(kind, namespace, name string) (
-	[]ovsdb.Operation, func(), time.Time, error) {
+	[]ovsdb.Operation, func(), time.Time, error,
+) {
 	if !bnc.IsUserDefinedNetwork() {
 		return recorders.GetConfigDurationRecorder().AddOVN(bnc.nbClient, kind, namespace, name)
 	}
@@ -518,7 +521,8 @@ func (bnc *BaseNetworkController) syncNodeClusterRouterPort(node *corev1.Node, h
 }
 
 func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostSubnets []*net.IPNet,
-	clusterLoadBalancerGroupUUID, switchLoadBalancerGroupUUID string) error {
+	clusterLoadBalancerGroupUUID, switchLoadBalancerGroupUUID string,
+) error {
 	// logical router port MAC is based on IPv4 subnet if there is one, else IPv6
 	var nodeLRPMAC net.HardwareAddr
 	switchName := bnc.GetNetworkScopedSwitchName(nodeName)
@@ -544,8 +548,7 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 		if utilnet.IsIPv6CIDR(hostSubnet) {
 			v6Gateway = gwIfAddr.IP
 
-			logicalSwitch.OtherConfig["ipv6_prefix"] =
-				hostSubnet.IP.String()
+			logicalSwitch.OtherConfig["ipv6_prefix"] = hostSubnet.IP.String()
 		} else {
 			v4Gateway = gwIfAddr.IP
 			excludeIPs := mgmtIfAddr.IP.String()
@@ -1003,7 +1006,6 @@ func (bnc *BaseNetworkController) isLocalZoneNode(node *corev1.Node) bool {
 
 // GetNetworkRole returns the role of this controller's network for the given pod
 func (bnc *BaseNetworkController) GetNetworkRole(pod *corev1.Pod) (string, error) {
-
 	role, err := util.GetNetworkRole(bnc.GetNetInfo(), bnc.networkManager.GetActiveNetworkForNamespace, pod)
 	if err != nil {
 		if util.IsUnprocessedActiveNetworkError(err) {
@@ -1161,8 +1163,8 @@ func (bnc *BaseNetworkController) newNetworkQoSController() error {
 }
 
 func initLoadBalancerGroups(nbClient libovsdbclient.Client, netInfo util.NetInfo) (
-	clusterLoadBalancerGroupUUID, switchLoadBalancerGroupUUID, routerLoadBalancerGroupUUID string, err error) {
-
+	clusterLoadBalancerGroupUUID, switchLoadBalancerGroupUUID, routerLoadBalancerGroupUUID string, err error,
+) {
 	loadBalancerGroupName := netInfo.GetNetworkScopedLoadBalancerGroupName(types.ClusterLBGroupName)
 	clusterLBGroup := nbdb.LoadBalancerGroup{Name: loadBalancerGroupName}
 	ops, err := libovsdbops.CreateOrUpdateLoadBalancerGroupOps(nbClient, nil, &clusterLBGroup)
@@ -1246,4 +1248,26 @@ func (bnc *BaseNetworkController) GetSamplingConfig() *libovsdbops.SamplingConfi
 		return bnc.observManager.SamplingConfig()
 	}
 	return nil
+}
+
+func (bnc *BaseNetworkController) ensureDHCP(pod *corev1.Pod, podAnnotation *util.PodAnnotation, lsp *nbdb.LogicalSwitchPort) error {
+	opts := []kubevirt.DHCPConfigsOpt{}
+
+	ipv4DNSServer, ipv6DNSServer, err := kubevirt.RetrieveDNSServiceClusterIPs(bnc.watchFactory)
+	if err != nil {
+		return err
+	}
+
+	ipv4Gateway, _ := util.MatchFirstIPFamily(false /*ipv4*/, podAnnotation.Gateways)
+	if ipv4Gateway != nil {
+		opts = append(opts, kubevirt.WithIPv4Router(ipv4Gateway.String()))
+	}
+
+	if bnc.MTU() > 0 {
+		opts = append(opts, kubevirt.WithIPv4MTU(bnc.MTU()))
+	}
+
+	opts = append(opts, kubevirt.WithIPv4DNSServer(ipv4DNSServer), kubevirt.WithIPv6DNSServer(ipv6DNSServer))
+
+	return kubevirt.EnsureDHCPOptionsForLSP(bnc.controllerName, bnc.nbClient, pod, podAnnotation.IPs, lsp, opts...)
 }

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -227,7 +227,6 @@ func (bsnc *BaseUserDefinedNetworkController) DeleteUserDefinedNetworkResourceCo
 // ensurePodForUserDefinedNetwork tries to set up the User Defined Network for a pod. It returns nil on success and error
 // on failure; failure indicates the pod set up should be retried later.
 func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod *corev1.Pod, addPort bool) error {
-
 	// Try unscheduled pods later
 	if !util.PodScheduled(pod) {
 		return nil
@@ -302,7 +301,8 @@ func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod
 }
 
 func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod *corev1.Pod, nadName, switchName string,
-	network *nadapi.NetworkSelectionElement, kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus) error {
+	network *nadapi.NetworkSelectionElement, kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus,
+) error {
 	var libovsdbExecuteTime time.Duration
 
 	start := time.Now()
@@ -920,28 +920,6 @@ func getClusterNodesDestinationBasedSNATMatch(ipFamily utilnet.IPFamily, address
 	}
 }
 
-func (bsnc *BaseUserDefinedNetworkController) ensureDHCP(pod *corev1.Pod, podAnnotation *util.PodAnnotation, lsp *nbdb.LogicalSwitchPort) error {
-	opts := []kubevirt.DHCPConfigsOpt{}
-
-	ipv4DNSServer, ipv6DNSServer, err := kubevirt.RetrieveDNSServiceClusterIPs(bsnc.watchFactory)
-	if err != nil {
-		return err
-	}
-
-	ipv4Gateway, _ := util.MatchFirstIPFamily(false /*ipv4*/, podAnnotation.Gateways)
-	if ipv4Gateway != nil {
-		opts = append(opts, kubevirt.WithIPv4Router(ipv4Gateway.String()))
-	}
-
-	if bsnc.MTU() > 0 {
-		opts = append(opts, kubevirt.WithIPv4MTU(bsnc.MTU()))
-	}
-
-	opts = append(opts, kubevirt.WithIPv4DNSServer(ipv4DNSServer), kubevirt.WithIPv6DNSServer(ipv6DNSServer))
-
-	return kubevirt.EnsureDHCPOptionsForLSP(bsnc.controllerName, bsnc.nbClient, pod, podAnnotation.IPs, lsp, opts...)
-}
-
 func (bsnc *BaseUserDefinedNetworkController) requireDHCP(pod *corev1.Pod) bool {
 	// Configure DHCP only for kubevirt VMs layer2 primary udn with subnets
 	return kubevirt.IsPodOwnedByVirtualMachine(pod) &&
@@ -951,7 +929,8 @@ func (bsnc *BaseUserDefinedNetworkController) requireDHCP(pod *corev1.Pod) bool 
 }
 
 func (bsnc *BaseUserDefinedNetworkController) setPodLogicalSwitchPortAddressesAndEnabledField(
-	pod *corev1.Pod, nadName string, mac string, ips []string, enabled bool, ops []ovsdb.Operation) ([]ovsdb.Operation, *nbdb.LogicalSwitchPort, error) {
+	pod *corev1.Pod, nadName string, mac string, ips []string, enabled bool, ops []ovsdb.Operation,
+) ([]ovsdb.Operation, *nbdb.LogicalSwitchPort, error) {
 	lsp := &nbdb.LogicalSwitchPort{Name: bsnc.GetLogicalPortName(pod, nadName)}
 	lsp.Enabled = ptr.To(enabled)
 	customFields := []libovsdbops.ModelUpdateField{
@@ -987,7 +966,8 @@ func (bsnc *BaseUserDefinedNetworkController) setPodLogicalSwitchPortAddressesAn
 
 func (bsnc *BaseUserDefinedNetworkController) disableLiveMigrationSourceLSPOps(
 	kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus,
-	nadName string, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+	nadName string, ops []ovsdb.Operation,
+) ([]ovsdb.Operation, error) {
 	// closing the sourcePod lsp to ensure traffic goes to the now ready targetPod.
 	ops, _, err := bsnc.setPodLogicalSwitchPortAddressesAndEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadName, "", nil, false, ops)
 	return ops, err

--- a/go-controller/pkg/ovn/kubevirt_test.go
+++ b/go-controller/pkg/ovn/kubevirt_test.go
@@ -106,6 +106,8 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 		lrpNetworkIPv6        string
 		subnetIPv4            string
 		subnetIPv6            string
+		gwIPv4                string
+		gwIPv6                string
 		transitSwitchPortIPv4 string
 		transitSwitchPortIPv6 string
 		addressIPv4           string
@@ -126,6 +128,8 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				nodeID:                "4",
 				subnetIPv4:            "10.128.1.0/24",
 				subnetIPv6:            "fd11::/64",
+				gwIPv4:                "10.128.1.1",
+				gwIPv6:                "fd11::1",
 				lrpNetworkIPv4:        "100.64.0.4/24",
 				lrpNetworkIPv6:        "fd98::4/64",
 				transitSwitchPortIPv4: "100.65.0.4/24",
@@ -137,6 +141,8 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				nodeID:                "5",
 				subnetIPv4:            "10.128.2.0/24",
 				subnetIPv6:            "fd12::/64",
+				gwIPv4:                "10.128.2.1",
+				gwIPv6:                "fd12::1",
 				lrpNetworkIPv4:        "100.64.0.5/24",
 				lrpNetworkIPv6:        "fd98::5/64",
 				transitSwitchPortIPv4: "100.65.0.5/24",
@@ -148,6 +154,8 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				nodeID:                "6",
 				subnetIPv4:            "10.128.3.0/24",
 				subnetIPv6:            "fd13::/64",
+				gwIPv4:                "10.128.3.1",
+				gwIPv6:                "fd13::1",
 				lrpNetworkIPv4:        "100.64.0.6/24",
 				lrpNetworkIPv6:        "fd98::6/64",
 				transitSwitchPortIPv4: "100.65.0.6/24",
@@ -298,7 +306,8 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				pod.Annotations[k] = v
 			}
 		}
-		ComposeDHCPv4Options = func(uuid, namespace string, t *testDHCPOptions) *nbdb.DHCPOptions {
+		ComposeDHCPv4Options = func(uuid, namespace string, nodeName string, t *testDHCPOptions) *nbdb.DHCPOptions {
+			GinkgoHelper()
 			dhcpOptions := kubevirt.ComposeDHCPv4Options(
 				t.cidr,
 				DefaultNetworkControllerName,
@@ -307,8 +316,10 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 					Name:      t.hostname,
 				},
 			)
+
+			dhcpOptions.Options["mtu"] = "1400"
 			dhcpOptions.Options["dns_server"] = t.dns
-			dhcpOptions.Options["router"] = kubevirt.ARPProxyIPv4
+			dhcpOptions.Options["router"] = nodeByName[nodeName].gwIPv4
 			dhcpOptions.UUID = uuid
 
 			return dhcpOptions
@@ -458,14 +469,14 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				addressIPv4 = vmByName[t.vmName].addressIPv4
 				addresses = addressIPv4
 				mac = util.IPAddrToHWAddr(net.ParseIP(addressIPv4)).String()
-				nodeGWIP = kubevirt.ARPProxyIPv4
+				nodeGWIP = nodeByName[t.nodeName].gwIPv4
 			} else if config.IPv6Mode && !config.IPv4Mode {
 				subnetIPv6 = nodeByName[t.nodeName].subnetIPv6
 				subnets = subnetIPv6
 				addressIPv6 = vmByName[t.vmName].addressIPv6
 				addresses = addressIPv6
 				mac = util.IPAddrToHWAddr(net.ParseIP(addressIPv6)).String()
-				nodeGWIP = kubevirt.ARPProxyIPv6
+				nodeGWIP = nodeByName[t.nodeName].gwIPv6
 			} else if config.IPv4Mode && config.IPv6Mode {
 				subnetIPv4 = nodeByName[t.nodeName].subnetIPv4
 				subnetIPv6 = nodeByName[t.nodeName].subnetIPv6
@@ -474,7 +485,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				addressIPv6 = vmByName[t.vmName].addressIPv6
 				addresses = addressIPv4 + " " + addressIPv6
 				mac = util.IPAddrToHWAddr(net.ParseIP(addressIPv4)).String()
-				nodeGWIP = kubevirt.ARPProxyIPv4 + " " + kubevirt.ARPProxyIPv6
+				nodeGWIP = nodeByName[t.nodeName].gwIPv4 + " " + nodeByName[t.nodeName].gwIPv6
 			}
 			labels := map[string]string{
 				kubevirtv1.VirtualMachineNameLabel: t.vmName,
@@ -489,7 +500,6 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 			for k, v := range t.extraAnnotations {
 				annotations[k] = v
 			}
-
 			t.testPod = newTPod(t.nodeName, subnets, "", nodeGWIP, "virt-launcher-"+t.suffix, addresses, mac, "namespace1")
 			t.annotations = annotations
 			t.labels = labels
@@ -642,7 +652,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 			}
 
 			for i, d := range t.dhcpv4 {
-				initialDB.NBData = append(initialDB.NBData, ComposeDHCPv4Options(fmt.Sprintf("dhcpv4%d%s", i, d.hostname), t.namespace, &d))
+				initialDB.NBData = append(initialDB.NBData, ComposeDHCPv4Options(fmt.Sprintf("dhcpv4%d%s", i, d.hostname), t.namespace, t.nodeName, &d))
 			}
 
 			for i, d := range t.dhcpv6 {
@@ -847,7 +857,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 					expectedOVN = append(expectedOVN, expectedStaticRoute)
 				}
 				for _, d := range t.expectedDhcpv4 {
-					expectedOVN = append(expectedOVN, ComposeDHCPv4Options(dhcpv4OptionsUUID+d.hostname, t.namespace, &d))
+					expectedOVN = append(expectedOVN, ComposeDHCPv4Options(dhcpv4OptionsUUID+d.hostname, t.namespace, t.nodeName, &d))
 				}
 
 				for _, d := range t.expectedDhcpv6 {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -381,12 +381,12 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *corev1.Pod) (err error) 
 	_ = oc.logicalPortCache.add(pod, switchName, types.DefaultNetworkName, lsp.UUID, podAnnotation.MAC, podAnnotation.IPs)
 
 	if kubevirt.IsPodLiveMigratable(pod) {
-		if err := kubevirt.EnsureDHCPOptionsForMigratablePod(oc.controllerName, oc.nbClient, oc.watchFactory, pod, podAnnotation.IPs, lsp); err != nil {
-			return err
+		if err := oc.ensureDHCP(pod, podAnnotation, lsp); err != nil {
+			return fmt.Errorf("failed configuring DHCP for default network at pod %s/%s: %w", pod.Namespace, pod.Name, err)
 		}
 	}
 
-	//observe the pod creation latency metric for newly created pods only
+	// observe the pod creation latency metric for newly created pods only
 	if newlyCreatedPort {
 		metrics.RecordPodCreated(pod, oc.GetNetInfo())
 	}


### PR DESCRIPTION
## 📑 Description
Replace the hardcoded ARP proxy IP with the actual subnet gateway IP when configuring DHCP options for migratable KubeVirt pods. This ensures VMs receive the correct default gateway matching their pod's subnet configuration.

On scenarios where the primary interfaces has multiple addresses the and there are some nftables masquerade rules, the address to masquerade with is choosen from the routing, so if the default gw is pointing to a link local address then the link local address of the of the interfaces will be choose as src ip, while the one that should be choose is the global address assigned as pod subnet on VM.

Fixes #https://issues.redhat.com/browse/OCPBUGS-65688

## Additional Information for reviewers
This is related to hypershift kubevirt provider where the VMs are worker nodes for a openshift cluster with local gateway mode so masquerading is done with nftables.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
The tests are already verifying it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated live-migration docs with revised gateway examples, clarified DHCP replies advertising the subnet gateway, and refined ARP proxy behavior and routing explanations.

* **Bug Fixes / Behavior**
  * DHCP now uses per-node gateway addresses and collects cluster DNS servers; DHCP failures include pod namespace/name for clearer troubleshooting.
  * Removed one legacy DHCP configuration path for user-defined networks.

* **Tests**
  * Test coverage extended for per-node gateway scenarios (IPv4, IPv6, dual-stack).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->