### PR TITLE
Fix coderabbit path_filters

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -12,6 +12,6 @@ reviews:
     enabled: true
     drafts: false
   path_filters:
-    - "**/vendor/**"
+    - "!**/vendor/**"
 chat:
   auto_reply: true


### PR DESCRIPTION
The previous change didn't do what I thought it does... :facepalm: 
```
path_filters
array of string
Specify file patterns to include or exclude in a review using glob patterns (e.g., !dist/, src/). These patterns also apply to ‘git sparse-checkout’, including specified patterns and ignoring excluded ones (starting with ’!’) when cloning the repository.Defaults to [].
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**No User-Facing Changes**

This release contains internal configuration updates only. No changes to end-user functionality, features, or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->