### PR TITLE
Add network policy tests with Static IP

### DIFF
--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -105,6 +105,8 @@ type networkAttachmentConfigParams struct {
 	role                string
 	mtu                 int
 	physicalNetworkName string
+	labelKey            string
+	labelValue          string
 }
 
 type networkAttachmentConfig struct {
@@ -202,11 +204,12 @@ type podConfiguration struct {
 	nodeSelector           map[string]string
 	isPrivileged           bool
 	labels                 map[string]string
-	annotations                  map[string]string
+	annotations            map[string]string
 	requiresExtraNamespace bool
 	hostNetwork            bool
 	ipRequestFromSubnet    string
 	usesExternalRouter     bool
+	staticIP               string // IP address without CIDR suffix, set by withStaticIPMAC
 }
 
 func generatePodSpec(config podConfiguration) *v1.Pod {

--- a/test/e2e/network_segmentation_policy.go
+++ b/test/e2e/network_segmentation_policy.go
@@ -20,8 +20,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 )
+
+const cudnResourceType = "ClusterUserDefinedNetwork"
 
 var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.NetworkSegmentation, func() {
 	f := wrappedTestFramework("network-segmentation")
@@ -550,6 +553,488 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					withLabels(denyServerPodLabel),
 				),
 			))
+
+		ginkgo.Context("Network policies with static IP and MAC assignments", func() {
+			const (
+				l2Subnet       = "192.168.40.0/24"
+				staticPort     = 8080
+				cudnLabel      = "cudn-group"
+				cudnLabelValue = "l2-net"
+			)
+			ginkgo.BeforeEach(func() {
+				if IsIPv6Cluster(f.ClientSet) {
+					ginkgo.Skip("Test not supported on IPv6 clusters")
+				}
+			})
+
+			var cudnCleanup func()
+
+			ginkgo.AfterEach(func() {
+				if cudnCleanup != nil {
+					cudnCleanup()
+					cudnCleanup = nil
+				}
+			})
+
+			// Verify ingress network policies with static IP and MAC assignments
+			ginkgo.DescribeTable(
+				"ingress network policies in L2 primary UDN with static IP and MAC",
+				func(
+					pod1Config podConfiguration,
+					pod2Config podConfiguration,
+					pod3Config podConfiguration,
+					pod4Config podConfiguration,
+				) {
+					const (
+						cudnName         = "l2-network-ingress"
+						defaultGatewayIP = "192.168.40.1"
+					)
+
+					namespaceA1Suffix := "a1"
+					namespaceA2Suffix := "a2"
+					namespaceA1 := fmt.Sprintf("%s-%s", f.Namespace.Name, namespaceA1Suffix)
+					namespaceA2 := fmt.Sprintf("%s-%s", f.Namespace.Name, namespaceA2Suffix)
+
+					// Step 1: Create a CUDN with L2 network
+					ginkgo.By("1: Creating ClusterUserDefinedNetwork with Layer2 topology")
+					cudn := generateClusterUserDefinedNetwork(
+						cudnName,
+						cudnLabel,
+						cudnLabelValue,
+						"Layer2",
+						"Primary",
+						[]string{l2Subnet},
+						[]string{defaultGatewayIP},
+					)
+					var err error
+					cudnCleanup, err = createClusterUserDefinedNetwork(cs, cudn)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					// Step 2: Create UDN namespace, label it and verify NAD is created
+					ginkgo.By("2: Creating namespace a1 with UDN labels and verifying NAD creation")
+					ns1, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: namespaceA1,
+							Labels: map[string]string{
+								RequiredUDNNamespaceLabel: "",
+								cudnLabel:                 cudnLabelValue,
+							},
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					f.AddNamespacesToDelete(ns1)
+
+					gomega.Eventually(func() error {
+						_, err := nadClient.NetworkAttachmentDefinitions(namespaceA1).Get(
+							context.Background(),
+							cudnName,
+							metav1.GetOptions{},
+						)
+						return err
+					}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+					// Step 3: Create pods with static IPs and MACs
+					ginkgo.By("3: Creating pods with statically assigned IP and MAC addresses in namespace a1")
+					pod1Config.namespace = namespaceA1
+					runUDNPod(cs, namespaceA1, pod1Config, nil)
+
+					pod2Config.namespace = namespaceA1
+					runUDNPod(cs, namespaceA1, pod2Config, nil)
+
+					// Step 4: Verify ingress traffic from one pod to another works
+					ginkgo.By("4: Verifying ingress traffic between pods in namespace a1 works")
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod2Config, pod1Config.staticIP, staticPort)
+					}, 2*time.Minute, 6*time.Second).Should(gomega.Succeed())
+
+					// Step 5: Create ingress deny network policy to block traffic
+					ginkgo.By("5: Creating default-deny-ingress network policy and verifying traffic is blocked")
+					_, err = makeDenyIngressPolicy(cs, namespaceA1, "default-deny-ingress")
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod2Config, pod1Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+
+					// Step 6: Create allow ingress from same namespace policy
+					ginkgo.By("6: Creating allow-same-namespace policy and verifying traffic is allowed")
+					allowSameNSPolicy := &knet.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "allow-same-namespace",
+							Namespace: namespaceA1,
+						},
+						Spec: knet.NetworkPolicySpec{
+							PodSelector: metav1.LabelSelector{},
+							PolicyTypes: []knet.PolicyType{knet.PolicyTypeIngress},
+							Ingress: []knet.NetworkPolicyIngressRule{{
+								From: []knet.NetworkPolicyPeer{{
+									PodSelector: &metav1.LabelSelector{},
+								}},
+							}},
+						},
+					}
+					_, err = cs.NetworkingV1().NetworkPolicies(namespaceA1).Create(
+						context.TODO(),
+						allowSameNSPolicy,
+						metav1.CreateOptions{},
+					)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod2Config, pod1Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).Should(gomega.Succeed())
+
+					// Step 7: Create another namespace with pods and verify ingress from a2 to a1 does not work
+					ginkgo.By("7: Creating namespace a2 with pods and verifying cross-namespace traffic is blocked")
+					ns2, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: namespaceA2,
+							Labels: map[string]string{
+								RequiredUDNNamespaceLabel: "",
+								cudnLabel:                 cudnLabelValue,
+							},
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					f.AddNamespacesToDelete(ns2)
+
+					gomega.Eventually(func() error {
+						_, err := nadClient.NetworkAttachmentDefinitions(namespaceA2).Get(
+							context.Background(),
+							cudnName,
+							metav1.GetOptions{},
+						)
+						return err
+					}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+					pod3Config.namespace = namespaceA2
+					runUDNPod(cs, namespaceA2, pod3Config, nil)
+
+					pod4Config.namespace = namespaceA2
+					runUDNPod(cs, namespaceA2, pod4Config, nil)
+
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod3Config, pod1Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod4Config, pod1Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+
+					// Step 8: Create allow ingress from IP block
+					ginkgo.By("8: Creating ipblock-ingress policy to allow traffic from specific IP")
+					ipBlockPolicy := &knet.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ipblock-ingress",
+							Namespace: namespaceA1,
+						},
+						Spec: knet.NetworkPolicySpec{
+							PodSelector: metav1.LabelSelector{},
+							Ingress: []knet.NetworkPolicyIngressRule{{
+								From: []knet.NetworkPolicyPeer{{
+									IPBlock: &knet.IPBlock{
+										CIDR: fmt.Sprintf("%s/32", pod4Config.staticIP),
+									},
+								}},
+							}},
+						},
+					}
+					_, err = cs.NetworkingV1().NetworkPolicies(namespaceA1).Create(
+						context.TODO(),
+						ipBlockPolicy,
+						metav1.CreateOptions{},
+					)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					ginkgo.By("Verifying traffic from allowed IP (pod4) succeeds but blocked IP (pod3) fails")
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod4Config, pod1Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).Should(gomega.Succeed())
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod3Config, pod1Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+
+					// Step 9: Add allow from all namespaces policy
+					ginkgo.By("9: Creating allow-from-all-namespace policy and verifying traffic from all namespaces is allowed")
+					allowAllNSPolicy := &knet.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "allow-from-all-namespace",
+							Namespace: namespaceA1,
+						},
+						Spec: knet.NetworkPolicySpec{
+							PodSelector: metav1.LabelSelector{},
+							Ingress: []knet.NetworkPolicyIngressRule{{
+								From: []knet.NetworkPolicyPeer{{
+									NamespaceSelector: &metav1.LabelSelector{},
+								}},
+							}},
+						},
+					}
+					_, err = cs.NetworkingV1().NetworkPolicies(namespaceA1).Create(
+						context.TODO(),
+						allowAllNSPolicy,
+						metav1.CreateOptions{},
+					)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod3Config, pod1Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).Should(gomega.Succeed())
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod1Config, pod4Config, pod1Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).Should(gomega.Succeed())
+				},
+				ginkgo.Entry(
+					"with default pod configuration",
+					*podConfig(
+						"hello-pod",
+						withLabels(map[string]string{"name": "hello-pod"}),
+						withStaticIPMAC("192.168.40.3", "02:03:04:05:06:01"),
+						withCommand(func() []string {
+							return httpServerContainerCmd(8080)
+						}),
+					),
+					*podConfig(
+						"hello-pod-1",
+						withLabels(map[string]string{"name": "hello-pod"}),
+						withStaticIPMAC("192.168.40.4", "02:03:04:05:06:02"),
+					),
+					*podConfig(
+						"hello-pod",
+						withStaticIPMAC("192.168.40.5", "02:03:04:05:06:04"),
+					),
+					*podConfig(
+						"hello-pod-1",
+						withStaticIPMAC("192.168.40.6", "02:03:04:05:06:05"),
+					),
+				),
+			)
+
+			// Verify egress network policies with static IP and MAC assignments
+			ginkgo.DescribeTable(
+				"egress network policies in L2 primary UDN with static IP and MAC",
+				func(
+					pod1Config podConfiguration,
+					pod2Config podConfiguration,
+					pod3Config podConfiguration,
+					pod4Config podConfiguration,
+				) {
+					const (
+						cudnName        = "l2-network-egress"
+						gatewayIP       = "192.168.40.3"
+						reservedSubnet1 = "192.168.40.4/32"
+						reservedSubnet2 = "192.168.40.5/32"
+					)
+
+					namespaceA1Suffix := "a1"
+					namespaceA2Suffix := "a2"
+					namespaceA3Suffix := "a3"
+					namespaceA1 := fmt.Sprintf("%s-%s", f.Namespace.Name, namespaceA1Suffix)
+					namespaceA2 := fmt.Sprintf("%s-%s", f.Namespace.Name, namespaceA2Suffix)
+					namespaceA3 := fmt.Sprintf("%s-%s", f.Namespace.Name, namespaceA3Suffix)
+
+					// Step 1: Create two UDN namespaces and CUDN for them
+					ginkgo.By("1: Creating ClusterUserDefinedNetwork with Layer2 topology and reserved subnets")
+					cudn := generateClusterUserDefinedNetworkWithReserved(
+						cudnName,
+						cudnLabel,
+						cudnLabelValue,
+						"Layer2",
+						"Primary",
+						[]string{l2Subnet},
+						[]string{gatewayIP},
+						[]string{reservedSubnet1, reservedSubnet2},
+					)
+					var err error
+					cudnCleanup, err = createClusterUserDefinedNetwork(cs, cudn)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					ginkgo.By("Creating namespaces a1 and a2 with UDN labels")
+					ns1, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: namespaceA1,
+							Labels: map[string]string{
+								RequiredUDNNamespaceLabel: "",
+								cudnLabel:                 cudnLabelValue,
+							},
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					f.AddNamespacesToDelete(ns1)
+
+					ns2, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: namespaceA2,
+							Labels: map[string]string{
+								RequiredUDNNamespaceLabel: "",
+								cudnLabel:                 cudnLabelValue,
+							},
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					f.AddNamespacesToDelete(ns2)
+
+					gomega.Eventually(func() error {
+						_, err := nadClient.NetworkAttachmentDefinitions(namespaceA1).Get(
+							context.Background(),
+							cudnName,
+							metav1.GetOptions{},
+						)
+						return err
+					}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
+					gomega.Eventually(func() error {
+						_, err := nadClient.NetworkAttachmentDefinitions(namespaceA2).Get(
+							context.Background(),
+							cudnName,
+							metav1.GetOptions{},
+						)
+						return err
+					}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+					// Step 2: Create pods in both namespaces with static IPs
+					ginkgo.By("2: Creating pods with static IP and MAC in namespaces a1 and a2")
+					pod1Config.namespace = namespaceA1
+					runUDNPod(cs, namespaceA1, pod1Config, nil)
+
+					pod2Config.namespace = namespaceA2
+					runUDNPod(cs, namespaceA2, pod2Config, nil)
+
+					pod3Config.namespace = namespaceA2
+					runUDNPod(cs, namespaceA2, pod3Config, nil)
+
+					// Step 3: Create egress default deny policy in a1 and verify pods in a2 are inaccessible
+					ginkgo.By("3: Creating default-deny-egress policy and verifying pods in a2 are inaccessible")
+					_, err = makeDenyEgressPolicy(cs, namespaceA1, "default-deny-egress")
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod2Config, pod1Config, pod2Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod3Config, pod1Config, pod3Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+
+					// Step 4: Create another namespace a3 with label and pod
+					ginkgo.By("4: Creating namespace a3 with team=operations label and pod")
+					ns3, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: namespaceA3,
+							Labels: map[string]string{
+								RequiredUDNNamespaceLabel: "",
+								cudnLabel:                 cudnLabelValue,
+								"team":                    "operations",
+							},
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					f.AddNamespacesToDelete(ns3)
+
+					gomega.Eventually(func() error {
+						_, err := nadClient.NetworkAttachmentDefinitions(namespaceA3).Get(
+							context.Background(),
+							cudnName,
+							metav1.GetOptions{},
+						)
+						return err
+					}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+					pod4Config.namespace = namespaceA3
+					runUDNPod(cs, namespaceA3, pod4Config, nil)
+
+					// Step 5: Label pods and namespaces
+					ginkgo.By("5: Labeling pods with color=red and namespace a2 with team=operations")
+					pod2Obj, err := cs.CoreV1().Pods(namespaceA2).Get(context.Background(), pod2Config.name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					pod2Obj.Labels["color"] = "red"
+					_, err = cs.CoreV1().Pods(namespaceA2).Update(context.Background(), pod2Obj, metav1.UpdateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					pod4Obj, err := cs.CoreV1().Pods(namespaceA3).Get(context.Background(), pod4Config.name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					pod4Obj.Labels["color"] = "red"
+					_, err = cs.CoreV1().Pods(namespaceA3).Update(context.Background(), pod4Obj, metav1.UpdateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					ns2Updated, err := cs.CoreV1().Namespaces().Get(context.Background(), namespaceA2, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ns2Updated.Labels["team"] = "operations"
+					_, err = cs.CoreV1().Namespaces().Update(context.Background(), ns2Updated, metav1.UpdateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					// Step 6: Create network policy with namespace and pod selector
+					ginkgo.By("6: Creating egress policy with namespace and pod selectors and verifying selective access")
+					allowPodAndPodPolicy := &knet.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "allow-pod-and-pod",
+							Namespace: namespaceA1,
+						},
+						Spec: knet.NetworkPolicySpec{
+							PodSelector: metav1.LabelSelector{},
+							Egress: []knet.NetworkPolicyEgressRule{{
+								To: []knet.NetworkPolicyPeer{{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"team": "operations"},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"color": "red"},
+									},
+								}},
+							}},
+						},
+					}
+					_, err = cs.NetworkingV1().NetworkPolicies(namespaceA1).Create(
+						context.TODO(),
+						allowPodAndPodPolicy,
+						metav1.CreateOptions{},
+					)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					ginkgo.By("Verifying labeled pods in a2 and a3 are accessible")
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod2Config, pod1Config, pod2Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).Should(gomega.Succeed())
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod4Config, pod1Config, pod4Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).Should(gomega.Succeed())
+
+					ginkgo.By("Verifying unlabeled pod in a2 is not accessible")
+					gomega.Eventually(func() error {
+						return reachServerPodFromClient(cs, pod3Config, pod1Config, pod3Config.staticIP, staticPort)
+					}, 1*time.Minute, 6*time.Second).ShouldNot(gomega.Succeed())
+				},
+				ginkgo.Entry(
+					"with default pod configuration",
+					*podConfig(
+						"hello-pod",
+						withLabels(map[string]string{"name": "hello-pod"}),
+						withStaticIPMAC("192.168.40.6", "02:03:04:05:06:01"),
+					),
+					*podConfig(
+						"hello-pod",
+						withLabels(map[string]string{"name": "hello-pod"}),
+						withStaticIPMAC("192.168.40.7", "02:03:04:05:06:02"),
+						withCommand(func() []string {
+							return httpServerContainerCmd(8080)
+						}),
+					),
+					*podConfig(
+						"hello-pod-1",
+						withLabels(map[string]string{"name": "hello-pod"}),
+						withStaticIPMAC("192.168.40.8", "02:03:04:05:06:03"),
+						withCommand(func() []string {
+							return httpServerContainerCmd(8080)
+						}),
+					),
+					*podConfig(
+						"hello-pod",
+						withLabels(map[string]string{"name": "hello-pod"}),
+						withStaticIPMAC("192.168.40.9", "02:03:04:05:06:04"),
+						withCommand(func() []string {
+							return httpServerContainerCmd(8080)
+						}),
+					),
+				),
+			)
+		})
 	})
 })
 
@@ -571,4 +1056,144 @@ func allowTrafficToPodFromNamespacePolicy(f *framework.Framework, namespace, fro
 		},
 	}
 	return f.ClientSet.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), policy, metav1.CreateOptions{})
+}
+
+// Helper function to create a default deny ingress policy
+func makeDenyIngressPolicy(cs clientset.Interface, namespace, policyName string) (*knet.NetworkPolicy, error) {
+	policy := &knet.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: namespace,
+		},
+		Spec: knet.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []knet.PolicyType{knet.PolicyTypeIngress},
+		},
+	}
+	return cs.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), policy, metav1.CreateOptions{})
+}
+
+// Helper function to create a default deny egress policy
+func makeDenyEgressPolicy(cs clientset.Interface, namespace, policyName string) (*knet.NetworkPolicy, error) {
+	policy := &knet.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: namespace,
+		},
+		Spec: knet.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []knet.PolicyType{knet.PolicyTypeEgress},
+		},
+	}
+	return cs.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), policy, metav1.CreateOptions{})
+}
+
+// Helper function to set static IP and MAC via annotations.
+// The ip parameter should be the IP address without CIDR suffix (e.g., "192.168.40.3").
+// The CIDR suffix "/24" is added automatically.
+func withStaticIPMAC(ip, mac string) podOption {
+	ipWithCIDR := ip + "/24"
+	annotation := fmt.Sprintf(`[{"name":"default","namespace":"ovn-kubernetes","ips":["%s"],"mac":"%s"}]`, ipWithCIDR, mac)
+	return func(pod *podConfiguration) {
+		if pod.annotations == nil {
+			pod.annotations = make(map[string]string)
+		}
+		pod.annotations["v1.multus-cni.io/default-network"] = annotation
+		pod.staticIP = ip
+	}
+}
+
+// Helper to generate CUDN manifest params without reserved subnets
+func generateClusterUserDefinedNetwork(name, labelKey, labelValue, topology, role string, subnets, gatewayIPs []string) *networkAttachmentConfigParams {
+	// For label-based CUDN, we store the label info in namespace field temporarily
+	// The actual CUDN creation will use label selectors
+	return &networkAttachmentConfigParams{
+		name:              name,
+		topology:          strings.ToLower(topology),
+		cidr:              joinStrings(subnets...),
+		role:              strings.ToLower(role),
+		defaultGatewayIPs: joinStrings(gatewayIPs...),
+		labelKey:          labelKey,
+		labelValue:        labelValue,
+	}
+}
+
+// Helper to generate CUDN manifest params with reserved subnets
+func generateClusterUserDefinedNetworkWithReserved(name, labelKey, labelValue, topology, role string, subnets, gatewayIPs, reservedSubnets []string) *networkAttachmentConfigParams {
+	return &networkAttachmentConfigParams{
+		name:              name,
+		topology:          strings.ToLower(topology),
+		cidr:              joinStrings(subnets...),
+		role:              strings.ToLower(role),
+		defaultGatewayIPs: joinStrings(gatewayIPs...),
+		reservedCIDRs:     joinStrings(reservedSubnets...),
+		labelKey:          labelKey,
+		labelValue:        labelValue,
+	}
+}
+
+// Helper to create CUDN from params - generates manifest with label-based selector and creates it
+func createClusterUserDefinedNetwork(cs clientset.Interface, params *networkAttachmentConfigParams) (func(), error) {
+	// Generate CUDN manifest with label-based namespace selector
+	if params.labelKey == "" || params.labelValue == "" {
+		return nil, fmt.Errorf("label key and value cannot be empty")
+	}
+	labelKey := params.labelKey
+	labelValue := params.labelValue
+
+	if len(params.topology) == 0 {
+		return nil, fmt.Errorf("topology type cannot be empty")
+	}
+	topologyType := "layer2"
+	if strings.ToLower(params.topology) == "layer3" {
+		topologyType = "layer3"
+	}
+	roleType := "Primary"
+	if strings.ToLower(params.role) == "secondary" {
+		roleType = "Secondary"
+	}
+
+	manifest := fmt.Sprintf(`apiVersion: k8s.ovn.org/v1
+kind: %s
+metadata:
+  name: %s
+spec:
+  namespaceSelector:
+    matchLabels:
+      %s: %s
+  network:
+    topology: %s
+    %s:
+      role: %s
+      subnets: [%s]`, cudnResourceType, params.name, labelKey, labelValue,
+		strings.ToUpper(topologyType[:1])+topologyType[1:], topologyType, roleType, params.cidr)
+
+	// Add optional fields
+	if len(params.defaultGatewayIPs) > 0 {
+		manifest += fmt.Sprintf("\n      defaultGatewayIPs: [%s]", params.defaultGatewayIPs)
+	}
+	if len(params.reservedCIDRs) > 0 {
+		manifest += fmt.Sprintf("\n      reservedSubnets: [%s]", params.reservedCIDRs)
+	}
+	if len(params.infrastructureCIDRs) > 0 {
+		manifest += fmt.Sprintf("\n      infrastructureSubnets: [%s]", params.infrastructureCIDRs)
+	}
+
+	// Create the CUDN using createManifest helper
+	fileCleanup, err := createManifest("", manifest)
+	if err != nil {
+		return fileCleanup, err
+	}
+
+	// Return a cleanup function that deletes the CUDN and the temp file
+	cleanup := func() {
+		// Delete the CUDN resource with timeout to prevent hanging
+		_, err := e2ekubectl.RunKubectl("", "delete", "clusteruserdefinednetwork", params.name, "--ignore-not-found=true", "--timeout=60s", "--wait=true")
+		if err != nil {
+			// Clean up the temp file
+			framework.Logf("Warning: failed to delete CUDN %s: %v", params.name, err)
+		}
+		fileCleanup()
+	}
+	return cleanup, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
E2E test for network policies for pods with Static IP in Layer 2 primary user defined network created with CUDN.

1. static IP/MAC pod assignments
2.  Default deny network policies and allow rules with IP‑block, pod and namespace selector allow rules for testing ingress and egress are created.
3.  Pod to pod egress and ingress traffic is tested.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive end-to-end coverage for Layer‑2 cluster user‑defined networks: static IP/MAC pod assignments, multi‑namespace ingress/egress scenarios, IP‑block and namespace allow rules, default‑deny policies, attachment verification, and automated per‑test lifecycle management.

* **Chores**
  * Added reusable test utilities for creating/managing cluster user‑defined networks (including reserved subnets), annotating pods with static IP/MAC, and extended network attachment metadata with label fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->