### PR TITLE
Add drop iptables rules for pod subnet

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -815,9 +815,6 @@ func (c *Controller) updateEIP(existing *state, update *config) error {
 }
 
 func (c *Controller) deleteIPConfig(podIPConfigToDelete *podIPConfig) error {
-	if err := c.ruleManager.Delete(podIPConfigToDelete.ipRule); err != nil {
-		return err
-	}
 	if podIPConfigToDelete.v6 {
 		if err := c.iptablesManager.DeleteRule(utiliptables.TableNAT, iptChainName, utiliptables.ProtocolIPv6,
 			podIPConfigToDelete.ipTableRule); err != nil {
@@ -828,6 +825,9 @@ func (c *Controller) deleteIPConfig(podIPConfigToDelete *podIPConfig) error {
 			podIPConfigToDelete.ipTableRule); err != nil {
 			return err
 		}
+	}
+	if err := c.ruleManager.Delete(podIPConfigToDelete.ipRule); err != nil {
+		return err
 	}
 	return nil
 }
@@ -846,10 +846,6 @@ func (c *Controller) applyPodConfig(existingPodIPsConfig *podIPConfigList, updat
 		}
 	}
 	for _, newPodIPConfig := range newPodIPConfigs.elems {
-		if err := c.ruleManager.Add(newPodIPConfig.ipRule); err != nil {
-			existingPodIPsConfig.insertOverwriteFailed(*newPodIPConfig)
-			return err
-		}
 		if newPodIPConfig.v6 {
 			if err := c.iptablesManager.EnsureRule(utiliptables.TableNAT, iptChainName, utiliptables.ProtocolIPv6, newPodIPConfig.ipTableRule); err != nil {
 				existingPodIPsConfig.insertOverwriteFailed(*newPodIPConfig)
@@ -860,6 +856,10 @@ func (c *Controller) applyPodConfig(existingPodIPsConfig *podIPConfigList, updat
 				existingPodIPsConfig.insertOverwriteFailed(*newPodIPConfig)
 				return fmt.Errorf("failed to ensure rules (%+v) in chain %s: %v", newPodIPConfig.ipTableRule, iptChainName, err)
 			}
+		}
+		if err := c.ruleManager.Add(newPodIPConfig.ipRule); err != nil {
+			existingPodIPsConfig.insertOverwriteFailed(*newPodIPConfig)
+			return err
 		}
 		existingPodIPsConfig.insertOverwrite(*newPodIPConfig)
 	}

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -263,6 +263,39 @@ func getExternalIPTRules(svcPort corev1.ServicePort, externalIP, dstIP string, s
 	}
 }
 
+func getEgressDropRules(srcCIDRs []*net.IPNet, egressInterface string) []nodeipt.Rule {
+	var returnRules []nodeipt.Rule
+	// Add rules for all CIDRs.
+	for _, cidr := range srcCIDRs {
+		protocol := getIPTablesProtocol(cidr.IP.String())
+		returnRules = append(returnRules, []nodeipt.Rule{
+			{
+				Table: "filter",
+				Chain: "FORWARD",
+				Args: []string{
+					"-s", cidr.String(),
+					"-o", egressInterface,
+					"-m", "comment", "--comment", "Drop un-SNATed pod egress traffic",
+					"-j", "DROP",
+				},
+				Protocol: protocol,
+			},
+			{
+				Table: "filter",
+				Chain: "OUTPUT",
+				Args: []string{
+					"-s", cidr.String(),
+					"-o", egressInterface,
+					"-m", "comment", "--comment", "Drop un-SNATed pod egress traffic",
+					"-j", "DROP",
+				},
+				Protocol: protocol,
+			},
+		}...)
+	}
+	return returnRules
+}
+
 func getGatewayForwardRules(cidrs []*net.IPNet) []nodeipt.Rule {
 	var returnRules []nodeipt.Rule
 	protocols := make(map[iptables.Protocol]struct{})

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1706,6 +1706,19 @@ func newGateway(
 				return err
 			}
 		}
+		if config.OVNKubernetesFeature.EnableEgressIP {
+			// Add drop rules for the pod subnet. This prevents pod IPs from leaking
+			// externally during the window before EgressIP SNAT rules are programmed
+			// on nodes using a secondary interface.
+			var subnets []*net.IPNet
+			for _, subnet := range config.Default.ClusterSubnets {
+				subnets = append(subnets, subnet.CIDR)
+			}
+			err = insertIptRules(getEgressDropRules(subnets, gwBridge.GetBridgeName()))
+			if err != nil {
+				return fmt.Errorf("failed to add egress drop rules for cluster subnets: %w", err)
+			}
+		}
 		if util.IsNetworkSegmentationSupportEnabled() && config.OVNKubernetesFeature.EnableInterconnect && config.Gateway.Mode != config.GatewayModeDisabled {
 			gw.bridgeEIPAddrManager = egressip.NewBridgeEIPAddrManager(nodeName, gwBridge.GetBridgeName(), linkManager, kube, watchFactory.EgressIPInformer(), watchFactory.NodeCoreInformer())
 			gwBridge.SetEIPMarkIPs(gw.bridgeEIPAddrManager.GetCache())


### PR DESCRIPTION
When EgressIP is enabled for the cluster, it may be configured on a secondary interface. Because of this, there can be a delay in programming the IP rule and SNAT iptables rule for a pod that is served by an EgressIP. During this window, if the pod initiates egress traffic, its IP may leak onto the external network through the egress gateway interface (breth0 or br-ex).

This PR adds iptables rules to drop such un-SNATed traffic. Dropping the initial packets is acceptable because they will be retried once the EgressIP rules for the pod are fully programmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved gateway rules to better control egress traffic with per-subnet handling and protocol-aware filtering for IPv4/IPv6.
  * Automatic drop rules applied for cluster subnets across forward and output paths to strengthen isolation.

* **Bug Fixes**
  * Fixed ordering of rule application and cleanup to ensure NAT/iptables rules are applied and removed reliably before related routing entries are changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->