### PR TITLE
[CI] use fixed host network port range for ANP tests

### DIFF
--- a/test/conformance/go.mod
+++ b/test/conformance/go.mod
@@ -9,7 +9,7 @@ require (
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
 	sigs.k8s.io/controller-runtime v0.22.1
-	sigs.k8s.io/network-policy-api v0.1.7
+	sigs.k8s.io/network-policy-api v0.1.8
 )
 
 require (

--- a/test/conformance/go.sum
+++ b/test/conformance/go.sum
@@ -182,8 +182,8 @@ sigs.k8s.io/controller-runtime v0.22.1 h1:Ah1T7I+0A7ize291nJZdS1CabF/lB4E++WizgV
 sigs.k8s.io/controller-runtime v0.22.1/go.mod h1:FwiwRjkRPbiN+zp2QRp7wlTCzbUXxZ/D4OzuQUDwBHY=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/network-policy-api v0.1.7 h1:obY2FTEidLXVdRYu7gJ4q1RYE57pBnrpMqoE2LZgp4g=
-sigs.k8s.io/network-policy-api v0.1.7/go.mod h1:QIWX6Th2h0SmCwOwa1+9Urs0W+WDJGL5rujAPUemdkk=
+sigs.k8s.io/network-policy-api v0.1.8 h1:p/VY4aX6LqohGx4sH1X3jdQh6BZ/Gb+8DoQhHKC1fZQ=
+sigs.k8s.io/network-policy-api v0.1.8/go.mod h1:QIWX6Th2h0SmCwOwa1+9Urs0W+WDJGL5rujAPUemdkk=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/fXCbTiQEco=

--- a/test/conformance/network_policy_v2_test.go
+++ b/test/conformance/network_policy_v2_test.go
@@ -1,7 +1,6 @@
 package conformance
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -20,12 +19,9 @@ import (
 )
 
 const (
-	showDebug               = true
-	shouldCleanup           = true
-	NetworkPolicyAPIRepoURL = "https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5"
+	showDebug     = true
+	shouldCleanup = true
 )
-
-var conformanceTestsBaseManifests = fmt.Sprintf("%s/conformance/base/manifests.yaml", NetworkPolicyAPIRepoURL)
 
 func TestNetworkPolicyV2Conformance(t *testing.T) {
 	t.Log("Configuring environment for network policy V2 API conformance tests")
@@ -70,8 +66,12 @@ func TestNetworkPolicyV2Conformance(t *testing.T) {
 					suite.SupportAdminNetworkPolicyNamedPorts,
 					suite.SupportBaselineAdminNetworkPolicyNamedPorts,
 				),
-				BaseManifests: conformanceTestsBaseManifests,
 				TimeoutConfig: netpolv1config.TimeoutConfig{GetTimeout: 300 * time.Second},
+				// Use fixed port range for host network pods.
+				// Should not intersect with the default ephemeral port range > 32768
+				// and any ports used by the default kind cluster components.
+				HostNetworkPortRangeStart: 11000,
+				HostNetworkPortRangeEnd:   11010,
 			},
 			Implementation: confv1a1.Implementation{
 				Organization:          "ovn-org",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
https://github.com/kubernetes-sigs/network-policy-api/issues/341 (B)ANP conformance uses ports in range 34345-36366. 
This intersects with the default ephemeral port range > 32768.
This can cause an attempt to bind a port that is already used by another process and leads to test failure.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4348

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policy API dependency to a newer version.

* **Refactor**
  * Streamlined conformance test configuration by introducing configurable host network port range settings for improved test flexibility and removing unused manifest references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->