### PR TITLE
ci: Allow build-go.sh to work in git worktrees inside containers

### DIFF
--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -16,8 +16,8 @@ build_binaries() {
 
     # Add a buildid to the executable - needed by rpmbuild
     BUILDID=${BUILDID:-0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')}
-    GIT_COMMIT=$(git rev-parse HEAD)
-    GIT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+    GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}
+    GIT_BRANCH=${GIT_BRANCH:-$(git rev-parse --symbolic-full-name --abbrev-ref HEAD 2>/dev/null || echo "unknown")}
     BUILD_USER=$(whoami)
     BUILD_DATE=$(date +"%Y-%m-%d")
     K8S_CLIENT_VERSION=$(grep 'k8s.io/client-go' ${OVN_KUBE_ROOT}/go.mod | head -1 |cut -f2 -d' ')


### PR DESCRIPTION
When building container images (e.g., fedora-image), the source directory is copied into the container build context. In git worktrees, the .git file is only a reference to the actual git directory, so git commands fail inside the container when the referenced path is not available.

Add error suppression and fallback to "unknown" for GIT_COMMIT and GIT_BRANCH to allow builds to succeed. Also allow environment variable overrides for CI/CD systems.

## 📑 Description

Fixes the issue that `make fedora-image` doesn't work in a git worktree folder anymore after https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5551

## Additional Information for reviewers


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

Create a git worktree, run `make -C dist/images fedora-image` in that directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process resilience by adding fallback values for version and branch information when unavailable in non-standard contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->