### PR TITLE
Fix MAC conflict detection configuration

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -244,7 +244,6 @@ func (ncc *networkClusterController) init() error {
 		var podAllocOpts []annotationalloc.AllocatorOption
 		if util.IsPreconfiguredUDNAddressesEnabled() &&
 			ncc.IsPrimaryNetwork() &&
-			persistentIPsEnabled &&
 			ncc.TopologyType() == types.Layer2Topology {
 			podAllocOpts = append(podAllocOpts, annotationalloc.WithMACRegistry(mac.NewManager()))
 		}


### PR DESCRIPTION
Remove the persistent IP requirement for enabling MAC conflict detection in layer2 UDNs. MAC conflict detection should be enabled when preconfigured UDN addresses are enabled, regardless of whether persistent IPs are enabled, making it consistent with IP conflict detection behavior.

@asood-rh @qinqon @oribon @RamLavi ptal 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pod allocation now considers MAC registry options for Layer2 topology when preconfigured UDN addresses are enabled on primary networks, regardless of persistent IP allocation settings.
* **Tests**
  * Added end-to-end scenarios covering both persistent and non-persistent IPAM lifecycles to validate Layer2 allocation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->