### PR TITLE
fix(localnet, ipamless): Prevent LSP deletion on sync

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -282,7 +282,7 @@ func (bsnc *BaseUserDefinedNetworkController) ensurePodForUserDefinedNetwork(pod
 		return nil
 	}
 
-	if bsnc.doesNetworkRequireIPAM() && bsnc.lsManager.IsNonHostSubnetSwitch(switchName) {
+	if bsnc.isNonHostSubnetSwitch(switchName) {
 		klog.V(5).Infof(
 			"Pod %s/%s requires IPAM but does not have an assigned IP address", pod.Namespace, pod.Name)
 		return nil

--- a/test/e2e/network_segmentation_localnet.go
+++ b/test/e2e/network_segmentation_localnet.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider"
 	infraapi "github.com/ovn-org/ovn-kubernetes/test/e2e/infraprovider/api"
 
@@ -18,6 +19,7 @@ import (
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
@@ -141,6 +143,147 @@ var _ = Describe("Network Segmentation: Localnet", feature.NetworkSegmentation, 
 			}).WithTimeout(2 * time.Minute).WithPolling(6 * time.Second).Should(Succeed())
 		}
 	})
+
+	It("should preserve LSPs for IPAM-less localnet pods after ovnkube-node restart", func() {
+		const (
+			vlan = 201
+		)
+		var (
+			ovsBrName           = "ovsbr-ipamless"
+			cudnName            = uniqueMetaName("ipamless-localnet")
+			physicalNetworkName = uniqueMetaName("physnet-ipamless")
+		)
+
+		By("setup the localnet underlay")
+		c := networkAttachmentConfig{networkAttachmentConfigParams: networkAttachmentConfigParams{networkName: physicalNetworkName, vlanID: vlan}}
+		Expect(providerCtx.SetupUnderlay(f, infraapi.Underlay{
+			BridgeName:         ovsBrName,
+			LogicalNetworkName: c.networkName,
+			VlanID:             c.vlanID,
+		})).To(Succeed())
+
+		By("create test namespace")
+		namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+			"e2e-framework": f.BaseName,
+		})
+		f.Namespace = namespace
+		Expect(err).NotTo(HaveOccurred())
+
+		By("create IPAM-less localnet CUDN CR (no subnets)")
+		netConf := networkAttachmentConfigParams{
+			name:                cudnName,
+			physicalNetworkName: physicalNetworkName,
+			vlanID:              vlan,
+			cidr:                "", // Empty CIDR = IPAM-less
+			excludeCIDRs:        []string{},
+		}
+
+		cudnYAML := newLocalnetIPAMLessCUDNYaml(netConf, f.Namespace.Name)
+		cleanup, err := createManifest("", cudnYAML)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("cleanup CUDN CR")
+			cleanup()
+			By(fmt.Sprintf("delete pods in namespace %q to unblock CUDN CR & associate NAD deletion", f.Namespace.Name))
+			Expect(f.ClientSet.CoreV1().Pods(f.Namespace.Name).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(Succeed())
+			_, err := e2ekubectl.RunKubectl("", "delete", "clusteruserdefinednetwork", cudnName, "--wait", fmt.Sprintf("--timeout=%ds", 120))
+			Expect(err).NotTo(HaveOccurred())
+		})
+		Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName)).WithTimeout(5*time.Second).WithPolling(time.Second).
+			Should(Succeed(), "CUDN CR is not ready")
+
+		By("create test pod with IPAM-less localnet network")
+		podCfg := podConfiguration{
+			name:        "test-ipamless-pod",
+			namespace:   f.Namespace.Name,
+			attachments: []nadapi.NetworkSelectionElement{{Name: cudnName}},
+			labels: map[string]string{
+				"app": "test-ipamless",
+			},
+		}
+		testPod, err := f.ClientSet.CoreV1().Pods(podCfg.namespace).Create(context.Background(), generatePodSpec(podCfg), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("cleanup test pod")
+			Expect(f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.Background(), testPod.Name, metav1.DeleteOptions{})).To(Succeed())
+		})
+
+		By("wait for pod to be running and annotated")
+		Eventually(func() bool {
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.Background(), testPod.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			// Check that pod has network annotation
+			_, hasAnnotation := pod.Annotations["k8s.ovn.org/pod-networks"]
+			return pod.Status.Phase == corev1.PodRunning && hasAnnotation
+		}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(BeTrue(), "pod should be running and annotated")
+
+		By("get node where pod is running")
+		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.Background(), testPod.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		nodeName := pod.Spec.NodeName
+		framework.Logf("Pod is running on node: %s", nodeName)
+
+		By("find ovnkube-node pod on the node where test pod is running")
+		ovnNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+		ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ovnkubeNodePods.Items).NotTo(BeEmpty(), "should find ovnkube-node pod on node %s", nodeName)
+		ovnkubeNodePod := ovnkubeNodePods.Items[0]
+		framework.Logf("Found ovnkube-node pod: %s on node %s", ovnkubeNodePod.Name, nodeName)
+
+		By("verify LSP exists in OVN NB database")
+		// Expected LSP name format: GetUserDefinedNetworkPrefix(nadName) + composePortName(podNamespace, podName)
+		// NAD name for CUDN is: <namespace>/<cudn-name>
+		// GetUserDefinedNetworkPrefix replaces hyphens and slashes with dots and adds underscore
+		nadName := fmt.Sprintf("%s/%s", f.Namespace.Name, cudnName)
+		nadNameWithDots := strings.ReplaceAll(strings.ReplaceAll(nadName, "-", "."), "/", ".")
+		expectedLSPName := fmt.Sprintf("%s_%s_%s", nadNameWithDots, f.Namespace.Name, testPod.Name)
+		framework.Logf("Expected LSP name: %s", expectedLSPName)
+		findLSP := func() (string, error) {
+			stdout, stderr, err := ExecCommandInContainerWithFullOutput(f, ovnNamespace, ovnkubeNodePod.Name, "nb-ovsdb",
+				"ovn-nbctl", "get", "logical-switch-port", expectedLSPName, "_uuid")
+			if err != nil {
+				return "", fmt.Errorf("failed to find LSP %w, stderr: %s", err, stderr)
+			}
+			return stdout, nil
+		}
+		expectedLSP, err := findLSP()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(expectedLSP).ToNot(BeEmpty())
+
+		By("restart ovnkube-node pod on the node where test pod is running")
+		err = restartOVNKubeNodePod(f.ClientSet, deploymentconfig.Get().OVNKubernetesNamespace(), nodeName)
+		Expect(err).NotTo(HaveOccurred(), "should successfully restart ovnkube-node pod")
+
+		By("wait for ovnkube-node to complete sync")
+		// Give ovnkube-node time to complete sync operation
+		time.Sleep(30 * time.Second)
+
+		By("find new ovnkube-node pod after restart")
+		ovnkubeNodePods, err = f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ovnkubeNodePods.Items).NotTo(BeEmpty(), "should find ovnkube-node pod on node %s after restart", nodeName)
+		ovnkubeNodePod = ovnkubeNodePods.Items[0]
+		framework.Logf("Found new ovnkube-node pod after restart: %s on node %s", ovnkubeNodePod.Name, nodeName)
+
+		By("verify LSP still exists after ovnkube-node restart (this will fail due to bug)")
+		Consistently(findLSP).WithTimeout(10*time.Second).WithPolling(2*time.Second).
+			Should(Equal(expectedLSP), "LSP should not have being recreated after ovnkube-node restart")
+
+		By("verify pod still has network annotation")
+		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.Background(), testPod.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		_, hasAnnotation := pod.Annotations["k8s.ovn.org/pod-networks"]
+		Expect(hasAnnotation).To(BeTrue(), "pod should still have network annotation")
+	})
 })
 
 func newLocalnetCUDNYaml(params networkAttachmentConfigParams, selectedNamespaces ...string) string {
@@ -164,6 +307,34 @@ spec:
       physicalNetworkName: ` + params.physicalNetworkName + `
       subnets: [` + params.cidr + `]
       excludeSubnets: [` + excludeSubnets + `]
+      vlan:
+        mode: Access
+        access: {id: ` + strconv.Itoa(params.vlanID) + `}
+`
+}
+
+// newLocalnetIPAMLessCUDNYaml creates a ClusterUserDefinedNetwork YAML for IPAM-less localnet topology
+func newLocalnetIPAMLessCUDNYaml(params networkAttachmentConfigParams, selectedNamespaces ...string) string {
+	selectedNs := strings.Join(selectedNamespaces, ",")
+	// For IPAM-less, we explicitly set ipam.mode to Disabled
+	return `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: ` + params.name + `
+spec:
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values: [ ` + selectedNs + `]
+  network:
+    topology: Localnet
+    localnet:
+      role: Secondary
+      physicalNetworkName: ` + params.physicalNetworkName + `
+      ipam:
+        mode: Disabled
       vlan:
         mode: Access
         access: {id: ` + strconv.Itoa(params.vlanID) + `}


### PR DESCRIPTION
## 📑 Description
When ovnkube-node restarts, it runs syncPodsForUserDefinedNetwork which calls
allocatePodIPs. For IPAM-less localnet networks (switches with no subnets),
IsNonHostSubnetSwitch returns true, causing allocatePodIPs to return empty string.
This prevents the pod from being added to expectedLogicalPorts map, causing
deleteStaleLogicalSwitchPorts to delete the LSP.

This change add an explicit flag at the subnet allocator to denote that
that allocator was created as part of a no host subnet switch, this way
code explicitly diferenciates between localnet ipamless and no host
subnet since both do no have a subnet but no host subnet do not even
have LSPs


Fixes #https://issues.redhat.com/browse/OCPBUGS-66994

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IP allocation now only runs when allocation is required, avoiding unnecessary attempts and errors.
  * Pods on non-host-subnet (IPAM-less) switches are consistently skipped, improving stability during network processing.

* **Infrastructure**
  * Underlay setup/teardown reworked to centrally discover and manage OVS pods and per-node bridge mappings with a consolidated cleanup flow.

* **Tests**
  * New end-to-end test ensures IPAM-less localnet pod ports and network annotations persist across node restarts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->