### PR TITLE
e2e: fix util function isCIDRIPFamilySupported()

### DIFF
--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -92,7 +92,7 @@ var _ = Describe("Multi Homing", feature.MultiHoming, func() {
 			By("creating the attachment configuration")
 			_, err := nadClient.NetworkAttachmentDefinitions(netConfig.namespace).Create(
 				context.Background(),
-				generateNAD(netConfig, f.ClientSet),
+				generateNetAttachDef(netConfig.namespace, netConfig.name, generateNADSpec(netConfig)),
 				metav1.CreateOptions{},
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1314,6 +1314,10 @@ func randStr(n int) string {
 func isCIDRIPFamilySupported(cs kubernetes.Interface, cidr string) bool {
 	ginkgo.GinkgoHelper()
 	gomega.Expect(cidr).To(gomega.ContainSubstring("/"))
+	// if cidr in format 2010:100:200::0/60/64, trim to 2010:100:200::0/60
+	if tokens := strings.Split(cidr, "/"); len(tokens) == 3 {
+		cidr = fmt.Sprintf(`%s/%s`, tokens[0], tokens[1])
+	}
 	isIPv6 := utilnet.IsIPv6CIDRString(cidr)
 	return (isIPv4Supported(cs) && !isIPv6) || (isIPv6Supported(cs) && isIPv6)
 }


### PR DESCRIPTION
The `cidr` passed to  function `isCIDRIPFamilySupported()` could have a host subnet length, which should be trimmed before further checks.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for NetworkAttachmentDefinition object creation with improved clarity and structure.
  * Improved CIDR format normalization handling in test utilities to support additional input patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->