### PR TITLE
egressip: handle LinkNotFoundError gracefully in isEgressIPOnLink

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -1534,6 +1534,12 @@ func generateIPTablesSNATRuleArg(srcIP net.IP, isIPv6 bool, infName, snatIP stri
 func isEgressIPOnLink(linkIndex, ipFamily int, assignedEIPs sets.Set[string]) (bool, error) {
 	link, err := netlink.LinkByIndex(linkIndex)
 	if err != nil {
+		// If the link doesn't exist, there can't be an EgressIP on it.
+		// This can happen when a route is added/deleted causing the interface
+		// to momentarily disappear or change its index.
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	addresses, err := netlink.AddrList(link, ipFamily)


### PR DESCRIPTION
When a route is added/deleted from the main routing table on the same interface the EgressIP is associated with, the link can temporarily disappear or change its index. The isEgressIPOnLink function was returning an error when netlink.LinkByIndex() failed with 'Link not found', causing the EgressIP sync to fail and eventually be dropped from the queue without proper cleanup. This resulted in duplicate IP assignment across nodes.

Fix isEgressIPOnLink to return (false, nil) when the link doesn't exist, since if the link doesn't exist there can't be an EgressIP on it. This allows the EgressIP controller to continue processing gracefully instead of failing.

Added unit tests to verify:
- Returns false when link does not exist (the fix)
- Returns true when EgressIP is on link (normal behavior)
- Returns false when no EgressIP is on link (normal behavior)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling when network links are unavailable during EgressIP validation. The system now gracefully handles missing links instead of propagating errors, providing better resilience.

* **Tests**
  * Added comprehensive unit tests for EgressIP link validation, covering missing links, links with EgressIP assigned, and links without EgressIP.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->