### PR TITLE
Skip FRR bfdd process Coredumps

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,7 @@ DUALSTACK_CONVERSION?=false
 COREDUMP_DIR?=/tmp/kind/logs/coredumps
 # Processes to skip when checking for coredumps (pipe-separated for grep)
 # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5782
-SKIPPED_COREDUMPS?=zebra|bgpd|mgmtd
+SKIPPED_COREDUMPS?=zebra|bgpd|mgmtd|bfdd
 
 # Check for coredumps and fail if any are found (excluding skipped processes)
 # Usage: $(call check-coredumps)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1143,7 +1143,7 @@ func wrappedTestFramework(basename string) *framework.Framework {
 		coredumpDir := "/tmp/kind/logs/coredumps"
 		dbLocation := "/var/lib/openvswitch"
 		// https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5782
-		skippedCoredumps := []string{"zebra", "bgpd", "mgmtd"}
+		skippedCoredumps := []string{"zebra", "bgpd", "mgmtd", "bfdd"}
 
 		// Check for coredumps on host
 		var coredumpFiles []string


### PR DESCRIPTION
## 📑 Description

We are seeing bfdd process crash and go into coredump state:
```
• [ABORTED] [2.945 seconds]
ClusterNetworkConnect ClusterManagerController [JustAfterEach] when CNC is created before networks single network created after CNC: annotations are updated L3 P-UDN [Feature:NetworkConnect]
  [JustAfterEach] /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/util.go:1141
  [It] /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/cluster_network_connect.go:691

  [ABORTED] Coredumps found during test execution: core.426704.bfdd.ovn-control-plane.6
  In [JustAfterEach] at: /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/util.go:1212 @ 12/18/25 19:07:23.097
```

Fixes #5817 

## Additional Information for reviewers

I don't understand why bfdd, bgpd, zebrea or mgmtd are crashing and these are not components we own. Relates to https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5782

I also don't know why are we running all these frr processes in the network segmentation lanes? Aren't these only supposed to run in the BGP lanes?

I do see a services test leveraging frr container in the `network_segmentation_services.go` file and ~I don't think this should be a frr container and instead should be some normal external container~ I think that's because of metallb load balancer test perhaps?

```
				By("Connect to the UDN service from the UDN client external container")
				externalContainer := infraapi.ExternalContainer{Name: "frr"}
				checkConnectionToLoadBalancersFromExternalContainer(f, externalContainer, udnService, udnServerPod.Name)
```
Yes its metallb:

```
install_metallb() {
  # Using latest v0.14.9 as the commit we were using would not build and this
  # version is the one having least issues for dual stack. However tests might
  # have to workaround these two outstanding issue until fixed
  # https://github.com/metallb/metallb/issues/2723
  # https://github.com/metallb/metallb/issues/2724
  local metallb_version=v0.14.9
  mkdir -p /tmp/metallb
  local builddir
  builddir=$(mktemp -d "${METALLB_DIR}/XXXXXX")

  pushd "${builddir}"
  git clone https://github.com/metallb/metallb.git
  cd metallb
  git checkout $metallb_version

  # kindest/node image v1.32+ that we use is only compatible with kind v0.27+
  # when using 'kind load' command however metallb builds and uses older
  # incompatible kind version patch it so that it uses our own kind install
  # instead of their build
  patch tasks.py << 'EOF'
@@ -29,7 +29,7 @@ extra_network = "network2"
-controller_gen_version = "v0.16.3"
+controller_gen_version = "v0.19.0"
 build_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "build")
 kubectl_path = os.path.join(build_path, "kubectl")
-kind_path = os.path.join(build_path, "kind")
+kind_path = "kind"
 ginkgo_path = os.path.join(build_path, "bin", "ginkgo")
 controller_gen_path = os.path.join(build_path, "bin", "controller-gen")
 kubectl_version = "v1.31.0"
EOF

  pip install -r dev-env/requirements.txt

  local ip_family ipv6_network
  if [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
    ip_family="dual"
    ipv6_network="--ipv6 --subnet=${METALLB_CLIENT_NET_SUBNET_IPV6}"
  elif  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
    ip_family="ipv6"
    ipv6_network="--ipv6 --subnet=${METALLB_CLIENT_NET_SUBNET_IPV6}"
  else
    ip_family="ipv4"
    ipv6_network=""
  fi
  # Override GOBIN until https://github.com/metallb/metallb/issues/2218 is fixed.
  GOBIN="" inv dev-env -n ovn -b frr -p bgp -i "${ip_family}"
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure coredump handling to exclude additional process diagnostics during test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->