### PR TITLE
Refactor BGP Setup for Default Network BGP Session

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1264,7 +1264,7 @@ run_bgp_setup() {
     --ipv6="$ipv6_flag" \
     --bgp-server-subnet-ipv4="${BGP_SERVER_NET_SUBNET_IPV4}" \
     --bgp-server-subnet-ipv6="${BGP_SERVER_NET_SUBNET_IPV6}" \
-    --frr-k8s-version="${FRR_K8S_VERSION:-v0.0.21}" \
+    --frr-k8s-version="${FRR_K8S_GIT_REF:-${FRR_K8S_VERSION:-v0.0.21}}" \
     --frr-image="${FRR_DEPLOYED_IMAGE}" \
     --network-name="${NETWORK_NAME:-default}" \
     --cluster-name="${KIND_CLUSTER_NAME:-ovn}" \

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1220,229 +1220,6 @@ readonly FRR_DEPLOYED_IMAGE=quay.io/frrouting/frr:10.6.0
 # without changing the pinned frr-k8s release.
 FRR_K8S_FRR_IMAGE=${FRR_K8S_FRR_IMAGE:-${FRR_DEPLOYED_IMAGE}}
 readonly FRR_EXTERNAL_DEMO_IMAGE=${FRR_DEPLOYED_IMAGE}
-readonly FRR_TMP_DIR=$(mktemp -d -u)
-
-clone_frr() {
-  [ -d "$FRR_TMP_DIR" ] || {
-    mkdir -p "$FRR_TMP_DIR" && trap 'rm -rf $FRR_TMP_DIR' EXIT
-    pushd "$FRR_TMP_DIR" || exit 1
-    git clone --no-tags --single-branch --branch main https://github.com/metallb/frr-k8s
-    pushd frr-k8s
-    git checkout --detach "$FRR_K8S_GIT_REF"
-    popd
-
-    # Download the patches
-    curl -Ls https://github.com/jcaamano/frr-k8s/archive/refs/heads/ovnk-bgp-v0.0.21.tar.gz | tar xzvf - frr-k8s-ovnk-bgp-v0.0.21/patches --strip-components 1
-
-    # Change into the cloned repo directory before applying patches
-    pushd frr-k8s
-    # The OVN-K demo patch was authored before upstream bumped the demo
-    # image. Normalize that context before applying the patch; the image is
-    # bumped to FRR_EXTERNAL_DEMO_IMAGE below.
-    sed -i 's|quay.io/frrouting/frr:10.4.3|quay.io/frrouting/frr:9.1.0|g' hack/demo/demo.sh
-    git apply ../patches/*
-
-    # The upstream frr-k8s demo.sh hardcodes quay.io/frrouting/frr:9.1.0,
-    # which crashes on musl libc (Alpine) due to a race condition in
-    # pthread_setname_np during BGP keepalive thread startup
-    # (https://github.com/FRRouting/frr/issues/15699, fixed in FRR 10.1 by
-    # https://github.com/FRRouting/frr/pull/15714).
-    #
-    # Bump to 10.4.1 for upstream demo was posted here: https://github.com/metallb/frr-k8s/pull/404
-    # We bump further to 10.6.0 to include additional fixes for EVPN and coredumps:
-    # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3907335193
-    # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3898408592
-    # https://github.com/FRRouting/frr/pull/20496
-    #
-    # Note: 10.6.0 carries the bfdd coredump fix:
-    # https://github.com/FRRouting/frr/pull/19822
-    # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6299
-    replace_in_file_or_exit \
-      hack/demo/demo.sh \
-      "${FRR_K8S_UPSTREAM_FRR_IMAGE}" \
-      "${FRR_EXTERNAL_DEMO_IMAGE}"
-
-    popd
-
-    popd || exit 1
-  }
-}
-
-deploy_frr_external_container() {
-  echo "Deploying FRR external container ..."
-  clone_frr
- 
-  pushd "$FRR_TMP_DIR" || exit 1
-  run_kubectl apply -f frr-k8s/charts/frr-k8s/charts/crds/templates/
-  popd || exit 1
- 
-  # apply the demo which will deploy an external FRR container that the cluster
-  # can peer with acting as BGP (reflector) external gateway
-  pushd "${FRR_TMP_DIR}"/frr-k8s/hack/demo || exit 1
-  # modify config template to configure neighbors as route reflector clients
-  # First check if IPv4 network already exists
-  grep -q 'network '"${BGP_SERVER_NET_SUBNET_IPV4}" frr/frr.conf.tmpl || \
-    sed -i '/address-family ipv4 unicast/a \ \ network '"${BGP_SERVER_NET_SUBNET_IPV4}"'' frr/frr.conf.tmpl
-
-  # Add route reflector client config
-  sed -i '/remote-as 64512/a \ neighbor {{ . }} route-reflector-client' frr/frr.conf.tmpl
-
-  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    # Check if IPv6 address-family section exists
-    if ! grep -q 'address-family ipv6 unicast' frr/frr.conf.tmpl; then
-      # Add IPv6 address-family section if it doesn't exist
-      sed -i '/exit-address-family/a \ \
-  address-family ipv6 unicast\
-    network '"${BGP_SERVER_NET_SUBNET_IPV6}"'\
-  exit-address-family' frr/frr.conf.tmpl
-    else
-      # Add network to existing IPv6 section
-      sed -i '/address-family ipv6 unicast/a \ \ network '"${BGP_SERVER_NET_SUBNET_IPV6}"'' frr/frr.conf.tmpl
-    fi
-
-    # Add route-reflector-client for IPv6 neighbors
-    sed -i '/neighbor fc00.*remote-as 64512/a \ neighbor {{ . }} route-reflector-client' frr/frr.conf.tmpl
-  fi
-  if [ "${OCI_BIN}" == "podman" ]; then
-    # frr-k8s' demo script prefers docker when both docker and podman are
-    # installed. Force its podman path, and avoid its host-network fallback
-    # because podman cannot later attach a host-network container to bgpnet.
-    replace_in_file_or_exit \
-      ./demo.sh \
-      'CLI=docker' \
-      'CLI=podman'
-    replace_in_file_or_exit \
-      ./demo.sh \
-      'CLI_BR_NET_BY_SUBNET_FN="docker_get_br_net_by_subnet"' \
-      'CLI_BR_NET_BY_SUBNET_FN="podman_get_br_net_by_subnet"'
-    sed -i '/^pushd \.\/frr\/ && {/i\
-if [ "$CLI" = "podman" ]; then\
-    NETWORK=${FRR_K8S_DEMO_NETWORK:-kind}\
-fi\
-' ./demo.sh
-  fi
-  ./demo.sh
-  popd || exit 1
-  if frr_k8s_remote_enabled && [ -n "${DPU_SIM_GATEWAY_NETWORK:-}" ]; then
-    configure_dpu_sim_frr_gateway_peers
-  fi
-  if  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    # Enable IPv6 forwarding in FRR
-    $OCI_BIN exec frr sysctl -w net.ipv6.conf.all.forwarding=1
-    # Enable keep_addr_on_down to preserve IPv6 addresses during VRF enslavement.
-    # Without this, IPv6 global addresses are removed when interfaces are moved to a VRF,
-    # causing FRR/zebra to fail creating FIB nexthop groups ("no fib nhg" bug).
-    # See: https://docs.kernel.org/networking/vrf.html (section 4: Enslave L3 interfaces)
-    #      https://github.com/FRRouting/frr/issues/1666
-    $OCI_BIN exec frr sysctl -w net.ipv6.conf.all.keep_addr_on_down=1
-  fi
-
-  if [ "$ENABLE_EVPN" == true ]; then
-    echo "Configuring global EVPN BGP on external FRR (advertise-all-vni + neighbor activation)..."
-    # Enable l2vpn evpn address-family, activate all neighbors, and advertise-all-vni.
-    # Neighbors are already configured by demo.sh; extract them from the running config.
-    # This is cluster-level infrastructure shared across all EVPN tests; configured once
-    # at install time so individual tests don't need to manage it.
-    # Wait for FRR daemons to be ready ("Not all daemons are up, cannot write config").
-    local attempts=0 daemon_status
-    while ! daemon_status=$($OCI_BIN exec frr vtysh -c "show daemons" 2>&1); do
-      if (( ++attempts > 30 )); then
-        echo "error: FRR daemons did not become ready after 30 attempts"
-        echo "last daemon status: $daemon_status"
-        exit 1
-      fi
-      sleep 1
-    done
-    local bgp_neighbors vtysh_cmds
-    bgp_neighbors=$($OCI_BIN exec frr vtysh -c "show running-config" | grep "^ neighbor.*remote-as" | awk '{print $2}')
-    vtysh_cmds=(-c "configure terminal" -c "router bgp 64512" -c "address-family l2vpn evpn")
-    for neighbor in $bgp_neighbors; do
-      vtysh_cmds+=(-c "neighbor $neighbor activate")
-      vtysh_cmds+=(-c "neighbor $neighbor route-reflector-client")
-    done
-    vtysh_cmds+=(-c "advertise-all-vni" -c "exit-address-family" -c "end" -c "write memory")
-    $OCI_BIN exec frr vtysh "${vtysh_cmds[@]}"
-    echo "Global EVPN BGP config complete on external FRR"
-  fi
-}
-
-deploy_bgp_external_server() {
-  # We create an external docker container that acts as the server (or client) outside the cluster
-  # in the e2e tests that levergae router advertisements.
-  # This container will be connected to the frr container deployed above to simulate a realistic
-  # network topology
-  # -----------------               ------------------                         ---------------------
-  # |               | 172.26.0.0/16 |                |       172.18.0.0/16     | ovn-control-plane |
-  # |   external    |<------------- |   FRR router   |<------ KIND cluster --  ---------------------
-  # |    server     |               |                |                         |    ovn-worker     |   (client pod advertised
-  # -----------------               ------------------                         ---------------------    using RouteAdvertisements
-  #                                                                            |    ovn-worker2    |    from default pod network)
-  #                                                                            ---------------------
-  local ip_family ipv6_network
-  if [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    ip_family="dual"
-    ipv6_network="--ipv6 --subnet=${BGP_SERVER_NET_SUBNET_IPV6}"
-  elif  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    ip_family="ipv6"
-    ipv6_network="--ipv6 --subnet=${BGP_SERVER_NET_SUBNET_IPV6}"
-  else
-    ip_family="ipv4"
-    ipv6_network=""
-  fi
-  $OCI_BIN rm -f bgpserver
-  $OCI_BIN network rm -f bgpnet
-  $OCI_BIN network create --subnet="${BGP_SERVER_NET_SUBNET_IPV4}" ${ipv6_network} --driver bridge bgpnet
-  $OCI_BIN network connect bgpnet frr
-  $OCI_BIN run  --cap-add NET_ADMIN --user 0  -d --network bgpnet  --rm  --name bgpserver -p "${BGP_SERVER_HOST_PORT}:8080"  registry.k8s.io/e2e-test-images/agnhost:2.45 netexec
-  # let's make the bgp external server have its default route towards FRR router so that we don't need to add routes during tests back to the pods in the
-  # cluster for return traffic
-  local bgp_network_frr_v4 bgp_network_frr_v6 kind_network_frr_v4 kind_network_frr_v6
-  bgp_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.bgpnet.IPAddress}}' frr)
-  echo "FRR bgp network IPv4: ${bgp_network_frr_v4}"
-  $OCI_BIN exec bgpserver ip route replace default via "$bgp_network_frr_v4"
-  if  [ "$PLATFORM_IPV6_SUPPORT" == true ] ; then
-    bgp_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.bgpnet.GlobalIPv6Address}}' frr)
-    echo "FRR bgp network IPv6: ${bgp_network_frr_v6}"
-    $OCI_BIN exec bgpserver ip -6 route replace default via "$bgp_network_frr_v6"
-  fi
-  if [ "$ADVERTISED_UDN_ISOLATION_MODE" == "loose" ]; then
-    kind_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' frr)
-    echo "FRR kind network IPv4: ${kind_network_frr_v4}"
-    # If UDN isolation is in loose disabled, we need to set the default gateway for the nodes in the cluster
-    # to the FRR router so that cross-UDN traffic can be routed back to the pods in the cluster in the loose mode.
-    echo "Setting default gateway for nodes in the cluster to FRR router IPv4: ${kind_network_frr_v4}"
-    set_nodes_default_gw "$kind_network_frr_v4"
-    if  [ "$PLATFORM_IPV6_SUPPORT" == true ] ; then
-      kind_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' frr)
-      echo "FRR kind network IPv6: ${kind_network_frr_v6}"
-      set_nodes_default_gw "$kind_network_frr_v6"
-    fi
-  else
-    # disable the default route to make sure the container only routes accross
-    # directly connected or learnt networks (doing this at the very end since
-    # docker changes the routing table when a new network is connected)
-    $OCI_BIN exec frr ip route delete default
-    $OCI_BIN exec frr ip route
-    $OCI_BIN exec frr ip -6 route delete default
-    $OCI_BIN exec frr ip -6 route
-  fi
-}
-
-set_nodes_default_gw() {
-  local gw="$1"
-  local ip_cmd="ip"
-  local route_cmd="route replace default via"
-
-  # Check if $gw is IPv6 (contains ':')
-  if [[ "$gw" == *:* ]]; then
-    ip_cmd="ip -6"
-  fi
-
-  KIND_NODES=$(kind_get_nodes)
-  for node in $KIND_NODES; do
-    $OCI_BIN exec "$node" $ip_cmd $route_cmd "$gw"
-  done
-}
 
 destroy_bgp() {
   if $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^bgpserver$'; then
@@ -1456,173 +1233,45 @@ destroy_bgp() {
   fi
 }
 
-install_frr_k8s_crds() {
-  echo "Installing frr-k8s CRDs ..."
-  clone_frr
-  kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/
-}
-
-install_frr_k8s() {
-  local bgp_port=${1:-0}
-  echo "Installing frr-k8s ..."
-  clone_frr
-
-  # apply frr-k8s
-
-  # The all-in-one manifest is only consumed here (deploy_frr_external_container
-  # uses CRDs and the demo scripts, not this manifest), so the fix lives here
-  # rather than in clone_frr.
-  #
-  # gcr.io/kubebuilder/kube-rbac-proxy is unavailable after Google's Container
-  # Registry shutdown (https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation).
-  # Upstream bug: https://github.com/metallb/metallb/issues/2619
-  # Use the same image from the Kubernetes community registry instead.
-  # REVERT ME: when https://github.com/metallb/metallb/issues/2619 is fixed
-  sed -i 's|gcr.io/kubebuilder/kube-rbac-proxy|registry.k8s.io/kubebuilder/kube-rbac-proxy|g' \
-    "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml
-
-  replace_in_file_or_exit \
-    "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml \
-    "${FRR_K8S_ALL_IN_ONE_UPSTREAM_FRR_IMAGE}" \
-    "${FRR_K8S_FRR_IMAGE}"
-
-  if [ "${bgp_port}" -ne 0 ]; then
-    local frr_yaml="${FRR_TMP_DIR}/frr-k8s/config/all-in-one/frr-k8s.yaml"
-    grep -q 'bgpd_options=.*-p 0' "$frr_yaml" || {
-      echo "expected bgpd_options with '-p 0' not found in $frr_yaml"
-      exit 1
-    }
-    sed -i "s/bgpd_options=\"\(.*\)-p 0\(.*\)\"/bgpd_options=\"\1-p ${bgp_port}\2\"/g" "$frr_yaml"
-    grep -q "bgpd_options=.*-p ${bgp_port}" "$frr_yaml" || {
-      echo "failed to patch bgpd_options to use port ${bgp_port}"
-      exit 1
-    }
-  fi
-  install_frr_k8s_host_api_crds
-  kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml
-  create_frr_k8s_remote_kubeconfig_secret
-  configure_frr_k8s_remote_daemonsets
-}
-
-wait_for_frr_k8s() {
-  if kubectl -n frr-k8s-system get deployment frr-k8s-statuscleaner >/dev/null 2>&1; then
-    kubectl wait -n frr-k8s-system deployment frr-k8s-statuscleaner --for condition=Available --timeout 2m
-  fi
-  if kubectl -n frr-k8s-system get daemonset frr-k8s-daemon >/dev/null 2>&1; then
-    kubectl rollout status -n frr-k8s-system daemonset frr-k8s-daemon --timeout 2m
-    return
-  fi
-  local ds found=false
-  for ds in $(kubectl -n frr-k8s-system get daemonset -l dpu-sim.ovn.org/frr-remote=true -o name); do
-    found=true
-    kubectl rollout status -n frr-k8s-system "${ds}" --timeout 2m
-  done
-  if [ "${found}" != true ]; then
-    echo "No local or remote FRR-K8S daemonsets were found in namespace frr-k8s-system" >&2
-    return 1
-  fi
-}
-
-apply_frr_k8s_receive_config() {
-  # apply a BGP peer configration with the external gateway that does not
-  # exchange routes
-  pushd "${FRR_TMP_DIR}"/frr-k8s/hack/demo/configs || exit 1
-  sed 's/mode: all/mode: filtered/g' receive_all.yaml > receive_filtered.yaml
-  if frr_k8s_remote_enabled && [ -n "${DPU_SIM_GATEWAY_NETWORK:-}" ]; then
-    configure_dpu_sim_frr_receive_config receive_filtered.yaml
-  fi
-  # Allow receiving the bgp external server's prefix
-  sed -i '/mode: filtered/a\            prefixes:\n            - prefix: '"${BGP_SERVER_NET_SUBNET_IPV4}"'' receive_filtered.yaml
-  # If IPv6 is enabled, add the IPv6 prefix as well
-  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    # Find all line numbers where the IPv4 prefix is defined
-    IPv6_LINE="            - prefix: ${BGP_SERVER_NET_SUBNET_IPV6}"
-    # Process each occurrence of the IPv4 prefix in reverse order to avoid line number shifting
-    for LINE_NUM in $(grep -n "prefix: ${BGP_SERVER_NET_SUBNET_IPV4}" receive_filtered.yaml | cut -d ':' -f 1 | sort -rn); do
-      # Insert the IPv6 prefix after each IPv4 prefix line
-      sed -i "${LINE_NUM}a\\${IPv6_LINE}" receive_filtered.yaml
-    done
+# Build and run the bgp-setup tool from test/e2e/_output/bin/bgp-setup
+# Arguments:
+#   $1 - phase: "deploy-frr", "deploy-bgp-server", "deploy-containers", "install-frr-k8s", or "all"
+#   $2 - (optional) extra flags to pass to bgp-setup (e.g., "--bgp-port=179")
+run_bgp_setup() {
+  local phase="${1:-all}"
+  local extra_flags="${2:-}"
+  local bgp_setup_bin="${DIR}/../test/e2e/_output/bin/bgp-setup"
+  
+  # Build bgp-setup if it doesn't exist or if source is newer
+  if [ ! -f "$bgp_setup_bin" ] || [ "${DIR}/../test/e2e/cmd/bgp-setup/main.go" -nt "$bgp_setup_bin" ]; then
+    echo "Building bgp-setup tool..."
+    mkdir -p "${DIR}/../test/e2e/_output/bin"
+    pushd "${DIR}/../test/e2e" > /dev/null
+    go build -o _output/bin/bgp-setup ./cmd/bgp-setup
+    popd > /dev/null
   fi
   
-  # frr-k8s webhook is declaring readiness before its endpoint is serving.
-  # Let's do our own probing. Also will print logs in case of failure so we get
-  # insights on why this is hapenning. In remote mode the host API does not use
-  # the DPU-cluster webhook service, so skip this probe.
-  local r
-  r=0
-  if ! frr_k8s_remote_enabled; then
-    timeout 60s bash -x <<EOF || r=$?
-echo "Attempting to reach frr-k8s webhook"
-kind export kubeconfig --name ovn
-while true; do
-CLUSTER_IP=\$(kubectl get svc -n frr-k8s-system frr-k8s-webhook-service -o jsonpath='{.spec.clusterIP}')
-# Wrap IPv6 addresses in brackets for URL syntax
-[[ \${CLUSTER_IP} =~ : ]] && CLUSTER_IP="[\${CLUSTER_IP}]"
-$OCI_BIN exec ovn-control-plane curl -ksS --connect-timeout 0.1 https://\${CLUSTER_IP}
-[ \$? -eq 0 ] && exit 0
-echo "Couldn't reach frr-k8s webhook, trying in 1s..."
-sleep 1s
-done
-EOF
-  fi
-  echo "r=$r"
-  if [ "$r" -ne "0" ]; then
-    kubectl describe pod -n frr-k8s-system -l app=frr-k8s-webhook-server
-    kubectl logs -n frr-k8s-system -l app=frr-k8s-webhook-server
-  fi
-
-  local kubectl_cmd=(kubectl)
-  if frr_k8s_remote_enabled; then
-    kubectl_cmd=(kubectl --kubeconfig "$(frr_k8s_host_kubeconfig)")
-  fi
-  "${kubectl_cmd[@]}" apply -n frr-k8s-system -f receive_filtered.yaml
-  popd || exit 1
-}
-
-configure_frr_k8s_routes() {
-  # Add routes for pod networks dynamically into the github runner for return traffic to pass back
-  if [ "$ADVERTISE_DEFAULT_NETWORK" = "true" ]; then
-    echo "Adding routes for Kubernetes pod networks..."
-    NODES=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
-    echo "Found nodes: $NODES"
-    for node in $NODES; do
-      # Get the addresses
-      node_ips=$(kubectl get node $node -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
-      # Get subnet information
-      subnet_json=$(kubectl get node $node -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}')
-      
-      if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
-        # Extract IPv4 address (first address)
-        node_ipv4=$(echo "$node_ips" | awk '{print $1}')
-        ipv4_subnet=$(echo "$subnet_json" | jq -r '.default[0]')
-        
-        # Add IPv4 route
-        if [ -n "$ipv4_subnet" ] && [ -n "$node_ipv4" ]; then
-          echo "Adding IPv4 route for $node ($node_ipv4): $ipv4_subnet"
-          sudo ip route replace $ipv4_subnet via $node_ipv4
-        fi
-      fi
-
-      # Add IPv6 route if enabled
-      if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-        # Extract IPv6 address (second address, if present)
-        node_ipv6=$(echo "$node_ips" | awk '{print $2}')
-        ipv6_subnet=$(echo "$subnet_json" | jq -r '.default[1] // empty')
-        
-        if [ -n "$ipv6_subnet" ] && [ -n "$node_ipv6" ]; then
-          echo "Adding IPv6 route for $node ($node_ipv6): $ipv6_subnet"
-          sudo ip -6 route replace $ipv6_subnet via $node_ipv6
-        fi
-      fi
-    done
-  fi
-
-  rm -rf "${FRR_TMP_DIR}"
-}
-
-configure_frr_k8s() {
-  apply_frr_k8s_receive_config
-  configure_frr_k8s_routes
+  echo "Running bgp-setup with phase: $phase"
+  
+  # Determine IPv4/IPv6 flags
+  local ipv4_flag="${PLATFORM_IPV4_SUPPORT:-true}"
+  local ipv6_flag="${PLATFORM_IPV6_SUPPORT:-false}"
+  
+  "$bgp_setup_bin" \
+    --phase="$phase" \
+    --container-runtime="$OCI_BIN" \
+    --ipv4="$ipv4_flag" \
+    --ipv6="$ipv6_flag" \
+    --bgp-server-subnet-ipv4="${BGP_SERVER_NET_SUBNET_IPV4}" \
+    --bgp-server-subnet-ipv6="${BGP_SERVER_NET_SUBNET_IPV6}" \
+    --frr-k8s-version="${FRR_K8S_VERSION:-v0.0.21}" \
+    --frr-image="${FRR_DEPLOYED_IMAGE}" \
+    --network-name="${NETWORK_NAME:-default}" \
+    --cluster-name="${KIND_CLUSTER_NAME:-ovn}" \
+    --isolation-mode="${ADVERTISED_UDN_ISOLATION_MODE:-strict}" \
+    --advertise-default-network="${ADVERTISE_DEFAULT_NETWORK:-false}" \
+    --kubeconfig="${KUBECONFIG}" \
+    ${extra_flags}
 }
 
 setup_coredumps() {
@@ -1888,6 +1537,21 @@ delete() {
   timeout 5 kubectl --kubeconfig "${KUBECONFIG}" delete namespace ovn-kubernetes || true
   sleep 5
   kind delete cluster --name "${KIND_CLUSTER_NAME:-ovn}"
+
+  # Clean up stale endpoints from kind network that kind delete may leave behind
+  # Use network inspect to get containers still connected to the kind network
+  local cluster_name="${KIND_CLUSTER_NAME:-ovn}"
+  local stale_endpoints
+  stale_endpoints=$($OCI_BIN network inspect kind --format '{{range .Containers}}{{.Name}} {{end}}' 2>/dev/null || true)
+  if [ -n "$stale_endpoints" ]; then
+    echo "Cleaning up stale endpoints from kind network..."
+    for endpoint in $stale_endpoints; do
+      # Only disconnect endpoints belonging to this cluster or frr
+      if [[ "$endpoint" == "${cluster_name}-"* ]] || [[ "$endpoint" == "frr" ]] || [[ "$endpoint" == "bgpserver" ]]; then
+        $OCI_BIN network disconnect -f kind "$endpoint" 2>/dev/null || true
+      fi
+    done
+  fi
 }
 
 create_kind_cluster() {

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -718,19 +718,15 @@ if [ "$OVN_ENABLE_DNSNAMERESOLVER" == true ]; then
     update_coredns_deployment_image
 fi
 if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
-  frr_port=0
   if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" == true ]; then
-    # Enable bgp port listening on node, required for managed mode. FRR will listen on port 179 to receive BGP updates from other nodes.
-    frr_port=179
-  elif [ "${DPU_MODE}" != "host" ]; then
-    # external FRR is required for unmanaged mode where the FRR-K8S speakers run.
-    deploy_frr_external_container
-    deploy_bgp_external_server
-  fi
-  if [ "${DPU_MODE}" == "host" ]; then
-    install_frr_k8s_crds
+    # Managed routing: install frr-k8s with bgpd on port 179 before OVN
+    run_bgp_setup install-frr-k8s "--bgp-port=179"
   else
-    install_frr_k8s $frr_port
+    # Phase 1a: Deploy external FRR container (before OVN installation)
+    run_bgp_setup deploy-frr
+
+    # Phase 1b: Deploy BGP server container (before OVN installation)
+    run_bgp_setup deploy-bgp-server
   fi
 fi
 if [ "$KIND_REMOVE_TAINT" == true ]; then
@@ -780,11 +776,10 @@ if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
   fi
 fi
 
-if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ] && [ "${DPU_MODE}" != "host" ]; then
-  # wait for frr-k8s to be ready
-  wait_for_frr_k8s
+if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
   if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" != true ]; then
-    configure_frr_k8s
+    # Phase 2: Install frr-k8s and create FRRConfiguration (after OVN is installed)
+    run_bgp_setup install-frr-k8s
   fi
 fi
 

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -777,7 +777,10 @@ if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
 fi
 
 if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
-  if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" != true ]; then
+  if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" == true ]; then
+    # Managed routing: frr-k8s manifest was applied pre-OVN; now wait for pods
+    run_bgp_setup wait-frr-k8s
+  else
     # Phase 2: Install frr-k8s and create FRRConfiguration (after OVN is installed)
     run_bgp_setup install-frr-k8s
   fi

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+_output/

--- a/test/e2e/cmd/bgp-setup/README.md
+++ b/test/e2e/cmd/bgp-setup/README.md
@@ -1,0 +1,272 @@
+# BGP Setup Tool
+
+A standalone Go program that sets up BGP infrastructure for route advertisement testing in OVN-Kubernetes KinD clusters.
+
+## Overview
+
+This tool sets up the BGP infrastructure required for route advertisement testing:
+- Deploys an external FRR container for BGP peering with the cluster nodes
+- Creates a BGP server container (agnhost) on a separate network for testing external connectivity
+- Installs the frr-k8s operator and applies FRRConfiguration CRs
+
+This tool reuses packages from the e2e test framework:
+- `infraprovider/frr` - for FRR configuration template rendering
+- `images` - for container image defaults
+
+## Network Topology
+
+The tool creates a multi-network topology with an external FRR router acting as a bridge
+between the KIND cluster and an isolated BGP server network. The FRR router container
+(image configurable via `--frr-image`) connects to both the `kind` network (for BGP peering
+with cluster nodes: ovn-control-plane, ovn-worker, ovn-worker2) and the `bgpnet` network.
+The `bgpserver` container (an agnhost instance) resides on the `bgpnet` network, simulating
+an external endpoint that is only reachable through the FRR router via BGP-advertised routes.
+
+```text
+-----------------                 ------------------                         ---------------
+|               |  bgpnet         |                |       kind network      |             |
+|   bgpserver   |<--------------- |   FRR router   |<------( Default )-------|   cluster   |
+|   (agnhost)   |                 |                |                         |             |
+-----------------                 ------------------                         ---------------
+```
+
+## Building
+
+From the `test/e2e` directory:
+
+```bash
+go build -o bgp-setup ./cmd/bgp-setup
+```
+
+Or from the repository root:
+
+```bash
+cd test/e2e && go build -o bgp-setup ./cmd/bgp-setup
+```
+
+### Building with `-trimpath`
+
+When building with `go build -trimpath` (common for reproducible/privacy-focused builds),
+the binary cannot automatically locate template files because source paths are stripped.
+You must provide the testdata path explicitly at runtime:
+
+```bash
+# Build with -trimpath
+go build -trimpath -o bgp-setup ./cmd/bgp-setup
+
+# Run with explicit testdata path
+./bgp-setup --testdata-path /path/to/test/e2e/testdata/routeadvertisements
+
+# Or via environment variable
+BGP_TESTDATA_PATH=/path/to/test/e2e/testdata/routeadvertisements ./bgp-setup
+```
+
+## Usage
+
+### Basic Usage
+
+Run with default settings (IPv4 only, strict isolation):
+```bash
+./bgp-setup
+```
+
+### IP Stack Configuration
+
+Single-stack IPv6 only:
+```bash
+./bgp-setup --ipv4=false --ipv6
+```
+
+Dual-stack (both IPv4 and IPv6):
+```bash
+./bgp-setup --ipv4 --ipv6
+```
+
+### Custom Network Configuration
+
+Override the default subnets if they conflict with your existing network configuration.
+The BGP server subnet configures the `bgpnet` Docker network where the `bgpserver`
+container resides. This network is separate from the KIND cluster network - the
+bgpserver is only reachable through the FRR router via BGP-advertised routes
+(see Network Topology diagram above).
+
+```bash
+./bgp-setup \
+  --bgp-server-subnet-ipv4 172.26.0.0/16 \
+  --bgp-server-subnet-ipv6 fc00:f853:ccd:e796::/64
+```
+
+### Loose Isolation Mode
+
+For UDN loose isolation mode (sets nodes' default gateway to FRR router):
+```bash
+./bgp-setup --isolation-mode loose
+```
+
+### Cleanup
+
+To remove all BGP infrastructure:
+```bash
+./bgp-setup --cleanup
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--phase` | `all` | Phase to run: `all`, `deploy-frr`, `deploy-bgp-server`, `deploy-containers`, `install-frr-k8s`, or `wait-frr-k8s` |
+| `--container-runtime` | `docker` | Container runtime to use (docker/podman) |
+| `--ipv4` | `true` | Enable IPv4 support |
+| `--ipv6` | `false` | Enable IPv6 support |
+| `--bgp-server-subnet-ipv4` | `172.26.0.0/16` | IPv4 CIDR for `bgpnet` network (where bgpserver resides) |
+| `--bgp-server-subnet-ipv6` | `fc00:f853:ccd:e796::/64` | IPv6 CIDR for `bgpnet` network (where bgpserver resides) |
+| `--frr-k8s-version` | `v0.0.21` | Version of frr-k8s to use |
+| `--frr-image` | (from `FRR_IMAGE` env or images package default) | FRR container image to use |
+| `--agnhost-image` | (upstream k8s agnhost image) | agnhost container image for the BGP server |
+| `--network-name` | `default` | Name for the BGP network |
+| `--isolation-mode` | `strict` | UDN isolation mode: strict or loose |
+| `--advertise-default-network` | `true` | Add pod network routes for default network advertisement |
+| `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file |
+| `--cluster-name` | `ovn` | Kind cluster name; used to derive the control-plane container name (`<cluster-name>-control-plane`) |
+| `--bgp-port` | `0` | BGP port for frr-k8s daemon (0 = default/disabled, 179 = managed routing) |
+| `--enable-evpn` | `false` | Enable EVPN (l2vpn evpn) configuration on external FRR container |
+| `--cleanup` | `false` | Only cleanup existing BGP infrastructure |
+| `--use-direct-api` | `false` | Use direct API server address (control plane container IP) instead of kubeconfig server. Only works when Docker bridge network is routable from host. |
+| `--testdata-path` | (auto-detected) | Path to `testdata/routeadvertisements` directory containing templates. Required when built with `-trimpath`. |
+
+### Phase Options
+
+The `--phase` flag allows running specific parts of the setup:
+
+- **`all`** (default): Run all phases in sequence - useful for standalone testing
+- **`deploy-frr`**: Deploy FRR external container only
+- **`deploy-bgp-server`**: Deploy BGP server container only
+- **`deploy-containers`**: Deploy both FRR container and BGP server (combines deploy-frr + deploy-bgp-server)
+- **`install-frr-k8s`**: Install frr-k8s operator and create FRRConfiguration for BGP peering. When `--bgp-port` is set (managed routing), only applies the manifest and skips the readiness wait (use `wait-frr-k8s` post-OVN).
+- **`wait-frr-k8s`**: Wait for frr-k8s pods (statuscleaner deployment, daemon daemonset, webhook) to become ready. Used post-OVN for managed routing where the manifest is applied pre-OVN but pods need the CNI to start.
+
+#### Running All Phases (Standalone Usage)
+
+When running `bgp-setup` outside of `kind.sh`/`kind-helm.sh`, use phase `all` to set up everything at once:
+
+```bash
+# Run all phases - deploys FRR, BGP server, and installs frr-k8s
+./bgp-setup --phase all
+
+# Or simply (all is the default):
+./bgp-setup
+```
+
+#### Running Individual Phases (Integration with kind.sh/kind-helm.sh)
+
+When integrated with `kind.sh` or `kind-helm.sh`, phases are run separately because some must execute before OVN installation and others after:
+
+```bash
+# Phase 1a: Deploy FRR container (before OVN installation)
+./bgp-setup --phase deploy-frr
+
+# Phase 1b: Deploy BGP server (before OVN installation)  
+./bgp-setup --phase deploy-bgp-server
+
+# Phase 2: Install frr-k8s (after OVN is installed and cluster is ready)
+./bgp-setup --phase install-frr-k8s
+
+# Managed routing: apply manifest pre-OVN, wait post-OVN
+./bgp-setup --phase install-frr-k8s --bgp-port 179   # pre-OVN (apply only)
+./bgp-setup --phase wait-frr-k8s                      # post-OVN (wait for pods)
+```
+
+## Environment Variables
+
+All flags can also be set via environment variables:
+
+| Environment Variable | Flag |
+|---------------------|------|
+| `CONTAINER_RUNTIME` | `--container-runtime` |
+| `PLATFORM_IPV4_SUPPORT` | `--ipv4` |
+| `PLATFORM_IPV6_SUPPORT` | `--ipv6` |
+| `BGP_SERVER_NET_SUBNET_IPV4` | `--bgp-server-subnet-ipv4` |
+| `BGP_SERVER_NET_SUBNET_IPV6` | `--bgp-server-subnet-ipv6` |
+| `FRR_K8S_VERSION` | `--frr-k8s-version` |
+| `FRR_IMAGE` | `--frr-image` |
+| `NETWORK_NAME` | `--network-name` |
+| `ADVERTISED_UDN_ISOLATION_MODE` | `--isolation-mode` |
+| `ADVERTISE_DEFAULT_NETWORK` | `--advertise-default-network` |
+| `KUBECONFIG` | `--kubeconfig` |
+| `KIND_CLUSTER_NAME` | `--cluster-name` |
+| `BGP_TESTDATA_PATH` | `--testdata-path` |
+
+## Integration with kind.sh and kind-helm.sh
+
+This tool is integrated into `contrib/kind-common.sh` via the `run_bgp_setup` function,
+which is used by both `kind.sh` (standard deployment) and `kind-helm.sh` (Helm-based deployment).
+The shell scripts call the tool in separate phases:
+
+```bash
+# Before OVN installation:
+if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
+  if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" == true ]; then
+    # Managed routing: apply frr-k8s manifest with bgpd on port 179 (skip wait;
+    # pods can't start until the CNI is available)
+    run_bgp_setup install-frr-k8s "--bgp-port=179"
+  else
+    # Phase 1a: Deploy external FRR container
+    run_bgp_setup deploy-frr
+    # Phase 1b: Deploy BGP server container
+    run_bgp_setup deploy-bgp-server
+  fi
+fi
+
+# ... OVN installation happens here ...
+
+# After OVN installation:
+if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
+  if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" == true ]; then
+    # Managed routing: now that OVN/CNI is ready, wait for frr-k8s pods
+    run_bgp_setup wait-frr-k8s
+  else
+    # Phase 2: Install frr-k8s and create FRRConfiguration for BGP peering
+    run_bgp_setup install-frr-k8s
+  fi
+fi
+```
+
+The `run_bgp_setup` function in `kind-common.sh` automatically builds the tool if needed
+and passes the appropriate configuration flags.
+
+## What It Does
+
+1. **Apply FRR-K8s CRDs** - Installs the FRRConfiguration CRD directly from GitHub (no git clone required)
+2. **Deploy FRR container** - Creates an FRR router container attached to the kind network
+3. **Create bgpnet network** - Creates a separate network for the BGP server
+4. **Deploy bgpserver** - Creates an agnhost container acting as an external server
+5. **Configure routing** - Sets up routing between bgpserver, FRR router, and cluster nodes
+6. **Configure EVPN** - When `--enable-evpn` is set, enables l2vpn evpn address-family on the external FRR container with neighbor activation, route-reflector-client, and advertise-all-vni
+7. **Install frr-k8s** - Deploys the frr-k8s operator directly from GitHub (patches `gcr.io` image references to `registry.k8s.io`; optionally patches bgpd port for managed routing via `--bgp-port`)
+8. **Apply FRRConfiguration** - Creates BGP peering configuration for the cluster when route advertisements are enabled
+9. **Add pod network routes** - When `--advertise-default-network=true`, adds host-level `ip route` entries on the local machine so that each node's pod subnet (read from the `k8s.ovn.org/node-subnets` annotation) is reachable via that node's internal IP. This allows the CI runner or developer's machine to reach pod IPs directly for end-to-end connectivity validation (requires sudo)
+
+## Dependencies
+
+- Go 1.25+
+- kubectl configured with cluster access
+- Docker or Podman
+- A running KinD cluster with OVN-Kubernetes
+
+## Template Files
+
+This tool uses the shared templates from `test/e2e/testdata/routeadvertisements/`.
+
+By default, the template path is auto-detected using `runtime.Caller()` to determine
+the source file location and find the templates relative to it. However, this approach
+has limitations:
+
+- **`-trimpath` builds**: When building with `go build -trimpath`, source file paths are
+  stripped from the binary, causing the auto-detection to fail. You must provide the
+  testdata path explicitly via `--testdata-path` or `BGP_TESTDATA_PATH`.
+
+- **Relocated binaries**: If the binary is moved to a different location than where it
+  was built, the auto-detected path may be incorrect. Use `--testdata-path` to override.
+
+The same templates are also used by the route advertisement e2e tests in
+`test/e2e/route_advertisements.go`.

--- a/test/e2e/cmd/bgp-setup/main.go
+++ b/test/e2e/cmd/bgp-setup/main.go
@@ -1,0 +1,1160 @@
+// bgp-setup is a standalone program that sets up BGP infrastructure for route advertisement testing.
+// It
+//   - deploys an external FRR container for BGP peering
+//   - deploy bgp server container for testing
+//   - install frr-k8s and create FRRConfiguration for BGP peering when route advertisements are enabled
+//   - optionally, add pod network routes if `--advertise-default-network=true`
+//
+// Usage:
+//
+//	bgp-setup [flags]
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/containerengine"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/frr"
+	k8simage "k8s.io/kubernetes/test/utils/image"
+)
+
+// testdataPathOverride stores the user-provided testdata path (from flag or env var).
+// This is set during flag parsing and used by getTestdataPath().
+var testdataPathOverride string
+
+// getTestdataPath returns the path to the shared testdata templates.
+// These templates are used by both the route_advertisements tests and this setup tool.
+//
+// The path is determined in the following order of precedence:
+//  1. The --testdata-path flag or BGP_TESTDATA_PATH environment variable
+//  2. Derived from this source file's location using runtime.Caller()
+//
+// Note: When building with `go build -trimpath`, the runtime.Caller() fallback will not work
+// because file paths are stripped from the binary. In this case, you must provide the
+// testdata path explicitly via the flag or environment variable.
+func getTestdataPath() string {
+	// Check if an override was provided via flag or environment variable
+	if testdataPathOverride != "" {
+		return testdataPathOverride
+	}
+
+	// Fall back to runtime.Caller() based detection
+	// Note: This will not work with `go build -trimpath`
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("failed to get current file path via runtime.Caller(); " +
+			"this can happen when built with -trimpath. " +
+			"Please provide the testdata path via --testdata-path flag or BGP_TESTDATA_PATH environment variable")
+	}
+
+	// Validate that the path looks reasonable (not trimmed)
+	// When -trimpath is used, the path might be something like "command-line-arguments/main.go"
+	if !filepath.IsAbs(thisFile) {
+		panic(fmt.Sprintf("runtime.Caller() returned a non-absolute path %q; "+
+			"this can happen when built with -trimpath. "+
+			"Please provide the testdata path via --testdata-path flag or BGP_TESTDATA_PATH environment variable", thisFile))
+	}
+
+	// thisFile is .../test/e2e/cmd/bgp-setup/main.go
+	// We need .../test/e2e/testdata/routeadvertisements
+	// Go up 3 levels: bgp-setup -> cmd -> e2e
+	cmdDir := filepath.Dir(thisFile)
+	e2eCmdDir := filepath.Dir(cmdDir)
+	e2eDir := filepath.Dir(e2eCmdDir)
+	return filepath.Join(e2eDir, "testdata", "routeadvertisements")
+}
+
+// getTemplateSource returns a FilesystemSource for FRR templates from the testdata directory.
+// This is shared by FRR daemon config generation and FRR-k8s configuration generation.
+func getTemplateSource() *frr.FilesystemSource {
+	return frr.NewFilesystemSource(getTestdataPath())
+}
+
+const (
+	// Container and network names
+	kindNetwork              = "kind"
+	frrK8sNS                 = "frr-k8s-system"
+	frrK8sDeploymentName     = "frr-k8s-statuscleaner"
+	frrK8sDaemonsetName      = "frr-k8s-daemon"
+	frrK8sWebhookServiceName = "frr-k8s-webhook-service"
+	frrContainerName         = "frr"
+
+	// BGP server configuration
+	bgpServerContainerName = "bgpserver"
+	bgpNetworkName         = "bgpnet"
+	bgpServerPortMapping   = "8080:8080"
+
+	// Persistent directory for FRR configuration files
+	// This directory persists for the cluster lifetime and is cleaned up with the cluster
+	frrConfigDir = "/tmp/bgp-setup/frr-config"
+
+	// Environment variable names
+	envContainerRuntime        = "CONTAINER_RUNTIME"
+	envBGPServerSubnetIPv4     = "BGP_SERVER_NET_SUBNET_IPV4"
+	envBGPServerSubnetIPv6     = "BGP_SERVER_NET_SUBNET_IPV6"
+	envIPv4Support             = "PLATFORM_IPV4_SUPPORT"
+	envIPv6Support             = "PLATFORM_IPV6_SUPPORT"
+	envFRRK8sVersion           = "FRR_K8S_VERSION"
+	envNetworkName             = "NETWORK_NAME"
+	envKubeconfig              = "KUBECONFIG"
+	envAdvertiseDefaultNetwork = "ADVERTISE_DEFAULT_NETWORK"
+	envIsolationMode           = "ADVERTISED_UDN_ISOLATION_MODE"
+	envTestdataPath            = "BGP_TESTDATA_PATH"
+	envClusterName             = "KIND_CLUSTER_NAME"
+
+	// Default configuration values
+	defaultContainerRuntime    = "docker"
+	defaultBGPServerSubnetIPv4 = "172.26.0.0/16"
+	defaultBGPServerSubnetIPv6 = "fc00:f853:ccd:e796::/64"
+	defaultFRRK8sVersion       = "v0.0.21"
+	defaultNetworkName         = "default"
+	defaultIsolationMode       = "strict"
+	defaultClusterName         = "ovn"
+
+	// Timeouts and intervals
+	pollInterval     = time.Second
+	containerTimeout = 60 * time.Second
+	deployTimeout    = "2m"
+
+	// Phase constants for running specific parts of the setup
+	PhaseAll              = "all"
+	PhaseDeployContainers = "deploy-containers" // Phase 1: deploy FRR container and BGP server (combined)
+	PhaseDeployFRR        = "deploy-frr"        // Phase 1a: deploy FRR external container only
+	PhaseDeployBGPServer  = "deploy-bgp-server" // Phase 1b: deploy BGP server container only
+	PhaseInstallFRRK8s    = "install-frr-k8s"   // Phase 2: install frr-k8s and create FRRConfiguration for BGP peering
+)
+
+// frrK8sRemoteURL returns the raw GitHub URL for a file in the frr-k8s repo at a specific version
+func frrK8sRemoteURL(version, path string) string {
+	return fmt.Sprintf("https://raw.githubusercontent.com/metallb/frr-k8s/%s/%s", version, path)
+}
+
+func downloadURL(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP GET failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// Config holds the configuration for BGP setup
+type Config struct {
+	ContainerRuntime        string
+	BGPServerSubnetIPv4     string
+	BGPServerSubnetIPv6     string
+	IPv4Enabled             bool
+	IPv6Enabled             bool
+	FRRK8sVersion           string
+	FRRImage                string
+	AgnHostImage            string
+	NetworkName             string
+	Kubeconfig              string
+	AdvertiseDefaultNetwork bool
+	IsolationMode           string
+	CleanupOnly             bool
+	Phase                   string
+	UseDirectAPI            bool
+	TestdataPath            string
+	ClusterName             string
+	BGPPort                 int
+}
+
+func main() {
+	cfg := parseFlags()
+
+	// Set kubeconfig for kubectl commands
+	kubeconfig = cfg.Kubeconfig
+
+	// Derive control plane node name from cluster name
+	controlPlaneNodeName = deriveControlPlaneNodeName(cfg.ClusterName)
+	fmt.Printf("Using control plane node: %s\n", controlPlaneNodeName)
+
+	// Set container engine based on config
+	// NOTE: This must be set before any calls to containerengine.Get() since
+	// the containerengine package caches the runtime value on first access.
+	if cfg.ContainerRuntime != "" {
+		os.Setenv("CONTAINER_RUNTIME", cfg.ContainerRuntime)
+	}
+
+	// Get control plane IP for direct API server access
+	// Only enabled when --use-direct-api=true, as it requires Docker bridge network to be routable
+	if cfg.UseDirectAPI {
+		if err := setupKubectlServer(); err != nil {
+			fmt.Printf("Warning: could not get control plane IP, kubectl may fail: %v\n", err)
+		}
+	}
+
+	if cfg.CleanupOnly {
+		fmt.Println("Cleaning up BGP infrastructure...")
+		if err := cleanup(); err != nil {
+			fmt.Fprintf(os.Stderr, "Cleanup failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Cleanup completed successfully")
+		return
+	}
+
+	fmt.Println("Setting up BGP infrastructure for route advertisement testing...")
+
+	if err := run(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("BGP setup completed successfully!")
+}
+
+func parseFlags() *Config {
+	cfg := &Config{}
+
+	flag.StringVar(&cfg.Phase, "phase", PhaseAll, "Phase to run: 'all', 'deploy-containers' (FRR + BGP server), 'deploy-frr' (FRR only), 'deploy-bgp-server' (BGP server only), or 'install-frr-k8s' (frr-k8s + FRRConfiguration)")
+	flag.StringVar(&cfg.ContainerRuntime, "container-runtime", getEnvOrDefault(envContainerRuntime, defaultContainerRuntime), "Container runtime to use (docker/podman)")
+	flag.BoolVar(&cfg.IPv4Enabled, "ipv4", getBoolEnvOrDefault(envIPv4Support, true), "Enable IPv4 support")
+	flag.BoolVar(&cfg.IPv6Enabled, "ipv6", getBoolEnvOrDefault(envIPv6Support, false), "Enable IPv6 support")
+	flag.StringVar(&cfg.BGPServerSubnetIPv4, "bgp-server-subnet-ipv4", getEnvOrDefault(envBGPServerSubnetIPv4, defaultBGPServerSubnetIPv4), "IPv4 CIDR for BGP server network")
+	flag.StringVar(&cfg.BGPServerSubnetIPv6, "bgp-server-subnet-ipv6", getEnvOrDefault(envBGPServerSubnetIPv6, defaultBGPServerSubnetIPv6), "IPv6 CIDR for BGP server network")
+	flag.StringVar(&cfg.FRRK8sVersion, "frr-k8s-version", getEnvOrDefault(envFRRK8sVersion, defaultFRRK8sVersion), "Version of frr-k8s to use")
+	flag.StringVar(&cfg.FRRImage, "frr-image", images.FRR(), "FRR container image to use (defaults to FRR_IMAGE env var or the images package default)")
+	flag.StringVar(&cfg.AgnHostImage, "agnhost-image", k8simage.GetE2EImage(k8simage.Agnhost), "agnhost container image for the BGP server (defaults to the upstream k8s agnhost image)")
+	flag.StringVar(&cfg.NetworkName, "network-name", getEnvOrDefault(envNetworkName, defaultNetworkName), "Name for the BGP network")
+	flag.StringVar(&cfg.IsolationMode, "isolation-mode", getEnvOrDefault(envIsolationMode, defaultIsolationMode), "UDN isolation mode: strict or loose")
+	flag.BoolVar(&cfg.AdvertiseDefaultNetwork, "advertise-default-network", getBoolEnvOrDefault(envAdvertiseDefaultNetwork, true), "Add pod network routes for default network advertisement")
+	flag.StringVar(&cfg.Kubeconfig, "kubeconfig", getEnvOrDefault(envKubeconfig, filepath.Join(os.Getenv("HOME"), ".kube", "config")), "Path to kubeconfig file")
+	flag.StringVar(&cfg.ClusterName, "cluster-name", getEnvOrDefault(envClusterName, defaultClusterName), "Kind cluster name. Used to derive control-plane container name (${cluster-name}-control-plane)")
+	flag.IntVar(&cfg.BGPPort, "bgp-port", 0, "BGP port for frr-k8s daemon (0 = default/disabled, 179 = managed routing)")
+	flag.BoolVar(&cfg.CleanupOnly, "cleanup", false, "Only cleanup existing BGP infrastructure")
+	flag.BoolVar(&cfg.UseDirectAPI, "use-direct-api", false, "Use direct API server address (control plane container IP) instead of kubeconfig server. Only works when Docker bridge network is routable from host.")
+	flag.StringVar(&cfg.TestdataPath, "testdata-path", getEnvOrDefault(envTestdataPath, ""), "Path to the testdata/routeadvertisements directory containing templates. Required when built with -trimpath.")
+
+	flag.Parse()
+
+	// Set the global override for getTestdataPath()
+	testdataPathOverride = cfg.TestdataPath
+
+	return cfg
+}
+
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func getBoolEnvOrDefault(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		return strings.ToLower(value) == "true"
+	}
+	return defaultValue
+}
+
+func run(cfg *Config) error {
+	// Create Kubernetes client
+	clientset, err := createK8sClient(cfg.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	// Get supported IP families based on cluster configuration
+	ipv4Supported, ipv6Supported := detectClusterIPFamilies(clientset)
+	if cfg.IPv4Enabled {
+		cfg.IPv4Enabled = ipv4Supported
+	}
+	if cfg.IPv6Enabled {
+		cfg.IPv6Enabled = ipv6Supported
+	}
+	fmt.Printf("IP family support - IPv4: %v, IPv6: %v\n", cfg.IPv4Enabled, cfg.IPv6Enabled)
+
+	// Get all cluster node names
+	nodes, err := getClusterNodes(clientset)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster nodes: %w", err)
+	}
+	fmt.Printf("Found %d cluster nodes: %v\n", len(nodes), nodeNames(nodes))
+
+	// Determine which phases to run based on --phase flag
+	runDeployFRR := cfg.Phase == PhaseAll || cfg.Phase == PhaseDeployContainers || cfg.Phase == PhaseDeployFRR
+	runDeployBGPServer := cfg.Phase == PhaseAll || cfg.Phase == PhaseDeployContainers || cfg.Phase == PhaseDeployBGPServer
+	runInstallFRRK8s := cfg.Phase == PhaseAll || cfg.Phase == PhaseInstallFRRK8s
+
+	if !runDeployFRR && !runDeployBGPServer && !runInstallFRRK8s {
+		return fmt.Errorf("invalid phase %q (expected: %s, %s, %s, %s, %s)",
+			cfg.Phase, PhaseAll, PhaseDeployContainers, PhaseDeployFRR, PhaseDeployBGPServer, PhaseInstallFRRK8s)
+	}
+	// Phase 1a: Deploy FRR external container
+	if runDeployFRR {
+		fmt.Println("\n====================== Deploying FRR external container ======================")
+		if err := deployFRRExternalContainer(cfg, nodes); err != nil {
+			return fmt.Errorf("failed to deploy FRR external container: %w", err)
+		}
+	}
+
+	// Phase 1b: Deploy BGP external server
+	if runDeployBGPServer {
+		fmt.Println("\n====================== Deploying BGP external server ======================")
+		if err := deployBGPExternalServer(cfg, nodes); err != nil {
+			return fmt.Errorf("failed to deploy BGP external server: %w", err)
+		}
+	}
+
+	// Phase 2: Install frr-k8s (install_frr_k8s + create FRRConfiguration)
+	if runInstallFRRK8s {
+		fmt.Println("\n====================== Installing frr-k8s ======================")
+		if err := installFRRK8s(cfg); err != nil {
+			return fmt.Errorf("failed to install frr-k8s: %w", err)
+		}
+
+		// In managed routing mode (--bgp-port != 0), frr-k8s handles BGP
+		// internally so we skip FRRConfiguration and pod route setup.
+		if cfg.BGPPort == 0 {
+			// Create FRRConfiguration to establish BGP peering between cluster nodes and the external FRR router.
+			fmt.Println("\n====================== Creating FRRConfiguration for BGP peering ======================")
+			if err := createFRRConfiguration(cfg); err != nil {
+				return fmt.Errorf("failed to create FRRConfiguration: %w", err)
+			}
+
+			// Add routes for pod networks if `--advertise-default-network=true`
+			if cfg.AdvertiseDefaultNetwork {
+				fmt.Println("\n====================== Adding routes for pod networks ======================")
+				if err := addPodNetworkRoutes(cfg, clientset); err != nil {
+					fmt.Printf("Warning: failed to add pod network routes: %v\n", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func createK8sClient(kubeconfig string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build config from kubeconfig %q: %w", kubeconfig, err)
+	}
+
+	// Override the API server address when using direct API access.
+	if kubectlServer != "" {
+		config.Host = kubectlServer
+	}
+
+	return kubernetes.NewForConfig(config)
+}
+
+func detectClusterIPFamilies(clientset *kubernetes.Clientset) (ipv4, ipv6 bool) {
+	nodes, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Printf("Warning: failed to list nodes for IP family detection: %v\n", err)
+		return true, false // Default to IPv4 only
+	}
+
+	for _, node := range nodes.Items {
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				ip := net.ParseIP(addr.Address)
+				if ip == nil {
+					continue
+				}
+				if ip.To4() != nil {
+					ipv4 = true
+				} else {
+					ipv6 = true
+				}
+			}
+		}
+	}
+
+	if !ipv4 && !ipv6 {
+		ipv4 = true // Default to IPv4 if nothing detected
+	}
+	return
+}
+
+func getClusterNodes(clientset *kubernetes.Clientset) ([]corev1.Node, error) {
+	nodeList, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return nodeList.Items, nil
+}
+
+func nodeNames(nodes []corev1.Node) []string {
+	names := make([]string, len(nodes))
+	for i, node := range nodes {
+		names[i] = node.Name
+	}
+	return names
+}
+
+// containerRuntime returns the container runtime command
+func containerRuntime() string {
+	return containerengine.Get().String()
+}
+
+func runCmd(name string, args ...string) error {
+	fmt.Printf("Running: %s %s\n", name, strings.Join(args, " "))
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func runCmdOutput(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// kubeconfig stores the path to kubeconfig for kubectl commands
+var kubeconfig string
+
+// kubectlServer stores the direct API server address (control plane IP)
+var kubectlServer string
+
+// controlPlaneNodeName stores the derived control plane node/container name
+var controlPlaneNodeName string
+
+// deriveControlPlaneNodeName returns the control plane node name based on the cluster name.
+// Kind clusters use the naming convention: ${cluster-name}-control-plane
+func deriveControlPlaneNodeName(clusterName string) string {
+	return clusterName + "-control-plane"
+}
+
+// setupKubectlServer gets the control plane container's IP for direct API server access
+func setupKubectlServer() error {
+	runtime := containerRuntime()
+	// Get control plane container IP on the kind network specifically
+	output, err := runCmdOutput(runtime, "inspect", "-f", "{{.NetworkSettings.Networks.kind.IPAddress}}", controlPlaneNodeName)
+	if err != nil {
+		return fmt.Errorf("failed to get control plane IPv4 for %s: %w", controlPlaneNodeName, err)
+	}
+	ip := strings.TrimSpace(output)
+	if ip == "" {
+		output, err = runCmdOutput(runtime, "inspect", "-f", "{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}", controlPlaneNodeName)
+		if err != nil {
+			return fmt.Errorf("failed to get control plane IPv6 for %s: %w", controlPlaneNodeName, err)
+		}
+		ip = strings.TrimSpace(output)
+		if ip == "" {
+			return fmt.Errorf("control plane IP is empty for %s", controlPlaneNodeName)
+		}
+	}
+	if strings.Contains(ip, ":") {
+		kubectlServer = fmt.Sprintf("https://[%s]:6443", ip)
+	} else {
+		kubectlServer = fmt.Sprintf("https://%s:6443", ip)
+	}
+	fmt.Printf("Using direct API server address: %s\n", kubectlServer)
+	return nil
+}
+
+// runKubectl runs kubectl with the configured kubeconfig and server
+func runKubectl(args ...string) error {
+	kubectlArgs := []string{"--kubeconfig", kubeconfig}
+	if kubectlServer != "" {
+		kubectlArgs = append(kubectlArgs, "--server", kubectlServer)
+	}
+	kubectlArgs = append(kubectlArgs, args...)
+	fmt.Printf("Running: kubectl %s\n", strings.Join(kubectlArgs, " "))
+	cmd := exec.Command("kubectl", kubectlArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+	return cmd.Run()
+}
+
+// runKubectlOutput runs kubectl with --kubeconfig and optional --server flags and returns the output
+func runKubectlOutput(args ...string) (string, error) {
+	kubectlArgs := []string{"--kubeconfig", kubeconfig}
+	if kubectlServer != "" {
+		kubectlArgs = append(kubectlArgs, "--server", kubectlServer)
+	}
+	kubectlArgs = append(kubectlArgs, args...)
+	cmd := exec.Command("kubectl", kubectlArgs...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// runKubectlWithRetry runs kubectl with retries for transient failures
+func runKubectlWithRetry(maxRetries int, args ...string) error {
+	var lastErr error
+	for i := 0; i < maxRetries; i++ {
+		if i > 0 {
+			fmt.Printf("Retrying kubectl command (attempt %d/%d)...\n", i+1, maxRetries)
+			time.Sleep(5 * time.Second)
+		}
+		err := runKubectl(args...)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// Always retry - exec.ExitError doesn't contain the actual error message
+		// The kubectl error output (with "connection refused" etc.) goes to stderr
+	}
+	return lastErr
+}
+
+// waitForAPIServer waits for the Kubernetes API server to be ready
+func waitForAPIServer(timeout time.Duration) error {
+	fmt.Println("Waiting for Kubernetes API server to be ready...")
+	fmt.Printf("Using kubeconfig: %s\n", kubeconfig)
+	start := time.Now()
+	var lastErr string
+	for {
+		if time.Since(start) > timeout {
+			return fmt.Errorf("timeout waiting for API server to be ready (last error: %s)", lastErr)
+		}
+		// Try a simple kubectl command to check API server connectivity
+		kubectlArgs := []string{"--kubeconfig", kubeconfig}
+		if kubectlServer != "" {
+			kubectlArgs = append(kubectlArgs, "--server", kubectlServer)
+		}
+		kubectlArgs = append(kubectlArgs, "get", "nodes", "--no-headers")
+		cmd := exec.Command("kubectl", kubectlArgs...)
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			fmt.Println("API server is ready")
+			return nil
+		}
+		lastErr = strings.TrimSpace(string(output))
+		if lastErr == "" {
+			lastErr = err.Error()
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func containerExists(name string) bool {
+	runtime := containerRuntime()
+	out, _ := runCmdOutput(runtime, "ps", "-a", "-f", fmt.Sprintf("name=^%s$", name), "--format", "{{.Names}}")
+	return strings.Contains(out, name)
+}
+
+func networkExists(name string) bool {
+	runtime := containerRuntime()
+	out, _ := runCmdOutput(runtime, "network", "ls", "--format", "{{.Name}}")
+	for _, n := range strings.Split(out, "\n") {
+		if strings.TrimSpace(n) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanupStaleResources removes any leftover BGP containers and networks from previous runs.
+// This ensures a clean state even if the previous cluster was deleted with "kind delete cluster"
+// instead of using the proper cleanup procedure.
+func cleanupStaleResources() {
+	runtime := containerRuntime()
+
+	// Stop and remove bgpserver container if it exists
+	if containerExists(bgpServerContainerName) {
+		fmt.Println("Cleaning up stale bgpserver container...")
+		runCmd(runtime, "stop", bgpServerContainerName)
+		runCmd(runtime, "rm", "-f", bgpServerContainerName)
+	}
+
+	// Stop and remove FRR container if it exists
+	// First disconnect from kind network if connected, then stop and remove
+	if containerExists(frrContainerName) {
+		fmt.Println("Cleaning up stale FRR container...")
+		if networkExists(kindNetwork) {
+			runCmdOutput(runtime, "network", "disconnect", "-f", kindNetwork, frrContainerName)
+		}
+		runCmd(runtime, "stop", frrContainerName)
+		runCmd(runtime, "rm", "-f", frrContainerName)
+	}
+
+	// Remove bgpnet network if it exists
+	if networkExists(bgpNetworkName) {
+		fmt.Println("Cleaning up stale bgpnet network...")
+		runCmd(runtime, "network", "rm", bgpNetworkName)
+	}
+
+	// Clean up persistent FRR config directory
+	if _, err := os.Stat(frrConfigDir); err == nil {
+		fmt.Println("Cleaning up stale FRR config directory...")
+		os.RemoveAll(frrConfigDir)
+	}
+}
+
+func deployFRRExternalContainer(cfg *Config, nodes []corev1.Node) error {
+	runtime := containerRuntime()
+
+	// Clean up any stale resources from previous runs
+	cleanupStaleResources()
+
+	// Wait for the API server to be ready before running kubectl commands
+	// This handles cases where the cluster was just created and API server may not be fully ready
+	if err := waitForAPIServer(90 * time.Second); err != nil {
+		return fmt.Errorf("API server not ready: %w", err)
+	}
+
+	// Apply FRR-K8s CRDs from remote URL
+	crdURL := frrK8sRemoteURL(cfg.FRRK8sVersion, "charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml")
+	fmt.Printf("Applying FRR-K8s CRDs from %s...\n", crdURL)
+	if err := runKubectlWithRetry(3, "apply", "--validate=false", "-f", crdURL); err != nil {
+		return fmt.Errorf("failed to apply FRR-K8s CRDs: %w", err)
+	}
+
+	// Get node IPs on the kind network for FRR neighbor configuration
+	var nodeIPsV4, nodeIPsV6 []string
+	for _, node := range nodes {
+		ipv4, ipv6, err := getContainerNetworkIPs(node.Name, kindNetwork)
+		if err != nil {
+			fmt.Printf("Warning: failed to get IPs for node %s: %v\n", node.Name, err)
+			continue
+		}
+		if cfg.IPv4Enabled && ipv4 != "" {
+			nodeIPsV4 = append(nodeIPsV4, ipv4)
+		}
+		if cfg.IPv6Enabled && ipv6 != "" {
+			nodeIPsV6 = append(nodeIPsV6, ipv6)
+		}
+	}
+
+	fmt.Printf("Node IPs for BGP peering - IPv4: %v, IPv6: %v\n", nodeIPsV4, nodeIPsV6)
+
+	// Create persistent directory for FRR configuration files
+	if err := os.MkdirAll(frrConfigDir, 0755); err != nil {
+		return fmt.Errorf("failed to create FRR config directory: %w", err)
+	}
+
+	// Generate config files
+	if err := generateFRRConfigFiles(cfg, nodeIPsV4, nodeIPsV6, frrConfigDir); err != nil {
+		return fmt.Errorf("failed to generate FRR configuration: %w", err)
+	}
+
+	// Remove existing FRR container if present
+	if containerExists(frrContainerName) {
+		fmt.Println("Removing existing FRR container...")
+		runCmd(runtime, "rm", "-f", frrContainerName)
+	}
+
+	// Create and run FRR container with config files mounted
+	fmt.Println("Creating FRR container with configuration...")
+	args := []string{
+		"run", "-d", "--privileged",
+		"--name", frrContainerName,
+		"--network", kindNetwork,
+		"--hostname", frrContainerName,
+		"-v", fmt.Sprintf("%s/frr.conf:/etc/frr/frr.conf:ro", frrConfigDir),
+		"-v", fmt.Sprintf("%s/daemons:/etc/frr/daemons:ro", frrConfigDir),
+	}
+	// Enable IPv6 forwarding at container start if needed
+	if cfg.IPv6Enabled {
+		args = append(args, "--sysctl", "net.ipv6.conf.all.forwarding=1")
+	}
+	args = append(args, cfg.FRRImage)
+	if err := runCmd(runtime, args...); err != nil {
+		return fmt.Errorf("failed to create FRR container: %w", err)
+	}
+
+	// Wait for container to be running and FRR daemons to be ready
+	fmt.Println("Waiting for FRR container and daemons to be ready...")
+	if err := waitForContainer(frrContainerName); err != nil {
+		return fmt.Errorf("FRR container failed to start: %w", err)
+	}
+
+	if err := waitForFRRDaemons(frrContainerName); err != nil {
+		return fmt.Errorf("FRR daemons failed to become ready: %w", err)
+	}
+
+	fmt.Println("FRR external container deployed successfully")
+	return nil
+}
+
+func getContainerNetworkIPs(containerName, networkName string) (ipv4, ipv6 string, err error) {
+	runtime := containerRuntime()
+
+	// Get IPv4 container IP
+	ipv4Tmpl := fmt.Sprintf("{{ with index .NetworkSettings.Networks %q }}{{ .IPAddress }}{{ end }}", networkName)
+	ipv4, err = runCmdOutput(runtime, "inspect", "-f", ipv4Tmpl, containerName)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to inspect container %s for IPv4: %w", containerName, err)
+	}
+	ipv4 = strings.Trim(ipv4, "'\"")
+	if ipv4 == "<no value>" {
+		ipv4 = ""
+	}
+
+	// Get IPv6 container IP
+	ipv6Tmpl := fmt.Sprintf("{{ with index .NetworkSettings.Networks %q }}{{ .GlobalIPv6Address }}{{ end }}", networkName)
+	ipv6, err = runCmdOutput(runtime, "inspect", "-f", ipv6Tmpl, containerName)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to inspect container %s for IPv6: %w", containerName, err)
+	}
+	ipv6 = strings.Trim(ipv6, "'\"")
+	if ipv6 == "<no value>" {
+		ipv6 = ""
+	}
+
+	return ipv4, ipv6, nil
+}
+
+// generateFRRConfigFiles generates FRR configuration files in the specified directory
+func generateFRRConfigFiles(cfg *Config, neighborsIPv4, neighborsIPv6 []string, outputDir string) error {
+	// Combine neighbor IPs
+	neighborIPs := append(neighborsIPv4, neighborsIPv6...)
+
+	// Prepare networks to advertise (the BGP server network)
+	var advertiseNetworks []string
+	if cfg.IPv4Enabled {
+		advertiseNetworks = append(advertiseNetworks, cfg.BGPServerSubnetIPv4)
+	}
+	if cfg.IPv6Enabled {
+		advertiseNetworks = append(advertiseNetworks, cfg.BGPServerSubnetIPv6)
+	}
+
+	if err := frr.WriteConfigToDir(getTemplateSource(), outputDir, neighborIPs, advertiseNetworks); err != nil {
+		return err
+	}
+
+	fmt.Printf("Generated FRR configuration in %s\n", outputDir)
+	return nil
+}
+
+func waitForContainer(name string) error {
+	runtime := containerRuntime()
+	return wait.PollUntilContextTimeout(context.Background(), pollInterval, containerTimeout, true, func(ctx context.Context) (bool, error) {
+		out, err := runCmdOutput(runtime, "inspect", "-f", "{{.State.Running}}", name)
+		if err != nil {
+			return false, nil
+		}
+		return strings.TrimSpace(out) == "true", nil
+	})
+}
+
+// waitForFRRDaemons waits for FRR daemons (zebra and bgpd) to be fully operational
+// by checking if vtysh can successfully query the running configuration.
+func waitForFRRDaemons(containerName string) error {
+	runtime := containerRuntime()
+	return wait.PollUntilContextTimeout(context.Background(), pollInterval, containerTimeout, true, func(ctx context.Context) (bool, error) {
+		// Check if vtysh can connect and query BGP - this confirms both zebra and bgpd are running
+		out, err := runCmdOutput(runtime, "exec", containerName, "vtysh", "-c", "show bgp summary")
+		if err != nil {
+			// Daemon not ready yet
+			return false, nil
+		}
+		// If we get any output (even "No BGP neighbors"), the daemons are operational
+		return len(strings.TrimSpace(out)) > 0, nil
+	})
+}
+
+func deployBGPExternalServer(cfg *Config, nodes []corev1.Node) error {
+	runtime := containerRuntime()
+
+	// Remove existing bgpserver container if present
+	if containerExists(bgpServerContainerName) {
+		fmt.Println("Removing existing bgpserver container...")
+		runCmd(runtime, "rm", "-f", bgpServerContainerName)
+	}
+
+	// Remove existing bgpnet network if present
+	if networkExists(bgpNetworkName) {
+		fmt.Println("Removing existing bgpnet network...")
+		runCmd(runtime, "network", "rm", bgpNetworkName)
+	}
+
+	// Create bgpnet network
+	fmt.Println("Creating bgpnet network...")
+	networkArgs := []string{"network", "create", "--driver", "bridge", "--subnet", cfg.BGPServerSubnetIPv4}
+	if cfg.IPv6Enabled {
+		networkArgs = append(networkArgs, "--ipv6", "--subnet", cfg.BGPServerSubnetIPv6)
+	}
+	networkArgs = append(networkArgs, bgpNetworkName)
+	if err := runCmd(runtime, networkArgs...); err != nil {
+		return fmt.Errorf("failed to create bgpnet network: %w", err)
+	}
+
+	// Connect FRR container to bgpnet
+	fmt.Println("Connecting FRR container to bgpnet...")
+	if err := runCmd(runtime, "network", "connect", bgpNetworkName, frrContainerName); err != nil {
+		return fmt.Errorf("failed to connect FRR to bgpnet: %w", err)
+	}
+
+	fmt.Println("Creating bgpserver container...")
+	agnhost := cfg.AgnHostImage
+	serverArgs := []string{
+		"run", "-d",
+		"--cap-add", "NET_ADMIN",
+		"--user", "0",
+		"--network", bgpNetworkName,
+		"--rm",
+		"--name", bgpServerContainerName,
+		"-p", bgpServerPortMapping,
+		agnhost,
+		"netexec",
+	}
+	if err := runCmd(runtime, serverArgs...); err != nil {
+		return fmt.Errorf("failed to create bgpserver container: %w", err)
+	}
+
+	// Wait for container to be running
+	if err := waitForContainer(bgpServerContainerName); err != nil {
+		return fmt.Errorf("bgpserver container failed to start: %w", err)
+	}
+
+	// Get FRR's IP on bgpnet and set as default gateway for bgpserver
+	frrIPv4, frrIPv6, err := getContainerNetworkIPs(frrContainerName, bgpNetworkName)
+	if err != nil {
+		return fmt.Errorf("failed to get FRR IPs on bgpnet: %w", err)
+	}
+
+	if cfg.IPv4Enabled && frrIPv4 != "" {
+		fmt.Printf("Setting bgpserver default IPv4 gateway via FRR (%s)...\n", frrIPv4)
+		if err := runCmd(runtime, "exec", bgpServerContainerName, "ip", "route", "replace", "default", "via", frrIPv4); err != nil {
+			return fmt.Errorf("failed to set IPv4 default gateway: %w", err)
+		}
+	}
+
+	if cfg.IPv6Enabled && frrIPv6 != "" {
+		fmt.Printf("Setting bgpserver default IPv6 gateway via FRR (%s)...\n", frrIPv6)
+		if err := runCmd(runtime, "exec", bgpServerContainerName, "ip", "-6", "route", "replace", "default", "via", frrIPv6); err != nil {
+			return fmt.Errorf("failed to set IPv6 default gateway: %w", err)
+		}
+	}
+
+	// Handle isolation mode specific setup
+	if cfg.IsolationMode == "loose" {
+		// In loose mode, set nodes' default gateway to FRR router
+		frrKindIPv4, frrKindIPv6, err := getContainerNetworkIPs(frrContainerName, kindNetwork)
+		if err != nil {
+			return fmt.Errorf("failed to get FRR IPs on kind network: %w", err)
+		}
+
+		for _, node := range nodes {
+			if cfg.IPv4Enabled && frrKindIPv4 != "" {
+				fmt.Printf("In loose mode, setting node %s default IPv4 gateway to FRR (%s)...\n", node.Name, frrKindIPv4)
+				if err := runCmd(runtime, "exec", node.Name, "ip", "route", "replace", "default", "via", frrKindIPv4); err != nil {
+					fmt.Printf("Warning: failed to set IPv4 default gateway on node %s: %v\n", node.Name, err)
+				}
+			}
+			if cfg.IPv6Enabled && frrKindIPv6 != "" {
+				fmt.Printf("In loose mode, setting node %s default IPv6 gateway to FRR (%s)...\n", node.Name, frrKindIPv6)
+				if err := runCmd(runtime, "exec", node.Name, "ip", "-6", "route", "replace", "default", "via", frrKindIPv6); err != nil {
+					fmt.Printf("Warning: failed to set IPv6 default gateway on node %s: %v\n", node.Name, err)
+				}
+			}
+		}
+	} else {
+		// In strict mode, disable default routes on FRR
+		fmt.Println("Disabling default routes on FRR container (strict mode)...")
+		if err := runCmd(runtime, "exec", frrContainerName, "ip", "route", "delete", "default"); err != nil {
+			fmt.Printf("Warning: failed to delete IPv4 default route on FRR container: %v\n", err)
+		}
+		if cfg.IPv6Enabled {
+			if err := runCmd(runtime, "exec", frrContainerName, "ip", "-6", "route", "delete", "default"); err != nil {
+				fmt.Printf("Warning: failed to delete IPv6 default route on FRR container: %v\n", err)
+			}
+		}
+	}
+
+	fmt.Println("BGP external server deployed successfully")
+	return nil
+}
+
+func installFRRK8s(cfg *Config) error {
+	// Wait for API server to be ready
+	if err := waitForAPIServer(60 * time.Second); err != nil {
+		return fmt.Errorf("API server not ready: %w", err)
+	}
+
+	// Download frr-k8s manifest, patch the unavailable gcr.io image, then apply.
+	// gcr.io/kubebuilder/kube-rbac-proxy is unavailable after Google Container
+	// Registry shutdown (https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation).
+	// Upstream bug: https://github.com/metallb/metallb/issues/2619
+	frrK8sURL := frrK8sRemoteURL(cfg.FRRK8sVersion, "config/all-in-one/frr-k8s.yaml")
+	fmt.Printf("Downloading frr-k8s deployment from %s...\n", frrK8sURL)
+	yamlBytes, err := downloadURL(frrK8sURL)
+	if err != nil {
+		return fmt.Errorf("failed to download frr-k8s manifest: %w", err)
+	}
+	yamlContent := strings.ReplaceAll(string(yamlBytes), "gcr.io/kubebuilder/kube-rbac-proxy", "registry.k8s.io/kubebuilder/kube-rbac-proxy")
+	if cfg.BGPPort != 0 {
+		if !strings.Contains(yamlContent, "-p 0") {
+			return fmt.Errorf("expected bgpd_options with '-p 0' not found in frr-k8s manifest")
+		}
+		yamlContent = strings.Replace(yamlContent, "-p 0", fmt.Sprintf("-p %d", cfg.BGPPort), 1)
+		fmt.Printf("Patched bgpd port to %d for managed routing\n", cfg.BGPPort)
+	}
+	tmpFile, err := os.CreateTemp("", "frr-k8s-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.WriteString(yamlContent); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write patched manifest: %w", err)
+	}
+	tmpFile.Close()
+	fmt.Println("Applying patched frr-k8s deployment...")
+	if err := runKubectlWithRetry(3, "apply", "--validate=false", "-f", tmpFile.Name()); err != nil {
+		return fmt.Errorf("failed to apply frr-k8s: %w", err)
+	}
+
+	// Wait for statuscleaner deployment
+	fmt.Println("Waiting for frr-k8s statuscleaner deployment...")
+	if err := runKubectl("wait", "-n", frrK8sNS, "deployment", frrK8sDeploymentName, "--for", "condition=Available", "--timeout", deployTimeout); err != nil {
+		return fmt.Errorf("frr-k8s statuscleaner did not become ready: %w", err)
+	}
+
+	// Wait for daemon rollout
+	fmt.Println("Waiting for frr-k8s daemon rollout...")
+	if err := runKubectl("rollout", "status", "-n", frrK8sNS, "daemonset", frrK8sDaemonsetName, "--timeout", deployTimeout); err != nil {
+		return fmt.Errorf("frr-k8s daemon rollout failed: %w", err)
+	}
+
+	// Wait for frr-k8s webhook endpoint to be actually serving
+	fmt.Println("Probing frr-k8s webhook endpoint...")
+	if err := waitForFRRK8sWebhook(); err != nil {
+		fmt.Printf("Warning: webhook probe failed: %v\n", err)
+	}
+
+	fmt.Println("frr-k8s installed successfully")
+	return nil
+}
+
+func waitForFRRK8sWebhook() error {
+	runtime := containerRuntime()
+	return wait.PollUntilContextTimeout(context.Background(), pollInterval, containerTimeout, true, func(ctx context.Context) (bool, error) {
+		// Get webhook service cluster IP
+		clusterIP, err := runKubectlOutput("get", "svc", "-n", frrK8sNS, frrK8sWebhookServiceName, "-o", "jsonpath={.spec.clusterIP}")
+		if err != nil {
+			return false, nil
+		}
+		clusterIP = strings.TrimSpace(clusterIP)
+		if clusterIP == "" {
+			return false, nil
+		}
+
+		// Wrap IPv6 addresses in brackets
+		if strings.Contains(clusterIP, ":") {
+			clusterIP = "[" + clusterIP + "]"
+		}
+
+		// Try to curl the webhook from control plane
+		url := fmt.Sprintf("https://%s", clusterIP)
+		_, err = runCmdOutput(runtime, "exec", controlPlaneNodeName, "curl", "-ksS", "--connect-timeout", "1", url)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// createFRRConfiguration creates an FRRConfiguration to establish BGP peering between
+// cluster nodes and the external FRR router.
+func createFRRConfiguration(cfg *Config) error {
+	// Get FRR container IPs on the primary (kind) network for BGP peering
+	frrIPv4, frrIPv6, err := getContainerNetworkIPs(frrContainerName, kindNetwork)
+	if err != nil {
+		return fmt.Errorf("failed to get FRR IPs on kind network: %w", err)
+	}
+
+	var neighborIPs []string
+	if cfg.IPv4Enabled && frrIPv4 != "" {
+		neighborIPs = append(neighborIPs, frrIPv4)
+	}
+	if cfg.IPv6Enabled && frrIPv6 != "" {
+		neighborIPs = append(neighborIPs, frrIPv6)
+	}
+
+	fmt.Printf("FRR container IPs for BGP peering: %v\n", neighborIPs)
+
+	// Prepare receive networks (the BGP server subnet)
+	var receiveNetworks []string
+	if cfg.IPv4Enabled {
+		receiveNetworks = append(receiveNetworks, cfg.BGPServerSubnetIPv4)
+	}
+	if cfg.IPv6Enabled {
+		receiveNetworks = append(receiveNetworks, cfg.BGPServerSubnetIPv6)
+	}
+
+	// Generate FRRConfiguration YAML
+	frrConfigDir, err := generateFRRk8sConfiguration(cfg.NetworkName, neighborIPs, receiveNetworks)
+	if err != nil {
+		return fmt.Errorf("failed to generate FRR-k8s configuration: %w", err)
+	}
+	defer os.RemoveAll(frrConfigDir)
+
+	// Apply the FRRConfiguration
+	frrConfPath := filepath.Join(frrConfigDir, "frrconf.yaml")
+	if err := runKubectl("apply", "--validate=false", "-n", frrK8sNS, "-f", frrConfPath); err != nil {
+		return fmt.Errorf("failed to apply FRRConfiguration: %w", err)
+	}
+
+	fmt.Println("FRRConfiguration for BGP peering created successfully")
+	return nil
+}
+
+func generateFRRk8sConfiguration(networkName string, neighborIPs, receiveNetworks []string) (string, error) {
+	// Labels must include "name: receive-all" to match the RouteAdvertisements selector
+	// which expects frrConfigurationSelector.matchLabels.name: receive-all
+	labels := map[string]string{
+		"network": networkName,
+		"name":    "receive-all",
+	}
+
+	// For the default network, don't specify a VRF (it uses the main routing table).
+	// For other networks (UDNs), the VRF should be the network name.
+	var vrf string
+	if networkName != "default" {
+		vrf = networkName
+	}
+
+	tmpDir, err := frr.GenerateFRRK8sConfigWithVRF(getTemplateSource(), networkName, vrf, labels, neighborIPs, receiveNetworks)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Printf("Generated FRR-k8s configuration in %s\n", tmpDir)
+	return tmpDir, nil
+}
+
+func addPodNetworkRoutes(cfg *Config, clientset *kubernetes.Clientset) error {
+	nodes, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	for _, node := range nodes.Items {
+		// Get node's internal IPs
+		var nodeIPv4, nodeIPv6 string
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				ip := net.ParseIP(addr.Address)
+				if ip == nil {
+					continue
+				}
+				if ip.To4() != nil {
+					nodeIPv4 = addr.Address
+				} else {
+					nodeIPv6 = addr.Address
+				}
+			}
+		}
+
+		// Get node subnets from annotations
+		subnetAnnotation := node.Annotations["k8s.ovn.org/node-subnets"]
+		if subnetAnnotation == "" {
+			fmt.Printf("Warning: Node %s has no subnet annotation\n", node.Name)
+			continue
+		}
+
+		// Parse subnet annotation (JSON format like {"default":["10.244.0.0/24"]})
+		subnets := parseSubnetAnnotation(subnetAnnotation, cfg.NetworkName)
+
+		for _, subnet := range subnets {
+			_, ipNet, err := net.ParseCIDR(subnet)
+			if err != nil {
+				continue
+			}
+
+			isIPv6 := ipNet.IP.To4() == nil
+			var via string
+			if isIPv6 && cfg.IPv6Enabled && nodeIPv6 != "" {
+				via = nodeIPv6
+			} else if !isIPv6 && cfg.IPv4Enabled && nodeIPv4 != "" {
+				via = nodeIPv4
+			}
+
+			if via != "" {
+				fmt.Printf("Adding route for %s via %s (node %s)\n", subnet, via, node.Name)
+				args := []string{"route", "replace", subnet, "via", via}
+				if isIPv6 {
+					args = append([]string{"-6"}, args...)
+				}
+				// Add route on node (requires root privileges)
+				if err := runCmd("sudo", append([]string{"-n", "ip"}, args...)...); err != nil {
+					return fmt.Errorf("failed to add route for %s via %s on node %s: %w", subnet, via, node.Name, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseSubnetAnnotation(annotation, networkName string) []string {
+	var subnets []string
+
+	// Parse the JSON annotation which has format: {"default":["10.244.0.0/24"]}
+	// It's a map of network names to arrays of subnet strings
+	var networkSubnets map[string][]string
+	if err := json.Unmarshal([]byte(annotation), &networkSubnets); err != nil {
+		return subnets
+	}
+
+	// Collect subnets only for the requested network
+	if nets, ok := networkSubnets[networkName]; ok {
+		subnets = append(subnets, nets...)
+	}
+
+	return subnets
+}
+
+func cleanup() error {
+	runtime := containerRuntime()
+
+	// Remove bgpserver container
+	if containerExists(bgpServerContainerName) {
+		fmt.Println("Removing bgpserver container...")
+		runCmd(runtime, "stop", bgpServerContainerName)
+		runCmd(runtime, "rm", "-f", bgpServerContainerName)
+	}
+
+	// Remove FRR container
+	if containerExists(frrContainerName) {
+		fmt.Println("Removing FRR container...")
+		runCmd(runtime, "stop", frrContainerName)
+		runCmd(runtime, "rm", "-f", frrContainerName)
+	}
+
+	// Remove bgpnet network
+	if networkExists(bgpNetworkName) {
+		fmt.Println("Removing bgpnet network...")
+		runCmd(runtime, "network", "rm", bgpNetworkName)
+	}
+
+	// Delete FRRConfiguration resources
+	fmt.Println("Deleting FRRConfiguration resources...")
+	runKubectl("delete", "frrconfigurations", "--all", "-n", frrK8sNS)
+
+	// Delete frr-k8s deployment
+	fmt.Println("Deleting frr-k8s deployment...")
+	runKubectl("delete", "-n", frrK8sNS, "deployment", frrK8sDeploymentName, "--ignore-not-found")
+	runKubectl("delete", "-n", frrK8sNS, "daemonset", frrK8sDaemonsetName, "--ignore-not-found")
+
+	// Clean up persistent FRR config directory
+	if _, err := os.Stat(frrConfigDir); err == nil {
+		fmt.Println("Removing FRR config directory...")
+		os.RemoveAll(frrConfigDir)
+	}
+
+	return nil
+}

--- a/test/e2e/cmd/bgp-setup/main.go
+++ b/test/e2e/cmd/bgp-setup/main.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/containerengine"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/frr"
 	k8simage "k8s.io/kubernetes/test/utils/image"
@@ -192,13 +191,10 @@ func main() {
 	controlPlaneNodeName = deriveControlPlaneNodeName(cfg.ClusterName)
 	fmt.Printf("Using control plane node: %s\n", controlPlaneNodeName)
 
-	// Set container engine based on config
-	// NOTE: This must be set before any calls to containerengine.Get() since
-	// the containerengine package caches the runtime value on first access.
+	// Set container runtime for use by containerRuntime() throughout the program.
 	if cfg.ContainerRuntime != "" {
-		os.Setenv("CONTAINER_RUNTIME", cfg.ContainerRuntime)
+		runtimeBin = cfg.ContainerRuntime
 	}
-
 	// Get control plane IP for direct API server access
 	// Only enabled when --use-direct-api=true, as it requires Docker bridge network to be routable
 	if cfg.UseDirectAPI {
@@ -408,9 +404,12 @@ func nodeNames(nodes []corev1.Node) []string {
 	return names
 }
 
+// runtimeBin stores the container runtime binary name (docker or podman)
+var runtimeBin = "docker"
+
 // containerRuntime returns the container runtime command
 func containerRuntime() string {
-	return containerengine.Get().String()
+	return runtimeBin
 }
 
 func runCmd(name string, args ...string) error {

--- a/test/e2e/cmd/bgp-setup/main.go
+++ b/test/e2e/cmd/bgp-setup/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // bgp-setup is a standalone program that sets up BGP infrastructure for route advertisement testing.
 // It
 //   - deploys an external FRR container for BGP peering
@@ -140,6 +143,7 @@ const (
 	PhaseDeployFRR        = "deploy-frr"        // Phase 1a: deploy FRR external container only
 	PhaseDeployBGPServer  = "deploy-bgp-server" // Phase 1b: deploy BGP server container only
 	PhaseInstallFRRK8s    = "install-frr-k8s"   // Phase 2: install frr-k8s and create FRRConfiguration for BGP peering
+	PhaseWaitFRRK8s       = "wait-frr-k8s"      // Wait for frr-k8s pods to be ready (used post-OVN for managed routing)
 )
 
 // frrK8sRemoteURL returns the raw GitHub URL for a file in the frr-k8s repo at a specific version
@@ -179,6 +183,7 @@ type Config struct {
 	TestdataPath            string
 	ClusterName             string
 	BGPPort                 int
+	EnableEVPN              bool
 }
 
 func main() {
@@ -191,9 +196,9 @@ func main() {
 	controlPlaneNodeName = deriveControlPlaneNodeName(cfg.ClusterName)
 	fmt.Printf("Using control plane node: %s\n", controlPlaneNodeName)
 
-	// Set container runtime for use by containerRuntime() throughout the program.
+	// Set container engine based on config
 	if cfg.ContainerRuntime != "" {
-		runtimeBin = cfg.ContainerRuntime
+		os.Setenv("CONTAINER_RUNTIME", cfg.ContainerRuntime)
 	}
 	// Get control plane IP for direct API server access
 	// Only enabled when --use-direct-api=true, as it requires Docker bridge network to be routable
@@ -226,7 +231,7 @@ func main() {
 func parseFlags() *Config {
 	cfg := &Config{}
 
-	flag.StringVar(&cfg.Phase, "phase", PhaseAll, "Phase to run: 'all', 'deploy-containers' (FRR + BGP server), 'deploy-frr' (FRR only), 'deploy-bgp-server' (BGP server only), or 'install-frr-k8s' (frr-k8s + FRRConfiguration)")
+	flag.StringVar(&cfg.Phase, "phase", PhaseAll, "Phase to run: 'all', 'deploy-containers', 'deploy-frr', 'deploy-bgp-server', 'install-frr-k8s', or 'wait-frr-k8s'")
 	flag.StringVar(&cfg.ContainerRuntime, "container-runtime", getEnvOrDefault(envContainerRuntime, defaultContainerRuntime), "Container runtime to use (docker/podman)")
 	flag.BoolVar(&cfg.IPv4Enabled, "ipv4", getBoolEnvOrDefault(envIPv4Support, true), "Enable IPv4 support")
 	flag.BoolVar(&cfg.IPv6Enabled, "ipv6", getBoolEnvOrDefault(envIPv6Support, false), "Enable IPv6 support")
@@ -241,6 +246,7 @@ func parseFlags() *Config {
 	flag.StringVar(&cfg.Kubeconfig, "kubeconfig", getEnvOrDefault(envKubeconfig, filepath.Join(os.Getenv("HOME"), ".kube", "config")), "Path to kubeconfig file")
 	flag.StringVar(&cfg.ClusterName, "cluster-name", getEnvOrDefault(envClusterName, defaultClusterName), "Kind cluster name. Used to derive control-plane container name (${cluster-name}-control-plane)")
 	flag.IntVar(&cfg.BGPPort, "bgp-port", 0, "BGP port for frr-k8s daemon (0 = default/disabled, 179 = managed routing)")
+	flag.BoolVar(&cfg.EnableEVPN, "enable-evpn", false, "Enable EVPN (l2vpn evpn) configuration on external FRR container")
 	flag.BoolVar(&cfg.CleanupOnly, "cleanup", false, "Only cleanup existing BGP infrastructure")
 	flag.BoolVar(&cfg.UseDirectAPI, "use-direct-api", false, "Use direct API server address (control plane container IP) instead of kubeconfig server. Only works when Docker bridge network is routable from host.")
 	flag.StringVar(&cfg.TestdataPath, "testdata-path", getEnvOrDefault(envTestdataPath, ""), "Path to the testdata/routeadvertisements directory containing templates. Required when built with -trimpath.")
@@ -295,10 +301,11 @@ func run(cfg *Config) error {
 	runDeployFRR := cfg.Phase == PhaseAll || cfg.Phase == PhaseDeployContainers || cfg.Phase == PhaseDeployFRR
 	runDeployBGPServer := cfg.Phase == PhaseAll || cfg.Phase == PhaseDeployContainers || cfg.Phase == PhaseDeployBGPServer
 	runInstallFRRK8s := cfg.Phase == PhaseAll || cfg.Phase == PhaseInstallFRRK8s
+	runWaitFRRK8s := cfg.Phase == PhaseAll || cfg.Phase == PhaseInstallFRRK8s || cfg.Phase == PhaseWaitFRRK8s
 
-	if !runDeployFRR && !runDeployBGPServer && !runInstallFRRK8s {
-		return fmt.Errorf("invalid phase %q (expected: %s, %s, %s, %s, %s)",
-			cfg.Phase, PhaseAll, PhaseDeployContainers, PhaseDeployFRR, PhaseDeployBGPServer, PhaseInstallFRRK8s)
+	if !runDeployFRR && !runDeployBGPServer && !runInstallFRRK8s && !runWaitFRRK8s {
+		return fmt.Errorf("invalid phase %q (expected: %s, %s, %s, %s, %s, %s)",
+			cfg.Phase, PhaseAll, PhaseDeployContainers, PhaseDeployFRR, PhaseDeployBGPServer, PhaseInstallFRRK8s, PhaseWaitFRRK8s)
 	}
 	// Phase 1a: Deploy FRR external container
 	if runDeployFRR {
@@ -316,28 +323,37 @@ func run(cfg *Config) error {
 		}
 	}
 
-	// Phase 2: Install frr-k8s (install_frr_k8s + create FRRConfiguration)
+	// Phase 2: Install frr-k8s (apply manifest only; wait is deferred when
+	// --bgp-port is set because the CNI may not be ready pre-OVN)
 	if runInstallFRRK8s {
 		fmt.Println("\n====================== Installing frr-k8s ======================")
-		if err := installFRRK8s(cfg); err != nil {
+		skipWait := cfg.BGPPort != 0 && cfg.Phase == PhaseInstallFRRK8s
+		if err := installFRRK8s(cfg, skipWait); err != nil {
 			return fmt.Errorf("failed to install frr-k8s: %w", err)
 		}
+	}
 
-		// In managed routing mode (--bgp-port != 0), frr-k8s handles BGP
-		// internally so we skip FRRConfiguration and pod route setup.
-		if cfg.BGPPort == 0 {
-			// Create FRRConfiguration to establish BGP peering between cluster nodes and the external FRR router.
-			fmt.Println("\n====================== Creating FRRConfiguration for BGP peering ======================")
-			if err := createFRRConfiguration(cfg); err != nil {
-				return fmt.Errorf("failed to create FRRConfiguration: %w", err)
-			}
+	// Wait for frr-k8s pods (separate phase for managed routing, where
+	// install happens pre-OVN but pods only become ready post-OVN)
+	if cfg.Phase == PhaseWaitFRRK8s {
+		fmt.Println("\n====================== Waiting for frr-k8s ======================")
+		if err := waitForFRRK8sReady(); err != nil {
+			return fmt.Errorf("failed waiting for frr-k8s: %w", err)
+		}
+	}
 
-			// Add routes for pod networks if `--advertise-default-network=true`
-			if cfg.AdvertiseDefaultNetwork {
-				fmt.Println("\n====================== Adding routes for pod networks ======================")
-				if err := addPodNetworkRoutes(cfg, clientset); err != nil {
-					fmt.Printf("Warning: failed to add pod network routes: %v\n", err)
-				}
+	// Post frr-k8s install: create FRRConfiguration and add pod routes
+	// (skipped in managed routing mode where frr-k8s handles BGP internally)
+	if runInstallFRRK8s && cfg.BGPPort == 0 {
+		fmt.Println("\n====================== Creating FRRConfiguration for BGP peering ======================")
+		if err := createFRRConfiguration(cfg); err != nil {
+			return fmt.Errorf("failed to create FRRConfiguration: %w", err)
+		}
+
+		if cfg.AdvertiseDefaultNetwork {
+			fmt.Println("\n====================== Adding routes for pod networks ======================")
+			if err := addPodNetworkRoutes(cfg, clientset); err != nil {
+				fmt.Printf("Warning: failed to add pod network routes: %v\n", err)
 			}
 		}
 	}
@@ -404,12 +420,13 @@ func nodeNames(nodes []corev1.Node) []string {
 	return names
 }
 
-// runtimeBin stores the container runtime binary name (docker or podman)
-var runtimeBin = "docker"
-
-// containerRuntime returns the container runtime command
+// containerRuntime returns the container runtime command.
+// Reads CONTAINER_RUNTIME env var (set from --container-runtime flag), defaulting to "docker".
 func containerRuntime() string {
-	return runtimeBin
+	if cr, found := os.LookupEnv("CONTAINER_RUNTIME"); found && cr != "" {
+		return cr
+	}
+	return defaultContainerRuntime
 }
 
 func runCmd(name string, args ...string) error {
@@ -648,6 +665,11 @@ func deployFRRExternalContainer(cfg *Config, nodes []corev1.Node) error {
 		return fmt.Errorf("failed to generate FRR configuration: %w", err)
 	}
 
+	// Minimal vtysh.conf silences "Can't open vtysh.conf" when vtysh starts (EVPN uses vtysh heavily).
+	if err := os.WriteFile(filepath.Join(frrConfigDir, "vtysh.conf"), []byte("!\n"), 0644); err != nil {
+		return fmt.Errorf("failed to write vtysh.conf: %w", err)
+	}
+
 	// Remove existing FRR container if present
 	if containerExists(frrContainerName) {
 		fmt.Println("Removing existing FRR container...")
@@ -656,13 +678,20 @@ func deployFRRExternalContainer(cfg *Config, nodes []corev1.Node) error {
 
 	// Create and run FRR container with config files mounted
 	fmt.Println("Creating FRR container with configuration...")
+	// frr.conf must be writable when EVPN is enabled: configureEVPN runs `write memory`, which
+	// updates /etc/frr/frr.conf.
+	frrConfMountOpt := "ro"
+	if cfg.EnableEVPN {
+		frrConfMountOpt = "rw"
+	}
 	args := []string{
 		"run", "-d", "--privileged",
 		"--name", frrContainerName,
 		"--network", kindNetwork,
 		"--hostname", frrContainerName,
-		"-v", fmt.Sprintf("%s/frr.conf:/etc/frr/frr.conf:ro", frrConfigDir),
+		"-v", fmt.Sprintf("%s/frr.conf:/etc/frr/frr.conf:%s", frrConfigDir, frrConfMountOpt),
 		"-v", fmt.Sprintf("%s/daemons:/etc/frr/daemons:ro", frrConfigDir),
+		"-v", fmt.Sprintf("%s/vtysh.conf:/etc/frr/vtysh.conf:ro", frrConfigDir),
 	}
 	// Enable IPv6 forwarding at container start if needed
 	if cfg.IPv6Enabled {
@@ -681,6 +710,23 @@ func deployFRRExternalContainer(cfg *Config, nodes []corev1.Node) error {
 
 	if err := waitForFRRDaemons(frrContainerName); err != nil {
 		return fmt.Errorf("FRR daemons failed to become ready: %w", err)
+	}
+
+	if cfg.IPv6Enabled {
+		// Preserve IPv6 addresses during VRF enslavement. Without this, IPv6 global
+		// addresses are removed when interfaces are moved to a VRF, causing FRR/zebra
+		// to fail creating FIB nexthop groups.
+		// See: https://docs.kernel.org/networking/vrf.html
+		//      https://github.com/FRRouting/frr/issues/1666
+		if err := runCmd(runtime, "exec", frrContainerName, "sysctl", "-w", "net.ipv6.conf.all.keep_addr_on_down=1"); err != nil {
+			return fmt.Errorf("failed to set keep_addr_on_down sysctl: %w", err)
+		}
+	}
+
+	if cfg.EnableEVPN {
+		if err := configureEVPN(frrContainerName); err != nil {
+			return err
+		}
 	}
 
 	fmt.Println("FRR external container deployed successfully")
@@ -749,19 +795,80 @@ func waitForContainer(name string) error {
 }
 
 // waitForFRRDaemons waits for FRR daemons (zebra and bgpd) to be fully operational
-// by checking if vtysh can successfully query the running configuration.
+// AND for frr.conf to be fully loaded (BGP neighbors appear in bgp summary).
+// This is important because vtysh uses CombinedOutput and may return non-empty output
+// (e.g. "% Can't open vtysh.conf") before bgpd has loaded its frr.conf config.
+// Waiting for "Neighbor" in the BGP summary ensures frr.conf is fully processed
+// before we attempt to apply EVPN configuration on top of it.
 func waitForFRRDaemons(containerName string) error {
 	runtime := containerRuntime()
 	return wait.PollUntilContextTimeout(context.Background(), pollInterval, containerTimeout, true, func(ctx context.Context) (bool, error) {
-		// Check if vtysh can connect and query BGP - this confirms both zebra and bgpd are running
+		// Check if vtysh can connect and bgpd has loaded its frr.conf config.
+		// We look for "Neighbor" in the BGP summary which appears once bgpd has
+		// loaded its configuration and registered BGP peers from frr.conf.
+		// This avoids a false-positive from vtysh warnings (e.g. missing vtysh.conf)
+		// that would appear in CombinedOutput before bgpd is ready.
 		out, err := runCmdOutput(runtime, "exec", containerName, "vtysh", "-c", "show bgp summary")
 		if err != nil {
 			// Daemon not ready yet
 			return false, nil
 		}
-		// If we get any output (even "No BGP neighbors"), the daemons are operational
-		return len(strings.TrimSpace(out)) > 0, nil
+		return strings.Contains(out, "Neighbor"), nil
 	})
+}
+
+// configureEVPN enables l2vpn evpn address-family on the external FRR container,
+// activates all BGP neighbors for EVPN, sets them as route-reflector-clients,
+// and enables advertise-all-vni. This must be called after the FRR container
+// is deployed and BGP neighbors are already configured.
+func configureEVPN(containerName string) error {
+	runtime := containerRuntime()
+
+	fmt.Println("Configuring global EVPN BGP on external FRR (advertise-all-vni + neighbor activation)...")
+
+	output, err := runCmdOutput(runtime, "exec", containerName, "vtysh", "-c", "show running-config")
+	if err != nil {
+		return fmt.Errorf("failed to get FRR running config: %w", err)
+	}
+
+	var neighbors []string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "neighbor ") && strings.Contains(trimmed, "remote-as") {
+			parts := strings.Fields(trimmed)
+			if len(parts) >= 2 {
+				neighbors = append(neighbors, parts[1])
+			}
+		}
+	}
+
+	if len(neighbors) == 0 {
+		return fmt.Errorf("no BGP neighbors found in FRR running config for EVPN activation")
+	}
+
+	fmt.Printf("Activating EVPN for %d BGP neighbors: %v\n", len(neighbors), neighbors)
+
+	vtyshArgs := []string{"exec", containerName, "vtysh",
+		"-c", "configure terminal",
+		"-c", "router bgp 64512",
+		"-c", "address-family l2vpn evpn",
+	}
+	for _, neighbor := range neighbors {
+		vtyshArgs = append(vtyshArgs, "-c", fmt.Sprintf("neighbor %s activate", neighbor))
+		vtyshArgs = append(vtyshArgs, "-c", fmt.Sprintf("neighbor %s route-reflector-client", neighbor))
+	}
+	// "write memory" persists the EVPN config to frr.conf so it survives any
+	// frr.conf reload race and potential FRR restarts. This matches the behavior
+	// of the original bash deploy_frr_external_container() which also ran
+	// "write memory" after configuring EVPN.
+	vtyshArgs = append(vtyshArgs, "-c", "advertise-all-vni", "-c", "exit-address-family", "-c", "end", "-c", "write memory")
+
+	if err := runCmd(runtime, vtyshArgs...); err != nil {
+		return fmt.Errorf("failed to configure EVPN on FRR: %w", err)
+	}
+
+	fmt.Println("Global EVPN BGP config complete on external FRR")
+	return nil
 }
 
 func deployBGPExternalServer(cfg *Config, nodes []corev1.Node) error {
@@ -877,7 +984,7 @@ func deployBGPExternalServer(cfg *Config, nodes []corev1.Node) error {
 	return nil
 }
 
-func installFRRK8s(cfg *Config) error {
+func installFRRK8s(cfg *Config, skipWait bool) error {
 	// Wait for API server to be ready
 	if err := waitForAPIServer(60 * time.Second); err != nil {
 		return fmt.Errorf("API server not ready: %w", err)
@@ -916,25 +1023,33 @@ func installFRRK8s(cfg *Config) error {
 		return fmt.Errorf("failed to apply frr-k8s: %w", err)
 	}
 
-	// Wait for statuscleaner deployment
+	if skipWait {
+		fmt.Println("Skipping frr-k8s readiness wait (will be done post-OVN via wait-frr-k8s phase)")
+		return nil
+	}
+
+	return waitForFRRK8sReady()
+}
+
+// waitForFRRK8sReady waits for the frr-k8s statuscleaner deployment, daemon
+// daemonset, and webhook endpoint to become ready.
+func waitForFRRK8sReady() error {
 	fmt.Println("Waiting for frr-k8s statuscleaner deployment...")
 	if err := runKubectl("wait", "-n", frrK8sNS, "deployment", frrK8sDeploymentName, "--for", "condition=Available", "--timeout", deployTimeout); err != nil {
 		return fmt.Errorf("frr-k8s statuscleaner did not become ready: %w", err)
 	}
 
-	// Wait for daemon rollout
 	fmt.Println("Waiting for frr-k8s daemon rollout...")
 	if err := runKubectl("rollout", "status", "-n", frrK8sNS, "daemonset", frrK8sDaemonsetName, "--timeout", deployTimeout); err != nil {
 		return fmt.Errorf("frr-k8s daemon rollout failed: %w", err)
 	}
 
-	// Wait for frr-k8s webhook endpoint to be actually serving
 	fmt.Println("Probing frr-k8s webhook endpoint...")
 	if err := waitForFRRK8sWebhook(); err != nil {
 		fmt.Printf("Warning: webhook probe failed: %v\n", err)
 	}
 
-	fmt.Println("frr-k8s installed successfully")
+	fmt.Println("frr-k8s is ready")
 	return nil
 }
 

--- a/test/e2e/infraprovider/frr/frr.go
+++ b/test/e2e/infraprovider/frr/frr.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package frr provides shared FRR (Free Range Routing) configuration utilities
 // for both e2e tests and the bgp-setup tool.
 package frr

--- a/test/e2e/infraprovider/frr/frr.go
+++ b/test/e2e/infraprovider/frr/frr.go
@@ -1,0 +1,231 @@
+// Package frr provides shared FRR (Free Range Routing) configuration utilities
+// for both e2e tests and the bgp-setup tool.
+package frr
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"text/template"
+
+	utilnet "k8s.io/utils/net"
+)
+
+// Router contains BGP router configuration for FRR templates
+type Router struct {
+	VRF           string
+	NeighborsIPv4 []string
+	NeighborsIPv6 []string
+	NetworksIPv4  []string
+	NetworksIPv6  []string
+}
+
+// FRRKubernetesConfig contains the full FRR configuration data for templates
+type FRRKubernetesConfig struct {
+	// Name and Labels are used for FRRConfiguration metadata (frr-k8s)
+	Name    string
+	Labels  map[string]string
+	Routers []Router
+}
+
+// TemplateSource provides access to FRR configuration templates.
+// This interface allows using either embedded templates (for e2e tests)
+// or filesystem templates (for the bgp-setup tool).
+type TemplateSource interface {
+	// ParseFRRTemplates parses the FRR daemon configuration templates
+	ParseFRRTemplates() (*template.Template, error)
+	// ParseFRRK8sTemplates parses the FRR-k8s CRD templates
+	ParseFRRK8sTemplates() (*template.Template, error)
+}
+
+// EmbeddedSource reads templates from an embedded filesystem
+type EmbeddedSource struct {
+	fs      embed.FS
+	baseDir string
+}
+
+// NewEmbeddedSource creates a template source from an embedded filesystem.
+// baseDir is the path within the embed.FS where the frr/ and frr-k8s/ directories are located.
+func NewEmbeddedSource(efs embed.FS, baseDir string) *EmbeddedSource {
+	return &EmbeddedSource{fs: efs, baseDir: baseDir}
+}
+
+func (e *EmbeddedSource) ParseFRRTemplates() (*template.Template, error) {
+	return template.New("").Option("missingkey=error").ParseFS(e.fs, path.Join(e.baseDir, "frr", "*.tmpl"))
+}
+
+func (e *EmbeddedSource) ParseFRRK8sTemplates() (*template.Template, error) {
+	return template.New("").Option("missingkey=error").ParseFS(e.fs, path.Join(e.baseDir, "frr-k8s", "*.tmpl"))
+}
+
+// FilesystemSource reads templates from the local filesystem
+type FilesystemSource struct {
+	baseDir string
+}
+
+// NewFilesystemSource creates a template source from a filesystem directory.
+// baseDir should contain frr/ and frr-k8s/ subdirectories with *.tmpl files.
+func NewFilesystemSource(baseDir string) *FilesystemSource {
+	return &FilesystemSource{baseDir: baseDir}
+}
+
+func (f *FilesystemSource) ParseFRRTemplates() (*template.Template, error) {
+	pattern := filepath.Join(f.baseDir, "frr", "*.tmpl")
+	return template.New("").Option("missingkey=error").ParseGlob(pattern)
+}
+
+func (f *FilesystemSource) ParseFRRK8sTemplates() (*template.Template, error) {
+	pattern := filepath.Join(f.baseDir, "frr-k8s", "*.tmpl")
+	return template.New("").Option("missingkey=error").ParseGlob(pattern)
+}
+
+// WriteConfigToDir generates FRR daemon configuration files (frr.conf and daemons)
+// in the specified output directory.
+// neighborIPs are the BGP peer IP addresses (mixed IPv4 and IPv6).
+// advertiseNetworks are the networks to advertise via BGP.
+func WriteConfigToDir(source TemplateSource, outputDir string, neighborIPs, advertiseNetworks []string) error {
+	templates, err := source.ParseFRRTemplates()
+	if err != nil {
+		return fmt.Errorf("failed to parse FRR templates: %w", err)
+	}
+
+	// Split IPs by family
+	neighborsIPv4, neighborsIPv6 := splitIPStringsByIPFamily(neighborIPs)
+	networksIPv4, networksIPv6 := splitCIDRStringsByIPFamily(advertiseNetworks)
+
+	conf := FRRKubernetesConfig{
+		Routers: []Router{
+			{
+				NeighborsIPv4: neighborsIPv4,
+				NeighborsIPv6: neighborsIPv6,
+				NetworksIPv4:  networksIPv4,
+				NetworksIPv6:  networksIPv6,
+			},
+		},
+	}
+
+	if err := executeFileTemplate(templates, outputDir, "frr.conf", conf); err != nil {
+		return fmt.Errorf("failed to execute frr.conf template: %w", err)
+	}
+
+	if err := executeFileTemplate(templates, outputDir, "daemons", nil); err != nil {
+		return fmt.Errorf("failed to execute daemons template: %w", err)
+	}
+
+	return nil
+}
+
+// GenerateFRRDaemonConfig generates FRR daemon configuration files in a temporary directory.
+// Returns the path to the temporary directory containing the configuration files.
+// The caller is responsible for cleaning up the directory.
+func GenerateFRRDaemonConfig(source TemplateSource, neighborIPs, advertiseNetworks []string) (string, error) {
+	dir, err := os.MkdirTemp("", "frrconf-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
+
+	if err := WriteConfigToDir(source, dir, neighborIPs, advertiseNetworks); err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+
+	return dir, nil
+}
+
+// GenerateFRRK8sConfig generates an FRRConfiguration CRD YAML file for frr-k8s.
+// networkName is used as the resource name and VRF name.
+// Returns the path to a temporary directory containing the frrconf.yaml file.
+// The caller is responsible for cleaning up the directory.
+func GenerateFRRK8sConfig(source TemplateSource, networkName string, labels map[string]string, neighborIPs, receiveNetworks []string) (string, error) {
+	return GenerateFRRK8sConfigWithVRF(source, networkName, networkName, labels, neighborIPs, receiveNetworks)
+}
+
+// GenerateFRRK8sConfigWithVRF generates an FRRConfiguration CRD YAML file for frr-k8s
+// with an explicit VRF name (which can be different from networkName or empty for default network).
+// Returns the path to a temporary directory containing the frrconf.yaml file.
+// The caller is responsible for cleaning up the directory.
+func GenerateFRRK8sConfigWithVRF(source TemplateSource, networkName, vrf string, labels map[string]string, neighborIPs, receiveNetworks []string) (string, error) {
+	templates, err := source.ParseFRRK8sTemplates()
+	if err != nil {
+		return "", fmt.Errorf("failed to parse FRR-k8s templates: %w", err)
+	}
+
+	dir, err := os.MkdirTemp("", "frrk8sconf-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
+
+	// Split by IP family
+	neighborsIPv4, neighborsIPv6 := splitIPStringsByIPFamily(neighborIPs)
+	receivesIPv4, receivesIPv6 := splitCIDRStringsByIPFamily(receiveNetworks)
+
+	conf := FRRKubernetesConfig{
+		Name:   networkName,
+		Labels: labels,
+		Routers: []Router{
+			{
+				VRF:           vrf,
+				NeighborsIPv4: neighborsIPv4,
+				NeighborsIPv6: neighborsIPv6,
+				NetworksIPv4:  receivesIPv4,
+				NetworksIPv6:  receivesIPv6,
+			},
+		},
+	}
+
+	if err := executeFileTemplate(templates, dir, "frrconf.yaml", conf); err != nil {
+		os.RemoveAll(dir)
+		return "", fmt.Errorf("failed to execute frrconf.yaml template: %w", err)
+	}
+
+	return dir, nil
+}
+
+// Helper functions
+
+func splitCIDRStringsByIPFamily(cidrs []string) (ipv4 []string, ipv6 []string) {
+	for _, cidr := range cidrs {
+		switch {
+		case utilnet.IsIPv4CIDRString(cidr):
+			ipv4 = append(ipv4, cidr)
+		case utilnet.IsIPv6CIDRString(cidr):
+			ipv6 = append(ipv6, cidr)
+		default:
+			if cidr != "" {
+				panic(fmt.Sprintf("frr: splitCIDRStringsByIPFamily: invalid CIDR %q", cidr))
+			}
+		}
+	}
+	return
+}
+
+func splitIPStringsByIPFamily(ips []string) (ipv4 []string, ipv6 []string) {
+	for _, ip := range ips {
+		switch {
+		case utilnet.IsIPv4String(ip):
+			ipv4 = append(ipv4, ip)
+		case utilnet.IsIPv6String(ip):
+			ipv6 = append(ipv6, ip)
+		default:
+			if ip != "" {
+				panic(fmt.Sprintf("frr: splitIPStringsByIPFamily: invalid IP %q", ip))
+			}
+		}
+	}
+	return
+}
+
+func executeFileTemplate(templates *template.Template, directory, name string, data any) error {
+	f, err := os.OpenFile(filepath.Join(directory, name), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := templates.ExecuteTemplate(f, name, data); err != nil {
+		return fmt.Errorf("executing template %q: %w", name, err)
+	}
+	return nil
+}
+

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -16,8 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"text/template"
-
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -35,6 +33,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
 	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/frr"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -3203,122 +3202,29 @@ func routeAdvertisementsReadyFunc(c raclientset.Clientset, name string) func() e
 	}
 }
 
-// templateInputRouter data
-type templateInputRouter struct {
-	VRF           string
-	NeighborsIPv4 []string
-	NeighborsIPv6 []string
-	NetworksIPv4  []string
-	NetworksIPv6  []string
-}
-
-// templateInputFRR data
-type templateInputFRR struct {
-	// Name and Label are used for FRRConfiguration metadata
-	Name    string
-	Labels  map[string]string
-	Routers []templateInputRouter
-}
-
-// for routeadvertisements test cases we generate configuration from templates embed in the program
+// for routeadvertisements test cases we generate configuration from templates embedded in the program
 //
 //go:embed testdata/routeadvertisements
 var ratestdata embed.FS
-var tmplDir = filepath.Join("testdata", "routeadvertisements")
 
-// generateFRRConfiguration to establish a BGP session towards the provided
-// neighbors in the network's VRF configured to advertised the provided
-// networks. Returns a temporary directory where the configuration is generated.
-func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (directory string, err error) {
-	// parse configuration templates
-	var templates *template.Template
-	templates, err = template.ParseFS(ratestdata, filepath.Join(tmplDir, "frr", "*.tmpl"))
-	if err != nil {
-		return "", fmt.Errorf("failed to parse templates: %w", err)
-	}
+// frrTemplateSource provides access to FRR templates for route advertisement tests
+var frrTemplateSource = frr.NewEmbeddedSource(ratestdata, "testdata/routeadvertisements")
 
-	// create the directory that will hold the configuration files
-	directory, err = os.MkdirTemp("", "frrconf-")
-	if err != nil {
-		return "", fmt.Errorf("failed to make temp directory: %w", err)
-	}
-	defer func() {
-		if err != nil {
-			os.RemoveAll(directory)
-		}
-	}()
-
-	// generate external frr configuration executing the templates
-	networksIPv4, networksIPv6 := splitCIDRStringsByIPFamily(advertiseNetworks)
-	neighborsIPv4, neighborsIPv6 := splitIPStringsByIPFamily(neighborIPs)
-	conf := templateInputFRR{
-		Routers: []templateInputRouter{
-			{
-				NeighborsIPv4: neighborsIPv4,
-				NetworksIPv4:  networksIPv4,
-				NeighborsIPv6: neighborsIPv6,
-				NetworksIPv6:  networksIPv6,
-			},
-		},
-	}
-
-	err = executeFileTemplate(templates, directory, "frr.conf", conf)
-	if err != nil {
-		return "", fmt.Errorf("failed to execute template %q: %w", "frr.conf", err)
-	}
-	err = executeFileTemplate(templates, directory, "daemons", nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to execute template %q: %w", "daemons", err)
-	}
-
-	return directory, nil
+// generateFRRConfiguration generates FRR daemon configuration to establish a BGP session
+// towards the provided neighbors, configured to advertise the provided networks.
+// Returns a temporary directory where the configuration is generated.
+func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (string, error) {
+	return frr.GenerateFRRDaemonConfig(frrTemplateSource, neighborIPs, advertiseNetworks)
 }
 
-// generateFRRk8sConfiguration for the provided network (which doubles up as the
-// FRRConfiguration instance name, VRF name and used as value of `network`
-// label) to establish a BGP session towards the provided neighbors in the
-// network's VRF, configured to receive advertisements for the provided
-// networks. Returns a temporary directory where the configuration is generated.
-func generateFRRk8sConfiguration(networkName string, neighborIPs, receiveNetworks []string) (directory string, err error) {
-	// parse configuration templates
-	var templates *template.Template
-	templates, err = template.ParseFS(ratestdata, filepath.Join(tmplDir, "frr-k8s", "*.tmpl"))
-	if err != nil {
-		return "", fmt.Errorf("failed to parse templates: %w", err)
-	}
-
-	// create the directory that will hold the configuration files
-	directory, err = os.MkdirTemp("", "frrk8sconf-")
-	if err != nil {
-		return "", fmt.Errorf("failed to make temp directory: %w", err)
-	}
-	defer func() {
-		if err != nil {
-			os.RemoveAll(directory)
-		}
-	}()
-
-	receivesIPv4, receivesIPv6 := splitCIDRStringsByIPFamily(receiveNetworks)
-	neighborsIPv4, neighborsIPv6 := splitIPStringsByIPFamily(neighborIPs)
-	conf := templateInputFRR{
-		Name:   networkName,
-		Labels: map[string]string{"network": networkName},
-		Routers: []templateInputRouter{
-			{
-				VRF:           networkName,
-				NeighborsIPv4: neighborsIPv4,
-				NeighborsIPv6: neighborsIPv6,
-				NetworksIPv4:  receivesIPv4,
-				NetworksIPv6:  receivesIPv6,
-			},
-		},
-	}
-	err = executeFileTemplate(templates, directory, "frrconf.yaml", conf)
-	if err != nil {
-		return "", fmt.Errorf("failed to execute template %q: %w", "frrconf.yaml", err)
-	}
-
-	return directory, nil
+// generateFRRk8sConfiguration generates an FRRConfiguration CRD for the provided network
+// (which doubles up as the FRRConfiguration instance name, VRF name and used as value
+// of `network` label) to establish a BGP session towards the provided neighbors in the
+// network's VRF, configured to receive advertisements for the provided networks.
+// Returns a temporary directory where the configuration is generated.
+func generateFRRk8sConfiguration(networkName string, neighborIPs, receiveNetworks []string) (string, error) {
+	labels := map[string]string{"network": networkName}
+	return frr.GenerateFRRK8sConfig(frrTemplateSource, networkName, labels, neighborIPs, receiveNetworks)
 }
 
 // runBGPNetworkAndServer configures a topology appropriate to be used with
@@ -3377,26 +3283,26 @@ func runBGPNetworkAndServer(
 		return fmt.Errorf("failed to generate FRR configuration: %w", err)
 	}
 	ictx.AddCleanUpFn(func() error { return os.RemoveAll(frrConfig) })
-	frr := infraapi.ExternalContainer{
+	frrContainer := infraapi.ExternalContainer{
 		Name:        networkName + "-frr",
 		Image:       images.FRR(),
 		Network:     bgpPeerNetwork,
 		RuntimeArgs: []string{"--volume", frrConfig + ":" + filepath.Join(filepath.FromSlash("/"), "etc", "frr")},
 	}
-	frr, err = ictx.CreateExternalContainer(frr)
+	frrContainer, err = ictx.CreateExternalContainer(frrContainer)
 	if err != nil {
 		return fmt.Errorf("failed to create frr container: %w", err)
 	}
 	// enable IPv6 forwarding if required
-	if frr.IPv6 != "" {
-		_, err = infraprovider.Get().ExecExternalContainerCommand(frr, []string{"sysctl", "-w", "net.ipv6.conf.all.forwarding=1"})
+	if frrContainer.IPv6 != "" {
+		_, err = infraprovider.Get().ExecExternalContainerCommand(frrContainer, []string{"sysctl", "-w", "net.ipv6.conf.all.forwarding=1"})
 		if err != nil {
 			return fmt.Errorf("failed to set enable IPv6 forwading on frr container: %w", err)
 		}
 	}
 
 	// connect frr to server network
-	frrServerNetworkInterface, err := ictx.AttachNetwork(serverNetwork, frr.Name)
+	frrServerNetworkInterface, err := ictx.AttachNetwork(serverNetwork, frrContainer.Name)
 	if err != nil {
 		return fmt.Errorf("failed to connect frr to server network: %w", err)
 	}
@@ -3430,7 +3336,7 @@ func runBGPNetworkAndServer(
 
 	// apply FRR-K8s Configuration
 	receiveNetworks := serverNetworks
-	frrK8sConfig, err := generateFRRk8sConfiguration(networkName, []string{frr.IPv4, frr.IPv6}, receiveNetworks)
+	frrK8sConfig, err := generateFRRk8sConfiguration(networkName, []string{frrContainer.IPv4, frrContainer.IPv6}, receiveNetworks)
 	if err != nil {
 		return fmt.Errorf("failed to generate FRR-k8s configuration: %w", err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

This PR refactors the BGP cluster bootstrap setup for the **default network BGP session** by replacing the previous dependency on an external `demo.sh` script and a git-patched repository with a self-contained Go-based toolchain that shares its core FRR configuration logic with the existing e2e route advertisement tests.

### Problem

The previous shell-based BGP setup in `kind-common.sh` had several fragility issues:

- Relied on cloning an external repository and applying a git patch at runtime
- Duplicated FRR template rendering that already existed inline in `route_advertisements.go`
- `go build -trimpath` (used in CI) strips `runtime.Caller()` paths, breaking template discovery at runtime
- The FRR image version was hardcoded in shell and Go code independently, creating drift

### Module Hierarchy and Dependency

Three components are involved, arranged in a clear dependency hierarchy:

```
test/e2e/infraprovider/frr/frr.go        ← shared library (no external dependencies)
        ↑                    ↑
        |                    |
test/e2e/cmd/bgp-setup/    test/e2e/route_advertisements.go
  main.go                   (e2e test suite)
(standalone binary)
```

**`test/e2e/infraprovider/frr/frr.go` — shared FRR configuration package**

- Owns the `Router` and `FRRKubernetesConfig` types that model FRR BGP peer configuration
- Provides a `TemplateSource` abstraction (embedded templates compiled into the binary via `//go:embed`, or filesystem-based for development)
- Exposes `GenerateFRRDaemonConfig` and `GenerateFRRK8sConfig` / `GenerateFRRK8sConfigToDir` to render FRR and frr-k8s configuration from those types
- Has no dependency on any e2e test framework (`ginkgo`, `k8s.io/kubernetes/test/e2e/framework`)

**`test/e2e/cmd/bgp-setup/main.go` — standalone cluster bootstrap binary**

- Imports `infraprovider/frr` for template rendering — the only test-infrastructure package it uses
- Uses `frr.NewEmbeddedSource()` so templates are baked into the binary (no runtime file lookup)
- Implements its own `os/exec` wrappers (`runCmd`, `runKubectl`) rather than reusing helpers from `test/e2e/executor.go` or `infraprovider/providers/kind/kind.go` because those helpers transitively pull in `k8s.io/kubernetes/test/e2e/framework` and `ginkgo`, both of which require test suite initialization (`RegisterFailHandler`, `RunSpecs`) that never happens in a standalone binary — the same class of problem as the `deploymentconfig.Get()` panic that was observed before the `--agnhost-image` flag was added
- Accepts all image references (`--frr-image`, `--agnhost-image`) and other configuration as command-line flags so it is self-contained and requires no e2e framework initialization

**`test/e2e/route_advertisements.go` — e2e test suite**

- Also imports `infraprovider/frr` for template rendering — the same package `bgp-setup` uses
- Runs inside a full Ginkgo test suite where framework initialization has already occurred, so it can use `images.FRR()` and other framework helpers freely
- Does **not** call `bgp-setup`; it uses the `infraprovider/frr` types directly to generate configs that it applies to the already-running FRR container that `bgp-setup` deployed during cluster setup

**Execution flow — cluster setup (kind.sh)**

```
kind.sh
  └─ run_bgp_setup deploy-frr          # Phase 1a, before OVN
  └─ run_bgp_setup deploy-bgp-server   # Phase 1b, before OVN
  └─ (install OVN / ovn-kubernetes)
  └─ run_bgp_setup install-frr-k8s     # Phase 2, after OVN + CNI ready
```

`bgp-setup` is built once per invocation of `kind.sh` (lazy rebuild via mtime check) and executed as a subprocess. The FRR container it deploys in Phase 1a is the same container that the e2e tests will later configure through `infraprovider/frr`.

**Execution flow — e2e tests (route_advertisements.go)**

```
Ginkgo suite
  └─ BeforeSuite / test setup
       └─ route_advertisements.go calls frr.GenerateFRRDaemonConfig(...)
                                    and frr.GenerateFRRK8sConfig(...)
          using the already-running FRR container (deployed by bgp-setup)
```

The e2e tests do not re-deploy infrastructure; they reconfigure the existing FRR container by writing updated configs and reloading.

### Solution

**4 logical commits:**

1. **`test/e2e/infraprovider`: extract shared FRR configuration package**
   Pulls the inline FRR template rendering from `route_advertisements.go` into a reusable `infraprovider/frr` package. Uses `//go:embed` so templates are compiled into binaries. `route_advertisements.go` is updated to use `frr.NewEmbeddedSource()`.

2. **`test/e2e/cmd/bgp-setup`: add standalone Go tool for BGP cluster bootstrap**
   Introduces the `bgp-setup` binary with phase-based execution. Fixes a panic caused by `images.AgnHost()` calling `deploymentconfig.Get()` (uninitialized outside a test suite) by adding an `--agnhost-image` flag. Adds `--frr-image` flag so the image version is sourced from `${FRR_DEPLOYED_IMAGE}` in the shell environment rather than being hardcoded.

3. **`contrib`: delegate BGP cluster provisioning to bgp-setup (phased execution)**
   Removes ~360 lines of shell FRR/BGP functions from `kind-common.sh` and `kind-helm.sh`, replacing them with a `run_bgp_setup()` function that builds and invokes `bgp-setup` at the correct phases:

   | Phase | Timing | What |
   |---|---|---|
   | `deploy-frr` | Before OVN | FRR container ready |
   | `deploy-bgp-server` | Before OVN | BGP server ready |
   | `install-frr-k8s` | After OVN | CNI available for frr-k8s |

   Cluster destroy now cleans up stale Kind network endpoints and the bgpserver container.

4. **`test/e2e, contrib`: add EVPN and managed routing support to bgp-setup**
   Ports the remaining feature areas from the original shell implementation:
   - **EVPN** (`--enable-evpn`): configures l2vpn evpn address-family, activates all BGP neighbors as route-reflector-clients, and sets `advertise-all-vni`. Waits for `"Neighbor"` in `show bgp summary` before applying config to avoid races with bgpd startup. Sets `net.ipv6.conf.all.keep_addr_on_down=1` for IPv6 VRF enslavement.
   - **Managed routing** (`--bgp-port`): patches frr-k8s bgpd to listen on port 179 before OVN starts; splits `install-frr-k8s` (apply manifest only) from `wait-frr-k8s` (readiness wait post-OVN) because frr-k8s pods cannot become ready until the CNI is available.

### Testing

Validated by building a BGP Kind cluster using `contrib/kind.sh` with the refactored scripts, verifying:
- Standard BGP cluster
- EVPN cluster (`--enable-evpn`)
- Managed routing cluster (`ENABLE_NO_OVERLAY_MANAGED_ROUTING=true`)

Assisted-By: claude-4.5-opus-high

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers

See the "Module Hierarchy and Dependency" section above for a detailed explanation of how `infraprovider/frr`, `cmd/bgp-setup/main.go`, and `route_advertisements.go` relate to each other and the two execution flows (cluster setup vs. e2e).

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

Build a BGP-enabled KinD cluster:
```bash
KIND_INSTALL_INGRESS=false OVN_HA=false ENABLE_MULTI_NET=false \
  ENABLE_ROUTE_ADVERTISEMENTS=true \
  ./contrib/kind.sh
```

Run route advertisement e2e tests:
```bash
./test/scripts/e2e-kind.sh -focus "route-advertisement"
```