### PR TITLE
Reset MTU of both VF and VF-Reps when the Pod is gone

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -59,6 +59,9 @@ const DefaultAPIServer = "http://localhost:8443"
 // Default IANA-assigned UDP port number for VXLAN
 const DefaultVXLANPort = 4789
 
+// Default VF MTU
+const DefaultVFMTU = 1500
+
 const DefaultDBTxnTimeout = time.Second * 100
 
 // DefaultEphemeralPortRange is used for unit testing only

--- a/go-controller/pkg/node/base_node_network_controller_dpu.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu.go
@@ -321,8 +321,11 @@ func (bnnc *BaseNodeNetworkController) delRepPort(pod *corev1.Pod, dpuCD *util.D
 	if err != nil {
 		klog.Warningf("Failed to get link device for representor port %s. %v", vfRepName, err)
 	} else {
-		if linkDownErr := util.GetNetLinkOps().LinkSetDown(link); linkDownErr != nil {
-			klog.Warningf("Failed to set link down for representor port %s. %v", vfRepName, linkDownErr)
+		if err = util.GetNetLinkOps().LinkSetDown(link); err != nil {
+			klog.Warningf("Failed to set link down for representor port %s. %v", vfRepName, err)
+		}
+		if err = util.GetNetLinkOps().LinkSetMTU(link, config.DefaultVFMTU); err != nil {
+			klog.Warningf("Failed to reset the link MTU for representor port %s. %v", vfRepName, err)
 		}
 	}
 

--- a/go-controller/pkg/node/base_node_network_controller_dpu_test.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu_test.go
@@ -258,6 +258,7 @@ var _ = Describe("Node DPU tests", func() {
 			// Mock netlink/ovs calls for cleanup
 			netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
 			netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
+			netlinkOpsMock.On("LinkSetMTU", vfLink, 1500).Return(nil)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSDelPortCmd(vfRep),
 			})
@@ -341,6 +342,7 @@ var _ = Describe("Node DPU tests", func() {
 					// Mock netlink/ovs calls for cleanup
 					checkOVSPortPodInfo(execMock, vfRep, true, "15", "a8d09931", "default")
 					netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
+					netlinkOpsMock.On("LinkSetMTU", vfLink, 1500).Return(nil)
 					execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 						Cmd: genOVSDelPortCmd("pf0vf9"),
 					})
@@ -359,6 +361,7 @@ var _ = Describe("Node DPU tests", func() {
 					// Mock netlink/ovs calls for cleanup
 					checkOVSPortPodInfo(execMock, vfRep, true, "15", "a8d09931", "default")
 					netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
+					netlinkOpsMock.On("LinkSetMTU", vfLink, 1500).Return(nil)
 					execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 						Cmd: genOVSDelPortCmd("pf0vf9"),
 					})
@@ -408,6 +411,7 @@ var _ = Describe("Node DPU tests", func() {
 				// Mock netlink/ovs calls for cleanup
 				checkOVSPortPodInfo(execMock, vfRep, true, "15", "a8d09931", "default")
 				netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
+				netlinkOpsMock.On("LinkSetMTU", vfLink, 1500).Return(nil)
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: genOVSDelPortCmd("pf0vf9"),
 				})
@@ -444,6 +448,7 @@ var _ = Describe("Node DPU tests", func() {
 			checkOVSPortPodInfo(execMock, vfRep, true, "15", scd.SandboxId, types.DefaultNetworkName)
 			netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
 			netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
+			netlinkOpsMock.On("LinkSetMTU", vfLink, 1500).Return(nil)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 --if-exists del-port br-int %s", "pf0vf9"),
 			})
@@ -467,6 +472,7 @@ var _ = Describe("Node DPU tests", func() {
 			checkOVSPortPodInfo(execMock, vfRep, true, "15", scd.SandboxId, types.DefaultNetworkName)
 			netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
 			netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
+			netlinkOpsMock.On("LinkSetMTU", vfLink, 1500).Return(nil)
 			// fail on first try
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSDelPortCmd("pf0vf9"),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
During pod creation, MTU may be set to a new value for VF and VF representor interfaces through the functions:
-  `(*defaultPodRequestInterfaceOps) ConfigureInterface`
- `(bnnc *BaseNodeNetworkController) addRepPort`

However, the corresponding functions for pod deletion do not change the MTU value back:
- `(*defaultPodRequestInterfaceOps) UnconfigureInterface`
- `(bnnc *BaseNodeNetworkController) delRepPort`

This commit adds an option in the config module as the default MTU value for VF. When a pod is removed, the corresponding functions will reset the MTU of both VF and VF representor to the default value.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Minor updates in `go-controller/pkg/node/base_node_network_controller_dpu_test.go` to verify the MTU reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MTU values now reliably reset to the default during SR-IOV/port cleanup and reconfiguration.
  * Improved error handling and logging for host-side network interface operations.

* **Tests**
  * Extended tests to verify MTU reset behavior during cleanup and failure recovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->