### PR TITLE
Bug fix: Skip BridgeEIPAddrManager in DPU-host mode

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -475,6 +475,10 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(kubeNodeIP ne
 		return err
 	}
 
+	// In DPU-host mode, bridgeEIPAddrManager is not initialized because:
+	// - There's no OVS on the host (it runs on the DPU)
+	// - Traffic is handled on the DPU which has the EgressIP configuration
+	// - There's no openflow manager to use the mark-to-IP cache
 	nc.Gateway = &gateway{
 		initFunc:     func() error { return nil },
 		readyFunc:    func() (bool, error) { return true, nil },


### PR DESCRIPTION
Bug fix: Skip BridgeEIPAddrManager in DPU-host mode
In DPU-host mode, BridgeEIPAddrManager should not be initialized
because EgressIP is handled by ovnkube running on the DPU where
OVS runs. The DPU-host has no OVS and no openflow manager.

This fix:
- Adds shouldHandleBridgeEgressIP() helper function that checks:
  - Network Segmentation is enabled
  - Interconnect is enabled
  - Gateway mode is not disabled
  - Not running in DPU-host mode
- Uses this helper in all EgressIP handler methods
- Removes unused egressip import from gateway_init.go

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized guard for bridge EgressIP processing to consistently skip bridge-specific logic when not applicable, and ensure egress IP add/update/delete/sync operations trigger reconciliation when needed.

* **Bug Fixes**
  * Prevented bridge/OVS-related initialization during DPU-host pre-start so bridge-specific watchers and next-hop setup are not run inapplicable environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->