### PR TITLE
Set the value of gateway representor port in DPU mode

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -409,7 +409,7 @@ func (b *BridgeConfiguration) ConfigureBridgePorts() error {
 		if err != nil {
 			return err
 		}
-
+		b.gwIfaceRep = hostRep
 		b.ofPortHost, stderr, err = util.RunOVSVsctl("get", "interface", hostRep, "ofport")
 		if err != nil {
 			return fmt.Errorf("failed to get ofport of host interface %s, stderr: %q, error: %v",

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/networkmanager"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/managementport"
 	nodenft "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
@@ -103,6 +104,13 @@ func getBaseNFTRules(mgmtPort string) string {
 
 func getBaseLGWNFTablesRules(mgmtPort string) string {
 	return getBaseNFTRules(mgmtPort) + baseLGWNFTablesRules
+}
+
+func getGatewayBridge(gw *gateway) *bridgeconfig.BridgeConfiguration {
+	if gw == nil || gw.openflowManager == nil {
+		return nil
+	}
+	return gw.openflowManager.defaultBridge
 }
 
 func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
@@ -829,6 +837,11 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
 			Expect(err).NotTo(HaveOccurred())
+
+			// check that the representor port is set correctly
+			gatewayBridge := getGatewayBridge(sharedGw)
+			Expect(gatewayBridge).NotTo(BeNil())
+			Expect(gatewayBridge.GetGatewayIfaceRep()).To(Equal(hostRep))
 
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
During configuring the bridge ports in DPU mode, assign the host representor port to `gwIfaceRep` so that `GetGatewayIfaceRep()` returns the correct result.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sequencing so DPU gateway interface representor is populated earlier during bridge port setup, improving DPU network initialization reliability.

* **Tests**
  * Added unit checks to validate the gateway bridge representor is set correctly in both standard and DPU gateway initialization paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->