### PR TITLE
test: fix race condition in waitForRollout

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -657,11 +657,14 @@ func waitClusterHealthy(f *framework.Framework, numControlPlanePods int, control
 	})
 }
 
-// waitForRollout waits for the daemon set in a given namespace to be
+// updateAndWaitForRollout waits for the resource in a given namespace to be
 // successfully rolled out following an update.
 //
+// The updateFunc parameter is a callback that performs the update operation
+// (e.g., applying a new configuration).
+//
 // If allowedNotReadyNodes is -1, this method returns immediately without waiting.
-func waitForRollout(c kubernetes.Interface, ns string, resource string, allowedNotReadyNodes int32, timeout time.Duration) error {
+func updateAndWaitForRollout(c kubernetes.Interface, ns string, resource string, allowedNotReadyNodes int32, timeout time.Duration, updateFunc func()) error {
 	if allowedNotReadyNodes == -1 {
 		return nil
 	}
@@ -673,8 +676,25 @@ func waitForRollout(c kubernetes.Interface, ns string, resource string, allowedN
 	resourceType := resourceAtoms[0]
 	resourceName := resourceAtoms[1]
 
+	var oldGeneration int64
+	switch resourceType {
+	case "daemonset", "daemonsets", "ds":
+		ds, err := c.AppsV1().DaemonSets(ns).Get(context.TODO(), resourceName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		oldGeneration = ds.Generation
+	case "deployment", "deployments", "deploy":
+		dp, err := c.AppsV1().Deployments(ns).Get(context.TODO(), resourceName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		oldGeneration = dp.Generation
+	}
+	updateFunc()
+
 	start := time.Now()
-	framework.Logf("Waiting up to %v for daemonset %s in namespace %s to update",
+	framework.Logf("Waiting up to %v for %s in namespace %s to update",
 		timeout, resource, ns)
 
 	return wait.Poll(framework.Poll, timeout, func() (bool, error) {
@@ -710,6 +730,10 @@ func waitForRollout(c kubernetes.Interface, ns string, resource string, allowedN
 		}
 
 		if generation <= observedGeneration {
+			if generation <= oldGeneration {
+				framework.Logf("Waiting for %s generation to increase (currently %d)...", resource, generation)
+				return false, nil
+			}
 			if updated < desired {
 				framework.Logf("Waiting for %s rollout to finish: %d out of %d new pods have been updated (%d seconds elapsed)", resource,
 					updated, desired, int(time.Since(start).Seconds()))
@@ -1271,17 +1295,30 @@ func setUnsetTemplateContainerEnv(c kubernetes.Interface, namespace, resource, c
 	args := []string{"set", "env", resource, "-c", container}
 	env := make([]string, 0, len(set)+len(unset))
 	for k, v := range set {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
+		currentValue := getTemplateContainerEnv(namespace, resource, container, k)
+		if currentValue != v {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
 	}
 	for _, k := range unset {
-		env = append(env, fmt.Sprintf("%s-", k))
+		currentValue := getTemplateContainerEnv(namespace, resource, container, k)
+		if currentValue != "" {
+			env = append(env, fmt.Sprintf("%s-", k))
+		}
 	}
+
+	if len(env) == 0 {
+		framework.Logf("No environment changes needed for %s container %s in namespace %s, skipping update", resource, container, namespace)
+		return
+	}
+
 	framework.Logf("Setting environment in %s container %s of namespace %s to %v", resource, container, namespace, env)
-	e2ekubectl.RunKubectlOrDie(namespace, append(args, env...)...)
 
 	// Make sure the change has rolled out
 	// TODO (Change this to use the exported upstream function)
-	err := waitForRollout(c, namespace, resource, 0, rolloutTimeout)
+	err := updateAndWaitForRollout(c, namespace, resource, 0, rolloutTimeout, func() {
+		e2ekubectl.RunKubectlOrDie(namespace, append(args, env...)...)
+	})
 	framework.ExpectNoError(err)
 }
 


### PR DESCRIPTION
Add a new parameter updateFunc and capture resource generation
before applying the update. This ensures the function properly waits
for the generation to increase after the update is applied to the API
server, fixing a race condition where the function might check the
resource status before the update takes effect.

Rename waitForRollout to updateAndWaitForRollout to better reflect
that the function both applies an update via the callback and waits
for the rollout to complete.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Fix CI flack for tests `Should validate flow data of br-int is sent to an external gateway`.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

CI test `Should validate flow data of br-int is sent to an external gateway` can verify it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved rollout verification: an update action is executed before polling, and polling now requires the resource generation to advance beyond its prior value before declaring success—reducing false positives.
  * Skips rollout wait when no environment changes are needed and emits clearer, generic diagnostic logging during waits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->