### PR TITLE
parallelize multi-platform Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build Fedora (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
         - platform: linux/amd64
@@ -163,7 +163,7 @@ jobs:
     name: Build Ubuntu (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
         - platform: linux/amd64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Improvements to the second issue proposed in #5841

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

### Problem : Multi-platform builds on a single runner causing disk space exhaustion (ref: https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/20444176734)

Building both `linux/amd64` and `linux/arm64` images on a single runner causes disk space issues. GitHub-hosted runners have limited disk space (~14GB free), and building multi-arch images with QEMU emulation consumes significant storage.

### Proposed Solution

**Split builds across multiple runners** using the matrix strategy pattern from [Docker's official documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners):
   - Build each platform (amd64, arm64) on separate runners in parallel
   - Upload digests as artifacts
   - Merge into a multi-platform manifest in a final job

### Proof of Concept

I have already implemented and tested these fixes in my fork:

- **Fixed workflow**: https://github.com/Soli0222/ovn-kubernetes/blob/master/.github/workflows/docker.yml
- **Successful workflow run**: https://github.com/Soli0222/ovn-kubernetes/actions/runs/20880137190
- **Published images**:
  - https://github.com/Soli0222/ovn-kubernetes/pkgs/container/ovn-kubernetes%2Fovn-kube-ubuntu
  - https://github.com/Soli0222/ovn-kubernetes/pkgs/container/ovn-kubernetes%2Fovn-kube-fedora


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs separate per-platform Fedora and Ubuntu build jobs, enabling parallel amd64/arm64 image builds.
  * Per-platform caching, digest export/upload, and metadata propagation implemented to produce reliable digest-based multi-arch manifests.
  * Merge steps assemble and inspect multi-arch manifests from per-platform digests; global QEMU setup replaced by per-platform execution.
  * Workflow triggers and PR-run support improved for more consistent, faster publishes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->