### PR TITLE
Improve nftables unit test debugging

### DIFF
--- a/go-controller/pkg/node/nftables/testing.go
+++ b/go-controller/pkg/node/nftables/testing.go
@@ -5,34 +5,68 @@ package nftables
 
 import (
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MatchNFTRules checks that the expected nftables rules match the actual ones, ignoring
-// order.
+// order and extra whitespace.
 func MatchNFTRules(expected, actual string) error {
-	expectedSet := sets.New(strings.Split(expected, "\n")...)
-	actualSet := sets.New(strings.Split(actual, "\n")...)
-
-	// ignore blank lines
-	expectedSet.Delete("")
-	actualSet.Delete("")
-
-	missing := expectedSet.Difference(actualSet)
-	extra := actualSet.Difference(expectedSet)
-
+	missing, extra := diffNFTRules(expected, actual)
 	if len(missing) == 0 && len(extra) == 0 {
 		return nil
 	}
 
 	msg := "nftables rule mismatch:"
 	if len(missing) > 0 {
-		msg += fmt.Sprintf("\nMissing rules: %v\n", missing.UnsortedList())
+		msg += fmt.Sprintf("\nRules missing from `nft dump ruleset`:\n%s\n", strings.Join(missing, "\n"))
 	}
 	if len(extra) > 0 {
-		msg += fmt.Sprintf("\nExtra rules: %v\n", extra.UnsortedList())
+		msg += fmt.Sprintf("\nUnexpected extra rules in `nft dump ruleset`:\n%s\n", strings.Join(extra, "\n"))
 	}
 	return fmt.Errorf("%s", msg)
+}
+
+// helper function, for ease of unit testing
+func diffNFTRules(expected, actual string) (missing, extra []string) {
+	expectedLines := strings.Split(expected, "\n")
+	expectedSet := sets.New[string]()
+	for _, line := range expectedLines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			expectedSet.Insert(line)
+		}
+	}
+
+	actualLines := strings.Split(actual, "\n")
+	actualSet := sets.New[string]()
+	for _, line := range actualLines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			actualSet.Insert(line)
+		}
+	}
+
+	missingSet := expectedSet.Difference(actualSet)
+	extraSet := actualSet.Difference(expectedSet)
+
+	// While we ignore order for purposes of the comparison, it's confusing to output
+	// the missing/extra rules in essentially random order (and makes it harder to see
+	// what the problem is in cases like "the rules are basically correct, except that
+	// they have the wrong IP"). So we sort the `missing` rules back into the same
+	// order as they appeared in `expected`, and the `extra` rules into the same order
+	// as they appeared in `actual`.
+	missingSorted := missingSet.UnsortedList()
+	sort.Slice(missingSorted, func(i, j int) bool {
+		return slices.Index(expectedLines, missingSorted[i]) < slices.Index(expectedLines, missingSorted[j])
+	})
+	extraSorted := extraSet.UnsortedList()
+	sort.Slice(extraSorted, func(i, j int) bool {
+		return slices.Index(actualLines, extraSorted[i]) < slices.Index(actualLines, extraSorted[j])
+	})
+
+	return missingSorted, extraSorted
 }

--- a/go-controller/pkg/node/nftables/testing_test.go
+++ b/go-controller/pkg/node/nftables/testing_test.go
@@ -1,0 +1,86 @@
+//go:build linux
+// +build linux
+
+package nftables
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_diffNFTRules(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		expected string
+		actual   string
+		missing  []string
+		extra    []string
+	}{
+		{
+			name:     "empty match",
+			expected: "",
+			actual:   "",
+			missing:  []string{},
+			extra:    []string{},
+		},
+		{
+			name:     "non-empty match",
+			expected: "line one\nline two\nline three\n",
+			actual:   "line three\nline one\nline two\n",
+			missing:  []string{},
+			extra:    []string{},
+		},
+		{
+			name:     "match with extra whitespace",
+			expected: "	line one\n	line two\n	line three\n",
+			actual:   "\nline three\nline one\nline two\n\n",
+			missing:  []string{},
+			extra:    []string{},
+		},
+		{
+			name:     "missing lines",
+			expected: "line one\nline two\nline three\nline four\n",
+			actual:   "line two\nline four\n",
+			missing:  []string{"line one", "line three"},
+			extra:    []string{},
+		},
+		{
+			name:     "missing lines, alternate order",
+			expected: "line one\nline two\nline three\nline four\n",
+			actual:   "line four\nline two\n",
+			missing:  []string{"line one", "line three"},
+			extra:    []string{},
+		},
+		{
+			name:     "extra lines",
+			expected: "line two\nline four\n",
+			actual:   "line one\nline two\nline three\nline four\n",
+			missing:  []string{},
+			extra:    []string{"line one", "line three"},
+		},
+		{
+			name:     "extra lines, alternate order",
+			expected: "line four\nline two\n",
+			actual:   "line one\nline two\nline three\nline four\n",
+			missing:  []string{},
+			extra:    []string{"line one", "line three"},
+		},
+		{
+			name:     "missing and extra lines, inconsistent whitespace",
+			expected: "	line one\n    line two\n	line three\n",
+			actual:   " line two\n line two-and-a-half\nline three",
+			missing:  []string{"line one"},
+			extra:    []string{"line two-and-a-half"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			missing, extra := diffNFTRules(tc.expected, tc.actual)
+			if !reflect.DeepEqual(tc.missing, missing) {
+				t.Errorf("expected missing=%#v, got %#v", tc.missing, missing)
+			}
+			if !reflect.DeepEqual(tc.extra, extra) {
+				t.Errorf("expected extra=%#v, got %#v", tc.extra, extra)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This just improves `nodenft.MatchNFTRules` so that the unit tests that use it show more useful output if they fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved NFTable rule comparison used in tests to produce deterministic, human-friendly output and clearer failure messages.
  * Enhanced handling of whitespace, blank lines, and ordering when comparing rules.
  * Added comprehensive unit tests covering empty inputs, reordered lines, whitespace variations, missing/extra rules, and mixed cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->