### PR TITLE
Use `nft destroy` to simplify the UDN cleanup code

### DIFF
--- a/go-controller/pkg/node/nftables/helpers.go
+++ b/go-controller/pkg/node/nftables/helpers.go
@@ -28,7 +28,7 @@ func SetFakeNFTablesHelper() *knftables.Fake {
 // called, it will create a "real" knftables.Interface
 func GetNFTablesHelper() (knftables.Interface, error) {
 	if nftHelper == nil {
-		nft, err := knftables.New(knftables.InetFamily, OVNKubernetesNFTablesName)
+		nft, err := knftables.New(knftables.InetFamily, OVNKubernetesNFTablesName, knftables.RequireDestroy)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/node/nftables/util.go
+++ b/go-controller/pkg/node/nftables/util.go
@@ -34,10 +34,7 @@ func DeleteNFTElements(elements []*knftables.Element) error {
 
 	tx := nft.NewTransaction()
 	for _, elem := range elements {
-		// We add+delete the elements, rather than just deleting them, so that if
-		// they weren't already in the set/map, we won't get an error on delete.
-		tx.Add(elem)
-		tx.Delete(elem)
+		tx.Destroy(elem)
 	}
 	return nft.Run(context.TODO(), tx)
 }


### PR DESCRIPTION
## 📑 Description
Requires a kernel/userspace that supports `nft destroy`, and then replaces the hacky UDN map cleanup code.

## Additional Information for reviewers
**This makes ovn-kubernetes require kernel 6.3 or later (or RHEL 9) and `nft` 1.0.8 or later; ie, something from July 2023 or newer.**

If that's a problem, I could also make it only use `tx.Destroy` when you're using UDNs (and so make it only require the new-ish stuff when you're using UDNs)?

## ✅ Checks
not sure if we document kernel/userspace requirements here or on the web site?

cc @kyrtapz since you added the "``TODO: Switch to `nft destroy` when supported``" that this PR removes...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal network gateway rule management by consolidating deletion operations into a unified flow.
  * Optimized network rule deletion to use direct destruction operations instead of intermediate steps, improving efficiency.
  * Enhanced gateway initialization configuration for stricter operational requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->