### PR TITLE
node: Recreate management port if deleted externally

### DIFF
--- a/go-controller/pkg/node/managementport/port_test.go
+++ b/go-controller/pkg/node/managementport/port_test.go
@@ -1,0 +1,153 @@
+package managementport
+
+import (
+	"errors"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// mockManagementPort is a mock implementation of managementPort interface for testing
+type mockManagementPort struct {
+	createFunc      func() error
+	doReconcileFunc func() error
+	period          time.Duration
+
+	createCalls      int32
+	doReconcileCalls int32
+}
+
+func (m *mockManagementPort) create() error {
+	atomic.AddInt32(&m.createCalls, 1)
+	if m.createFunc != nil {
+		return m.createFunc()
+	}
+	return nil
+}
+
+func (m *mockManagementPort) reconcilePeriod() time.Duration {
+	if m.period > 0 {
+		return m.period
+	}
+	return 10 * time.Millisecond
+}
+
+func (m *mockManagementPort) doReconcile() error {
+	atomic.AddInt32(&m.doReconcileCalls, 1)
+	if m.doReconcileFunc != nil {
+		return m.doReconcileFunc()
+	}
+	return nil
+}
+
+func (m *mockManagementPort) getCreateCalls() int {
+	return int(atomic.LoadInt32(&m.createCalls))
+}
+
+var _ = Describe("Management Port start() tests", func() {
+	var stopChan chan struct{}
+
+	BeforeEach(func() {
+		stopChan = make(chan struct{})
+	})
+
+	AfterEach(func() {
+		close(stopChan)
+	})
+
+	Context("When starting management port", func() {
+		It("should call create() once on start", func() {
+			mp := &mockManagementPort{}
+			_, err := start(mp, stopChan)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mp.getCreateCalls()).To(Equal(1))
+		})
+
+		It("should return error if create() fails on start", func() {
+			mp := &mockManagementPort{
+				createFunc: func() error {
+					return errors.New("create failed")
+				},
+			}
+			_, err := start(mp, stopChan)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("create failed"))
+		})
+
+		It("should return nil reconcile function for nil managementPort", func() {
+			reconcile, err := start(nil, stopChan)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reconcile).NotTo(BeNil())
+			// Should not panic when called
+			reconcile()
+		})
+	})
+
+	Context("When reconciling management port", func() {
+		It("should call create() when doReconcile() fails", func() {
+			reconcileErr := errors.New("interface not found")
+			doReconcileCalled := make(chan struct{}, 10)
+			createCalled := make(chan struct{}, 10)
+
+			mp := &mockManagementPort{
+				period: 50 * time.Millisecond,
+				doReconcileFunc: func() error {
+					doReconcileCalled <- struct{}{}
+					return reconcileErr
+				},
+				createFunc: func() error {
+					createCalled <- struct{}{}
+					return nil
+				},
+			}
+
+			reconcile, err := start(mp, stopChan)
+			Expect(err).NotTo(HaveOccurred())
+			// create() called once during start
+			Expect(mp.getCreateCalls()).To(Equal(1))
+
+			// Trigger reconciliation
+			reconcile()
+
+			// Wait for doReconcile to be called
+			Eventually(doReconcileCalled, 1*time.Second).Should(Receive())
+			// Wait for create to be called (due to doReconcile failure)
+			Eventually(createCalled, 1*time.Second).Should(Receive())
+
+			// create() should have been called again (once at start + once during reconcile)
+			Eventually(func() int {
+				return mp.getCreateCalls()
+			}, 1*time.Second).Should(BeNumerically(">=", 2))
+		})
+
+		It("should not call create() when doReconcile() succeeds", func() {
+			doReconcileCalled := make(chan struct{}, 10)
+
+			mp := &mockManagementPort{
+				period: 50 * time.Millisecond,
+				doReconcileFunc: func() error {
+					doReconcileCalled <- struct{}{}
+					return nil
+				},
+			}
+
+			reconcile, err := start(mp, stopChan)
+			Expect(err).NotTo(HaveOccurred())
+			// create() called once during start
+			Expect(mp.getCreateCalls()).To(Equal(1))
+
+			// Trigger reconciliation
+			reconcile()
+
+			// Wait for doReconcile to be called
+			Eventually(doReconcileCalled, 1*time.Second).Should(Receive())
+
+			// create() should still only have been called once (at start)
+			Consistently(func() int {
+				return mp.getCreateCalls()
+			}, 100*time.Millisecond).Should(Equal(1))
+		})
+	})
+})


### PR DESCRIPTION
When the management port interface (ovn-k8s-mp0) is deleted externally (e.g., by running 'netplan apply' on a DPU-host), the doReconcile() function would fail because the interface no longer exists. Previously, this would leave the node in a broken state requiring a pod restart to recover.

This change modifies the reconciliation loop to call create() when doReconcile() fails, which will recreate the management port interface along with its IP configuration and routes.

The create() functions for all management port types (OVS, netdev, representor) are idempotent - they use '--may-exist' flags for OVS commands and check existing state before making changes, so calling them multiple times is safe.

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5823

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Management port reconciliation now attempts a safe recreation when reconciliation detects a missing interface; failures are logged and recreation errors are returned, while successful recreation suppresses the reconciliation error.

* **Tests**
  * Added tests covering management port startup and reconciliation flows, including create-on-start, recreate-on-reconcile-failure, and no-recreate-on-success behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->