### PR TITLE
EgressFirewall: Use exponential backoff to refresh IP addresses for DNS names

### DIFF
--- a/go-controller/pkg/util/dns_test.go
+++ b/go-controller/pkg/util/dns_test.go
@@ -70,13 +70,16 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 	tests := []struct {
 		desc             string
 		errExp           bool
+		retry            bool
 		ipv4Mode         bool
 		ipv6Mode         bool
 		dnsOpsMockHelper []ovntest.TestifyMockHelper
+		expectedTTL      time.Duration
 	}{
 		{
 			desc:     "call to Exchange fails IPv4 only",
 			errExp:   true,
+			retry:    true,
 			ipv4Mode: true,
 			ipv6Mode: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
@@ -89,10 +92,12 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 					CallTimes:           1,
 				},
 			},
+			expectedTTL: defaultMinTTL,
 		},
 		{
 			desc:     "Exchange returns correctly but Rcode != RcodeSuccess IPv4 only",
 			errExp:   true,
+			retry:    true,
 			ipv4Mode: true,
 			ipv6Mode: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
@@ -105,6 +110,46 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 					CallTimes:           1,
 				},
 			},
+			expectedTTL: defaultMinTTL,
+		},
+		{
+			desc:     "Exchange returns correctly but with TTL 0 IPv4 only",
+			errExp:   false,
+			retry:    false,
+			ipv4Mode: true,
+			ipv6Mode: false,
+			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"www.test.com"}, CallTimes: 1},
+				{OnCallMethodName: "Exchange", OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"}, RetArgList: []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: net.ParseIP("1.2.3.4")}}}, 0 * time.Second, nil}, CallTimes: 1},
+			},
+			expectedTTL: defaultMinTTL,
+		},
+		{
+			desc:     "Exchange returns correctly but no Answer IPv4 only",
+			errExp:   true,
+			retry:    true,
+			ipv4Mode: true,
+			ipv6Mode: false,
+			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"www.test.com"}, CallTimes: 1},
+				{OnCallMethodName: "Exchange", OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"}, RetArgList: []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{}}, 0 * time.Second, nil}, CallTimes: 1},
+			},
+			expectedTTL: defaultMinTTL,
+		},
+		{
+			desc:     "Exchange returns correctly but with non-zero TTL IPv4 only",
+			errExp:   false,
+			retry:    false,
+			ipv4Mode: true,
+			ipv6Mode: false,
+			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1},
+				{OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"www.test.com"}, CallTimes: 1},
+				{OnCallMethodName: "Exchange", OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"}, RetArgList: []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{Hdr: dns.RR_Header{Ttl: 100}, A: net.ParseIP("1.2.3.4")}}}, 0 * time.Second, nil}, CallTimes: 1},
+			},
+			expectedTTL: 100 * time.Second,
 		},
 	}
 
@@ -128,19 +173,22 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 			}
 			config.IPv4Mode = tc.ipv4Mode
 			config.IPv6Mode = tc.ipv6Mode
-			res, _, err := testDNS.getIPsAndMinTTL("www.test.com")
-			t.Log(res, err)
+			res, ttl, retry, err := testDNS.getIPsAndMinTTL("www.test.com")
+			t.Log(res, ttl, retry, err)
 			if tc.errExp {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
+			assert.Equal(t, tc.retry, retry, "the exponentialBackoff variable should match the return from dns.getIPsAndMinTTL()")
+			assert.Equal(t, tc.expectedTTL, ttl, "the ttl variable should match the return from dns.getIPsAndMinTTL()")
 			mockDNSOps.AssertExpectations(t)
 		})
 	}
 }
 
 func TestUpdate(t *testing.T) {
+	config.IPv4Mode = true
 	mockDNSOps := new(util_mocks.DNSOps)
 	SetDNSLibOpsMockInst(mockDNSOps)
 
@@ -252,6 +300,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
+	config.IPv4Mode = true
 	dnsName := "www.testing.com"
 	mockDNSOps := new(util_mocks.DNSOps)
 	SetDNSLibOpsMockInst(mockDNSOps)
@@ -318,4 +367,212 @@ func TestAdd(t *testing.T) {
 		})
 	}
 
+}
+
+func TestIPsEqual(t *testing.T) {
+	tests := []struct {
+		desc     string
+		oldips   []net.IP
+		newips   []net.IP
+		expEqual bool
+	}{
+		{
+			desc:     "oldips and newips are the same",
+			oldips:   []net.IP{net.ParseIP("1.2.3.4")},
+			newips:   []net.IP{net.ParseIP("1.2.3.4")},
+			expEqual: true,
+		},
+		{
+			desc:     "oldips and newips are different",
+			oldips:   []net.IP{net.ParseIP("1.2.3.4")},
+			newips:   []net.IP{net.ParseIP("1.2.3.5")},
+			expEqual: false,
+		},
+		{
+			desc:     "oldips and newips are different length",
+			oldips:   []net.IP{net.ParseIP("1.2.3.4")},
+			newips:   []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("1.2.3.5")},
+			expEqual: false,
+		},
+		{
+			desc:     "oldips is nil and newips is not nil",
+			oldips:   nil,
+			newips:   []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("1.2.3.5")},
+			expEqual: false,
+		},
+		{
+			desc:     "oldips is empty and newips is not empty",
+			oldips:   []net.IP{},
+			newips:   []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("1.2.3.5")},
+			expEqual: false,
+		},
+		{
+			desc:     "oldips is not nil and newips is nil",
+			oldips:   []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("1.2.3.5")},
+			newips:   nil,
+			expEqual: false,
+		},
+		{
+			desc:     "oldips is not empty and newips is empty",
+			oldips:   []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("1.2.3.5")},
+			newips:   []net.IP{},
+			expEqual: false,
+		},
+		{
+			desc:     "oldips and newips are both nil",
+			oldips:   nil,
+			newips:   nil,
+			expEqual: true,
+		},
+		{
+			desc:     "oldips and newips are both empty",
+			oldips:   []net.IP{},
+			newips:   []net.IP{},
+			expEqual: true,
+		},
+		{
+			desc:     "oldips is nil and newips is empty",
+			oldips:   nil,
+			newips:   []net.IP{},
+			expEqual: true,
+		},
+		{
+			desc:     "oldips is empty and newips is nil",
+			oldips:   []net.IP{},
+			newips:   nil,
+			expEqual: true,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			res := ipsEqual(tc.oldips, tc.newips)
+			assert.Equal(t, tc.expEqual, res)
+		})
+	}
+}
+
+func TestUpdateOne(t *testing.T) {
+	config.IPv4Mode = true
+	dnsName := "www.testing.com"
+	newIP := net.ParseIP("1.2.3.4")
+	fqdnOpsMockHelper := ovntest.TestifyMockHelper{
+		OnCallMethodName: "Fqdn", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{dnsName}, CallTimes: 1,
+	}
+	setQuestionOpsMockHelper := ovntest.TestifyMockHelper{
+		OnCallMethodName: "SetQuestion", OnCallMethodArgType: []string{"*dns.Msg", "string", "uint16"}, RetArgList: []interface{}{&dns.Msg{}}, CallTimes: 1,
+	}
+	exchangeSuccessNoAnswerOpsMockHelper := ovntest.TestifyMockHelper{
+		OnCallMethodName: "Exchange", OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"}, RetArgList: []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{}}, 0 * time.Second, nil}, CallTimes: 1,
+	}
+	exchangeSuccessZeroTTLOpsMockHelper := ovntest.TestifyMockHelper{
+		OnCallMethodName: "Exchange", OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"}, RetArgList: []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil}, CallTimes: 1,
+	}
+	exchangeSuccessNonZeroTTLOpsMockHelper := ovntest.TestifyMockHelper{
+		OnCallMethodName: "Exchange", OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"}, RetArgList: []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{Hdr: dns.RR_Header{Ttl: 100}, A: newIP}}}, 0 * time.Second, nil}, CallTimes: 1,
+	}
+	exchangeFailureOpsMockHelper := ovntest.TestifyMockHelper{
+		OnCallMethodName: "Exchange", OnCallMethodArgType: []string{"*dns.Client", "*dns.Msg", "string"}, RetArgList: []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}}, 0 * time.Second, nil}, CallTimes: 1,
+	}
+	tests := []struct {
+		desc                  string
+		numCalls              int
+		exchangeOpsMockHelper ovntest.TestifyMockHelper
+		expTTL                time.Duration
+	}{
+		{
+			desc:                  "when Exchange function returns with Rcode != RcodeSuccess, defaultMinTTL is used",
+			numCalls:              1,
+			exchangeOpsMockHelper: exchangeFailureOpsMockHelper,
+			expTTL:                defaultMinTTL,
+		},
+		{
+			desc:                  "when Exchange function returns successfully but without Answer, defaultMinTTL is used",
+			numCalls:              1,
+			exchangeOpsMockHelper: exchangeSuccessNoAnswerOpsMockHelper,
+			expTTL:                defaultMinTTL,
+		},
+		{
+			desc:                  "when TTL returned is 0 by Exchange function, defaultMinTTL is used",
+			numCalls:              1,
+			exchangeOpsMockHelper: exchangeSuccessZeroTTLOpsMockHelper,
+			expTTL:                defaultMinTTL,
+		},
+		{
+			desc:                  "when TTL returned is 0 by Exchange function 2 times, defaultMinTTL is used",
+			numCalls:              2,
+			exchangeOpsMockHelper: exchangeSuccessZeroTTLOpsMockHelper,
+			expTTL:                defaultMinTTL,
+		},
+		{
+			desc:                  "when TTL returned is 0 by Exchange function 11 times, defaultMinTTL is used",
+			numCalls:              11,
+			exchangeOpsMockHelper: exchangeSuccessZeroTTLOpsMockHelper,
+			expTTL:                defaultMinTTL,
+		},
+		{
+			desc:                  "when Exchange function returns with Rcode != RcodeSuccess twice, defaultMinTTL is used",
+			numCalls:              2,
+			exchangeOpsMockHelper: exchangeFailureOpsMockHelper,
+			expTTL:                defaultMinTTL,
+		},
+		{
+			desc:                  "when Exchange function returns with Rcode != RcodeSuccess 10 times, defaultMinTTL is used",
+			numCalls:              10,
+			exchangeOpsMockHelper: exchangeFailureOpsMockHelper,
+			expTTL:                defaultMinTTL,
+		},
+		{
+			desc:                  "when Exchange function returns with Rcode != RcodeSuccess 11 times, defaultMinTTL is doubled",
+			numCalls:              11,
+			exchangeOpsMockHelper: exchangeFailureOpsMockHelper,
+			expTTL:                2 * defaultMinTTL,
+		},
+		{
+			desc:                  "when Exchange function returns with Rcode != RcodeSuccess 14 times, 16 (2^4) times defaultMinTTL is used",
+			numCalls:              14,
+			exchangeOpsMockHelper: exchangeFailureOpsMockHelper,
+			expTTL:                16 * defaultMinTTL,
+		},
+		{
+			desc:                  "when Exchange function returns with Rcode != RcodeSuccess 15 times, defaultMaxTTL is used",
+			numCalls:              15,
+			exchangeOpsMockHelper: exchangeFailureOpsMockHelper,
+			expTTL:                defaultMaxTTL,
+		},
+		{
+			desc:                  "when TTL returned is non-zero by Exchange function, it is used",
+			numCalls:              1,
+			exchangeOpsMockHelper: exchangeSuccessNonZeroTTLOpsMockHelper,
+			expTTL:                100 * time.Second,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			mockDNSOps := new(util_mocks.DNSOps)
+			SetDNSLibOpsMockInst(mockDNSOps)
+			dnsOpsMockHelper := []ovntest.TestifyMockHelper{fqdnOpsMockHelper, setQuestionOpsMockHelper, tc.exchangeOpsMockHelper}
+			for index := 0; index < tc.numCalls; index++ {
+				for _, item := range dnsOpsMockHelper {
+					call := mockDNSOps.On(item.OnCallMethodName)
+					for _, arg := range item.OnCallMethodArgType {
+						call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
+					}
+					for _, ret := range item.RetArgList {
+						call.ReturnArguments = append(call.ReturnArguments, ret)
+					}
+					call.Once()
+				}
+			}
+			dns := DNS{
+				dnsMap:      make(map[string]dnsValue),
+				nameservers: []string{"1.1.1.1"},
+			}
+			dns.dnsMap[dnsName] = dnsValue{}
+			for i := 0; i < tc.numCalls; i++ {
+				_, _ = dns.updateOne(dnsName)
+			}
+			assert.Equal(t, tc.expTTL, dns.dnsMap[dnsName].ttl)
+			mockDNSOps.AssertExpectations(t)
+		})
+	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

For the following DNS name lookup scenarios, the TTL of a DNS name was being set at 30 minutes:
- When an error is encountered during DNS name lookup
- TTL value can't be parsed into duration
- When TTL returned is zero

Except for the zero TTL scenario, the rest of the scenarios can be transient in nature in some cases, and the 30 minutes delay can cause a significant synchronization issue for DNS name rules in EgressFirewall. 

For the zero TTL scenario, a TTL of 5 seconds is used to refresh the IP addresses.

In the case of the error scenarios, instead of directly using a conservative TTL of 30 minutes, 5 seconds TTL is used for the first 10 times, then exponential backoff, is used which is capped off at 2 minutes. This can help mitigate the synchronization issues when these transient scenarios are encountered. Additionally, capping off at 2 minutes rather than 30 minutes will let ovnk pods to get the latest IP addresses quickly when the transient problem goes away.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds retry tracking and exponential backoff for DNS lookups with enforced minimum and maximum TTL behavior.

* **Bug Fixes**
  * Better handling of missing/invalid TTLs (including TTL=0), deduplicated IP results, and fallback to previously known IPs when lookups fail.

* **Tests**
  * Expanded coverage for TTL handling, backoff/doubling/capping, retry semantics, IP equality, and update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->