### PR TITLE
EgressIP: Add ecmp_symmetric_reply option to fix connection resets

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2970,6 +2970,9 @@ func (e *EgressIPController) createReroutePolicyOps(ni util.NetInfo, ops []ovsdb
 		}
 		addPktMarkToLRPOptions(options, mark.String())
 	}
+	// Enable connection-tracked ECMP to ensure all packets from the same connection
+	// use the same nexthop, preventing connection resets with multiple egress IPs
+	options["ecmp_symmetric_reply"] = "true"
 	dbIDs := getEgressIPLRPReRouteDbIDs(egressIPName, podNamespace, podName, ipFamily, ni.GetNetworkName(), e.controllerName)
 	p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, nil)
 	// Handle all pod IPs that match the egress IP address family

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -388,6 +388,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Nexthops:    nodeLogicalRouterIPv4,
 					ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 					UUID:        "reroute-UUID",
+					Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 				},
 				&nbdb.LogicalRouterPolicy{
 					Priority:    types.DefaultNoRereoutePriority,
@@ -604,6 +605,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Nexthops:    []string{node1MgntIP.To4().String()},
 					ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 					UUID:        "reroute-UUID",
+					Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 				},
 				&nbdb.LogicalRouterPolicy{
 					Priority:    types.DefaultNoRereoutePriority,
@@ -868,6 +870,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Nexthops:    node2LogicalRouterIPv4,
 							ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 							UUID:        "reroute-UUID",
+							Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
@@ -1225,6 +1228,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Nexthops:    node2LogicalRouterIPv4,
 							ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 							UUID:        "reroute-UUID",
+							Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
@@ -1646,6 +1650,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Nexthops:    []string{node2MgntIP.To4().String()},
 							ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 							UUID:        "reroute-UUID",
+							Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
@@ -4258,6 +4263,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    nodeLogicalRouterIPv6,
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV6, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
@@ -6262,6 +6268,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    node2LogicalRouterIPv6,
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV6, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
@@ -7010,6 +7017,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    nodeLogicalRouterIPv4,
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod1.Namespace, egressPod1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID1",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.OVNClusterRouter,
@@ -7339,6 +7347,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Nexthops:    nodeLogicalRouterIPv4,
 					ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod1.Namespace, egressPod1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 					UUID:        "reroute-UUID1",
+					Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 				}
 				node1GR := &nbdb.LogicalRouter{
 					Name:    types.GWRouterPrefix + node1.Name,
@@ -7775,6 +7784,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    nodeLogicalRouterIPv4,
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(pas.egressIPName, egressPod1.Namespace, egressPod1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID1",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					}
 					node1GR.Nat = []string{"egressip-nat-UUID1"}
 
@@ -9092,6 +9102,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    node2LogicalRouterIPv4,
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.NAT{
 						UUID:        "egressip-nat-UUID",
@@ -9237,6 +9248,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								Match:       "ip.src == 10.128.3.8",
 								Priority:    types.EgressIPReroutePriority,
 								Action:      nbdb.LogicalRouterPolicyActionReroute,
+								Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 							},
 							&nbdb.LogicalRouter{
 								Name:     types.OVNClusterRouter,
@@ -10703,6 +10715,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Nexthops:    nodeLogicalRouterIPv4,
 					ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 					UUID:        "reroute-UUID1",
+					Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 				}
 				node1GR.Nat = []string{"egressip-nat-UUID1"}
 				egressSVCServedPodsASv4, _ := buildEgressServiceAddressSets(nil)
@@ -11042,6 +11055,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    nodeLogicalRouterIPv4,
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, ipfamily, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID1",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					}
 					if isEgressIPv6 {
 						podReRoutePolicy.Nexthops = nodeLogicalRouterIPv6
@@ -11394,6 +11408,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    []string{node2IPv4TranSwitchIP},
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID1",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.LogicalRouter{
 						Name:     types.OVNClusterRouter,
@@ -11772,6 +11787,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 									Nexthops:    []string{"100.64.0.2"},
 									ExternalIDs: getEgressIPLRPReRouteDbIDs(egressIPName, eipNamespace, "egress-pod2", IPFamilyValueV4, types.DefaultNetworkName, DefaultNetworkControllerName).GetExternalIDs(),
 									UUID:        "hostnet-pod-reroute-UUID1",
+									Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 								},
 								&nbdb.NAT{
 									UUID:        "hostnet-pod-egressip-nat-UUID1",
@@ -12008,6 +12024,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								Nexthops:    []string{"100.64.0.2"},
 								ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod3.Namespace, egressPod3.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 								UUID:        "reroute-UUID1",
+								Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 							},
 							&nbdb.LogicalRouterPolicy{
 								Priority:    types.EgressIPReroutePriority,
@@ -12016,6 +12033,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 								Nexthops:    []string{"100.64.0.2"},
 								ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod4.Namespace, egressPod4.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 								UUID:        "reroute-UUID2",
+								Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 							},
 							&nbdb.LogicalRouter{
 								Name:     types.OVNClusterRouter,
@@ -12391,6 +12409,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Nexthops:    node2LogicalRouterIPv4,
 							ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 							UUID:        "reroute-UUID",
+							Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.EgressIPReroutePriority,
@@ -12399,6 +12418,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Nexthops:    nodeLogicalRouterIPv4,
 							ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP2.Name, egressPod2.Namespace, egressPod2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 							UUID:        "eip2-reroute-UUID",
+							Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
@@ -12902,6 +12922,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    []string{"100.64.0.2"},
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod1.Namespace, egressPod1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID1",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority:    types.EgressIPReroutePriority,
@@ -12910,6 +12931,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    []string{"100.64.0.2"},
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod2.Namespace, egressPod2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID2",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.LogicalRouter{
 						Name: types.OVNClusterRouter,
@@ -13059,6 +13081,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    []string{"100.64.0.2", "100.64.0.3"},
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod1.Namespace, egressPod1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID1",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority:    types.EgressIPReroutePriority,
@@ -13067,6 +13090,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    []string{"100.64.0.2", "100.64.0.3"},
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod2.Namespace, egressPod2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID2",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.NAT{
 						UUID:        "egressip-nat-UUID1",
@@ -13220,6 +13244,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    nodeLogicalRouterIPv4,
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod1.Namespace, egressPod1.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID1",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.LogicalRouterPolicy{
 						Priority:    types.EgressIPReroutePriority,
@@ -13228,6 +13253,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops:    nodeLogicalRouterIPv4,
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod2.Namespace, egressPod2.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 						UUID:        "reroute-UUID2",
+						Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.NAT{
 						UUID:        "egressip-nat-UUID1",
@@ -14101,7 +14127,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops: []string{"100.64.0.2", "100.64.0.4"},
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(egressIPName, egressPod1.Namespace, egressPod1.Name,
 							"ip4", types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
-						UUID: "reroute-UUID1",
+						UUID:    "reroute-UUID1",
+						Options: map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.NAT{
 						UUID:        "egressip-nat-UUID1",
@@ -14287,7 +14314,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 						Nexthops: []string{"100.64.0.2", "100.64.0.3"},
 						ExternalIDs: getEgressIPLRPReRouteDbIDs(egressIPName, egressPod1.Namespace, egressPod1.Name,
 							"ip4", types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
-						UUID: "reroute-UUID1",
+						UUID:    "reroute-UUID1",
+						Options: map[string]string{"ecmp_symmetric_reply": "true"},
 					},
 					&nbdb.NAT{
 						UUID:        "egressip-nat-UUID1",
@@ -15265,6 +15293,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Nexthops:    []string{"100.64.0.2"},
 					ExternalIDs: getEgressIPLRPReRouteDbIDs(eipName, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs(),
 					UUID:        reroutePolicyUUID,
+					Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 				})
 				data = append(data, &nbdb.NAT{
 					UUID:        podNatUUID,
@@ -15709,6 +15738,7 @@ func getReRoutePolicy(podIP, ipFamily, uuid string, nextHops []string, externalI
 		Nexthops:    nextHops,
 		ExternalIDs: externalID,
 		UUID:        uuid,
+		Options:     map[string]string{"ecmp_symmetric_reply": "true"},
 	}
 }
 

--- a/go-controller/pkg/ovn/egressip_udn_l3_test.go
+++ b/go-controller/pkg/ovn/egressip_udn_l3_test.go
@@ -3008,13 +3008,15 @@ func getReRouteStaticRouteForController(clusterSubnet, nextHop, network string) 
 }
 
 func getReRoutePolicyForController(eIPName, podNamespace, podName, podIP string, mark int, ipFamily egressIPFamilyValue, nextHops []string, network, controller string) *nbdb.LogicalRouterPolicy {
+	options := getMarkOptions(mark)
+	options["ecmp_symmetric_reply"] = "true"
 	return &nbdb.LogicalRouterPolicy{
 		Priority:    ovntypes.EgressIPReroutePriority,
 		Match:       fmt.Sprintf("%s.src == %s", ipFamily, podIP),
 		Action:      nbdb.LogicalRouterPolicyActionReroute,
 		Nexthops:    nextHops,
 		ExternalIDs: getEgressIPLRPReRouteDbIDs(eIPName, podNamespace, podName, ipFamily, network, controller).GetExternalIDs(),
-		Options:     getMarkOptions(mark),
+		Options:     options,
 		UUID:        getReRoutePolicyUUID(podNamespace, podName, ipFamily, network),
 	}
 }


### PR DESCRIPTION
When multiple egress IPs are assigned to a namespace, the Logical Router Policy (LRP) has multiple nexthops and uses ECMP load balancing. Without the ecmp_symmetric_reply option, different packets from the same TCP connection can be hashed to different nexthops, resulting in different SNAT IPs and connection resets from the remote server.

This adds the ecmp_symmetric_reply option to ensure all packets from the same connection use the same nexthop, maintaining consistent SNAT IP and preventing connection resets.

This aligns with the existing pattern used in egress gateway (egressgw.go) and APB routes (apbroute/network_client.go).

Fixes: Connection resets with multiple egress IPs and external endpoints

Assisted-by: Claude Sonnet 4.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Egress IP reroute policies now enable ECMP symmetric-reply by default, ensuring consistent bidirectional routing behavior across network types.

* **Tests**
  * Unit tests and fixtures updated to validate symmetric-reply behavior in reroute policies and related NAT entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->