### PR TITLE
CUDN: cleanup NADs in terminating namespaces without pods

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/notifier/namespace.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/notifier/namespace.go
@@ -46,10 +46,11 @@ func NewNamespaceNotifier(nsInformer corev1informer.NamespaceInformer, subscribe
 func (c *NamespaceNotifier) needUpdate(old, new *corev1.Namespace) bool {
 	nsCreated := old == nil && new != nil
 	nsDeleted := old != nil && new == nil
+	nsDeleting := new != nil && !new.DeletionTimestamp.IsZero()
 	nsLabelsChanged := old != nil && new != nil &&
 		!reflect.DeepEqual(old.Labels, new.Labels)
 
-	return nsCreated || nsDeleted || nsLabelsChanged
+	return nsCreated || nsDeleted || nsDeleting || nsLabelsChanged
 }
 
 // reconcile notify subscribers with the request namespace key following namespace events.


### PR DESCRIPTION
Skip namespaces with deletionTimestamp set when selecting target namespaces, triggering NAD deletion for terminating namespaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter handling of deleted/terminating namespaces: terminating namespaces are skipped from normal selection, marked as deleting, and now trigger targeted cleanup reconciliations (with deletion-aware logging and safer nil-handling) to remove stale network attachments.

* **Tests**
  * Added unit and end-to-end tests validating NetworkAttachmentDefinition lifecycle: ensure NADs are removed when target namespaces terminate and created when namespace selection changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->