### PR TITLE
Fix IC cluster cleanup tests zone configuration

### DIFF
--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -365,13 +365,8 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 		"user-defined network controller DB entities are properly cleaned up",
 		func(netInfo userDefinedNetInfo, testConfig testConfiguration) {
 			podInfo := dummyTestPod(ns, netInfo)
-			if testConfig.configToOverride != nil {
-				config.OVNKubernetesFeature = *testConfig.configToOverride
-				if testConfig.gatewayConfig != nil {
-					config.Gateway.DisableSNATMultipleGWs = testConfig.gatewayConfig.DisableSNATMultipleGWs
-				}
-				config.OVNKubernetesFeature.EnableMultiNetwork = true
-			}
+			setupConfig(netInfo, testConfig, config.GatewayModeShared)
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
 			app.Action = func(*cli.Context) error {
 				netConf := netInfo.netconf()
 				networkConfig, err := util.NewNetInfo(netConf)
@@ -395,7 +390,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 				gwConfig, err := util.ParseNodeL3GatewayAnnotation(testNode)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(gwConfig.NextHops).NotTo(BeEmpty())
-				nbZone := &nbdb.NBGlobal{Name: ovntypes.OvnDefaultZone, UUID: ovntypes.OvnDefaultZone}
+				nbZone := &nbdb.NBGlobal{Name: config.Default.Zone, UUID: config.Default.Zone}
 
 				n := newNamespace(ns)
 				if netInfo.isPrimary {


### PR DESCRIPTION
Layer2 UDN cleanup tests for IC clusters were failing:
```
Summarizing 2 Failures:
  [FAIL] OVN Multi-Homed pod operations for layer 2 network user-defined network controller DB entities are properly cleaned up [It] pod on a user defined primary network on an IC cluster
  /home/pdiak/dev/ovn-kubernetes/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go:469
  [FAIL] OVN Multi-Homed pod operations for layer 2 network user-defined network controller DB entities are properly cleaned up [It] pod on a user defined primary network on an IC cluster with per-pod SNATs enabled
  /home/pdiak/dev/ovn-kubernetes/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go:469 
```

This is because of a zone mismatch between the controller and the test node:
- Controller zone: read from `NBGlobal.Name ("global")`
- Node zone: set via annotation (`test` when IC enabled)

This mismatch was previously masked in two spots:

1. The HACK in `isLocalZoneNode()` (removed by commit 7d408c1ca): When the controller's zone was `global` (the default), the HACK bypassed the zone comparison entirely and instead checked whether the node had a migration annotation. Since the test node had no migration annotation, it was treated as local despite the zone mismatch.

2. Unconditional gateway cleanup in `deleteNodeEvent`, changed by commit 8725a93dc to only cleanup nodes tracked in localZoneNodes

With both items above removed/changed, the test correctly fails because the node is treated as remote (zones don't match), so it's not added to `localZoneNodes`, and cleanup is skipped.

Fix the test by:
- setting `config.Default.Zone` to `testICZone` when IC is enabled
- setting `NBGlobal.Name` to `testICZone` when IC is enabled

This ensures the controller and node are in the same zone, so the node is correctly treated as local and its gateway entities are cleaned up.

Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5887


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test configuration setup and zone initialization handling in network controller tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->