### PR TITLE
Fix race condition in GetNadNamespaces

### DIFF
--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -461,6 +461,8 @@ func (nInfo *mutableNetInfo) getNamespaces() sets.Set[string] {
 }
 
 func (nInfo *mutableNetInfo) GetNADNamespaces() []string {
+	nInfo.RLock()
+	defer nInfo.RUnlock()
 	return nInfo.getNamespaces().UnsortedList()
 }
 


### PR DESCRIPTION
Add missing RLock to prevent concurrent map access panic when reading namespaces while AddNADs/DeleteNADs modify the map.

Tested with:
```
func TestGetNADNamespacesConcurrency(t *testing.T) {
	netInfo, err := NewNetInfo(&ovncnitypes.NetConf{
		NetConf:  cnitypes.NetConf{Name: "test"},
		Topology: ovntypes.Layer2Topology,
	})
	if err != nil {
		t.Fatalf("failed to create NetInfo: %v", err)
	}

	m := NewMutableNetInfo(netInfo)

	var wg sync.WaitGroup
	for i := range 20 {
		wg.Add(2)
		go func() {
			defer wg.Done()
			m.AddNADs(fmt.Sprintf("ns%d/nad", i))
			m.DeleteNADs(fmt.Sprintf("ns%d/nad", i))
		}()
		go func() { defer wg.Done(); _ = m.GetNADNamespaces() }()
	}
	wg.Wait()
}
```
Agreed with @jcaamano that there is no point of adding this test to the code.
We are not extensively testing locking in our unit tests and ~we are not running our UTs with `-race` today :( - something we should probably fix.~

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5890
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety for namespace retrieval operations to prevent potential race conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->