### PR TITLE
Remove bits about docker ipv6 support being experimental

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/containerengine"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
@@ -358,54 +357,6 @@ func createServiceForPodsWithLabel(f *framework.Framework, namespace string, ser
 		return "", errors.Wrapf(err, "Failed to get service %s %s", service.Name, namespace)
 	}
 	return res.Spec.ClusterIP, nil
-}
-
-// HACK: 'container runtime' is statically set to docker. For EIP multi network scenario, we require ip6tables support to
-// allow isolated ipv6 networks and prevent the bridges from forwarding to each other.
-// Docker ipv6+ip6tables support is currently experimental (11/23) [1], and enabling this requires altering the
-// container runtime config. To avoid altering the runtime config, add ip6table rules to prevent the bridges talking
-// to each other. Not required to remove the iptables, because when we delete the network, the iptable rules will be removed.
-// Remove when this func when it is no longer experimental.
-// [1] https://docs.docker.com/config/daemon/ipv6/
-func isolateKinDIPv6Networks(networkA, networkB string) error {
-	if infraprovider.Get().Name() != "kind" {
-		// nothing to do
-		return nil
-	}
-	if containerengine.Get() != containerengine.Docker {
-		panic("unsupported container runtime")
-	}
-	var bridgeInfNames []string
-	// docker creates bridges by appending 12 chars from network ID to 'br-'
-	bridgeIDLimit := 12
-	exec := kexec.New()
-	for _, network := range []string{networkA, networkB} {
-		// output will be wrapped in single quotes
-		idByte, err := exec.Command("docker", "inspect", network, "--format", "'{{.Id}}'").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("failed to inspect network %s: %v", network, err)
-		}
-		id := string(idByte)
-		if len(id) <= bridgeIDLimit+1 {
-			return fmt.Errorf("invalid bridge ID %q", id)
-		}
-		bridgeInfName := fmt.Sprintf("br-%s", id[1:bridgeIDLimit+1])
-		// validate bridge exists
-		_, err = exec.Command("ip", "link", "show", bridgeInfName).CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("bridge %q doesnt exist: %v", bridgeInfName, err)
-		}
-		bridgeInfNames = append(bridgeInfNames, bridgeInfName)
-	}
-	if len(bridgeInfNames) != 2 {
-		return fmt.Errorf("expected two bridge names but found %d", len(bridgeInfNames))
-	}
-	_, err := exec.Command("sudo", "ip6tables", "-t", "filter", "-A", "FORWARD", "-i", bridgeInfNames[0], "-o", bridgeInfNames[1], "-j", "DROP").CombinedOutput()
-	if err != nil {
-		return err
-	}
-	_, err = exec.Command("sudo", "ip6tables", "-t", "filter", "-A", "FORWARD", "-i", bridgeInfNames[1], "-o", bridgeInfNames[0], "-j", "DROP").CombinedOutput()
-	return err
 }
 
 // forwardIPWithIPTables inserts an iptables rule to always accept source and destination of arg ip

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -807,14 +807,6 @@ var _ = ginkgo.DescribeTableSubtree("e2e egress IP validation", feature.EgressIP
 		// configure and add additional network to worker containers for EIP multi NIC feature
 		secondaryProviderNetwork, err := providerCtx.CreateNetwork(secondaryNetworkName, secondarySubnet)
 		framework.ExpectNoError(err, "creation of network %q with subnet %s must succeed", secondaryNetworkName, secondarySubnet)
-		// this is only required for KinD infra provider
-		if isIPv6TestRun && infraprovider.Get().Name() == "kind" {
-			// HACK: ensure bridges don't talk to each other. For IPv6, docker support for isolated networks is experimental.
-			// Remove when it is no longer experimental. See func description for full details.
-			if err := isolateKinDIPv6Networks(primaryProviderNetwork.Name(), secondaryProviderNetwork.Name()); err != nil {
-				framework.Failf("failed to isolate IPv6 networks: %v", err)
-			}
-		}
 		nodes, err = f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		framework.ExpectNoError(err, "must list all Nodes")
 		for _, node := range nodes.Items {


### PR DESCRIPTION
Working on porting iptables stuff in the e2e tests and found this hack, which says

    // Remove this func when [docker ipv6 support] is no longer experimental.

It's supported by default as of docker 27.0.0 (https://github.com/moby/moby/pull/47747), and our CI images are using Ubuntu 28.04, which has docker 28.0.4 (https://github.com/actions/runner-images/blob/ubuntu24/20260119.4/images/ubuntu/Ubuntu2404-Readme.md#tools).

So assuming the comment is correct, this hack can just be removed...

cc @martinkennelly 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed KinD-specific IPv6 isolation workaround from end-to-end tests. This simplifies the test setup, reduces special-case failure paths for IPv6 test runs on KinD, and streamlines node listing/attachment steps during e2e execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->