### PR TITLE
Enable golangci-lint staticcheck QF* and fix QF* lint issues

### DIFF
--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -43,18 +43,6 @@ linters:
         - name: duplicated-imports
         - name: error-naming
         - name: unused-parameter
-    staticcheck:
-        checks:
-          # Default
-          - all
-          - -ST1000
-          - -ST1003
-          - -ST1016
-          - -ST1020
-          - -ST1021
-          - -ST1022
-          # Disable quickfix checks
-          - -QF*
   exclusions:
     generated: lax
     presets:

--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -186,7 +186,7 @@ func runOvnKubeDBChecker(ctx *cli.Context) error {
 		&kube.Kube{KClient: ovnClientset.KubeClient},
 		stopChan)
 	// run until cancelled
-	<-ctx.Context.Done()
+	<-ctx.Done()
 	close(stopChan)
 	return nil
 }

--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
@@ -151,7 +151,7 @@ func runHybridOverlay(ctx *cli.Context) error {
 	}()
 
 	// run until cancelled
-	<-ctx.Context.Done()
+	<-ctx.Done()
 	close(stopChan)
 	wg.Wait()
 	return nil

--- a/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux.go
@@ -167,7 +167,7 @@ func (n *NodeController) hybridOverlayNodeUpdate(node *corev1.Node) error {
 
 	// (re)add flows for the node
 	cookie := nameToCookie(node.Name)
-	drMACRaw := strings.Replace(drMAC.String(), ":", "", -1)
+	drMACRaw := strings.ReplaceAll(drMAC.String(), ":", "")
 
 	var flows []string
 	// Distributed Router MAC ARP responder flow; responds to ARP requests by OVN for
@@ -368,8 +368,8 @@ func (n *NodeController) recalculateFlowCache(oldDRIP net.IP, oldDRMAC net.Hardw
 	if oldDRMAC != nil {
 		macReplace = -1
 	}
-	oldDRMACRaw := strings.Replace(oldDRMAC.String(), ":", "", -1)
-	newDRMACRaw := strings.Replace(n.drMAC.String(), ":", "", -1)
+	oldDRMACRaw := strings.ReplaceAll(oldDRMAC.String(), ":", "")
+	newDRMACRaw := strings.ReplaceAll(n.drMAC.String(), ":", "")
 
 	portIPRawOld := getIPAsHexString(oldDRIP)
 	portIPRawNew := getIPAsHexString(n.drIP)
@@ -589,7 +589,7 @@ func (n *NodeController) EnsureHybridOverlayBridge(node *corev1.Node) error {
 	}
 	// Handle ARP for gateway address internally towards pods
 	// resubmit to table 1 for gateway mode arp processing
-	portMACRaw := strings.Replace(n.drMAC.String(), ":", "", -1)
+	portMACRaw := strings.ReplaceAll(n.drMAC.String(), ":", "")
 	portIPRaw := getIPAsHexString(n.drIP)
 	flows = append(flows,
 		fmt.Sprintf("table=0,priority=100,in_port=%s,arp_op=1,arp,arp_tpa=%s,"+

--- a/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux_test.go
@@ -85,7 +85,7 @@ func generateInitialFlowCacheEntry(mgmtInterfaceAddr, drIP, drMAC string) *flowC
 	Expect(err).NotTo(HaveOccurred())
 	gwIfAddr := util.GetNodeGatewayIfAddr(ipNet)
 	gwPortMAC := util.IPAddrToHWAddr(gwIfAddr.IP)
-	drMACRaw := strings.Replace(drMAC, ":", "", -1)
+	drMACRaw := strings.ReplaceAll(drMAC, ":", "")
 	return &flowCacheEntry{
 		flows: []string{
 			"table=0,priority=0,actions=drop",

--- a/go-controller/pkg/allocator/pod/pod_annotation_test.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation_test.go
@@ -1226,7 +1226,7 @@ func Test_allocatePodAnnotationWithRollback(t *testing.T) {
 			}
 
 			if tt.invalidNetworkAnnotation {
-				pod.ObjectMeta.Annotations = map[string]string{
+				pod.Annotations = map[string]string{
 					nadapi.NetworkAttachmentAnnot: "",
 				}
 			}

--- a/go-controller/pkg/clustermanager/networkconnect/controller_components_test.go
+++ b/go-controller/pkg/clustermanager/networkconnect/controller_components_test.go
@@ -134,13 +134,13 @@ func (tn testNAD) NAD() *nadv1.NetworkAttachmentDefinition {
 	// Set owner reference for CUDN
 	if tn.IsCUDN {
 		ownerRef := makeCUDNOwnerRef(tn.Network)
-		nad.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerRef}
+		nad.OwnerReferences = []metav1.OwnerReference{ownerRef}
 	}
 
 	// Set owner reference for UDN
 	if tn.IsUDN {
 		ownerRef := makeUDNOwnerRef(tn.Name)
-		nad.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerRef}
+		nad.OwnerReferences = []metav1.OwnerReference{ownerRef}
 	}
 
 	// Build NAD spec config

--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -76,7 +76,7 @@ func (p testPod) getPod(t *testing.T) *corev1.Pod {
 		if err != nil {
 			t.Fatalf("Invalid network selection")
 		}
-		pod.ObjectMeta.Annotations[nadapi.NetworkAttachmentAnnot] = string(bytes)
+		pod.Annotations[nadapi.NetworkAttachmentAnnot] = string(bytes)
 	}
 
 	return pod
@@ -1015,10 +1015,7 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 			}
 
 			var obtainedEvents []string
-			for {
-				if len(fakeRecorder.Events) == 0 {
-					break
-				}
+			for len(fakeRecorder.Events) > 0 {
 				obtainedEvents = append(obtainedEvents, <-fakeRecorder.Events)
 			}
 			g.Expect(tt.expectEvents).To(gomega.Equal(obtainedEvents))

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -332,7 +332,7 @@ func (tn testNAD) NAD() *nadtypes.NetworkAttachmentDefinition {
 			&metav1.ObjectMeta{Name: tn.Network},
 			userdefinednetworkv1.SchemeGroupVersion.WithKind("ClusterUserDefinedNetwork"),
 		)
-		nad.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerRef}
+		nad.OwnerReferences = []metav1.OwnerReference{ownerRef}
 	}
 
 	// Build the config as a map to properly marshal EVPN config

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
@@ -94,13 +94,13 @@ func (c *Controller) updateNAD(obj client.Object, namespace string) (*netv1.Netw
 		}
 	}
 
-	if reflect.DeepEqual(nadCopy.Spec.Config, desiredNAD.Spec.Config) && reflect.DeepEqual(nadCopy.ObjectMeta.Labels, desiredNAD.ObjectMeta.Labels) &&
+	if reflect.DeepEqual(nadCopy.Spec.Config, desiredNAD.Spec.Config) && reflect.DeepEqual(nadCopy.Labels, desiredNAD.Labels) &&
 		reflect.DeepEqual(desiredNAD.Annotations, nadCopy.Annotations) {
 		return nadCopy, nil
 	}
 
 	nadCopy.Spec.Config = desiredNAD.Spec.Config
-	nadCopy.ObjectMeta.Labels = desiredNAD.ObjectMeta.Labels
+	nadCopy.Labels = desiredNAD.Labels
 	nadCopy.Annotations = desiredNAD.Annotations
 	updatedNAD, err := c.nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nadCopy.Namespace).Update(context.Background(), nadCopy, metav1.UpdateOptions{})
 	if err != nil {

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -231,7 +231,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should fail when foreign NAD exist", func() {
 				udn := testPrimaryUDN()
 				foreignNad := testNAD()
-				foreignNad.ObjectMeta.OwnerReferences = nil
+				foreignNad.OwnerReferences = nil
 				c = newTestController(noopRenderNadStub(), udn, foreignNad, testNamespace("test"))
 				Expect(c.Run()).To(Succeed())
 
@@ -1762,7 +1762,7 @@ var _ = Describe("User Defined Network Controller", func() {
 		It("should fail when NAD owner-reference is malformed", func() {
 			udn := testPrimaryUDN()
 			mutatedNAD := testNAD()
-			mutatedNAD.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{Kind: "DifferentKind"}}
+			mutatedNAD.OwnerReferences = []metav1.OwnerReference{{Kind: "DifferentKind"}}
 			c := newTestController(noopRenderNadStub(), udn, mutatedNAD, testNamespace("test"))
 
 			_, err := c.syncUserDefinedNetwork(udn)
@@ -2654,7 +2654,7 @@ func testNADWithDeletionTimestamp(ts time.Time) *netv1.NetworkAttachmentDefiniti
 
 func testNamespace(name string) *corev1.Namespace {
 	ns := invalidTestNamespace(name)
-	ns.ObjectMeta.Labels[ovntypes.RequiredUDNNamespaceLabel] = ""
+	ns.Labels[ovntypes.RequiredUDNNamespaceLabel] = ""
 	return ns
 }
 

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -56,9 +56,10 @@ func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) 
 var expectedResult cnitypes.Result
 
 func serverHandleCNI(request *PodRequest, _ *ClientSet, _ *KubeAPIAuth, _ networkmanager.Interface, _ client.Client) ([]byte, error) {
-	if request.Command == CNIAdd {
+	switch request.Command {
+	case CNIAdd:
 		return json.Marshal(&expectedResult)
-	} else if request.Command == CNIDel || request.Command == CNIUpdate || request.Command == CNICheck || request.Command == CNIStatus {
+	case CNIDel, CNIUpdate, CNICheck, CNIStatus:
 		return nil, nil
 	}
 	return nil, fmt.Errorf("unhandled CNI command %v", request.Command)

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -2952,7 +2952,7 @@ func parseAddress(urlString string) (string, OvnDBScheme, error) {
 	var parsedAddress, scheme string
 	var parsedScheme OvnDBScheme
 
-	urlString = strings.Replace(urlString, "//", "", -1)
+	urlString = strings.ReplaceAll(urlString, "//", "")
 	for _, ovnAddress := range strings.Split(urlString, ",") {
 		splits := strings.SplitN(ovnAddress, ":", 2)
 		if len(splits) != 2 {
@@ -2985,12 +2985,12 @@ func parseAddress(urlString string) (string, OvnDBScheme, error) {
 		}
 	}
 
-	switch {
-	case scheme == "ssl":
+	switch scheme {
+	case "ssl":
 		parsedScheme = OvnDBSchemeSSL
-	case scheme == "tcp":
+	case "tcp":
 		parsedScheme = OvnDBSchemeTCP
-	case scheme == "unix":
+	case "unix":
 		parsedScheme = OvnDBSchemeUnix
 	default:
 		return "", "", fmt.Errorf("unknown OVN DB scheme %q", scheme)
@@ -3057,16 +3057,16 @@ func buildOvnAuth(exec kexec.Interface, northbound bool, cliAuth, confAuth *OvnA
 		return nil, err
 	}
 
-	switch {
-	case auth.Scheme == OvnDBSchemeSSL:
+	switch auth.Scheme {
+	case OvnDBSchemeSSL:
 		if auth.PrivKey == "" || auth.Cert == "" || auth.CACert == "" || auth.CertCommonName == "" {
 			return nil, fmt.Errorf("must specify private key, certificate, CA certificate, and common name used in the certificate for 'ssl' scheme")
 		}
-	case auth.Scheme == OvnDBSchemeTCP:
+	case OvnDBSchemeTCP:
 		if auth.PrivKey != "" || auth.Cert != "" || auth.CACert != "" {
 			return nil, fmt.Errorf("certificate or key given; perhaps you mean to use the 'ssl' scheme?")
 		}
-	case auth.Scheme == OvnDBSchemeUnix:
+	case OvnDBSchemeUnix:
 		if auth.PrivKey != "" || auth.Cert != "" || auth.CACert != "" {
 			return nil, fmt.Errorf("certificate or key given; perhaps you mean to use the 'ssl' scheme?")
 		}
@@ -3231,7 +3231,7 @@ func buildOvnKubeNodeConfig(cli, file *config) error {
 	// when DPU is used, management port is always backed by a representor. On the
 	// host side, it needs to be provided through --ovnkube-node-mgmt-port-netdev.
 	// On the DPU, it is derrived from the annotation exposed on the host side.
-	if OvnKubeNode.Mode == types.NodeModeDPU && !(OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "") {
+	if OvnKubeNode.Mode == types.NodeModeDPU && (OvnKubeNode.MgmtPortNetdev != "" || OvnKubeNode.MgmtPortDPResourceName != "") {
 		return fmt.Errorf("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must not be provided")
 	}
 	if OvnKubeNode.Mode == types.NodeModeDPUHost && OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "" {

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -589,11 +589,12 @@ var _ = Describe("Watch Factory Operations", func() {
 
 	Context("when a processExisting is given", func() {
 		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector, priority int) {
-			if objType == EndpointSliceType {
+			switch objType {
+			case EndpointSliceType:
 				wf, err = NewNodeWatchFactory(ovnClientset.GetNodeClientset(), nodeName)
-			} else if objType == CloudPrivateIPConfigType {
+			case CloudPrivateIPConfigType:
 				wf, err = NewClusterManagerWatchFactory(ovnCMClientset)
-			} else {
+			default:
 				wf, err = NewMasterWatchFactory(ovnClientset)
 			}
 			Expect(err).NotTo(HaveOccurred())
@@ -613,11 +614,12 @@ var _ = Describe("Watch Factory Operations", func() {
 		}
 
 		testExistingFilteredHandler := func(objType reflect.Type, realObj reflect.Type, namespace string, sel labels.Selector, priority int) {
-			if objType == EndpointSliceType {
+			switch objType {
+			case EndpointSliceType:
 				wf, err = NewNodeWatchFactory(ovnClientset.GetNodeClientset(), nodeName)
-			} else if objType == CloudPrivateIPConfigType {
+			case CloudPrivateIPConfigType:
 				wf, err = NewClusterManagerWatchFactory(ovnCMClientset)
-			} else {
+			default:
 				wf, err = NewMasterWatchFactory(ovnClientset)
 			}
 			Expect(err).NotTo(HaveOccurred())
@@ -733,7 +735,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		It("is called for each existing pod that matches a given namespace and label", func() {
 			pod := newPod("pod1", "default")
-			pod.ObjectMeta.Labels["blah"] = "foobar"
+			pod.Labels["blah"] = "foobar"
 			pods = append(pods, pod)
 
 			sel, err := metav1.LabelSelectorAsSelector(
@@ -749,11 +751,12 @@ var _ = Describe("Watch Factory Operations", func() {
 
 	Context("when existing items are known to the informer", func() {
 		testExisting := func(objType reflect.Type) {
-			if objType == EndpointSliceType {
+			switch objType {
+			case EndpointSliceType:
 				wf, err = NewNodeWatchFactory(ovnClientset.GetNodeClientset(), nodeName)
-			} else if objType == CloudPrivateIPConfigType {
+			case CloudPrivateIPConfigType:
 				wf, err = NewClusterManagerWatchFactory(ovnCMClientset)
-			} else {
+			default:
 				wf, err = NewMasterWatchFactory(ovnClientset)
 			}
 			Expect(err).NotTo(HaveOccurred())
@@ -2170,11 +2173,11 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		passesFilter := newPod("pod1", "default")
-		passesFilter.ObjectMeta.Labels["blah"] = "foobar"
+		passesFilter.Labels["blah"] = "foobar"
 		failsFilter := newPod("pod2", "default")
-		failsFilter.ObjectMeta.Labels["blah"] = "baz"
+		failsFilter.Labels["blah"] = "baz"
 		failsFilter2 := newPod("pod3", "otherns")
-		failsFilter2.ObjectMeta.Labels["blah"] = "foobar"
+		failsFilter2.Labels["blah"] = "foobar"
 
 		sel, err := metav1.LabelSelectorAsSelector(
 			&metav1.LabelSelector{
@@ -2242,7 +2245,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		pod := newPod("pod1", "default")
-		pod.ObjectMeta.Labels["blah"] = "baz"
+		pod.Labels["blah"] = "baz"
 
 		sel, err := metav1.LabelSelectorAsSelector(
 			&metav1.LabelSelector{
@@ -2280,14 +2283,14 @@ var _ = Describe("Watch Factory Operations", func() {
 		// Update pod to pass filter; should be treated as add.  Need
 		// to deep-copy pod when modifying because it's a pointer all
 		// the way through when using FakeClient
-		podCopy.ObjectMeta.Labels["blah"] = "foobar"
+		podCopy.Labels["blah"] = "foobar"
 		pods = []*corev1.Pod{podCopy}
 		equalPod = podCopy
 		podWatch.Modify(podCopy)
 		Eventually(c.getAdded, 2).Should(Equal(1))
 
 		// Update pod to fail filter; should be treated as delete
-		podCopy2.ObjectMeta.Labels["blah"] = "baz"
+		podCopy2.Labels["blah"] = "baz"
 		podWatch.Modify(podCopy2)
 		Eventually(c.getDeleted, 2).Should(Equal(1))
 		Consistently(c.getAdded, 2).Should(Equal(1))

--- a/go-controller/pkg/generator/udn/join_ips.go
+++ b/go-controller/pkg/generator/udn/join_ips.go
@@ -54,7 +54,7 @@ func GetGWRouterIPv6(node *corev1.Node, netInfo util.NetInfo) (net.IP, error) {
 func GetGWRouterIPs(node *corev1.Node, netInfo util.NetInfo) ([]*net.IPNet, error) {
 	var gwRouterAddrs []*net.IPNet
 	// we allocate join subnets for L3/L2 primary user defined networks or default network
-	if !(netInfo.IsDefault() || (util.IsNetworkSegmentationSupportEnabled() && netInfo.IsPrimaryNetwork())) {
+	if !netInfo.IsDefault() && (!util.IsNetworkSegmentationSupportEnabled() || !netInfo.IsPrimaryNetwork()) {
 		return gwRouterAddrs, nil
 	}
 	// Allocate the IP address(es) for the node Gateway router port connecting

--- a/go-controller/pkg/kube/kube_test.go
+++ b/go-controller/pkg/kube/kube_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Kube", func() {
 
 		It("adds a resourceVersion guard when creating a missing annotation key", func() {
 			var patchOps []jsonPatchOp
-			kube.KClient.(*fake.Clientset).Fake.PrependReactor("patch", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+			kube.KClient.(*fake.Clientset).PrependReactor("patch", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
 				patchAction := action.(ktesting.PatchAction)
 				Expect(patchAction.GetSubresource()).To(Equal("status"))
 				Expect(json.Unmarshal(patchAction.GetPatch(), &patchOps)).To(Succeed())
@@ -215,7 +215,7 @@ var _ = Describe("Kube", func() {
 
 		It("uses a per-key guard when updating an existing annotation key", func() {
 			var patchOps []jsonPatchOp
-			kube.KClient.(*fake.Clientset).Fake.PrependReactor("patch", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+			kube.KClient.(*fake.Clientset).PrependReactor("patch", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
 				patchAction := action.(ktesting.PatchAction)
 				Expect(patchAction.GetSubresource()).To(Equal("status"))
 				Expect(json.Unmarshal(patchAction.GetPatch(), &patchOps)).To(Succeed())

--- a/go-controller/pkg/libovsdb/util/acl.go
+++ b/go-controller/pkg/libovsdb/util/acl.go
@@ -177,11 +177,12 @@ type ACLLoggingLevels struct {
 func getLogSeverity(action string, aclLogging *ACLLoggingLevels) (log bool, severity string) {
 	severity = ""
 	if aclLogging != nil {
-		if action == nbdb.ACLActionAllow || action == nbdb.ACLActionAllowRelated || action == nbdb.ACLActionAllowStateless {
+		switch action {
+		case nbdb.ACLActionAllow, nbdb.ACLActionAllowRelated, nbdb.ACLActionAllowStateless:
 			severity = aclLogging.Allow
-		} else if action == nbdb.ACLActionDrop || action == nbdb.ACLActionReject {
+		case nbdb.ACLActionDrop, nbdb.ACLActionReject:
 			severity = aclLogging.Deny
-		} else if action == nbdb.ACLActionPass {
+		case nbdb.ACLActionPass:
 			severity = aclLogging.Pass
 		}
 	}

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -120,13 +120,14 @@ func getCoverageShowOutputMap(component string) (map[string]string, error) {
 		}
 	}()
 
-	if component == ovnController {
+	switch component {
+	case ovnController:
 		stdout, stderr, err = util.RunOVNControllerAppCtl("coverage/show")
-	} else if component == ovnNorthd {
+	case ovnNorthd:
 		stdout, stderr, err = util.RunOVNNorthAppCtl("coverage/show")
-	} else if component == ovsVswitchd {
+	case ovsVswitchd:
 		stdout, stderr, err = util.RunOvsVswitchdAppCtl("coverage/show")
-	} else {
+	default:
 		return nil, fmt.Errorf("component is unknown, and it isn't %s, %s, or %s",
 			ovnNorthd, ovnController, ovsVswitchd)
 	}
@@ -427,8 +428,8 @@ func klogSetter(val string) (string, error) {
 // stringFlagPutHandler wraps an http Handler to set string type flag.
 func stringFlagPutHandler(setter stringFlagSetterFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		switch {
-		case req.Method == "PUT":
+		switch req.Method {
+		case "PUT":
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				writePlainText(http.StatusBadRequest, "error reading request body: "+err.Error(), w)

--- a/go-controller/pkg/metrics/ovnkube_controller.go
+++ b/go-controller/pkg/metrics/ovnkube_controller.go
@@ -577,13 +577,14 @@ func UpdateEgressFirewallRuleCount(count float64) {
 // 1: If it is local gateway mode
 // 2: invalid mode
 func RecordEgressRoutingViaHost() {
-	if config.Gateway.Mode == config.GatewayModeLocal {
+	switch config.Gateway.Mode {
+	case config.GatewayModeLocal:
 		// routingViaHost is enabled
 		metricEgressRoutingViaHost.Set(1)
-	} else if config.Gateway.Mode == config.GatewayModeShared {
+	case config.GatewayModeShared:
 		// routingViaOVN is enabled
 		metricEgressRoutingViaHost.Set(0)
-	} else {
+	default:
 		// invalid mode
 		metricEgressRoutingViaHost.Set(2)
 	}

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -1422,7 +1422,7 @@ func TestSyncAll(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
 					Annotations: map[string]string{
-						util.OvnNetworkIDs: fmt.Sprintf(`{"%s": "%d"}`, network_A.NetConf.Name, nodeNetworkID),
+						util.OvnNetworkIDs: fmt.Sprintf(`{"%s": "%d"}`, network_A.Name, nodeNetworkID),
 					},
 				},
 			},
@@ -1440,7 +1440,7 @@ func TestSyncAll(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-node",
 					Annotations: map[string]string{
-						util.OvnNetworkIDs: fmt.Sprintf(`{"%s": "%d"}`, network_A.NetConf.Name, nodeNetworkID),
+						util.OvnNetworkIDs: fmt.Sprintf(`{"%s": "%d"}`, network_A.Name, nodeNetworkID),
 					},
 				},
 			},
@@ -1522,11 +1522,12 @@ func TestSyncAll(t *testing.T) {
 			}
 
 			var controller Controller
-			if tt.mode == modeZone {
+			switch tt.mode {
+			case modeZone:
 				controller, err = NewForZone("test", tcm, wf)
-			} else if tt.mode == modeNode {
+			case modeNode:
 				controller, err = NewForNode("test", tcm, wf)
-			} else {
+			default:
 				controller, err = NewForCluster(
 					tcm,
 					wf,

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1089,13 +1089,14 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	}
 
 	if nc.dpuNodeLeaseManager != nil {
-		if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		switch config.OvnKubeNode.Mode {
+		case types.NodeModeDPU:
 			nc.wg.Add(1)
 			go func() {
 				defer nc.wg.Done()
 				nc.dpuNodeLeaseManager.RunUpdater(ctx)
 			}()
-		} else if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+		case types.NodeModeDPUHost:
 			if err := nc.dpuNodeLeaseManager.CheckStatus(ctx); err != nil {
 				klog.Warningf("Initial DPU node lease check failed: %v", err)
 			}

--- a/go-controller/pkg/node/dpulease/manager.go
+++ b/go-controller/pkg/node/dpulease/manager.go
@@ -296,7 +296,7 @@ func (m *Manager) isExpired(lease *coordinationv1.Lease) (bool, string) {
 		return true, "DPU node lease missing renew time or duration"
 	}
 
-	expire := lease.Spec.RenewTime.Time.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second)
+	expire := lease.Spec.RenewTime.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second)
 	if time.Now().After(expire) {
 		return true, fmt.Sprintf("DPU node lease expired at %s", expire.UTC().Format(time.RFC3339))
 	}

--- a/go-controller/pkg/node/dpulease/manager_test.go
+++ b/go-controller/pkg/node/dpulease/manager_test.go
@@ -118,7 +118,7 @@ func TestEnsureLeaseRetriesOnAlreadyExists(t *testing.T) {
 	mgr := NewManager(client, "ovn-kubernetes", node, time.Second, 20*time.Second)
 
 	getCalls := 0
-	client.Fake.PrependReactor("get", "leases", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("get", "leases", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		getCalls++
 		if getCalls == 1 {
 			return true, nil, apierrors.NewNotFound(schema.GroupResource{Group: coordinationv1.GroupName, Resource: "leases"}, "ovn-dpu-worker")
@@ -127,7 +127,7 @@ func TestEnsureLeaseRetriesOnAlreadyExists(t *testing.T) {
 	})
 
 	createCalls := 0
-	client.Fake.PrependReactor("create", "leases", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("create", "leases", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		createCalls++
 		if createCalls == 1 {
 			now := metav1.NowMicro()

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -85,7 +85,7 @@ func getGatewayNextHops() ([]net.IP, string, error) {
 	if needIPv4NextHop || needIPv6NextHop || gatewayIntf == "" {
 		defaultGatewayIntf, defaultGatewayNextHops, err := getDefaultGatewayInterfaceDetails(gatewayIntf, config.IPv4Mode, config.IPv6Mode)
 		if err != nil {
-			if !(errors.As(err, new(*GatewayInterfaceMismatchError)) && config.Gateway.Mode == config.GatewayModeLocal && config.Gateway.AllowNoUplink) {
+			if !errors.As(err, new(*GatewayInterfaceMismatchError)) || config.Gateway.Mode != config.GatewayModeLocal || !config.Gateway.AllowNoUplink {
 				return nil, "", err
 			}
 		}

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -194,11 +194,12 @@ func makeConntrackFilter(ip string, port int, protocol corev1.Protocol, filterTy
 	filter := &netlink.ConntrackFilter{}
 
 	var err error
-	if protocol == corev1.ProtocolUDP {
+	switch protocol {
+	case corev1.ProtocolUDP:
 		err = filter.AddProtocol(17)
-	} else if protocol == corev1.ProtocolTCP {
+	case corev1.ProtocolTCP:
 		err = filter.AddProtocol(6)
-	} else if protocol == corev1.ProtocolSCTP {
+	case corev1.ProtocolSCTP:
 		err = filter.AddProtocol(132)
 	}
 	Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1837,11 +1837,12 @@ func newNodePortWatcher(
 	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
 	// NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
 	if config.OvnKubeNode.Mode == types.NodeModeFull {
-		if config.Gateway.Mode == config.GatewayModeLocal {
+		switch config.Gateway.Mode {
+		case config.GatewayModeLocal:
 			if err := initLocalGatewayIPTables(); err != nil {
 				return nil, err
 			}
-		} else if config.Gateway.Mode == config.GatewayModeShared {
+		case config.GatewayModeShared:
 			if err := initSharedGatewayIPTables(); err != nil {
 				return nil, err
 			}
@@ -1874,10 +1875,7 @@ func newNodePortWatcher(
 	}
 
 	// used to tell addServiceRules which rules to add
-	dpuMode := false
-	if config.OvnKubeNode.Mode != types.NodeModeFull {
-		dpuMode = true
-	}
+	dpuMode := config.OvnKubeNode.Mode != types.NodeModeFull
 
 	// Get Physical IPs of Node, Can be IPV4 IPV6 or both
 	gatewayIPv4, gatewayIPv6 := getGatewayFamilyAddrs(gwBridge.GetIPs())

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -213,7 +213,7 @@ func (udng *UserDefinedNetworkGateway) addMarkChain() error {
 // required by this UDN on the gateway side
 func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && udng.openflowManager == nil {
-		return fmt.Errorf("openflow manager has not been provided for network: %s", udng.NetInfo.GetNetworkName())
+		return fmt.Errorf("openflow manager has not been provided for network: %s", udng.GetNetworkName())
 	}
 
 	nodeSubnets, err := udng.getLocalSubnets()
@@ -442,7 +442,7 @@ func (udng *UserDefinedNetworkGateway) addUDNManagementPortIPs(mpLink netlink.Li
 // computeRoutesForUDN returns a list of routes programmed into a given UDN's VRF
 // when adding new routes please leave a sample comment on how that route looks like
 func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) ([]netlink.Route, error) {
-	networkMTU := udng.NetInfo.MTU()
+	networkMTU := udng.MTU()
 	if networkMTU == 0 {
 		networkMTU = config.Default.MTU
 	}
@@ -527,7 +527,7 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 			Gw:    gwIP.IP,
 			Table: udng.vrfTableId,
 		})
-		if udng.NetInfo.TopologyType() == types.Layer3Topology {
+		if udng.TopologyType() == types.Layer3Topology {
 			for _, clusterSubnet := range udng.Subnets() {
 				if clusterSubnet.CIDR.Contains(gwIP.IP) {
 					retVal = append(retVal, netlink.Route{
@@ -569,14 +569,14 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 }
 
 func (udng *UserDefinedNetworkGateway) getDefaultRoute() ([]netlink.Route, error) {
-	networkMTU := udng.NetInfo.MTU()
+	networkMTU := udng.MTU()
 	if networkMTU == 0 {
 		networkMTU = config.Default.MTU
 	}
 
 	var retVal []netlink.Route
 	var defaultAnyCIDR *net.IPNet
-	for _, nextHop := range udng.gateway.nextHops {
+	for _, nextHop := range udng.nextHops {
 		isV6 := utilnet.IsIPv6(nextHop)
 		_, defaultAnyCIDR, _ = net.ParseCIDR("0.0.0.0/0")
 		if isV6 {

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -267,10 +267,10 @@ func getDummyOpenflowManager() *openflowManager {
 
 var _ = Describe("UserDefinedNetworkGateway", func() {
 	var (
-		netName               = "bluenet"
-		netID                 = "3"
-		nodeName       string = "worker1"
-		mgtPortMAC     string = "00:00:00:55:66:77" // dummy MAC used for fake commands
+		netName        = "bluenet"
+		netID          = "3"
+		nodeName       = "worker1"
+		mgtPortMAC     = "00:00:00:55:66:77" // dummy MAC used for fake commands
 		fexec          *ovntest.FakeExec
 		testNS         ns.NetNS
 		factoryMock    factoryMocks.NodeWatchFactory
@@ -703,7 +703,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			udnGateway, err := NewUserDefinedNetworkGateway(netInfo, node, wf.NodeCoreInformer().Lister(),
 				&kubeMock, vrf, ipRulesManager, localGw)
 			Expect(err).NotTo(HaveOccurred())
-			flowMap := udnGateway.gateway.openflowManager.flowCache
+			flowMap := udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
@@ -721,7 +721,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // only default network
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
-			flowMap = udnGateway.gateway.openflowManager.flowCache
+			flowMap = udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(70))                                      // 18 UDN Flows are added by default
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
@@ -757,7 +757,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			cnode := node.DeepCopy()
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
-			flowMap = udnGateway.gateway.openflowManager.flowCache
+			flowMap = udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
@@ -940,7 +940,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(err).NotTo(HaveOccurred())
 			udnGateway.mgmtPortController, err = managementport.NewUDNManagementPortController(udnGateway.nodeLister, udnGateway.node.Name, localSubnets, udnGateway.NetInfo)
 			Expect(err).NotTo(HaveOccurred())
-			flowMap := udnGateway.gateway.openflowManager.flowCache
+			flowMap := udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
@@ -960,7 +960,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			err = udnGateway.DelNetwork()
 			Expect(err).To(MatchError(ContainSubstring("fake delete metadata error")))
 			By("Ensuring everything else was still cleaned up correctly")
-			flowMap = udnGateway.gateway.openflowManager.flowCache
+			flowMap = udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
@@ -1133,7 +1133,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			udnGateway, err := NewUserDefinedNetworkGateway(netInfo, node, wf.NodeCoreInformer().Lister(),
 				&kubeMock, vrf, ipRulesManager, localGw)
 			Expect(err).NotTo(HaveOccurred())
-			flowMap := udnGateway.gateway.openflowManager.flowCache
+			flowMap := udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
@@ -1150,7 +1150,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // only default network
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
-			flowMap = udnGateway.gateway.openflowManager.flowCache
+			flowMap = udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(70))                                      // 18 UDN Flows are added by default
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
@@ -1186,7 +1186,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			cnode := node.DeepCopy()
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
-			flowMap = udnGateway.gateway.openflowManager.flowCache
+			flowMap = udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
@@ -1373,7 +1373,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			udnGateway, err := NewUserDefinedNetworkGateway(mutableNetInfo, node, wf.NodeCoreInformer().Lister(),
 				&kubeMock, vrf, ipRulesManager, localGw)
 			Expect(err).NotTo(HaveOccurred())
-			flowMap := udnGateway.gateway.openflowManager.flowCache
+			flowMap := udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
@@ -1391,7 +1391,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // only default network
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
-			flowMap = udnGateway.gateway.openflowManager.flowCache
+			flowMap = udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(80))                                      // 18 UDN Flows, 5 advertisedUDN flows, and 2 packet mark flows (IPv4+IPv6) are added by default
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
@@ -1429,7 +1429,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			cnode := node.DeepCopy()
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
-			flowMap = udnGateway.gateway.openflowManager.flowCache
+			flowMap = udnGateway.openflowManager.flowCache
 			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0

--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -300,7 +300,7 @@ func (c *Controller) isAddressValid(address netlink.Addr) bool {
 	if address.IPNet == nil {
 		return false
 	}
-	if address.IPNet.IP.IsUnspecified() {
+	if address.IP.IsUnspecified() {
 		return false
 	}
 	if utilnet.IsIPv4(address.IP) && !c.ipv4Enabled {

--- a/go-controller/pkg/node/linkmanager/link_network_manager_test.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager_test.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("Link network manager", func() {
 		nlMock.On("AddrAdd", nlLink1Mock, &linkAddr).Return(nil)
 		c = NewController("test", v4Enabled, v6Enabled, nil)
 		gomega.Expect(c.AddAddress(linkAddr)).Should(gomega.Succeed())
-		nlMock.Mock.ExpectedCalls = nil
+		nlMock.ExpectedCalls = nil
 		nlMock.On("LinkByIndex", getLinkIndexFromName(linkName1)).Return(nil, netlink.LinkNotFoundError{})
 		nlMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 		gomega.Expect(c.DelAddress(linkAddr)).Should(gomega.Succeed())

--- a/go-controller/pkg/node/netlinkdevicemanager/link.go
+++ b/go-controller/pkg/node/netlinkdevicemanager/link.go
@@ -146,13 +146,13 @@ func normalizeLinkState(desired netlink.Link, state netlink.Link) netlink.Link {
 	case *netlink.Vlan:
 		r := result.(*netlink.Vlan)
 		if des.Attrs().ParentIndex == 0 {
-			r.LinkAttrs.ParentIndex = 0
+			r.ParentIndex = 0
 		}
 		if des.VlanProtocol == 0 {
 			r.VlanProtocol = 0
 		}
 		if len(des.Attrs().HardwareAddr) == 0 {
-			r.LinkAttrs.HardwareAddr = nil
+			r.HardwareAddr = nil
 		}
 	case *netlink.Vrf:
 		// No conditional fields — Table is always compared
@@ -228,7 +228,7 @@ func linkImmutableFieldsEqual(l, r netlink.Link) bool {
 	case *netlink.Vlan:
 		rv := r.(*netlink.Vlan)
 		if lv.VlanId != rv.VlanId ||
-			lv.LinkAttrs.ParentIndex != rv.LinkAttrs.ParentIndex ||
+			lv.ParentIndex != rv.ParentIndex ||
 			lv.VlanProtocol != rv.VlanProtocol ||
 			!bytes.Equal(lv.Attrs().HardwareAddr, rv.Attrs().HardwareAddr) {
 			return false
@@ -349,7 +349,7 @@ func validateConfig(cfg *DeviceConfig) error {
 		return fmt.Errorf("device %q: VLANParent set but Link is %T, not *netlink.Vlan", name, cfg.Link)
 	}
 	for _, addr := range cfg.Addresses {
-		if addr.IPNet != nil && isLinkLocalAddress(addr.IPNet.IP) {
+		if addr.IPNet != nil && isLinkLocalAddress(addr.IP) {
 			return fmt.Errorf("device %q: link-local address %s cannot be managed (kernel-managed)", name, addr.IPNet)
 		}
 	}

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("UserDefinedNodeNetworkController", func() {
 		nad       = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
 		fexec      *ovntest.FakeExec
-		mgtPortMAC string = "00:00:00:55:66:77" // dummy MAC used for fake commands
+		mgtPortMAC = "00:00:00:55:66:77" // dummy MAC used for fake commands
 	)
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -158,10 +158,10 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 	var (
 		nad = ovntest.GenerateNAD("bluenet", "rednad", "greenamespace",
 			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
-		netName                 = "bluenet"
-		netID                   = 3
-		nodeName         string = "worker1"
-		mgtPortMAC       string = "00:00:00:55:66:77"
+		netName          = "bluenet"
+		netID            = 3
+		nodeName         = "worker1"
+		mgtPortMAC       = "00:00:00:55:66:77"
 		fexec            *ovntest.FakeExec
 		testNS           ns.NetNS
 		vrf              *vrfmanager.Controller

--- a/go-controller/pkg/ovn/admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/admin_network_policy_test.go
@@ -1571,11 +1571,12 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 					acl := acl
 					// update ACL logging information
 					acl.Log = true
-					if acl.Action == nbdb.ACLActionPass {
+					switch acl.Action {
+					case nbdb.ACLActionPass:
 						acl.Severity = ptr.To(nbdb.ACLSeverityNotice)
-					} else if acl.Action == nbdb.ACLActionDrop {
+					case nbdb.ACLActionDrop:
 						acl.Severity = ptr.To(nbdb.ACLSeverityAlert)
-					} else if acl.Action == nbdb.ACLActionAllowRelated {
+					case nbdb.ACLActionAllowRelated:
 						acl.Severity = ptr.To(nbdb.ACLSeverityInfo)
 					}
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -1602,11 +1603,12 @@ var _ = ginkgo.Describe("OVN ANP Operations", func() {
 					acl := acl.(*nbdb.ACL)
 					// update ACL logging information
 					acl.Log = true
-					if acl.Action == nbdb.ACLActionPass {
+					switch acl.Action {
+					case nbdb.ACLActionPass:
 						acl.Severity = ptr.To(nbdb.ACLSeverityInfo)
-					} else if acl.Action == nbdb.ACLActionDrop {
+					case nbdb.ACLActionDrop:
 						acl.Severity = ptr.To(nbdb.ACLSeverityWarning)
-					} else if acl.Action == nbdb.ACLActionAllowRelated {
+					case nbdb.ACLActionAllowRelated:
 						acl.Severity = ptr.To(nbdb.ACLSeverityDebug)
 					}
 				}

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -1280,7 +1280,7 @@ func (bnc *BaseNetworkController) newNetworkQoSController() error {
 	}
 	bnc.nqosController, err = nqoscontroller.NewController(
 		bnc.controllerName,
-		bnc.ReconcilableNetInfo.GetNetInfo(),
+		bnc.GetNetInfo(),
 		bnc.nbClient,
 		bnc.recorder,
 		bnc.kube.NetworkQoSClient,

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -574,9 +574,10 @@ func getPolicyType(policy *knet.NetworkPolicy) (bool, bool) {
 	var policyTypeEgress bool
 
 	for _, policyType := range policy.Spec.PolicyTypes {
-		if policyType == knet.PolicyTypeIngress {
+		switch policyType {
+		case knet.PolicyTypeIngress:
 			policyTypeIngress = true
-		} else if policyType == knet.PolicyTypeEgress {
+		case knet.PolicyTypeEgress:
 			policyTypeEgress = true
 		}
 	}

--- a/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
@@ -824,9 +824,10 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					acl := acl
 					// update ACL logging information
 					acl.Log = true
-					if acl.Action == nbdb.ACLActionDrop {
+					switch acl.Action {
+					case nbdb.ACLActionDrop:
 						acl.Severity = ptr.To(nbdb.ACLSeverityAlert)
-					} else if acl.Action == nbdb.ACLActionAllowRelated {
+					case nbdb.ACLActionAllowRelated:
 						acl.Severity = ptr.To(nbdb.ACLSeverityInfo)
 					}
 					expectedDatabaseState = append(expectedDatabaseState, acl)
@@ -850,9 +851,10 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 					acl := acl.(*nbdb.ACL)
 					// update ACL logging information
 					acl.Log = true
-					if acl.Action == nbdb.ACLActionDrop {
+					switch acl.Action {
+					case nbdb.ACLActionDrop:
 						acl.Severity = ptr.To(nbdb.ACLSeverityWarning)
-					} else if acl.Action == nbdb.ACLActionAllowRelated {
+					case nbdb.ACLActionAllowRelated:
 						acl.Severity = ptr.To(nbdb.ACLSeverityDebug)
 					}
 				}

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
@@ -69,7 +69,7 @@ func deletePolicy(policyName string, fakeRouteClient *adminpolicybasedrouteclien
 func deleteNamespace(namespaceName string, fakeClient *fake.Clientset) {
 	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	ns.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	ns.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 	_, err = fakeClient.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	err = fakeClient.CoreV1().Namespaces().Delete(context.Background(), namespaceName, metav1.DeleteOptions{})

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
@@ -63,10 +63,10 @@ func getPodIPs(pod *corev1.Pod) sets.Set[string] {
 func getMultusIPsFromNetworkName(pod *corev1.Pod, networkName string) (sets.Set[string], error) {
 	foundGws := sets.New[string]()
 	var multusNetworks []nettypes.NetworkStatus
-	err := json.Unmarshal([]byte(pod.ObjectMeta.Annotations[nettypes.NetworkStatusAnnot]), &multusNetworks)
+	err := json.Unmarshal([]byte(pod.Annotations[nettypes.NetworkStatusAnnot]), &multusNetworks)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshall annotation on pod %s %s '%s': %v",
-			pod.Name, nettypes.NetworkStatusAnnot, pod.ObjectMeta.Annotations[nettypes.NetworkStatusAnnot], err)
+			pod.Name, nettypes.NetworkStatusAnnot, pod.Annotations[nettypes.NetworkStatusAnnot], err)
 	}
 	for _, multusNetwork := range multusNetworks {
 		if multusNetwork.Name == networkName {

--- a/go-controller/pkg/ovn/controller/apbroute/repair.go
+++ b/go-controller/pkg/ovn/controller/apbroute/repair.go
@@ -35,11 +35,12 @@ func (c *ExternalGatewayMasterController) Repair() error {
 
 	// migration from LGW to SGW mode
 	// for shared gateway mode, these LRPs shouldn't exist, so delete them all
-	if config.Gateway.Mode == config.GatewayModeShared {
+	switch config.Gateway.Mode {
+	case config.GatewayModeShared:
 		if err := c.nbClient.delAllHybridRoutePolicies(); err != nil {
 			klog.Errorf("Error while removing hybrid policies on moving to SGW mode, error: %v", err)
 		}
-	} else if config.Gateway.Mode == config.GatewayModeLocal {
+	case config.GatewayModeLocal:
 		// remove all legacy hybrid route policies
 		if err := c.nbClient.delAllLegacyHybridRoutePolicies(); err != nil {
 			klog.Errorf("Error while removing legacy hybrid policies, error: %v", err)

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_controller.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_controller.go
@@ -510,7 +510,7 @@ func (c *Controller) onNQOSPodUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *Controller) podNetworkResolver() func(nadKey string) string {
-	if !c.NetInfo.IsUserDefinedNetwork() {
+	if !c.IsUserDefinedNetwork() {
 		return nil
 	}
 	return c.networkManager.GetNetworkNameForNADKey

--- a/go-controller/pkg/ovn/controller/services/svc_template_var.go
+++ b/go-controller/pkg/ovn/controller/services/svc_template_var.go
@@ -61,7 +61,7 @@ func templateNameFromReference(template string) string {
 // "Service__default_node_port_svc__UDP__30957__node__router__template__IPv4"
 func makeTemplateName(name string) string {
 	invalidChars := regexp.MustCompile(`[/\-$@]`)
-	name = strings.Replace(name, "_", "__", -1)
+	name = strings.ReplaceAll(name, "_", "__")
 	return invalidChars.ReplaceAllString(name, "_")
 }
 

--- a/go-controller/pkg/ovn/controller/unidling/unidle.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle.go
@@ -196,11 +196,12 @@ func (uc *unidlingController) handleLbEmptyBackendsEvent(event sbdb.ControllerEv
 	}
 	proto := event.EventInfo["protocol"]
 	var protocol corev1.Protocol
-	if proto == "udp" {
+	switch proto {
+	case "udp":
 		protocol = corev1.ProtocolUDP
-	} else if proto == "sctp" {
+	case "sctp":
 		protocol = corev1.ProtocolSCTP
-	} else {
+	default:
 		protocol = corev1.ProtocolTCP
 	}
 

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -614,7 +614,7 @@ func (oc *DefaultNetworkController) run(_ context.Context) error {
 }
 
 func (oc *DefaultNetworkController) Reconcile(netInfo util.NetInfo) error {
-	return oc.BaseNetworkController.reconcile(
+	return oc.reconcile(
 		netInfo,
 		func(node string) { oc.gatewaysFailed.Store(node, true) },
 	)

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -935,7 +935,7 @@ func getExGwPodIPs(gatewayPod *corev1.Pod) (sets.Set[string], error) {
 	foundGws := sets.New[string]()
 	if gatewayPod.Annotations[util.RoutingNetworkAnnotation] != "" {
 		var multusNetworks []nettypes.NetworkStatus
-		err := json.Unmarshal([]byte(gatewayPod.ObjectMeta.Annotations[nettypes.NetworkStatusAnnot]), &multusNetworks)
+		err := json.Unmarshal([]byte(gatewayPod.Annotations[nettypes.NetworkStatusAnnot]), &multusNetworks)
 		if err != nil {
 			return nil, fmt.Errorf("unable to unmarshall annotation k8s.v1.cni.cncf.io/network-status on pod %s: %v",
 				gatewayPod.Name, err)

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -927,7 +927,7 @@ func (e *EgressIPController) addPodEgressIPAssignments(ni util.NetInfo, name str
 		for _, status := range statusAssignments {
 			// Add the status if it's not already in the cache, or if it exists but is in pending state
 			// (meaning it was populated during EIP sync and needs to be processed for the pod).
-			if value, exists := podState.egressStatuses.statusMap[status]; !exists || value == egressStatusStatePending {
+			if value, exists := podState.statusMap[status]; !exists || value == egressStatusStatePending {
 				remainingAssignments = append(remainingAssignments, status)
 			} else if podIPsChanged {
 				// A pod can be re-created with the same name but a different IP.
@@ -936,7 +936,7 @@ func (e *EgressIPController) addPodEgressIPAssignments(ni util.NetInfo, name str
 			}
 			// Detect stale EIP status entries (same EgressIP reassigned to a different node)
 			// and queue the outdated entry for cleanup.
-			if staleStatus := podState.egressStatuses.hasStaleEIPStatus(status); staleStatus != nil {
+			if staleStatus := podState.hasStaleEIPStatus(status); staleStatus != nil {
 				staleAssignments = append(staleAssignments, *staleStatus)
 			}
 		}
@@ -971,7 +971,7 @@ func (e *EgressIPController) addPodEgressIPAssignments(ni util.NetInfo, name str
 		if err != nil {
 			klog.Warningf("Failed to delete stale EgressIP status %s/%v for pod %s: %v", name, staleStatus, podKey, err)
 		}
-		delete(podState.egressStatuses.statusMap, staleStatus)
+		delete(podState.statusMap, staleStatus)
 	}
 	if len(reprogramAssignments) > 0 {
 		klog.V(2).Infof("Pod %s IPs changed, forcing egress IP status reprogram for statuses: %+v", podKey, reprogramAssignments)
@@ -980,7 +980,7 @@ func (e *EgressIPController) addPodEgressIPAssignments(ni util.NetInfo, name str
 				podKey, reprogramAssignments, name, err)
 		}
 		for _, status := range reprogramAssignments {
-			delete(podState.egressStatuses.statusMap, status)
+			delete(podState.statusMap, status)
 		}
 		remainingAssignments = append(remainingAssignments, reprogramAssignments...)
 	}
@@ -1019,7 +1019,7 @@ func (e *EgressIPController) addPodEgressIPAssignments(ni util.NetInfo, name str
 				if err := e.addPodEgressIPAssignment(ni, name, status, mark, pod, podIPNets); err != nil {
 					return fmt.Errorf("unable to create egressip configuration for pod %s/%s/%v, err: %w", pod.Namespace, pod.Name, podIPNets, err)
 				}
-				podState.egressStatuses.statusMap[status] = ""
+				podState.statusMap[status] = ""
 				return nil
 			}
 			return e.nodeZoneState.DoWithLock(nodesToLock[1], func(_ string) error {
@@ -1027,7 +1027,7 @@ func (e *EgressIPController) addPodEgressIPAssignments(ni util.NetInfo, name str
 				if err := e.addPodEgressIPAssignment(ni, name, status, mark, pod, podIPNets); err != nil {
 					return fmt.Errorf("unable to create egressip configuration for pod %s/%s/%v, err: %w", pod.Namespace, pod.Name, podIPNets, err)
 				}
-				podState.egressStatuses.statusMap[status] = ""
+				podState.statusMap[status] = ""
 				return nil
 			})
 		})
@@ -1066,7 +1066,7 @@ func (e *EgressIPController) deleteEgressIPAssignments(name string, statusesToRe
 					podStatus.standbyEgressIPNames.Delete(name)
 					return nil
 				}
-				if ok := podStatus.egressStatuses.contains(statusToRemove); !ok {
+				if ok := podStatus.contains(statusToRemove); !ok {
 					// we can continue here since this pod was not managed by this statusToRemove
 					return nil
 				}
@@ -1094,13 +1094,13 @@ func (e *EgressIPController) deleteEgressIPAssignments(name string, statusesToRe
 					if err := e.addExternalGWPodSNAT(cachedNetwork, podNamespace, podName, statusToRemove); err != nil {
 						return err
 					}
-					podStatus.egressStatuses.delete(statusToRemove)
+					podStatus.delete(statusToRemove)
 					return nil
 				})
 				if err != nil {
 					return err
 				}
-				if len(podStatus.egressStatuses.statusMap) == 0 && len(podStatus.standbyEgressIPNames) == 0 {
+				if len(podStatus.statusMap) == 0 && len(podStatus.standbyEgressIPNames) == 0 {
 					// pod could be managed by more than one egressIP
 					// so remove the podKey from cache only if we are sure
 					// there are no more egressStatuses managing this pod
@@ -1112,7 +1112,7 @@ func (e *EgressIPController) deleteEgressIPAssignments(name string, statusesToRe
 						return fmt.Errorf("cannot delete egressPodIPs for the pod %s from the address set: err: %v", podKey, err)
 					}
 					e.podAssignment.Delete(podKey)
-				} else if len(podStatus.egressStatuses.statusMap) == 0 && len(podStatus.standbyEgressIPNames) > 0 {
+				} else if len(podStatus.statusMap) == 0 && len(podStatus.standbyEgressIPNames) > 0 {
 					klog.V(2).Infof("Pod %s has standby egress IP %+v", podKey, podStatus.standbyEgressIPNames.UnsortedList())
 					podStatus.egressIPName = "" // we have deleted the current egressIP that was managing the pod
 					if err := e.addStandByEgressIPAssignment(cachedNetwork, podKey, podStatus); err != nil {
@@ -1182,7 +1182,7 @@ func (e *EgressIPController) deletePodEgressIPAssignments(ni util.NetInfo, name 
 		podStatus.standbyEgressIPNames.Delete(name)
 	} else {
 		for _, statusToRemove := range statusesToRemove {
-			if ok := podStatus.egressStatuses.contains(statusToRemove); !ok {
+			if ok := podStatus.contains(statusToRemove); !ok {
 				// we can continue here since this pod was not managed by this statusToRemove
 				continue
 			}
@@ -1197,14 +1197,14 @@ func (e *EgressIPController) deletePodEgressIPAssignments(ni util.NetInfo, name 
 					if err := e.deletePodEgressIPAssignment(ni, name, statusToRemove, pod); err != nil {
 						return err
 					}
-					podStatus.egressStatuses.delete(statusToRemove)
+					podStatus.delete(statusToRemove)
 					return nil
 				}
 				return e.nodeZoneState.DoWithLock(nodesToLock[1], func(_ string) error {
 					if err := e.deletePodEgressIPAssignment(ni, name, statusToRemove, pod); err != nil {
 						return err
 					}
-					podStatus.egressStatuses.delete(statusToRemove)
+					podStatus.delete(statusToRemove)
 					return nil
 				})
 			})
@@ -1215,7 +1215,7 @@ func (e *EgressIPController) deletePodEgressIPAssignments(ni util.NetInfo, name 
 	}
 	// Delete the key if there are no more status assignments to keep
 	// for the pod and no other assigned standby EgressIPs.
-	if len(podStatus.egressStatuses.statusMap) == 0 && len(podStatus.standbyEgressIPNames) == 0 {
+	if len(podStatus.statusMap) == 0 && len(podStatus.standbyEgressIPNames) == 0 {
 		// pod could be managed by more than one egressIP
 		// so remove the podKey from cache only if we are sure
 		// there are no more egressStatuses managing this pod
@@ -1226,7 +1226,7 @@ func (e *EgressIPController) deletePodEgressIPAssignments(ni util.NetInfo, name 
 			}
 		}
 		e.podAssignment.Delete(podKey)
-	} else if len(podStatus.egressStatuses.statusMap) == 0 && len(podStatus.standbyEgressIPNames) > 0 && assignStandby {
+	} else if len(podStatus.statusMap) == 0 && len(podStatus.standbyEgressIPNames) > 0 && assignStandby {
 		// If the pod is no longer assigned an active EgressIP, promote a standby EgressIP to active.
 		// If the pod is already deleted, addStandByEgressIPAssignment is a no-op, so calling it is safe.
 		// The pod's state is removed from the podAssignment cache when deletePodEgressIPAssignments is invoked
@@ -1834,7 +1834,7 @@ func (e *EgressIPController) syncPodAssignmentCache(egressIPCache egressIPCache)
 					// populate podState.egressStatuses with assigned node for active egressIP IPs.
 					if podState.egressIPName == egressIPName {
 						for egressIPIP, nodeName := range egressIPCache.egressIPToAssignedNodes[egressIPName] {
-							podState.egressStatuses.statusMap[egressipv1.EgressIPStatusItem{
+							podState.statusMap[egressipv1.EgressIPStatusItem{
 								EgressIP: egressIPIP, Node: nodeName}] = egressStatusStatePending
 						}
 					}
@@ -2592,7 +2592,7 @@ func (pas *podAssignmentState) Clone() *podAssignmentState {
 		podIPs:               make([]net.IP, 0, len(pas.podIPs)),
 		network:              pas.network,
 	}
-	clone.egressStatuses = egressStatuses{make(map[egressipv1.EgressIPStatusItem]string, len(pas.egressStatuses.statusMap))}
+	clone.egressStatuses = egressStatuses{make(map[egressipv1.EgressIPStatusItem]string, len(pas.statusMap))}
 	for k, v := range pas.statusMap {
 		clone.statusMap[k] = v
 	}
@@ -3781,11 +3781,7 @@ func (e *EgressIPController) ensureDefaultNoReRouteQosRulesForNode(ni util.NetIn
 			return nil, fmt.Errorf("failed to get existing IPv6 QOS rules: %v", err)
 		}
 	}
-	qosExists := false
-	if e.v4 && e.v6 && len(existingQoSes) == 2 {
-		// no need to create QoS Rule ops; already exists; dualstack
-		qosExists = true
-	}
+	qosExists := e.v4 && e.v6 && len(existingQoSes) == 2
 	if len(existingQoSes) == 1 && ((e.v4 && !e.v6) || (e.v6 && !e.v4)) {
 		// no need to create QoS Rule ops; already exists; single stack
 		qosExists = true

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -4468,7 +4468,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-				node1.ObjectMeta.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\"]", node1IPv4CIDR, node1IPv6CIDR)
+				node1.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\"]", node1IPv4CIDR, node1IPv6CIDR)
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node1, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -7636,14 +7636,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 							Items: []corev1.Pod{egressPod1},
 						},
 					)
-					isNode1Local := true
-					if node1Zone == "remote" {
-						isNode1Local = false
-					}
-					isNode2Local := true
-					if node2Zone == "remote" {
-						isNode2Local = false
-					}
+					isNode1Local := node1Zone != "remote"
+					isNode2Local := node2Zone != "remote"
 					fakeOvn.controller.localZoneNodes.Store(node1.Name, isNode1Local)
 					fakeOvn.controller.localZoneNodes.Store(node2.Name, isNode2Local)
 					err := fakeOvn.controller.lsManager.AddOrUpdateSwitch(node1.Name, []*net.IPNet{ovntest.MustParseIPNet(v4Node1Subnet)}, nil)

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -653,7 +653,7 @@ func (oc *DefaultNetworkController) egressQoSSwitches() ([]string, error) {
 	// Find all node switches
 	p := func(item *nbdb.LogicalSwitch) bool {
 		// Ignore external and Join switches(both legacy and current)
-		return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || oc.RemoveNetworkScopeFromName(item.Name) == types.OVNJoinSwitch || item.Name == types.TransitSwitch || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
+		return !strings.HasPrefix(item.Name, types.JoinSwitchPrefix) && oc.RemoveNetworkScopeFromName(item.Name) != types.OVNJoinSwitch && item.Name != types.TransitSwitch && !strings.HasPrefix(item.Name, types.ExternalSwitchPrefix)
 	}
 
 	nodeLocalSwitches, err := libovsdbops.FindLogicalSwitchesWithPredicate(oc.nbClient, p)

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -1503,7 +1503,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkControllerName)
 				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 
-				node2.ObjectMeta.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\", \"%s\", \"%s\"]", node2IPv4+"/24", node2IPv6+"/64", vipIPv4+"/24", vipIPv6+"/64")
+				node2.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\", \"%s\", \"%s\"]", node2IPv4+"/24", node2IPv6+"/64", vipIPv4+"/24", vipIPv6+"/64")
 				node2.ResourceVersion = "3"
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1511,7 +1511,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6, vipIPv4, vipIPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-				node2.ObjectMeta.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\"]", node2IPv4+"/24", node2IPv6+"/64")
+				node2.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\"]", node2IPv4+"/24", node2IPv6+"/64")
 				node2.ResourceVersion = "4"
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/kubevirt_test.go
+++ b/go-controller/pkg/ovn/kubevirt_test.go
@@ -231,7 +231,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 			if t.migrationTarget.nodeName != "" && isLocalNode(t, t.migrationTarget.nodeName) {
 				if !virtLauncherCompleted(t.migrationTarget.testVirtLauncherPod) {
 					testVirtLauncherPods = append(testVirtLauncherPods, t.migrationTarget.testVirtLauncherPod)
-					testPods = append(testPods, t.migrationTarget.testVirtLauncherPod.testPod)
+					testPods = append(testPods, t.migrationTarget.testPod)
 				}
 				nodeSet[t.migrationTarget.nodeName] = true
 			}
@@ -703,7 +703,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 			config.IPv6Mode = t.ipv6
 			config.OVNKubernetesFeature.EnableInterconnect = t.interconnected
 
-			if t.testVirtLauncherPod.vmName != "" {
+			if t.vmName != "" {
 				initVirtLauncherPod(&t.testVirtLauncherPod)
 			}
 			if t.migrationTarget.nodeName != "" {
@@ -780,7 +780,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 						},
 					},
 				)
-				t.testPod.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn)
 				if t.migrationTarget.nodeName != "" {
 					t.migrationTarget.populateLogicalSwitchCache(fakeOvn)
 				}

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -415,7 +415,7 @@ func (oc *Layer2UserDefinedNetworkController) Cleanup() error {
 
 	// Switch that holds management ports is deleted below (BaseLayer2UserDefinedNetworkController.cleanup);
 	// LSPs are cascade-deleted with the logical switch.
-	if err := oc.BaseLayer2UserDefinedNetworkController.cleanup(); err != nil {
+	if err := oc.cleanup(); err != nil {
 		return fmt.Errorf("failed to cleanup network %q: %w", networkName, err)
 	}
 
@@ -523,12 +523,12 @@ func (oc *Layer2UserDefinedNetworkController) init() error {
 }
 
 func (oc *Layer2UserDefinedNetworkController) Stop() {
-	klog.Infof("Stopping controller for UDN %s", oc.GetNetworkName())
-	oc.BaseLayer2UserDefinedNetworkController.stop()
+	klog.Infof("Stoping controller for UDN %s", oc.GetNetworkName())
+	oc.stop()
 }
 
 func (oc *Layer2UserDefinedNetworkController) Reconcile(netInfo util.NetInfo) error {
-	return oc.BaseNetworkController.reconcile(
+	return oc.reconcile(
 		netInfo,
 		func(node string) { oc.gatewaysFailed.Store(node, true) },
 	)

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -590,7 +590,7 @@ func (oc *Layer3UserDefinedNetworkController) waitForLocalZoneNodeLogicalSwitche
 }
 
 func (oc *Layer3UserDefinedNetworkController) Reconcile(netInfo util.NetInfo) error {
-	return oc.BaseNetworkController.reconcile(
+	return oc.reconcile(
 		netInfo,
 		func(node string) {
 			oc.addNodeFailed.Store(node, true)

--- a/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
@@ -259,7 +259,7 @@ func (oc *LocalnetUserDefinedNetworkController) run() error {
 // Cleanup cleans up logical entities for the given network, called from net-attach-def routine
 // could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
 func (oc *LocalnetUserDefinedNetworkController) Cleanup() error {
-	return oc.BaseLayer2UserDefinedNetworkController.cleanup()
+	return oc.cleanup()
 }
 
 func (oc *LocalnetUserDefinedNetworkController) init() error {
@@ -295,11 +295,11 @@ func (oc *LocalnetUserDefinedNetworkController) init() error {
 
 func (oc *LocalnetUserDefinedNetworkController) Stop() {
 	klog.Infof("Stoping controller for UDN %s", oc.GetNetworkName())
-	oc.BaseLayer2UserDefinedNetworkController.stop()
+	oc.stop()
 }
 
 func (oc *LocalnetUserDefinedNetworkController) Reconcile(netInfo util.NetInfo) error {
-	return oc.BaseNetworkController.reconcile(
+	return oc.reconcile(
 		netInfo,
 		func(_ string) {},
 	)

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -2364,7 +2364,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 				completedPod := ovntest.NewPod(completedTPod.namespace, completedTPod.podName, completedTPod.nodeName, completedTPod.podIP)
 				setPodAnnotations(completedPod, completedTPod)
-				completedPod.UID = types.UID(completedPod.ObjectMeta.Name)
+				completedPod.UID = types.UID(completedPod.Name)
 				completedPod.Status.Phase = corev1.PodSucceeded
 
 				runningTPod := newTPod(
@@ -2379,7 +2379,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 				runningPod := ovntest.NewPod(runningTPod.namespace, runningTPod.podName, runningTPod.nodeName, runningTPod.podIP)
 				setPodAnnotations(runningPod, runningTPod)
-				runningPod.UID = types.UID(runningPod.ObjectMeta.Name)
+				runningPod.UID = types.UID(runningPod.Name)
 
 				fakeOvn.startWithDBSetup(initialDB,
 					&corev1.NamespaceList{

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1582,7 +1582,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Update namespace labels
-				namespace2.ObjectMeta.Labels = map[string]string{"labels": "test"}
+				namespace2.Labels = map[string]string{"labels": "test"}
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().
 					Update(context.TODO(), &namespace2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -197,11 +197,12 @@ func ensureClusterRaftMembership(db *util.OvsDbProperties, kclient kube.Interfac
 	dbServerRegexp := `(ssl|tcp):(\[?([a-z0-9\-.:]+)\]?:\d+)`
 	r := regexp.MustCompile(dbServerRegexp)
 
-	if db.DbName == "OVN_Northbound" {
+	switch db.DbName {
+	case "OVN_Northbound":
 		knownMembers = strings.Split(config.OvnNorth.Address, ",")
-	} else if db.DbName == "OVN_Southbound" {
+	case "OVN_Southbound":
 		knownMembers = strings.Split(config.OvnSouth.Address, ",")
-	} else {
+	default:
 		return fmt.Errorf("invalid database name %s for database %s", db.DbName, db.DbAlias)
 	}
 	for _, knownMember := range knownMembers {
@@ -211,7 +212,7 @@ func ensureClusterRaftMembership(db *util.OvsDbProperties, kclient kube.Interfac
 			continue
 		}
 		server := match[3]
-		if !(utilnet.IsIPv4String(server) || utilnet.IsIPv6String(server) || govalidator.IsDNSName(server)) {
+		if !utilnet.IsIPv4String(server) && !utilnet.IsIPv6String(server) && !govalidator.IsDNSName(server) {
 			klog.Warningf("Found invalid value for IP address of known %s member %s: %s",
 				db.DbName, knownMember, server)
 			continue
@@ -237,7 +238,7 @@ func ensureClusterRaftMembership(db *util.OvsDbProperties, kclient kube.Interfac
 			return fmt.Errorf("unable to parse member in %s: %s", db.DbName, member)
 		}
 		matchedServer := member[4]
-		if !(utilnet.IsIPv4String(matchedServer) || utilnet.IsIPv6String(matchedServer) || govalidator.IsDNSName(matchedServer)) {
+		if !utilnet.IsIPv4String(matchedServer) && !utilnet.IsIPv6String(matchedServer) && !govalidator.IsDNSName(matchedServer) {
 			klog.Warningf("Unable to parse address portion of member entry in %v: %s",
 				db, matchedServer)
 			continue

--- a/go-controller/pkg/testing/libovsdb/libovsdb.go
+++ b/go-controller/pkg/testing/libovsdb/libovsdb.go
@@ -467,7 +467,7 @@ func (t *TestOvsdbServer) CreateTestData(data []TestData) error {
 	}
 
 	var rawReply []*ovsdb.OperationResult
-	if err := t.OvsdbServer.Transact(nil, rawArgs.Params, &rawReply); err != nil {
+	if err := t.Transact(nil, rawArgs.Params, &rawReply); err != nil {
 		return fmt.Errorf("failed to transact test data: %v", err)
 	}
 

--- a/go-controller/pkg/util/dns.go
+++ b/go-controller/pkg/util/dns.go
@@ -129,10 +129,7 @@ func (d *DNS) updateOne(dns string) (bool, error) {
 		res.retryCount = 0
 	}
 
-	changed := false
-	if !ipsEqual(res.ips, ips) {
-		changed = true
-	}
+	changed := !ipsEqual(res.ips, ips)
 	res.ips = ips
 	res.ttl = ttl
 	res.nextQueryTime = time.Now().Add(res.ttl)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -955,11 +955,11 @@ func IsLastUpdatedByManager(manager string, managedFields []metav1.ManagedFields
 	for _, managedFieldEntry := range managedFields {
 		switch managedFieldEntry.Manager {
 		case manager:
-			if managedFieldEntry.Time.Time.After(lastUpdateOurs) {
+			if managedFieldEntry.Time.After(lastUpdateOurs) {
 				lastUpdateOurs = managedFieldEntry.Time.Time
 			}
 		default:
-			if managedFieldEntry.Time.Time.After(lastUpdateTheirs) {
+			if managedFieldEntry.Time.After(lastUpdateTheirs) {
 				lastUpdateTheirs = managedFieldEntry.Time.Time
 			}
 		}

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -473,7 +473,7 @@ func (nInfo *DefaultNetInfo) GetNetInfo() NetInfo {
 
 func (nInfo *DefaultNetInfo) copy() *DefaultNetInfo {
 	c := &DefaultNetInfo{}
-	c.mutableNetInfo.copyFrom(&nInfo.mutableNetInfo)
+	c.copyFrom(&nInfo.mutableNetInfo)
 
 	return c
 }
@@ -1115,7 +1115,7 @@ func (nInfo *userDefinedNetInfo) copy() *userDefinedNetInfo {
 		evpn:                  nInfo.evpn,
 	}
 	// copy mutables
-	c.mutableNetInfo.copyFrom(&nInfo.mutableNetInfo)
+	c.copyFrom(&nInfo.mutableNetInfo)
 
 	return c
 }
@@ -1899,7 +1899,7 @@ func IsPreconfiguredUDNAddressesEnabled() bool {
 }
 
 func DoesNetworkRequireIPAM(netInfo NetInfo) bool {
-	return !((netInfo.TopologyType() == types.Layer2Topology || netInfo.TopologyType() == types.LocalnetTopology) && len(netInfo.Subnets()) == 0)
+	return (netInfo.TopologyType() != types.Layer2Topology && netInfo.TopologyType() != types.LocalnetTopology) || len(netInfo.Subnets()) != 0
 }
 
 func DoesNetworkRequireTunnelIDs(netInfo NetInfo) bool {

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -450,7 +450,7 @@ func LinkAddrGetIPNet(link netlink.Link, ip net.IP) (*net.IPNet, error) {
 			link.Attrs().Name, err)
 	}
 	for _, addr := range addrs {
-		if addr.IPNet.IP.Equal(ip) {
+		if addr.IP.Equal(ip) {
 			return addr.IPNet, nil
 		}
 	}
@@ -695,17 +695,18 @@ func DeleteConntrack(ip string, port int32, protocol corev1.Protocol, ipFilterTy
 	}
 
 	filter := &netlink.ConntrackFilter{}
-	if protocol == corev1.ProtocolUDP {
+	switch protocol {
+	case corev1.ProtocolUDP:
 		// 17 = UDP protocol
 		if err := filter.AddProtocol(17); err != nil {
 			return 0, fmt.Errorf("could not add Protocol UDP to conntrack filter %v", err)
 		}
-	} else if protocol == corev1.ProtocolSCTP {
+	case corev1.ProtocolSCTP:
 		// 132 = SCTP protocol
 		if err := filter.AddProtocol(132); err != nil {
 			return 0, fmt.Errorf("could not add Protocol SCTP to conntrack filter %v", err)
 		}
-	} else if protocol == corev1.ProtocolTCP {
+	case corev1.ProtocolTCP:
 		// 6 = TCP protocol
 		if err := filter.AddProtocol(6); err != nil {
 			return 0, fmt.Errorf("could not add Protocol TCP to conntrack filter %v", err)

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -179,13 +179,14 @@ func setupDefaultFile() {
 	}
 
 	var defaultFile, text string
-	if platform == ubuntu {
+	switch platform {
+	case ubuntu:
 		defaultFile = ubuntuDefaultFile
 		text = "OVS_CTL_OPTS=\"$OVS_CTL_OPTS --delete-transient-ports\""
-	} else if platform == rhel {
+	case rhel:
 		defaultFile = rhelDefaultFile
 		text = "OPTIONS=--delete-transient-ports"
-	} else {
+	default:
 		return
 	}
 

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -420,13 +420,14 @@ func runOVNretry(cmdPath string, envVars []string, extraArgsFunc func() ([]strin
 func getNbctlArgsAndEnv(timeout int, args ...string) ([]string, []string) {
 	var cmdArgs []string
 
-	if config.OvnNorth.Scheme == config.OvnDBSchemeSSL {
+	switch config.OvnNorth.Scheme {
+	case config.OvnDBSchemeSSL:
 		cmdArgs = append(cmdArgs,
 			fmt.Sprintf("--private-key=%s", config.OvnNorth.PrivKey),
 			fmt.Sprintf("--certificate=%s", config.OvnNorth.Cert),
 			fmt.Sprintf("--bootstrap-ca-cert=%s", config.OvnNorth.CACert),
 			fmt.Sprintf("--db=%s", config.OvnNorth.GetURL()))
-	} else if config.OvnNorth.Scheme == config.OvnDBSchemeTCP {
+	case config.OvnDBSchemeTCP:
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--db=%s", config.OvnNorth.GetURL()))
 	}
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--timeout=%d", timeout))
@@ -474,14 +475,15 @@ func RunOVNNbctl(args ...string) (string, string, error) {
 func RunOVNSbctlWithTimeout(timeout int, args ...string) (string, string,
 	error) {
 	var cmdArgs []string
-	if config.OvnSouth.Scheme == config.OvnDBSchemeSSL {
+	switch config.OvnSouth.Scheme {
+	case config.OvnDBSchemeSSL:
 		cmdArgs = []string{
 			fmt.Sprintf("--private-key=%s", config.OvnSouth.PrivKey),
 			fmt.Sprintf("--certificate=%s", config.OvnSouth.Cert),
 			fmt.Sprintf("--bootstrap-ca-cert=%s", config.OvnSouth.CACert),
 			fmt.Sprintf("--db=%s", config.OvnSouth.GetURL()),
 		}
-	} else if config.OvnSouth.Scheme == config.OvnDBSchemeTCP {
+	case config.OvnDBSchemeTCP:
 		cmdArgs = []string{
 			fmt.Sprintf("--db=%s", config.OvnSouth.GetURL()),
 		}
@@ -662,7 +664,7 @@ func AddOFFlowWithSpecificAction(bridgeName, action string) (string, string, err
 	args := []string{"-O", "OpenFlow13", "replace-flows", bridgeName, "-"}
 
 	stdin := &bytes.Buffer{}
-	stdin.Write([]byte(fmt.Sprintf("table=0,priority=0,actions=%s\n", action)))
+	fmt.Fprintf(stdin, "table=0,priority=0,actions=%s\n", action)
 
 	cmd := runner.exec.Command(runner.ofctlPath, args...)
 	cmd.SetStdin(stdin)


### PR DESCRIPTION
This PR enables golangci-lint staticcheck QuickFix which is disabled in #5678 before and resolve https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5724 

And then fix some QF* lint issues:

```
> QF1008: Remove redundant embedded field selectors
> QF1002/QF1003: Convert if-else chains to switch statements pkg/node/gateway_shared_intf.go
> QF1001: Apply De Morgan's law for clearer boolean expressions go-controller/pkg/config/config.go
> QF1011: could omit type string from declaration
> QF1007: could merge conditional assignment into variable declaration go-controller/cmd/ovnkube-trace/ovnkube-trace.go
> QF1006: could lift into loop condition
> QF1004: Use strings.ReplaceAll instead of strings.Replace(..., -1) go-controller/cmd/ovnkube-trace/ovnkube-trace.go
> QF1012: Use fmt.Fprintf(...) instead of Write([]byte(fmt.Sprintf(...))) go-controller/pkg/util/ovs.go
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broad internal refactoring for clearer conditional logic, consistent string handling, and idiomatic Go field access.
  * Removed an explicit staticcheck configuration from linting settings.

* **Tests**
  * Adjusted tests to align with refactors; no behavioral or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->