### PR TITLE
fix: panic in runKubeletRestartTracker when reading from closed dbus channel

### DIFF
--- a/go-controller/pkg/node/udn_isolation.go
+++ b/go-controller/pkg/node/udn_isolation.go
@@ -357,7 +357,11 @@ func (m *UDNHostIsolationManager) runKubeletRestartTracker(ctx context.Context) 
 					klog.Errorf("Error closing dbus connection for UDN isolation: %v", err)
 				}
 				return
-			case signal := <-signalChan:
+			case signal, ok := <-signalChan:
+				if !ok || signal == nil {
+					// Channel was closed, connection is shutting down
+					return
+				}
 				klog.V(5).Infof("D-Bus event received: %#v", signal)
 				// Extract unit name from path
 				unitPath := signal.Path


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

`godbus/dbus` will close the signal channel on `conn.Close()`.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5878

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for channel operations to prevent potential crashes from nil dereferences when channels close or receive nil signals. Ensures more stable operation during kubelet restart tracking and graceful handling of shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->