### PR TITLE
Remove limit on ovs-node

### DIFF
--- a/dist/templates/ovs-node.yaml.j2
+++ b/dist/templates/ovs-node.yaml.j2
@@ -85,9 +85,6 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
-          limits:
-            cpu: 500m
-            memory: 500Mi
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "1.2.0"

--- a/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
@@ -84,9 +84,6 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
-          limits:
-            cpu: 500m
-            memory: 500Mi
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "1.2.0"


### PR DESCRIPTION


## 📑 Description
<!-- Add a brief description of the pr -->
Removing cpu/mem limit from ovs-node. This is causing issues with the performance workload, and there doesn't seem to be a good reason to limit the ovs-node pods. Most deployments have ovs running outside of a pod/container.


Fixes #5903 

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed CPU and memory resource limits from the OVS node container in Kubernetes deployments.
  * Confirmed no other container configuration (environment variables, probes, mounts, or resource requests) was changed as part of this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->