### PR TITLE
no-overlay: Add validation controller for RouteAdvertisements 

### DIFF
--- a/go-controller/pkg/clustermanager/nooverlay/controller.go
+++ b/go-controller/pkg/clustermanager/nooverlay/controller.go
@@ -1,0 +1,309 @@
+package nooverlay
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	controllerutil "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/controller"
+	ratypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
+	apitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+)
+
+// validationErrorType represents different types of validation failures
+type validationErrorType int
+
+const (
+	errTypeNotAccepted validationErrorType = iota
+	errTypeNoRouteAdvertise
+)
+
+// eventReason represents Kubernetes event reasons
+type eventReason string
+
+const (
+	eventReasonRANotAccepted eventReason = "RouteAdvertisementsNotAccepted"
+	eventReasonNoRA          eventReason = "NoRouteAdvertisements"
+	eventReasonConfigError   eventReason = "NoOverlayConfigurationError"
+	eventReasonConfigReady   eventReason = "NoOverlayConfigurationReady"
+)
+
+// conditionTypeAccepted is the Accepted condition type for RouteAdvertisements
+const conditionTypeAccepted = "Accepted"
+
+// validationError represents different types of validation failures
+type validationError struct {
+	errorType validationErrorType
+	message   string
+	raNames   []string // Names of RAs that exist but aren't accepted (for notAccepted scenario)
+}
+
+func (e *validationError) Error() string {
+	return e.message
+}
+
+// Controller validates no-overlay configuration with RouteAdvertisements.
+// It watches RouteAdvertisements CRs, triggering validation when relevant changes occur.
+type Controller struct {
+	wf       *factory.WatchFactory
+	recorder record.EventRecorder
+
+	// raController watches RouteAdvertisements resources
+	raController controllerutil.Controller
+
+	// validationLock protects validation state
+	validationLock sync.Mutex
+	// lastValidationError tracks the last validation error to avoid spamming events
+	lastValidationError string
+}
+
+// NewController creates a new no-overlay validation controller.
+func NewController(wf *factory.WatchFactory, recorder record.EventRecorder) *Controller {
+	klog.Infof("Creating no-overlay validation controller")
+
+	c := &Controller{
+		wf:       wf,
+		recorder: recorder,
+	}
+
+	// Create controller config with RouteAdvertisements informer
+	raConfig := &controllerutil.ControllerConfig[ratypes.RouteAdvertisements]{
+		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		Reconcile:      c.reconcileRA,
+		Threadiness:    1,
+		Informer:       wf.RouteAdvertisementsInformer().Informer(),
+		Lister:         wf.RouteAdvertisementsInformer().Lister().List,
+		ObjNeedsUpdate: c.raNeedsValidation,
+	}
+	c.raController = controllerutil.NewController("no-overlay-ra-watcher", raConfig)
+
+	return c
+}
+
+// Start starts the no-overlay validation controller
+func (c *Controller) Start() error {
+	// Start controller with initial validation after cache sync.
+	// This ensures the informer cache is populated before validation runs,
+	// preventing false errors from reading an empty cache.
+	if err := controllerutil.StartWithInitialSync(func() error {
+		c.runValidation()
+		return nil
+	}, c.raController); err != nil {
+		return err
+	}
+	klog.Infof("no-overlay validation controller started")
+	return nil
+}
+
+// Stop stops the no-overlay validation controller
+func (c *Controller) Stop() {
+	if c == nil {
+		return
+	}
+
+	klog.Infof("Stopping no-overlay validation controller")
+
+	controllerutil.Stop(c.raController)
+}
+
+// reconcileRA is called whenever a RouteAdvertisements resource changes
+func (c *Controller) reconcileRA(key string) error {
+	klog.V(5).Infof("No-overlay controller reconciling RouteAdvertisements %q", key)
+	c.runValidation()
+	return nil
+}
+
+// selectsDefaultNetwork returns true if the RouteAdvertisements selects the default network
+func selectsDefaultNetwork(ra *ratypes.RouteAdvertisements) bool {
+	for _, networkSelector := range ra.Spec.NetworkSelectors {
+		if networkSelector.NetworkSelectionType == apitypes.DefaultNetwork {
+			return true
+		}
+	}
+	return false
+}
+
+// raNeedsValidation checks if the RouteAdvertisements update requires validation
+func (c *Controller) raNeedsValidation(oldRA, newRA *ratypes.RouteAdvertisements) bool {
+	// If either object is nil, we need to validate, e.g., on deletion or addition
+	if oldRA == nil || newRA == nil {
+		return true
+	}
+
+	// If the RA started or stopped advertising default network, validate
+	if selectsDefaultNetwork(oldRA) != selectsDefaultNetwork(newRA) {
+		return true
+	}
+
+	// Check if NetworkSelectors changed
+	if !reflect.DeepEqual(oldRA.Spec.NetworkSelectors, newRA.Spec.NetworkSelectors) {
+		return true
+	}
+
+	// Check if Advertisements changed
+	if !reflect.DeepEqual(oldRA.Spec.Advertisements, newRA.Spec.Advertisements) {
+		return true
+	}
+
+	// Check if Accepted condition changed
+	return isRAAccepted(oldRA.Status.Conditions) != isRAAccepted(newRA.Status.Conditions)
+}
+
+// runValidation runs validation and emits events if the state changed
+func (c *Controller) runValidation() {
+	c.validationLock.Lock()
+	defer c.validationLock.Unlock()
+
+	err := c.validate()
+	currentError := ""
+	if err != nil {
+		currentError = err.Error()
+	}
+
+	// Only emit event if error state changed
+	if currentError != c.lastValidationError {
+		if err != nil {
+			klog.Errorf("No-overlay validation failed: %v", err)
+			c.emitValidationEvent(err)
+		} else {
+			klog.Infof("No-overlay validation passed: RouteAdvertisements configuration is now valid")
+			c.emitReadyEvent()
+		}
+		c.lastValidationError = currentError
+	}
+}
+
+// validate checks if the no-overlay configuration is valid
+func (c *Controller) validate() error {
+	// Get all RouteAdvertisements CRs
+	ras, err := c.wf.RouteAdvertisementsInformer().Lister().List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list RouteAdvertisements: %w", err)
+	}
+
+	// Track if we found RAs advertising default network that are not accepted
+	foundDefaultNetworkRA := false
+	notAcceptedRANames := []string{}
+
+	// Check if any RouteAdvertisements CR is configured for the default network
+	for _, ra := range ras {
+		// Check if this RouteAdvertisements selects the default network
+		for _, networkSelector := range ra.Spec.NetworkSelectors {
+			if networkSelector.NetworkSelectionType == apitypes.DefaultNetwork {
+				// Found a RouteAdvertisements for default network
+				// Check if it advertises pod networks
+				if !slices.Contains(ra.Spec.Advertisements, ratypes.PodNetwork) {
+					continue
+				}
+
+				// We found at least one RA advertising default network
+				foundDefaultNetworkRA = true
+
+				if isRAAccepted(ra.Status.Conditions) {
+					// Valid configuration found
+					klog.V(5).Infof("Found valid RouteAdvertisements %q for default network with no-overlay transport", ra.Name)
+					return nil
+				} else {
+					klog.Warningf("RouteAdvertisements %q selects default network but status is not Accepted", ra.Name)
+					notAcceptedRANames = append(notAcceptedRANames, ra.Name)
+				}
+			}
+		}
+	}
+
+	// Return specific error based on what we found
+	if !foundDefaultNetworkRA {
+		return &validationError{
+			errorType: errTypeNoRouteAdvertise,
+			message:   "no RouteAdvertisements CR is advertising the default network pod networks",
+		}
+	}
+
+	// Found RAs advertising default network, but none are accepted
+	// Sort names to ensure deterministic error messages for event deduplication
+	slices.Sort(notAcceptedRANames)
+	return &validationError{
+		errorType: errTypeNotAccepted,
+		message:   fmt.Sprintf("RouteAdvertisements CRs %q are advertising the default network pod networks but none have status Accepted=True", notAcceptedRANames),
+		raNames:   notAcceptedRANames,
+	}
+}
+
+// emitValidationEvent emits a Kubernetes event for validation failures
+func (c *Controller) emitValidationEvent(err error) {
+	var reason eventReason
+	var eventMessage string
+
+	// Check if this is our custom validation error type
+	if valErr, ok := err.(*validationError); ok {
+		switch valErr.errorType {
+		case errTypeNotAccepted:
+			// Scenario: RAs exist but none are accepted
+			reason = eventReasonRANotAccepted
+			if len(valErr.raNames) > 0 {
+				eventMessage = fmt.Sprintf("RouteAdvertisements CR(s) %v exist for the default network but none have status Accepted=True. "+
+					"When transport=no-overlay, at least one RouteAdvertisements CR must be accepted to advertise pod networks.",
+					strings.Join(valErr.raNames, ", "))
+			} else {
+				eventMessage = "RouteAdvertisements CR(s) exist for the default network but none have status Accepted=True. " +
+					"When transport=no-overlay, at least one RouteAdvertisements CR must be accepted to advertise pod networks."
+			}
+		case errTypeNoRouteAdvertise:
+			// Scenario: No RAs advertising default network
+			reason = eventReasonNoRA
+			eventMessage = "No RouteAdvertisements CR is advertising the default network. " +
+				"RouteAdvertisements configuration is required when transport=no-overlay."
+		default:
+			// Unknown validation error type
+			reason = eventReasonConfigError
+			eventMessage = fmt.Sprintf("No-overlay transport configuration error: %v", err)
+		}
+	} else {
+		// Generic error
+		reason = eventReasonConfigError
+		eventMessage = fmt.Sprintf("No-overlay transport configuration error: %v", err)
+	}
+
+	c.emitEvent(corev1.EventTypeWarning, string(reason), eventMessage)
+}
+
+// emitReadyEvent emits a Normal event when validation passes
+func (c *Controller) emitReadyEvent() {
+	c.emitEvent(
+		corev1.EventTypeNormal,
+		string(eventReasonConfigReady),
+		"No-overlay transport is properly configured with RouteAdvertisements CR advertising the default network pod networks with status Accepted=True",
+	)
+}
+
+// emitEvent emits a Kubernetes event on the default network NAD.
+func (c *Controller) emitEvent(eventType, reason, message string) {
+	c.recorder.Eventf(
+		&corev1.ObjectReference{
+			Kind:      "NetworkAttachmentDefinition",
+			Name:      types.DefaultNetworkName,
+			Namespace: config.Kubernetes.OVNConfigNamespace,
+		},
+		eventType,
+		reason,
+		message,
+	)
+}
+
+func isRAAccepted(conditions []metav1.Condition) bool {
+	condition := meta.FindStatusCondition(conditions, conditionTypeAccepted)
+	return condition != nil && condition.Status == metav1.ConditionTrue
+}

--- a/go-controller/pkg/clustermanager/nooverlay/controller_suite_test.go
+++ b/go-controller/pkg/clustermanager/nooverlay/controller_suite_test.go
@@ -1,0 +1,13 @@
+package nooverlay
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNoOverlayController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Manager No-Overlay Controller Suite")
+}

--- a/go-controller/pkg/clustermanager/nooverlay/controller_test.go
+++ b/go-controller/pkg/clustermanager/nooverlay/controller_test.go
@@ -1,0 +1,502 @@
+package nooverlay
+
+import (
+	"context"
+	"time"
+
+	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
+	frrfake "github.com/metallb/frr-k8s/pkg/client/clientset/versioned/fake"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ratypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
+	rafake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned/fake"
+	apitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// Test helper types
+type testRA struct {
+	Name             string
+	SelectsDefault   bool
+	AdvertisePods    bool
+	AcceptedStatus   *metav1.ConditionStatus
+	NetworkSelectors []apitypes.NetworkSelector
+	Advertisements   []ratypes.AdvertisementType
+}
+
+func (tra testRA) RouteAdvertisements() *ratypes.RouteAdvertisements {
+	ra := &ratypes.RouteAdvertisements{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tra.Name,
+		},
+		Spec: ratypes.RouteAdvertisementsSpec{
+			NetworkSelectors: tra.NetworkSelectors,
+			Advertisements:   tra.Advertisements,
+		},
+	}
+
+	// Handle simple case flags
+	if tra.SelectsDefault && len(tra.NetworkSelectors) == 0 {
+		ra.Spec.NetworkSelectors = append(ra.Spec.NetworkSelectors, apitypes.NetworkSelector{
+			NetworkSelectionType: apitypes.DefaultNetwork,
+		})
+	}
+	if tra.AdvertisePods && len(tra.Advertisements) == 0 {
+		ra.Spec.Advertisements = append(ra.Spec.Advertisements, ratypes.PodNetwork)
+	}
+
+	if tra.AcceptedStatus != nil {
+		ra.Status.Conditions = []metav1.Condition{
+			{
+				Type:   "Accepted",
+				Status: *tra.AcceptedStatus,
+			},
+		}
+	}
+
+	return ra
+}
+
+var _ = ginkgo.Describe("No-Overlay Controller", func() {
+	var (
+		recorder *record.FakeRecorder
+	)
+
+	ginkgo.BeforeEach(func() {
+		// Restore global default values before each testcase
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		recorder = record.NewFakeRecorder(100)
+		// Enable multi-network and route advertisements features
+		// These are required for the no-overlay controller to function
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+		// Set transport to no-overlay for all tests in this suite
+		config.Default.Transport = types.NetworkTransportNoOverlay
+	})
+
+	ginkgo.Context("Controller creation", func() {
+		ginkgo.It("should create controller when transport is no-overlay", func() {
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			controller := NewController(wf, recorder)
+			gomega.Expect(controller).NotTo(gomega.BeNil())
+			gomega.Expect(controller.wf).To(gomega.Equal(wf))
+			gomega.Expect(controller.recorder).To(gomega.Equal(recorder))
+			gomega.Expect(controller.raController).NotTo(gomega.BeNil())
+		})
+
+		ginkgo.It("should have empty last validation error on creation", func() {
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			controller := NewController(wf, recorder)
+			gomega.Expect(controller.lastValidationError).To(gomega.BeEmpty())
+		})
+	})
+
+	ginkgo.DescribeTable("Validation logic",
+		func(ras []*testRA, expectError bool, expectErrorSubstring string) {
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+
+			// Create RAs with both spec and status
+			for _, tra := range ras {
+				ra := tra.RouteAdvertisements()
+				_, err := fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(
+					context.Background(), ra, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Update status separately if it exists
+				if tra.AcceptedStatus != nil {
+					ra.Status.Conditions = []metav1.Condition{
+						{
+							Type:   "Accepted",
+							Status: *tra.AcceptedStatus,
+						},
+					}
+					_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().UpdateStatus(
+						context.Background(), ra, metav1.UpdateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			err = wf.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			controller := NewController(wf, recorder)
+
+			// Give time for informers to sync
+			gomega.Eventually(func() bool {
+				return wf.RouteAdvertisementsInformer().Informer().HasSynced()
+			}, 2*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
+
+			err = controller.validate()
+			if expectError {
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				if expectErrorSubstring != "" {
+					gomega.Expect(err.Error()).To(gomega.ContainSubstring(expectErrorSubstring))
+				}
+			} else {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		},
+		ginkgo.Entry("should fail when no RouteAdvertisements CR exists",
+			[]*testRA{},
+			true,
+			"no RouteAdvertisements CR is advertising the default network",
+		),
+		ginkgo.Entry("should pass when valid RouteAdvertisements CR exists",
+			[]*testRA{
+				{
+					Name:           "test-ra",
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+			},
+			false,
+			"",
+		),
+		ginkgo.Entry("should fail when RouteAdvertisements CR exists but not Accepted",
+			[]*testRA{
+				{
+					Name:           "test-ra",
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionFalse),
+				},
+			},
+			true,
+			"but none have status Accepted=True",
+		),
+		ginkgo.Entry("should fail when RouteAdvertisements CR doesn't advertise PodNetwork",
+			[]*testRA{
+				{
+					Name:           "test-ra",
+					SelectsDefault: true,
+					AdvertisePods:  false,
+					Advertisements: []ratypes.AdvertisementType{ratypes.EgressIP},
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+			},
+			true,
+			"no RouteAdvertisements CR is advertising the default network",
+		),
+		ginkgo.Entry("should pass when multiple RouteAdvertisements exist and one is valid",
+			[]*testRA{
+				{
+					Name: "test-ra-1",
+					NetworkSelectors: []apitypes.NetworkSelector{
+						{NetworkSelectionType: apitypes.NetworkSelectionType("CustomNetwork")},
+					},
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+				{
+					Name:           "test-ra-2",
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+			},
+			false,
+			"",
+		),
+	)
+
+	ginkgo.Context("RA needsValidation logic", func() {
+		var controller *Controller
+		var wf *factory.WatchFactory
+		var err error
+
+		ginkgo.BeforeEach(func() {
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+
+			wf, err = factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			controller = NewController(wf, recorder)
+		})
+
+		ginkgo.AfterEach(func() {
+			if wf != nil {
+				wf.Shutdown()
+			}
+		})
+
+		ginkgo.DescribeTable("raNeedsValidation",
+			func(oldRA *testRA, newRA *testRA, expectValidate bool) {
+				var oldRAObj, newRAObj *ratypes.RouteAdvertisements
+				if oldRA != nil {
+					oldRAObj = oldRA.RouteAdvertisements()
+				}
+				if newRA != nil {
+					newRAObj = newRA.RouteAdvertisements()
+				}
+				result := controller.raNeedsValidation(oldRAObj, newRAObj)
+				gomega.Expect(result).To(gomega.Equal(expectValidate))
+			},
+			ginkgo.Entry("should return true when NetworkSelectors change",
+				&testRA{
+					NetworkSelectors: []apitypes.NetworkSelector{
+						{NetworkSelectionType: apitypes.DefaultNetwork},
+					},
+				},
+				&testRA{
+					NetworkSelectors: []apitypes.NetworkSelector{
+						{NetworkSelectionType: apitypes.DefaultNetwork},
+						{NetworkSelectionType: apitypes.NetworkSelectionType("CustomNetwork")},
+					},
+				},
+				true,
+			),
+			ginkgo.Entry("should return true when Advertisements change",
+				&testRA{
+					SelectsDefault: true,
+					Advertisements: []ratypes.AdvertisementType{ratypes.PodNetwork},
+				},
+				&testRA{
+					SelectsDefault: true,
+					Advertisements: []ratypes.AdvertisementType{ratypes.PodNetwork, ratypes.EgressIP},
+				},
+				true,
+			),
+			ginkgo.Entry("should return true when Accepted condition changes",
+				&testRA{
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionFalse),
+				},
+				&testRA{
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+				true,
+			),
+			ginkgo.Entry("should return false when nothing relevant changes",
+				&testRA{
+					Name:           "test-ra",
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+				&testRA{
+					Name:           "test-ra",
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+				false,
+			),
+			ginkgo.Entry("should return true when old RA is nil (addition)",
+				nil,
+				&testRA{
+					Name:           "test-ra",
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+				true,
+			),
+			ginkgo.Entry("should return true when new RA is nil (deletion)",
+				&testRA{
+					Name:           "test-ra",
+					SelectsDefault: true,
+					AdvertisePods:  true,
+					AcceptedStatus: ptr.To(metav1.ConditionTrue),
+				},
+				nil,
+				true,
+			),
+		)
+	})
+
+	ginkgo.Context("Event emission", func() {
+		ginkgo.It("should emit event on validation failure", func() {
+			localRecorder := record.NewFakeRecorder(100)
+
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			gomega.Expect(wf.Start()).To(gomega.Succeed())
+
+			controller := NewController(wf, localRecorder)
+
+			// Start controller which will run initial validation
+			err = controller.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer controller.Stop()
+
+			// Wait a bit for the event to be emitted
+			gomega.Eventually(func() int {
+				return len(localRecorder.Events)
+			}, 2*time.Second, 100*time.Millisecond).Should(gomega.BeNumerically(">", 0))
+
+			// Check event was emitted
+			event := <-localRecorder.Events
+			gomega.Expect(event).To(gomega.ContainSubstring("Warning"))
+			gomega.Expect(event).To(gomega.ContainSubstring("NoRouteAdvertisements"))
+			gomega.Expect(event).To(gomega.ContainSubstring("RouteAdvertisements"))
+		})
+
+		ginkgo.It("should not spam events when validation stays failed", func() {
+			localRecorder := record.NewFakeRecorder(100)
+
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			gomega.Expect(wf.Start()).To(gomega.Succeed())
+
+			controller := NewController(wf, localRecorder)
+
+			// Run validation multiple times with the same error
+			controller.runValidation()
+			controller.runValidation()
+			controller.runValidation()
+
+			// Should only have one event (first validation)
+			gomega.Expect(localRecorder.Events).To(gomega.HaveLen(1))
+		})
+
+		ginkgo.It("should emit Ready event when validation passes after being failed", func() {
+			localRecorder := record.NewFakeRecorder(100)
+
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			gomega.Expect(wf.Start()).To(gomega.Succeed())
+
+			controller := NewController(wf, localRecorder)
+
+			// First validation will fail (no RouteAdvertisements)
+			controller.runValidation()
+			gomega.Expect(localRecorder.Events).To(gomega.HaveLen(1))
+			event1 := <-localRecorder.Events
+			gomega.Expect(event1).To(gomega.ContainSubstring("Warning"))
+
+			// Now, create a valid RA to fix the configuration
+			validRA := testRA{
+				Name:           "test-ra",
+				SelectsDefault: true,
+				AdvertisePods:  true,
+				AcceptedStatus: ptr.To(metav1.ConditionTrue),
+			}
+			ra := validRA.RouteAdvertisements()
+			_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), ra, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().UpdateStatus(context.Background(), ra, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Wait for informer to see the new RA with Accepted=True status
+			gomega.Eventually(func() bool {
+				raObj, getErr := wf.RouteAdvertisementsInformer().Lister().Get("test-ra")
+				if getErr != nil || raObj == nil {
+					return false
+				}
+				for _, c := range raObj.Status.Conditions {
+					if c.Type == "Accepted" && c.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, 2*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
+
+			// Second validation will pass
+			controller.runValidation()
+			gomega.Expect(localRecorder.Events).To(gomega.HaveLen(1))
+			event2 := <-localRecorder.Events
+			gomega.Expect(event2).To(gomega.ContainSubstring("Normal"))
+			gomega.Expect(event2).To(gomega.ContainSubstring("NoOverlayConfigurationReady"))
+		})
+	})
+
+	ginkgo.Context("Controller lifecycle", func() {
+		ginkgo.It("should start and stop without errors", func() {
+			ra := testRA{
+				Name:           "test-ra",
+				SelectsDefault: true,
+				AdvertisePods:  true,
+				AcceptedStatus: ptr.To(metav1.ConditionTrue),
+			}
+
+			fakeClient := &util.OVNClusterManagerClientset{
+				KubeClient:                fake.NewSimpleClientset(),
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: rafake.NewSimpleClientset(ra.RouteAdvertisements()),
+				FRRClient:                 frrfake.NewSimpleClientset(),
+			}
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			gomega.Expect(wf.Start()).To(gomega.Succeed())
+
+			controller := NewController(wf, recorder)
+
+			err = controller.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Stop should not panic
+			gomega.Expect(func() { controller.Stop() }).NotTo(gomega.Panic())
+		})
+	})
+})


### PR DESCRIPTION
Adds a new no-overlay validation controller to ClusterManager that ensures the default network has proper RouteAdvertisements configuration when transport=no-overlay mode is enabled.

The controller watches both NetworkAttachmentDefinition (NAD) and RouteAdvertisements (RA) resources:
- NAD watcher: triggers validation when route-advertisements annotation changes for the default network
- RA watcher: triggers validation when RouteAdvertisements spec or status changes

Validation ensures:
- At least one RouteAdvertisements CR selects the default network
- The RA advertises PodNetwork
- The RA has status Accepted=True

Events are emitted when validation state changes:
- Warning events on validation failures with detailed error context
- Normal events when validation succeeds
- Anti-spam logic prevents duplicate events

The controller is conditionally created only when no-overlay is enabled for CDN.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added no‑overlay RouteAdvertisement validation to ensure the default network is advertised and at least one advertisement is accepted.
  * Emits Kubernetes events for validation failures and readiness; controller starts/stops as part of cluster manager when no‑overlay transport is enabled.

* **Tests**
  * Added a comprehensive test suite covering validation scenarios, event emission behavior, and controller lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->