### PR TITLE
e2e: add step to bgp scenario to wait for cudn routes propagated to frr

### DIFF
--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1026,6 +1026,19 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				}
 			}
 
+			ginkgo.By("routes from CUDN are exported to external FRR router")
+			for _, serverContainerIP := range serverContainerIPs {
+				for _, node := range advertisedNodes {
+					if cudnTemplate.Spec.Network.Layer3 != nil {
+						checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cUDN.Name)
+					} else if cudnTemplate.Spec.Network.Layer2 != nil {
+						checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnTemplate.Spec.Network.Layer2.Subnets)
+					} else {
+						ginkgo.Fail("unexpected topology: neither Layer3 nor Layer2 network spec is set")
+					}
+				}
+			}
+
 			expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
 				cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
 


### PR DESCRIPTION
This test failed in:
https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/21602486489/job/62252730622

The test case failed during data plane curl check. This patch is
probably not a fix for the root cause of the failure, but may reveal
more info as to what happened there.

Signed-off-by: Ihar Hrachyshka <ihrachyshka@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->