### PR TITLE
e2e: always wait for NAD network-id before proceeding

### DIFF
--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -161,11 +161,8 @@ func egressFirewallPolicyValidationTests(useUDN bool, udnTopology string) {
 
 				netConfig = newNetworkAttachmentConfig(nadCfg)
 				netConfig.namespace = f.Namespace.Name
-				_, err = nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
-					context.Background(),
-					generateNAD(netConfig, f.ClientSet),
-					metav1.CreateOptions{},
-				)
+				nad := generateNAD(netConfig, f.ClientSet)
+				_, err = createNADAndWaitForNetworkReady(nadClient, nad)
 				framework.ExpectNoError(err)
 			}
 		})

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -860,11 +860,8 @@ var _ = ginkgo.DescribeTableSubtree("e2e egress IP validation", feature.EgressIP
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		netConfig := newNetworkAttachmentConfig(netConfigParams)
 		netConfig.namespace = f.Namespace.Name
-		_, err = nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
-			context.Background(),
-			generateNAD(netConfig, f.ClientSet),
-			metav1.CreateOptions{},
-		)
+		nad := generateNAD(netConfig, f.ClientSet)
+		_, err = createNADAndWaitForNetworkReady(nadClient, nad)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -3120,12 +3117,10 @@ spec:
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		netConfig := newNetworkAttachmentConfig(netConfigParams)
 		netConfig.namespace = otherNetworkNamespace.Name
-		_, err = nadClient.NetworkAttachmentDefinitions(otherNetworkNamespace.Name).Create(
-			context.Background(),
-			generateNAD(netConfig, f.ClientSet),
-			metav1.CreateOptions{},
-		)
+		nad := generateNAD(netConfig, f.ClientSet)
+		_, err = createNADAndWaitForNetworkReady(nadClient, nad)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		egressNodeAvailabilityHandler := egressNodeAvailabilityHandlerViaLabel{f}
 		ginkgo.By("1. Set one node as available for egress")
 		egressNodeAvailabilityHandler.Enable(egress1Node.name)
@@ -3593,11 +3588,8 @@ spec:
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			netConfig := newNetworkAttachmentConfig(otherNetworkAttachParms)
 			netConfig.namespace = otherNetworkNamespace.Name
-			_, err = nadClient.NetworkAttachmentDefinitions(otherNetworkNamespace.Name).Create(
-				context.Background(),
-				generateNAD(netConfig, f.ClientSet),
-				metav1.CreateOptions{},
-			)
+			nad := generateNAD(netConfig, f.ClientSet)
+			_, err = createNADAndWaitForNetworkReady(nadClient, nad)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		} else {
 			ginkgo.By(fmt.Sprintf("Building other namespace api object for CDN, basename %s", f.BaseName))

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -737,7 +737,7 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 			Entry("NetworkAttachmentDefinitions", func(c *networkAttachmentConfigParams) error {
 				netConfig := newNetworkAttachmentConfig(*c)
 				nad := generateNAD(netConfig, f.ClientSet)
-				_, err := nadClient.NetworkAttachmentDefinitions(c.namespace).Create(context.Background(), nad, metav1.CreateOptions{})
+				_, err := createNADAndWaitForNetworkReady(nadClient, nad)
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c *networkAttachmentConfigParams) error {
@@ -896,11 +896,8 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 				netConfigParams.namespace = f.Namespace.Name
 				filterSupportedNetworkConfig(f.ClientSet, &netConfigParams)
 				netConfig := newNetworkAttachmentConfig(netConfigParams)
-				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
-					context.Background(),
-					generateNAD(netConfig, f.ClientSet),
-					metav1.CreateOptions{},
-				)
+				nad := generateNAD(netConfig, f.ClientSet)
+				_, err := createNADAndWaitForNetworkReady(nadClient, nad)
 				framework.ExpectNoError(err)
 				testMulticastUDPTraffic(f, clientNodeInfo, serverNodeInfo, udnPodInterface)
 			},
@@ -931,11 +928,8 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 				netConfigParams.namespace = f.Namespace.Name
 				filterSupportedNetworkConfig(f.ClientSet, &netConfigParams)
 				netConfig := newNetworkAttachmentConfig(netConfigParams)
-				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
-					context.Background(),
-					generateNAD(netConfig, f.ClientSet),
-					metav1.CreateOptions{},
-				)
+				nad := generateNAD(netConfig, f.ClientSet)
+				_, err := createNADAndWaitForNetworkReady(nadClient, nad)
 				framework.ExpectNoError(err)
 				testMulticastIGMPQuery(f, clientNodeInfo, serverNodeInfo)
 			},
@@ -1638,7 +1632,7 @@ spec:
 			Entry("NetworkAttachmentDefinitions", func(c *networkAttachmentConfigParams) error {
 				netConfig := newNetworkAttachmentConfig(*c)
 				nad := generateNAD(netConfig, f.ClientSet)
-				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(context.Background(), nad, metav1.CreateOptions{})
+				_, err := createNADAndWaitForNetworkReady(nadClient, nad)
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c *networkAttachmentConfigParams) error {

--- a/test/e2e/network_segmentation_endpointslices_mirror.go
+++ b/test/e2e/network_segmentation_endpointslices_mirror.go
@@ -165,7 +165,8 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 			Entry("NetworkAttachmentDefinitions", func(c networkAttachmentConfigParams) error {
 				netConfig := newNetworkAttachmentConfig(c)
 				nad := generateNAD(netConfig, f.ClientSet)
-				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(context.Background(), nad, metav1.CreateOptions{})
+				nad.Namespace = f.Namespace.Name
+				_, err := createNADAndWaitForNetworkReady(nadClient, nad)
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c networkAttachmentConfigParams) error {
@@ -251,7 +252,8 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 			Entry("NetworkAttachmentDefinitions", func(c networkAttachmentConfigParams) error {
 				netConfig := newNetworkAttachmentConfig(c)
 				nad := generateNAD(netConfig, f.ClientSet)
-				_, err := nadClient.NetworkAttachmentDefinitions(fmt.Sprintf("%s-default", f.Namespace.Name)).Create(context.Background(), nad, metav1.CreateOptions{})
+				nad.Namespace = fmt.Sprintf("%s-default", f.Namespace.Name)
+				_, err := createNADAndWaitForNetworkReady(nadClient, nad)
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c networkAttachmentConfigParams) error {

--- a/test/e2e/network_segmentation_policy.go
+++ b/test/e2e/network_segmentation_policy.go
@@ -93,11 +93,8 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 				netConfig := newNetworkAttachmentConfig(netConfigParams)
 				netConfig.namespace = f.Namespace.Name
 				netConfig.cidr = filterCIDRsAndJoin(cs, netConfig.cidr)
-				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
-					context.Background(),
-					generateNAD(netConfig, f.ClientSet),
-					metav1.CreateOptions{},
-				)
+				nad := generateNAD(netConfig, f.ClientSet)
+				_, err := createNADAndWaitForNetworkReady(nadClient, nad)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ginkgo.By("creating client/server pods")
@@ -239,11 +236,8 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					netConfig.namespace = namespace
 					netConfig.name = netConfName
 
-					_, err := nadClient.NetworkAttachmentDefinitions(namespace).Create(
-						context.Background(),
-						generateNAD(netConfig, f.ClientSet),
-						metav1.CreateOptions{},
-					)
+					generatedNAD := generateNAD(netConfig, f.ClientSet)
+					_, err := createNADAndWaitForNetworkReady(nadClient, generatedNAD)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 
@@ -341,11 +335,8 @@ var _ = ginkgo.Describe("Network Segmentation: Network Policies", feature.Networ
 					netConfig.namespace = namespace
 					netConfig.name = netConfName
 
-					_, err := nadClient.NetworkAttachmentDefinitions(namespace).Create(
-						context.Background(),
-						generateNAD(netConfig, f.ClientSet),
-						metav1.CreateOptions{},
-					)
+					generatedNAD := generateNAD(netConfig, f.ClientSet)
+					_, err := createNADAndWaitForNetworkReady(nadClient, generatedNAD)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 				gomega.Eventually(func() v1.PodPhase {

--- a/test/e2e/network_segmentation_services.go
+++ b/test/e2e/network_segmentation_services.go
@@ -120,11 +120,8 @@ var _ = Describe("Network Segmentation: services", feature.NetworkSegmentation, 
 				By("Creating the attachment configuration")
 				netConfig := newNetworkAttachmentConfig(netConfigParams)
 				netConfig.namespace = f.Namespace.Name
-				_, err = nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
-					context.Background(),
-					generateNAD(netConfig, f.ClientSet),
-					metav1.CreateOptions{},
-				)
+				nad := generateNAD(netConfig, f.ClientSet)
+				_, err = createNADAndWaitForNetworkReady(nadClient, nad)
 				Expect(err).NotTo(HaveOccurred())
 
 				By(fmt.Sprintf("Creating a UDN LoadBalancer service"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

There's a race condition when a pod is created right after a NAD is
created. The cluster manager allocates the network-id annotation
asynchronously, so the NAD can be without network-id for a moment. If
the node's nad_controller processes the NAD during this window, it
returns early without setting up the network and doesn't reconcile
later. This breaks all tests that depend on the NAD, as pods timeout
waiting for OVN annotations that are never set.

Some tests were dealing with this problem by sleeping. Instead of that,
we are going to wait for the annotation before proceeding.

This patch introduces a helper function to create NADs in e2e tests that
will guarantee the annotation. All existing occurrences of NAD creation
in e2e suite are updated to use the helper.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

I'm hitting failures in multihoming tests that suggest this race condition
happening. I haven't seen other tests I touched here to do the same, but I
think it's wise to cover all occurrences of a potential race in one place.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions in end-to-end tests where resources were created but not fully initialized before test execution.

* **Tests**
  * Enhanced test reliability by adding synchronization to ensure network resources reach a ready state before proceeding with test assertions across multiple test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->