### PR TITLE
e2e: fix race condition in startEastWestIperfTraffic

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -336,9 +336,19 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			}
 
 			By(fmt.Sprintf("check iperf3 connectivity for %s: %s", address, stage))
-			output, err = execFn(fmt.Sprintf("iperf3 -c %s -p %d -t 1", address, port))
-			if err != nil {
-				return fmt.Errorf("failed checking iperf3 connectivity %s: %w", output, err)
+			connectivityBackoff := wait.Backoff{
+				Steps:    4,
+				Duration: 5 * time.Second,
+				Factor:   2.0,
+			}
+			if err := retry.OnError(connectivityBackoff, func(error) bool { return true }, func() error {
+				output, err = execFn(fmt.Sprintf("iperf3 -c %s -p %d -t 1", address, port))
+				if err != nil {
+					return fmt.Errorf("failed checking iperf3 connectivity %s: %w", output, err)
+				}
+				return nil
+			}); err != nil {
+				return err
 			}
 
 			By(fmt.Sprintf("start iperf3 client to %s: %s", address, stage))

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -332,7 +332,7 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			By(fmt.Sprintf("remove iperf3 log for %s: %s", address, stage))
 			output, err := execFn(fmt.Sprintf("rm -f %s", iperfLogFile))
 			if err != nil {
-				return fmt.Errorf("failed removing iperf3 log file %s: %w", output, err)
+				return fmt.Errorf("failed removing iperf3 log file %s: %s: %w", iperfLogFile, output, err)
 			}
 
 			By(fmt.Sprintf("check iperf3 connectivity for %s: %s", address, stage))

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -323,30 +323,43 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			}
 		}
 
+		// startIperfClient starts an iperf3 client in background after verifying connectivity.
+		// It removes any old log file, checks connectivity with a short foreground run,
+		// then starts the background iperf3 process.
+		startIperfClient = func(execFn execFnType, address string, port int32, iperfLogFile, stage string) error {
+			GinkgoHelper()
+
+			By(fmt.Sprintf("remove iperf3 log for %s: %s", address, stage))
+			output, err := execFn(fmt.Sprintf("rm -f %s", iperfLogFile))
+			if err != nil {
+				return fmt.Errorf("failed removing iperf3 log file %s: %w", output, err)
+			}
+
+			By(fmt.Sprintf("check iperf3 connectivity for %s: %s", address, stage))
+			output, err = execFn(fmt.Sprintf("iperf3 -c %s -p %d -t 1", address, port))
+			if err != nil {
+				return fmt.Errorf("failed checking iperf3 connectivity %s: %w", output, err)
+			}
+
+			By(fmt.Sprintf("start iperf3 client to %s: %s", address, stage))
+			output, err = execFn(fmt.Sprintf("nohup iperf3 -t 0 -c %[1]s -p %[2]d --logfile %[3]s &", address, port, iperfLogFile))
+			if err != nil {
+				return fmt.Errorf("failed starting iperf3 in background %s: %w", output, err)
+			}
+			return nil
+		}
+
 		startEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, serverPodIPsByName map[string][]string, stage string) error {
 			GinkgoHelper()
 			Expect(serverPodIPsByName).NotTo(BeEmpty())
-			polling := 15 * time.Second
+			execFn := func(cmd string) (string, error) {
+				return virtClient.RunCommand(vmi, cmd, 15*time.Second)
+			}
 			for podName, serverPodIPs := range serverPodIPsByName {
 				for _, serverPodIP := range serverPodIPs {
 					iperfLogFile := fmt.Sprintf("/tmp/%s_%s_iperf3.log", podName, serverPodIP)
-
-					By(fmt.Sprintf("remove iperf3 log for %s: %s", serverPodIP, stage))
-					output, err := virtClient.RunCommand(vmi, fmt.Sprintf("rm -f %s", iperfLogFile), polling)
-					if err != nil {
-						return fmt.Errorf("failed removing iperf3 log file %s: %w", output, err)
-					}
-
-					By(fmt.Sprintf("check iperf3 connectivity for %s: %s", serverPodIP, stage))
-					output, err = virtClient.RunCommand(vmi, fmt.Sprintf("iperf3 -t 1 -c %s", serverPodIP), polling)
-					if err != nil {
-						return fmt.Errorf("failed checking iperf3 connectivity %s: %w", output, err)
-					}
-
-					By(fmt.Sprintf("start iperf3 to %s: %s", serverPodIP, stage))
-					output, err = virtClient.RunCommand(vmi, fmt.Sprintf("nohup iperf3 -t 0 -c %[2]s --logfile %[1]s &", iperfLogFile, serverPodIP), polling)
-					if err != nil {
-						return fmt.Errorf("%s: %w", output, err)
+					if err := startIperfClient(execFn, serverPodIP, iperf3DefaultPort, iperfLogFile, stage); err != nil {
+						return err
 					}
 				}
 			}
@@ -400,22 +413,8 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			Expect(addresses).NotTo(BeEmpty())
 			for _, address := range addresses {
 				iperfLogFile := fmt.Sprintf("/tmp/%s_test_%s_%d_iperf3.log", logPrefix, address, port)
-				By(fmt.Sprintf("remove iperf3 log for %s: %s", address, stage))
-				output, err := execFn(fmt.Sprintf("rm -f %s", iperfLogFile))
-				if err != nil {
-					return fmt.Errorf("failed removing iperf3 log file %s: %w", output, err)
-				}
-
-				By(fmt.Sprintf("check iperf3 connectivity for %s: %s", address, stage))
-				output, err = execFn(fmt.Sprintf("iperf3 -c %s -p %d", address, port))
-				if err != nil {
-					return fmt.Errorf("failed checking iperf3 connectivity %s: %w", output, err)
-				}
-
-				By(fmt.Sprintf("start from %s: %s", address, stage))
-				output, err = execFn(fmt.Sprintf("nohup iperf3 -t 0 -c %[1]s -p %[2]d --logfile %[3]s &", address, port, iperfLogFile))
-				if err != nil {
-					return fmt.Errorf("failed at starting iperf3 in background %s: %w", output, err)
+				if err := startIperfClient(execFn, address, port, iperfLogFile, stage); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -432,7 +431,7 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 		startNorthSouthEgressIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, addresses []string, port int32, stage string) error {
 			GinkgoHelper()
 			execFn := func(cmd string) (string, error) {
-				return virtClient.RunCommand(vmi, cmd, 5*time.Second)
+				return virtClient.RunCommand(vmi, cmd, 15*time.Second)
 			}
 			return startNorthSouthIperfTraffic(execFn, addresses, port, "egress", stage)
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

startEastWestIperfTraffic started iperf3 in background without verifying
connectivity first, causing flaky failures when checkEastWestIperfTraffic
ran before iperf3 had established connection.

Apply the same pattern used by startNorthSouthIperfTraffic: confirm
connectivity with a short foreground iperf3 run before starting the
background process.

Introduce startIperfClient helper to share this logic between both
functions.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: #5443

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized iperf3 startup and per-host logging to improve reliability of East‑West and North‑South traffic tests.
  * Added upfront connectivity verification and background process management for consistent test initialization.
  * Introduced a standardized command execution wrapper with extended timeouts for longer operations.
  * Refactored traffic setup flows for more predictable failures and easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->