### PR TITLE
e2e: clean up stale networks before VRF-Lite BGP tests

### DIFF
--- a/test/e2e/infraprovider/api/api.go
+++ b/test/e2e/infraprovider/api/api.go
@@ -18,6 +18,8 @@ type Provider interface {
 
 	// PrimaryNetwork returns OVN-Kubernetes primary infrastructure network information
 	PrimaryNetwork() (Network, error)
+	// ListNetworks returns the names of all networks
+	ListNetworks() ([]string, error)
 	// GetNetwork returns a network
 	GetNetwork(name string) (Network, error)
 	// GetExternalContainerNetworkInterface fetches network interface information from the external container attached to a specific network


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

When a VRF-Lite test times out during cleanup, Docker networks may be
left behind. On retry, new networks with the same subnets fail to
create.

Add ListNetworks() to the infraprovider API and use it to find and
delete any stale networks with matching subnets before creating new
ones in BeforeEach.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added the ability for tests to list available networks.
  * Improved cleanup to detect and remove stale network resources from prior runs.
  * Adjusted test setup to better isolate and configure additional networks and subnets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->