### PR TITLE
helm: replace non-functional critical-pod annotation with priorityClassName

### DIFF
--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -27,7 +27,7 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
-      priorityClassName: "system-cluster-critical"
+      priorityClassName: "system-node-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default

--- a/dist/templates/ovnkube-single-node-zone-dpu.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone-dpu.yaml.j2
@@ -26,9 +26,8 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
         ovn-db-pod: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: "system-node-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -26,9 +26,8 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
         ovn-db-pod: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: "system-node-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -26,9 +26,8 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
         ovn-db-pod: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: "system-cluster-critical"
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.
       serviceAccountName: ovnkube-node

--- a/dist/templates/ovs-node.yaml.j2
+++ b/dist/templates/ovs-node.yaml.j2
@@ -28,7 +28,7 @@ spec:
         kubernetes.io/os: "linux"
       annotations:
     spec:
-      priorityClassName: "system-cluster-critical"
+      priorityClassName: "system-node-critical"
       hostNetwork: true
       dnsPolicy: Default
       {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
-      priorityClassName: "system-cluster-critical"
+      priorityClassName: "system-node-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
-      priorityClassName: "system-cluster-critical"
+      priorityClassName: "system-node-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
-      priorityClassName: "system-cluster-critical"
+      priorityClassName: "system-node-critical"
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -25,9 +25,8 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
         ovn-db-pod: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: "system-node-critical"
       {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -25,9 +25,8 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
         ovn-db-pod: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: "system-node-critical"
       {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -25,9 +25,8 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
         ovn-db-pod: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: "system-cluster-critical"
       {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}

--- a/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovs-node/templates/ovs-node.yaml
@@ -31,7 +31,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
-      priorityClassName: "system-cluster-critical"
+      priorityClassName: "system-node-critical"
       hostNetwork: true
       dnsPolicy: Default
       {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

This should address:

```
  I0205 01:12:49.383618 65129 builder.go:156] stderr: "Warning:
  spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]:
  non-functional in v1.16+; use the \"priorityClassName\" field
  instead\n"
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Pod scheduling priority across relevant system components has been modernized to use Kubernetes PriorityClass ("system-cluster-critical") instead of deprecated scheduling annotations.
  * This update removes legacy annotations and standardizes priority configuration in pod specs for more consistent and supported scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->