### PR TITLE
Add UDN performance metrics for reconciliation, node allocation, and NBDB programming

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -156,18 +156,18 @@ func New(
 	vidAllocator := id.NewIDAllocator("EVPN-VIDs", MaxEVPNVIDs)
 
 	c := &Controller{
-		nadClient:         nadClient,
-		nadLister:         nadInfomer.Lister(),
-		udnClient:         udnClient,
-		udnLister:         udnLister,
-		cudnLister:        cudnLister,
-		renderNadFn:       renderNadFn,
-		podInformer:       podInformer,
-		namespaceInformer: namespaceInformer,
-		networkManager:    networkManager,
-		namespaceTracker:  map[string]sets.Set[string]{},
-		vidAllocator:      vidAllocator,
-		eventRecorder:     eventRecorder,
+		nadClient:                     nadClient,
+		nadLister:                     nadInfomer.Lister(),
+		udnClient:                     udnClient,
+		udnLister:                     udnLister,
+		cudnLister:                    cudnLister,
+		renderNadFn:                   renderNadFn,
+		podInformer:                   podInformer,
+		namespaceInformer:             namespaceInformer,
+		networkManager:                networkManager,
+		namespaceTracker:              map[string]sets.Set[string]{},
+		vidAllocator:                  vidAllocator,
+		eventRecorder:                 eventRecorder,
 	}
 	udnCfg := &controller.ControllerConfig[userdefinednetworkv1.UserDefinedNetwork]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -581,6 +581,37 @@ func (c *Controller) UpdateSubsystemCondition(
 		c.eventRecorder.Event(udnRef, event.EventType, event.Reason, event.Note)
 	}
 
+	// Record network allocation duration when NetworkAllocationSucceeded becomes True for the first time
+	if condition != nil && condition.Type == "NetworkAllocationSucceeded" && condition.Status == metav1.ConditionTrue {
+		wasAlreadyTrue := meta.IsStatusConditionTrue(udn.Status.Conditions, "NetworkAllocationSucceeded")
+		if !wasAlreadyTrue {
+			allocationDuration := condition.LastTransitionTime.Time.Sub(udn.CreationTimestamp.Time)
+			// Record workflow phase metric for network ready
+			// This is creation → NetworkAllocationSucceeded time (total time until network is ready)
+			metrics.RecordUDNWorkflowPhaseDuration(udnName, "network_ready", allocationDuration.Seconds())
+
+			// Calculate async node allocation time (excluding UDN controller synchronous work)
+			// async_node_allocation = NetworkCreated.LastTransitionTime → NetworkAllocationSucceeded.LastTransitionTime
+			// This represents the wall-clock time for network cluster controller async operations
+			// including controller init, per-node processing, and waiting for all nodes to complete
+			wasNetworkCreatedBefore := meta.IsStatusConditionTrue(udn.Status.Conditions, conditionTypeNetworkCreated)
+			if wasNetworkCreatedBefore {
+				// NetworkCreated was set during reconciliation, so we can calculate async work
+				// by finding when reconciliation completed (when NetworkCreated was set)
+				networkCreatedCondition := meta.FindStatusCondition(udn.Status.Conditions, conditionTypeNetworkCreated)
+				if networkCreatedCondition != nil {
+					// Async node allocation time = NetworkAllocationSucceeded - NetworkCreated
+					// This is the wall-clock time for network cluster controller to allocate network on all nodes
+					asyncNodeAllocationDuration := condition.LastTransitionTime.Time.Sub(networkCreatedCondition.LastTransitionTime.Time)
+					metrics.RecordUDNWorkflowPhaseDuration(udnName, "async_node_allocation", asyncNodeAllocationDuration.Seconds())
+					klog.V(5).Infof("Recorded async node allocation duration for UDN %s: %v (NetworkCreated→NetworkAllocationSucceeded)", udnName, asyncNodeAllocationDuration)
+				}
+			}
+
+			klog.Infof("Recorded allocation duration for UDN %s: %v", udnName, allocationDuration)
+		}
+	}
+
 	if condition == nil {
 		return nil
 	}
@@ -630,6 +661,29 @@ func (c *Controller) reconcileUDN(key string) error {
 	}
 
 	udnCopy := udn.DeepCopy()
+
+	// Check if NetworkCreated was already True before this reconcile
+	wasNetworkCreatedBefore := meta.IsStatusConditionTrue(udnCopy.Status.Conditions, conditionTypeNetworkCreated)
+
+	// Track queue wait time for first reconciliation
+	if !wasNetworkCreatedBefore {
+		reconcileStartTime := time.Now()
+		queueWaitDuration := reconcileStartTime.Sub(udnCopy.CreationTimestamp.Time)
+
+		// Record workflow phase metric
+		metrics.RecordUDNWorkflowPhaseDuration(udnCopy.Name, "queue_wait", queueWaitDuration.Seconds())
+		klog.Infof("UDN %s/%s spent %v in queue before reconciliation", namespace, name, queueWaitDuration)
+	}
+	// Defer metric recording to measure total reconciliation time including queue wait
+	// For first reconciliation, measure from UDN creation time to include queue wait
+	defer func() {
+		if !wasNetworkCreatedBefore && udnCopy != nil {
+			reconciliationDuration := time.Since(udnCopy.CreationTimestamp.Time)
+			metrics.RecordUDNReconciliationDuration(udnCopy.Name, reconciliationDuration.Seconds())
+			klog.Infof("Recorded reconciliation duration for UDN %s: %v (includes queue wait + processing)",
+				udnCopy.Name, reconciliationDuration)
+		}
+	}()
 
 	nadCopy, syncErr := c.syncUserDefinedNetwork(udnCopy)
 

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -134,6 +134,12 @@ type Controller struct {
 
 	networkInUseRequeueInterval time.Duration
 	eventRecorder               record.EventRecorder
+
+	// firstReconcileMetricsRecorded tracks UDNs that have already recorded their first-reconcile metrics
+	// (queue_wait and reconciliation_duration) to prevent duplicate observations on retries.
+	// Key is namespace/name of the UDN.
+	firstReconcileMetricsRecorded     map[string]struct{}
+	firstReconcileMetricsRecordedLock sync.Mutex
 }
 
 func New(
@@ -168,6 +174,7 @@ func New(
 		namespaceTracker:              map[string]sets.Set[string]{},
 		vidAllocator:                  vidAllocator,
 		eventRecorder:                 eventRecorder,
+		firstReconcileMetricsRecorded: map[string]struct{}{},
 	}
 	udnCfg := &controller.ControllerConfig[userdefinednetworkv1.UserDefinedNetwork]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -586,9 +593,17 @@ func (c *Controller) UpdateSubsystemCondition(
 		wasAlreadyTrue := meta.IsStatusConditionTrue(udn.Status.Conditions, "NetworkAllocationSucceeded")
 		if !wasAlreadyTrue {
 			allocationDuration := condition.LastTransitionTime.Time.Sub(udn.CreationTimestamp.Time)
+			metricName := util.GenerateUDNNetworkName(udnNamespace, udnName)
+
 			// Record workflow phase metric for network ready
 			// This is creation → NetworkAllocationSucceeded time (total time until network is ready)
-			metrics.RecordUDNWorkflowPhaseDuration(udnName, "network_ready", allocationDuration.Seconds())
+			// Guard against negative durations from clock skew
+			if allocationDuration > 0 {
+				metrics.RecordUDNWorkflowPhaseDuration(metricName, "network_ready", allocationDuration.Seconds())
+				klog.Infof("Recorded allocation duration for UDN %s: %v", metricName, allocationDuration)
+			} else {
+				klog.Warningf("Skipping network_ready metric for UDN %s: non-positive duration %v (likely clock skew)", metricName, allocationDuration)
+			}
 
 			// Calculate async node allocation time (excluding UDN controller synchronous work)
 			// async_node_allocation = NetworkCreated.LastTransitionTime → NetworkAllocationSucceeded.LastTransitionTime
@@ -603,12 +618,15 @@ func (c *Controller) UpdateSubsystemCondition(
 					// Async node allocation time = NetworkAllocationSucceeded - NetworkCreated
 					// This is the wall-clock time for network cluster controller to allocate network on all nodes
 					asyncNodeAllocationDuration := condition.LastTransitionTime.Time.Sub(networkCreatedCondition.LastTransitionTime.Time)
-					metrics.RecordUDNWorkflowPhaseDuration(udnName, "async_node_allocation", asyncNodeAllocationDuration.Seconds())
-					klog.V(5).Infof("Recorded async node allocation duration for UDN %s: %v (NetworkCreated→NetworkAllocationSucceeded)", udnName, asyncNodeAllocationDuration)
+					// Guard against negative durations from clock skew
+					if asyncNodeAllocationDuration > 0 {
+						metrics.RecordUDNWorkflowPhaseDuration(metricName, "async_node_allocation", asyncNodeAllocationDuration.Seconds())
+						klog.V(5).Infof("Recorded async node allocation duration for UDN %s: %v (NetworkCreated→NetworkAllocationSucceeded)", metricName, asyncNodeAllocationDuration)
+					} else {
+						klog.Warningf("Skipping async_node_allocation metric for UDN %s: non-positive duration %v (likely clock skew)", metricName, asyncNodeAllocationDuration)
+					}
 				}
 			}
-
-			klog.Infof("Recorded allocation duration for UDN %s: %v", udnName, allocationDuration)
 		}
 	}
 
@@ -662,30 +680,80 @@ func (c *Controller) reconcileUDN(key string) error {
 
 	udnCopy := udn.DeepCopy()
 
-	// Check if NetworkCreated was already True before this reconcile
-	wasNetworkCreatedBefore := meta.IsStatusConditionTrue(udnCopy.Status.Conditions, conditionTypeNetworkCreated)
+	// Declare syncErr before defer so defer closure can check reconciliation outcome
+	var syncErr error
 
-	// Track queue wait time for first reconciliation
-	if !wasNetworkCreatedBefore {
-		reconcileStartTime := time.Now()
-		queueWaitDuration := reconcileStartTime.Sub(udnCopy.CreationTimestamp.Time)
+	// Guard against nil UDN (deleted before reconcile)
+	if udnCopy != nil {
+		// Check if NetworkCreated was already True before this reconcile
+		wasNetworkCreatedBefore := meta.IsStatusConditionTrue(udnCopy.Status.Conditions, conditionTypeNetworkCreated)
 
-		// Record workflow phase metric
-		metrics.RecordUDNWorkflowPhaseDuration(udnCopy.Name, "queue_wait", queueWaitDuration.Seconds())
-		klog.Infof("UDN %s/%s spent %v in queue before reconciliation", namespace, name, queueWaitDuration)
-	}
-	// Defer metric recording to measure total reconciliation time including queue wait
-	// For first reconciliation, measure from UDN creation time to include queue wait
-	defer func() {
-		if !wasNetworkCreatedBefore && udnCopy != nil {
-			reconciliationDuration := time.Since(udnCopy.CreationTimestamp.Time)
-			metrics.RecordUDNReconciliationDuration(udnCopy.Name, reconciliationDuration.Seconds())
-			klog.Infof("Recorded reconciliation duration for UDN %s: %v (includes queue wait + processing)",
-				udnCopy.Name, reconciliationDuration)
+		// Check if this is the first reconcile attempt (not a retry) by checking our tracking map
+		// This ensures queue_wait and reconciliation_duration metrics are recorded exactly once
+		c.firstReconcileMetricsRecordedLock.Lock()
+		_, alreadyRecorded := c.firstReconcileMetricsRecorded[key]
+		isFirstReconcile := !alreadyRecorded && !wasNetworkCreatedBefore
+		// Don't mark as recorded yet — defer will mark on successful reconciliation
+		c.firstReconcileMetricsRecordedLock.Unlock()
+
+		// Capture queue wait time for first reconciliation only (not retries)
+		// Recording is deferred until sync succeeds to avoid counting failed attempts
+		var queueWaitDuration time.Duration
+		if isFirstReconcile {
+			reconcileStartTime := time.Now()
+			queueWaitDuration = reconcileStartTime.Sub(udnCopy.CreationTimestamp.Time)
 		}
-	}()
+		// Defer metric recording to measure total reconciliation time
+		// Only record on successful first reconciliation to avoid counting failed attempts
+		defer func() {
+			if isFirstReconcile && syncErr == nil {
+				// Mark as recorded now that reconciliation succeeded
+				c.firstReconcileMetricsRecordedLock.Lock()
+				c.firstReconcileMetricsRecorded[key] = struct{}{}
+				c.firstReconcileMetricsRecordedLock.Unlock()
 
-	nadCopy, syncErr := c.syncUserDefinedNetwork(udnCopy)
+				metricName := util.GenerateUDNNetworkName(namespace, name)
+
+				// Record queue_wait only on successful reconciliation
+				// Skip queue_wait observation if duration exceeds reasonable bounds or is negative.
+				// After controller restarts, the in-memory tracking map is empty, causing
+				// inflated queue_wait times (creation → now instead of creation → first reconcile).
+				// Cap at 180s (3min) to prevent skewing statistics while still capturing genuine delays.
+				// Guard against negative durations from clock skew.
+				const maxReasonableQueueWait = 180 * time.Second
+				if queueWaitDuration > 0 && queueWaitDuration <= maxReasonableQueueWait {
+					metrics.RecordUDNWorkflowPhaseDuration(metricName, "queue_wait", queueWaitDuration.Seconds())
+					klog.Infof("UDN %s/%s spent %v in queue before reconciliation", namespace, name, queueWaitDuration)
+				} else if queueWaitDuration <= 0 {
+					klog.Warningf("Skipping queue_wait metric for UDN %s/%s: non-positive duration %v (likely clock skew)", namespace, name, queueWaitDuration)
+				} else {
+					klog.Warningf("UDN %s/%s queue wait duration %v exceeds reasonable bounds (%v), likely due to controller restart; skipping metric observation",
+						namespace, name, queueWaitDuration, maxReasonableQueueWait)
+				}
+
+				reconciliationDuration := time.Since(udnCopy.CreationTimestamp.Time)
+				// Cap reconciliation duration to prevent restart-inflation.
+				// After controller restarts, the in-memory tracking map is empty, causing
+				// inflated reconciliation times (creation → now instead of creation → first successful reconcile).
+				// Cap at 180s (3min) to prevent skewing statistics while still capturing genuine durations.
+				// Guard against negative durations from clock skew.
+				const maxReasonableReconciliationDuration = 180 * time.Second
+				if reconciliationDuration > 0 && reconciliationDuration <= maxReasonableReconciliationDuration {
+					metrics.RecordUDNReconciliationDuration(metricName, reconciliationDuration.Seconds())
+					klog.Infof("Recorded reconciliation duration for UDN %s: %v (includes queue wait + processing)",
+						metricName, reconciliationDuration)
+				} else if reconciliationDuration <= 0 {
+					klog.Warningf("Skipping reconciliation_duration metric for UDN %s: non-positive duration %v (likely clock skew)", metricName, reconciliationDuration)
+				} else {
+					klog.Warningf("UDN %s reconciliation duration %v exceeds reasonable bounds (%v), likely due to controller restart; skipping metric observation",
+						metricName, reconciliationDuration, maxReasonableReconciliationDuration)
+				}
+			}
+		}()
+	}
+
+	var nadCopy *netv1.NetworkAttachmentDefinition
+	nadCopy, syncErr = c.syncUserDefinedNetwork(udnCopy)
 
 	updateStatusErr := c.updateUserDefinedNetworkStatus(udnCopy, nadCopy, syncErr)
 
@@ -732,6 +800,15 @@ func (c *Controller) syncUserDefinedNetwork(udn *userdefinednetworkv1.UserDefine
 			klog.Infof("Finalizer removed from UserDefinedNetworks [%s/%s]", udn.Namespace, udn.Name)
 			metrics.DecrementUDNCount(role, topology)
 			metrics.DeleteDynamicUDNNodeCount(util.GenerateUDNNetworkName(udn.Namespace, udn.Name))
+
+			// Clean up first-reconcile metrics tracking to prevent memory leak
+			c.firstReconcileMetricsRecordedLock.Lock()
+			delete(c.firstReconcileMetricsRecorded, udn.Namespace+"/"+udn.Name)
+			c.firstReconcileMetricsRecordedLock.Unlock()
+
+			// Clean up UDN metric time series to prevent cardinality explosion
+			networkName := util.GenerateUDNNetworkName(udn.Namespace, udn.Name)
+			metrics.CleanupUDNMetrics(networkName)
 		}
 
 		return nil, nil
@@ -909,6 +986,10 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 			metrics.DecrementCUDNCount(role, topology)
 			metrics.DeleteDynamicUDNNodeCount(util.GenerateCUDNNetworkName(cudn.Name))
 			c.releaseVIDForNetwork(cudnName)
+
+			// Clean up CUDN metric time series to prevent cardinality explosion
+			networkName := util.GenerateCUDNNetworkName(cudn.Name)
+			metrics.CleanupUDNMetrics(networkName)
 		}
 
 		return nil, nil

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -17,12 +18,19 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/userdefinednetwork/template"
 	userdefinednetworkv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utiludn "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/udn"
 )
 
 func (c *Controller) updateNAD(obj client.Object, namespace string) (*netv1.NetworkAttachmentDefinition, error) {
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		// Record workflow phase metric for NAD sync
+		metrics.RecordUDNWorkflowPhaseDuration(obj.GetName(), "nad_sync", duration.Seconds())
+	}()
 	if utiludn.IsPrimaryNetwork(template.GetSpec(obj)) {
 		// check if required UDN label is on namespace
 		ns, err := c.namespaceInformer.Lister().Get(namespace)

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -98,6 +98,14 @@ var metricOVNControllerSBDBConnection = prometheus.NewGauge(prometheus.GaugeOpts
 	Help:      "Specifies if OVN controller is connected to OVN southbound database (1) or not (0)",
 })
 
+var metricUDNNBDBProgrammedDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Namespace: types.MetricOvnNamespace,
+	Subsystem: types.MetricOvnSubsystemController,
+	Name:      "udn_nbdb_programmed_duration_seconds",
+	Help:      "NBDB programming duration for UDN network initialization (aggregated across all networks to reduce cardinality)",
+	Buckets:   prometheus.ExponentialBuckets(.001, 2, 14), // 1ms to 8.192s
+})
+
 var (
 	ovnControllerVersion       string
 	ovnControllerOvsLibVersion string
@@ -383,6 +391,7 @@ func RegisterOvnControllerMetrics(ovsDBClient libovsdbclient.Client, ovnRegistry
 
 	// ovn-controller metrics
 	ovnRegistry.MustRegister(metricOVNControllerSBDBConnection)
+	ovnRegistry.MustRegister(metricUDNNBDBProgrammedDuration)
 	ovnRegistry.MustRegister(prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
 			Namespace: types.MetricOvnNamespace,
@@ -442,4 +451,11 @@ func RegisterOvnControllerMetrics(ovsDBClient libovsdbclient.Client, ovnRegistry
 	// Register the ovn-controller coverage/show metrics
 	componentStopwatchShowMetricsMap[ovnController] = ovnControllerStopwatchShowMetricsMap
 	registerStopwatchShowMetrics(ovnRegistry, ovnController, types.MetricOvnNamespace, types.MetricOvnSubsystemController)
+}
+
+// RecordUDNNBDBProgrammedDuration records the NBDB programming duration for UDN network initialization.
+// The network name parameter is currently unused because the histogram is aggregated across
+// all networks to reduce cardinality, but is retained for future extensibility.
+func RecordUDNNBDBProgrammedDuration(_ string, duration float64) {
+	metricUDNNBDBProgrammedDuration.Observe(duration)
 }

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -661,6 +661,7 @@ func TestHandleMetrics(t *testing.T) {
 				"ovn_controller_txn_try_again",
 				"ovn_controller_txn_unchanged",
 				"ovn_controller_txn_uncommitted",
+				"ovn_controller_udn_nbdb_programmed_duration_seconds",
 				"ovn_controller_vconn_open",
 				"ovn_controller_vconn_received",
 				"ovn_controller_vconn_sent",

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -567,6 +567,12 @@ func (oc *Layer2UserDefinedNetworkController) Cleanup() error {
 }
 
 func (oc *Layer2UserDefinedNetworkController) init() error {
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		metrics.RecordUDNNBDBProgrammedDuration(oc.GetNetworkName(), duration.Seconds())
+	}()
+
 	// Create default Control Plane Protection (COPP) entry for routers
 	defaultCOPPUUID, err := EnsureDefaultCOPP(oc.nbClient)
 	if err != nil {

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -713,6 +713,12 @@ func (oc *Layer3UserDefinedNetworkController) WatchNodes() error {
 }
 
 func (oc *Layer3UserDefinedNetworkController) init() error {
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		metrics.RecordUDNNBDBProgrammedDuration(oc.GetNetworkName(), duration.Seconds())
+	}()
+
 	if err := oc.gatherJoinSwitchIPs(); err != nil {
 		return fmt.Errorf("failed to gather join switch IPs for network %s: %v", oc.GetNetworkName(), err)
 	}


### PR DESCRIPTION
  ## UDN Performance Metrics

  This PR adds comprehensive performance metrics for User-Defined Network (UDN) creation and allocation, enabling operators to
  identify bottlenecks and monitor UDN infrastructure health in production clusters.

  ### Metrics Added

  **1. `ovnkube_clustermanager_udn_reconciliation_duration_seconds`**
  - Tracks total time to reconcile a UDN (queue wait + NAD creation + allocation + status update)
  - Helps identify overall controller performance

  **2. `ovnkube_clustermanager_udn_workflow_phase_duration_seconds`**
  - Breaks down UDN creation into sequential phases: `queue_wait`, `nad_sync`, `async_node_allocation`, `network_ready`
  - Pinpoints which phase is causing delays (API server, controller queue, or node allocation)

  **3. `ovnkube_clustermanager_udn_node_alloc_operation_duration_seconds`**
  - Granular per-node operation timing: `parse_annotations`, `allocate_subnets`, `allocate_tunnel_id`, 
   `update_node_annotations`
  - Identifies slow API server operations or subnet allocation issues

  **4. `ovnkube_controller_udn_nbdb_programming_duration_seconds`**
  - Measures NBDB logical object programming time in network controllers
  - Detects NBDB performance degradation

  ### Use Cases

  - **Detect API server slowness**: Monitor `update_node_annotations` operation times
  - **Identify queue backlog**: Track `queue_wait` phase duration
  - **Debug scale issues**: Compare performance across 100s of UDNs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Monitoring & Observability**
  * Added new metrics for tracking User-Defined Network operations: reconciliation duration, node allocation phases, network synchronization timing, and database programming time
  * Implemented automatic cleanup of network-specific metrics when networks are deleted
  * Enhanced first-reconcile tracking to provide improved insights into network initialization performance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->