### PR TITLE
Fix broken Kind deployment when using -ric flag

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -240,7 +240,11 @@ build_ovn_image() {
 }
 
 run_kubectl() {
-  kind export kubeconfig --name ${KIND_CLUSTER_NAME} 
+  # Skip kubeconfig export in container mode - it overwrites container IPs with localhost.
+  if [ "$RUN_IN_CONTAINER" != true ]; then
+    kind export kubeconfig --name ${KIND_CLUSTER_NAME}
+  fi
+
   local retries=0
   local attempts=10
   while true; do


### PR DESCRIPTION
 Kind deployment with  -ric flag is currently broken, getting the following error:
                                                            
```
  [cluster1] + kubectl apply -f k8s.ovn.org_egressfirewalls.yaml                                                                                  
  [cluster1] error: error validating "k8s.ovn.org_egressfirewalls.yaml": error validating data:
  failed to download openapi: Get "https://127.0.0.1:46851/openapi/v2?timeout=32s":
  dial tcp 127.0.0.1:46851: connect: connection refused

  After retrying 10 times:
  [cluster1] error: 'kubectl apply -f k8s.ovn.org_egressfirewalls.yaml' did not succeed, failing
  Failed to run './ovn-kubernetes/contrib/kind.sh ...', removing the cluster

```

run_kubectl() calls 'kind export kubeconfig' which overwrites the kubeconfig with localhost addresses, breaking the container IP fix applied by run_script_in_container() when using the -ric flag.

This PR skip the kubeconfig export when RUN_IN_CONTAINER=true to preserve the container IP addresses needed for kubectl to work in container mode.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes kubeconfig export behavior when running in containerized environments to avoid unnecessary export and prevent incorrect local configuration or address replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->