### PR TITLE
Minimize ACLs by combining ipBlocks into single ACL

### DIFF
--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -250,9 +250,10 @@ var ACLNetworkPolicyPortIndex = newObjectIDsType(acl, NetworkPolicyPortIndexOwne
 // ingress/egress + NetworkPolicy[In/E]gressRule idx - defines given gressPolicy.
 // ACLs are created for gp.portPolicies which are grouped by protocol:
 // - for empty policy (no selectors and no ip blocks) - empty ACL (see allIPsMatch)
+// with idx=emptyIdx (-1)
 // OR
-// - all selector-based peers ACL
-// - for every IPBlock +1 ACL
+// - all selector-based peers ACL with idx=emptyIdx (-1)
+// - all ipBlocks combined into a single ACL with idx=ipBlockCombinedIdx (-2)
 // Therefore unique id for a given gressPolicy is protocol name + IPBlock idx
 // (protocol will be "None" if no port policy is defined, and empty policy and all
 // selector-based peers ACLs will have idx=-1)

--- a/go-controller/pkg/ovn/gress_policy_test.go
+++ b/go-controller/pkg/ovn/gress_policy_test.go
@@ -16,7 +16,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 		ipBlocks   []*knet.IPBlock
 		lportMatch string
 		l4Match    string
-		expected   []string
+		expected   string
 	}{
 		{
 			desc: "IPv4 only no except",
@@ -27,7 +27,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 			},
 			lportMatch: "fake",
 			l4Match:    "input",
-			expected:   []string{"ip4.src == 0.0.0.0/0 && input && fake"},
+			expected:   "ip4.src == 0.0.0.0/0 && input && fake",
 		},
 		{
 			desc: "multiple IPv4 only no except",
@@ -41,8 +41,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 			},
 			lportMatch: "fake",
 			l4Match:    "input",
-			expected: []string{"ip4.src == 0.0.0.0/0 && input && fake",
-				"ip4.src == 10.1.0.0/16 && input && fake"},
+			expected:   "(ip4.src == 0.0.0.0/0 || ip4.src == 10.1.0.0/16) && input && fake",
 		},
 		{
 			desc: "IPv6 only no except",
@@ -53,7 +52,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 			},
 			lportMatch: "fake",
 			l4Match:    "input",
-			expected:   []string{"ip6.src == fd00:10:244:3::49/32 && input && fake"},
+			expected:   "ip6.src == fd00:10:244:3::49/32 && input && fake",
 		},
 		{
 			desc: "mixed IPv4 and IPv6  no except",
@@ -67,8 +66,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 			},
 			lportMatch: "fake",
 			l4Match:    "input",
-			expected: []string{"ip6.src == ::/0 && input && fake",
-				"ip4.src == 0.0.0.0/0 && input && fake"},
+			expected:   "(ip6.src == ::/0 || ip4.src == 0.0.0.0/0) && input && fake",
 		},
 		{
 			desc: "IPv4 only with except",
@@ -80,7 +78,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 			},
 			lportMatch: "fake",
 			l4Match:    "input",
-			expected:   []string{"ip4.src == 0.0.0.0/0 && ip4.src != {10.1.0.0/16} && input && fake"},
+			expected:   "(ip4.src == 0.0.0.0/0 && ip4.src != {10.1.0.0/16}) && input && fake",
 		},
 		{
 			desc: "multiple IPv4 with except",
@@ -95,8 +93,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 			},
 			lportMatch: "fake",
 			l4Match:    "input",
-			expected: []string{"ip4.src == 0.0.0.0/0 && ip4.src != {10.1.0.0/16} && input && fake",
-				"ip4.src == 10.1.0.0/16 && input && fake"},
+			expected:   "((ip4.src == 0.0.0.0/0 && ip4.src != {10.1.0.0/16}) || ip4.src == 10.1.0.0/16) && input && fake",
 		},
 		{
 			desc: "IPv4 with IPv4 except",
@@ -108,7 +105,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 			},
 			lportMatch: "fake",
 			l4Match:    "input",
-			expected:   []string{"ip4.src == 0.0.0.0/0 && ip4.src != {10.1.0.0/16} && input && fake"},
+			expected:   "(ip4.src == 0.0.0.0/0 && ip4.src != {10.1.0.0/16}) && input && fake",
 		},
 	}
 


### PR DESCRIPTION
Combine all ipBlocks in a NetworkPolicy rule into single ACL instead of creating one ACL per ipBlock.
This reduces ACL bloat when policy having multiple ipBlocks for ingress/egress rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized network policy IP block handling by consolidating multiple per-block ACLs into a single unified ACL for improved performance and streamlined management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->