### PR TITLE
fix kind load docker-image content digest not found

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -209,6 +209,20 @@ jobs:
       run: |
         sudo ufw disable
 
+    - name: Disable containerd image store
+      # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
+      run: |
+        sudo mkdir -p /etc/docker
+        docker --version || true
+        containerd --version || true
+        [ -s "/etc/docker/daemon.json" ] && {
+          cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+        } || {
+          echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+        }
+        sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Download test-image-pr
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -355,9 +355,24 @@ jobs:
       run: |
         sudo ufw disable
 
+    - name: Disable containerd image store
+      # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
+      run: |
+        sudo mkdir -p /etc/docker
+        docker --version || true
+        containerd --version || true
+        [ -s "/etc/docker/daemon.json" ] && {
+          cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+        } || {
+          echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+        }
+        sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Load docker image
       run: |
         docker load --input ${CI_IMAGE_BASE_TAR} && rm -rf ${CI_IMAGE_BASE_TAR}
+        docker images || true
 
     - name: kind setup
       run: |
@@ -634,9 +649,24 @@ jobs:
       with:
         name: test-image-pr
 
+    - name: Disable containerd image store
+      # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
+      run: |
+        sudo mkdir -p /etc/docker
+        docker --version || true
+        containerd --version || true
+        [ -s "/etc/docker/daemon.json" ] && {
+          cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+        } || {
+          echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+        }
+        sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Load docker image
       run: |
         docker load --input ${CI_IMAGE_PR_TAR} && rm -rf ${CI_IMAGE_PR_TAR}
+        docker images || true
 
     - name: kind setup
       timeout-minutes: 30
@@ -791,9 +821,25 @@ jobs:
       with:
         name: test-image-pr
 
+    - name: Disable containerd image store
+      # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
+      run: |
+        sudo mkdir -p /etc/docker
+        docker --version || true
+        containerd --version || true
+        [ -s "/etc/docker/daemon.json" ] && {
+          cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+        } || {
+          echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+        }
+        sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Load docker image
       run: |
         docker load --input ${CI_IMAGE_PR_TAR} && rm -rf ${CI_IMAGE_PR_TAR}
+        docker images || true
+
 
     - name: kind IPv4 setup
       run: |


### PR DESCRIPTION
`kind setup` starts to fail with error:
```
ERROR: failed to load image: command "docker exec --privileged -i ovn-worker
    ctr --namespace=k8s.io images import --all-platforms --digests
    --snapshotter=overlayfs -" failed with error: exit status 1

Command Output: ctr: content digest sha256:9c04829e9...: not found
```

Related kind issue is https://github.com/kubernetes-sigs/kind/issues/3795.
This change uses the workaround mentioned in the kind issue.
    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to disable the containerd snapshotter during test runs to avoid a known Kind-related issue.
  * Test workflows now report Docker image details after image operations and tolerate transient image-load failures so runs surface image info without blocking on intermittent load errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->