### PR TITLE
Fix docker IP parsing

### DIFF
--- a/test/e2e/infraprovider/providers/kind/kind.go
+++ b/test/e2e/infraprovider/providers/kind/kind.go
@@ -607,6 +607,8 @@ const (
 	inspectNetworkMACKeyStr        = "{{ with index .NetworkSettings.Networks %q }}{{ .MacAddress }}{{ end }}"
 	inspectNetworkContainersKeyStr = "{{ range $key, $value := .Containers }}{{ printf \"%s\\n\" $value.Name}}{{ end }}'"
 	emptyValue                     = "<no value>"
+	// Docker 29+ returns "invalid IP" for IP fields
+	emptyIPValue                   = "invalid IP"
 )
 
 func isNetworkAttachedToContainer(networkName, containerName string) bool {
@@ -715,7 +717,7 @@ func getNetworkInterface(containerName, networkName string) (api.NetworkInterfac
 		}
 		valueStr := strings.Trim(string(value), "\n")
 		valueStr = strings.Trim(valueStr, "'")
-		if valueStr == emptyValue {
+		if valueStr == emptyValue || valueStr == emptyIPValue {
 			return "", nil
 		}
 		return valueStr, nil


### PR DESCRIPTION
Docker 29+ changed Go template rendering to return "invalid IP" instead of an empty string/`<no value>` for IP fields (GlobalIPv6Address, IPv6Gateway) that are not set. This broke secondary network interface discovery in e2e tests.

Eventually we should move to something more resilient(json) but this blocks CI currently. 

Example failure:
https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/21978379636/job/63495505704?pr=5967


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated network interface IP field handling for Docker 29+ compatibility in test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->