### PR TITLE
[WIP] skip CI jobs when only files in docs/ dir are modified

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'mkdocs.yml'
+      - 'docs/**'
   schedule:
     - cron: '0 */12 * * *'
   workflow_dispatch:


### PR DESCRIPTION
The paths-ignore list in `test.yml` only excluded `*.md` files all throughout the repo and `mkdocs.yml`, but the docs/ directory also contains images (.png, .svg) and other types of files (.odg, .pdf). Changes to these files would unnecessarily trigger the full CI pipeline, as in https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5956.

Add `docs/**` to paths-ignore so that PRs modifying only documentation files will skip the main CI. The dedicated `docs.yml` workflow (which validates `mkdocs` builds) is unaffected and continues to run on all PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to ignore documentation-only changes (docs/** and existing markdown/mkdocs files), so test runs are skipped when only docs are modified.
  * Behavior for code changes remains unchanged; CI continues to run for any non-documentation updates, improving pipeline efficiency and reducing unnecessary builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->