### PR TITLE
node: improve management port resilience after interface changes

### DIFF
--- a/go-controller/pkg/node/managementport/port_dpu_linux.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux.go
@@ -4,10 +4,12 @@
 package managementport
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"time"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/vishvananda/netlink"
 
 	"k8s.io/klog/v2"
@@ -17,6 +19,8 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
+
+var errMgmtPortDeviceNotFound = errors.New("management port PCI device not found")
 
 type managementPortRepresentor struct {
 	cfg        *managementPortConfig
@@ -104,25 +108,48 @@ func (mp *managementPortRepresentor) doReconcile() error {
 }
 
 type managementPortNetdev struct {
-	ifName        string
-	netdevDevName string
-	cfg           *managementPortConfig
-	routeManager  *routemanager.Controller
+	ifName       string
+	deviceID     string
+	cfg          *managementPortConfig
+	routeManager *routemanager.Controller
 }
 
-// newManagementPortNetdev creates a new managementPortNetdev
-func newManagementPortNetdev(netdevDevName string, cfg *managementPortConfig, routeManager *routemanager.Controller) *managementPortNetdev {
+// newManagementPortNetdev creates a new managementPortNetdev.
+// deviceID is the PCI device ID (e.g., "0000:03:00.2") used to identify the VF.
+func newManagementPortNetdev(deviceID string, cfg *managementPortConfig, routeManager *routemanager.Controller) *managementPortNetdev {
 	return &managementPortNetdev{
-		ifName:        types.K8sMgmtIntfName,
-		netdevDevName: netdevDevName,
-		cfg:           cfg,
-		routeManager:  routeManager,
+		ifName:       types.K8sMgmtIntfName,
+		deviceID:     deviceID,
+		cfg:          cfg,
+		routeManager: routeManager,
 	}
 }
 
+// findNetdevByDeviceID resolves the current interface name from the PCI device ID.
+func (mp *managementPortNetdev) findNetdevByDeviceID() (netlink.Link, error) {
+	if mp.deviceID == "" {
+		return nil, fmt.Errorf("no device ID available")
+	}
+
+	netdevName, err := util.GetNetdevNameFromDeviceId(mp.deviceID, nadapi.DeviceInfo{})
+	if err != nil {
+		return nil, fmt.Errorf("%w: device ID %s lookup failed: %v", errMgmtPortDeviceNotFound, mp.deviceID, err)
+	}
+	if netdevName == "" {
+		return nil, fmt.Errorf("%w: device ID %s resolved to empty netdev name", errMgmtPortDeviceNotFound, mp.deviceID)
+	}
+
+	link, err := util.GetNetLinkOps().LinkByName(netdevName)
+	if err != nil {
+		return nil, fmt.Errorf("device ID %s resolved to %s but LinkByName failed: %w", mp.deviceID, netdevName, err)
+	}
+
+	return link, nil
+}
+
 func (mp *managementPortNetdev) create() error {
-	klog.V(5).Infof("Lookup netdevice link and existing management port using '%v'", mp.netdevDevName)
-	link, err := util.GetNetLinkOps().LinkByName(mp.netdevDevName)
+	klog.Infof("Management port netdev create: deviceID=%s, ifName=%s", mp.deviceID, mp.ifName)
+	link, err := mp.findNetdevByDeviceID()
 	if err != nil {
 		return err
 	}
@@ -136,22 +163,20 @@ func (mp *managementPortNetdev) create() error {
 
 	// configure management port: name, mac, MTU, iptables
 	// mac addr, derived from the first entry in host subnets using the .2 address as mac with a fixed prefix.
-	klog.V(5).Infof("Setup netdevice management port: %s", link.Attrs().Name)
+	klog.V(5).Infof("Setup netdevice management port: %s (deviceID: %s)", link.Attrs().Name, mp.deviceID)
 	mgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(mp.cfg.hostSubnets[0]).IP)
 	err = bringupManagementPortLink(types.DefaultNetworkName, link, &mgmtPortMac, mp.ifName, config.Default.MTU)
 	if err != nil {
 		return err
 	}
 
-	if mp.netdevDevName != mp.ifName && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
-		// Store original interface name for later use
+	if link.Attrs().Name != mp.ifName && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
 		if _, stderr, err := util.RunOVSVsctl("set", "Open_vSwitch", ".",
-			"external-ids:ovn-orig-mgmt-port-netdev-name="+mp.netdevDevName); err != nil {
+			"external-ids:ovn-orig-mgmt-port-netdev-name="+link.Attrs().Name); err != nil {
 			return fmt.Errorf("failed to store original mgmt port interface name: %s", stderr)
 		}
 	}
 
-	// Setup Iptable and routes
 	err = createPlatformManagementPort(mp.ifName, mp.cfg, mp.routeManager)
 	if err != nil {
 		return err
@@ -164,5 +189,22 @@ func (mp *managementPortNetdev) reconcilePeriod() time.Duration {
 }
 
 func (mp *managementPortNetdev) doReconcile() error {
-	return createPlatformManagementPort(mp.ifName, mp.cfg, mp.routeManager)
+	if err := createPlatformManagementPort(mp.ifName, mp.cfg, mp.routeManager); err != nil {
+		klog.Warningf("Failed to reconcile management port netdev, attempting to recreate: %v", err)
+		if err := mp.create(); err != nil {
+			if errors.Is(err, errMgmtPortDeviceNotFound) {
+				// The VF's PCI device is no longer present on the bus.
+				// For example, a DPU reboot while the host container is
+				// still running destroys all VFs and recreates them from
+				// scratch — potentially under different PCI addresses
+				// (e.g., after a firmware settings change).
+				// We cannot safely pick a replacement VF at runtime; only a
+				// container restart allows the device plugin to re-allocate
+				// the correct device.
+				klog.Fatalf("Failed to recreate management port netdev, terminating so device plugin can re-allocate the correct VF on restart: %v", err)
+			}
+			return fmt.Errorf("failed to recreate management port: %w", err)
+		}
+	}
+	return nil
 }

--- a/go-controller/pkg/node/managementport/port_dpu_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux_test.go
@@ -4,6 +4,7 @@
 package managementport
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -13,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
@@ -23,6 +25,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
+	multinetworkmocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks/multinetwork"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -223,29 +226,66 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	})
 
 	Context("Create Management port DPU host", func() {
-		It("Fails if netdev link lookup failed", func() {
-			mgmtPortDpuHost := managementPortNetdev{
-				netdevDevName: "non-existent-netdev",
-			}
-			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
-			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
+		const deviceID = "0000:03:00.2"
+		var sriovnetOpsMock *utilMocks.SriovnetOps
+		var vdpaOpsMock *utilMocks.VdpaOps
+		var origSriovnetOps util.SriovnetOps
+		var origVdpaOps util.VdpaOps
 
-			err := mgmtPortDpuHost.create()
-			Expect(err).To(HaveOccurred())
+		BeforeEach(func() {
+			origSriovnetOps = util.GetSriovnetOps()
+			origVdpaOps = util.GetVdpaOps()
+			sriovnetOpsMock = &utilMocks.SriovnetOps{}
+			vdpaOpsMock = &utilMocks.VdpaOps{}
+			util.SetSriovnetOpsInst(sriovnetOpsMock)
+			util.SetVdpaOpsInst(vdpaOpsMock)
 		})
 
-		It("Fails if netdev does not exist", func() {
-			mgmtPortDpuHost := managementPortNetdev{
-				netdevDevName: "non-existent-netdev",
+		AfterEach(func() {
+			util.SetSriovnetOpsInst(origSriovnetOps)
+			util.SetVdpaOpsInst(origVdpaOps)
+		})
+
+		// mockDeviceIDToNetdev sets up mock expectations for findNetdevByDeviceID
+		mockDeviceIDToNetdev := func(pciAddr, netdevName string) {
+			vdpaOpsMock.On("GetVdpaDeviceByPci", pciAddr).Return(nil, fmt.Errorf("no vdpa device"))
+			sriovnetOpsMock.On("GetNetDevicesFromPci", pciAddr).Return([]string{netdevName}, nil)
+		}
+
+		It("Fails with errMgmtPortDeviceNotFound when PCI device is gone", func() {
+			mgmtPortDpuHost := &managementPortNetdev{
+				deviceID: deviceID,
 			}
-			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(
-				nil, fmt.Errorf("failed to get interface"))
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
-				nil, fmt.Errorf("failed to get interface"))
-			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+			vdpaOpsMock.On("GetVdpaDeviceByPci", deviceID).Return(nil, fmt.Errorf("no vdpa device"))
+			sriovnetOpsMock.On("GetNetDevicesFromPci", deviceID).Return(nil, fmt.Errorf("no device"))
 
 			err := mgmtPortDpuHost.create()
 			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, errMgmtPortDeviceNotFound)).To(BeTrue())
+		})
+
+		It("Fails when deviceID is empty", func() {
+			mgmtPortDpuHost := &managementPortNetdev{
+				deviceID: "",
+			}
+
+			err := mgmtPortDpuHost.create()
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, errMgmtPortDeviceNotFound)).To(BeFalse(),
+				"empty deviceID should not be confused with PCI device gone")
+		})
+
+		It("Fails with errMgmtPortDeviceNotFound when device ID resolves to empty netdev name", func() {
+			mgmtPortDpuHost := &managementPortNetdev{
+				deviceID: deviceID,
+			}
+			vdpaOpsMock.On("GetVdpaDeviceByPci", deviceID).Return(nil, fmt.Errorf("no vdpa device"))
+			sriovnetOpsMock.On("GetNetDevicesFromPci", deviceID).Return([]string{""}, nil)
+
+			err := mgmtPortDpuHost.create()
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, errMgmtPortDeviceNotFound)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("resolved to empty netdev name"))
 		})
 
 		It("Configures VF and calls createPlatformManagementPort", func() {
@@ -258,23 +298,23 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpuHost := newManagementPortNetdev("enp3s0f0v0", cfg, nil)
+			mgmtPortDpuHost := newManagementPortNetdev(deviceID, cfg, nil)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: "enp3s0f0v0", MTU: 1500, HardwareAddr: currentMgmtPortMac})
 
-			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
-				linkMock, nil)
-			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+			mockDeviceIDToNetdev(deviceID, "enp3s0f0v0")
+			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(linkMock, nil)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetHardwareAddr", linkMock, expectedMgmtPortMac).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
 			netlinkOpsMock.On("LinkSetAlias", linkMock, "enp3s0f0v0").Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil)
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
 			execMock.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevDevName,
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=enp3s0f0v0",
 			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
@@ -287,34 +327,173 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			Expect(err.Error()).To(ContainSubstring("createPlatformManagementPort error"))
 		})
 
-		It("Does not configure VF if already configured", func() {
+		It("Does not configure VF if already configured as ovn-k8s-mp0", func() {
 			_, ipnet, err := net.ParseCIDR("192.168.0.1/24")
-			Expect(err).ToNot(HaveOccurred())
-			_, clusterCidr, err := net.ParseCIDR("192.168.0.0/16")
 			Expect(err).ToNot(HaveOccurred())
 			expectedMgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipnet).IP)
 			config.Default.MTU = 1400
-			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: clusterCidr, HostSubnetLength: 8}}
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpuHost := managementPortNetdev{
-				cfg:           cfg,
-				netdevDevName: "enp3s0f0v0",
-			}
+			mgmtPortDpuHost := newManagementPortNetdev(deviceID, cfg, nil)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
-				Name: "ovn-k8s-mp0", MTU: 1400, HardwareAddr: expectedMgmtPortMac})
+				Name: types.K8sMgmtIntfName, MTU: 1400, HardwareAddr: expectedMgmtPortMac})
+
+			mockDeviceIDToNetdev(deviceID, types.K8sMgmtIntfName)
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(linkMock, nil).Once()
+			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.
 			netlinkOpsMock.On("LinkByName", mock.Anything).Return(nil, fmt.Errorf(
-				"createPlatformManagementPort error")).Once()
+				"createPlatformManagementPort error"))
 
 			err = mgmtPortDpuHost.create()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(
-				"createPlatformManagementPort error"))
+			Expect(err.Error()).To(ContainSubstring("createPlatformManagementPort error"))
+		})
+	})
+
+	Context("doReconcile Management port DPU host", func() {
+		const deviceID = "0000:03:00.2"
+		var sriovnetOpsMock *utilMocks.SriovnetOps
+		var vdpaOpsMock *utilMocks.VdpaOps
+		var origSriovnetOps util.SriovnetOps
+		var origVdpaOps util.VdpaOps
+
+		BeforeEach(func() {
+			origSriovnetOps = util.GetSriovnetOps()
+			origVdpaOps = util.GetVdpaOps()
+			sriovnetOpsMock = &utilMocks.SriovnetOps{}
+			vdpaOpsMock = &utilMocks.VdpaOps{}
+			util.SetSriovnetOpsInst(sriovnetOpsMock)
+			util.SetVdpaOpsInst(vdpaOpsMock)
+		})
+
+		AfterEach(func() {
+			util.SetSriovnetOpsInst(origSriovnetOps)
+			util.SetVdpaOpsInst(origVdpaOps)
+		})
+
+		mockDeviceIDToNetdev := func(pciAddr, netdevName string) {
+			vdpaOpsMock.On("GetVdpaDeviceByPci", pciAddr).Return(nil, fmt.Errorf("no vdpa device"))
+			sriovnetOpsMock.On("GetNetDevicesFromPci", pciAddr).Return([]string{netdevName}, nil)
+		}
+
+		It("Succeeds when createPlatformManagementPort succeeds (no recreation needed)", func() {
+			_, ipnet, err := net.ParseCIDR("192.168.0.1/24")
+			Expect(err).ToNot(HaveOccurred())
+			expectedMgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipnet).IP)
+			config.Default.MTU = 1400
+			netInfoMock := &multinetworkmocks.NetInfo{}
+			netInfoMock.On("IsPrimaryNetwork").Return(false)
+			netInfoMock.On("GetPodNetworkAdvertisedOnNodeVRFs", mock.Anything).Return(nil)
+			cfg := &managementPortConfig{
+				hostSubnets: []*net.IPNet{ipnet},
+				netInfo:     netInfoMock,
+			}
+			Expect(SetupManagementPortNFTSets()).To(Succeed())
+			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil)
+			linkMock := &mocks.Link{}
+			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
+				Name: types.K8sMgmtIntfName, MTU: 1400, HardwareAddr: expectedMgmtPortMac,
+				Index: 10})
+
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(linkMock, nil)
+			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
+
+			err = mgmtPort.doReconcile()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Recreates management port successfully when reconciliation fails but VF exists", func() {
+			_, ipnet, err := net.ParseCIDR("192.168.0.1/24")
+			Expect(err).ToNot(HaveOccurred())
+			expectedMgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipnet).IP)
+			config.Default.MTU = 1400
+			config.OvnKubeNode.Mode = types.NodeModeDPUHost
+			netInfoMock := &multinetworkmocks.NetInfo{}
+			netInfoMock.On("IsPrimaryNetwork").Return(false)
+			netInfoMock.On("GetPodNetworkAdvertisedOnNodeVRFs", mock.Anything).Return(nil)
+			cfg := &managementPortConfig{
+				hostSubnets: []*net.IPNet{ipnet},
+				netInfo:     netInfoMock,
+			}
+			Expect(SetupManagementPortNFTSets()).To(Succeed())
+			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil)
+			linkMock := &mocks.Link{}
+			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
+				Name: types.K8sMgmtIntfName, MTU: 1400, HardwareAddr: expectedMgmtPortMac,
+				Index: 10})
+
+			// createPlatformManagementPort fails on first attempt
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(nil, fmt.Errorf("link gone")).Once()
+
+			// create() succeeds: device ID resolves, VF already named ovn-k8s-mp0
+			mockDeviceIDToNetdev(deviceID, types.K8sMgmtIntfName)
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(linkMock, nil)
+			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
+
+			err = mgmtPort.doReconcile()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Returns error on transient create() failure (VF exists but config fails)", func() {
+			_, ipnet, err := net.ParseCIDR("192.168.0.1/24")
+			Expect(err).ToNot(HaveOccurred())
+			config.Default.MTU = 1400
+			cfg := &managementPortConfig{
+				hostSubnets: []*net.IPNet{ipnet},
+			}
+			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil)
+
+			// createPlatformManagementPort fails
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(nil, fmt.Errorf("link gone")).Once()
+
+			// create() finds the VF via device ID; VF has a different name so syncMgmtPortInterface runs
+			mockDeviceIDToNetdev(deviceID, "enp3s0f0v0")
+			linkMock2 := &mocks.Link{}
+			linkMock2.On("Attrs").Return(&netlink.LinkAttrs{
+				Name: "enp3s0f0v0", MTU: 1500})
+			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(linkMock2, nil)
+			// syncMgmtPortInterface calls LinkByName("ovn-k8s-mp0") → not found (already consumed .Once())
+			// then unconfigureMgmtNetdevicePort calls LinkByName("ovn-k8s-mp0") and IsLinkNotFoundError
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(nil, fmt.Errorf("not found"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
+			// bringupManagementPortLink fails with transient error
+			netlinkOpsMock.On("LinkSetDown", linkMock2).Return(fmt.Errorf("transient error"))
+
+			err = mgmtPort.doReconcile()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to recreate management port"))
+			Expect(errors.Is(err, errMgmtPortDeviceNotFound)).To(BeFalse())
+		})
+
+		It("Fatals when PCI device is gone during doReconcile", func() {
+			_, ipnet, err := net.ParseCIDR("192.168.0.1/24")
+			Expect(err).ToNot(HaveOccurred())
+			config.Default.MTU = 1400
+			cfg := &managementPortConfig{
+				hostSubnets: []*net.IPNet{ipnet},
+			}
+			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil)
+
+			// createPlatformManagementPort fails
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(nil, fmt.Errorf("link gone")).Once()
+
+			// create() fails: PCI device not found
+			vdpaOpsMock.On("GetVdpaDeviceByPci", deviceID).Return(nil, fmt.Errorf("no vdpa device"))
+			sriovnetOpsMock.On("GetNetDevicesFromPci", deviceID).Return(nil, fmt.Errorf("no such device"))
+
+			origOsExit := klog.OsExit
+			defer func() { klog.OsExit = origOsExit }()
+			klog.OsExit = func(_ int) {
+				panic("klog.Fatal called")
+			}
+
+			Expect(func() { _ = mgmtPort.doReconcile() }).To(PanicWith("klog.Fatal called"))
 		})
 	})
 })

--- a/go-controller/pkg/node/managementport/port_linux.go
+++ b/go-controller/pkg/node/managementport/port_linux.go
@@ -90,7 +90,22 @@ func NewManagementPortController(
 		c.ports[ovsPort] = newManagementPortOVS(cfg, routeManager)
 	}
 	if hasNetdev {
-		c.ports[netdevPort] = newManagementPortNetdev(netdevDevName, cfg, routeManager)
+		var deviceID string
+		if cfgs, err := util.ParseNodeManagementPortAnnotation(node); err == nil {
+			if devCfg, ok := cfgs[types.DefaultNetworkName]; ok && devCfg.DeviceId != "" {
+				deviceID = devCfg.DeviceId
+				klog.Infof("Management port PCI device ID: %s (from node annotation)", deviceID)
+			}
+		}
+		if deviceID == "" {
+			var err error
+			deviceID, err = util.GetDeviceIDFromNetdevice(netdevDevName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get PCI device ID for %s: %v", netdevDevName, err)
+			}
+			klog.Infof("Management port PCI device ID: %s (resolved from netdev %s)", deviceID, netdevDevName)
+		}
+		c.ports[netdevPort] = newManagementPortNetdev(deviceID, cfg, routeManager)
 	}
 	if hasRepresentor {
 		ifName := types.K8sMgmtIntfName

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -426,7 +426,26 @@ func testManagementPortDPUHost(ctx *cli.Context, fexec *ovntest.FakeExec, testNS
 		mgtPortMAC string = "0a:58:0a:01:01:02"
 		mgtPort    string = types.K8sMgmtIntfName
 		mtu        int    = 1400
+		deviceID   string = "0000:03:00.0"
 	)
+
+	origFsOps := util.GetFileSystemOps()
+	defer util.SetFileSystemOps(origFsOps)
+	mockFsOps := &utilMocks.FileSystemOps{}
+	mockFsOps.On("Readlink", mock.AnythingOfType("string")).Return("../../"+deviceID, nil)
+	util.SetFileSystemOps(mockFsOps)
+
+	origSriovOps := util.GetSriovnetOps()
+	defer util.SetSriovnetOpsInst(origSriovOps)
+	sriovMock := &utilMocks.SriovnetOps{}
+	sriovMock.On("GetNetDevicesFromPci", deviceID).Return([]string{"pf0vf0"}, nil)
+	util.SetSriovnetOpsInst(sriovMock)
+
+	origVdpaOps := util.GetVdpaOps()
+	defer util.SetVdpaOpsInst(origVdpaOps)
+	vdpaMock := &utilMocks.VdpaOps{}
+	vdpaMock.On("GetVdpaDeviceByPci", deviceID).Return(nil, fmt.Errorf("no vdpa"))
+	util.SetVdpaOpsInst(vdpaMock)
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1171,8 +1190,18 @@ var _ = Describe("Management Port tests", func() {
 	})
 
 	Context("NewManagementPortController creates a controller according to config.OvnKubeNode.Mode", func() {
+		var origFsOps util.FileSystemOps
+
 		BeforeEach(func() {
 			Expect(config.PrepareTestConfig()).To(Succeed())
+			origFsOps = util.GetFileSystemOps()
+			mockFsOps := &utilMocks.FileSystemOps{}
+			mockFsOps.On("Readlink", mock.AnythingOfType("string")).Return("../../0000:03:00.2", nil)
+			util.SetFileSystemOps(mockFsOps)
+		})
+
+		AfterEach(func() {
+			util.SetFileSystemOps(origFsOps)
 		})
 
 		node := &corev1.Node{
@@ -1208,7 +1237,18 @@ var _ = Describe("Management Port tests", func() {
 			repImpl := mgmtPortImpl.ports[representorPort].(*managementPortRepresentor)
 			Expect(repImpl.repDevName).To(Equal(rep))
 		})
-		It("Creates managementPortNetdev for Ovnkube Node mode dpu-host", func() {
+		It("Creates managementPortNetdev for dpu-host using device ID from node annotation", func() {
+			config.OvnKubeNode.Mode = types.NodeModeDPUHost
+			nodeWithAnnotation := node.DeepCopy()
+			nodeWithAnnotation.Annotations[util.OvnNodeManagementPort] = `{"default":{"DeviceId":"0000:05:00.7","PfId":1,"FuncId":3}}`
+			mgmtPort, err := NewManagementPortController(nodeWithAnnotation, hostSubnets, netdevName, rep, nil, netInfo)
+			Expect(err).NotTo(HaveOccurred())
+			mgmtPortImpl := mgmtPort.(*managementPortController)
+			Expect(mgmtPortImpl.ports[netdevPort]).ToNot(BeNil())
+			netdevImpl := mgmtPortImpl.ports[netdevPort].(*managementPortNetdev)
+			Expect(netdevImpl.deviceID).To(Equal("0000:05:00.7"))
+		})
+		It("Creates managementPortNetdev for dpu-host falling back to sysfs when annotation is missing", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
 			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
@@ -1217,9 +1257,35 @@ var _ = Describe("Management Port tests", func() {
 			Expect(mgmtPortImpl.ports[netdevPort]).ToNot(BeNil())
 			Expect(mgmtPortImpl.ports[representorPort]).To(BeNil())
 			netdevImpl := mgmtPortImpl.ports[netdevPort].(*managementPortNetdev)
-			Expect(netdevImpl.netdevDevName).To(Equal(netdevName))
+			Expect(netdevImpl.deviceID).To(Equal("0000:03:00.2"))
 		})
-		It("Creates managementPortNetdev and managementPortRepresentor for Ovnkube Node mode full", func() {
+		It("Fails to create managementPortNetdev when PCI resolution fails and annotation is missing", func() {
+			config.OvnKubeNode.Mode = types.NodeModeDPUHost
+			util.SetFileSystemOps(origFsOps)
+			mockFsOpsFail := &utilMocks.FileSystemOps{}
+			mockFsOpsFail.On("Readlink", mock.AnythingOfType("string")).Return("", fmt.Errorf("no such file"))
+			util.SetFileSystemOps(mockFsOpsFail)
+
+			_, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get PCI device ID"))
+		})
+		It("Creates managementPortNetdev and managementPortRepresentor for full mode using annotation", func() {
+			config.OvnKubeNode.MgmtPortNetdev = netdevName
+			nodeWithAnnotation := node.DeepCopy()
+			nodeWithAnnotation.Annotations[util.OvnNodeManagementPort] = `{"default":{"DeviceId":"0000:05:00.7","PfId":1,"FuncId":3}}`
+			mgmtPort, err := NewManagementPortController(nodeWithAnnotation, hostSubnets, netdevName, rep, nil, netInfo)
+			Expect(err).NotTo(HaveOccurred())
+			mgmtPortImpl := mgmtPort.(*managementPortController)
+			Expect(mgmtPortImpl.ports[ovsPort]).To(BeNil())
+			Expect(mgmtPortImpl.ports[netdevPort]).ToNot(BeNil())
+			Expect(mgmtPortImpl.ports[representorPort]).ToNot(BeNil())
+			netdevImpl := mgmtPortImpl.ports[netdevPort].(*managementPortNetdev)
+			Expect(netdevImpl.deviceID).To(Equal("0000:05:00.7"))
+			repImpl := mgmtPortImpl.ports[representorPort].(*managementPortRepresentor)
+			Expect(repImpl.repDevName).To(Equal(rep))
+		})
+		It("Creates managementPortNetdev and managementPortRepresentor for full mode falling back to sysfs", func() {
 			config.OvnKubeNode.MgmtPortNetdev = netdevName
 			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
@@ -1228,7 +1294,7 @@ var _ = Describe("Management Port tests", func() {
 			Expect(mgmtPortImpl.ports[netdevPort]).ToNot(BeNil())
 			Expect(mgmtPortImpl.ports[representorPort]).ToNot(BeNil())
 			netdevImpl := mgmtPortImpl.ports[netdevPort].(*managementPortNetdev)
-			Expect(netdevImpl.netdevDevName).To(Equal(netdevName))
+			Expect(netdevImpl.deviceID).To(Equal("0000:03:00.2"))
 			repImpl := mgmtPortImpl.ports[representorPort].(*managementPortRepresentor)
 			Expect(repImpl.repDevName).To(Equal(rep))
 		})


### PR DESCRIPTION
node: improve management port resilience in DPU host mode
Identify the management port VF by its PCI device ID instead of
interface name. At startup, the device ID is resolved from the current
netdev name and stored in the managementPortNetdev struct. All
subsequent lookups (create, reconcile) use the PCI device ID to find
the VF, making the management port resilient to interface renames.

When reconciliation fails, the code attempts to recreate the management
port by resolving the VF from its device ID. If the PCI device itself
is no longer present — due to a DPU reboot, an administrator destroying
VFs, or a firmware settings change that causes PCI re-enumeration — the
process terminates so the container can restart and the device plugin
can re-allocate the correct VF. Transient errors (route, iptables,
config failures) are returned to the retry loop instead.

Assisted-by: Cursor
Signed-off-by: Igal Tsoiref <itsoiref@redhat.com>