### PR TITLE
node: reconcile masquerade resources via link and address events

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -135,6 +135,8 @@ type DefaultNodeNetworkController struct {
 
 	udnHostIsolationManager *UDNHostIsolationManager
 
+	masqReconciler *masqueradeReconciler
+
 	nodeAddress net.IP
 	sbZone      string
 
@@ -159,7 +161,22 @@ func newDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, sto
 		c.udnHostIsolationManager = NewUDNHostIsolationManager(config.IPv4Mode, config.IPv6Mode,
 			cnnci.watchFactory.PodCoreInformer(), cnnci.name, cnnci.recorder)
 	}
-	c.linkManager = linkmanager.NewController(cnnci.name, config.IPv4Mode, config.IPv6Mode, c.updateGatewayMAC)
+	c.masqReconciler = &masqueradeReconciler{
+		routeManager: routeManager,
+		nodeName:     cnnci.name,
+		watchFactory: cnnci.watchFactory,
+	}
+	c.linkManager = linkmanager.NewController(cnnci.name, config.IPv4Mode, config.IPv6Mode, func(link netlink.Link) error {
+		if err := c.updateGatewayMAC(link); err != nil {
+			return err
+		}
+		if c.Gateway != nil && config.Gateway.Interface != "" && link.Attrs().Name == config.Gateway.Interface {
+			if err := c.masqReconciler.ensure(); err != nil {
+				klog.Errorf("Masquerade reconciler on link event: %v", err)
+			}
+		}
+		return nil
+	})
 	return c
 }
 
@@ -964,6 +981,22 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	start := time.Now()
 	if err := waiter.Wait(); err != nil {
 		return err
+	}
+	// Set masquerade IP reconciliation callback for all modes except DPU.
+	// DPU mode does not configure masquerade resources.
+	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+		gw, ok := nc.Gateway.(*gateway)
+		if !ok {
+			return fmt.Errorf("unexpected gateway type %T, expected *gateway", nc.Gateway)
+		}
+		if gw.nodeIPManager == nil {
+			return fmt.Errorf("node IP manager not initialized for gateway")
+		}
+		gw.nodeIPManager.OnMasqueradeIPChanged = func() {
+			if err := nc.masqReconciler.ensure(); err != nil {
+				klog.Errorf("Masquerade reconciler on masquerade IP change: %v", err)
+			}
+		}
 	}
 	err = nc.Gateway.Start()
 	if err != nil {

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -448,26 +448,13 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHostPreStart(kubeNodeIP ne
 		return fmt.Errorf("failed to remove stale masquerade resources: %w", err)
 	}
 
-	if err := setNodeMasqueradeIPOnExtBridge(kubeIntf); err != nil {
-		return fmt.Errorf("failed to set the node masquerade IP on the ext bridge %s: %v", kubeIntf, err)
-	}
-
-	if err := addMasqueradeRoute(nc.routeManager, kubeIntf, nc.name, ifAddrs, nc.watchFactory); err != nil {
-		return fmt.Errorf("failed to set the node masquerade route to OVN: %v", err)
+	if err := nc.masqReconciler.ensure(); err != nil {
+		return err
 	}
 
 	// Masquerade config mostly done on node, update annotation
 	if err := updateMasqueradeAnnotation(nc.name, nc.Kube); err != nil {
 		return fmt.Errorf("failed to update masquerade subnet annotation on node: %s, error: %v", nc.name, err)
-	}
-
-	err = configureSvcRouteViaInterface(nc.routeManager, config.Gateway.Interface, DummyNextHopIPs())
-	if err != nil {
-		return err
-	}
-
-	if err = addHostMACBindings(kubeIntf); err != nil {
-		return fmt.Errorf("failed to add MAC bindings for service routing: %w", err)
 	}
 
 	gatewayNextHops, _, err := getGatewayNextHops()
@@ -496,8 +483,8 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 	klog.Info("Initializing Shared Gateway Functionality for Gateway Start on DPU host")
 	var err error
 
-	// TODO(adrianc): revisit if support for nodeIPManager is needed.
 	gw := nc.Gateway.(*gateway)
+	gw.nodeIPManager = newAddressManager(nc.name, nc.Kube, nil, nc.watchFactory, nil)
 	if config.Gateway.NodeportEnable {
 		if err := initSharedGatewayIPTables(); err != nil {
 			return err

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1793,7 +1793,6 @@ func newGateway(
 			}
 			gw.openflowManager.requestFlowSync()
 		}
-
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Gateway Node Port Watcher")
 			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge, gw.openflowManager, gw.nodeIPManager, watchFactory, networkManager)
@@ -2097,6 +2096,96 @@ func setNodeMasqueradeIPOnExtBridge(extBridgeName string) error {
 		}
 	}
 
+	return nil
+}
+
+// masqueradeIPConfigured checks if the masquerade IPv4/IPv6 addresses are
+// present on the given link.
+func masqueradeIPConfigured(link netlink.Link) bool {
+	if config.IPv4Mode {
+		_, masqIPNet, _ := net.ParseCIDR(config.Gateway.V4MasqueradeSubnet)
+		masqIPNet.IP = config.Gateway.MasqueradeIPs.V4HostMasqueradeIP
+		if exists, err := util.LinkAddrExist(link, masqIPNet); err != nil || !exists {
+			return false
+		}
+	}
+	if config.IPv6Mode {
+		_, masqIPNet, _ := net.ParseCIDR(config.Gateway.V6MasqueradeSubnet)
+		masqIPNet.IP = config.Gateway.MasqueradeIPs.V6HostMasqueradeIP
+		if exists, err := util.LinkAddrExist(link, masqIPNet); err != nil || !exists {
+			return false
+		}
+	}
+	return true
+}
+
+// masqueradeReconciler ensures that all masquerade-related resources
+// (IP addresses, routes, and MAC bindings) are configured on the gateway interface.
+// It is idempotent and safe to call concurrently from multiple event sources
+// (linkManager, addressManager). A mutex serializes concurrent calls.
+//
+// A fast path checks if the masquerade IP is present and the interface has not changed
+// (same LinkIndex as last successful run). This makes frequent calls cheap (~2 netlink reads).
+// The slow path restores all resources in dependency order: masquerade IP first (routes
+// depend on it for gateway reachability), then routes, then MAC bindings.
+type masqueradeReconciler struct {
+	mu            sync.Mutex
+	lastLinkIndex int
+	routeManager  *routemanager.Controller
+	nodeName      string
+	watchFactory  factory.NodeWatchFactory
+}
+
+func (r *masqueradeReconciler) ensure() error {
+	if r.routeManager == nil || r.watchFactory == nil {
+		return fmt.Errorf("masquerade reconciler not fully initialized (routeManager=%v, watchFactory=%v)", r.routeManager, r.watchFactory)
+	}
+	gwIface := config.Gateway.Interface
+	if gwIface == "" || gwIface == types.DeriveFromMgmtPort {
+		return nil
+	}
+	if !r.mu.TryLock() {
+		return nil
+	}
+	defer r.mu.Unlock()
+
+	link, err := util.GetNetLinkOps().LinkByName(gwIface)
+	if err != nil {
+		return fmt.Errorf("interface %s not found: %w", gwIface, err)
+	}
+
+	// Fast path: same interface (LinkIndex) and masquerade IP present — resources are healthy.
+	if link.Attrs().Index == r.lastLinkIndex && masqueradeIPConfigured(link) {
+		return nil
+	}
+
+	klog.Infof("Ensuring masquerade resources on %s (ifindex=%d, lastSuccessful=%d)",
+		gwIface, link.Attrs().Index, r.lastLinkIndex)
+
+	// Verify interface has a primary (non-link-local, non-masquerade) IP before adding
+	// any resources. Prevents adding masquerade IP before DHCP completes.
+	ifAddrs, err := nodeutil.GetNetworkInterfaceIPAddresses(gwIface)
+	if err != nil {
+		return fmt.Errorf("failed to get IP addresses for interface %s: %w", gwIface, err)
+	}
+	// 1. Masquerade IP first — routes depend on it for gateway reachability.
+	if err := setNodeMasqueradeIPOnExtBridge(gwIface); err != nil {
+		return fmt.Errorf("failed to set masquerade IP: %w", err)
+	}
+	// 2. Routes with the current LinkIndex (interface may have been recreated).
+	if err := addMasqueradeRoute(r.routeManager, gwIface, r.nodeName, ifAddrs, r.watchFactory); err != nil {
+		return fmt.Errorf("failed to add masquerade route: %w", err)
+	}
+	if err := configureSvcRouteViaInterface(r.routeManager, gwIface, DummyNextHopIPs()); err != nil {
+		return fmt.Errorf("failed to configure service route: %w", err)
+	}
+	// 3. ARP/ND entries for masquerade IPs.
+	if err := addHostMACBindings(gwIface); err != nil {
+		return fmt.Errorf("failed to add MAC bindings: %w", err)
+	}
+
+	r.lastLinkIndex = link.Attrs().Index
+	klog.Infof("Masquerade resources ensured on %s (ifindex=%d)", gwIface, r.lastLinkIndex)
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -5,8 +5,10 @@ package node
 
 import (
 	"fmt"
+	"net"
 
 	nadfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
+	"github.com/vishvananda/netlink"
 
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -21,9 +23,12 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	utilMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -477,5 +482,94 @@ var _ = Describe("SyncServices", func() {
 			verifyIPTablesRule(iptV4, "10.96.0.40", 80, 30093, true,
 				"iptables rule should be created when UDN is active on this node")
 		})
+	})
+})
+
+var _ = Describe("masqueradeReconciler", func() {
+	var (
+		netlinkMock *utilMocks.NetLinkOps
+		rm          *routemanager.Controller
+		wf          factory.NodeWatchFactory
+	)
+
+	BeforeEach(func() {
+		netlinkMock = new(utilMocks.NetLinkOps)
+		util.SetNetLinkOpMockInst(netlinkMock)
+		rm = routemanager.NewController()
+		fakeClient := fake.NewSimpleClientset()
+		var err error
+		wf, err = factory.NewNodeWatchFactory(&util.OVNNodeClientset{KubeClient: fakeClient}, "node1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		util.ResetNetLinkOpMockInst()
+		wf.Shutdown()
+	})
+
+	It("skips reconciliation when interface name is empty", func() {
+		config.Gateway.Interface = ""
+		r := &masqueradeReconciler{nodeName: "node1", routeManager: rm, watchFactory: wf}
+		err := r.ensure()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns error when interface does not exist", func() {
+		config.Gateway.Interface = "nonexistent0"
+		r := &masqueradeReconciler{nodeName: "node1", routeManager: rm, watchFactory: wf}
+		netlinkMock.On("LinkByName", "nonexistent0").Return(nil, fmt.Errorf("no such network interface"))
+		err := r.ensure()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("interface nonexistent0 not found"))
+	})
+
+	It("skips reconciliation when mutex is already held", func() {
+		config.Gateway.Interface = "breth0"
+		r := &masqueradeReconciler{nodeName: "node1", routeManager: rm, watchFactory: wf}
+		r.mu.Lock()
+		defer r.mu.Unlock()
+
+		err := r.ensure()
+		Expect(err).NotTo(HaveOccurred())
+		netlinkMock.AssertNotCalled(GinkgoT(), "LinkByName")
+	})
+
+	It("reads config.Gateway.Interface at call time, not at construction", func() {
+		config.Gateway.Interface = "placeholder"
+		r := &masqueradeReconciler{nodeName: "node1", routeManager: rm, watchFactory: wf}
+
+		netlinkMock.On("LinkByName", "placeholder").Return(nil, fmt.Errorf("no such device"))
+		netlinkMock.On("LinkByName", "resolved0").Return(nil, fmt.Errorf("no such device"))
+
+		err := r.ensure()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("interface placeholder not found"))
+
+		config.Gateway.Interface = "resolved0"
+		err = r.ensure()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("interface resolved0 not found"))
+	})
+
+	It("takes fast path when link index matches and masquerade IP is present", func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.IPv4Mode = true
+		config.IPv6Mode = false
+		config.Gateway.Interface = "breth0"
+
+		linkMock := new(netlink_mocks.Link)
+		linkMock.On("Attrs").Return(&netlink.LinkAttrs{Index: 10, Name: "breth0"})
+
+		_, masqSubnet, _ := net.ParseCIDR(config.Gateway.V4MasqueradeSubnet)
+		masqSubnet.IP = config.Gateway.MasqueradeIPs.V4HostMasqueradeIP
+		netlinkMock.On("LinkByName", "breth0").Return(linkMock, nil)
+		netlinkMock.On("AddrList", linkMock, netlink.FAMILY_V4).Return([]netlink.Addr{
+			{IPNet: masqSubnet},
+		}, nil)
+
+		r := &masqueradeReconciler{nodeName: "node1", routeManager: rm, watchFactory: wf, lastLinkIndex: 10}
+		err := r.ensure()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(r.lastLinkIndex).To(Equal(10))
 	})
 })

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -41,7 +41,13 @@ type addressManager struct {
 	nodePrimaryAddr net.IP
 	gatewayBridge   *bridgeconfig.BridgeConfiguration
 
-	OnChanged func()
+	OnChanged             func()
+	OnMasqueradeIPChanged func()
+	// gatewayIfIndex caches the link index of config.Gateway.Interface.
+	// Used in DPUHost mode to filter address events to only the gateway
+	// interface. Refreshed in sync() every 30s; all access is from the
+	// runInternal goroutine so no synchronization is needed.
+	gatewayIfIndex int
 	sync.Mutex
 }
 
@@ -55,14 +61,15 @@ func newAddressManager(nodeName string, k kube.Interface, mgmtPort managementpor
 // reproducibility of unit tests.
 func newAddressManagerInternal(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration, useNetlink bool) *addressManager {
 	mgr := &addressManager{
-		nodeName:      nodeName,
-		watchFactory:  watchFactory,
-		cidrs:         sets.New[string](),
-		mgmtPort:      mgmtPort,
-		gatewayBridge: gwBridge,
-		OnChanged:     func() {},
-		useNetlink:    useNetlink,
-		syncPeriod:    30 * time.Second,
+		nodeName:              nodeName,
+		watchFactory:          watchFactory,
+		cidrs:                 sets.New[string](),
+		mgmtPort:              mgmtPort,
+		gatewayBridge:         gwBridge,
+		OnChanged:             func() {},
+		OnMasqueradeIPChanged: func() {},
+		useNetlink:            useNetlink,
+		syncPeriod:            30 * time.Second,
 	}
 	mgr.nodeAnnotator = kube.NewNodeAnnotator(k, nodeName)
 	if config.OvnKubeNode.Mode == types.NodeModeDPU {
@@ -135,7 +142,9 @@ func (c *addressManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) {
 		return
 	}
 
-	c.addHandlerForAddrChange()
+	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+		c.addHandlerForAddrChange()
+	}
 	doneWg.Add(1)
 	go func() {
 		c.runInternal(stopChan, c.getNetlinkAddrSubFunc(stopChan))
@@ -166,6 +175,16 @@ func (c *addressManager) runInternal(stopChan <-chan struct{}, subscribe subscri
 			if !ok {
 				if subscribed, addrChan, err = subscribe(); err != nil {
 					klog.Errorf("Error during netlink re-subscribe due to channel closing for IP Manager: %v", err)
+				}
+				continue
+			}
+			if a.LinkAddress.IP != nil && util.IsAddressReservedForInternalUse(a.LinkAddress.IP) {
+				c.reconcileMasqueradeResources()
+				continue
+			}
+			if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+				if c.gatewayIfIndex != 0 && a.LinkIndex == c.gatewayIfIndex {
+					c.reconcileMasqueradeResources()
 				}
 				continue
 			}
@@ -474,8 +493,30 @@ func (c *addressManager) isValidNodeIP(addr net.IP, linkIndex int) bool {
 	return true
 }
 
+func (c *addressManager) reconcileMasqueradeResources() {
+	c.OnMasqueradeIPChanged()
+	c.refreshGatewayIfIndex()
+}
+
+func (c *addressManager) refreshGatewayIfIndex() {
+	if config.Gateway.Interface == "" {
+		return
+	}
+	link, err := util.GetNetLinkOps().LinkByName(config.Gateway.Interface)
+	if err != nil {
+		klog.V(5).Infof("Gateway interface %s not found, resetting cached index: %v", config.Gateway.Interface, err)
+		c.gatewayIfIndex = 0
+		return
+	}
+	c.gatewayIfIndex = link.Attrs().Index
+}
+
 func (c *addressManager) sync() {
 	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		return
+	}
+	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+		c.reconcileMasqueradeResources()
 		return
 	}
 
@@ -517,6 +558,7 @@ func (c *addressManager) sync() {
 		}
 		c.OnChanged()
 	}
+	c.reconcileMasqueradeResources()
 }
 
 // getSecondaryHostEgressIPs returns the set of egress IPs that are assigned to standard linux interfaces (non ovs type). The

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -25,8 +25,10 @@ import (
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	mgmtportmock "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
+	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	utilMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -145,6 +147,62 @@ var _ = Describe("Node IP Handler event tests", func() {
 				}
 			})
 		})
+
+		Context("by adding and removing a masquerade IP", func() {
+			It("should trigger OnMasqueradeIPChanged callback", func() {
+				var masqueradeCallCount atomic.Int32
+				tc.ipManager.OnMasqueradeIPChanged = func() {
+					masqueradeCallCount.Add(1)
+				}
+
+				masqAddr := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String() + "/29"
+				ipEvent(masqAddr, true, tc.addrChan)
+				Eventually(func() int32 {
+					return masqueradeCallCount.Load()
+				}, 5).Should(Equal(int32(1)))
+
+				ipEvent(masqAddr, false, tc.addrChan)
+				Eventually(func() int32 {
+					return masqueradeCallCount.Load()
+				}, 5).Should(Equal(int32(2)))
+			})
+
+			It("should not update node annotations for masquerade IPs", func() {
+				masqAddr := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String() + "/29"
+				ipNet := ipEvent(masqAddr, true, tc.addrChan)
+				Consistently(func() bool {
+					return nodeHasAddress(tc.fakeClient, nodeName, ipNet)
+				}, 3).Should(BeFalse())
+			})
+		})
+
+		Context("when receiving an event with nil IP", func() {
+			It("should not panic and should not trigger masquerade or address change callbacks", func() {
+				var changedCount atomic.Int32
+				var masqueradeCount atomic.Int32
+				tc.ipManager.OnChanged = func() {
+					changedCount.Add(1)
+				}
+				tc.ipManager.OnMasqueradeIPChanged = func() {
+					masqueradeCount.Add(1)
+				}
+
+				tc.addrChan <- netlink.AddrUpdate{
+					LinkAddress: net.IPNet{},
+					NewAddr:     true,
+				}
+
+				Consistently(func() int32 {
+					return changedCount.Load() + masqueradeCount.Load()
+				}, 3).Should(Equal(int32(0)))
+
+				// Confirm normal events still work after nil IP event
+				ipNet := ipEvent(nodeAddr4, true, tc.addrChan)
+				Eventually(func() bool {
+					return nodeHasAddress(tc.fakeClient, nodeName, ipNet)
+				}, 5).Should(BeTrue())
+			})
+		})
 	})
 
 	Describe("Subscription errors", func() {
@@ -167,6 +225,163 @@ var _ = Describe("Node IP Handler event tests", func() {
 				return nodeHasAddress(tc.fakeClient, nodeName, ipNet)
 			}, 5).Should(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("Node IP Handler DPUHost event filtering", func() {
+	var tc *testCtx
+
+	const (
+		nodeName     = "node1"
+		gwIfIndex    = 42
+		otherIfIndex = 99
+		someAddr     = "192.168.1.50/24"
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.OvnKubeNode.Mode = ovntypes.NodeModeDPUHost
+		fexec := ovntest.NewFakeExec()
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
+			Output: "10.1.1.10",
+		})
+		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
+		tc = configureKubeOVNContext(nodeName, false)
+		tc.ipManager.gatewayIfIndex = gwIfIndex
+
+		subscribe := func() (bool, chan netlink.AddrUpdate, error) {
+			defer atomic.StoreUint32(&tc.subscribed, 1)
+			tc.addrChan = make(chan netlink.AddrUpdate)
+			return true, tc.addrChan, nil
+		}
+		tc.doneWg.Add(1)
+		go func() {
+			tc.ipManager.runInternal(tc.stopCh, subscribe)
+			tc.doneWg.Done()
+		}()
+		Eventually(func() bool {
+			return atomic.LoadUint32(&tc.subscribed) == 1
+		}, 5).Should(BeTrue())
+	})
+
+	AfterEach(func() {
+		close(tc.stopCh)
+		tc.doneWg.Wait()
+		tc.watchFactory.Shutdown()
+		close(tc.addrChan)
+		util.ResetRunner()
+	})
+
+	It("triggers masquerade reconciliation for events on the gateway interface", func() {
+		var masqueradeCount atomic.Int32
+		tc.ipManager.OnMasqueradeIPChanged = func() {
+			masqueradeCount.Add(1)
+		}
+
+		tc.addrChan <- netlink.AddrUpdate{
+			LinkAddress: *ovntest.MustParseIPNet(someAddr),
+			LinkIndex:   gwIfIndex,
+			NewAddr:     true,
+		}
+		Eventually(func() int32 {
+			return masqueradeCount.Load()
+		}, 5).Should(Equal(int32(1)))
+	})
+
+	It("does not trigger masquerade reconciliation for events on other interfaces", func() {
+		var masqueradeCount atomic.Int32
+		tc.ipManager.OnMasqueradeIPChanged = func() {
+			masqueradeCount.Add(1)
+		}
+
+		tc.addrChan <- netlink.AddrUpdate{
+			LinkAddress: *ovntest.MustParseIPNet(someAddr),
+			LinkIndex:   otherIfIndex,
+			NewAddr:     true,
+		}
+		Consistently(func() int32 {
+			return masqueradeCount.Load()
+		}, 3).Should(Equal(int32(0)))
+	})
+
+	It("does not trigger masquerade reconciliation when gateway index is unresolved", func() {
+		var masqueradeCount atomic.Int32
+		tc.ipManager.OnMasqueradeIPChanged = func() {
+			masqueradeCount.Add(1)
+		}
+		tc.ipManager.gatewayIfIndex = 0
+
+		tc.addrChan <- netlink.AddrUpdate{
+			LinkAddress: *ovntest.MustParseIPNet(someAddr),
+			LinkIndex:   gwIfIndex,
+			NewAddr:     true,
+		}
+		Consistently(func() int32 {
+			return masqueradeCount.Load()
+		}, 3).Should(Equal(int32(0)))
+	})
+
+	It("skips regular address processing for all events", func() {
+		tc.addrChan <- netlink.AddrUpdate{
+			LinkAddress: *ovntest.MustParseIPNet(someAddr),
+			LinkIndex:   otherIfIndex,
+			NewAddr:     true,
+		}
+		Consistently(func() bool {
+			return nodeHasAddress(tc.fakeClient, nodeName, ovntest.MustParseIPNet(someAddr))
+		}, 3).Should(BeFalse())
+	})
+})
+
+var _ = Describe("refreshGatewayIfIndex", func() {
+	const nodeName = "node1"
+
+	It("does nothing when Gateway.Interface is empty", func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.Gateway.Interface = ""
+		tc := configureKubeOVNContext(nodeName, false)
+		defer tc.watchFactory.Shutdown()
+
+		tc.ipManager.gatewayIfIndex = 42
+		tc.ipManager.refreshGatewayIfIndex()
+		Expect(tc.ipManager.gatewayIfIndex).To(Equal(42))
+	})
+
+	It("resets index to 0 when interface is not found", func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.Gateway.Interface = "nonexistent0"
+		tc := configureKubeOVNContext(nodeName, false)
+		defer tc.watchFactory.Shutdown()
+
+		nlMock := new(utilMocks.NetLinkOps)
+		util.SetNetLinkOpMockInst(nlMock)
+		defer util.ResetNetLinkOpMockInst()
+
+		nlMock.On("LinkByName", "nonexistent0").Return(nil, fmt.Errorf("not found"))
+
+		tc.ipManager.gatewayIfIndex = 42
+		tc.ipManager.refreshGatewayIfIndex()
+		Expect(tc.ipManager.gatewayIfIndex).To(Equal(0))
+	})
+
+	It("sets index from link when interface exists", func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		config.Gateway.Interface = "breth0"
+		tc := configureKubeOVNContext(nodeName, false)
+		defer tc.watchFactory.Shutdown()
+
+		nlMock := new(utilMocks.NetLinkOps)
+		linkMock := new(netlink_mocks.Link)
+		util.SetNetLinkOpMockInst(nlMock)
+		defer util.ResetNetLinkOpMockInst()
+
+		nlMock.On("LinkByName", "breth0").Return(linkMock, nil)
+		linkMock.On("Attrs").Return(&netlink.LinkAttrs{Index: 77, Name: "breth0"})
+
+		tc.ipManager.gatewayIfIndex = 0
+		tc.ipManager.refreshGatewayIfIndex()
+		Expect(tc.ipManager.gatewayIfIndex).To(Equal(77))
 	})
 })
 


### PR DESCRIPTION
node: reconcile masquerade resources via link and address events
Masquerade resources (IPs, routes, MAC bindings) on the gateway
interface can be lost when the interface is recreated or addresses
are removed externally. Add ensureMasqueradeResources to restore
them in the correct dependency order (primary IP check, masquerade
IP, routes, MAC bindings), with a fast path that skips when the
interface LinkIndex and masquerade IP are unchanged.

Hook into existing infrastructure for all node modes:
- linkManager: gateway interface link events
- addressManager: new OnMasqueradeIPChanged callback for masquerade
  IP events, periodic sync as fallback
- DPU host mode: minimal addressManager for netlink subscription,
  skipping annotation management


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a masquerade reconciler that runs in host mode and is triggered on gateway startup, gateway MAC updates, link/address events, and masquerade IP changes to ensure configuration is reapplied when needed.

* **Improvements**
  * Consolidates one-time masquerade setup into an idempotent reconciliation flow that restores IPs, routes, and neighbor (ARP/ND) bindings for greater reliability when interfaces or addresses change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->