### PR TITLE
Fix broken Live Migration link in Overview navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,7 @@ nav:
     - Host To NodePort Hairpin: design/host-to-node-port-hairpin-trafficflow.md
     - ExternalIPs/LoadBalancerIngress: design/external-ip-and-loadbalancer-ingress.md
     - Internal Subnets: design/ovn-kubernetes-subnets.md
-    - Kubevirt VM Live Migration: design/live-migration.md
+    - Kubevirt VM Live Migration: features/live-migration.md
   - Getting Started:
     - Launching OVN-Kubernetes: installation/launching-ovn-kubernetes-on-kind.md
     - Launching OVN-Kubernetes Using Helm: installation/launching-ovn-kubernetes-with-helm.md


### PR DESCRIPTION
## Problem
Clicking "Kubevirt VM Live Migration" in the Overview section of the left navigation did not open or render the page. The link did not work properly (no navigation/re-render).

## Root cause
In `mkdocs.yml`, the Overview nav entry for "Kubevirt VM Live Migration" pointed to a **non-existent file**:
- **Incorrect path:** `design/live-migration.md`
- The file `docs/design/live-migration.md` does not exist in the repo (only other design docs like `architecture.md`, `topology.md`, etc. exist there).
- The actual Live Migration documentation lives in **`docs/features/live-migration.md`**.

With Material’s `navigation.instant` feature, the theme tries to load the page without a full reload; the request for the missing page fails, so the content area does not update and the link appears broken.

## Fix
**File changed:** `mkdocs.yml`  
**Line 85:**

- **Before:** `- Kubevirt VM Live Migration: design/live-migration.md`
- **After:** `- Kubevirt VM Live Migration: features/live-migration.md`

The Overview nav item now points to the existing page `features/live-migration.md`, which is the same page already used under Features → LiveMigration. No new files were added; no UI or styling was changed. This is a one-line config fix.

## Verification
- Built/served the site locally with `mkdocs serve`.
- Confirmed that clicking "Kubevirt VM Live Migration" in the Overview section now opens and renders the Live Migration page correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VM Live Migration documentation location within the navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->