### PR TITLE
e2e: add SpecTimeout to EndpointSlices mirroring tests

### DIFF
--- a/test/e2e/network_segmentation_endpointslices_mirror.go
+++ b/test/e2e/network_segmentation_endpointslices_mirror.go
@@ -122,6 +122,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 					},
 					Entry(
 						"L2 primary UDN, cluster-networked pods",
+						SpecTimeout(5*time.Minute),
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
@@ -132,6 +133,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 					),
 					Entry(
 						"L3 primary UDN, cluster-networked pods",
+						SpecTimeout(5*time.Minute),
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
@@ -142,6 +144,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 					),
 					Entry(
 						"L2 primary UDN, host-networked pods",
+						SpecTimeout(5*time.Minute),
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
@@ -152,6 +155,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 					),
 					Entry(
 						"L3 primary UDN, host-networked pods",
+						SpecTimeout(5*time.Minute),
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
@@ -230,6 +234,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 					},
 					Entry(
 						"L2 secondary UDN",
+						SpecTimeout(5*time.Minute),
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
@@ -239,6 +244,7 @@ var _ = Describe("Network Segmentation EndpointSlices mirroring", feature.Networ
 					),
 					Entry(
 						"L3 secondary UDN",
+						SpecTimeout(5*time.Minute),
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

Hitting this issue downstream where the test suite times out while running
through these test cases. Regardless of the underlying failure, test suite
should not let these test cases to consume so much time.

## 📑 Description
<!-- Add a brief description of the pr -->

Add a 5-minute SpecTimeout to each Entry in the EndpointSlices
mirroring DescribeTable blocks. Without per-spec timeouts, a single
stuck deployment (5-min WaitForDeploymentComplete default) plus three
2-minute Eventually polls can burn ~11 minutes per spec. With
--flake-attempts 2, that doubles to ~22 minutes. Across 12+ specs,
a sustained infrastructure issue can exhaust the Ginkgo suite timeout.

With SpecTimeout(5*time.Minute), each spec is bounded regardless of
the underlying failure, preventing cascade timeouts from consuming
the entire suite budget.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
