### PR TITLE
WIP: Partially add kind cluster for dpu mode and dpu host mode.

### DIFF
--- a/contrib/kind-dpu.yaml
+++ b/contrib/kind-dpu.yaml
@@ -1,0 +1,54 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # kube proxy will be disabled
+  kubeProxyMode: "none"
+  # the default CNI will not be installed
+  disableDefaultCNI: true
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: "10.96.0.0/16"
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "v": "4"
+  controllerManager:
+    extraArgs:
+      "v": "4"
+      # Disable service-lb-controller for now
+      # https://github.com/kubernetes/kubernetes/issues/128121
+      # Once the upstream issue is fixed we can remove this controller
+      # customization fully. Tracked with
+      # https://github.com/ovn-org/ovn-kubernetes/issues/4785
+      "controllers": "*,bootstrap-signer-controller,token-cleaner-controller,-service-lb-controller"
+  scheduler:
+    extraArgs:
+      "v": "4"
+  networking: 
+    dnsDomain: cluster.local
+  ---
+  kind: InitConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "4"
+  ---
+  kind: JoinConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "4"
+nodes:
+ - role: control-plane
+   kubeadmConfigPatches:
+   - |
+     kind: InitConfiguration
+     nodeRegistration:
+       kubeletExtraArgs:
+         node-labels: "ingress-ready=true"
+         authorization-mode: "AlwaysAllow"
+ - role: worker
+ - role: worker
+ - role: worker
+ - role: worker

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1185,8 +1185,10 @@ ovn-master() {
   wait_for_event process_ready ovn-northd
 
   # wait for ovs-servers to start since ovn-master sets some fields in OVS DB
+  if [[ ${ovnkube_node_mode} != "dpu-host" ]]; then
   echo "=============== ovn-master - (wait for ovs)"
   wait_for_event ovs_ready
+  fi
 
   hybrid_overlay_flags=
   if [[ ${ovn_hybrid_overlay_enable} == "true" ]]; then
@@ -1477,8 +1479,10 @@ ovnkube-controller() {
   wait_for_event process_ready ovn-northd
 
   # wait for ovs-servers to start since ovn-master sets some fields in OVS DB
+  if [[ ${ovnkube_node_mode} != "dpu-host" ]]; then
   echo "=============== ovnkube-controller - (wait for ovs)"
   wait_for_event ovs_ready
+  fi
 
   hybrid_overlay_flags=
   if [[ ${ovn_hybrid_overlay_enable} == "true" ]]; then
@@ -1812,8 +1816,10 @@ ovnkube-controller-with-node() {
   wait_for_event process_ready ovn-northd
 
   # wait for ovs-servers to start since ovn-master sets some fields in OVS DB
+  if [[ ${ovnkube_node_mode} != "dpu-host" ]]; then
   echo "=============== ovnkube-controller-with-node - (wait for ovs)"
   wait_for_event ovs_ready
+  fi
 
   if [[ ${ovnkube_node_mode} != "dpu-host" ]]; then
     echo "=============== ovnkube-controller-with-node - (ovn-node  wait for ovn-controller.pid)"

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -627,7 +627,7 @@ func ConfigureOVS(ctx context.Context, namespace, podName, podIfName, hostIfaceN
 	}
 
 	if br_type == types.DatapathUserspace {
-		_, err := util.GetSriovnetOps().GetRepresentorPortFlavour(hostIfaceName)
+		_, err := util.GetDPUProvider().GetRepresentorPortFlavour(hostIfaceName)
 		if err != nil {
 			// The error is not important: the given port is not a switchdev one and won't
 			// be used with DPDK. It can happen for legitimate reason. Keep a trace of the

--- a/go-controller/pkg/node/managementport/port_udn_linux.go
+++ b/go-controller/pkg/node/managementport/port_udn_linux.go
@@ -125,7 +125,7 @@ func NewUDNManagementPortController(
 		c.ports[netdevPort] = newUDNManagementPortNetdev(cfg, mgmtIfName, mpdev.DeviceId)
 		c.ports[representorPort] = newUDNManagementPortRep(cfg, repDeviceName)
 	case types.NodeModeDPU:
-		repDeviceName, err := util.GetSriovnetOps().GetVfRepresentorDPU(fmt.Sprintf("%d", mpdev.PfId), fmt.Sprintf("%d", mpdev.FuncId))
+		repDeviceName, err := util.GetDPUProvider().GetVfRepresentorDPU(fmt.Sprintf("%d", mpdev.PfId), fmt.Sprintf("%d", mpdev.FuncId))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get management port representor for pfID %v vfID %v network %s: %v",
 				mpdev.PfId, mpdev.FuncId, netInfo.GetNetworkName(), err)
@@ -256,7 +256,7 @@ func syncUDNManagementPort(cfg *udnManagementPortConfig, mgmtIfName string, mpde
 			}
 		}
 	} else if ovsRepIfName != "" {
-		repDeviceName, _ := util.GetSriovnetOps().GetVfRepresentorDPU(fmt.Sprintf("%d", mpdev.PfId), fmt.Sprintf("%d", mpdev.FuncId))
+		repDeviceName, _ := util.GetDPUProvider().GetVfRepresentorDPU(fmt.Sprintf("%d", mpdev.PfId), fmt.Sprintf("%d", mpdev.FuncId))
 		if repDeviceName != ovsRepIfName {
 			err = DeleteManagementPortRepInterface(cfg.GetNetworkName(), ovsRepIfName, ovsRepIfName)
 			if err != nil {

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -328,7 +328,7 @@ func bootstrapOVSFlows(nodeName string) error {
 		if err != nil {
 			return err
 		}
-		bridgeMACAddress, err = util.GetSriovnetOps().GetRepresentorPeerMacAddress(hostRep)
+		bridgeMACAddress, err = util.GetDPUProvider().GetRepresentorPeerMacAddress(hostRep)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/util/dpu_provider.go
+++ b/go-controller/pkg/util/dpu_provider.go
@@ -1,0 +1,498 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/k8snetworkplumbingwg/sriovnet"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"k8s.io/klog/v2"
+)
+
+var (
+	dpuProviderInstance DPUProvider
+	dpuProviderOnce     sync.Once
+)
+
+// GetDPUProvider returns the appropriate DPU provider based on configuration
+func GetDPUProvider() DPUProvider {
+	dpuProviderOnce.Do(func() {
+		switch config.Default.DPUProviderMode {
+		case "veth":
+			klog.V(2).Infof("Using VethRepresentorProvider for DPU operations")
+			dpuProviderInstance = NewVethRepresentorProvider()
+		case "sriov":
+			klog.V(2).Infof("Using SriovDPUProvider for DPU operations")
+			dpuProviderInstance = NewSriovDPUProvider()
+		default:
+			klog.Warningf("Unknown DPU provider mode '%s', falling back to SR-IOV", config.Default.DPUProviderMode)
+			dpuProviderInstance = NewSriovDPUProvider()
+		}
+	})
+	return dpuProviderInstance
+}
+
+// DPUProvider defines the interface for DPU connection management
+// This allows swapping between different DPU implementations (SR-IOV hardware vs veth simulation)
+type DPUProvider interface {
+	// Pod networking operations
+	// Host side: DeviceID string -> DPUConnectionDetails
+	// Creates DPU connection details from device information
+	CreateConnectionDetails(deviceID, sandboxID, netdevName string) (*DPUConnectionDetails, error)
+
+	// DPU side: DPUConnectionDetails -> (representor name, device identifier)
+	// Gets representor information needed for OVS configuration
+	GetRepresentorInfo(dpuCD *DPUConnectionDetails) (string, string, error)
+
+	// Management port operations
+	// Host side: Management interface -> NetworkDeviceDetails for annotation
+	// Creates management port details for DPU-Host mode
+	CreateManagementPortDetails(mgmtNetdev string) (*NetworkDeviceDetails, error)
+
+	// DPU side: NetworkDeviceDetails -> representor name
+	// Gets management port representor for DPU mode
+	GetManagementPortRepresentor(mgmtDetails *NetworkDeviceDetails) (string, error)
+
+	// Gateway bridge operations
+	// DPU side: Get the interface name for the gateway/management interface that should be connected to br-ex
+	// This replaces hardcoded detection logic and follows the DPU provider abstraction
+	GetHostRepresentor() (string, error)
+
+	// MAC address operations
+	// DPU side: Get the MAC address of the peer interface for bridge configuration
+	// This replaces direct sriovnet calls that expect SR-IOV eswitch metadata
+	GetRepresentorPeerMacAddress(netdev string) (net.HardwareAddr, error)
+
+	// Port flavour operations
+	// DPU side: Get the representor port flavour (PF vs VF) for port validation
+	// This replaces direct sriovnet calls that check eswitch port metadata
+	GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error)
+
+	// VF representor operations
+	// DPU side: Get VF representor name from PF and VF identifiers
+	// This replaces direct sriovnet calls used in management port setup
+	GetVfRepresentorDPU(pfId, vfId string) (string, error)
+
+	// PCI device conversion operations
+	// Get PCI address from network device name
+	GetPciFromNetDevice(netdev string) (string, error)
+	// Get PF PCI address from VF PCI address
+	GetPfPciFromVfPci(vfPci string) (string, error)
+	// Get network devices from PCI address
+	GetNetDevicesFromPci(pciAddress string) ([]string, error)
+}
+
+// SriovDPUProvider implements DPUProvider for SR-IOV hardware using existing sriovnet logic
+type SriovDPUProvider struct{}
+
+// NewSriovDPUProvider creates a new SR-IOV DPU provider
+func NewSriovDPUProvider() *SriovDPUProvider {
+	return &SriovDPUProvider{}
+}
+
+// CreateConnectionDetails implements the host side logic - converts PCI device ID to DPU connection details
+func (p *SriovDPUProvider) CreateConnectionDetails(deviceID, sandboxID, netdevName string) (*DPUConnectionDetails, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("DeviceID must be set for SR-IOV DPU provider")
+	}
+
+	vfindex, err := GetSriovnetOps().GetVfIndexByPciAddress(deviceID)
+	if err != nil {
+		return nil, err
+	}
+	pfindex, err := GetSriovnetOps().GetPfIndexByVfPciAddress(deviceID)
+	if err != nil {
+		return nil, err
+	}
+
+	dpuConnDetails := DPUConnectionDetails{
+		PfId:         fmt.Sprint(pfindex),
+		VfId:         fmt.Sprint(vfindex),
+		SandboxId:    sandboxID,
+		VfNetdevName: netdevName,
+	}
+
+	return &dpuConnDetails, nil
+}
+
+// GetRepresentorInfo implements the DPU side logic - converts DPU connection details to representor info
+func (p *SriovDPUProvider) GetRepresentorInfo(dpuCD *DPUConnectionDetails) (string, string, error) {
+	vfRepName, err := GetSriovnetOps().GetVfRepresentorDPU(dpuCD.PfId, dpuCD.VfId)
+	if err != nil {
+		return "", "", err
+	}
+
+	vfPciAddress, err := GetSriovnetOps().GetPCIFromDeviceName(vfRepName)
+	if err != nil {
+		return "", "", err
+	}
+
+	return vfRepName, vfPciAddress, nil
+}
+
+// CreateManagementPortDetails implements the management port logic for DPU-Host side
+func (p *SriovDPUProvider) CreateManagementPortDetails(mgmtNetdev string) (*NetworkDeviceDetails, error) {
+	deviceID, err := GetDeviceIDFromNetdevice(mgmtNetdev)
+	if err != nil {
+		return nil, err
+	}
+	return GetNetworkDeviceDetails(deviceID)
+}
+
+// GetManagementPortRepresentor implements the management port logic for DPU side
+func (p *SriovDPUProvider) GetManagementPortRepresentor(mgmtDetails *NetworkDeviceDetails) (string, error) {
+	return GetSriovnetOps().GetVfRepresentorDPU(fmt.Sprint(mgmtDetails.PfId), fmt.Sprint(mgmtDetails.FuncId))
+}
+
+// GetHostRepresentor implements the gateway interface detection for SR-IOV hardware
+func (p *SriovDPUProvider) GetHostRepresentor() (string, error) {
+	// For SR-IOV hardware, the gateway interface is typically pf0
+	// This follows the existing SR-IOV DPU pattern where pf0 is the management interface
+	return "pf0", nil
+}
+
+// GetRepresentorPeerMacAddress delegates to existing sriovnet function for SR-IOV hardware
+func (p *SriovDPUProvider) GetRepresentorPeerMacAddress(netdev string) (net.HardwareAddr, error) {
+	return GetSriovnetOps().GetRepresentorPeerMacAddress(netdev)
+}
+
+// GetRepresentorPortFlavour delegates to existing sriovnet function for SR-IOV hardware
+func (p *SriovDPUProvider) GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error) {
+	return GetSriovnetOps().GetRepresentorPortFlavour(netdev)
+}
+
+// GetVfRepresentorDPU delegates to existing sriovnet function for SR-IOV hardware
+func (p *SriovDPUProvider) GetVfRepresentorDPU(pfId, vfId string) (string, error) {
+	return GetSriovnetOps().GetVfRepresentorDPU(pfId, vfId)
+}
+
+// GetPciFromNetDevice delegates to existing sriovnet function for SR-IOV hardware
+func (p *SriovDPUProvider) GetPciFromNetDevice(netdev string) (string, error) {
+	return GetSriovnetOps().GetPciFromNetDevice(netdev)
+}
+
+// GetPfPciFromVfPci delegates to existing sriovnet function for SR-IOV hardware
+func (p *SriovDPUProvider) GetPfPciFromVfPci(vfPci string) (string, error) {
+	return GetSriovnetOps().GetPfPciFromVfPci(vfPci)
+}
+
+// GetNetDevicesFromPci delegates to existing sriovnet function for SR-IOV hardware
+func (p *SriovDPUProvider) GetNetDevicesFromPci(pciAddress string) ([]string, error) {
+	return GetSriovnetOps().GetNetDevicesFromPci(pciAddress)
+}
+
+// VethRepresentorProvider implements DPUProvider for veth-based DPU simulation
+// This provider works with the established veth topology where host interfaces
+// (eth0-0..15) connect to DPU representor interfaces (rep0-0..15, rep1-0..15)
+type VethRepresentorProvider struct{}
+
+// NewVethRepresentorProvider creates a new veth-based DPU provider
+func NewVethRepresentorProvider() *VethRepresentorProvider {
+	return &VethRepresentorProvider{}
+}
+
+// parseVethInterface parses veth interface names like "eth0-5" to extract pfId and vfId
+func parseVethInterface(name string) (pfId, vfId string, err error) {
+	// Match patterns like "eth0-5", "eth1-10", etc.
+	re := regexp.MustCompile(`^eth(\d+)-(\d+)$`)
+	matches := re.FindStringSubmatch(name)
+	if len(matches) != 3 {
+		return "", "", fmt.Errorf("invalid veth interface name format: %s (expected ethX-Y)", name)
+	}
+	return matches[1], matches[2], nil
+}
+
+// detectLocalPfId auto-detects which PF this DPU node serves by scanning for rep{pfId}-* interfaces
+func (p *VethRepresentorProvider) detectLocalPfId() (string, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", fmt.Errorf("failed to list network interfaces: %v", err)
+	}
+
+	// Look for representor interfaces like "rep0-0", "rep1-5", etc.
+	re := regexp.MustCompile(`^rep(\d+)-\d+$`)
+	pfIds := make(map[string]bool)
+
+	for _, iface := range interfaces {
+		matches := re.FindStringSubmatch(iface.Name)
+		if len(matches) == 2 {
+			pfIds[matches[1]] = true
+		}
+	}
+
+	// We should find exactly one PF ID on a DPU node
+	if len(pfIds) == 0 {
+		return "", fmt.Errorf("no representor interfaces found (rep{pfId}-{vfId} pattern)")
+	}
+	if len(pfIds) > 1 {
+		var found []string
+		for pfId := range pfIds {
+			found = append(found, pfId)
+		}
+		return "", fmt.Errorf("multiple PF IDs detected: %v (DPU should serve only one PF)", found)
+	}
+
+	// Return the single PF ID found
+	for pfId := range pfIds {
+		return pfId, nil
+	}
+	return "", fmt.Errorf("unexpected error in PF ID detection")
+}
+
+// generateFakePCI creates deterministic fake PCI addresses for veth simulation
+func generateFakePCI(pfId, vfId string) string {
+	return fmt.Sprintf("veth:00:%02s.%s", pfId, vfId)
+}
+
+// CreateConnectionDetails implements the host side logic for veth provider
+// Parses interface names like "eth0-5" to extract pfId="0", vfId="5"
+func (p *VethRepresentorProvider) CreateConnectionDetails(deviceID, sandboxID, netdevName string) (*DPUConnectionDetails, error) {
+	var interfaceName string
+
+	// Try both deviceID and netdevName as interface name sources
+	if netdevName != "" {
+		interfaceName = netdevName
+	} else if deviceID != "" {
+		interfaceName = deviceID
+	} else {
+		return nil, fmt.Errorf("both deviceID and netdevName are empty for veth DPU provider")
+	}
+
+	// Parse the interface name to extract PF and VF IDs
+	pfId, vfId, err := parseVethInterface(interfaceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse veth interface %s: %v", interfaceName, err)
+	}
+
+	dpuConnDetails := DPUConnectionDetails{
+		PfId:         pfId,
+		VfId:         vfId,
+		SandboxId:    sandboxID,
+		VfNetdevName: interfaceName,
+	}
+
+	return &dpuConnDetails, nil
+}
+
+// GetRepresentorInfo implements the DPU side logic for veth provider
+// Auto-detects local DPU node and maps DPUConnectionDetails to representor name
+func (p *VethRepresentorProvider) GetRepresentorInfo(dpuCD *DPUConnectionDetails) (string, string, error) {
+	if dpuCD == nil {
+		return "", "", fmt.Errorf("DPUConnectionDetails cannot be nil")
+	}
+
+	// Auto-detect which PF this DPU serves
+	localPfId, err := p.detectLocalPfId()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to detect local PF ID: %v", err)
+	}
+
+	// Verify this connection belongs to our PF
+	if dpuCD.PfId != localPfId {
+		return "", "", fmt.Errorf("connection PF ID %s does not match local DPU PF ID %s", dpuCD.PfId, localPfId)
+	}
+
+	// Generate representor name: rep{pfId}-{vfId}
+	representorName := fmt.Sprintf("rep%s-%s", dpuCD.PfId, dpuCD.VfId)
+
+	// Check if representor interface actually exists
+	if _, err := net.InterfaceByName(representorName); err != nil {
+		return "", "", fmt.Errorf("representor interface %s not found: %v", representorName, err)
+	}
+
+	// Generate fake PCI address for simulation
+	pciAddress := generateFakePCI(dpuCD.PfId, dpuCD.VfId)
+
+	return representorName, pciAddress, nil
+}
+
+// CreateManagementPortDetails implements the management port logic for veth DPU-Host side
+func (p *VethRepresentorProvider) CreateManagementPortDetails(mgmtNetdev string) (*NetworkDeviceDetails, error) {
+	// For veth simulation, the management port uses a data VF interface (eth0-0),
+	// matching the SR-IOV pattern where one VF is dedicated to management.
+	// Parse the interface name to extract PF and VF IDs.
+	pfId, vfId, err := parseVethInterface(mgmtNetdev)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse management interface %s: %v", mgmtNetdev, err)
+	}
+
+	pfIdInt, err := strconv.Atoi(pfId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PF ID %s: %v", pfId, err)
+	}
+	vfIdInt, err := strconv.Atoi(vfId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid VF ID %s: %v", vfId, err)
+	}
+
+	deviceID := fmt.Sprintf("veth-mgmt:%s:%s", pfId, vfId)
+
+	return &NetworkDeviceDetails{
+		PfId:     pfIdInt,
+		FuncId:   vfIdInt,
+		DeviceId: deviceID,
+	}, nil
+}
+
+// GetManagementPortRepresentor implements the management port logic for veth DPU side
+func (p *VethRepresentorProvider) GetManagementPortRepresentor(mgmtDetails *NetworkDeviceDetails) (string, error) {
+	if mgmtDetails == nil {
+		return "", fmt.Errorf("NetworkDeviceDetails cannot be nil")
+	}
+
+	// For veth simulation, use a data representor (rep0-0) as the management port,
+	// matching the SR-IOV pattern where a VF representor is dedicated to management.
+	// pfrep is reserved for the gateway bridge (breth0) via GetHostRepresentor().
+	localPfId, err := p.detectLocalPfId()
+	if err != nil {
+		return "", fmt.Errorf("failed to detect local PF ID: %v", err)
+	}
+	mgmtRepresentor := fmt.Sprintf("rep%s-%d", localPfId, mgmtDetails.FuncId)
+
+	// Verify the interface exists
+	if _, err := net.InterfaceByName(mgmtRepresentor); err != nil {
+		return "", fmt.Errorf("management representor interface %s not found: %v", mgmtRepresentor, err)
+	}
+
+	return mgmtRepresentor, nil
+}
+
+// GetHostRepresentor implements the gateway interface detection for veth simulation
+func (p *VethRepresentorProvider) GetHostRepresentor() (string, error) {
+	// For veth simulation, use pfrep as the dedicated management representor
+	// This separates management (pfrep) from data (rep0-*) channels
+	managementRepresentor := "pfrep"
+
+	// Verify the interface exists
+	if _, err := net.InterfaceByName(managementRepresentor); err != nil {
+		return "", fmt.Errorf("management representor interface %s not found: %v", managementRepresentor, err)
+	}
+
+	return managementRepresentor, nil
+}
+
+// GetRepresentorPeerMacAddress generates deterministic MAC address for veth simulation
+func (p *VethRepresentorProvider) GetRepresentorPeerMacAddress(netdev string) (net.HardwareAddr, error) {
+	// Handle management interface (pfrep)
+	if netdev == "pfrep" {
+		// Generate deterministic MAC address for management interface
+		// Format: 02:42:01:FF:00:00 (local unicast + veth identifier + management marker)
+		mac := net.HardwareAddr{
+			0x02, 0x42, // Local unicast prefix (Docker-style)
+			0x01, 0xFF, // veth pair identifier + management marker (0xFF)
+			0x00, 0x00, // Management interface (00:00)
+		}
+		return mac, nil
+	}
+
+	// Parse representor interface name (rep0-0, rep1-5, etc.) to get PF and VF IDs
+	re := regexp.MustCompile(`^rep(\d+)-(\d+)$`)
+	matches := re.FindStringSubmatch(netdev)
+	if len(matches) != 3 {
+		return nil, fmt.Errorf("interface name %s does not match rep{pfId}-{vfId} pattern", netdev)
+	}
+
+	pfId, vfId := matches[1], matches[2]
+
+	pfIdInt, err := strconv.Atoi(pfId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PF ID %s: %v", pfId, err)
+	}
+
+	vfIdInt, err := strconv.Atoi(vfId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid VF ID %s: %v", vfId, err)
+	}
+
+	// Generate deterministic MAC address for bridge configuration
+	// Format: 02:42:01:00:PF:VF (local unicast + veth identifier + IDs)
+	mac := net.HardwareAddr{
+		0x02, 0x42, // Local unicast prefix (Docker-style)
+		0x01, 0x00, // veth pair identifier
+		byte(pfIdInt), byte(vfIdInt), // PF and VF IDs
+	}
+
+	return mac, nil
+}
+
+// GetRepresentorPortFlavour simulates SR-IOV port flavour for veth interfaces
+func (p *VethRepresentorProvider) GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error) {
+	// Check if this is the management interface
+	if netdev == "pfrep" {
+		return sriovnet.PORT_FLAVOUR_PCI_PF, nil
+	}
+
+	// Parse interface name to determine type
+	re := regexp.MustCompile(`^rep(\d+)-(\d+)$`)
+	matches := re.FindStringSubmatch(netdev)
+	if len(matches) != 3 {
+		return sriovnet.PORT_FLAVOUR_UNKNOWN, fmt.Errorf("interface name %s does not match rep{pfId}-{vfId} pattern", netdev)
+	}
+
+	// All rep{pfId}-{vfId} interfaces are now data representors (VF equivalent)
+	// Including rep0-0, which is no longer the management interface
+	return sriovnet.PORT_FLAVOUR_PCI_VF, nil
+}
+
+// GetVfRepresentorDPU generates VF representor name for veth simulation
+func (p *VethRepresentorProvider) GetVfRepresentorDPU(pfId, vfId string) (string, error) {
+	// For veth simulation, always use PF 0 since we assume rep0-* interfaces
+	return fmt.Sprintf("rep0-%s", vfId), nil
+}
+
+// GetPciFromNetDevice generates fake PCI address for veth simulation
+func (p *VethRepresentorProvider) GetPciFromNetDevice(netdev string) (string, error) {
+	// Handle management interface (pfrep)
+	if netdev == "pfrep" {
+		return "veth-mgmt:00:00.0", nil
+	}
+
+	// Parse representor interface name (rep0-5 -> pfId=0, vfId=5)
+	re := regexp.MustCompile(`^rep(\d+)-(\d+)$`)
+	matches := re.FindStringSubmatch(netdev)
+	if len(matches) != 3 {
+		return "", fmt.Errorf("interface name %s does not match rep{pfId}-{vfId} pattern", netdev)
+	}
+
+	pfId, vfId := matches[1], matches[2]
+	return fmt.Sprintf("veth:00:%02s.%s", pfId, vfId), nil
+}
+
+// GetPfPciFromVfPci converts VF PCI to PF PCI for veth simulation
+func (p *VethRepresentorProvider) GetPfPciFromVfPci(vfPci string) (string, error) {
+	// Convert VF PCI to PF PCI (set VF ID to 0)
+	// Example: veth:00:00.5 -> veth:00:00.0
+	parts := strings.Split(vfPci, ".")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid PCI address format: %s", vfPci)
+	}
+	return parts[0] + ".0", nil
+}
+
+// GetNetDevicesFromPci returns the veth interface name for the given PCI address
+func (p *VethRepresentorProvider) GetNetDevicesFromPci(pciAddress string) ([]string, error) {
+	// Extract PF and VF IDs from fake PCI address (veth:00:00.5 -> pfId=0, vfId=5)
+	parts := strings.Split(pciAddress, ":")
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("invalid PCI address format: %s", pciAddress)
+	}
+
+	deviceFunc := strings.Split(parts[2], ".")
+	if len(deviceFunc) != 2 {
+		return nil, fmt.Errorf("invalid PCI address format: %s", pciAddress)
+	}
+
+	pfId, vfId := deviceFunc[0], deviceFunc[1]
+
+	// Remove leading zeros from pfId (00 -> 0)
+	pfIdInt, err := strconv.Atoi(pfId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PF ID in PCI address %s: %v", pciAddress, err)
+	}
+
+	return []string{fmt.Sprintf("rep%d-%s", pfIdInt, vfId)}, nil
+}

--- a/kind-dpu/README-dpu-ovnk.md
+++ b/kind-dpu/README-dpu-ovnk.md
@@ -1,0 +1,459 @@
+# DPU Topology with OVN-Kubernetes
+
+This guide sets up a kind cluster with DPU simulation topology and deploys OVN-Kubernetes on it. OVN-K will work on DPU nodes but fail on isolated host nodes (expected).
+
+## Topology
+
+```
+                    +-------------------+
+                    |   Control Plane   |
+                    +--------+----------+
+                             |
+                      Kind Network
+                             |
+          +------------------+------------------+
+          |                                     |
+  +-------+-------+                     +-------+-------+
+  |     DPU1      |                     |     DPU2      |
+  | (dpu-worker2) |                     | (dpu-worker4) |
+  | eth0(cluster) |                     | eth0(cluster) |
+  | rep0-0..15    |                     | rep1-0..15    |
+  | (16 reps)     |                     | (16 reps)     |
+  +-------+-------+                     +-------+-------+
+          |                                     |
+          | 16 veth pairs                       | 16 veth pairs
+          | (to rep interfaces)                 | (to rep interfaces)
+          |                                     |
+  +-------+-------+                     +-------+-------+
+  |     Host1     |                     |     Host2     |
+  | (dpu-worker)  |                     | (dpu-worker3) |
+  | eth0-0..15    |                     | eth0-0..15    |
+  | (16 interfaces)|                    | (16 interfaces)|
+  +---------------+                     +---------------+
+```
+
+The setup includes two host-DPU pairs, each with 16 veth pairs connecting host interfaces to DPU representor interfaces:
+- **Pair 1**: Host1 (dpu-worker) ↔ DPU1 (dpu-worker2)
+  - Host side: eth0-0 to eth0-15 (16 host interfaces)
+  - DPU side: rep0-0 to rep0-15 (16 representor interfaces)
+- **Pair 2**: Host2 (dpu-worker3) ↔ DPU2 (dpu-worker4)
+  - Host side: eth0-0 to eth0-15 (16 host interfaces)
+  - DPU side: rep1-0 to rep1-15 (16 representor interfaces)
+
+## Prerequisites
+
+```bash
+pip install jinjanator[yaml]
+```
+
+## Step 1: Delete existing clusters
+
+```bash
+kind delete cluster --name=dpu
+```
+
+## Step 2: Generate kind config (parameterized workers)
+
+```bash
+cd /root/ovn-kubernetes/contrib
+
+# Configuration: Number of DPU-host pairs (each pair = 2 workers: 1 host + 1 DPU)
+NUM_DPU_PAIRS=2
+TOTAL_WORKERS=$((NUM_DPU_PAIRS * 2))
+
+echo "Generating kind config for ${NUM_DPU_PAIRS} DPU-host pairs (${TOTAL_WORKERS} workers total)"
+
+ovn_ip_family="" \
+ovn_ha=false \
+net_cidr="10.244.0.0/16" \
+svc_cidr="10.96.0.0/16" \
+use_local_registy=false \
+dns_domain="cluster.local" \
+ovn_num_master=1 \
+ovn_num_worker=${TOTAL_WORKERS} \
+cluster_log_level=4 \
+kind_local_registry_port=5000 \
+kind_local_registry_name="kind-registry" \
+jinjanate kind.yaml.j2 -o kind-dpu.yaml
+
+cd ..
+```
+
+## Step 3: Create kind cluster
+
+```bash
+kind create cluster \
+  --name dpu \
+  --kubeconfig $HOME/dpu.conf \
+  --image kindest/node:v1.34.0 \
+  --config contrib/kind-dpu.yaml \
+  --retain
+
+export KUBECONFIG=$HOME/dpu.conf
+```
+
+## Step 4: Set up DPU topology with PROPER HOST ISOLATION
+
+This creates the exact topology from the diagram: DPU nodes have cluster access, host nodes are completely isolated and can only communicate through veth pairs.
+
+**✅ Parameterized approach for scalable DPU-host pair creation**
+
+```bash
+# Configuration: Number of DPU-host pairs and interfaces per pair
+NUM_DPU_PAIRS=2
+INTERFACES_PER_PAIR=16
+
+# Clean up any existing veth interfaces
+echo "Cleaning up existing veth interfaces..."
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  for iface_id in $(seq 1 $((INTERFACES_PER_PAIR - 1))); do
+    sudo ip link delete host${pair_id}-eth0-${iface_id} 2>/dev/null || true
+    sudo ip link delete dpu${pair_id}-rep${pair_id}-${iface_id} 2>/dev/null || true
+  done
+done
+
+# Create additional veth pairs for each DPU-host pair (15 pairs, since we reuse original eth0)
+echo "Creating ${NUM_DPU_PAIRS} DPU-host pairs with $((INTERFACES_PER_PAIR - 1)) additional veth pairs each..."
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  echo "  Creating additional veth pairs for DPU-host pair ${pair_id}..."
+  for iface_id in $(seq 1 $((INTERFACES_PER_PAIR - 1))); do
+    # Create veth pair: host side ↔ DPU side
+    # Host side: host${pair_id}-eth0-${iface_id} (will become eth0-${iface_id})
+    # DPU side: dpu${pair_id}-rep${pair_id}-${iface_id} (will become rep${pair_id}-${iface_id})
+    sudo ip link add host${pair_id}-eth0-${iface_id} type veth peer name dpu${pair_id}-rep${pair_id}-${iface_id}
+  done
+done
+
+# Define container names for each pair
+# Pair 0: dpu-worker (host) ↔ dpu-worker2 (DPU)
+# Pair 1: dpu-worker3 (host) ↔ dpu-worker4 (DPU)
+declare -a HOST_CONTAINERS=("dpu-worker" "dpu-worker3")
+declare -a DPU_CONTAINERS=("dpu-worker2" "dpu-worker4")
+
+# Get container PIDs for all DPU-host pairs
+echo "Getting container PIDs..."
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  eval "HOST${pair_id}_PID=\$(docker inspect --format '{{.State.Pid}}' ${HOST_CONTAINERS[$pair_id]})"
+  eval "DPU${pair_id}_PID=\$(docker inspect --format '{{.State.Pid}}' ${DPU_CONTAINERS[$pair_id]})"
+  eval echo "  Pair ${pair_id}: Host \${HOST_CONTAINERS[$pair_id]} PID=\${HOST${pair_id}_PID}, DPU \${DPU_CONTAINERS[$pair_id]} PID=\${DPU${pair_id}_PID}"
+done
+
+# Reuse original eth0 as eth0-0
+echo "Renaming original eth0 to eth0-0..."
+docker exec dpu-worker ip link set eth0 name eth0-0
+docker exec dpu-worker3 ip link set eth0 name eth0-0
+
+# Create veth pairs for eth0-0 connections
+echo "Creating veth pairs for eth0-0 connections..."
+sudo ip link add temp-host0-0 type veth peer name temp-rep0-0
+sudo ip link add temp-host1-0 type veth peer name temp-rep1-0
+
+# Move eth0-0 veth pairs to containers
+sudo ip link set temp-host0-0 netns ${HOST0_PID}
+sudo ip link set temp-rep0-0 netns ${DPU0_PID}
+sudo ip link set temp-host1-0 netns ${HOST1_PID}
+sudo ip link set temp-rep1-0 netns ${DPU1_PID}
+
+# Rename eth0-0 veth pairs
+docker exec dpu-worker ip link set temp-host0-0 name eth0-0
+docker exec dpu-worker2 ip link set temp-rep0-0 name rep0-0
+docker exec dpu-worker3 ip link set temp-host1-0 name eth0-0
+docker exec dpu-worker4 ip link set temp-rep1-0 name rep1-0
+
+# Move additional veth interfaces to containers (eth0-1 through eth0-15)
+echo "Moving additional veth interfaces to containers..."
+for iface_id in $(seq 1 $((INTERFACES_PER_PAIR - 1))); do
+  sudo ip link set host0-eth0-${iface_id} netns ${HOST0_PID}
+  sudo ip link set dpu0-rep0-${iface_id} netns ${DPU0_PID}
+  sudo ip link set host1-eth0-${iface_id} netns ${HOST1_PID}
+  sudo ip link set dpu1-rep1-${iface_id} netns ${DPU1_PID}
+done
+
+# Rename additional interfaces inside containers
+echo "Renaming additional interfaces inside containers..."
+for iface_id in $(seq 1 $((INTERFACES_PER_PAIR - 1))); do
+  docker exec dpu-worker ip link set host0-eth0-${iface_id} name eth0-${iface_id} 2>/dev/null || true
+  docker exec dpu-worker2 ip link set dpu0-rep0-${iface_id} name rep0-${iface_id} 2>/dev/null || true
+  docker exec dpu-worker3 ip link set host1-eth0-${iface_id} name eth0-${iface_id} 2>/dev/null || true
+  docker exec dpu-worker4 ip link set dpu1-rep1-${iface_id} name rep1-${iface_id} 2>/dev/null || true
+done
+
+# Isolate host nodes from kind network
+echo "Isolating host nodes from kind network..."
+docker exec dpu-worker ip route del default 2>/dev/null || true
+docker exec dpu-worker3 ip route del default 2>/dev/null || true
+
+echo "✅ All interfaces configured and host nodes isolated"
+
+# Veth interfaces are now ready for OVN-Kubernetes management
+echo "Veth interfaces created and ready for OVN-Kubernetes..."
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  echo "  Pair ${pair_id}: ${HOST_CONTAINERS[$pair_id]}.eth0-0..15 ↔ ${DPU_CONTAINERS[$pair_id]}.rep${pair_id}-0..15"
+done
+
+# Verify the topology
+echo ""
+echo "✅ Perfect isolated topology created:"
+echo "   Total: ${NUM_DPU_PAIRS} DPU-host pairs with ${INTERFACES_PER_PAIR} connections each"
+echo "   New veth pairs created: $((NUM_DPU_PAIRS * (INTERFACES_PER_PAIR - 1))) + ${NUM_DPU_PAIRS} repurposed connections"
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  echo "   Pair ${pair_id}:"
+  echo "     Host ${HOST_CONTAINERS[$pair_id]}: exactly 16 interfaces (eth0-0..15) - ISOLATED from kind network"
+  echo "     DPU ${DPU_CONTAINERS[$pair_id]}: 17 interfaces - eth0 (transferred cluster access) + rep${pair_id}-0..15"
+done
+echo "   Host isolation: Complete - no direct cluster access, exactly 16 interfaces per host"
+```
+
+After this setup:
+- **Scalable Configuration**: `NUM_DPU_PAIRS=2` and `INTERFACES_PER_PAIR=16` for easy adjustment
+- **Host Nodes**: Each has exactly 16 interfaces (COMPLETELY ISOLATED from kind network)
+  - **Host1 (dpu-worker)**: eth0-0 to eth0-15 (eth0-0 is repurposed original, eth0-1..15 are new)
+  - **Host2 (dpu-worker3)**: eth0-0 to eth0-15 (eth0-0 is repurposed original, eth0-1..15 are new)
+- **DPU Nodes**: Each has transferred kind network access + 16 representor interfaces
+  - **DPU1 (dpu-worker2)**: eth0 (cluster access from Host1) + rep0-0 to rep0-15 (to Host1)
+  - **DPU2 (dpu-worker4)**: eth0 (cluster access from Host2) + rep1-0 to rep1-15 (to Host2)
+- **Veth Connectivity**: Raw connections ready for OVN-Kubernetes management
+  - Pair 0: Host1.eth0-0..15 ↔ DPU1.rep0-0..15 (no IP addresses assigned)
+  - Pair 1: Host2.eth0-0..15 ↔ DPU2.rep1-0..15 (no IP addresses assigned)
+- **Perfect Topology**: Hosts have exactly 16 interfaces, DPUs have 17 interfaces
+- **Efficient Design**: Reuses existing infrastructure instead of creating redundant interfaces
+
+**Key Design Principles**:
+1. **Each Host has exactly 16 interfaces**: eth0-0 (repurposed) + eth0-1..15 (new veth ends)
+2. **Each DPU has exactly 17 interfaces**: eth0 (transferred kind network) + rep${pair_id}-0..15
+3. **Efficient resource usage**: Repurposes existing eth0 instead of creating redundant interfaces
+4. **Total new veth pairs**: 30 (15 per DPU-host pair) + 2 repurposed connections = 32 total connections
+5. **Parameterized approach**: Easy to scale to different numbers of DPU-host pairs
+6. **Representor simulation**: Each connection simulates a host interface ↔ representor relationship
+
+This creates the foundation for veth-based DPU simulation where OVN-Kubernetes will run on DPU nodes and manage pod connectivity through representor interfaces.
+
+## Step 5: Enable IPv6 and fix inotify limits
+
+```bash
+for node in $(kind get nodes --name dpu); do
+  podman exec "$node" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
+  podman exec "$node" sysctl --ignore net.ipv6.conf.all.forwarding=1
+  podman exec "$node" sysctl -w fs.inotify.max_user_watches=524288
+  podman exec "$node" sysctl -w fs.inotify.max_user_instances=512
+done
+```
+
+## Step 6: Build OVN image (skip if already built)
+
+```bash
+make -C dist/images \
+  IMAGE="localhost/ovn-daemonset-fedora:dev" \
+  OVN_REPO="" \
+  OVN_GITREF="" \
+  OCI_BIN="podman" \
+  fedora-image
+```
+
+## Step 7: Load image into kind
+
+```bash
+kind load docker-image localhost/ovn-daemonset-fedora:dev --name dpu
+```
+
+## Step 8: Get API URL and generate manifests
+
+```bash
+DNS_NAME_URL=$(kind get kubeconfig --internal --name dpu | grep server | awk '{ print $2 }')
+CP_NODE=${DNS_NAME_URL#*//}
+CP_NODE=${CP_NODE%:*}
+NODE_IP=$(podman inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$CP_NODE")
+API_URL=${DNS_NAME_URL/$CP_NODE/$NODE_IP}
+
+cd dist/images
+
+./daemonset.sh \
+  --output-directory="../yaml-dpu" \
+  --image="localhost/ovn-daemonset-fedora:dev" \
+  --ovnkube-image="localhost/ovn-daemonset-fedora:dev" \
+  --net-cidr="10.244.0.0/16" \
+  --svc-cidr="10.96.0.0/16" \
+  --gateway-mode="shared" \
+  --dummy-gateway-bridge="false" \
+  --gateway-options="" \
+  --enable-ipsec="false" \
+  --hybrid-enabled="false" \
+  --disable-snat-multiple-gws="false" \
+  --disable-forwarding="false" \
+  --ovn-encap-port="" \
+  --disable-pkt-mtu-check="false" \
+  --ovn-empty-lb-events="false" \
+  --multicast-enabled="false" \
+  --k8s-apiserver="$API_URL" \
+  --ovn-master-count="1" \
+  --ovn-unprivileged-mode=no \
+  --master-loglevel="5" \
+  --node-loglevel="5" \
+  --dbchecker-loglevel="5" \
+  --ovn-loglevel-northd="-vconsole:info -vfile:info" \
+  --ovn-loglevel-nb="-vconsole:info -vfile:info" \
+  --ovn-loglevel-sb="-vconsole:info -vfile:info" \
+  --ovn-loglevel-controller="-vconsole:info" \
+  --ovnkube-libovsdb-client-logfile="" \
+  --enable-coredumps="false" \
+  --ovnkube-config-duration-enable=true \
+  --admin-network-policy-enable=true \
+  --egress-ip-enable=true \
+  --egress-ip-healthcheck-port="9107" \
+  --egress-firewall-enable=true \
+  --egress-qos-enable=true \
+  --egress-service-enable=true \
+  --v4-join-subnet="100.64.0.0/16" \
+  --v6-join-subnet="fd98::/64" \
+  --v4-masquerade-subnet="169.254.0.0/17" \
+  --v6-masquerade-subnet="fd69::/112" \
+  --v4-transit-subnet="100.88.0.0/16" \
+  --v6-transit-subnet="fd97::/64" \
+  --ex-gw-network-interface="" \
+  --multi-network-enable="false" \
+  --network-segmentation-enable="false" \
+  --network-connect-enable="false" \
+  --preconfigured-udn-addresses-enable="false" \
+  --route-advertisements-enable="false" \
+  --advertise-default-network="false" \
+  --advertised-udn-isolation-mode="strict" \
+  --ovnkube-metrics-scale-enable="false" \
+  --compact-mode="false" \
+  --enable-interconnect="true" \
+  --enable-multi-external-gateway=true \
+  --enable-ovnkube-identity="true" \
+  --enable-persistent-ips=true \
+  --network-qos-enable="false" \
+  --mtu="1400" \
+  --enable-dnsnameresolver="false" \
+  --enable-observ="false"
+
+cd ../..
+```
+
+## Step 9: Apply CRDs
+
+```bash
+cd dist/yaml-dpu
+
+kubectl apply -f k8s.ovn.org_egressfirewalls.yaml
+kubectl apply -f k8s.ovn.org_egressips.yaml
+kubectl apply -f k8s.ovn.org_egressqoses.yaml
+kubectl apply -f k8s.ovn.org_egressservices.yaml
+kubectl apply -f k8s.ovn.org_adminpolicybasedexternalroutes.yaml
+kubectl apply -f k8s.ovn.org_networkqoses.yaml
+kubectl apply -f k8s.ovn.org_userdefinednetworks.yaml
+kubectl apply -f k8s.ovn.org_clusteruserdefinednetworks.yaml
+kubectl apply -f k8s.ovn.org_routeadvertisements.yaml
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+```
+
+## Step 10: Apply setup and RBAC
+
+```bash
+kubectl apply -f ovn-setup.yaml
+kubectl apply -f rbac-ovnkube-identity.yaml
+kubectl apply -f rbac-ovnkube-cluster-manager.yaml
+kubectl apply -f rbac-ovnkube-master.yaml
+kubectl apply -f rbac-ovnkube-node.yaml
+kubectl apply -f rbac-ovnkube-db.yaml
+```
+
+## Step 11: Label and untaint control plane
+
+```bash
+kubectl label node dpu-control-plane k8s.ovn.org/ovnkube-db=true node-role.kubernetes.io/control-plane="" --overwrite
+kubectl taint node dpu-control-plane node-role.kubernetes.io/master:NoSchedule- || true
+kubectl taint node dpu-control-plane node-role.kubernetes.io/control-plane:NoSchedule- || true
+```
+
+## Step 12: Apply OVS and label zones
+
+```bash
+kubectl apply -f ovs-node.yaml
+
+for node in $(kind get nodes --name dpu); do
+  kubectl label node "$node" k8s.ovn.org/zone-name=${node} --overwrite
+done
+```
+
+## Step 13: Apply OVN-Kubernetes components
+
+```bash
+kubectl apply -f ovnkube-identity.yaml
+kubectl apply -f ovnkube-control-plane.yaml
+kubectl apply -f ovnkube-single-node-zone.yaml
+
+kubectl patch ds -n ovn-kubernetes ovnkube-node --type='json' \
+  -p='[{"op": "add", "path": "/spec/updateStrategy/rollingUpdate", "value": {"maxUnavailable": "100%"}}]'
+```
+
+## Step 14: Verify
+
+```bash
+kubectl get nodes
+kubectl get pods -n ovn-kubernetes -o wide
+```
+
+Expected result:
+- DPU nodes (dpu-worker2, dpu-worker4) and control-plane: OVN-K pods Running
+- Host nodes (dpu-worker, dpu-worker3): OVN-K pods Pending (expected - isolated)
+
+## Step 15: Label nodes for DPU mode deployment
+
+To deploy OVN-K in DPU mode (separate DaemonSets for DPU and host nodes), label the nodes:
+
+```bash
+# Label host nodes
+kubectl label nodes dpu-worker k8s.ovn.org/dpu-host= --overwrite
+kubectl label nodes dpu-worker3 k8s.ovn.org/dpu-host= --overwrite
+
+# Label DPU nodes
+kubectl label nodes dpu-worker2 k8s.ovn.org/dpu= --overwrite
+kubectl label nodes dpu-worker4 k8s.ovn.org/dpu= --overwrite
+```
+
+## Step 16: Create separate DaemonSets for DPU mode (optional)
+
+When using the VethRepresentorProvider for veth-based simulation, create separate DaemonSets with the `DPU_REPRESENTOR_MODE=veth` environment variable.
+
+### DaemonSet for DPU nodes
+
+Key environment variables:
+- `OVNKUBE_NODE_MODE=dpu` - Enables DPU mode
+- `DPU_REPRESENTOR_MODE=veth` - Uses veth-based representor discovery
+- `K8S_NODE_DPU` instead of `K8S_NODE` - Node name reference
+
+The VethRepresentorProvider auto-detects interfaces using naming convention:
+- pfId "0" maps to `rep0-{vfIndex}` (rep0-0, rep0-1, ..., rep0-15)
+
+Node selector: `k8s.ovn.org/dpu: ""`
+
+### DaemonSet for DPU-host nodes
+
+Key environment variables:
+- `OVNKUBE_NODE_MODE=dpu-host` - Enables DPU-host mode
+
+Node selector: `k8s.ovn.org/dpu-host: ""`
+
+### Example manifest snippet for DPU node DaemonSet
+
+```yaml
+env:
+- name: OVNKUBE_NODE_MODE
+  value: "dpu"
+- name: DPU_REPRESENTOR_MODE
+  value: "veth"
+- name: K8S_NODE_DPU
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+```
+
+## Cleanup
+
+```bash
+kind delete cluster --name=dpu
+```

--- a/kind-dpu/README-ovnk-kind-setup.md
+++ b/kind-dpu/README-ovnk-kind-setup.md
@@ -1,0 +1,244 @@
+# Manual OVN-Kubernetes Kind Cluster Setup
+
+Copy-paste commands to set up a basic kind cluster with OVN-Kubernetes networking.
+
+## Prerequisites
+
+```bash
+pip install jinjanator[yaml]
+```
+
+## Step 1: Delete any existing cluster
+
+```bash
+kind delete cluster --name=ovn
+```
+
+## Step 2: Generate kind config
+
+```bash
+cd contrib
+
+ovn_ip_family="" \
+ovn_ha=false \
+net_cidr="10.244.0.0/16" \
+svc_cidr="10.96.0.0/16" \
+use_local_registy=false \
+dns_domain="cluster.local" \
+ovn_num_master=1 \
+ovn_num_worker=2 \
+cluster_log_level=4 \
+kind_local_registry_port=5000 \
+kind_local_registry_name="kind-registry" \
+jinjanate kind.yaml.j2 -o kind-ovn.yaml
+
+cd ..
+```
+
+## Step 3: Create kind cluster
+
+```bash
+kind create cluster \
+  --name ovn \
+  --kubeconfig $HOME/ovn.conf \
+  --image kindest/node:v1.34.0 \
+  --config contrib/kind-ovn.yaml \
+  --retain
+
+export KUBECONFIG=$HOME/ovn.conf
+```
+
+## Step 4: Enable IPv6 on nodes
+
+```bash
+for node in $(kind get nodes --name ovn); do
+  podman exec "$node" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
+  podman exec "$node" sysctl --ignore net.ipv6.conf.all.forwarding=1
+done
+```
+
+## Step 5: Build OVN image
+
+```bash
+make -C dist/images \
+  IMAGE="localhost/ovn-daemonset-fedora:dev" \
+  OVN_REPO="" \
+  OVN_GITREF="" \
+  OCI_BIN="podman" \
+  fedora-image
+```
+
+## Step 6: Load image into kind
+
+```bash
+kind load docker-image localhost/ovn-daemonset-fedora:dev --name ovn
+```
+
+## Step 7: Get API URL
+
+```bash
+DNS_NAME_URL=$(kind get kubeconfig --internal --name ovn | grep server | awk '{ print $2 }')
+CP_NODE=${DNS_NAME_URL#*//}
+CP_NODE=${CP_NODE%:*}
+NODE_IP=$(podman inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$CP_NODE")
+API_URL=${DNS_NAME_URL/$CP_NODE/$NODE_IP}
+echo "API URL: $API_URL"
+```
+
+## Step 8: Generate daemonset manifests
+
+```bash
+cd dist/images
+
+./daemonset.sh \
+  --output-directory="../yaml" \
+  --image="localhost/ovn-daemonset-fedora:dev" \
+  --ovnkube-image="localhost/ovn-daemonset-fedora:dev" \
+  --net-cidr="10.244.0.0/16" \
+  --svc-cidr="10.96.0.0/16" \
+  --gateway-mode="shared" \
+  --dummy-gateway-bridge="false" \
+  --gateway-options="" \
+  --enable-ipsec="false" \
+  --hybrid-enabled="false" \
+  --disable-snat-multiple-gws="false" \
+  --disable-forwarding="false" \
+  --ovn-encap-port="" \
+  --disable-pkt-mtu-check="false" \
+  --ovn-empty-lb-events="false" \
+  --multicast-enabled="false" \
+  --k8s-apiserver="$API_URL" \
+  --ovn-master-count="1" \
+  --ovn-unprivileged-mode=no \
+  --master-loglevel="5" \
+  --node-loglevel="5" \
+  --dbchecker-loglevel="5" \
+  --ovn-loglevel-northd="-vconsole:info -vfile:info" \
+  --ovn-loglevel-nb="-vconsole:info -vfile:info" \
+  --ovn-loglevel-sb="-vconsole:info -vfile:info" \
+  --ovn-loglevel-controller="-vconsole:info" \
+  --ovnkube-libovsdb-client-logfile="" \
+  --enable-coredumps="false" \
+  --ovnkube-config-duration-enable=true \
+  --admin-network-policy-enable=true \
+  --egress-ip-enable=true \
+  --egress-ip-healthcheck-port="9107" \
+  --egress-firewall-enable=true \
+  --egress-qos-enable=true \
+  --egress-service-enable=true \
+  --v4-join-subnet="100.64.0.0/16" \
+  --v6-join-subnet="fd98::/64" \
+  --v4-masquerade-subnet="169.254.0.0/17" \
+  --v6-masquerade-subnet="fd69::/112" \
+  --v4-transit-subnet="100.88.0.0/16" \
+  --v6-transit-subnet="fd97::/64" \
+  --ex-gw-network-interface="" \
+  --multi-network-enable="false" \
+  --network-segmentation-enable="false" \
+  --network-connect-enable="false" \
+  --preconfigured-udn-addresses-enable="false" \
+  --route-advertisements-enable="false" \
+  --advertise-default-network="false" \
+  --advertised-udn-isolation-mode="strict" \
+  --ovnkube-metrics-scale-enable="false" \
+  --compact-mode="false" \
+  --enable-interconnect="true" \
+  --enable-multi-external-gateway=true \
+  --enable-ovnkube-identity="true" \
+  --enable-persistent-ips=true \
+  --network-qos-enable="false" \
+  --mtu="1400" \
+  --enable-dnsnameresolver="false" \
+  --enable-observ="false"
+
+cd ../..
+```
+
+## Step 9: Apply CRDs
+
+```bash
+cd dist/yaml
+
+kubectl apply -f k8s.ovn.org_egressfirewalls.yaml
+kubectl apply -f k8s.ovn.org_egressips.yaml
+kubectl apply -f k8s.ovn.org_egressqoses.yaml
+kubectl apply -f k8s.ovn.org_egressservices.yaml
+kubectl apply -f k8s.ovn.org_adminpolicybasedexternalroutes.yaml
+kubectl apply -f k8s.ovn.org_networkqoses.yaml
+kubectl apply -f k8s.ovn.org_userdefinednetworks.yaml
+kubectl apply -f k8s.ovn.org_clusteruserdefinednetworks.yaml
+kubectl apply -f k8s.ovn.org_routeadvertisements.yaml
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+```
+
+## Step 10: Apply setup and RBAC
+
+```bash
+kubectl apply -f ovn-setup.yaml
+kubectl apply -f rbac-ovnkube-identity.yaml
+kubectl apply -f rbac-ovnkube-cluster-manager.yaml
+kubectl apply -f rbac-ovnkube-master.yaml
+kubectl apply -f rbac-ovnkube-node.yaml
+kubectl apply -f rbac-ovnkube-db.yaml
+```
+
+## Step 11: Label and untaint control plane
+
+```bash
+kubectl label node ovn-control-plane k8s.ovn.org/ovnkube-db=true node-role.kubernetes.io/control-plane="" --overwrite
+kubectl taint node ovn-control-plane node-role.kubernetes.io/master:NoSchedule- || true
+kubectl taint node ovn-control-plane node-role.kubernetes.io/control-plane:NoSchedule- || true
+```
+
+## Step 12: Apply OVS node daemonset
+
+```bash
+kubectl apply -f ovs-node.yaml
+```
+
+## Step 13: Label nodes with zone names (for interconnect)
+
+```bash
+for node in $(kind get nodes --name ovn); do
+  kubectl label node "$node" k8s.ovn.org/zone-name=${node} --overwrite
+done
+```
+
+## Step 14: Apply OVN-Kubernetes components
+
+```bash
+kubectl apply -f ovnkube-identity.yaml
+kubectl apply -f ovnkube-control-plane.yaml
+kubectl apply -f ovnkube-single-node-zone.yaml
+```
+
+## Step 15: Patch for faster rolling updates
+
+```bash
+kubectl patch ds -n ovn-kubernetes ovnkube-node --type='json' \
+  -p='[{"op": "add", "path": "/spec/updateStrategy/rollingUpdate", "value": {"maxUnavailable": "100%"}}]'
+```
+
+## Step 16: Wait for rollout
+
+```bash
+kubectl rollout status daemonset -n ovn-kubernetes ovs-node --timeout=300s
+kubectl rollout status daemonset -n ovn-kubernetes ovnkube-node --timeout=300s
+kubectl wait pods -n ovn-kubernetes -l name=ovnkube-control-plane --for condition=Ready --timeout=300s
+kubectl wait -n kube-system --for=condition=ready pods --all --timeout=300s
+```
+
+## Step 17: Verify
+
+```bash
+kubectl get pods -n ovn-kubernetes -o wide
+kubectl get nodes
+```
+
+## Cleanup
+
+```bash
+kind delete cluster --name=ovn
+```

--- a/kind-dpu/README.md
+++ b/kind-dpu/README.md
@@ -1,0 +1,261 @@
+# Kind DPU Simulation Topology
+
+This directory contains tools and instructions for setting up a 5-node kind cluster with manual veth rewiring to simulate DPU (Data Processing Unit) connectivity patterns.
+
+## Overview
+
+The setup creates:
+- 5 kind nodes with CNI disabled (1 control-plane + 4 workers: 2 hosts + 2 DPUs)
+- Point-to-point veth connections between host and DPU nodes
+- DPUs maintain Kind cluster connectivity while hosts are isolated to DPU connections only
+- Only host-networked pods can function (regular pods fail due to missing CNI)
+
+## Final Network Configuration
+
+| Node | Role | Interface Count | Interfaces |
+|------|------|----------------|------------|
+| **dpu-test-worker** | Host1 | **2** | `lo + eth0` (to DPU1) |
+| **dpu-test-worker2** | DPU1 | **3** | `lo + eth0` (Kind cluster) + `eth1` (from Host1) |
+| **dpu-test-worker3** | Host2 | **2** | `lo + eth0` (to DPU2) |
+| **dpu-test-worker4** | DPU2 | **3** | `lo + eth0` (Kind cluster) + `eth1` (from Host2) |
+
+## Interleaved Node Mapping
+
+**Note:** Kind will create containers with default names, arranged in an interleaved pattern:
+- `dpu-test-worker` → **Host1** (host-worker-1)
+- `dpu-test-worker2` → **DPU1** (dpu-worker-1)
+- `dpu-test-worker3` → **Host2** (host-worker-2)
+- `dpu-test-worker4` → **DPU2** (dpu-worker-2)
+
+## Point-to-Point Connections
+
+- **Host1 eth0** (192.168.1.1) ↔ **DPU1 eth1** (192.168.1.2)
+- **Host2 eth0** (192.168.2.1) ↔ **DPU2 eth1** (192.168.2.2)
+
+## Step 1: Create 5-Node Kind Cluster (CNI Disabled)
+
+Save the following as `kind-config.yaml`:
+
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # Disable default CNI so we can test with error-cni or manual setup
+  disableDefaultCNI: true
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: "10.96.0.0/12"
+nodes:
+- role: control-plane
+  image: kindest/node:v1.29.0
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni
+- role: worker
+  image: kindest/node:v1.29.0
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni
+- role: worker
+  image: kindest/node:v1.29.0
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni
+- role: worker
+  image: kindest/node:v1.29.0
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni
+```
+
+Create the cluster:
+```bash
+kind create cluster --config kind-config.yaml --name dpu-test
+```
+
+## Step 2: Configure Point-to-Point DPU Connections
+
+After the cluster is running, we'll configure point-to-point connections between hosts and DPUs.
+
+### Verify Initial State
+
+```bash
+# Get container names for the 5 nodes
+docker ps --format "table {{.Names}}\t{{.Image}}" | grep dpu-test
+
+# Check that all nodes are running
+kubectl get nodes --context kind-dpu-test
+```
+
+### Configure Point-to-Point Connections
+
+The configuration process:
+
+1. **Hosts** get isolated eth0 interfaces (lose Kind cluster connectivity)
+2. **DPUs** keep Kind cluster connectivity on eth0 + gain eth1 for host communication
+
+**Target connections:**
+- Host1 eth0 (192.168.1.1) ↔ DPU1 eth1 (192.168.1.2)
+- Host2 eth0 (192.168.2.1) ↔ DPU2 eth1 (192.168.2.2)
+
+```bash
+# Step 1: Create point-to-point veth pairs
+sudo ip link add host1-veth type veth peer name dpu1-veth
+sudo ip link add host2-veth type veth peer name dpu2-veth
+
+# Step 2: Configure Host1 with isolated eth0
+# Remove Kind networking from Host1 and replace with point-to-point
+podman exec dpu-test-worker ip addr flush dev eth0
+podman exec dpu-test-worker ip link set eth0 down
+
+# Replace Host1 eth0 with point-to-point connection
+sudo ip link set host1-veth netns $(podman inspect -f "{{.State.Pid}}" dpu-test-worker)
+podman exec dpu-test-worker ip link set host1-veth name eth0-new
+podman exec dpu-test-worker ip link delete eth0
+podman exec dpu-test-worker ip link set eth0-new name eth0
+podman exec dpu-test-worker ip addr add 192.168.1.1/24 dev eth0
+podman exec dpu-test-worker ip link set eth0 up
+
+# Step 3: Add eth1 to DPU1 (keep Kind cluster on eth0)
+sudo ip link set dpu1-veth netns $(podman inspect -f "{{.State.Pid}}" dpu-test-worker2)
+podman exec dpu-test-worker2 ip link set dpu1-veth name eth1
+podman exec dpu-test-worker2 ip addr add 192.168.1.2/24 dev eth1
+podman exec dpu-test-worker2 ip link set eth1 up
+
+# Step 4: Configure Host2 with isolated eth0
+# Remove Kind networking from Host2 and replace with point-to-point
+podman exec dpu-test-worker3 ip addr flush dev eth0
+podman exec dpu-test-worker3 ip link set eth0 down
+
+# Replace Host2 eth0 with point-to-point connection
+sudo ip link set host2-veth netns $(podman inspect -f "{{.State.Pid}}" dpu-test-worker3)
+podman exec dpu-test-worker3 ip link set host2-veth name eth0-new
+podman exec dpu-test-worker3 ip link delete eth0
+podman exec dpu-test-worker3 ip link set eth0-new name eth0
+podman exec dpu-test-worker3 ip addr add 192.168.2.1/24 dev eth0
+podman exec dpu-test-worker3 ip link set eth0 up
+
+# Step 5: Add eth1 to DPU2 (keep Kind cluster on eth0)
+sudo ip link set dpu2-veth netns $(podman inspect -f "{{.State.Pid}}" dpu-test-worker4)
+podman exec dpu-test-worker4 ip link set dpu2-veth name eth1
+podman exec dpu-test-worker4 ip addr add 192.168.2.2/24 dev eth1
+podman exec dpu-test-worker4 ip link set eth1 up
+```
+
+### Verify Configuration
+
+```bash
+# Check interface configuration
+echo "=== Host1 (dpu-test-worker) ==="
+podman exec dpu-test-worker ip addr show | grep -E "^[0-9]|inet "
+
+echo "=== DPU1 (dpu-test-worker2) ==="
+podman exec dpu-test-worker2 ip addr show | grep -E "^[0-9]|inet "
+
+echo "=== Host2 (dpu-test-worker3) ==="
+podman exec dpu-test-worker3 ip addr show | grep -E "^[0-9]|inet "
+
+echo "=== DPU2 (dpu-test-worker4) ==="
+podman exec dpu-test-worker4 ip addr show | grep -E "^[0-9]|inet "
+```
+
+### Test Connectivity
+
+```bash
+# Test Host-DPU point-to-point connections
+echo "Host1 → DPU1:"
+podman exec dpu-test-worker ip route get 192.168.1.2 >/dev/null 2>&1 && echo "✓ Route exists" || echo "✗ No route"
+
+echo "DPU1 → Host1:"
+podman exec dpu-test-worker2 ip route get 192.168.1.1 >/dev/null 2>&1 && echo "✓ Route exists" || echo "✗ No route"
+
+echo "Host2 → DPU2:"
+podman exec dpu-test-worker3 ip route get 192.168.2.2 >/dev/null 2>&1 && echo "✓ Route exists" || echo "✗ No route"
+
+echo "DPU2 → Host2:"
+podman exec dpu-test-worker4 ip route get 192.168.2.1 >/dev/null 2>&1 && echo "✓ Route exists" || echo "✗ No route"
+
+# Test DPU Kind cluster connectivity
+echo "DPU1 Kind cluster:"
+podman exec dpu-test-worker2 ip route get 10.89.1.1 >/dev/null 2>&1 && echo "✓ Kind network accessible" || echo "✗ Kind network not accessible"
+
+echo "DPU2 Kind cluster:"
+podman exec dpu-test-worker4 ip route get 10.89.1.1 >/dev/null 2>&1 && echo "✓ Kind network accessible" || echo "✗ Kind network not accessible"
+```
+
+## Testing with Error-CNI
+
+With this setup:
+- **Host-networked pods** will work on all nodes
+- **Regular pods** will fail because error-cni is mounted as the CNI plugin
+
+Deploy test pods to verify:
+
+```bash
+# Host-networked pod (should work)
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: host-net-test
+spec:
+  hostNetwork: true
+  containers:
+  - name: test
+    image: busybox
+    command: ["sleep", "3600"]
+EOF
+
+# Regular pod (should fail)
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regular-test
+spec:
+  containers:
+  - name: test
+    image: busybox
+    command: ["sleep", "3600"]
+EOF
+```
+
+## Topology Summary
+
+```
+                    ┌─────────────────┐
+                    │   Control Plane │
+                    │  (Kind cluster) │
+                    └─────────┬───────┘
+                              │
+                       Kind Network
+                     (10.89.1.x/24)
+                              │
+                ┌─────────────┴─────────────┐
+                │                           │
+        ┌───────────────┐           ┌───────────────┐
+        │     DPU1      │           │     DPU2      │
+        │ eth0(cluster) │           │ eth0(cluster) │
+        │ eth1(host)    │           │ eth1(host)    │
+        │(192.168.1.2)  │           │(192.168.2.2)  │
+        └───────┬───────┘           └───────┬───────┘
+                │                           │
+                │ veth                      │ veth
+                │                           │
+        ┌───────────────┐           ┌───────────────┐
+        │     Host1     │           │     Host2     │
+        │     eth0      │           │     eth0      │
+        │(192.168.1.1)  │           │(192.168.2.1)  │
+        └───────────────┘           └───────────────┘
+           (isolated)                  (isolated)
+```
+
+**Key Design:**
+- **Hosts**: Completely isolated, only connected to their paired DPU
+- **DPUs**: Connected to both Kind cluster AND their paired host
+- **Cluster access**: Hosts must route through DPUs to reach cluster resources
+
+This simulates a DPU environment where:
+- **Control plane**: Manages the cluster (no special connectivity)
+- **Host1 & Host2**: Act as "host" nodes with workloads
+- **DPU1 & DPU2**: Act as "DPU" nodes for offloaded processing
+- **Point-to-point connectivity**: Simulates dedicated DPU-host links

--- a/kind-dpu/dpu-host-template.yaml
+++ b/kind-dpu/dpu-host-template.yaml
@@ -1,0 +1,201 @@
+---
+# DPU Host Template - Production CNI-Only (Top Half)
+# Based on production dpu-host.yaml
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-node-dpu-host
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes CNI components for DPU host nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-node-dpu-host
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-node-dpu-host
+        name: ovnkube-node-dpu-host
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: ovnkube-node
+      hostNetwork: true
+      dnsPolicy: Default
+      hostPID: true
+      containers:
+      # Single container for CNI-only functionality
+      - name: ovnkube-controller
+        image: "localhost/ovn-daemonset-fedora:dev"
+        imagePullPolicy: "IfNotPresent"
+
+        # Use standard ovnkube.sh approach like all other nodes
+        command: ["/root/ovnkube.sh", "ovn-node"]
+
+        securityContext:
+          runAsUser: 0
+          privileged: true
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Common CNI mounts
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        - mountPath: /run/systemd/private
+          name: run-systemd
+          subPath: private
+          readOnly: true
+        # DPU host specific mounts (no OVS volumes)
+        - mountPath: /var/run/ovn
+          name: var-run-ovn
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.2.0"
+        - name: OVN_KUBE_LOG_LEVEL
+          value: "4"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "100"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "5"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "5"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_GATEWAY_MODE
+          value: "shared"
+        - name: OVN_GATEWAY_OPTS
+          value: ""
+        # CRITICAL: Standard ovnkube node mode environment variable
+        - name: OVNKUBE_NODE_MODE
+          value: "dpu-host"
+        # CRITICAL: Must match DPU node setting - use veth provider to avoid sysfs PCI lookups
+        - name: OVNKUBE_DPU_PROVIDER
+          value: "veth"
+        # Management interface for DPU-host mode
+        # This is the host-side veth end that pairs with rep0-0 (ovn-k8s-mp0) on the DPU
+        - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
+          value: "eth0-0"
+        # CRITICAL: Must match DPU node setting - enables IC mode and skips
+        # ready_to_start_node check (OVN DBs run on the DPU, not on the host)
+        - name: OVN_ENABLE_INTERCONNECT
+          value: "true"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+      # Target DPU host nodes only
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        k8s.ovn.org/dpu-host: ""
+      volumes:
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      - name: run-systemd
+        hostPath:
+          path: /run/systemd
+      - name: var-run-ovn
+        emptyDir: {}
+
+      tolerations:
+      - operator: "Exists"

--- a/kind-dpu/dpu-host.yaml
+++ b/kind-dpu/dpu-host.yaml
@@ -1,0 +1,288 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    deprecated.daemonset.template.generation: "16"
+    kubernetes.io/description: |
+      This daemonset launches the ovn-kubernetes per node networking components.
+    networkoperator.openshift.io/default-masquerade-network-cidrs: 169.254.0.0/17,fd69::/112
+    release.openshift.io/version: 4.20.4
+  creationTimestamp: "2026-01-28T00:39:22Z"
+  generation: 16
+  labels:
+    networkoperator.openshift.io/generates-operator-status: stand-alone
+  name: ovnkube-node-dpu-host
+  namespace: openshift-ovn-kubernetes
+  ownerReferences:
+  - apiVersion: operator.openshift.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Network
+    name: cluster
+    uid: d0dbe556-5517-4c03-9c64-9936c578a94f
+  resourceVersion: "5126735"
+  uid: 90495b4c-844a-49c6-a590-0b5b786524dc
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: ovnkube-node-dpu-host
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
+        network.operator.openshift.io/ovnkube-script-lib-hash: abb120bf3f179b02d48b101000dbb18d7a8c9011
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      creationTimestamp: null
+      labels:
+        app: ovnkube-node-dpu-host
+        component: network
+        kubernetes.io/os: linux
+        openshift.io/component: network
+        ovn-db-pod: "true"
+        type: infra
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/dpu-enabled
+                operator: Exists
+              - key: network.operator.openshift.io/smart-nic
+                operator: DoesNotExist
+              - key: network.operator.openshift.io/dpu
+                operator: DoesNotExist
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-rbac-proxy-node ovn-node-metrics 9103 29103 /etc/pki/tls/metrics-cert/tls.key /etc/pki/tls/metrics-cert/tls.crt
+        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8670caccf8fd94dc6d568dafd47a5cb5312a74ab5cd9d40daee38fdbce23e400
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy-node
+        ports:
+        - containerPort: 9103
+          name: https
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
+        - mountPath: /etc/pki/tls/metrics-cert
+          name: ovn-node-metrics-cert
+          readOnly: true
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-ovnkube-node ${OVN_KUBE_LOG_LEVEL} 29103 29105
+        env:
+        - name: KUBERNETES_SERVICE_PORT
+          value: "6443"
+        - name: KUBERNETES_SERVICE_HOST
+          value: api-int.doca4.nvidia.eng.rdu2.dc.redhat.com
+        - name: OVN_CONTROLLER_INACTIVITY_PROBE
+          value: "180000"
+        - name: OVN_KUBE_LOG_LEVEL
+          value: "4"
+        - name: OVN_NODE_MODE
+          value: dpu-host
+        - name: OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME
+          value: openshift.io/bf3-p0-vfs-mgmt
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b3a1b19106a0b56e4755b13d2b331c0ecab00365cbeccaeb6a30123068898187
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - rm
+              - -f
+              - /etc/cni/net.d/10-ovn-kubernetes.conf
+        name: ovnkube-controller
+        ports:
+        - containerPort: 29105
+          name: ovnmetrics-port
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              test -f /etc/cni/net.d/10-ovn-kubernetes.conf
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            openshift.io/bf3-p0-vfs-mgmt: "1"
+          requests:
+            cpu: 10m
+            memory: 600Mi
+            openshift.io/bf3-p0-vfs-mgmt: "1"
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
+        - mountPath: /etc/systemd/system
+          name: systemd-units
+          readOnly: true
+        - mountPath: /host
+          mountPropagation: HostToContainer
+          name: host-slash
+          readOnly: true
+        - mountPath: /run/ovn-kubernetes/
+          name: host-run-ovn-kubernetes
+        - mountPath: /run/netns
+          mountPropagation: HostToContainer
+          name: host-run-netns
+          readOnly: true
+        - mountPath: /run/systemd/private
+          mountPropagation: HostToContainer
+          name: run-systemd
+          readOnly: true
+          subPath: private
+        - mountPath: /cni-bin-dir
+          name: host-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+        - mountPath: /run/openvswitch
+          name: run-openvswitch
+        - mountPath: /var/log/ovnkube/
+          name: etc-openvswitch
+        - mountPath: /run/ovn/
+          name: run-ovn
+        - mountPath: /etc/openvswitch
+          name: etc-openvswitch
+        - mountPath: /etc/ovn/
+          name: etc-openvswitch
+        - mountPath: /var/lib/openvswitch
+          name: var-lib-openvswitch
+        - mountPath: /run/ovnkube-config/
+          name: ovnkube-config
+        - mountPath: /env
+          name: env-overrides
+      dnsPolicy: Default
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: ovn-kubernetes-node
+      serviceAccountName: ovn-kubernetes-node
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /etc/systemd/system
+          type: ""
+        name: systemd-units
+      - hostPath:
+          path: /
+          type: ""
+        name: host-slash
+      - hostPath:
+          path: /run/netns
+          type: ""
+        name: host-run-netns
+      - hostPath:
+          path: /run/systemd
+          type: ""
+        name: run-systemd
+      - hostPath:
+          path: /var/lib/openvswitch/data
+          type: ""
+        name: var-lib-openvswitch
+      - hostPath:
+          path: /var/lib/ovn-ic/etc
+          type: ""
+        name: etc-openvswitch
+      - hostPath:
+          path: /var/run/openvswitch
+          type: ""
+        name: run-openvswitch
+      - hostPath:
+          path: /var/run/ovn-ic
+          type: ""
+        name: run-ovn
+      - hostPath:
+          path: /run/ovn-kubernetes
+          type: ""
+        name: host-run-ovn-kubernetes
+      - hostPath:
+          path: /var/lib/cni/bin
+          type: ""
+        name: host-cni-bin
+      - hostPath:
+          path: /var/run/multus/cni/net.d
+          type: ""
+        name: host-cni-netd
+      - hostPath:
+          path: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          type: ""
+        name: host-var-lib-cni-networks-ovn-kubernetes
+      - configMap:
+          defaultMode: 420
+          name: ovnkube-config
+        name: ovnkube-config
+      - configMap:
+          defaultMode: 420
+          name: env-overrides
+          optional: true
+        name: env-overrides
+      - name: ovn-node-metrics-cert
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: ovn-node-metrics-cert
+      - configMap:
+          defaultMode: 484
+          name: ovnkube-script-lib
+        name: ovnkube-script-lib
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 10%
+    type: RollingUpdate
+status:
+  currentNumberScheduled: 1
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+  observedGeneration: 16
+  updatedNumberScheduled: 1

--- a/kind-dpu/dpu-template.yaml
+++ b/kind-dpu/dpu-template.yaml
@@ -1,0 +1,529 @@
+---
+# DPU Template - Production 6-Container OVN Stack (Bottom Half)
+# Based on production dpu.yaml with full OVN infrastructure
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-node-dpu
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the full ovn-kubernetes OVN stack for DPU nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-node-dpu
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-node-dpu
+        name: ovnkube-node-dpu
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+    spec:
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: ovnkube-node
+      hostNetwork: true
+      dnsPolicy: Default
+      hostPID: true
+      containers:
+
+      # Container 1: NB OVSDB
+      - name: nb-ovsdb
+        image: "localhost/ovn-daemonset-fedora:dev"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/root/ovnkube.sh", "local-nb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.2.0"
+        - name: OVN_LOGLEVEL_NB
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 30
+
+      # Container 2: SB OVSDB
+      - name: sb-ovsdb
+        image: "localhost/ovn-daemonset-fedora:dev"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/root/ovnkube.sh", "local-sb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.2.0"
+        - name: OVN_LOGLEVEL_SB
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 30
+
+      # Container 3: OVN Northd
+      - name: ovn-northd
+        image: "localhost/ovn-daemonset-fedora:dev"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.2.0"
+        - name: OVN_LOGLEVEL_NORTHD
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 30
+
+      # Container 4: OVNKube Controller with Node (Main Controller)
+      - name: ovnkube-controller-with-node
+        image: "localhost/ovn-daemonset-fedora:dev"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/root/ovnkube.sh", "ovnkube-controller-with-node"]
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.2.0"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "100"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "5"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "5"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_GATEWAY_MODE
+          value: "shared"
+        # REMOVED: OVN_GATEWAY_OPTS - now using automatic gateway interface detection via DPU provider
+        # The GetDPUHostInterface() function will auto-detect rep0-0 via VethRepresentorProvider
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: "true"
+        - name: OVN_EGRESSIP_ENABLE
+          value: "false"
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: "9107"
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: "false"
+        - name: OVN_EGRESSQOS_ENABLE
+          value: "false"
+        - name: OVN_NETWORK_QOS_ENABLE
+          value: "true"
+        - name: OVN_ENCAP_PORT
+          value: "6081"
+        - name: OVN_V4_JOIN_SUBNET
+          value: "100.64.0.0/16"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "fd98::/64"
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: "169.254.0.0/17"
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: "fd69::/112"
+        - name: OVN_MULTICAST_ENABLE
+          value: "true"
+        - name: OVN_UNPRIVILEGED_MODE
+          value: "no"
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        - name: OVN_DISABLE_OVN_IFACE_ID_VER
+          value: "false"
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: "100000"
+        - name: OVN_ENABLE_LFLOW_CACHE
+          value: "false"
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: "false"
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: "20"
+        - name: OVN_STATELESS_NETPOL_ENABLE
+          value: "true"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        - name: OVN_ENABLE_INTERCONNECT
+          value: "true"
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: "false"
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: "false"
+        - name: OVN_DISABLE_REQUESTEDCHASSIS
+          value: "true"
+        - name: OVN_ENABLE_SVC_TEMPLATE_SUPPORT
+          value: "false"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "false"
+        - name: OVN_NOHOSTSUBNET_LABEL
+          value: "k8s.ovn.org/ovn-managed=false"
+        # CRITICAL: DPU mode environment variable
+        - name: OVNKUBE_NODE_MODE
+          value: "dpu"
+        # DPU provider for VethRepresentorProvider
+        - name: OVNKUBE_DPU_PROVIDER
+          value: "veth"
+        - name: OVNKUBE_NODE_LEASE_NAMESPACE
+          value: "ovn-kubernetes"
+        # CRITICAL: OVN encapsulation IP required for DPU mode
+        - name: OVN_ENCAP_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 9476
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+
+      # Container 5: OVN Controller
+      - name: ovn-controller
+        image: "localhost/ovn-daemonset-fedora:dev"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/root/ovnkube.sh", "ovn-controller"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.2.0"
+        - name: OVN_LOGLEVEL_CONTROLLER
+          value: "-vconsole:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: ""
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-controller"]
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 30
+
+      # Container 6: OVS Metrics Exporter
+      - name: ovs-metrics-exporter
+        image: "localhost/ovn-daemonset-fedora:dev"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/root/ovnkube.sh", "ovs-metrics"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.2.0"
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+
+      # Target DPU nodes only
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        k8s.ovn.org/dpu: ""
+      volumes:
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      # OVS/OVN volumes (required for DPU nodes)
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-etc-ovs
+        hostPath:
+          path: /etc/openvswitch
+
+      tolerations:
+      - operator: "Exists"

--- a/kind-dpu/dpu.yaml
+++ b/kind-dpu/dpu.yaml
@@ -1,0 +1,833 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    deprecated.daemonset.template.generation: "1"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"apps/v1","kind":"DaemonSet","metadata":{"annotations":{"kubernetes.io/description":"This DaemonSet launches the ovn-kubernetes networking components for worker nodes.\n"},"labels":{"app.kubernetes.io/instance":"cluster-ovn-fkpms","svc.dpu.nvidia.com/service":"dpudeployment_dpudeployment_ovn"},"name":"cluster-ovn-fkpms-ovn-kubernetes-node","namespace":"dpf-operator-system"},"spec":{"selector":{"matchLabels":{"app.kubernetes.io/component":"ovnkube-node","app.kubernetes.io/instance":"cluster-ovn-fkpms","app.kubernetes.io/name":"ovn-kubernetes","svc.dpu.nvidia.com/service":"dpudeployment_dpudeployment_ovn"}},"template":{"metadata":{"annotations":{"dpf.nvidia.com/ip-requests":"[\n  {\n    \"name\": \"vtep\",\n    \"poolName\": \"pool1\",\n    \"poolType\": \"cidrpool\",\n    \"allocateIPWithIndex\": 0\n  },\n  {\n    \"name\": \"pf\",\n    \"poolName\": \"pool1\",\n    \"poolType\": \"cidrpool\",\n    \"allocateIPWithIndex\": 1\n  }\n]"},"labels":{"app.kubernetes.io/component":"ovnkube-node","app.kubernetes.io/instance":"cluster-ovn-fkpms","app.kubernetes.io/name":"ovn-kubernetes","kubernetes.io/os":"linux","svc.dpu.nvidia.com/service":"dpudeployment_dpudeployment_ovn"}},"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"svc.dpu.nvidia.com/dpuservice-ovn-version","operator":"In","values":["ovn-fkpms"]},{"key":"svc.dpu.nvidia.com/owned-by-dpudeployment","operator":"In","values":["dpf-operator-system_dpudeployment"]}]}]}}},"automountServiceAccountToken":false,"containers":[{"command":["/root/ovnkube.sh","local-nb-ovsdb"],"env":[{"name":"OVN_DAEMONSET_VERSION","value":"1.1.0"},{"name":"OVN_LOGLEVEL_NB","value":"-vconsole:info -vfile:info"},{"name":"K8S_APISERVER","valueFrom":{"configMapKeyRef":{"key":"k8s_apiserver","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"OVN_KUBERNETES_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"K8S_NODE_IP","valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}},{"name":"K8S_NODE","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62","imagePullPolicy":"IfNotPresent","name":"nb-ovsdb","readinessProbe":{"exec":{"command":["/usr/bin/ovn-kube-util","readiness-probe","-t","ovnnb-db"]},"initialDelaySeconds":30,"periodSeconds":60,"timeoutSeconds":30},"resources":{"requests":{"cpu":"100m","memory":"300Mi"}},"securityContext":{"capabilities":{"add":["NET_ADMIN"]},"runAsUser":0},"terminationMessagePolicy":"FallbackToLogsOnError","volumeMounts":[{"mountPath":"/etc/openvswitch/","name":"host-etc-ovs"},{"mountPath":"/etc/ovn/","name":"host-var-lib-ovs"},{"mountPath":"/var/log/openvswitch/","name":"host-var-log-ovs"},{"mountPath":"/var/log/ovn/","name":"host-var-log-ovs"},{"mountPath":"/ovn-cert","name":"host-ovn-cert","readOnly":true},{"mountPath":"/var/run/ovn/","name":"host-var-run-ovs"},{"mountPath":"/var/run/openvswitch/","name":"host-var-run-ovs"}]},{"command":["/root/ovnkube.sh","local-sb-ovsdb"],"env":[{"name":"OVN_DAEMONSET_VERSION","value":"1.1.0"},{"name":"OVN_LOGLEVEL_SB","value":"-vconsole:info -vfile:info"},{"name":"K8S_APISERVER","valueFrom":{"configMapKeyRef":{"key":"k8s_apiserver","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"OVN_KUBERNETES_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"K8S_NODE_IP","valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}},{"name":"K8S_NODE","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}},{"name":"OVN_SSL_ENABLE","value":"no"}],"image":"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62","imagePullPolicy":"IfNotPresent","name":"sb-ovsdb","readinessProbe":{"exec":{"command":["/usr/bin/ovn-kube-util","readiness-probe","-t","ovnsb-db"]},"initialDelaySeconds":30,"periodSeconds":60,"timeoutSeconds":30},"resources":{"requests":{"cpu":"100m","memory":"300Mi"}},"securityContext":{"capabilities":{"add":["NET_ADMIN"]},"runAsUser":0},"terminationMessagePolicy":"FallbackToLogsOnError","volumeMounts":[{"mountPath":"/etc/openvswitch/","name":"host-etc-ovs"},{"mountPath":"/etc/ovn/","name":"host-var-lib-ovs"},{"mountPath":"/var/log/openvswitch/","name":"host-var-log-ovs"},{"mountPath":"/var/log/ovn/","name":"host-var-log-ovs"},{"mountPath":"/ovn-cert","name":"host-ovn-cert","readOnly":true},{"mountPath":"/var/run/ovn/","name":"host-var-run-ovs"},{"mountPath":"/var/run/openvswitch/","name":"host-var-run-ovs"}]},{"command":["/root/ovnkube.sh","run-ovn-northd"],"env":[{"name":"OVN_DAEMONSET_VERSION","value":"1.1.0"},{"name":"OVN_LOGLEVEL_NORTHD","value":"-vconsole:info -vfile:info"},{"name":"K8S_APISERVER","valueFrom":{"configMapKeyRef":{"key":"k8s_apiserver","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"OVN_KUBERNETES_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"OVN_SSL_ENABLE","value":"no"},{"name":"OVN_NORTH","value":"local"},{"name":"OVN_SOUTH","value":"local"}],"image":"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62","imagePullPolicy":"IfNotPresent","name":"ovn-northd","readinessProbe":{"exec":{"command":["/usr/bin/ovn-kube-util","readiness-probe","-t","ovn-northd"]},"initialDelaySeconds":30,"periodSeconds":60,"timeoutSeconds":30},"resources":{"requests":{"cpu":"100m","memory":"300Mi"}},"securityContext":{"capabilities":{"add":["SYS_NICE"]},"runAsUser":0},"terminationMessagePolicy":"FallbackToLogsOnError","volumeMounts":[{"mountPath":"/var/run/dbus/","name":"host-var-run-dbus","readOnly":true},{"mountPath":"/var/log/openvswitch/","name":"host-var-log-ovs"},{"mountPath":"/var/log/ovn/","name":"host-var-log-ovs"},{"mountPath":"/var/run/openvswitch/","name":"host-var-run-ovs"},{"mountPath":"/var/run/ovn/","name":"host-var-run-ovs"},{"mountPath":"/ovn-cert","name":"host-ovn-cert","readOnly":true}]},{"command":["/root/ovnkube.sh","ovnkube-controller-with-node"],"env":[{"name":"OVN_EGRESSSERVICE_ENABLE","value":"false"},{"name":"OVN_DAEMONSET_VERSION","value":"1.1.0"},{"name":"OVNKUBE_LOGLEVEL","value":"4"},{"name":"OVNKUBE_LOGFILE_MAXSIZE","value":"100"},{"name":"OVNKUBE_LOGFILE_MAXBACKUPS","value":"5"},{"name":"OVNKUBE_LOGFILE_MAXAGE","value":"5"},{"name":"OVNKUBE_LIBOVSDB_CLIENT_LOGFILE","value":""},{"name":"OVNKUBE_CONFIG_DURATION_ENABLE","value":""},{"name":"OVNKUBE_METRICS_SCALE_ENABLE","value":""},{"name":"OVN_GATEWAY_ROUTER_SUBNET","value":""},{"name":"OVN_NET_CIDR","valueFrom":{"configMapKeyRef":{"key":"net_cidr","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"OVN_SVC_CIDR","valueFrom":{"configMapKeyRef":{"key":"svc_cidr","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"K8S_APISERVER","valueFrom":{"configMapKeyRef":{"key":"k8s_apiserver","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"OVN_MTU","valueFrom":{"configMapKeyRef":{"key":"mtu","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"OVN_ROUTABLE_MTU","valueFrom":{"configMapKeyRef":{"key":"routable_mtu","name":"cluster-ovn-fkpms-ovn-kubernetes-config","optional":true}}},{"name":"K8S_NODE","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}},{"name":"K8S_NODE_IP","valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}},{"name":"OVN_KUBERNETES_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"OVN_GATEWAY_MODE","value":"shared"},{"name":"OVN_GATEWAY_OPTS","value":"--gateway-interface=br-dpu"},{"name":"OVN_HYBRID_OVERLAY_ENABLE","value":""},{"name":"OVN_ADMIN_NETWORK_POLICY_ENABLE","value":"true"},{"name":"OVN_EGRESSIP_ENABLE","value":"false"},{"name":"OVN_EGRESSIP_HEALTHCHECK_PORT","value":"9107"},{"name":"OVN_EGRESSFIREWALL_ENABLE","value":"false"},{"name":"OVN_EGRESSQOS_ENABLE","value":"false"},{"name":"OVN_NETWORK_QOS_ENABLE","value":"true"},{"name":"OVN_HYBRID_OVERLAY_NET_CIDR","value":""},{"name":"OVN_DISABLE_SNAT_MULTIPLE_GWS","value":""},{"name":"OVN_DISABLE_FORWARDING","value":""},{"name":"OVN_ENCAP_PORT","value":"6081"},{"name":"OVN_DISABLE_PKT_MTU_CHECK","value":""},{"name":"OVN_NETFLOW_TARGETS","value":""},{"name":"OVN_SFLOW_TARGETS","value":""},{"name":"OVN_IPFIX_TARGETS","value":""},{"name":"OVN_IPFIX_SAMPLING","value":""},{"name":"OVN_IPFIX_CACHE_MAX_FLOWS","value":""},{"name":"OVN_IPFIX_CACHE_ACTIVE_TIMEOUT","value":""},{"name":"OVN_V4_JOIN_SUBNET","value":"100.64.0.0/16"},{"name":"OVN_V6_JOIN_SUBNET","value":"fd98::/64"},{"name":"OVN_V4_MASQUERADE_SUBNET","value":"169.254.0.0/17"},{"name":"OVN_V6_MASQUERADE_SUBNET","value":"fd69::/112"},{"name":"OVN_MULTICAST_ENABLE","value":"true"},{"name":"OVN_UNPRIVILEGED_MODE","value":"no"},{"name":"OVN_EX_GW_NETWORK_INTERFACE","value":""},{"name":"OVN_SSL_ENABLE","value":"no"},{"name":"OVN_DISABLE_OVN_IFACE_ID_VER","value":"false"},{"name":"OVN_REMOTE_PROBE_INTERVAL","value":"100000"},{"name":"OVN_MONITOR_ALL","value":""},{"name":"OVN_OFCTRL_WAIT_BEFORE_CLEAR","value":""},{"name":"OVN_ENABLE_LFLOW_CACHE","value":"false"},{"name":"OVN_LFLOW_CACHE_LIMIT","value":""},{"name":"OVN_LFLOW_CACHE_LIMIT_KB","value":""},{"name":"OVN_MULTI_NETWORK_ENABLE","value":"true"},{"name":"OVN_EMPTY_LB_EVENTS","value":""},{"name":"OVN_ACL_LOGGING_RATE_LIMIT","value":"20"},{"name":"OVN_STATELESS_NETPOL_ENABLE","value":"true"},{"name":"OVN_HOST_NETWORK_NAMESPACE","valueFrom":{"configMapKeyRef":{"key":"host_network_namespace","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"OVN_NORTH","value":"local"},{"name":"OVN_SOUTH","value":"local"},{"name":"OVN_ENABLE_INTERCONNECT","value":"true"},{"name":"OVN_ENABLE_MULTI_EXTERNAL_GATEWAY","value":"false"},{"name":"OVN_ENABLE_OVNKUBE_IDENTITY","value":"false"},{"name":"OVN_DISABLE_REQUESTEDCHASSIS","value":"true"},{"name":"OVN_ENABLE_SVC_TEMPLATE_SUPPORT","value":"false"},{"name":"OVN_ENABLE_DNSNAMERESOLVER","value":"false"},{"name":"OVN_NOHOSTSUBNET_LABEL","value":"k8s.ovn.org/ovn-managed=false"},{"name":"OVNKUBE_NODE_MODE","value":"dpu"},{"name":"OVNKUBE_NODE_LEASE_NAMESPACE","value":"openshift-ovn-kubernetes"}],"image":"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62","imagePullPolicy":"IfNotPresent","name":"doca-ovnkube-controller","readinessProbe":{"httpGet":{"path":"/metrics","port":9476,"scheme":"HTTP"},"initialDelaySeconds":30,"periodSeconds":30,"timeoutSeconds":5},"resources":{"requests":{"cpu":"100m","memory":"300Mi"}},"securityContext":{"privileged":true,"runAsUser":0},"terminationMessagePolicy":"FallbackToLogsOnError","volumeMounts":[{"mountPath":"/host","name":"host-slash","readOnly":true},{"mountPath":"/var/lib/kubelet","name":"host-kubelet","readOnly":true},{"mountPath":"/host-kubernetes","name":"host-kubeconfig","readOnly":true},{"mountPath":"/var/run/dbus/","name":"host-var-run-dbus","readOnly":true},{"mountPath":"/var/log/ovn-kubernetes/","name":"host-var-log-ovnkube"},{"mountPath":"/var/run/ovn-kubernetes","name":"host-var-run-ovn-kubernetes"},{"mountPath":"/opt/cni/bin","name":"host-opt-cni-bin"},{"mountPath":"/etc/cni/net.d","name":"host-etc-cni-netd"},{"mountPath":"/var/run/netns","mountPropagation":"Bidirectional","name":"host-netns"},{"mountPath":"/var/run/openvswitch/","name":"host-var-run-ovs"},{"mountPath":"/var/run/ovn/","name":"host-var-run-ovs"},{"mountPath":"/ovn-cert","name":"host-ovn-cert","readOnly":true},{"mountPath":"/etc/openvswitch/","name":"host-etc-ovs"},{"mountPath":"/etc/openvswitch/ovn_k8s.conf","name":"init-output","subPath":"ovn_k8s.conf"},{"mountPath":"/etc/ovn/","name":"host-var-lib-ovs","readOnly":true},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"tenant-cluster-access-secret","readOnly":true}]},{"command":["/root/ovnkube.sh","ovn-controller"],"env":[{"name":"OVN_DAEMONSET_VERSION","value":"1.1.0"},{"name":"OVN_LOGLEVEL_CONTROLLER","value":"-vconsole:info"},{"name":"K8S_APISERVER","valueFrom":{"configMapKeyRef":{"key":"k8s_apiserver","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"OVN_KUBERNETES_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"OVN_SSL_ENABLE","value":""},{"name":"OVN_NORTH","value":"local"},{"name":"OVN_SOUTH","value":"local"}],"image":"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62","imagePullPolicy":"IfNotPresent","name":"ovn-controller","readinessProbe":{"exec":{"command":["/usr/bin/ovn-kube-util","readiness-probe","-t","ovn-controller"]},"initialDelaySeconds":30,"periodSeconds":60,"timeoutSeconds":30},"resources":{"requests":{"cpu":"100m","memory":"300Mi"}},"securityContext":{"capabilities":{"add":["SYS_NICE"]},"runAsUser":0},"terminationMessagePolicy":"FallbackToLogsOnError","volumeMounts":[{"mountPath":"/var/run/dbus/","name":"host-var-run-dbus","readOnly":true},{"mountPath":"/var/log/openvswitch/","name":"host-var-log-ovs"},{"mountPath":"/var/log/ovn/","name":"host-var-log-ovs"},{"mountPath":"/var/run/openvswitch/","name":"host-var-run-ovs"},{"mountPath":"/var/run/ovn/","name":"host-var-run-ovs"},{"mountPath":"/ovn-cert","name":"host-ovn-cert","readOnly":true}]},{"command":["/root/ovnkube.sh","ovs-metrics"],"env":[{"name":"OVN_DAEMONSET_VERSION","value":"1.1.0"},{"name":"K8S_NODE_IP","valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}}],"image":"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62","imagePullPolicy":"IfNotPresent","name":"ovs-metrics-exporter","resources":{"requests":{"cpu":"100m","memory":"300Mi"}},"securityContext":{"capabilities":{"add":["NET_ADMIN"]},"runAsUser":0},"terminationMessagePolicy":"FallbackToLogsOnError","volumeMounts":[{"mountPath":"/var/run/dbus/","name":"host-var-run-dbus","readOnly":true},{"mountPath":"/var/log/openvswitch/","name":"host-var-log-ovs"},{"mountPath":"/var/run/openvswitch/","name":"host-var-run-ovs"}]}],"dnsPolicy":"Default","hostNetwork":true,"hostPID":true,"imagePullSecrets":[{"name":"dpf-pull-secret"}],"initContainers":[{"command":["/ipallocator","allocator"],"env":[{"name":"IP_ALLOCATOR_REQUESTS","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations['dpf.nvidia.com/ip-requests']"}}},{"name":"K8S_POD_NAME","valueFrom":{"fieldRef":{"fieldPath":"metadata.name"}}},{"name":"K8S_POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"K8S_POD_UID","valueFrom":{"fieldRef":{"fieldPath":"metadata.uid"}}}],"image":"ghcr.io/mellanox/ovn-kubernetes-dpf-utils:v0.1.0-latest-alin","imagePullPolicy":"IfNotPresent","lifecycle":{"preStop":{"exec":{"command":["/ipallocator","deallocator"]}}},"name":"ipallocator","readinessProbe":{"exec":{"command":["cat","/var/run/readyz"]}},"restartPolicy":"Always","securityContext":{"runAsUser":0},"startupProbe":{"exec":{"command":["cat","/var/run/readyz"]}},"volumeMounts":[{"mountPath":"/opt/cni/bin","name":"cni-bin-dir","readOnly":true},{"mountPath":"/var/lib/cni/nv-ipam","name":"nvipam-daemon-socket-dir","readOnly":true},{"mountPath":"/tmp/ips","name":"ips"},{"mountPath":"/var/lib/cni","name":"cni-cache"}]},{"args":["internal-ipam"],"command":["/cniprovisioner"],"env":[{"name":"NODE_NAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}},{"name":"OVN_MTU","valueFrom":{"configMapKeyRef":{"key":"mtu","name":"cluster-ovn-fkpms-ovn-kubernetes-config"}}},{"name":"VTEP_CIDR","value":"10.6.156.208/28"},{"name":"HOST_CIDR","value":"10.6.135.0/24"}],"image":"ghcr.io/mellanox/ovn-kubernetes-dpf-utils:v0.1.0-latest-alin","imagePullPolicy":"IfNotPresent","name":"cniprovisioner","readinessProbe":{"exec":{"command":["cat","/var/run/readyz"]}},"restartPolicy":"Always","securityContext":{"privileged":true,"runAsUser":0},"startupProbe":{"exec":{"command":["cat","/var/run/readyz"]},"initialDelaySeconds":30},"volumeMounts":[{"mountPath":"/tmp/ips","name":"ips"},{"mountPath":"/etc/openvswitch","name":"init-output"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"incluster","readOnly":true},{"mountPath":"/var/run/openvswitch/","name":"host-var-run-ovs"}]}],"priorityClassName":"system-cluster-critical","serviceAccountName":"cluster-ovn-fkpms-ovn-kubernetes-node","tolerations":[{"operator":"Exists"}],"volumes":[{"emptyDir":{},"name":"ips"},{"hostPath":{"path":"/var/lib/cni/bin/","type":"Directory"},"name":"cni-bin-dir"},{"hostPath":{"path":"/var/lib/cni/nv-ipam","type":"Directory"},"name":"nvipam-daemon-socket-dir"},{"emptyDir":{},"name":"cni-cache"},{"emptyDir":{},"name":"init-output"},{"hostPath":{"path":"/var/run/dbus"},"name":"host-var-run-dbus"},{"hostPath":{"path":"/etc/kubernetes/"},"name":"host-kubeconfig"},{"hostPath":{"path":"/var/lib/kubelet"},"name":"host-kubelet"},{"hostPath":{"path":"/var/log/ovn-kubernetes"},"name":"host-var-log-ovnkube"},{"hostPath":{"path":"/var/run/ovn-kubernetes"},"name":"host-var-run-ovn-kubernetes"},{"hostPath":{"path":"/var/lib/cni/bin/"},"name":"host-opt-cni-bin"},{"hostPath":{"path":"/run/multus/cni/net.d"},"name":"host-etc-cni-netd"},{"hostPath":{"path":"/"},"name":"host-slash"},{"hostPath":{"path":"/var/run/netns"},"name":"host-netns"},{"hostPath":{"path":"/var/log/openvswitch"},"name":"host-var-log-ovs"},{"hostPath":{"path":"/run/openvswitch"},"name":"host-run-ovs"},{"hostPath":{"path":"/var/run/openvswitch"},"name":"host-var-run-ovs"},{"hostPath":{"path":"/etc/ovn","type":"DirectoryOrCreate"},"name":"host-ovn-cert"},{"hostPath":{"path":"/var/lib/openvswitch"},"name":"host-var-lib-ovs"},{"hostPath":{"path":"/etc/openvswitch"},"name":"host-etc-ovs"},{"name":"tenant-cluster-access-secret","secret":{"defaultMode":420,"items":[{"key":"KUBERNETES_CA_DATA","path":"ca.crt"},{"key":"TOKEN_FILE","path":"token"}],"secretName":"ovn-dpu"}},{"name":"incluster","projected":{"sources":[{"secret":{"items":[{"key":"ca.crt","path":"ca.crt"},{"key":"token","path":"token"}],"name":"cluster-ovn-fkpms-ovn-kubernetes-dpucniprovisioner-token"}}]}}]}}}}
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+  creationTimestamp: "2026-02-03T12:38:43Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: cluster-ovn-fkpms
+    svc.dpu.nvidia.com/service: dpudeployment_dpudeployment_ovn
+  name: cluster-ovn-fkpms-ovn-kubernetes-node
+  namespace: dpf-operator-system
+  resourceVersion: "1406941"
+  uid: f877b235-1953-403f-9421-c3fe34a5567b
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ovnkube-node
+      app.kubernetes.io/instance: cluster-ovn-fkpms
+      app.kubernetes.io/name: ovn-kubernetes
+      svc.dpu.nvidia.com/service: dpudeployment_dpudeployment_ovn
+  template:
+    metadata:
+      annotations:
+        dpf.nvidia.com/ip-requests: |-
+          [
+            {
+              "name": "vtep",
+              "poolName": "pool1",
+              "poolType": "cidrpool",
+              "allocateIPWithIndex": 0
+            },
+            {
+              "name": "pf",
+              "poolName": "pool1",
+              "poolType": "cidrpool",
+              "allocateIPWithIndex": 1
+            }
+          ]
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: ovnkube-node
+        app.kubernetes.io/instance: cluster-ovn-fkpms
+        app.kubernetes.io/name: ovn-kubernetes
+        kubernetes.io/os: linux
+        svc.dpu.nvidia.com/service: dpudeployment_dpudeployment_ovn
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: svc.dpu.nvidia.com/dpuservice-ovn-version
+                operator: In
+                values:
+                - ovn-fkpms
+              - key: svc.dpu.nvidia.com/owned-by-dpudeployment
+                operator: In
+                values:
+                - dpf-operator-system_dpudeployment
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - /root/ovnkube.sh
+        - local-nb-ovsdb
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: 1.1.0
+        - name: OVN_LOGLEVEL_NB
+          value: -vconsole:info -vfile:info
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              key: k8s_apiserver
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62
+        imagePullPolicy: IfNotPresent
+        name: nb-ovsdb
+        readinessProbe:
+          exec:
+            command:
+            - /usr/bin/ovn-kube-util
+            - readiness-probe
+            - -t
+            - ovnnb-db
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 30
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+      - command:
+        - /root/ovnkube.sh
+        - local-sb-ovsdb
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: 1.1.0
+        - name: OVN_LOGLEVEL_SB
+          value: -vconsole:info -vfile:info
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              key: k8s_apiserver
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62
+        imagePullPolicy: IfNotPresent
+        name: sb-ovsdb
+        readinessProbe:
+          exec:
+            command:
+            - /usr/bin/ovn-kube-util
+            - readiness-probe
+            - -t
+            - ovnsb-db
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 30
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+      - command:
+        - /root/ovnkube.sh
+        - run-ovn-northd
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: 1.1.0
+        - name: OVN_LOGLEVEL_NORTHD
+          value: -vconsole:info -vfile:info
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              key: k8s_apiserver
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        - name: OVN_NORTH
+          value: local
+        - name: OVN_SOUTH
+          value: local
+        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62
+        imagePullPolicy: IfNotPresent
+        name: ovn-northd
+        readinessProbe:
+          exec:
+            command:
+            - /usr/bin/ovn-kube-util
+            - readiness-probe
+            - -t
+            - ovn-northd
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 30
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        securityContext:
+          capabilities:
+            add:
+            - SYS_NICE
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+      - command:
+        - /root/ovnkube.sh
+        - ovnkube-controller-with-node
+        env:
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: "false"
+        - name: OVN_DAEMONSET_VERSION
+          value: 1.1.0
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "100"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "5"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "5"
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+        - name: OVNKUBE_METRICS_SCALE_ENABLE
+        - name: OVN_GATEWAY_ROUTER_SUBNET
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              key: net_cidr
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              key: svc_cidr
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              key: k8s_apiserver
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              key: mtu
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              key: routable_mtu
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: OVN_GATEWAY_MODE
+          value: shared
+        - name: OVN_GATEWAY_OPTS
+          value: --gateway-interface=br-dpu
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: "true"
+        - name: OVN_EGRESSIP_ENABLE
+          value: "false"
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: "9107"
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: "false"
+        - name: OVN_EGRESSQOS_ENABLE
+          value: "false"
+        - name: OVN_NETWORK_QOS_ENABLE
+          value: "true"
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+        - name: OVN_DISABLE_FORWARDING
+        - name: OVN_ENCAP_PORT
+          value: "6081"
+        - name: OVN_DISABLE_PKT_MTU_CHECK
+        - name: OVN_NETFLOW_TARGETS
+        - name: OVN_SFLOW_TARGETS
+        - name: OVN_IPFIX_TARGETS
+        - name: OVN_IPFIX_SAMPLING
+        - name: OVN_IPFIX_CACHE_MAX_FLOWS
+        - name: OVN_IPFIX_CACHE_ACTIVE_TIMEOUT
+        - name: OVN_V4_JOIN_SUBNET
+          value: 100.64.0.0/16
+        - name: OVN_V6_JOIN_SUBNET
+          value: fd98::/64
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: 169.254.0.0/17
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: fd69::/112
+        - name: OVN_MULTICAST_ENABLE
+          value: "true"
+        - name: OVN_UNPRIVILEGED_MODE
+          value: "no"
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        - name: OVN_DISABLE_OVN_IFACE_ID_VER
+          value: "false"
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: "100000"
+        - name: OVN_MONITOR_ALL
+        - name: OVN_OFCTRL_WAIT_BEFORE_CLEAR
+        - name: OVN_ENABLE_LFLOW_CACHE
+          value: "false"
+        - name: OVN_LFLOW_CACHE_LIMIT
+        - name: OVN_LFLOW_CACHE_LIMIT_KB
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: "true"
+        - name: OVN_EMPTY_LB_EVENTS
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: "20"
+        - name: OVN_STATELESS_NETPOL_ENABLE
+          value: "true"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              key: host_network_namespace
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: OVN_NORTH
+          value: local
+        - name: OVN_SOUTH
+          value: local
+        - name: OVN_ENABLE_INTERCONNECT
+          value: "true"
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: "false"
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: "false"
+        - name: OVN_DISABLE_REQUESTEDCHASSIS
+          value: "true"
+        - name: OVN_ENABLE_SVC_TEMPLATE_SUPPORT
+          value: "false"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "false"
+        - name: OVN_NOHOSTSUBNET_LABEL
+          value: k8s.ovn.org/ovn-managed=false
+        - name: OVNKUBE_NODE_MODE
+          value: dpu
+        - name: OVNKUBE_NODE_LEASE_NAMESPACE
+          value: openshift-ovn-kubernetes
+        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62
+        imagePullPolicy: IfNotPresent
+        name: doca-ovnkube-controller
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9476
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /host-kubernetes
+          name: host-kubeconfig
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          mountPropagation: Bidirectional
+          name: host-netns
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/openvswitch/ovn_k8s.conf
+          name: init-output
+          subPath: ovn_k8s.conf
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tenant-cluster-access-secret
+          readOnly: true
+      - command:
+        - /root/ovnkube.sh
+        - ovn-controller
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: 1.1.0
+        - name: OVN_LOGLEVEL_CONTROLLER
+          value: -vconsole:info
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              key: k8s_apiserver
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+        - name: OVN_NORTH
+          value: local
+        - name: OVN_SOUTH
+          value: local
+        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62
+        imagePullPolicy: IfNotPresent
+        name: ovn-controller
+        readinessProbe:
+          exec:
+            command:
+            - /usr/bin/ovn-kube-util
+            - readiness-probe
+            - -t
+            - ovn-controller
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 30
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        securityContext:
+          capabilities:
+            add:
+            - SYS_NICE
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+      - command:
+        - /root/ovnkube.sh
+        - ovs-metrics
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: 1.1.0
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9af8c6523a889c9cd5b301b3cd6441c1fe01cc0ef7d667bfeb152108ba735e62
+        imagePullPolicy: IfNotPresent
+        name: ovs-metrics-exporter
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+      dnsPolicy: Default
+      hostNetwork: true
+      hostPID: true
+      imagePullSecrets:
+      - name: dpf-pull-secret
+      initContainers:
+      - command:
+        - /ipallocator
+        - allocator
+        env:
+        - name: IP_ALLOCATOR_REQUESTS
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.annotations['dpf.nvidia.com/ip-requests']
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: K8S_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        image: ghcr.io/mellanox/ovn-kubernetes-dpf-utils:v0.1.0-latest-alin
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /ipallocator
+              - deallocator
+        name: ipallocator
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/readyz
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        restartPolicy: Always
+        securityContext:
+          runAsUser: 0
+        startupProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/readyz
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /opt/cni/bin
+          name: cni-bin-dir
+          readOnly: true
+        - mountPath: /var/lib/cni/nv-ipam
+          name: nvipam-daemon-socket-dir
+          readOnly: true
+        - mountPath: /tmp/ips
+          name: ips
+        - mountPath: /var/lib/cni
+          name: cni-cache
+      - args:
+        - internal-ipam
+        command:
+        - /cniprovisioner
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              key: mtu
+              name: cluster-ovn-fkpms-ovn-kubernetes-config
+        - name: VTEP_CIDR
+          value: 10.6.156.208/28
+        - name: HOST_CIDR
+          value: 10.6.135.0/24
+        image: ghcr.io/mellanox/ovn-kubernetes-dpf-utils:v0.1.0-latest-alin
+        imagePullPolicy: IfNotPresent
+        name: cniprovisioner
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/readyz
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        restartPolicy: Always
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        startupProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/readyz
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /tmp/ips
+          name: ips
+        - mountPath: /etc/openvswitch
+          name: init-output
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: incluster
+          readOnly: true
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+      priorityClassName: system-cluster-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: cluster-ovn-fkpms-ovn-kubernetes-node
+      serviceAccountName: cluster-ovn-fkpms-ovn-kubernetes-node
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: ips
+      - hostPath:
+          path: /var/lib/cni/bin/
+          type: Directory
+        name: cni-bin-dir
+      - hostPath:
+          path: /var/lib/cni/nv-ipam
+          type: Directory
+        name: nvipam-daemon-socket-dir
+      - emptyDir: {}
+        name: cni-cache
+      - emptyDir: {}
+        name: init-output
+      - hostPath:
+          path: /var/run/dbus
+          type: ""
+        name: host-var-run-dbus
+      - hostPath:
+          path: /etc/kubernetes/
+          type: ""
+        name: host-kubeconfig
+      - hostPath:
+          path: /var/lib/kubelet
+          type: ""
+        name: host-kubelet
+      - hostPath:
+          path: /var/log/ovn-kubernetes
+          type: ""
+        name: host-var-log-ovnkube
+      - hostPath:
+          path: /var/run/ovn-kubernetes
+          type: ""
+        name: host-var-run-ovn-kubernetes
+      - hostPath:
+          path: /var/lib/cni/bin/
+          type: ""
+        name: host-opt-cni-bin
+      - hostPath:
+          path: /run/multus/cni/net.d
+          type: ""
+        name: host-etc-cni-netd
+      - hostPath:
+          path: /
+          type: ""
+        name: host-slash
+      - hostPath:
+          path: /var/run/netns
+          type: ""
+        name: host-netns
+      - hostPath:
+          path: /var/log/openvswitch
+          type: ""
+        name: host-var-log-ovs
+      - hostPath:
+          path: /run/openvswitch
+          type: ""
+        name: host-run-ovs
+      - hostPath:
+          path: /var/run/openvswitch
+          type: ""
+        name: host-var-run-ovs
+      - hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+        name: host-ovn-cert
+      - hostPath:
+          path: /var/lib/openvswitch
+          type: ""
+        name: host-var-lib-ovs
+      - hostPath:
+          path: /etc/openvswitch
+          type: ""
+        name: host-etc-ovs
+      - name: tenant-cluster-access-secret
+        secret:
+          defaultMode: 420
+          items:
+          - key: KUBERNETES_CA_DATA
+            path: ca.crt
+          - key: TOKEN_FILE
+            path: token
+          secretName: ovn-dpu
+      - name: incluster
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              - key: token
+                path: token
+              name: cluster-ovn-fkpms-ovn-kubernetes-dpucniprovisioner-token
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  currentNumberScheduled: 1
+  desiredNumberScheduled: 1
+  numberMisscheduled: 0
+  numberReady: 0
+  numberUnavailable: 1
+  observedGeneration: 1
+  updatedNumberScheduled: 1

--- a/kind-dpu/error-cni
+++ b/kind-dpu/error-cni
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# error-cni: A CNI plugin that intentionally fails for testing purposes
+# This script follows the CNI specification for error responses
+#
+# Use case: Test scenarios where only host-networked pods should work
+# - Host-networked pods bypass CNI completely (they work)
+# - Regular pods invoke CNI and get this error (they fail)
+
+# CNI Environment Variables (for debugging/logging purposes)
+# CNI_COMMAND, CNI_CONTAINERID, CNI_NETNS, CNI_IFNAME, CNI_ARGS, CNI_PATH
+
+# Output a CNI-compliant error response as JSON to stdout
+cat <<EOF
+{
+    "code": 999,
+    "msg": "error-cni: intentional failure for testing",
+    "details": "This is a test CNI plugin designed to always fail. Command: ${CNI_COMMAND:-unknown}, Container: ${CNI_CONTAINERID:-unknown}, Interface: ${CNI_IFNAME:-unknown}"
+}
+EOF
+
+# Exit with non-zero status code as required by CNI spec
+exit 1

--- a/kind-dpu/kind-config.yaml
+++ b/kind-dpu/kind-config.yaml
@@ -1,0 +1,44 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # Disable default CNI so we can test with error-cni or manual setup
+  disableDefaultCNI: true
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: "10.96.0.0/12"
+nodes:
+# Control plane node
+- role: control-plane
+  image: kindest/node:v1.29.0
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni
+# Host nodes (2)
+- role: worker
+  image: kindest/node:v1.29.0
+  labels:
+    node-type: host
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni
+- role: worker
+  image: kindest/node:v1.29.0
+  labels:
+    node-type: host
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni
+# DPU nodes (2)
+- role: worker
+  image: kindest/node:v1.29.0
+  labels:
+    node-type: dpu
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni
+- role: worker
+  image: kindest/node:v1.29.0
+  labels:
+    node-type: dpu
+  extraMounts:
+  - hostPath: ./error-cni
+    containerPath: /opt/cni/bin/error-cni

--- a/kind-dpu/setup-dpu-topology.sh
+++ b/kind-dpu/setup-dpu-topology.sh
@@ -1,0 +1,607 @@
+#!/bin/bash
+set -euo pipefail
+
+# DPU Topology Setup Script for OVN-Kubernetes
+# This script creates a kind cluster with DPU simulation topology
+
+# Configuration
+NUM_DPU_PAIRS=2
+INTERFACES_PER_PAIR=16
+TOTAL_WORKERS=$((NUM_DPU_PAIRS * 2))
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Step 1: Comprehensive cleanup for idempotency
+log_info "Step 1: Comprehensive cleanup for idempotency..."
+
+# Delete existing kind cluster
+log_info "  Deleting existing kind cluster..."
+kind delete cluster --name=dpu || true
+
+# Clean up any leftover veth interfaces from previous runs
+log_info "  Cleaning up leftover veth interfaces..."
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  for iface_id in $(seq 0 $((INTERFACES_PER_PAIR - 1))); do
+    sudo ip link delete host${pair_id}-eth0-${iface_id} 2>/dev/null || true
+    sudo ip link delete dpu${pair_id}-rep${pair_id}-${iface_id} 2>/dev/null || true
+  done
+done
+
+# Clean up temp management interfaces (new)
+sudo ip link delete temp-pf0 2>/dev/null || true
+sudo ip link delete temp-pfrep0 2>/dev/null || true
+sudo ip link delete temp-pf1 2>/dev/null || true
+sudo ip link delete temp-pfrep1 2>/dev/null || true
+
+# Clean up old temp interfaces (for backward compatibility)
+sudo ip link delete temp-host0-0 2>/dev/null || true
+sudo ip link delete temp-rep0-0 2>/dev/null || true
+sudo ip link delete temp-host1-0 2>/dev/null || true
+sudo ip link delete temp-rep1-0 2>/dev/null || true
+
+# Clean up any other potential leftover interfaces
+for iface in $(ip link show | grep -E "host[0-9]+-eth0-|dpu[0-9]+-rep[0-9]+-|temp-host|temp-rep|temp-pf|temp-pfrep" | cut -d':' -f2 | cut -d'@' -f1 | xargs); do
+  sudo ip link delete "$iface" 2>/dev/null || true
+done
+
+log_info "  Cleanup complete"
+
+# Step 2: Install prerequisites
+log_info "Step 2: Checking prerequisites..."
+if ! command -v jinjanate &> /dev/null; then
+    log_error "jinjanate not found. Please install: pip install jinjanator[yaml]"
+    exit 1
+fi
+
+# Step 3: Generate kind config
+log_info "Step 3: Generating kind config for ${NUM_DPU_PAIRS} DPU-host pairs (${TOTAL_WORKERS} workers total)..."
+cd contrib
+
+ovn_ip_family="" \
+ovn_ha=false \
+net_cidr="10.244.0.0/16" \
+svc_cidr="10.96.0.0/16" \
+use_local_registy=false \
+dns_domain="cluster.local" \
+ovn_num_master=1 \
+ovn_num_worker=${TOTAL_WORKERS} \
+cluster_log_level=4 \
+kind_local_registry_port=5000 \
+kind_local_registry_name="kind-registry" \
+jinjanate kind.yaml.j2 -o kind-dpu.yaml
+
+cd ..
+
+# Step 4: Create kind cluster
+log_info "Step 4: Creating kind cluster..."
+kind create cluster \
+  --name dpu \
+  --kubeconfig $HOME/dpu.conf \
+  --image kindest/node:v1.34.0 \
+  --config contrib/kind-dpu.yaml \
+  --retain
+
+export KUBECONFIG=$HOME/dpu.conf
+
+# Step 5: Set up DPU topology with proper host isolation
+log_info "Step 5: Setting up DPU topology..."
+
+# Create data veth pairs for each DPU-host pair (16 pairs for pure data channels)
+log_info "Creating ${NUM_DPU_PAIRS} DPU-host pairs with ${INTERFACES_PER_PAIR} data veth pairs each..."
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  log_info "  Creating data veth pairs for DPU-host pair ${pair_id}..."
+  for iface_id in $(seq 0 $((INTERFACES_PER_PAIR - 1))); do
+    # Create veth pair: host side ↔ DPU side (data channels)
+    sudo ip link add host${pair_id}-eth0-${iface_id} type veth peer name dpu${pair_id}-rep0-${iface_id}
+  done
+done
+
+# Define container names for each pair
+declare -a HOST_CONTAINERS=("dpu-worker" "dpu-worker3")
+declare -a DPU_CONTAINERS=("dpu-worker2" "dpu-worker4")
+
+# Get container PIDs for all DPU-host pairs
+log_info "Getting container PIDs..."
+declare -a HOST_PIDS
+declare -a DPU_PIDS
+
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  HOST_PID=$(docker inspect --format '{{.State.Pid}}' ${HOST_CONTAINERS[$pair_id]})
+  DPU_PID=$(docker inspect --format '{{.State.Pid}}' ${DPU_CONTAINERS[$pair_id]})
+
+  if [[ -z "$HOST_PID" || "$HOST_PID" == "0" ]]; then
+    log_error "Failed to get PID for ${HOST_CONTAINERS[$pair_id]}"
+    exit 1
+  fi
+
+  if [[ -z "$DPU_PID" || "$DPU_PID" == "0" ]]; then
+    log_error "Failed to get PID for ${DPU_CONTAINERS[$pair_id]}"
+    exit 1
+  fi
+
+  HOST_PIDS[$pair_id]=$HOST_PID
+  DPU_PIDS[$pair_id]=$DPU_PID
+
+  log_info "  Pair ${pair_id}: Host ${HOST_CONTAINERS[$pair_id]} PID=${HOST_PID}, DPU ${DPU_CONTAINERS[$pair_id]} PID=${DPU_PID}"
+done
+
+# Create separate management veth pairs (management channel)
+log_info "Creating management veth pairs (pf/pfrep)..."
+sudo ip link add temp-pf0 type veth peer name temp-pfrep0
+sudo ip link add temp-pf1 type veth peer name temp-pfrep1
+
+# Move management veth pairs to containers
+log_info "Moving management veth pairs to containers..."
+sudo ip link set temp-pf0 netns ${HOST_PIDS[0]}
+sudo ip link set temp-pfrep0 netns ${DPU_PIDS[0]}
+sudo ip link set temp-pf1 netns ${HOST_PIDS[1]}
+sudo ip link set temp-pfrep1 netns ${DPU_PIDS[1]}
+
+# Replace original eth0 with management interface pf on hosts, keeping IP on host interface
+log_info "Setting up management interfaces (pf)..."
+log_info "  CHANGE: Management channel now uses pf interface (separate from data channels)"
+
+# Host: preserve Kind IP from eth0 to pf (management interface), then replace interface
+for host_container in dpu-worker dpu-worker3; do
+  # Get the current IP configuration from eth0
+  host_ip=$(docker exec "$host_container" ip addr show eth0 | grep 'inet ' | awk '{print $2}' | head -1)
+  host_gw=$(docker exec "$host_container" ip route | grep default | awk '{print $3}' | head -1)
+
+  if [[ -n "$host_ip" ]]; then
+    log_info "    ${host_container}: Preserving Kind IP ${host_ip} and gateway ${host_gw}"
+
+    # Determine which temp interface to use
+    if [[ "$host_container" == "dpu-worker" ]]; then
+      temp_iface="temp-pf0"
+    else
+      temp_iface="temp-pf1"
+    fi
+
+    # Rename veth to pf (management interface)
+    docker exec "$host_container" ip link set "$temp_iface" name pf
+    # Move IP configuration from eth0 to pf
+    docker exec "$host_container" ip addr add "$host_ip" dev pf
+    # Delete original eth0 after IP is preserved
+    docker exec "$host_container" ip link delete eth0
+    # Bring up pf and restore routing
+    docker exec "$host_container" ip link set pf up
+    if [[ -n "$host_gw" ]]; then
+      docker exec "$host_container" ip route add default via "$host_gw" dev pf
+    fi
+
+    log_info "    ✅ ${host_container}: Kind networking preserved on pf (management)"
+  else
+    log_warn "    ${host_container}: No IP found on eth0, using clean pf"
+    # Fallback to old behavior if no IP found
+    docker exec "$host_container" ip link delete eth0
+    docker exec "$host_container" ip link set "$temp_iface" name pf
+    docker exec "$host_container" ip link set pf up
+  fi
+done
+
+# DPU: keep original eth0, add pfrep from management veth
+docker exec dpu-worker2 ip link set temp-pfrep0 name pfrep
+docker exec dpu-worker4 ip link set temp-pfrep1 name pfrep
+
+# Move data veth interfaces to containers (eth0-0 through eth0-15)
+log_info "Moving data veth interfaces to containers..."
+for iface_id in $(seq 0 $((INTERFACES_PER_PAIR - 1))); do
+  log_info "  Moving data interface set ${iface_id}..."
+
+  # Move pair 0 interfaces
+  if sudo ip link show host0-eth0-${iface_id} &>/dev/null; then
+    sudo ip link set host0-eth0-${iface_id} netns ${HOST_PIDS[0]}
+  else
+    log_warn "Interface host0-eth0-${iface_id} not found"
+  fi
+
+  if sudo ip link show dpu0-rep0-${iface_id} &>/dev/null; then
+    sudo ip link set dpu0-rep0-${iface_id} netns ${DPU_PIDS[0]}
+  else
+    log_warn "Interface dpu0-rep0-${iface_id} not found"
+  fi
+
+  # Move pair 1 interfaces
+  if sudo ip link show host1-eth0-${iface_id} &>/dev/null; then
+    sudo ip link set host1-eth0-${iface_id} netns ${HOST_PIDS[1]}
+  else
+    log_warn "Interface host1-eth0-${iface_id} not found"
+  fi
+
+  if sudo ip link show dpu1-rep0-${iface_id} &>/dev/null; then
+    sudo ip link set dpu1-rep0-${iface_id} netns ${DPU_PIDS[1]}
+  else
+    log_warn "Interface dpu1-rep0-${iface_id} not found"
+  fi
+done
+
+# Rename data interfaces inside containers
+log_info "Renaming data interfaces inside containers..."
+for iface_id in $(seq 0 $((INTERFACES_PER_PAIR - 1))); do
+  # Rename in host containers
+  docker exec dpu-worker ip link set host0-eth0-${iface_id} name eth0-${iface_id} 2>/dev/null || log_warn "Failed to rename host0-eth0-${iface_id} in dpu-worker"
+  docker exec dpu-worker3 ip link set host1-eth0-${iface_id} name eth0-${iface_id} 2>/dev/null || log_warn "Failed to rename host1-eth0-${iface_id} in dpu-worker3"
+
+  # Rename in DPU containers
+  docker exec dpu-worker2 ip link set dpu0-rep0-${iface_id} name rep0-${iface_id} 2>/dev/null || log_warn "Failed to rename dpu0-rep0-${iface_id} in dpu-worker2"
+  docker exec dpu-worker4 ip link set dpu1-rep0-${iface_id} name rep0-${iface_id} 2>/dev/null || log_warn "Failed to rename dpu1-rep0-${iface_id} in dpu-worker4"
+done
+
+# Isolate host nodes from kind network
+log_info "Isolating host nodes from kind network..."
+docker exec dpu-worker ip route del default 2>/dev/null || true
+docker exec dpu-worker3 ip route del default 2>/dev/null || true
+
+# Verify interface counts
+log_info "Verifying interface counts..."
+for pair_id in $(seq 0 $((NUM_DPU_PAIRS - 1))); do
+  host_container=${HOST_CONTAINERS[$pair_id]}
+  dpu_container=${DPU_CONTAINERS[$pair_id]}
+
+  host_count=$(docker exec $host_container ip link show | grep -E "^[0-9]+:" | wc -l)
+  dpu_count=$(docker exec $dpu_container ip link show | grep -E "^[0-9]+:" | wc -l)
+
+  log_info "  ${host_container}: ${host_count} interfaces (target: 18 - 1 pf + 16 eth0-x + loopback)"
+  log_info "  ${dpu_container}: ${dpu_count} interfaces (target: 19 - 1 pfrep + 16 rep0-x + ovs-system + loopback)"
+
+  if [[ $host_count -ne 18 ]]; then
+    log_warn "${host_container} has ${host_count} interfaces, expected 18"
+  fi
+
+  if [[ $dpu_count -ne 19 ]]; then
+    log_warn "${dpu_container} has ${dpu_count} interfaces, expected 19"
+  fi
+done
+
+# Check for remaining veth interfaces on host
+remaining_veths=$(ip link show | grep -E "(host[0-9]+-eth0-|dpu[0-9]+-rep[0-9]+-)" | wc -l || true)
+if [[ $remaining_veths -gt 0 ]]; then
+  log_warn "${remaining_veths} veth interfaces remain on host system"
+  ip link show | grep -E "(host[0-9]+-eth0-|dpu[0-9]+-rep[0-9]+-)" || true
+fi
+
+log_info "✅ DPU topology setup complete!"
+
+# Step 5.5: Prepare management representors for OVN-K auto-detection
+log_info "Step 5.5: Preparing management representors for OVN-K auto-detection..."
+log_info "  TIMING: After veth topology creation, before IPv6 setup"
+
+# Ensure management representors are up and ready for NicToBridge()
+# Now using separate management interfaces: pfrep (not rep0-0)
+log_info "  Setting up management representor on dpu-worker2 (DPU) - PF0..."
+if docker exec dpu-worker2 ip link show pfrep >/dev/null 2>&1; then
+  docker exec dpu-worker2 ip link set pfrep up || log_warn "Failed to bring up pfrep on dpu-worker2"
+  log_info "    dpu-worker2: pfrep ready for OVN-K gateway bridge creation"
+else
+  log_warn "    dpu-worker2: pfrep interface not found - management veth topology may need verification"
+fi
+
+log_info "  Setting up management representor on dpu-worker4 (DPU) - PF1..."
+if docker exec dpu-worker4 ip link show pfrep >/dev/null 2>&1; then
+  docker exec dpu-worker4 ip link set pfrep up || log_warn "Failed to bring up pfrep on dpu-worker4"
+  log_info "    dpu-worker4: pfrep ready for OVN-K gateway bridge creation"
+else
+  log_warn "    dpu-worker4: pfrep interface not found - management veth topology may need verification"
+fi
+
+log_info "✅ Management representors prepared for OVN-K automatic bridge management"
+log_info "  NOTE: NicToBridge() will automatically create br-ex and connect pfrep management representors"
+
+# Step 6: Enable IPv6 and fix inotify limits
+log_info "Step 6: Enabling IPv6 and fixing inotify limits..."
+for node in $(kind get nodes --name dpu); do
+  docker exec "$node" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0 || true
+  docker exec "$node" sysctl --ignore net.ipv6.conf.all.forwarding=1 || true
+  docker exec "$node" sysctl -w fs.inotify.max_user_watches=524288 || true
+  docker exec "$node" sysctl -w fs.inotify.max_user_instances=512 || true
+done
+
+# Step 7: Build ovnkube binary with our DPU provider changes
+log_info "Step 7: Building ovnkube binary with VethRepresentorProvider changes..."
+log_info "  CRITICAL: Must rebuild binary to include our GetHostRepresentor() and DPU provider updates"
+log_info "  Working from: $(pwd)"
+log_info "  Target Makefile: $(realpath ../dist/images/Makefile 2>/dev/null || echo 'NOT FOUND')"
+make -C /root/balazs/ovn-kubernetes/dist/images fedora-image IMAGE="localhost/ovn-daemonset-fedora:dev" OVN_REPO="" OVN_GITREF="" OCI_BIN="docker"
+log_info "✅ ovnkube binary built and container image updated with VethRepresentorProvider support"
+
+# Step 8: Verify OVN container image was built
+log_info "Step 8: Verifying OVN image was built in previous step..."
+if docker image inspect localhost/ovn-daemonset-fedora:dev &>/dev/null; then
+  log_info "✅ OVN image localhost/ovn-daemonset-fedora:dev built successfully"
+else
+  log_error "❌ OVN image build failed in Step 7"
+  exit 1
+fi
+
+# Step 9: Load image into kind
+log_info "Step 9: Loading image into kind..."
+kind load docker-image localhost/ovn-daemonset-fedora:dev --name dpu
+
+# Step 10: Get API URL and generate manifests
+log_info "Step 10: Generating OVN-Kubernetes manifests..."
+DNS_NAME_URL=$(kind get kubeconfig --internal --name dpu | grep server | awk '{ print $2 }')
+CP_NODE=${DNS_NAME_URL#*//}
+CP_NODE=${CP_NODE%:*}
+NODE_IP=$(docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "$CP_NODE")
+API_URL=${DNS_NAME_URL/$CP_NODE/$NODE_IP}
+
+cd dist/images
+
+./daemonset.sh \
+  --output-directory="../yaml-dpu" \
+  --image="localhost/ovn-daemonset-fedora:dev" \
+  --ovnkube-image="localhost/ovn-daemonset-fedora:dev" \
+  --net-cidr="10.244.0.0/16" \
+  --svc-cidr="10.96.0.0/16" \
+  --gateway-mode="shared" \
+  --dummy-gateway-bridge="false" \
+  --gateway-options="" \
+  --enable-ipsec="false" \
+  --hybrid-enabled="false" \
+  --disable-snat-multiple-gws="false" \
+  --disable-forwarding="false" \
+  --ovn-encap-port="" \
+  --disable-pkt-mtu-check="false" \
+  --ovn-empty-lb-events="false" \
+  --multicast-enabled="false" \
+  --k8s-apiserver="$API_URL" \
+  --ovn-master-count="1" \
+  --ovn-unprivileged-mode=no \
+  --master-loglevel="5" \
+  --node-loglevel="5" \
+  --dbchecker-loglevel="5" \
+  --ovn-loglevel-northd="-vconsole:info -vfile:info" \
+  --ovn-loglevel-nb="-vconsole:info -vfile:info" \
+  --ovn-loglevel-sb="-vconsole:info -vfile:info" \
+  --ovn-loglevel-controller="-vconsole:info" \
+  --ovnkube-libovsdb-client-logfile="" \
+  --enable-coredumps="false" \
+  --ovnkube-config-duration-enable=true \
+  --admin-network-policy-enable=true \
+  --egress-ip-enable=true \
+  --egress-ip-healthcheck-port="9107" \
+  --egress-firewall-enable=true \
+  --egress-qos-enable=true \
+  --egress-service-enable=true \
+  --v4-join-subnet="100.64.0.0/16" \
+  --v6-join-subnet="fd98::/64" \
+  --v4-masquerade-subnet="169.254.0.0/17" \
+  --v6-masquerade-subnet="fd69::/112" \
+  --v4-transit-subnet="100.88.0.0/16" \
+  --v6-transit-subnet="fd97::/64" \
+  --ex-gw-network-interface="" \
+  --multi-network-enable="false" \
+  --network-segmentation-enable="false" \
+  --network-connect-enable="false" \
+  --preconfigured-udn-addresses-enable="false" \
+  --route-advertisements-enable="false" \
+  --advertise-default-network="false" \
+  --advertised-udn-isolation-mode="strict" \
+  --ovnkube-metrics-scale-enable="false" \
+  --compact-mode="false" \
+  --enable-interconnect="true" \
+  --enable-multi-external-gateway=true \
+  --enable-ovnkube-identity="true" \
+  --enable-persistent-ips=true \
+  --network-qos-enable="false" \
+  --mtu="1400" \
+  --enable-dnsnameresolver="false" \
+  --enable-observ="false"
+
+cd ../..
+
+# Step 11: Apply CRDs
+log_info "Step 11: Applying CRDs..."
+cd dist/yaml-dpu
+
+kubectl apply -f k8s.ovn.org_egressfirewalls.yaml
+kubectl apply -f k8s.ovn.org_egressips.yaml
+kubectl apply -f k8s.ovn.org_egressqoses.yaml
+kubectl apply -f k8s.ovn.org_egressservices.yaml
+kubectl apply -f k8s.ovn.org_adminpolicybasedexternalroutes.yaml
+kubectl apply -f k8s.ovn.org_networkqoses.yaml
+kubectl apply -f k8s.ovn.org_userdefinednetworks.yaml
+kubectl apply -f k8s.ovn.org_clusteruserdefinednetworks.yaml
+kubectl apply -f k8s.ovn.org_routeadvertisements.yaml
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+
+# Step 12: Apply setup and RBAC
+log_info "Step 12: Applying setup and RBAC..."
+kubectl apply -f ovn-setup.yaml
+kubectl apply -f rbac-ovnkube-identity.yaml
+kubectl apply -f rbac-ovnkube-cluster-manager.yaml
+kubectl apply -f rbac-ovnkube-master.yaml
+kubectl apply -f rbac-ovnkube-node.yaml
+kubectl apply -f rbac-ovnkube-db.yaml
+
+# Step 12.5: Fix DPU mode RBAC issue for Kind clusters
+log_info "Step 12.5: Fixing DPU mode RBAC permissions for Kind clusters..."
+log_info "  ISSUE: DPU mode disables ovnkube identity (OVN_ENABLE_OVNKUBE_IDENTITY=false)"
+log_info "  EFFECT: Pods authenticate as service account instead of system:ovn-nodes group"
+log_info "  FIX: Adding ovnkube-node service account to ovnkube-node ClusterRoleBinding"
+log_info "  NOTE: Regular OVN-K uses identity=true so pods authenticate as system:ovn-nodes group (works)"
+
+# Patch the ovnkube-node ClusterRoleBinding to include the service account
+# This fixes permission errors for pods, services, namespaces access in Kind
+kubectl patch clusterrolebinding ovnkube-node --type='json' \
+  -p='[{"op": "add", "path": "/subjects/-", "value": {"kind": "ServiceAccount", "name": "ovnkube-node", "namespace": "ovn-kubernetes"}}]'
+
+# Also add permissions for node annotations (needed for k8s.ovn.org/zone-name, k8s.ovn.org/node-encap-ips)
+log_info "  Adding permissions for node annotations (k8s.ovn.org/zone-name, k8s.ovn.org/node-encap-ips)..."
+kubectl patch clusterrole ovnkube-node --type=json \
+  -p='[{"op": "add", "path": "/rules/-", "value": {"apiGroups": [""], "resources": ["nodes"], "verbs": ["patch", "update"]}}]'
+
+# Verify the fix worked
+if kubectl auth can-i list pods --as=system:serviceaccount:ovn-kubernetes:ovnkube-node >/dev/null 2>&1; then
+  log_info "  ✅ RBAC fix successful: ovnkube-node service account can now list pods"
+else
+  log_warn "  ⚠️ RBAC fix verification failed - DPU containers may have permission issues"
+fi
+
+log_info "✅ Kind-specific RBAC permissions fixed"
+
+# Step 17: Label and untaint control plane
+log_info "Step 12: Labeling and untainting control plane..."
+kubectl label node dpu-control-plane k8s.ovn.org/ovnkube-db=true node-role.kubernetes.io/control-plane="" --overwrite
+kubectl taint node dpu-control-plane node-role.kubernetes.io/master:NoSchedule- || true
+kubectl taint node dpu-control-plane node-role.kubernetes.io/control-plane:NoSchedule- || true
+
+# Step 17: Apply OVS and label zones
+log_info "Step 17: Applying OVS and labeling zones..."
+kubectl apply -f ovs-node.yaml
+
+for node in $(kind get nodes --name dpu); do
+  kubectl label node "$node" k8s.ovn.org/zone-name=${node} --overwrite
+done
+
+
+# Step 17: Apply OVN-Kubernetes components (DPU-specific)
+log_info "Step 17: Applying OVN-Kubernetes components..."
+kubectl apply -f ovnkube-identity.yaml
+kubectl apply -f ovnkube-control-plane.yaml
+
+# Skip ovnkube-single-node-zone.yaml - we'll create DPU-specific DaemonSets instead
+
+# Step 17: Label nodes for DPU mode deployment
+log_info "Step 17: Labeling nodes for DPU mode..."
+kubectl label nodes dpu-worker k8s.ovn.org/dpu-host= --overwrite
+kubectl label nodes dpu-worker3 k8s.ovn.org/dpu-host= --overwrite
+kubectl label nodes dpu-worker2 k8s.ovn.org/dpu= --overwrite
+kubectl label nodes dpu-worker4 k8s.ovn.org/dpu= --overwrite
+
+# Step 17: Deploy production DPU architecture
+log_info "Step 17: Deploying production DPU top/bottom split architecture..."
+log_info "  Using VethRepresentorProvider for automatic br-ex bridge creation"
+
+# Deploy DPU HOST - CNI-only (top half)
+log_info "  Deploying DPU host template (CNI-only, top half)..."
+kubectl apply -f "${SCRIPT_DIR}/dpu-host-template.yaml"
+
+# Deploy DPU NODE - Full OVN stack (bottom half)
+log_info "  Deploying DPU template (6-container OVN stack, bottom half)..."
+log_info "    Production containers: nb-ovsdb, sb-ovsdb, ovn-northd, ovnkube-controller-with-node, ovn-controller, ovs-metrics-exporter"
+log_info "    NEW: Contains VethRepresentorProvider.GetHostRepresentor() for automatic br-ex creation"
+kubectl apply -f "${SCRIPT_DIR}/dpu-template.yaml"
+
+# Verify new architecture dependencies are met
+log_info "  Verifying separated veth architecture for DPU containers..."
+for dpu_node in dpu-worker2 dpu-worker4; do
+  # Check that pfrep management interface is ready for automatic br-ex creation
+  mgmt_status=$(docker exec "$dpu_node" ip link show pfrep 2>/dev/null || echo "MISSING")
+  if [[ "$mgmt_status" == "MISSING" ]]; then
+    log_error "  CRITICAL: pfrep management interface missing on ${dpu_node}!"
+    log_error "  Management channel setup will fail!"
+    exit 1
+  else
+    log_info "  ✅ ${dpu_node} pfrep ready for management channel"
+  fi
+
+  # Check that rep0-0 data interface is ready
+  data_status=$(docker exec "$dpu_node" ip link show rep0-0 2>/dev/null || echo "MISSING")
+  if [[ "$data_status" == "MISSING" ]]; then
+    log_error "  CRITICAL: rep0-0 data interface missing on ${dpu_node}!"
+    log_error "  Data plane setup will fail!"
+    exit 1
+  else
+    log_info "  ✅ ${dpu_node} rep0-0 ready as first data representor"
+  fi
+done
+log_info "  NOTE: Management (pfrep) and data (rep0-*) channels now properly separated"
+
+# Verify deployment status
+log_info "  Verifying DaemonSet deployment..."
+kubectl get daemonset -n ovn-kubernetes ovnkube-node-dpu-host
+kubectl get daemonset -n ovn-kubernetes ovnkube-node-dpu
+
+log_info "✅ Complete production DPU architecture deployed with separated management and data channels!"
+log_info "  Architecture Summary:"
+log_info "    Control Plane: dpu-control-plane (standard OVN-K control plane)"
+log_info "    DPU Host (Top Half): dpu-worker, dpu-worker3"
+log_info "      - Single CNI container"
+log_info "      - OVN_NODE_MODE=dpu-host"
+log_info "      - Management interface: pf (preserves Kind IP)"
+log_info "      - Data interfaces: eth0-0 through eth0-15 (16 data channels)"
+log_info "      - Goal: Provides connectivity to host backed network"
+log_info "    DPU Node (Bottom Half): dpu-worker2, dpu-worker4"
+log_info "      - 6-container OVN stack (nb-ovsdb, sb-ovsdb, ovn-northd, controller, ovn-controller, ovs-metrics)"
+log_info "      - OVNKUBE_NODE_MODE=dpu"
+log_info "      - Management interface: pfrep (separate management channel)"
+log_info "      - Data interfaces: rep0-0 through rep0-15 (16 data representors → breth0)"
+log_info "      - Goal: Full OVN brain, clear channel separation"
+log_info "    Management Flow: host pf (with IP) → management veth pair → DPU pfrep → management processing"
+log_info "    Data Flow: host eth0-0..15 → data veth pairs → DPU rep0-0..15 → breth0 bridge → workload traffic"
+log_info "    Key Changes:"
+log_info "      - SEPARATED: Management (pf ↔ pfrep) and Data (eth0-* ↔ rep0-*) channels"
+log_info "      - FIXED: rep0-0 now pure data interface (no management conflicts)"
+log_info "      - INCREASED: 16 data channels instead of 15"
+log_info "      - CLARIFIED: Architecture matches SR-IOV DPU separation pattern"
+
+cd ../..
+
+# Step 18: Set node management port annotations for DPU containers
+log_info "Step 18: Setting node management port annotations..."
+log_info "  Setting k8s.ovn.org/node-mgmt-port annotations based on interface topology..."
+log_info "  dpu-worker2: rep0-* interfaces → PfId=0, FuncId=0 (rep0-0)"
+log_info "  dpu-worker4: rep0-* interfaces → consistent naming with dpu-worker2 (rep0-0)"
+
+# Set annotations based on actual representor interfaces (format that works with VethRepresentorProvider)
+kubectl annotate node dpu-worker2 'k8s.ovn.org/node-mgmt-port={"default": {"pfId": 0, "vfId": 0, "deviceId": "test"}}' --overwrite
+kubectl annotate node dpu-worker4 'k8s.ovn.org/node-mgmt-port={"default": {"pfId": 0, "vfId": 0, "deviceId": "test"}}' --overwrite
+
+# Set primary DPU-host addresses for DPU communication (get actual host IPs)
+DPU_WORKER_HOST_IP=$(docker exec dpu-worker ip addr show pf | grep "inet " | awk '{print $2}')
+DPU_WORKER3_HOST_IP=$(docker exec dpu-worker3 ip addr show pf | grep "inet " | awk '{print $2}')
+log_info "  dpu-worker host IP: ${DPU_WORKER_HOST_IP}"
+log_info "  dpu-worker3 host IP: ${DPU_WORKER3_HOST_IP}"
+kubectl annotate node dpu-worker2 "k8s.ovn.org/primary-dpu-host-addr={\"ipv4\":\"${DPU_WORKER_HOST_IP}\"}" --overwrite
+kubectl annotate node dpu-worker4 "k8s.ovn.org/primary-dpu-host-addr={\"ipv4\":\"${DPU_WORKER3_HOST_IP}\"}" --overwrite
+
+log_info "✅ Node management port annotations set successfully"
+log_info "✅ Primary DPU-host address annotations set successfully"
+
+# Step 19: (Optional) Disable admission webhooks for testing
+log_info "Step 19: (Optional) Disabling admission webhooks for testing..."
+log_info "  NOTE: This is for testing only - production would need webhook fixes"
+log_info "  Removing both node and pod validation webhooks that block DPU annotation setup..."
+
+# Remove both validation webhooks that block DPU operation
+if kubectl get validatingwebhookconfiguration ovn-kubernetes-admission-webhook-node >/dev/null 2>&1; then
+  kubectl delete validatingwebhookconfiguration ovn-kubernetes-admission-webhook-node ovn-kubernetes-admission-webhook-pod
+  log_info "✅ Both validation webhooks disabled for testing"
+else
+  log_info "  Validation webhooks not found - skipping"
+fi
+
+log_info "✅ DPU topology setup complete!"
+log_info ""
+log_info "Next steps:"
+log_info "1. Verify node status: kubectl get nodes"
+log_info "2. Check pod status: kubectl get pods -n ovn-kubernetes -o wide"
+log_info "3. Expected result:"
+log_info "   - Control plane: OVN-K control plane pods Running"
+log_info "   - DPU host nodes (dpu-worker, dpu-worker3): ovnkube-node-dpu-host pods Running"
+log_info "   - DPU nodes (dpu-worker2, dpu-worker4): ovnkube-node-dpu pods Running"
+log_info "   - Clean deployment: Only DPU-specific DaemonSets created"
+log_info ""
+log_info "To clean up: kind delete cluster --name=dpu"


### PR DESCRIPTION
## 📑 Description
Add kind with veth based testing for dpu-host and dpu mode. This almost works. The infrastructure level code is done. There is one thing left to do on the host side in ovn-k code itself. All ovnkube-node pods are ready.
It includes a refactor of a few components to allow to abstract away the sriov related bits.

Once the missing bit is fixed, the next step is to add a CI lane to trigger this.

Feedback is welcome.


```
[root@wsfd-advnetlab223 ~]# k get no -A
NAME                STATUS     ROLES           AGE     VERSION
dpu-control-plane   NotReady   control-plane   4h58m   v1.34.0
dpu-worker          Ready      <none>          4h58m   v1.34.0           <--- dpu node is ready
dpu-worker2         NotReady   <none>          4h58m   v1.34.0
dpu-worker3         Ready      <none>          4h58m   v1.34.0          <--- dpu node is ready
dpu-worker4         NotReady   <none>          4h58m   v1.34.0
[root@wsfd-advnetlab223 ~]# k get po -A -o wide
NAMESPACE           NAME                                          READY   STATUS              RESTARTS   AGE     IP            NODE                NOMINAT
ED NODE  READINESS GATES
kube-system         coredns-66bc5c9577-k9k9h                      0/1     ContainerCreating   0          4h58m   <none>        dpu-worker3         <none>
         <none>
kube-system         coredns-66bc5c9577-wv5jq                      0/1     ContainerCreating   0          4h58m   <none>        dpu-worker3         <none>
         <none>
kube-system         etcd-dpu-control-plane                        1/1     Running             0          4h58m   10.89.1.163   dpu-control-plane   <none>
         <none>
kube-system         kube-apiserver-dpu-control-plane              1/1     Running             0          4h58m   10.89.1.163   dpu-control-plane   <none>
         <none>
kube-system         kube-controller-manager-dpu-control-plane     1/1     Running             0          4h58m   10.89.1.163   dpu-control-plane   <none>
         <none>
kube-system         kube-scheduler-dpu-control-plane              1/1     Running             0          4h58m   10.89.1.163   dpu-control-plane   <none>
         <none>
local-path-storage  local-path-provisioner-7b8c8ddbd6-66lb2       0/1     ContainerCreating   0          4h58m   <none>        dpu-worker3         <none>
         <none>
ovn-kubernetes      ovnkube-control-plane-f94b6c467-p68wj         1/1     Running             0          4h55m   10.89.1.163   dpu-control-plane   <none>
         <none>
ovn-kubernetes      ovnkube-identity-sxxl7                        1/1     Running             0          4h55m   10.89.1.163   dpu-control-plane   <none>
         <none>
ovn-kubernetes      ovnkube-node-dpu-cstmv                        6/6     Running             0          4h55m   10.89.1.161   dpu-worker4         <none>
         <none>
ovn-kubernetes      ovnkube-node-dpu-host-7w7pw                   1/1     Running             0          4h55m   10.89.1.162   dpu-worker          <none>
         <none>
ovn-kubernetes      ovnkube-node-dpu-host-lr8tw                   1/1     Running             0          4h55m   10.89.1.159   dpu-worker3         <none>
         <none>
ovn-kubernetes      ovnkube-node-dpu-s4svb                        6/6     Running             0          4h55m   10.89.1.160   dpu-worker2         <none>
         <none>
ovn-kubernetes      ovs-node-g7tdw                                1/1     Running             0          4h55m   10.89.1.163   dpu-control-plane   <none>
         <none>
ovn-kubernetes      ovs-node-hcb77                                1/1     Running             0          4h55m   10.89.1.161   dpu-worker4         <none>
         <none>
ovn-kubernetes      ovs-node-p8qpb                                1/1     Running             0          4h55m   10.89.1.160   dpu-worker2         <none>
         <none>
[root@wsfd-advnetlab223 ~]#
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DPU provider mode configuration (`dpu-provider` flag) with support for both SR-IOV and veth-based simulation.
  * Introduced Kind cluster configuration and automated setup scripts for DPU topology testing.

* **Documentation**
  * Added comprehensive guides for DPU-OVN topology setup, including step-by-step cluster creation and verification procedures.

* **Configuration**
  * Added environment variable `OVNKUBE_DPU_PROVIDER` for runtime DPU provider selection.
  * New CLI flags for DPU provider mode configuration at global and node levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->