### PR TITLE
e2e: fix static IP collision in ValidatingAdmissionPolicy test

### DIFF
--- a/test/e2e/network_segmentation_default_network_annotation.go
+++ b/test/e2e/network_segmentation_default_network_annotation.go
@@ -177,11 +177,6 @@ var _ = Describe("Network Segmentation: Default network multus annotation", feat
 			Expect(err).NotTo(HaveOccurred(), "Should create UserDefinedNetwork")
 			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, udn.Namespace, udn.Name), 5*time.Second, time.Second).Should(Succeed())
 
-			By("Creating a pod without the default-network annotation")
-			podWithoutAnnotation := e2epod.NewAgnhostPod(f.Namespace.Name, "pod-without-annotation", nil, nil, nil)
-			podWithoutAnnotation.Spec.Containers[0].Command = []string{"sleep", "infinity"}
-			podWithoutAnnotation = e2epod.NewPodClient(f).CreateSync(context.TODO(), podWithoutAnnotation)
-
 			By("Creating a pod with the default-network annotation")
 
 			nse := []nadapi.NetworkSelectionElement{{
@@ -199,6 +194,11 @@ var _ = Describe("Network Segmentation: Default network multus annotation", feat
 			}
 			podWithAnnotation.Spec.Containers[0].Command = []string{"sleep", "infinity"}
 			podWithAnnotation = e2epod.NewPodClient(f).CreateSync(context.TODO(), podWithAnnotation)
+
+			By("Creating a pod without the default-network annotation")
+			podWithoutAnnotation := e2epod.NewAgnhostPod(f.Namespace.Name, "pod-without-annotation", nil, nil, nil)
+			podWithoutAnnotation.Spec.Containers[0].Command = []string{"sleep", "infinity"}
+			podWithoutAnnotation = e2epod.NewPodClient(f).CreateSync(context.TODO(), podWithoutAnnotation)
 
 			By("Attempting to add the default-network annotation to the pod without annotation")
 			podWithoutAnnotation.Annotations = map[string]string{


### PR DESCRIPTION
Create the static-IP pod before the dynamically-allocated pod to
prevent the allocator from assigning the same IP (103.0.0.3) to the
unannotated pod first, causing a permanent "provided IP is already
allocated" error for the annotated pod.

Signed-off-by: Ihar Hrachyshka <ihrachyshka@nvidia.com>
Assisted-by: opus (claude-opus-4-5-20251101)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted test execution flow for network segmentation annotation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->