### PR TITLE
Bump frr image from frr-k8s demo to 10.4.2

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -957,8 +957,11 @@ clone_frr() {
     # (https://github.com/FRRouting/frr/issues/15699, fixed in FRR 10.1 by
     # https://github.com/FRRouting/frr/pull/15714).
     #
-    # TODO: remove this sed once https://github.com/metallb/frr-k8s/pull/404 is merged.
-    sed -i 's|quay.io/frrouting/frr:9.1.0|quay.io/frrouting/frr:10.4.1|g' hack/demo/demo.sh
+    # Bump to 10.4.1 for upstream demo was posted here: https://github.com/metallb/frr-k8s/pull/404
+    # We bump further to 10.4.2 to include additional fixes for EVPN:
+    # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3907335193
+    # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3898408592
+    sed -i 's|quay.io/frrouting/frr:9.1.0|quay.io/frrouting/frr:10.4.2|g' hack/demo/demo.sh
 
     popd
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5782

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the FRR version used by demo tooling to 10.4.2 to resolve a musl libc compatibility issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->