### PR TITLE
docs: add SR-IOV device plugin resource pool examples for derive-from-mgmt-port

### DIFF
--- a/docs/features/hardware-offload/derive-from-mgmt-port.md
+++ b/docs/features/hardware-offload/derive-from-mgmt-port.md
@@ -75,11 +75,42 @@ The implementation includes robust error handling for:
 
 ```bash
 --ovnkube-node-mode=dpu-host
+--ovnkube-node-mgmt-port-dp-resource-name=example.com/sriov_pool
+--gateway-interface=derive-from-mgmt-port
+```
+
+Alternatively, the management port VF can be specified directly by netdev name
+using `--ovnkube-node-mgmt-port-netdev`. Note that this approach does **not**
+support network segmentation (UDN); use `--ovnkube-node-mgmt-port-dp-resource-name`
+instead when network segmentation is enabled.
+
+```bash
+--ovnkube-node-mode=dpu-host
 --ovnkube-node-mgmt-port-netdev=pf0vf0
 --gateway-interface=derive-from-mgmt-port
 ```
 
+> **Note:** When both `--ovnkube-node-mgmt-port-dp-resource-name` and
+> `--ovnkube-node-mgmt-port-netdev` are specified,
+> `--ovnkube-node-mgmt-port-dp-resource-name` takes priority and the netdev
+> provided by `--ovnkube-node-mgmt-port-netdev` will be overridden by the
+> device chosen from the SR-IOV resource pool. Additionally, when network
+> segmentation (UDN) is enabled in DPU-host mode,
+> `--ovnkube-node-mgmt-port-dp-resource-name` is **mandatory** and
+> `--ovnkube-node-mgmt-port-netdev` is not supported.
+
 ### Helm Configuration
+
+```yaml
+ovnkube-node:
+  mode: dpu-host
+  mgmtPortVFResourceName: example.com/sriov_pool
+  
+gateway:
+  interface: derive-from-mgmt-port
+```
+
+Or using the netdev name directly (not supported with network segmentation / UDN):
 
 ```yaml
 ovnkube-node:
@@ -91,6 +122,17 @@ gateway:
 ```
 
 ### Configuration File
+
+```ini
+[OvnKubeNode]
+mode=dpu-host
+mgmt-port-dp-resource-name=example.com/sriov_pool
+
+[Gateway]
+interface=derive-from-mgmt-port
+```
+
+Or using the netdev name directly (not supported with network segmentation / UDN):
 
 ```ini
 [OvnKubeNode]


### PR DESCRIPTION

Add --ovnkube-node-mgmt-port-dp-resource-name configuration examples and document that it takes priority over --ovnkube-node-mgmt-port-netdev.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Basic Configuration for derive-from-mgmt-port with both resource-name and netdev approaches.
  * Clarified that resource-name takes precedence when both are provided and that netdev is not supported with network segmentation (UDN).
  * Added YAML and INI examples for mgmt-port variants, migrated related notes into new sections, and consolidated guidance on precedence and UDN constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->