### PR TITLE
Handle stale unprocessed NAD if namespace is already gone

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -480,6 +480,24 @@ func (c *Controller) ReconcileNetAttachDef(key string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get ClusterUserDefinedNetwork %q from cache: %v", ownerRef.Name, err)
 		}
+
+		// Check if this NAD's namespace is still tracked by the owning CUDN.
+		// If not, the NAD is stale: the CUDN sync already removed the namespace
+		// from the tracker (e.g., because the namespace is terminating) but the
+		// NAD was not yet in the lister cache at that time and could not be
+		// deleted. Now that the NAD has appeared in the cache, clean it up.
+		c.namespaceTrackerLock.RLock()
+		tracked := c.namespaceTracker[owner.Name].Has(namespace)
+		c.namespaceTrackerLock.RUnlock()
+
+		if !tracked {
+			klog.Infof("Detected stale NetworkAttachmentDefinition [%s/%s] owned by ClusterUserDefinedNetwork %q, cleaning up", namespace, name, owner.Name)
+			if err := c.deleteNAD(owner, namespace); err != nil {
+				return fmt.Errorf("failed to delete stale NetworkAttachmentDefinition [%s/%s]: %w", namespace, name, err)
+			}
+			return nil
+		}
+
 		ownerKey, err := cache.MetaNamespaceKeyFunc(owner)
 		if err != nil {
 			return fmt.Errorf("failed to generate meta namespace key for CUDN: %v", err)

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
@@ -118,21 +118,8 @@ func (c *Controller) deleteNAD(obj client.Object, namespace string) error {
 	}
 	nadCopy := nad.DeepCopy()
 
-	if nadCopy == nil {
-		// NAD not found in lister cache; verify it's truly gone from the API
-		// before treating as success. The lister cache may lag behind the API,
-		// especially right after the NAD was created.
-		_, apiErr := c.nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Get(context.Background(), obj.GetName(), metav1.GetOptions{})
-		if apiErr == nil {
-			return fmt.Errorf("NetworkAttachmentDefinition %s/%s not found in cache but still exists in the API, retrying", namespace, obj.GetName())
-		}
-		if !apierrors.IsNotFound(apiErr) {
-			return fmt.Errorf("failed to get NetworkAttachmentDefinition %s/%s from API: %v", namespace, obj.GetName(), apiErr)
-		}
-		return nil
-	}
-
-	if !metav1.IsControlledBy(nadCopy, obj) ||
+	if nadCopy == nil ||
+		!metav1.IsControlledBy(nadCopy, obj) ||
 		!controllerutil.ContainsFinalizer(nadCopy, template.FinalizerUserDefinedNetwork) {
 		return nil
 	}

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -2084,50 +2084,26 @@ var _ = Describe("User Defined Network Controller", func() {
 			}).Should(BeTrue(), "NAD should be deleted when namespace is terminating")
 		})
 
-		It("when namespace is being deleted and NAD is not yet in lister cache, should not lose track of NAD", func() {
+		It("when NAD is not tracked by namespace tracker, ReconcileNetAttachDef should delete stale NAD", func() {
 			const cudnName = "test-network"
 			testNs := testNamespace("blue")
 			cudn := testClusterUDN(cudnName, testNs.Name)
 			expectedNAD := testClusterUdnNAD(cudnName, testNs.Name)
-			c := newTestController(renderNadStub(expectedNAD), cudn, testNs)
 
-			By("initial sync creates NAD and populates namespace tracker")
-			nads, err := c.syncClusterUDN(cudn)
+			By("create controller with existing NAD but empty namespace tracker")
+			c := newTestController(renderNadStub(expectedNAD), cudn, testNs, expectedNAD)
+
+			By("verify NAD exists in the lister and tracker is empty")
+			_, err := c.nadLister.NetworkAttachmentDefinitions(testNs.Name).Get(cudnName)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(nads).To(HaveLen(1))
-			Expect(c.namespaceTracker).To(HaveKeyWithValue(cudnName, HaveKey("blue")))
+			Expect(c.namespaceTracker).ToNot(HaveKey(cudnName))
 
-			By("wait for informer to process NAD creation event")
-			Eventually(func() error {
-				_, err := c.nadLister.NetworkAttachmentDefinitions(testNs.Name).Get(cudnName)
-				return err
-			}).Should(Succeed())
+			By("ReconcileNetAttachDef should detect NAD as stale and delete it")
+			Expect(c.ReconcileNetAttachDef(testNs.Name + "/" + cudnName)).To(Succeed())
 
-			By("simulate lister cache lag by removing NAD from informer store")
-			nadStore := f.NADInformer().Informer().GetStore()
-			storedNADs := nadStore.List()
-			for _, obj := range storedNADs {
-				Expect(nadStore.Delete(obj)).To(Succeed())
-			}
-
-			By("verify NAD is absent from lister cache but still exists in the API")
-			_, err = c.nadLister.NetworkAttachmentDefinitions(testNs.Name).Get(cudnName)
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			By("verify NAD was deleted")
 			_, err = cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(testNs.Name).Get(context.Background(), cudnName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("mark namespace as terminating directly in the namespace informer store")
-			testNs.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-			nsStore := f.NamespaceInformer().Informer().GetStore()
-			Expect(nsStore.Update(testNs)).To(Succeed())
-
-			By("sync should return error because NAD is not in cache but exists in API")
-			_, err = c.syncClusterUDN(cudn)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not found in cache but still exists in the API"))
-
-			By("namespace should still be tracked so it can be retried")
-			Expect(c.namespaceTracker).To(HaveKeyWithValue(cudnName, HaveKey("blue")))
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
 		It("when CR is deleted, CR has no finalizer, should succeed", func() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

When a ClusterUserDefinedNetwork creates a NAD and the target namespace
is immediately marked as terminating, there is a race condition between
NAD creation and deletion. The deleteNAD function reads the NAD from the
informer lister cache, which may not have received the watch event for
the just-created NAD yet. When the lister returns NotFound, deleteNAD
treated this as "already deleted" and returned nil. The caller then
removed the namespace from namespaceTracker, permanently losing track of
it. Subsequent syncs never attempted to delete the NAD again, leaving it
orphaned.

Fix this by falling back to an API check when the NAD is not found in
the lister cache. If the NAD exists in the API, return an error so the
caller preserves the namespace in the tracker and the work queue retries
the sync. On the next attempt, the informer cache will have caught up
and the normal deletion path will proceed.

Includes a test case that simulates the scenario.

This issue was hit in:
https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/22238494590/job/64336007750

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network attachment definition deletion when the cache is out of sync with the API. The controller now verifies existence through the API and properly manages retry logic, ensuring reliable cleanup during namespace deletion scenarios.

* **Tests**
  * Added test coverage for cache-lag edge cases during namespace termination to ensure proper NAD tracking and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->