### PR TITLE
Fix UDN network controller deadlock due to stopChan nil race

### DIFF
--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -150,11 +150,11 @@ func (oc *BaseLayer2UserDefinedNetworkController) run() error {
 			return fmt.Errorf("unable to create network qos controller, err: %w", err)
 		}
 		oc.wg.Add(1)
-		go func() {
+		go func(ch <-chan struct{}) {
 			defer oc.wg.Done()
 			// Until we have scale issues in future let's spawn only one thread
-			oc.nqosController.Run(1, oc.stopChan)
-		}()
+			oc.nqosController.Run(1, ch)
+		}(oc.stopChan)
 	}
 
 	// Add ourselves to the route import manager

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -662,11 +662,11 @@ func (oc *Layer3UserDefinedNetworkController) run() error {
 			return fmt.Errorf("unable to create network qos controller, err: %w", err)
 		}
 		oc.wg.Add(1)
-		go func() {
+		go func(ch <-chan struct{}) {
 			defer oc.wg.Done()
 			// Until we have scale issues in future let's spawn only one thread
-			oc.nqosController.Run(1, oc.stopChan)
-		}()
+			oc.nqosController.Run(1, ch)
+		}(oc.stopChan)
 	}
 
 	klog.Infof("Completing all the Watchers for network %s took %v", oc.GetNetworkName(), time.Since(start))


### PR DESCRIPTION
In UDNs, goroutines are started for some controllers like NetworkQoS where a waitgroup is used to add a reference to the goroutine, and then stopChan is passed as a mechanism to shutdown the NetworkQoS controller.

If the UDN controller starts, and then shutsdown very quickly, the stopChan is closed and reset to nil. It is set to nil as a pattern we use to guard multiple Stop calls to the UDN controller (Stop may be called multiple times). However, if the NetworkQoS goroutine does not finish starting before the stopChan is closed and reset to nil, then by the time NetworkQos gets to read stopChan, it will hang forever, causing the UDN controller waitgroup to wait forever.

This will deadlock the entire network manager from being able to start/stop anymore UDN controllers!

We can see this behavior in CI here:
```
I0223 04:37:24.677192      77 network_controller.go:415] [zone-nad-controller network controller]: sync network wpnhc_tenant-blue
I0223 04:37:24.677203      77 localnet_user_defined_network_controller.go:311] Stoping controller for UDN wpnhc_tenant-blue
I0223 04:37:24.677209      77 base_secondary_layer2_network_controller.go:39] Stop secondary localnet network controller of network wpnhc_tenant-blue
I0223 04:37:24.677241      77 obj_retry.go:473] Stop channel got triggered: will stop retrying failed objects of type *v1.Namespace
I0223 04:37:24.677250      77 network_qos_controller.go:215] Starting controller wpnhc_tenant-blue-network-controller
I0223 04:37:24.677256      77 network_qos_controller.go:218] Waiting for informer caches (networkqos,namespace,pod,node) to sync
I0223 04:37:24.677263      77 obj_retry.go:473] Stop channel got triggered: will stop retrying failed objects of type *v1beta2.MultiNetworkPolicy
I0223 04:37:24.677270      77 shared_informer.go:349] "Waiting for caches to sync" controller="wpnhc_tenant-blue-network-controller"
I0223 04:37:24.677339      77 shared_informer.go:356] "Caches are synced" controller="wpnhc_tenant-blue-network-controller"
```

There is never a "finished syncing network wpnhc_tenant-blue" log again after this for zone-nad-controller, nor any other networks for that matter after this point in the log. However, there are logs for node-nad-controller as it did not hit this race.

To fix this, pass a copy of the oc.stopChan to the goroutines. Channels are copied as a reference so closing the oc.stopChan still closes the copy, and we can still allow oc.stopChan to be set to nil as a Stop guard.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of network QoS and network controllers by preventing race conditions in shutdown handling across multiple components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->