### PR TITLE
Hybrid Overlay: Do not reserve 3rd IP for UDN switches

### DIFF
--- a/go-controller/pkg/libovsdb/util/switch.go
+++ b/go-controller/pkg/libovsdb/util/switch.go
@@ -21,11 +21,11 @@ import (
 var updateNodeSwitchLock sync.Mutex
 
 // UpdateNodeSwitchExcludeIPs should be called after adding the management port
-// and after adding the hybrid overlay port, and ensures that each port's IP
-// is added to the logical switch's exclude_ips. This prevents ovn-northd log
-// spam about duplicate IP addresses.
+// and after adding the hybrid overlay port (for default network only), and
+// ensures that each port's IP is added to the logical switch's exclude_ips.
+// This prevents ovn-northd log spam about duplicate IP addresses.
 // See https://github.com/ovn-org/ovn-kubernetes/pull/779
-func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, mgmtIfName, switchName, nodeName string, subnet, mgmtIfAddr *net.IPNet) error {
+func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, mgmtIfName, switchName, nodeName string, subnet, mgmtIfAddr *net.IPNet, includeHybridOverlay bool) error {
 	if utilnet.IsIPv6CIDR(subnet) {
 		// We don't exclude any IPs in IPv6
 		return nil
@@ -34,7 +34,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, mgmtIfName, swit
 	updateNodeSwitchLock.Lock()
 	defer updateNodeSwitchLock.Unlock()
 
-	// Only query the cache for mp0 and HO LSPs
+	// Only query the cache for mp0 and (optionally) HO LSPs.
 	haveManagementPort := true
 	managmentPort := &nbdb.LogicalSwitchPort{Name: mgmtIfName}
 	_, err := libovsdbops.GetLogicalSwitchPort(nbClient, managmentPort)
@@ -46,20 +46,22 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, mgmtIfName, swit
 	}
 
 	haveHybridOverlayPort := true
-	HOPort := &nbdb.LogicalSwitchPort{Name: types.HybridOverlayPrefix + nodeName}
-	_, err = libovsdbops.GetLogicalSwitchPort(nbClient, HOPort)
-	if errors.Is(err, libovsdbclient.ErrNotFound) {
-		klog.V(5).Infof("Hybridoverlay port does not exist for node %s", nodeName)
-		haveHybridOverlayPort = false
-	} else if err != nil {
-		return fmt.Errorf("failed to get hybrid overlay port for node %s error: %v", nodeName, err)
+	var hybridOverlayIfAddr *net.IPNet
+	if includeHybridOverlay && config.HybridOverlay.Enabled {
+		HOPort := &nbdb.LogicalSwitchPort{Name: types.HybridOverlayPrefix + nodeName}
+		_, err = libovsdbops.GetLogicalSwitchPort(nbClient, HOPort)
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
+			klog.V(5).Infof("Hybridoverlay port does not exist for node %s", nodeName)
+			haveHybridOverlayPort = false
+		} else if err != nil {
+			return fmt.Errorf("failed to get hybrid overlay port for node %s error: %v", nodeName, err)
+		}
+		hybridOverlayIfAddr = util.GetNodeHybridOverlayIfAddr(subnet)
 	}
-
-	hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(subnet)
 
 	klog.V(5).Infof("haveMP %v haveHO %v ManagementPortAddress %v HybridOverlayAddressOA %v", haveManagementPort, haveHybridOverlayPort, mgmtIfAddr, hybridOverlayIfAddr)
 	var excludeIPs string
-	if config.HybridOverlay.Enabled {
+	if includeHybridOverlay && config.HybridOverlay.Enabled {
 		if haveHybridOverlayPort && haveManagementPort {
 			// no excluded IPs required
 		} else if !haveHybridOverlayPort && !haveManagementPort {

--- a/go-controller/pkg/libovsdb/util/switch_test.go
+++ b/go-controller/pkg/libovsdb/util/switch_test.go
@@ -29,6 +29,7 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 		desc                    string
 		inpSubnetStr            string
 		setCfgHybridOvlyEnabled bool
+		includeHybridOverlay    bool
 		initialNbdb             libovsdbtest.TestSetup
 		expectedNbdb            libovsdbtest.TestSetup
 	}{
@@ -58,12 +59,14 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 					fakeHoPort,
 				},
 			},
-			inpSubnetStr: "fd04:3e42:4a4e:3381::/64",
+			inpSubnetStr:         "fd04:3e42:4a4e:3381::/64",
+			includeHybridOverlay: true,
 		},
 		{
 			desc:                    "IPv4 CIDR, config.HybridOverlayEnable=true, haveHybridOverlayPort=true and haveManagementPort=true, excludes ips empty",
 			inpSubnetStr:            "192.168.1.0/24",
 			setCfgHybridOvlyEnabled: true,
+			includeHybridOverlay:    true,
 			initialNbdb: libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -98,6 +101,7 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			desc:                    "IPv4 CIDR, config.HybridOverlayEnable=true, haveHybridOverlayPort=false and haveManagementPort=false, excludes HO and MP ips",
 			inpSubnetStr:            "192.168.1.0/24",
 			setCfgHybridOvlyEnabled: true,
+			includeHybridOverlay:    true,
 			initialNbdb: libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -129,6 +133,7 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			desc:                    "IPv4 CIDR, config.HybridOverlayEnable=true, sets haveHybridOverlayPort=false and haveManagementPort=true, excludes HO ip",
 			inpSubnetStr:            "192.168.1.0/24",
 			setCfgHybridOvlyEnabled: true,
+			includeHybridOverlay:    true,
 			initialNbdb: libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -162,6 +167,7 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			desc:                    "IPv4 CIDR, config.HybridOverlayEnable=true, sets haveHybridOverlayPort=true and haveManagementPort=false, excludes MP ip",
 			inpSubnetStr:            "192.168.1.0/24",
 			setCfgHybridOvlyEnabled: true,
+			includeHybridOverlay:    true,
 			initialNbdb: libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -195,6 +201,7 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			desc:                    "IPv4 CIDR, config.HybridOverlayEnable=false, haveManagementPort=true, excludes ips empty",
 			inpSubnetStr:            "192.168.1.0/24",
 			setCfgHybridOvlyEnabled: false,
+			includeHybridOverlay:    true,
 			initialNbdb: libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -227,6 +234,7 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			desc:                    "IPv4 CIDR, config.HybridOverlayEnable=false, haveManagementPort=false, excludes MP ip",
 			inpSubnetStr:            "192.168.1.0/24",
 			setCfgHybridOvlyEnabled: false,
+			includeHybridOverlay:    true,
 			initialNbdb: libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -252,6 +260,38 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:                    "IPv4 CIDR, config.HybridOverlayEnable=true, includeHybridOverlay=false, excludes only MP ip",
+			inpSubnetStr:            "192.168.1.0/24",
+			setCfgHybridOvlyEnabled: true,
+			includeHybridOverlay:    false,
+			initialNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalSwitch{
+						UUID:  nodeName + "-uuid",
+						Name:  nodeName,
+						Ports: []string{},
+						OtherConfig: map[string]string{
+							"subnet":      "subnet",
+							"exclude_ips": "192.168.1.2..192.168.1.3",
+						},
+					},
+				},
+			},
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					&nbdb.LogicalSwitch{
+						UUID:  nodeName + "-uuid",
+						Name:  nodeName,
+						Ports: []string{},
+						OtherConfig: map[string]string{
+							"subnet":      "subnet",
+							"exclude_ips": "192.168.1.2",
+						},
+					},
+				},
+			},
+		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
@@ -268,12 +308,12 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			var e error
 			if tc.setCfgHybridOvlyEnabled {
 				config.HybridOverlay.Enabled = true
-				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, nodeName, ipnet, ovnutil.GetNodeManagementIfAddr(ipnet)); e != nil {
+				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, nodeName, ipnet, ovnutil.GetNodeManagementIfAddr(ipnet), tc.includeHybridOverlay); e != nil {
 					t.Fatal(fmt.Errorf("failed to update NodeSwitchExcludeIPs with Hybrid Overlay enabled err: %v", e))
 				}
 				config.HybridOverlay.Enabled = false
 			} else {
-				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, nodeName, ipnet, ovnutil.GetNodeManagementIfAddr(ipnet)); e != nil {
+				if e = UpdateNodeSwitchExcludeIPs(nbClient, ovnutil.GetK8sMgmtIntfName(nodeName), nodeName, nodeName, ipnet, ovnutil.GetNodeManagementIfAddr(ipnet), tc.includeHybridOverlay); e != nil {
 					t.Fatal(fmt.Errorf("failed to update NodeSwitchExcludeIPs with Hybrid Overlay disabled err: %v", e))
 				}
 

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -596,7 +596,7 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 		} else {
 			v4Gateway = gwIfAddr.IP
 			excludeIPs := mgmtIfAddr.IP.String()
-			if config.HybridOverlay.Enabled {
+			if config.HybridOverlay.Enabled && bnc.IsDefault() {
 				hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(hostSubnet)
 				excludeIPs += ".." + hybridOverlayIfAddr.IP.String()
 			}
@@ -917,7 +917,15 @@ func (bnc *BaseNetworkController) syncNodeManagementPort(node *corev1.Node, swit
 	}
 
 	if v4Subnet != nil {
-		if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(bnc.nbClient, bnc.GetNetworkScopedK8sMgmtIntfName(node.Name), bnc.GetNetworkScopedSwitchName(node.Name), node.Name, v4Subnet, bnc.GetNodeManagementIP(v4Subnet)); err != nil {
+		if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(
+			bnc.nbClient,
+			bnc.GetNetworkScopedK8sMgmtIntfName(node.Name),
+			bnc.GetNetworkScopedSwitchName(node.Name),
+			node.Name,
+			v4Subnet,
+			bnc.GetNodeManagementIP(v4Subnet),
+			bnc.IsDefault(),
+		); err != nil {
 			return nil, err
 		}
 	}

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -120,7 +120,15 @@ func (oc *DefaultNetworkController) handleHybridOverlayPort(node *corev1.Node, a
 			return fmt.Errorf("failed to add hybrid overlay port %+v for node %s: %w", lsp, node.Name, err)
 		}
 		for _, subnet := range subnets {
-			if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(oc.nbClient, oc.GetNetworkScopedK8sMgmtIntfName(node.Name), oc.GetNetworkScopedSwitchName(node.Name), node.Name, subnet, oc.GetNodeManagementIP(subnet)); err != nil {
+			if err := libovsdbutil.UpdateNodeSwitchExcludeIPs(
+				oc.nbClient,
+				oc.GetNetworkScopedK8sMgmtIntfName(node.Name),
+				oc.GetNetworkScopedSwitchName(node.Name),
+				node.Name,
+				subnet,
+				oc.GetNodeManagementIP(subnet),
+				oc.IsDefault(),
+			); err != nil {
 				return err
 			}
 		}

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -57,6 +57,7 @@ type testConfiguration struct {
 	configToOverride   *config.OVNKubernetesFeatureConfig
 	gatewayConfig      *config.GatewayConfig
 	expectationOptions []option
+	hybridOverlay      bool
 }
 
 var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
@@ -100,6 +101,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 					config.Gateway.DisableSNATMultipleGWs = testConfig.gatewayConfig.DisableSNATMultipleGWs
 				}
 			}
+			config.HybridOverlay.Enabled = testConfig.hybridOverlay
 			config.Gateway.Mode = gwMode
 			if config.OVNKubernetesFeature.EnableInterconnect {
 				config.Default.Zone = testICZone
@@ -255,6 +257,18 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 								expectationOptions...,
 							).expectedLogicalSwitchesAndPorts()...)))
 
+				if testConfig.hybridOverlay {
+					_, hostSubnet, err := net.ParseCIDR(netInfo.hostsubnets)
+					Expect(err).NotTo(HaveOccurred())
+					udnSwitchName := userDefinedNetController.bnc.GetNetworkScopedSwitchName(nodeName)
+					udnSwitch, err := libovsdbops.GetLogicalSwitch(fakeOvn.nbClient, &nbdb.LogicalSwitch{Name: udnSwitchName})
+					Expect(err).NotTo(HaveOccurred())
+					hybridOverlayIP := util.GetNodeHybridOverlayIfAddr(hostSubnet).IP.String()
+					if excludeIPs, found := udnSwitch.OtherConfig["exclude_ips"]; found {
+						Expect(excludeIPs).NotTo(ContainSubstring(hybridOverlayIP))
+					}
+				}
+
 				return nil
 			}
 
@@ -268,6 +282,13 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 		Entry("pod on a user defined primary network",
 			dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24"),
 			nonICClusterTestConfiguration(),
+			config.GatewayModeShared,
+		),
+		Entry("pod on a user defined primary network with hybrid overlay enabled",
+			dummyPrimaryLayer3UserDefinedNetwork("192.168.0.0/16", "192.168.1.0/24"),
+			nonICClusterTestConfiguration(func(config *testConfiguration) {
+				config.hybridOverlay = true
+			}),
 			config.GatewayModeShared,
 		),
 		Entry("pod on a user defined secondary network on an IC cluster",


### PR DESCRIPTION
When enabled, hybrid overlay is reserving the 3rd IP on the switch with exclude_ips. A UDN pod still gets assigned this 3rd IP, and then the port never binds in OVN.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hybrid overlay IP exclusion is now conditional based on network type, applying only to default networks.

* **Bug Fixes**
  * Improved IP exclusion handling for management ports across different network configurations, preventing incorrect exclusion scenarios.

* **Tests**
  * Enhanced test coverage for hybrid overlay and IP exclusion scenarios, including both enabled and disabled configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->