### PR TITLE
Revert "Use `nft destroy` to simplify the UDN cleanup code"

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -827,14 +827,38 @@ func delServiceRules(service *corev1.Service, localEndpoints util.PortToLBEndpoi
 		}
 		nftElems := getGatewayNFTRules(service, localEndpoints, true)
 		nftElems = append(nftElems, getGatewayNFTRules(service, localEndpoints, false)...)
-		if util.IsNetworkSegmentationSupportEnabled() {
-			nftElems = append(nftElems, getUDNNFTRules(service, nil)...)
-		}
 		if len(nftElems) > 0 {
 			if err := nodenft.DeleteNFTElements(nftElems); err != nil {
 				err = fmt.Errorf("failed to delete nftables rules for service %s/%s: %v",
 					service.Namespace, service.Name, err)
 				errors = append(errors, err)
+			}
+		}
+
+		if util.IsNetworkSegmentationSupportEnabled() {
+			// NOTE: The code below is not using nodenft.DeleteNFTElements because it first adds elements
+			// before removing them, which fails for UDN NFT rules. These rules only have map keys,
+			// not key-value pairs, making it impossible to add.
+			// Attempt to delete the elements directly and handle the IsNotFound error.
+			//
+			// TODO: Switch to `nft destroy` when supported.
+			nftElems = getUDNNFTRules(service, nil)
+			if len(nftElems) > 0 {
+				nft, err := nodenft.GetNFTablesHelper()
+				if err != nil {
+					return utilerrors.Join(append(errors, err)...)
+				}
+
+				tx := nft.NewTransaction()
+				for _, elem := range nftElems {
+					tx.Delete(elem)
+				}
+
+				if err := nft.Run(context.TODO(), tx); err != nil && !knftables.IsNotFound(err) {
+					err = fmt.Errorf("failed to delete nftables rules for UDN service %s/%s: %v",
+						service.Namespace, service.Name, err)
+					errors = append(errors, err)
+				}
 			}
 		}
 	}

--- a/go-controller/pkg/node/nftables/helpers.go
+++ b/go-controller/pkg/node/nftables/helpers.go
@@ -28,7 +28,7 @@ func SetFakeNFTablesHelper() *knftables.Fake {
 // called, it will create a "real" knftables.Interface
 func GetNFTablesHelper() (knftables.Interface, error) {
 	if nftHelper == nil {
-		nft, err := knftables.New(knftables.InetFamily, OVNKubernetesNFTablesName, knftables.RequireDestroy)
+		nft, err := knftables.New(knftables.InetFamily, OVNKubernetesNFTablesName)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/node/nftables/util.go
+++ b/go-controller/pkg/node/nftables/util.go
@@ -34,7 +34,10 @@ func DeleteNFTElements(elements []*knftables.Element) error {
 
 	tx := nft.NewTransaction()
 	for _, elem := range elements {
-		tx.Destroy(elem)
+		// We add+delete the elements, rather than just deleting them, so that if
+		// they weren't already in the set/map, we won't get an error on delete.
+		tx.Add(elem)
+		tx.Delete(elem)
 	}
 	return nft.Run(context.TODO(), tx)
 }


### PR DESCRIPTION
Reverts ovn-kubernetes/ovn-kubernetes#5858
Apparently that broke d/s and in general a newer kernel version is only needed if the user wants UDN to work, while a general nftables requirement affects all features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network segmentation rules cleanup to ensure proper removal of rules even when they consist of map keys only. Enhanced error handling to treat missing rules as non-fatal, improving reliability during network configuration teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->