### PR TITLE
Add GARP drop flows for patch ports

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -53,6 +53,14 @@ func (netConfig *BridgeUDNConfiguration) IsDefaultNetwork() bool {
 	return netConfig.MasqCTMark == nodetypes.CtMarkOVN
 }
 
+func (netConfig *BridgeUDNConfiguration) GetPatchPort() string {
+	return netConfig.PatchPort
+}
+
+func (netConfig *BridgeUDNConfiguration) GetOfPortPatch() string {
+	return netConfig.OfPortPatch
+}
+
 func (netConfig *BridgeUDNConfiguration) setOfPatchPort() error {
 	ofportPatch, stderr, err := util.GetOVSOfPort("get", "Interface", netConfig.PatchPort, "ofport")
 	if err != nil {
@@ -520,6 +528,17 @@ func (b *BridgeConfiguration) SetEIPMarkIPs(eipMarkIPs *egressip.MarkIPsCache) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 	b.eipMarkIPs = eipMarkIPs
+}
+
+// GetNetConfigs returns the network configurations for this bridge
+func (b *BridgeConfiguration) GetNetConfigs() []*BridgeUDNConfiguration {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	var netConfigs []*BridgeUDNConfiguration
+	for _, netConfig := range b.netConfig {
+		netConfigs = append(netConfigs, netConfig)
+	}
+	return netConfigs
 }
 
 func (b *BridgeConfiguration) SetDropGARP(drop bool) {

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -584,6 +584,14 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 				nodetypes.DefaultOpenFlowCookie, matchVLAN, bridgeMacAddress, actions))
 	}
 
+	// Workaround for FDP-1537: Drop GARP packets from patch ports to prevent duplicate
+	// GARPs during EgressIP failover. Remove when OVN v26.03+ with disable_garp_rarp is available.
+	for _, netConfig := range b.patchedNetConfigs() {
+		dftFlows = append(dftFlows,
+			fmt.Sprintf("cookie=0x0305,table=0,priority=499,in_port=%s,arp,arp_op=1,actions=drop",
+				netConfig.OfPortPatch))
+	}
+
 	// table 0, check packets coming from OVN have the correct mac address. Low priority flows that are a catch all
 	// for non-IP packets that would normally be forwarded with NORMAL action (table 0, priority 0 flow).
 	for _, netConfig := range b.patchedNetConfigs() {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1742,6 +1742,7 @@ func newGateway(
 				return err
 			}
 		}
+
 		if util.IsNetworkSegmentationSupportEnabled() && config.OVNKubernetesFeature.EnableInterconnect && config.Gateway.Mode != config.GatewayModeDisabled {
 			gw.bridgeEIPAddrManager = egressip.NewBridgeEIPAddrManager(nodeName, gwBridge.GetBridgeName(), linkManager, kube, watchFactory.EgressIPInformer(), watchFactory.NodeCoreInformer())
 			gwBridge.SetEIPMarkIPs(gw.bridgeEIPAddrManager.GetCache())

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -703,7 +703,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				&kubeMock, vrf, ipRulesManager, localGw)
 			Expect(err).NotTo(HaveOccurred())
 			flowMap := udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
+			Expect(flowMap["DEFAULT"]).To(HaveLen(51)) // 50 default + 1 GARP drop flow
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
@@ -721,7 +721,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(70))                                      // 18 UDN Flows are added by default
+			Expect(flowMap["DEFAULT"]).To(HaveLen(72))                                      // 50 default + 18 UDN + 2 GARP drop flows (default + UDN)
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("bluenet")
@@ -737,7 +737,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 					}
 				}
 			}
-			Expect(udnFlows).To(Equal(16))
+			Expect(udnFlows).To(Equal(17)) // 16 default + 1 GARP drop flow
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
@@ -757,7 +757,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
+			Expect(flowMap["DEFAULT"]).To(HaveLen(51))                                      // 50 default + 1 GARP drop flow                                      // only default network flows are present
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
@@ -941,7 +941,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			udnGateway.mgmtPortController, err = managementport.NewUDNManagementPortController(udnGateway.nodeLister, udnGateway.node.Name, localSubnets, udnGateway.NetInfo)
 			Expect(err).NotTo(HaveOccurred())
 			flowMap := udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
+			Expect(flowMap["DEFAULT"]).To(HaveLen(51)) // 50 default + 1 GARP drop flow
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
@@ -961,7 +961,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			Expect(err).To(MatchError(ContainSubstring("fake delete metadata error")))
 			By("Ensuring everything else was still cleaned up correctly")
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
+			Expect(flowMap["DEFAULT"]).To(HaveLen(51))                                      // 50 default + 1 GARP drop flow                                      // only default network flows are present
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
@@ -1135,7 +1135,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				&kubeMock, vrf, ipRulesManager, localGw)
 			Expect(err).NotTo(HaveOccurred())
 			flowMap := udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
+			Expect(flowMap["DEFAULT"]).To(HaveLen(51)) // 50 default + 1 GARP drop flow
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
 			for _, flows := range flowMap {
@@ -1152,7 +1152,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(70))                                      // 18 UDN Flows are added by default
+			Expect(flowMap["DEFAULT"]).To(HaveLen(72))                                      // 50 default + 18 UDN + 2 GARP drop flows (default + UDN)
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("bluenet")
@@ -1168,7 +1168,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 					}
 				}
 			}
-			Expect(udnFlows).To(Equal(16))
+			Expect(udnFlows).To(Equal(17)) // 16 default + 1 GARP drop flow
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
@@ -1188,7 +1188,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
+			Expect(flowMap["DEFAULT"]).To(HaveLen(51))                                      // 50 default + 1 GARP drop flow                                      // only default network flows are present
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {
@@ -1376,7 +1376,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				&kubeMock, vrf, ipRulesManager, localGw)
 			Expect(err).NotTo(HaveOccurred())
 			flowMap := udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))
+			Expect(flowMap["DEFAULT"]).To(HaveLen(51)) // 50 default + 1 GARP drop flow
 
 			Expect(udnGateway.masqCTMark).To(Equal(udnGateway.masqCTMark))
 			var udnFlows int
@@ -1394,7 +1394,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(80))                                      // 18 UDN Flows, 5 advertisedUDN flows, and 2 packet mark flows (IPv4+IPv6) are added by default
+			Expect(flowMap["DEFAULT"]).To(HaveLen(82))                                      // 50 default + 18 UDN + 5 advertised + 2 packet mark + 2 GARP drop flows + 5 more = 82
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("bluenet")
@@ -1410,7 +1410,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 					}
 				}
 			}
-			Expect(udnFlows).To(Equal(18))
+			Expect(udnFlows).To(Equal(19)) // 18 default + 1 GARP drop flow
 			openflowManagerCheckPorts(udnGateway.openflowManager)
 
 			for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
@@ -1432,7 +1432,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			kubeMock.On("UpdateNodeStatus", cnode).Return(nil) // check if network key gets deleted from annotation
 			Expect(udnGateway.DelNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(50))                                      // only default network flows are present
+			Expect(flowMap["DEFAULT"]).To(HaveLen(51))                                      // 50 default + 1 GARP drop flow                                      // only default network flows are present
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(1)) // default network only
 			udnFlows = 0
 			for _, flows := range flowMap {


### PR DESCRIPTION
Drop GARP packets from patch ports to prevent duplicate GARPs during EgressIP failover. When an EgressIP moves between nodes, OVN-controller on the old node may have stale SBDB entries causing it to send GARPs that compete with legitimate GARPs from the new node, corrupting ARP caches.

The flow rule targets only patch port traffic (in_port=<ofport>). Legitimate GARPs sent by link manager from physical interfaces bypass OVS and are unaffected.

Workaround until OVN v26.03+ with disable_garp_rarp option is available.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network stability during Egress IP failover scenarios by preventing duplicate gratuitous ARP packets on patch ports.

* **Chores**
  * Updated network configuration accessors and gateway initialization logic to support enhanced network segmentation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->