### PR TITLE
Documentation: UserDefinedNetwork Markdown does not render properly

### DIFF
--- a/docs/features/user-defined-networks/user-defined-networks.md
+++ b/docs/features/user-defined-networks/user-defined-networks.md
@@ -151,7 +151,7 @@ same layer2 flat switch.
     during live migration
   * Can be of type `primary` or `secondary`
 
-![l2-UDN](images/L2DeepDive-2segments.png)
+![l2-UDN](images/L2DeepDive-2segments.jpg)
 
 Here we can see a blue and green P-UDN. On node1, pod1 is part of green UDN and
 pod2 is part of blue UDN. They each have a udn-0 interface that is attached to


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

--------------------------------------------------------------------------------

## 📑 Description
<!-- Add a brief description of the pr -->

This PR fixes a rendering issue in the documentation where a newline was missing before the list.
This led to bad rendering by `mkdocs` in the user-facing documentation:

- https://ovn-kubernetes.io/features/user-defined-networks/user-defined-networks/#ovn-kubernetes-implementation-details

The Markdown rendering in GitHub was misleading because apparently everything was OK

- https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/user-defined-networks/user-defined-networks.md#ovn-kubernetes-implementation-details

I also fixed an issue where an image was referenced with a wrong extension, thus breaking the image link when `mkdocs` renders the Markdown source.

Taken from #6014:

> | Images in the user-facing documentation
> |:----------------------------------------|
> | <https://ovn-kubernetes.io/features/user-defined-networks/user-defined-networks/#ovn-kubernetes-implementation-details>
> | ![](https://github.com/user-attachments/assets/15385e45-230d-43c0-80bc-08421643912b)
> | ![](https://github.com/user-attachments/assets/505737ef-8cfb-48a3-bf87-c715bafd268d)
> 
> | Screenshots of the Markdown source
> |:-----------------------------------|
> | <https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/user-defined-networks/user-defined-networks.md#ovn-kubernetes-implementation-details>
> | ![](https://github.com/user-attachments/assets/2a741b6d-dfdd-44d0-a415-1183b472fea0)
> | ![](https://github.com/user-attachments/assets/7a5e659d-e60e-42d7-872d-f09301cd42a2)

--------------------------------------------------------------------------------

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes:

- #6014

--------------------------------------------------------------------------------

## Additional Information for reviewers

<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

I added newlines before the start of the lists, and fixed the image extension to properly render the UserDefinedNetwork page.

--------------------------------------------------------------------------------

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [ ] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

--------------------------------------------------------------------------------

## How to verify it

<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

- The UserDefinedNetwork static documentation renders properly (see screenshots)
- The image link is not broken and points to this image

Taken from #6014:

> | Broken image link
> |:-----------|
> | <https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/user-defined-networks/images/L2DeepDive-2segments.jpg>
> | ![](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/user-defined-networks/images/L2DeepDive-2segments.jpg?raw=true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated formatting and spacing in user-defined networks documentation.
  * Updated image file references for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->