### PR TITLE
kubevirt: detect completed migration when source pod is gone

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -477,6 +477,14 @@ func DiscoverLiveMigrationStatus(client *factory.WatchFactory, pod *corev1.Pod) 
 
 	// no migration
 	if len(vmPods) < 2 {
+		// If the only remaining pod has the migration target ready
+		// annotation, the migration completed and the source pod is gone.
+		if len(vmPods) == 1 && isTargetPodReady(vmPods[0]) {
+			return &LiveMigrationStatus{
+				TargetPod: vmPods[0],
+				State:     LiveMigrationTargetDomainReady,
+			}, nil
+		}
 		return nil, nil
 	}
 
@@ -503,8 +511,15 @@ func DiscoverLiveMigrationStatus(client *factory.WatchFactory, pod *corev1.Pod) 
 		}, nil
 	}
 
-	// no active migration
+	// Source pod completed but target is still living. If the target has the
+	// migration ready annotation, the migration completed successfully.
 	if len(livingPods) < 2 {
+		if isTargetPodReady(targetPod) {
+			return &LiveMigrationStatus{
+				TargetPod: targetPod,
+				State:     LiveMigrationTargetDomainReady,
+			}, nil
+		}
 		return nil, nil
 	}
 

--- a/go-controller/pkg/kubevirt/pod_test.go
+++ b/go-controller/pkg/kubevirt/pod_test.go
@@ -74,8 +74,12 @@ var _ = Describe("Kubevirt Pod", func() {
 			Expect(migrationStatus).To(BeNil())
 		} else {
 			Expect(migrationStatus.State).To(Equal(params.expectedMigrationStatus.State))
-			Expect(migrationStatus.SourcePod.Name).To(Equal(params.expectedMigrationStatus.SourcePod.Name))
 			Expect(migrationStatus.TargetPod.Name).To(Equal(params.expectedMigrationStatus.TargetPod.Name))
+			if params.expectedMigrationStatus.SourcePod == nil {
+				Expect(migrationStatus.SourcePod).To(BeNil())
+			} else {
+				Expect(migrationStatus.SourcePod.Name).To(Equal(params.expectedMigrationStatus.SourcePod.Name))
+			}
 		}
 	},
 		Entry("returns nil when pod is not kubevirt related",
@@ -151,6 +155,29 @@ var _ = Describe("Kubevirt Pod", func() {
 					TargetPod: &readyMigrationKvTargetPod,
 					State:     LiveMigrationTargetDomainReady,
 				},
+			},
+		),
+		Entry("returns Migration Ready status when source pod is gone and target has ready annotation",
+			testParams{
+				pods: []corev1.Pod{readyMigrationKvTargetPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					TargetPod: &readyMigrationKvTargetPod,
+					State:     LiveMigrationTargetDomainReady,
+				},
+			},
+		),
+		Entry("returns Migration Ready status when source pod is completed and target has ready annotation",
+			testParams{
+				pods: []corev1.Pod{readyMigrationKvTargetPod, successfullyMigratedKvSourcePod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					TargetPod: &readyMigrationKvTargetPod,
+					State:     LiveMigrationTargetDomainReady,
+				},
+			},
+		),
+		Entry("returns nil when source pod is gone and target has no ready annotation",
+			testParams{
+				pods: []corev1.Pod{duringMigrationKvTargetPod},
 			},
 		),
 		Entry("returns err when kubevirt VM has several living pods",

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -381,7 +381,10 @@ func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod 
 	}
 
 	if shouldHandleLiveMigration && kubevirtLiveMigrationStatus.IsTargetDomainReady() {
-		hasSourcePodLogicalPort := bsnc.isPodScheduledinLocalZone(kubevirtLiveMigrationStatus.SourcePod) || bsnc.isLayer2WithInterconnectTransport()
+		// We have a source pod LSP at this zone if the source pod and:
+		// - layer2 IC There is one at all the zones since we have the remote LSP to implement east/west
+		// - localnet only if this is the zone where the source pod is running
+		hasSourcePodLogicalPort := kubevirtLiveMigrationStatus.SourcePod != nil && (bsnc.isPodScheduledinLocalZone(kubevirtLiveMigrationStatus.SourcePod) || bsnc.isLayer2WithInterconnectTransport())
 		if hasSourcePodLogicalPort {
 			ops, err = bsnc.disableLiveMigrationSourceLSPOps(kubevirtLiveMigrationStatus, nadKey, ops)
 			if err != nil {


### PR DESCRIPTION
## 📑 Description
DiscoverLiveMigrationStatus required two pods to detect a migration.
Once the source pod was removed it returned nil, causing
shouldHandleLiveMigration to be false and the target LSP Enabled field
to never be updated to true. All traffic from the target pod was then
unconditionally dropped by port security.

Teach DiscoverLiveMigrationStatus to recognize a completed migration
when only the target pod remains (or the source is completed) and it
carries the MigrationTargetReadyTimestamp annotation. Return
LiveMigrationTargetDomainReady with a nil SourcePod so the target LSP
gets properly enabled. Guard the source pod disable path against nil
SourcePod since there is nothing to disable when the source is already
gone.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
The PR includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer handling during VM live-migration: network port operations now avoid errors if the migrating source pod is absent or completed, and the system recognizes a ready migration target sooner to keep connectivity stable.
* **Tests**
  * Added and updated tests covering scenarios with missing or completed source pods and ready migration targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->