### PR TITLE
ci: collect host docker daemon logs on export

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -173,6 +173,7 @@ set_common_default_params() {
   # Script behavior
   KIND_INSTALL_PROMETHEUS=${KIND_INSTALL_PROMETHEUS:-false}
   KIND_ALLOW_SYSTEM_WRITES=${KIND_ALLOW_SYSTEM_WRITES:-false}
+  HOST_DOCKER_DAEMON_LOG_SINCE_HOURS=${HOST_DOCKER_DAEMON_LOG_SINCE_HOURS:-4}
   RUN_IN_CONTAINER=${RUN_IN_CONTAINER:-false}
   OVN_DUMMY_GATEWAY_BRIDGE=${OVN_DUMMY_GATEWAY_BRIDGE:-false}
   OVN_GATEWAY_OPTS=${OVN_GATEWAY_OPTS:-""}
@@ -1719,6 +1720,11 @@ export_logs() {
 
   kind export logs --name "${KIND_CLUSTER_NAME}" --verbosity 4 "$logs_dir"
   collect_coredump_binaries
+
+  # Collect host docker daemon logs for debugging container/network lifecycle
+  # operations that happen outside the kind nodes (e.g. external container
+  # cleanup in e2e tests).
+  journalctl -u docker --since "-${HOST_DOCKER_DAEMON_LOG_SINCE_HOURS}h" --no-pager > "$logs_dir/host-docker-daemon.log" 2>&1 || true
 }
 
 # Helper function to try extracting a binary from a container


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Add host-level docker daemon journal to the exported logs. This
captures container and network lifecycle operations that happen
outside the kind nodes, which are not included in kind export logs.

This may help tracing what happens to infra containers and networks created by
e2e tests.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->