### PR TITLE
e2e: log cleanup operations in kind test context

### DIFF
--- a/test/e2e/infraprovider/providers/kind/kind.go
+++ b/test/e2e/infraprovider/providers/kind/kind.go
@@ -305,6 +305,7 @@ func (c *contextKind) deleteExternalContainer(container api.ExternalContainer) e
 			return false, fmt.Errorf("failed to check if external container (%s) is deleted: %v (%s)", container, err, stdOut)
 		}
 		if string(stdOut) != "" {
+			framework.Logf("Waiting for external container %s to be deleted", container.Name)
 			return false, nil
 		}
 		return true, nil
@@ -579,12 +580,14 @@ func (c *contextKind) cleanUp() error {
 	c.cleanUpFns = nil
 	// detach network(s) from nodes
 	for _, na := range c.cleanUpNetworkAttachments.List {
+		framework.Logf("Detaching network %s from %s", na.Network.Name(), na.Instance)
 		if err := c.detachNetwork(na.Network, na.Instance); err != nil && !errors.Is(err, api.NotFound) {
 			errs = append(errs, err)
 		}
 	}
 	// remove containers
 	for _, container := range c.cleanUpContainers {
+		framework.Logf("Deleting external container %s", container.Name)
 		if err := c.deleteExternalContainer(container); err != nil && !errors.Is(err, api.NotFound) {
 			errs = append(errs, err)
 		}
@@ -592,6 +595,7 @@ func (c *contextKind) cleanUp() error {
 	c.cleanUpContainers = nil
 	// delete secondary networks
 	for _, network := range c.cleanUpNetworks.List {
+		framework.Logf("Deleting network %s", network.Name())
 		if err := c.deleteNetwork(network); err != nil && !errors.Is(err, api.NotFound) {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Add logging to the cleanup phases (network detachment, container
deletion, network deletion) so that when a DeferCleanup times out,
the last log line identifies which specific operation was stuck.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced diagnostic logging in test cleanup procedures for improved troubleshooting visibility during infrastructure testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->