### PR TITLE
e2e: restore nodes before checking readiness in egressip AfterEach

### DIFF
--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -869,6 +869,15 @@ var _ = ginkgo.DescribeTableSubtree("e2e egress IP validation", feature.EgressIP
 	})
 
 	ginkgo.AfterEach(func() {
+		// ensure all nodes are ready and reachable before any other cleanup;
+		// tests may have left nodes NotReady or unreachable intentionally
+		for _, node := range []string{egress1Node.name, egress2Node.name} {
+			setNodeReady(providerCtx, node, true)
+			setNodeReachable(node, true)
+			waitForNoTaint(node, "node.kubernetes.io/unreachable")
+			waitForNoTaint(node, "node.kubernetes.io/not-ready")
+		}
+
 		nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
 		framework.ExpectNoError(err)
 		if len(nodes.Items) < 3 {
@@ -881,14 +890,6 @@ var _ = ginkgo.DescribeTableSubtree("e2e egress IP validation", feature.EgressIP
 		e2ekubectl.RunKubectlOrDie("default", "delete", "eip", egressIPName2, "--ignore-not-found=true")
 		e2ekubectl.RunKubectlOrDie("default", "label", "node", egress1Node.name, "k8s.ovn.org/egress-assignable-")
 		e2ekubectl.RunKubectlOrDie("default", "label", "node", egress2Node.name, "k8s.ovn.org/egress-assignable-")
-
-		// ensure all nodes are ready and reachable
-		for _, node := range []string{egress1Node.name, egress2Node.name} {
-			setNodeReady(providerCtx, node, true)
-			setNodeReachable(node, true)
-			waitForNoTaint(node, "node.kubernetes.io/unreachable")
-			waitForNoTaint(node, "node.kubernetes.io/not-ready")
-		}
 	})
 	// Validate the egress IP by creating a httpd container on the kind networking
 	// (effectively seen as "outside" the cluster) and curl it from a pod in the cluster


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
The AfterEach block checked for 3 Ready nodes before restoring nodes
that tests intentionally made NotReady/unreachable. When a test like
"Should re-assign egress IPs when node readiness / reachability goes
down/up" stopped kubelet on a node, the AfterEach would fail
immediately at the Ready check, skipping the cleanup that restarts
kubelet and removes taints. This left the node broken for subsequent
tests, causing cascading failures.

Move node restoration (setNodeReady, setNodeReachable, waitForNoTaint)
to run before the Ready-nodes check so cleanup always completes.

Fixes #6027


## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup procedures to ensure proper node preparation and readiness verification, eliminating redundant cleanup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->