### PR TITLE
e2e: fix MetalLB test failure reporter to dump correct namespace and pod info

### DIFF
--- a/test/e2e/reporter.go
+++ b/test/e2e/reporter.go
@@ -110,7 +110,7 @@ func DumpInfo(reporter *k8sreporter.KubernetesReporter) {
 // DumpBGPInfo dumps current bgp specific configuration from frr router container and metallb
 // speaker pod's frr container which helps to troubleshoot if there is any problem with route
 // advertisement for a load balancer service ip address.
-func DumpBGPInfo(basePath, testName string, f *framework.Framework) {
+func DumpBGPInfo(basePath, testName string, f *framework.Framework, namespaces ...string) {
 	testPath := path.Join(basePath, strings.ReplaceAll(testName, " ", "-"))
 	err := os.MkdirAll(testPath, 0755)
 	if err != nil && !errors.Is(err, os.ErrExist) {
@@ -157,7 +157,13 @@ func DumpBGPInfo(basePath, testName string, f *framework.Framework) {
 			continue
 		}
 	}
-	describeSvc(f.Namespace.Name)
+	if len(namespaces) == 0 {
+		namespaces = []string{f.Namespace.Name}
+	}
+	for _, ns := range namespaces {
+		describeSvc(ns)
+		describePods(ns)
+	}
 }
 
 func logFileFor(base string, kind string) (*os.File, error) {
@@ -275,8 +281,16 @@ func speakerPods(cs clientset.Interface) ([]*corev1.Pod, error) {
 
 // describeSvc logs the output of kubectl describe svc for the given namespace.
 func describeSvc(ns string) {
-	framework.Logf("\nOutput of kubectl describe svc:\n")
+	framework.Logf("\nOutput of kubectl describe svc in namespace %s:\n", ns)
 	desc, _ := e2ekubectl.RunKubectl(
 		ns, "describe", "svc", fmt.Sprintf("--namespace=%v", ns))
+	framework.Logf("%s", desc)
+}
+
+// describePods logs the output of kubectl describe pods for the given namespace.
+func describePods(ns string) {
+	framework.Logf("\nOutput of kubectl describe pods in namespace %s:\n", ns)
+	desc, _ := e2ekubectl.RunKubectl(
+		ns, "describe", "pods", fmt.Sprintf("--namespace=%v", ns))
 	framework.Logf("%s", desc)
 }

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1863,7 +1863,7 @@ spec:
 
 	ginkgo.JustAfterEach(func() {
 		if ginkgo.CurrentSpecReport().Failed() {
-			DumpBGPInfo(reportPath, ginkgo.CurrentSpecReport().LeafNodeText, f)
+			DumpBGPInfo(reportPath, ginkgo.CurrentSpecReport().LeafNodeText, f, namespaceName)
 			k8sReporter := InitReporter(framework.TestContext.KubeConfig, reportPath,
 				[]string{metallbNamespace, namespaceName})
 			DumpInfo(k8sReporter)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

The MetalLB LB service test creates resources in the "default" namespace,
but DumpBGPInfo was always calling describeSvc(f.Namespace.Name) which
points to the auto-generated framework namespace (e.g. lbservice-test-2918)
that contains no resources. This resulted in "No resources found" in CI
failure logs, making it impossible to diagnose why pods fail to start.

Fix DumpBGPInfo to accept explicit namespaces to dump, falling back to
f.Namespace.Name when none are provided. Also add describePods to dump
pod descriptions on failure, which would reveal image pull failures,
pending PVCs, scheduling issues, etc.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced BGP diagnostic reporting during test failures to capture Kubernetes resource descriptions (services and pods) across multiple namespaces.
  * Improved failure diagnostics with expanded logging of pod and service details for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->