### PR TITLE
Handle the UDN cleanup special case without using `nft destroy`

### DIFF
--- a/go-controller/pkg/node/nftables/util.go
+++ b/go-controller/pkg/node/nftables/util.go
@@ -26,18 +26,71 @@ func UpdateNFTElements(elements []*knftables.Element) error {
 
 // DeleteNFTElements deletes the given nftables set/map elements. The set or map must
 // exist, but if the elements aren't already in the set/map, no error is returned.
+//
+// To avoid depending on `nft destroy` (which requires kernel 6.3+), this Add()s each
+// element before Delete()ing it, so you won't get an error if the element wasn't already
+// in the set/map, which means that for map elements, the Value field must be set to the
+// correct value. Alternatively, you can leave Value unset, in which case
+// DeleteNFTElements will first "list" the map to find its current contents, and then only
+// try to delete the elements that are actually present.
 func DeleteNFTElements(elements []*knftables.Element) error {
 	nft, err := GetNFTablesHelper()
 	if err != nil {
 		return err
 	}
 
+	// If there are any partial Map Elements, list their maps' existing contents
+	existingMaps := make(map[string][]*knftables.Element)
+	for _, elem := range elements {
+		if elem.Map != "" && len(elem.Value) == 0 && existingMaps[elem.Map] == nil {
+			existingElements, err := nft.ListElements(context.TODO(), "map", elem.Map)
+			if err != nil {
+				return err
+			}
+			existingMaps[elem.Map] = existingElements
+		}
+	}
+
+	// Now build the actual transaction
 	tx := nft.NewTransaction()
 	for _, elem := range elements {
-		// We add+delete the elements, rather than just deleting them, so that if
-		// they weren't already in the set/map, we won't get an error on delete.
+		if elem.Map != "" && len(elem.Value) == 0 {
+			// We can't tx.Add() a Map Element with no Value, so try
+			// to find its existing value in the List output from
+			// above. If the element doesn't appear in that output
+			// then we just skip trying to delete it. Otherwise, we do
+			// the Add+Delete below just like in the normal case; the
+			// Add *should* be a no-op, but doing it anyway makes this
+			// work right even if another thread Deletes the element
+			// before we get to it (as long as they don't add it back
+			// with a different value).
+			elem = findElement(existingMaps[elem.Map], elem.Key)
+			if elem == nil {
+				continue
+			}
+		}
+
+		// Do Add+Delete, which ensures the object is deleted whether or
+		// not it previously existed.
 		tx.Add(elem)
 		tx.Delete(elem)
 	}
 	return nft.Run(context.TODO(), tx)
+}
+
+func findElement(elements []*knftables.Element, key []string) *knftables.Element {
+elemLoop:
+	for _, elem := range elements {
+		if len(elem.Key) != len(key) {
+			// All elements have the same key length, so if one fails, they all fail.
+			return nil
+		}
+		for i := range elem.Key {
+			if elem.Key[i] != key[i] {
+				continue elemLoop
+			}
+		}
+		return elem
+	}
+	return nil
 }

--- a/go-controller/pkg/node/nftables/util_test.go
+++ b/go-controller/pkg/node/nftables/util_test.go
@@ -1,0 +1,252 @@
+//go:build linux
+// +build linux
+
+package nftables
+
+import (
+	"testing"
+
+	"sigs.k8s.io/knftables"
+)
+
+func TestUpdateNFTElements(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		initial string
+		elems   []*knftables.Element
+		final   string
+	}{
+		{
+			name:    "empty transaction",
+			initial: "",
+			elems:   []*knftables.Element{},
+			final:   "add table inet ovn-kubernetes",
+		},
+		{
+			name: "add to empty set",
+			initial: `
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+			`,
+			elems: []*knftables.Element{
+				{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+				{
+					Set: "testset",
+					Key: []string{"5.6.7.8"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+			`,
+		},
+		{
+			name: "re-add existing object",
+			initial: `
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+			`,
+			elems: []*knftables.Element{
+				{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+				{
+					Set: "testset",
+					Key: []string{"5.6.7.8"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+			`,
+		},
+		{
+			name: "add map elements, multiple containers",
+			initial: `
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add map inet ovn-kubernetes testmap { type ipv4_addr : ipv4_addr ; }
+			`,
+			elems: []*knftables.Element{
+				{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+				{
+					Map:   "testmap",
+					Key:   []string{"10.0.0.1"},
+					Value: []string{"9.9.9.9"},
+				},
+				{
+					Set: "testset",
+					Key: []string{"5.6.7.8"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add map inet ovn-kubernetes testmap { type ipv4_addr : ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+				add element inet ovn-kubernetes testmap { 10.0.0.1 : 9.9.9.9 }
+			`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := SetFakeNFTablesHelper()
+			err := fake.ParseDump(tc.initial)
+			if err != nil {
+				t.Fatalf("unexpected error parsing initial state: %v", err)
+			}
+			err = UpdateNFTElements(tc.elems)
+			if err != nil {
+				t.Fatalf("unexpected error updating elements: %v", err)
+			}
+			err = MatchNFTRules(tc.final, fake.Dump())
+			if err != nil {
+				t.Fatalf("unexpected final result: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeleteNFTElements(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		initial string
+		elems   []*knftables.Element
+		final   string
+	}{
+		{
+			name:    "empty transaction",
+			initial: "",
+			elems:   []*knftables.Element{},
+			final:   "add table inet ovn-kubernetes",
+		},
+		{
+			name: "delete existing objects",
+			initial: `
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+			`,
+			elems: []*knftables.Element{
+				{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+				{
+					Set: "testset",
+					Key: []string{"5.6.7.8"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+			`,
+		},
+		{
+			name: "delete non-existing object",
+			initial: `
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+			`,
+			elems: []*knftables.Element{
+				{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+				{
+					Set: "testset",
+					Key: []string{"5.6.7.8"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+			`,
+		},
+		{
+			name: "delete map elements, multiple containers",
+			initial: `
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add map inet ovn-kubernetes testmap { type ipv4_addr : ipv4_addr ; }
+				add element inet ovn-kubernetes testset { 1.2.3.4 }
+				add element inet ovn-kubernetes testset { 5.6.7.8 }
+				add element inet ovn-kubernetes testmap { 10.0.0.1 : 9.9.9.9 }
+			`,
+			elems: []*knftables.Element{
+				{
+					Set: "testset",
+					Key: []string{"1.2.3.4"},
+				},
+				{
+					Map:   "testmap",
+					Key:   []string{"10.0.0.1"},
+					Value: []string{"9.9.9.9"},
+				},
+				{
+					Set: "testset",
+					Key: []string{"5.6.7.8"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add set inet ovn-kubernetes testset { type ipv4_addr ; }
+				add map inet ovn-kubernetes testmap { type ipv4_addr : ipv4_addr ; }
+			`,
+		},
+		{
+			name: "delete map elements without values",
+			initial: `
+				add map inet ovn-kubernetes testmap { type ipv4_addr : ipv4_addr ; }
+				add element inet ovn-kubernetes testmap { 10.0.0.1 : 9.9.9.9 }
+				add element inet ovn-kubernetes testmap { 10.0.0.2 : 8.8.8.8 }
+				add element inet ovn-kubernetes testmap { 10.0.0.3 : 7.7.7.7 }
+				add element inet ovn-kubernetes testmap { 10.0.0.4 : 6.6.6.6 }
+			`,
+			elems: []*knftables.Element{
+				{
+					Map: "testmap",
+					Key: []string{"10.0.0.1"},
+				},
+				{
+					Map: "testmap",
+					Key: []string{"10.0.0.3"},
+				},
+				{
+					Map: "testmap",
+					Key: []string{"10.0.0.5"},
+				},
+			},
+			final: `
+				add table inet ovn-kubernetes
+				add map inet ovn-kubernetes testmap { type ipv4_addr : ipv4_addr ; }
+				add element inet ovn-kubernetes testmap { 10.0.0.2 : 8.8.8.8 }
+				add element inet ovn-kubernetes testmap { 10.0.0.4 : 6.6.6.6 }
+			`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := SetFakeNFTablesHelper()
+			err := fake.ParseDump(tc.initial)
+			if err != nil {
+				t.Fatalf("unexpected error parsing initial state: %v", err)
+			}
+			err = DeleteNFTElements(tc.elems)
+			if err != nil {
+				t.Fatalf("unexpected error deleting objects: %v", err)
+			}
+			err = MatchNFTRules(tc.final, fake.Dump())
+			if err != nil {
+				t.Fatalf("unexpected final result: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Alternative to #6009 which is more compatible with future iptables→nftables porting plans.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFTables map element deletion by preloading existing map contents and verifying existence before removal, avoiding unnecessary operations.

* **Tests**
  * Added comprehensive Linux-only tests covering NFTables element updates and deletions, including map elements and non-existent objects.

* **Refactor**
  * Unified UDN rule deletion into the general NFT deletion flow when Network Segmentation is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->