### PR TITLE
[wip] Stop skipping serial k8s tests

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -13,10 +13,6 @@ env:
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true
   KIND_ALLOW_SYSTEM_WRITES: true
-  # This skips tests tagged as Serial
-  # Current Serial tests are not relevant for OVN
-  PARALLEL: true
-
   # This must be a directory
   CI_IMAGE_CACHE: tmp/image_cache/
   CI_IMAGE_BASE_TAR: image-base.tar

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -13,8 +13,8 @@ env:
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true
   KIND_ALLOW_SYSTEM_WRITES: true
-  # This skips tests tagged as Serial for most lanes
-  # Serial tests are run in a dedicated lane
+  # This skips tests tagged as Serial
+  # Current Serial tests are not relevant for OVN
   PARALLEL: true
 
   # This must be a directory
@@ -93,8 +93,6 @@ jobs:
       ENABLE_PRE_CONF_UDN_ADDR: "${{ matrix.ic == 'ic-single-node-zones' && (matrix.target == 'network-segmentation' || matrix.network-segmentation == 'enable-network-segmentation') }}"
       ENABLE_NETWORK_CONNECT: "${{ matrix.target == 'network-segmentation' }}"
       ADVERTISED_UDN_ISOLATION_MODE: "${{ matrix.advertised-udn-isolation-mode }}"
-      # Override PARALLEL=true for Serial tests target to run Serial tests
-      PARALLEL: "${{ matrix.target != 'serial' }}"
       OVN_UNPRIVILEGED_MODE: "${{ matrix.cni-mode == 'unprivileged' }}"
       MULTI_POD_SUBNET: true
       # Performance test specific settings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,6 @@ env:
   KIND_INSTALL_INGRESS: true
   KIND_ALLOW_SYSTEM_WRITES: true
   ENABLE_COREDUMPS: true
-  # This skips tests tagged as Serial
-  # Current Serial tests are not relevant for OVN
-  PARALLEL: true
-
   # This must be a directory
   CI_IMAGE_CACHE: tmp/image_cache/
   CI_IMAGE_BASE_TAR: image-base.tar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ env:
   KIND_INSTALL_INGRESS: true
   KIND_ALLOW_SYSTEM_WRITES: true
   ENABLE_COREDUMPS: true
-  # This skips tests tagged as Serial for most lanes
-  # Serial tests are run in a dedicated lane
+  # This skips tests tagged as Serial
+  # Current Serial tests are not relevant for OVN
   PARALLEL: true
 
   # This must be a directory
@@ -449,7 +449,7 @@ jobs:
       fail-fast: false
       matrix:
         # Valid options are:
-        # target: ["shard-conformance", "control-plane", "multi-homing", "multi-node-zones", "node-ip-mac-migration", "compact-mode", "serial"]
+        # target: ["shard-conformance", "control-plane", "multi-homing", "multi-node-zones", "node-ip-mac-migration", "compact-mode"]
         #         shard-conformance: hybrid-overlay = multicast-enable = emptylb-enable = false
         #         control-plane: hybrid-overlay = multicast-enable = emptylb-enable = true
         # ha: ["HA", "noHA"]
@@ -507,7 +507,6 @@ jobs:
           - {"target": "bgp-loose-isolation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "advertised-udn-isolation-mode": "loose"}
           - {"target": "traffic-flow-test-only","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "traffic-flow-tests": "1-24", "network-segmentation": "enable-network-segmentation"}
           - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "network-segmentation": "enable-network-segmentation"}
-          - {"target": "serial", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
@@ -540,8 +539,6 @@ jobs:
       ENABLE_NETWORK_CONNECT: "${{ startsWith(matrix.target, 'network-segmentation') }}"
       ENABLE_PRE_CONF_UDN_ADDR: "${{ matrix.ic == 'ic-single-node-zones' && (startsWith(matrix.target, 'network-segmentation') || matrix.network-segmentation == 'enable-network-segmentation') }}"
       ADVERTISED_UDN_ISOLATION_MODE: "${{ matrix.advertised-udn-isolation-mode }}"
-      # Override PARALLEL=true for Serial tests target to run Serial tests
-      PARALLEL: "${{ matrix.target != 'serial' }}"
       OVN_UNPRIVILEGED_MODE: "${{ matrix.cni-mode == 'unprivileged' }}"
       MULTI_POD_SUBNET: true
       DYNAMIC_UDN_ALLOCATION: "${{ matrix.target == 'network-segmentation-dynamic' }}"
@@ -715,9 +712,6 @@ jobs:
           make -C test control-plane WHAT="ClusterNetworkConnect"
         elif [[ "${{ matrix.target }}" == bgp* ]]; then
           make -C test control-plane
-        elif [ "${{ matrix.target }}" == "serial" ]; then
-          # Run only Serial tests with ginkgo focus
-          make -C test control-plane WHAT=Serial
         elif [ "${{ matrix.target }}" == "tools" ]; then
           make -C go-controller build
           make -C test tools

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -198,11 +198,40 @@ func NewBridgeConfiguration(intfName, nodeName,
 	if len(gwIPs) > 0 {
 		// use gwIPs if provided
 		res.ips = gwIPs
+		// After a node restart (e.g. docker stop/start), the bridge interface
+		// may exist in OVS but have lost its kernel IP addresses. The gwIPs
+		// came from reading the uplink interface, but weren't moved to the bridge.
+		// Check if the bridge actually has IPs; if not, re-migrate from uplink.
+		if res.uplinkName != "" {
+			if _, checkErr := nodeutil.GetNetworkInterfaceIPAddresses(gwIntf); checkErr != nil {
+				klog.Warningf("Bridge %s has gwIPs but no kernel IP addresses, migrating from uplink %s: %v",
+					gwIntf, res.uplinkName, checkErr)
+				if _, migrateErr := util.NicToBridge(res.uplinkName); migrateErr != nil {
+					klog.Warningf("Failed to migrate IPs from %s to %s: %v", res.uplinkName, gwIntf, migrateErr)
+				} else {
+					klog.Infof("Successfully migrated IP addresses from %s to bridge %s after restart", res.uplinkName, gwIntf)
+				}
+			}
+		}
 	} else {
 		// get IP addresses from OVS bridge. If IP does not exist,
 		// error out.
 		res.ips, err = nodeutil.GetNetworkInterfaceIPAddresses(gwIntf)
-		if err != nil {
+		if err != nil && res.uplinkName != "" {
+			// The bridge may have lost its IP addresses after a node restart
+			// (IPs are kernel state, not persisted across container restarts).
+			// Re-migrate IPs and routes from the uplink NIC to the bridge.
+			klog.Warningf("Bridge %s has no IP addresses, attempting to migrate from uplink %s: %v", gwIntf, res.uplinkName, err)
+			if _, migrateErr := util.NicToBridge(res.uplinkName); migrateErr != nil {
+				return nil, fmt.Errorf("failed to get interface details for %s (%v) and failed to migrate IPs from %s: %v",
+					gwIntf, err, res.uplinkName, migrateErr)
+			}
+			res.ips, err = nodeutil.GetNetworkInterfaceIPAddresses(gwIntf)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get interface details for %s after IP migration from %s: %w", gwIntf, res.uplinkName, err)
+			}
+			klog.Infof("Successfully migrated IP addresses from %s to %s", res.uplinkName, gwIntf)
+		} else if err != nil {
 			return nil, fmt.Errorf("failed to get interface details for %s: %w", gwIntf, err)
 		}
 	}
@@ -549,8 +578,14 @@ func getIntfName(gatewayIntf string) (string, error) {
 	}
 	_, stderr, err := util.RunOVSVsctl("get", "interface", intfName, "ofport")
 	if err != nil {
-		return "", fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
-			intfName, stderr, err)
+		klog.Warningf("Uplink port %s not found on bridge %s (stderr: %q), attempting to re-add it", intfName, gatewayIntf, stderr)
+		_, stderr, addErr := util.RunOVSVsctl(
+			"--", "--may-exist", "add-port", gatewayIntf, intfName,
+			"--", "set", "port", intfName, "other-config:transient=true")
+		if addErr != nil {
+			return "", fmt.Errorf("failed to re-add uplink port %s to bridge %s: stderr: %q, error: %v (original error: %v)",
+				intfName, gatewayIntf, stderr, addErr, err)
+		}
 	}
 	return intfName, nil
 }

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -40,19 +40,12 @@ skip() {
   SKIPPED_TESTS+=$*
 }
 
-LABELED_TESTS=""
+SKIPPED_LABELED_TESTS=""
 skip_label() {
-  if [ "$LABELED_TESTS" != "" ]; then
-  	LABELED_TESTS+=" && "
+  if [ "$SKIPPED_LABELED_TESTS" != "" ]; then
+  	SKIPPED_LABELED_TESTS+=" && "
   fi
-  LABELED_TESTS+="!($*)"
-}
-
-require_label() {
-  if [ "$LABELED_TESTS" != "" ]; then
-  	LABELED_TESTS+=" && "
-  fi
-  LABELED_TESTS+="$*"
+  SKIPPED_LABELED_TESTS+="!($*)"
 }
 
 if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
@@ -155,12 +148,6 @@ if [[ "${WHAT}" != "${CLUSTER_NETWORK_CONNECT_TESTS}"* ]]; then
   skip $CLUSTER_NETWORK_CONNECT_TESTS
 fi
 
-SERIAL_LABEL="Serial"
-if [[ "${WHAT}" = "$SERIAL_LABEL" ]]; then
-  require_label "$SERIAL_LABEL"
-  shift # don't "focus" on Serial since we filter by label
-fi
-
 if [ "$ENABLE_ROUTE_ADVERTISEMENTS" != true ]; then
   skip_label "Feature:RouteAdvertisements"
 else
@@ -227,7 +214,7 @@ fi
 if [ "${PARALLEL:-false}" = "true" ]; then
   export GINKGO_PARALLEL=y
   export GINKGO_PARALLEL_NODES=10
-  skip_label "$SERIAL_LABEL"
+  skip "[Serial]"
 fi
 
 if [ "$ENABLE_NO_OVERLAY" == true ]; then
@@ -266,7 +253,7 @@ go test -test.timeout ${GO_TEST_TIMEOUT}m -v . \
         -ginkgo.timeout ${TEST_TIMEOUT}m \
         -ginkgo.flake-attempts ${FLAKE_ATTEMPTS:-2} \
         -ginkgo.skip="${SKIPPED_TESTS}" \
-        ${LABELED_TESTS:+-ginkgo.label-filter="${LABELED_TESTS}"} \
+        ${SKIPPED_LABELED_TESTS:+-ginkgo.label-filter="${SKIPPED_LABELED_TESTS}"} \
         -ginkgo.junit-report=${E2E_REPORT_DIR}/junit_${E2E_REPORT_PREFIX}report.xml \
         -provider skeleton \
         -kubeconfig ${KUBECONFIG} \

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -210,13 +210,6 @@ else
   fi
 fi
 
-# if we set PARALLEL=true, skip serial test
-if [ "${PARALLEL:-false}" = "true" ]; then
-  export GINKGO_PARALLEL=y
-  export GINKGO_PARALLEL_NODES=10
-  skip "[Serial]"
-fi
-
 if [ "$ENABLE_NO_OVERLAY" == true ]; then
   # No-overlay mode uses underlying network infrastructure directly.
   # Overlay-dependent features are not supported.
@@ -246,6 +239,7 @@ GO_TEST_TIMEOUT=$((TEST_TIMEOUT + 5))
 
 pushd e2e
 
+# Note: currently all tests are run serially.
 go mod download
 go test -test.timeout ${GO_TEST_TIMEOUT}m -v . \
         -ginkgo.v \

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -159,13 +159,6 @@ fi
 
 SKIPPED_TESTS="$(groomTestList "${SKIPPED_TESTS}")"
 
-# if we set PARALLEL=true, skip serial test
-if [ "${PARALLEL:-false}" = "true" ]; then
-  export GINKGO_PARALLEL=y
-  export GINKGO_PARALLEL_NODES=10
-  SKIPPED_TESTS="${SKIPPED_TESTS}|\\[Serial\\]"
-fi
-
 case "$SHARD" in
 	shard-network)
 		FOCUS="\\[sig-network\\]"


### PR DESCRIPTION
Remove the PARALLEL env variable and associated logic that was unconditionally skipping all [Serial] tagged upstream Kubernetes tests. It was a confusing naming choice suggesting we ran our E2Es in parallel.

e2e-kind.sh uses `ginkgo --nodes=N` which handles serial tests at the end.
Reverts https://github.com/ovn-kubernetes/ovn-kubernetes/commit/bc9eacac17062500e81e78f951196cd14eb64c71 because we run our tests serially anyway. 

Lets see if anything breaks in the k8s serial e2es, will need to check how much longer our lanes take. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime network reliability by adding automatic recovery when gateway uplinks or bridge IPs are missing, with migration attempts, retries and clearer error reporting.

* **Chores**
  * Simplified CI and end-to-end test orchestration: removed legacy serial-test paths and explicit parallel-override behavior, and streamlined label-based test selection to use skip-based filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->