### PR TITLE
Fixes Dynamic UDN + CNC integration

### DIFF
--- a/go-controller/pkg/factory/mocks/NodeWatchFactory.go
+++ b/go-controller/pkg/factory/mocks/NodeWatchFactory.go
@@ -13,6 +13,7 @@ import (
 
 	egressipv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions/egressip/v1"
 
+	clusternetworkconnectv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1/apis/informers/externalversions/clusternetworkconnect/v1"
 	factory "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 
 	informerscorev1 "k8s.io/client-go/informers/core/v1"
@@ -221,6 +222,26 @@ func (_m *NodeWatchFactory) ClusterUserDefinedNetworkInformer() userdefinednetwo
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(userdefinednetworkv1.ClusterUserDefinedNetworkInformer)
+		}
+	}
+
+	return r0
+}
+
+// ClusterNetworkConnectInformer provides a mock function with no fields
+func (_m *NodeWatchFactory) ClusterNetworkConnectInformer() clusternetworkconnectv1.ClusterNetworkConnectInformer {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClusterNetworkConnectInformer")
+	}
+
+	var r0 clusternetworkconnectv1.ClusterNetworkConnectInformer
+	if rf, ok := ret.Get(0).(func() clusternetworkconnectv1.ClusterNetworkConnectInformer); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(clusternetworkconnectv1.ClusterNetworkConnectInformer)
 		}
 	}
 

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	adminpolicybasedrouteinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/informers/externalversions/adminpolicybasedroute/v1"
+	networkconnectinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1/apis/informers/externalversions/clusternetworkconnect/v1"
 	egressipinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions/egressip/v1"
 	routeadvertisementsinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions/routeadvertisements/v1"
 	userdefinednetworkinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/userdefinednetwork/v1"
@@ -66,6 +67,7 @@ type NodeWatchFactory interface {
 	APBRouteInformer() adminpolicybasedrouteinformer.AdminPolicyBasedExternalRouteInformer
 	EgressIPInformer() egressipinformer.EgressIPInformer
 	NADInformer() nadinformer.NetworkAttachmentDefinitionInformer
+	ClusterNetworkConnectInformer() networkconnectinformer.ClusterNetworkConnectInformer
 	UserDefinedNetworkInformer() userdefinednetworkinformer.UserDefinedNetworkInformer
 	ClusterUserDefinedNetworkInformer() userdefinednetworkinformer.ClusterUserDefinedNetworkInformer
 	RouteAdvertisementsInformer() routeadvertisementsinformer.RouteAdvertisementsInformer

--- a/go-controller/pkg/networkmanager/api.go
+++ b/go-controller/pkg/networkmanager/api.go
@@ -32,6 +32,17 @@ const (
 // NADReconciler is a level-driven controller notified of NAD key changes.
 type NADReconciler controller.Reconciler
 
+// NetworkRefReconciler is notified when node network activity changes.
+// The network is identified by name because activity can be observed before
+// the NAD controller has fully resolved the network into a local netInfo/ID.
+//
+// These are edge-style notifications. Controllers that need eventual
+// correctness after NAD/ID changes should also register an NADReconciler and
+// treat NAD callbacks as a catch-up signal.
+type NetworkRefReconciler interface {
+	Reconcile(node string, networkName string)
+}
+
 type watchFactory interface {
 	NADInformer() nadinformers.NetworkAttachmentDefinitionInformer
 	ClusterNetworkConnectInformer() networkconnectinformer.ClusterNetworkConnectInformer
@@ -96,6 +107,13 @@ type Interface interface {
 	RegisterNADReconciler(r NADReconciler) uint64
 	// DeRegisterNADReconciler removes a previously registered reconciler.
 	DeRegisterNADReconciler(id uint64)
+	// RegisterNetworkRefReconciler registers a reconciler to be notified when
+	// node network activity changes.
+	// Pair this with RegisterNADReconciler when the controller needs both
+	// immediate activity signals and eventual catch-up after NAD/ID changes.
+	RegisterNetworkRefReconciler(r NetworkRefReconciler) uint64
+	// DeRegisterNetworkRefReconciler removes a previously registered reconciler.
+	DeRegisterNetworkRefReconciler(id uint64)
 
 	// GetNetworkByID returns the network with the given ID or nil if not found.
 	// This is an O(1) lookup using an internal index.
@@ -305,6 +323,12 @@ func (nm defaultNetworkManager) RegisterNADReconciler(_ NADReconciler) uint64 {
 }
 
 func (nm defaultNetworkManager) DeRegisterNADReconciler(_ uint64) {}
+
+func (nm defaultNetworkManager) RegisterNetworkRefReconciler(_ NetworkRefReconciler) uint64 {
+	return 0
+}
+
+func (nm defaultNetworkManager) DeRegisterNetworkRefReconciler(_ uint64) {}
 
 func (nm defaultNetworkManager) GetNetworkByID(id int) util.NetInfo {
 	if id != types.DefaultNetworkID {

--- a/go-controller/pkg/networkmanager/api.go
+++ b/go-controller/pkg/networkmanager/api.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/id"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
+	networkconnectinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1/apis/informers/externalversions/clusternetworkconnect/v1"
 	egressipinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions/egressip/v1"
 	rainformers "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions/routeadvertisements/v1"
 	userdefinednetworkinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/userdefinednetwork/v1"
@@ -33,6 +34,7 @@ type NADReconciler controller.Reconciler
 
 type watchFactory interface {
 	NADInformer() nadinformers.NetworkAttachmentDefinitionInformer
+	ClusterNetworkConnectInformer() networkconnectinformer.ClusterNetworkConnectInformer
 	UserDefinedNetworkInformer() userdefinednetworkinformer.UserDefinedNetworkInformer
 	ClusterUserDefinedNetworkInformer() userdefinednetworkinformer.ClusterUserDefinedNetworkInformer
 	NamespaceInformer() coreinformers.NamespaceInformer

--- a/go-controller/pkg/networkmanager/fake.go
+++ b/go-controller/pkg/networkmanager/fake.go
@@ -61,9 +61,11 @@ type FakeNetworkManager struct {
 	// if netInfo is nil, it represents a namespace which contains the required UDN label but with no valid network. It will return invalid network error.
 	PrimaryNetworks map[string]util.NetInfo
 	// nad key -> netInfo for non-primary lookups
-	NADNetworks map[string]util.NetInfo
-	Reconcilers []reconcilerRegistration
-	nextID      uint64
+	NADNetworks           map[string]util.NetInfo
+	Reconcilers           []reconcilerRegistration
+	NetworkRefReconcilers []networkRefReconcilerRegistration
+	nextID                uint64
+	nextNetworkRefID      uint64
 	// UDNNamespaces are a list of namespaces that require UDN for primary network
 	UDNNamespaces sets.Set[string]
 	// ActiveNodes tracks node activity per network for Dynamic UDN tests.
@@ -85,6 +87,26 @@ func (fnm *FakeNetworkManager) DeRegisterNADReconciler(id uint64) {
 	for i, rec := range fnm.Reconcilers {
 		if rec.id == id {
 			fnm.Reconcilers = append(fnm.Reconcilers[:i], fnm.Reconcilers[i+1:]...)
+			return
+		}
+	}
+}
+
+func (fnm *FakeNetworkManager) RegisterNetworkRefReconciler(r NetworkRefReconciler) uint64 {
+	fnm.Lock()
+	defer fnm.Unlock()
+	fnm.nextNetworkRefID++
+	id := fnm.nextNetworkRefID
+	fnm.NetworkRefReconcilers = append(fnm.NetworkRefReconcilers, networkRefReconcilerRegistration{id: id, r: r})
+	return id
+}
+
+func (fnm *FakeNetworkManager) DeRegisterNetworkRefReconciler(id uint64) {
+	fnm.Lock()
+	defer fnm.Unlock()
+	for i, rec := range fnm.NetworkRefReconcilers {
+		if rec.id == id {
+			fnm.NetworkRefReconcilers = append(fnm.NetworkRefReconcilers[:i], fnm.NetworkRefReconcilers[i+1:]...)
 			return
 		}
 	}
@@ -239,6 +261,11 @@ func (fnm *FakeNetworkManager) GetNetworkByID(id int) util.NetInfo {
 	defer fnm.Unlock()
 	for _, ni := range fnm.PrimaryNetworks {
 		if ni.GetNetworkID() == id {
+			return ni
+		}
+	}
+	for _, ni := range fnm.NADNetworks {
+		if ni != nil && ni.GetNetworkID() == id {
 			return ni
 		}
 	}

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -29,6 +29,8 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/id"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
+	networkconnectv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1"
+	networkconnectlister "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1/apis/listers/clusternetworkconnect/v1"
 	userdefinednetworklister "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/listers/userdefinednetwork/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -56,9 +58,13 @@ type nadController struct {
 	cudnLister      userdefinednetworklister.ClusterUserDefinedNetworkLister
 	namespaceLister corelisters.NamespaceLister
 	nodeLister      corelisters.NodeLister
+	cncLister       networkconnectlister.ClusterNetworkConnectLister
 
 	controller controller.Controller
-	recorder   record.EventRecorder
+	// cncController tracks CNC connectivity and updates derived
+	// network activity for Dynamic UDN filtering.
+	cncController controller.Controller
+	recorder      record.EventRecorder
 
 	// networkController reconciles network specific controllers
 	networkController *networkController
@@ -70,6 +76,15 @@ type nadController struct {
 	// dynamicFilterNADs tracks whether a NAD should be activity-gated by Dynamic UDN.
 	// Bare NADs are not filtered and therefore should be treated as present on all nodes.
 	dynamicFilterNADs map[string]bool
+	// cncSelectedNetworks tracks network names selected by each CNC.
+	cncSelectedNetworks map[string]sets.Set[string]
+	// cncNetworkIDs tracks owner network IDs referenced by each CNC.
+	cncNetworkIDs map[string]sets.Set[int]
+	// cncsByNetworkID indexes CNCs by their referenced owner network IDs.
+	cncsByNetworkID map[int]sets.Set[string]
+	// cncConnectedNetworks is a symmetric adjacency map where key/value are
+	// network names connected through a CNC.
+	cncConnectedNetworks map[string]sets.Set[string]
 
 	// primaryNADs holds a mapping of namespace to NAD of primary UDNs
 	primaryNADs map[string]string
@@ -111,18 +126,22 @@ func newController(
 ) (*nadController, error) {
 	networkController := newNetworkController(name, zone, node, cm, wf)
 	c := &nadController{
-		name:              fmt.Sprintf("[%s NAD controller]", name),
-		stopChan:          make(chan struct{}),
-		recorder:          recorder,
-		nadLister:         wf.NADInformer().Lister(),
-		nodeLister:        wf.NodeCoreInformer().Lister(),
-		networkController: networkController,
-		reconcilers:       map[uint64]reconcilerRegistration{},
-		nads:              map[string]string{},
-		nadsByNetwork:     map[string]sets.Set[string]{},
-		dynamicFilterNADs: map[string]bool{},
-		primaryNADs:       map[string]string{},
-		markedForRemoval:  map[string]time.Time{},
+		name:                 fmt.Sprintf("[%s NAD controller]", name),
+		stopChan:             make(chan struct{}),
+		recorder:             recorder,
+		nadLister:            wf.NADInformer().Lister(),
+		nodeLister:           wf.NodeCoreInformer().Lister(),
+		networkController:    networkController,
+		reconcilers:          map[uint64]reconcilerRegistration{},
+		nads:                 map[string]string{},
+		nadsByNetwork:        map[string]sets.Set[string]{},
+		dynamicFilterNADs:    map[string]bool{},
+		cncSelectedNetworks:  map[string]sets.Set[string]{},
+		cncNetworkIDs:        map[string]sets.Set[int]{},
+		cncsByNetworkID:      map[int]sets.Set[string]{},
+		cncConnectedNetworks: map[string]sets.Set[string]{},
+		primaryNADs:          map[string]string{},
+		markedForRemoval:     map[string]time.Time{},
 	}
 	networkController.getNADKeysForNetwork = c.GetNADKeysForNetwork
 
@@ -136,6 +155,21 @@ func newController(
 			c.eipReconcilerID = eipID
 		}
 		c.filterNADsOnNode = filterNADsOnNode
+		if util.IsNetworkConnectEnabled() {
+			cncInformer := wf.ClusterNetworkConnectInformer()
+			c.cncLister = cncInformer.Lister()
+			c.cncController = controller.NewController(
+				fmt.Sprintf("%s-cnc-connectivity-controller", c.name),
+				&controller.ControllerConfig[networkconnectv1.ClusterNetworkConnect]{
+					RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+					Informer:       cncInformer.Informer(),
+					Lister:         c.cncLister.List,
+					Reconcile:      c.syncCNC,
+					ObjNeedsUpdate: c.cncNeedsUpdate,
+					Threadiness:    1,
+				},
+			)
+		}
 	}
 
 	c.networkController.nodeHasNetwork = c.NodeHasNetwork
@@ -183,7 +217,7 @@ func newController(
 	return c, nil
 }
 
-func (c *nadController) nodeHasNAD(node, nad string) bool {
+func (c *nadController) nodeHasDirectNAD(node, nad string) bool {
 	if !config.OVNKubernetesFeature.EnableDynamicUDNAllocation {
 		return true
 	}
@@ -192,6 +226,66 @@ func (c *nadController) nodeHasNAD(node, nad string) bool {
 	}
 	if c.egressIPTracker != nil && c.egressIPTracker.NodeHasNAD(node, nad) {
 		return true
+	}
+	return false
+}
+
+// nodeHasNAD reports whether a node should render the given NAD. A Dynamic UDN
+// NAD is active when its network is active; the network can be active through
+// any of its NADs' pod/EgressIP refs or through a CNC-connected network.
+// syncNAD records this NAD in nadsByNetwork before filtering, so the network
+// activity lookup can include the current NAD and all same-network peers.
+// Caller must hold nadController lock.
+func (c *nadController) nodeHasNAD(node string, nad *nettypes.NetworkAttachmentDefinition) bool {
+	if !config.OVNKubernetesFeature.EnableDynamicUDNAllocation {
+		return true
+	}
+	nadKey := util.GetNADName(nad.Namespace, nad.Name)
+	networkName := c.nads[nadKey]
+	if networkName == "" {
+		nadNetwork, err := util.ParseNADInfo(nad)
+		if err != nil || nadNetwork == nil {
+			return false
+		}
+		networkName = nadNetwork.GetNetworkName()
+	}
+
+	return c.nodeHasNetworkNoLock(node, networkName)
+}
+
+// nodeHasDirectNetworkNoLock reports whether the node has any direct NAD
+// reference for the provided network.
+// Caller must hold nadController lock.
+func (c *nadController) nodeHasDirectNetworkNoLock(node, networkName string) bool {
+	if networkName == "" {
+		return false
+	}
+	nadSet := c.nadsByNetwork[networkName]
+	if len(nadSet) == 0 {
+		return false
+	}
+	for nad := range nadSet {
+		if !c.dynamicFilterNADs[nad] {
+			return true
+		}
+		if c.nodeHasDirectNAD(node, nad) {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeHasNetworkNoLock reports whether the node is active for the network
+// either directly or via CNC-connected networks.
+// Caller must hold nadController lock.
+func (c *nadController) nodeHasNetworkNoLock(node, networkName string) bool {
+	if c.nodeHasDirectNetworkNoLock(node, networkName) {
+		return true
+	}
+	for connectedNetwork := range c.cncConnectedNetworks[networkName] {
+		if c.nodeHasDirectNetworkNoLock(node, connectedNetwork) {
+			return true
+		}
 	}
 	return false
 }
@@ -207,21 +301,8 @@ func (c *nadController) NodeHasNetwork(node, networkName string) bool {
 		return true
 	}
 	c.RLock()
-	nadSet := c.nadsByNetwork[networkName]
-	var nads []string
-	if len(nadSet) != 0 {
-		nads = nadSet.UnsortedList()
-	}
-	c.RUnlock()
-	for _, nad := range nads {
-		if !c.nadUsesDynamicFiltering(nad) {
-			return true
-		}
-		if c.nodeHasNAD(node, nad) {
-			return true
-		}
-	}
-	return false
+	defer c.RUnlock()
+	return c.nodeHasNetworkNoLock(node, networkName)
 }
 
 func nadRequiresDynamicFiltering(nad *nettypes.NetworkAttachmentDefinition) bool {
@@ -231,12 +312,6 @@ func nadRequiresDynamicFiltering(nad *nettypes.NetworkAttachmentDefinition) bool
 	}
 
 	return ownerRef.Kind == "ClusterUserDefinedNetwork" || ownerRef.Kind == "UserDefinedNetwork"
-}
-
-func (c *nadController) nadUsesDynamicFiltering(nadKey string) bool {
-	c.RLock()
-	defer c.RUnlock()
-	return c.dynamicFilterNADs[nadKey]
 }
 
 // addNADToNetworkLocked must be called with nadController locked
@@ -273,13 +348,14 @@ func (c *nadController) deleteNADFromNetworkLocked(networkName, nadKey string) {
 // OnNetworkRefChange is a callback function used to signal an action to this controller when
 // a network needs to be added or removed or just updated.
 // Used as a callback for pod/egress IP events when dynamic UDN allocation is enabled.
-// This callback is invoked by pod/egress IP trackers and is blocking. Therefore it's work should be as lightweight
+// This callback is invoked by pod/egress IP trackers and is blocking. Therefore its work should be as lightweight
 // as possible.
 // The function handles:
 //  1. Queuing local node event NADs to the NAD Controller for reconciliation later in the NAD Controller worker.
 //  2. Queuing remote node event networks to the Network Manager for reconciliation later in the Network Manager worker.
 //
-// This function should never call into the trackers (i.e. nodeHasNAD) as it would cause deadlock.
+// Trackers invoke this callback after releasing their cache locks, so local
+// activity checks are safe here but should stay brief.
 func (c *nadController) OnNetworkRefChange(node, nadNamespacedName string, active bool) {
 	klog.V(4).Infof("%s Network change for zone controller triggered by pod/egress IP events "+
 		"on node: %s, NAD: %s, active: %t", c.name, node, nadNamespacedName, active)
@@ -330,9 +406,74 @@ func (c *nadController) OnNetworkRefChange(node, nadNamespacedName string, activ
 	}
 	// Let the NAD controller handle lifecycle/teardown decisions asynchronously for local networks only.
 	if isLocal {
-		c.updateNADState(nadNamespacedName, active)
+		c.reconcileNetworkActivity(c.getNetworkAndConnectedNetworks(networkName), active, networkName, nadNamespacedName)
 	}
 
+}
+
+// getNetworkAndConnectedNetworks returns the provided network and all networks
+// directly connected to it through CNC connectivity.
+func (c *nadController) getNetworkAndConnectedNetworks(networkName string) []string {
+	if networkName == "" {
+		return nil
+	}
+	c.RLock()
+	defer c.RUnlock()
+
+	networks := make([]string, 0, len(c.cncConnectedNetworks[networkName])+1)
+	networks = append(networks, networkName)
+	for connectedNetwork := range c.cncConnectedNetworks[networkName] {
+		networks = append(networks, connectedNetwork)
+	}
+	return networks
+}
+
+// reconcileNetworkActivity updates Dynamic UDN removal state and requeues NAD
+// sync for all NADs belonging to the provided networks. changedNADActive is
+// used only for changedNADKey's own network, preserving direct activity before
+// NAD/network caches know about the key while still deriving CNC peer activity
+// from the current adjacency snapshot.
+func (c *nadController) reconcileNetworkActivity(networkNames []string, changedNADActive bool, changedNetworkName, changedNADKey string) {
+	if len(networkNames) == 0 {
+		return
+	}
+
+	seenNADs := sets.New[string]()
+	for _, networkName := range networkNames {
+		if networkName == "" {
+			continue
+		}
+		nadKeys := sets.New[string](c.GetNADKeysForNetwork(networkName)...)
+		if networkName == changedNetworkName && changedNADKey != "" {
+			// Tracker events can arrive before syncNAD has populated
+			// nadsByNetwork for this NAD. Include the changed key so the
+			// first activity event still requeues the NAD.
+			nadKeys.Insert(changedNADKey)
+		}
+		if len(nadKeys) == 0 {
+			continue
+		}
+
+		active := false
+		if c.filterNADsOnNode != "" {
+			active = c.NodeHasNetwork(c.filterNADsOnNode, networkName)
+			if !active && changedNADActive && networkName == changedNetworkName {
+				active = true
+			}
+		}
+
+		for nadKey := range nadKeys {
+			if seenNADs.Has(nadKey) {
+				continue
+			}
+			seenNADs.Insert(nadKey)
+			if c.filterNADsOnNode != "" {
+				c.updateNADState(nadKey, active)
+				continue
+			}
+			c.reconcile(nadKey)
+		}
+	}
 }
 
 // filter should only be called if cm.filterNADsOnNode is set
@@ -343,8 +484,8 @@ func (c *nadController) filter(nad *nettypes.NetworkAttachmentDefinition) (bool,
 
 	ourNode := c.filterNADsOnNode
 
-	// we don't support multiple nodes per zone, assume zone name is node name
-	if c.nodeHasNAD(ourNode, util.GetNADName(nad.Namespace, nad.Name)) {
+	// We don't support multiple nodes per zone; assume zone name is node name.
+	if c.nodeHasNAD(ourNode, nad) {
 		return false, nil
 	}
 
@@ -365,6 +506,16 @@ func (c *nadController) Start() error {
 	)
 	if err != nil {
 		return err
+	}
+
+	if c.cncController != nil {
+		err = controller.StartWithInitialSync(
+			c.syncAllCNCs,
+			c.cncController,
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Pod and Egress IP Trackers start and process existing pods/egress IPs.
@@ -399,6 +550,9 @@ func (c *nadController) Stop() {
 		close(c.stopChan)
 	})
 	controller.Stop(c.controller)
+	if c.cncController != nil {
+		controller.Stop(c.cncController)
+	}
 	c.networkController.Stop()
 	if c.podReconcilerID != 0 {
 		c.DeRegisterNADReconciler(c.podReconcilerID)
@@ -411,6 +565,235 @@ func (c *nadController) Stop() {
 	}
 	if c.egressIPTracker != nil {
 		c.egressIPTracker.Stop()
+	}
+}
+
+// cncNeedsUpdate decides if a CNC update may change derived activity mapping.
+func (c *nadController) cncNeedsUpdate(oldObj, newObj *networkconnectv1.ClusterNetworkConnect) bool {
+	if oldObj == nil || newObj == nil {
+		return true
+	}
+	return !reflect.DeepEqual(oldObj.Spec.Connectivity, newObj.Spec.Connectivity) ||
+		util.NetworkConnectSubnetAnnotationChanged(oldObj, newObj)
+}
+
+// networkNameForIDLocked resolves a network name from the cached network ID.
+// Caller must hold nadController lock.
+func (c *nadController) networkNameForIDLocked(networkID int) string {
+	if networkID == types.InvalidID {
+		return ""
+	}
+	for networkName := range c.nadsByNetwork {
+		if c.networkIDAllocator.GetID(networkName) == networkID {
+			return networkName
+		}
+	}
+	return ""
+}
+
+func (c *nadController) networkSelectionsForCNC(cnc *networkconnectv1.ClusterNetworkConnect) (sets.Set[string], sets.Set[int]) {
+	selectedNetworks := sets.New[string]()
+	networkIDs := sets.New[int]()
+	subnets, err := util.ParseNetworkConnectSubnetAnnotation(cnc)
+	if err != nil {
+		return selectedNetworks, networkIDs
+	}
+
+	c.RLock()
+	defer c.RUnlock()
+	for owner := range subnets {
+		_, networkID, err := util.ParseNetworkOwner(owner)
+		if err != nil {
+			continue
+		}
+		networkIDs.Insert(networkID)
+		networkName := c.networkNameForIDLocked(networkID)
+		if networkName == "" {
+			continue
+		}
+		selectedNetworks.Insert(networkName)
+	}
+	return selectedNetworks, networkIDs
+}
+
+// buildCNCConnectedNetworks returns network name -> connected peer network names
+// derived from each CNC's selected network set.
+func buildCNCConnectedNetworks(selectedNetworksByCNC map[string]sets.Set[string]) map[string]sets.Set[string] {
+	connectedNetworks := map[string]sets.Set[string]{}
+	for _, selectedNetworks := range selectedNetworksByCNC {
+		for selectedNetwork := range selectedNetworks {
+			peers := connectedNetworks[selectedNetwork]
+			if peers == nil {
+				peers = sets.New[string]()
+				connectedNetworks[selectedNetwork] = peers
+			}
+			for peer := range selectedNetworks {
+				if selectedNetwork == peer {
+					continue
+				}
+				peers.Insert(peer)
+			}
+		}
+	}
+	return connectedNetworks
+}
+
+func changedCNCNetworks(oldConnected, newConnected map[string]sets.Set[string]) sets.Set[string] {
+	changedNetworks := sets.New[string]()
+	for networkName := range oldConnected {
+		changedNetworks.Insert(networkName)
+	}
+	for networkName := range newConnected {
+		changedNetworks.Insert(networkName)
+	}
+
+	networksToReconcile := sets.New[string]()
+	for networkName := range changedNetworks {
+		oldPeers := oldConnected[networkName]
+		if oldPeers == nil {
+			oldPeers = sets.New[string]()
+		}
+		newPeers := newConnected[networkName]
+		if newPeers == nil {
+			newPeers = sets.New[string]()
+		}
+		if !oldPeers.Equal(newPeers) {
+			networksToReconcile.Insert(networkName)
+		}
+	}
+	return networksToReconcile
+}
+
+// updateCNCConnectivityLocked refreshes the derived CNC adjacency map from the
+// selected network cache and returns networks whose peer set changed.
+// Caller must hold nadController lock.
+func (c *nadController) updateCNCConnectivityLocked() sets.Set[string] {
+	connectedNetworks := buildCNCConnectedNetworks(c.cncSelectedNetworks)
+	networksToReconcile := changedCNCNetworks(c.cncConnectedNetworks, connectedNetworks)
+	c.cncConnectedNetworks = connectedNetworks
+	return networksToReconcile
+}
+
+// updateCNCNetworkIDsLocked updates the per-CNC owner ID cache and reverse
+// lookup used to target CNC reconciles when a NAD/network ID becomes available
+// or is removed.
+// Caller must hold nadController lock.
+func (c *nadController) updateCNCNetworkIDsLocked(cncName string, networkIDs sets.Set[int]) {
+	if c.cncNetworkIDs == nil {
+		c.cncNetworkIDs = map[string]sets.Set[int]{}
+	}
+	if c.cncsByNetworkID == nil {
+		c.cncsByNetworkID = map[int]sets.Set[string]{}
+	}
+
+	for networkID := range c.cncNetworkIDs[cncName] {
+		indexedCNCs := c.cncsByNetworkID[networkID]
+		indexedCNCs.Delete(cncName)
+		if len(indexedCNCs) == 0 {
+			delete(c.cncsByNetworkID, networkID)
+		}
+	}
+
+	if networkIDs == nil {
+		delete(c.cncNetworkIDs, cncName)
+		return
+	}
+
+	c.cncNetworkIDs[cncName] = networkIDs
+	for networkID := range networkIDs {
+		indexedCNCs := c.cncsByNetworkID[networkID]
+		if indexedCNCs == nil {
+			indexedCNCs = sets.New[string]()
+			c.cncsByNetworkID[networkID] = indexedCNCs
+		}
+		indexedCNCs.Insert(cncName)
+	}
+}
+
+// syncAllCNCs rebuilds CNC selection state from the lister. It is used for
+// controller startup; per-key queue events should use syncCNC.
+func (c *nadController) syncAllCNCs() error {
+	cncs, err := c.cncLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	selectedNetworksByCNC := map[string]sets.Set[string]{}
+	networkIDsByCNC := map[string]sets.Set[int]{}
+	cncsByNetworkID := map[int]sets.Set[string]{}
+	for _, cnc := range cncs {
+		selectedNetworks, networkIDs := c.networkSelectionsForCNC(cnc)
+		selectedNetworksByCNC[cnc.Name] = selectedNetworks
+		networkIDsByCNC[cnc.Name] = networkIDs
+		for networkID := range networkIDs {
+			indexedCNCs := cncsByNetworkID[networkID]
+			if indexedCNCs == nil {
+				indexedCNCs = sets.New[string]()
+				cncsByNetworkID[networkID] = indexedCNCs
+			}
+			indexedCNCs.Insert(cnc.Name)
+		}
+	}
+
+	c.Lock()
+	c.cncSelectedNetworks = selectedNetworksByCNC
+	c.cncNetworkIDs = networkIDsByCNC
+	c.cncsByNetworkID = cncsByNetworkID
+	networksToReconcile := c.updateCNCConnectivityLocked()
+	c.Unlock()
+
+	c.reconcileNetworkActivity(networksToReconcile.UnsortedList(), false, "", "")
+	return nil
+}
+
+// syncCNC refreshes one queued CNC and requeues affected networks when
+// connectivity relationships change.
+func (c *nadController) syncCNC(key string) error {
+	cnc, err := c.cncLister.Get(key)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	var selectedNetworks sets.Set[string]
+	var networkIDs sets.Set[int]
+	if err == nil {
+		selectedNetworks, networkIDs = c.networkSelectionsForCNC(cnc)
+	}
+
+	c.Lock()
+	if c.cncSelectedNetworks == nil {
+		c.cncSelectedNetworks = map[string]sets.Set[string]{}
+	}
+	if selectedNetworks == nil {
+		delete(c.cncSelectedNetworks, key)
+	} else {
+		c.cncSelectedNetworks[key] = selectedNetworks
+	}
+	c.updateCNCNetworkIDsLocked(key, networkIDs)
+	networksToReconcile := c.updateCNCConnectivityLocked()
+	c.Unlock()
+
+	c.reconcileNetworkActivity(networksToReconcile.UnsortedList(), false, "", "")
+	return nil
+}
+
+// reconcileCNCsForNetworkIDs requeues only CNCs indexed by one of the affected
+// network IDs in their subnet annotation owner keys.
+func (c *nadController) reconcileCNCsForNetworkIDs(networkIDs ...int) {
+	if c.cncController == nil || len(networkIDs) == 0 {
+		return
+	}
+	cncsToReconcile := sets.New[string]()
+	c.RLock()
+	for _, networkID := range networkIDs {
+		for cncName := range c.cncsByNetworkID[networkID] {
+			cncsToReconcile.Insert(cncName)
+		}
+	}
+	c.RUnlock()
+
+	for cncName := range cncsToReconcile {
+		c.cncController.Reconcile(cncName)
 	}
 }
 
@@ -468,6 +851,9 @@ func (c *nadController) setMarkedForRemoval(key string) {
 	if _, ok := c.markedForRemoval[key]; ok {
 		c.Unlock()
 		return
+	}
+	if c.markedForRemoval == nil {
+		c.markedForRemoval = map[string]time.Time{}
 	}
 	removalTime := time.Now().Add(config.OVNKubernetesFeature.UDNDeletionGracePeriod)
 	c.markedForRemoval[key] = removalTime
@@ -608,6 +994,18 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 	var oldNetwork, ensureNetwork util.MutableNetInfo
 	var err error
 	dynamicDelete := false
+	shouldReconcileCNC := false
+	affectedCNCNetworkIDs := sets.New[int]()
+
+	// Reconcile CNC connectivity after unlock when this NAD's network mapping
+	// changes. This closes the window where syncCNC can run before NAD/network
+	// mapping is available and skip that network.
+	defer func() {
+		if c.cncController == nil || syncErr != nil || !shouldReconcileCNC {
+			return
+		}
+		c.reconcileCNCsForNetworkIDs(affectedCNCNetworkIDs.UnsortedList()...)
+	}()
 
 	c.Lock()
 	defer c.Unlock()
@@ -617,6 +1015,10 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 		return fmt.Errorf("%s: failed splitting key %s: %v", c.name, key, err)
 	}
 	previousNetworkName := c.nads[key]
+	previousNetworkID := types.InvalidID
+	if previousNetworkName != "" {
+		previousNetworkID = c.networkIDAllocator.GetID(previousNetworkName)
+	}
 
 	deleteTime, setforDeletion := c.markedForRemoval[key]
 	if setforDeletion && time.Now().After(deleteTime) {
@@ -655,6 +1057,20 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 	}
 
 	defer func() {
+		currentNetworkName := c.nads[key]
+		currentNetworkID := types.InvalidID
+		if currentNetworkName != "" {
+			currentNetworkID = c.networkIDAllocator.GetID(currentNetworkName)
+		}
+		if previousNetworkName != currentNetworkName || previousNetworkID != currentNetworkID {
+			shouldReconcileCNC = true
+			if previousNetworkID != types.InvalidID {
+				affectedCNCNetworkIDs.Insert(previousNetworkID)
+			}
+			if currentNetworkID != types.InvalidID {
+				affectedCNCNetworkIDs.Insert(currentNetworkID)
+			}
+		}
 		c.notifyReconcilers(key) // notify reconcilers after the sync runs with the latest information
 	}()
 
@@ -1303,8 +1719,10 @@ func (c *nadController) GetNetworkByID(id int) util.NetInfo {
 		return netInfo
 	}
 	c.RLock()
-	nadKeys := make([]string, 0, len(c.nads))
-	for key := range c.nads {
+	networkName := c.networkNameForIDLocked(id)
+	nadSet := c.nadsByNetwork[networkName]
+	nadKeys := make([]string, 0, len(nadSet))
+	for key := range nadSet {
 		nadKeys = append(nadKeys, key)
 	}
 	c.RUnlock()

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -49,6 +49,9 @@ type nadController struct {
 	// reconcilers keyed by registration ID.
 	reconcilers      map[uint64]reconcilerRegistration
 	nextReconcilerID uint64
+	// networkRefReconcilers keyed by registration ID.
+	networkRefReconcilers      map[uint64]networkRefReconcilerRegistration
+	nextNetworkRefReconcilerID uint64
 
 	name            string
 	stopChan        chan struct{}
@@ -113,6 +116,11 @@ type reconcilerRegistration struct {
 	r  NADReconciler
 }
 
+type networkRefReconcilerRegistration struct {
+	id uint64
+	r  NetworkRefReconciler
+}
+
 func newController(
 	name string,
 	zone string,
@@ -126,22 +134,23 @@ func newController(
 ) (*nadController, error) {
 	networkController := newNetworkController(name, zone, node, cm, wf)
 	c := &nadController{
-		name:                 fmt.Sprintf("[%s NAD controller]", name),
-		stopChan:             make(chan struct{}),
-		recorder:             recorder,
-		nadLister:            wf.NADInformer().Lister(),
-		nodeLister:           wf.NodeCoreInformer().Lister(),
-		networkController:    networkController,
-		reconcilers:          map[uint64]reconcilerRegistration{},
-		nads:                 map[string]string{},
-		nadsByNetwork:        map[string]sets.Set[string]{},
-		dynamicFilterNADs:    map[string]bool{},
-		cncSelectedNetworks:  map[string]sets.Set[string]{},
-		cncNetworkIDs:        map[string]sets.Set[int]{},
-		cncsByNetworkID:      map[int]sets.Set[string]{},
-		cncConnectedNetworks: map[string]sets.Set[string]{},
-		primaryNADs:          map[string]string{},
-		markedForRemoval:     map[string]time.Time{},
+		name:                  fmt.Sprintf("[%s NAD controller]", name),
+		stopChan:              make(chan struct{}),
+		recorder:              recorder,
+		nadLister:             wf.NADInformer().Lister(),
+		nodeLister:            wf.NodeCoreInformer().Lister(),
+		networkController:     networkController,
+		reconcilers:           map[uint64]reconcilerRegistration{},
+		networkRefReconcilers: map[uint64]networkRefReconcilerRegistration{},
+		nads:                  map[string]string{},
+		nadsByNetwork:         map[string]sets.Set[string]{},
+		dynamicFilterNADs:     map[string]bool{},
+		cncSelectedNetworks:   map[string]sets.Set[string]{},
+		cncNetworkIDs:         map[string]sets.Set[int]{},
+		cncsByNetworkID:       map[int]sets.Set[string]{},
+		cncConnectedNetworks:  map[string]sets.Set[string]{},
+		primaryNADs:           map[string]string{},
+		markedForRemoval:      map[string]time.Time{},
 	}
 	networkController.getNADKeysForNetwork = c.GetNADKeysForNetwork
 
@@ -400,6 +409,7 @@ func (c *nadController) OnNetworkRefChange(node, nadNamespacedName string, activ
 
 	isLocal := node == c.filterNADsOnNode
 	networkName := nadNetwork.GetNetworkName()
+	c.notifyNetworkRefReconcilers(node, networkName)
 	// Enqueue a network reconcile for remote nodes (non-blocking).
 	if !isLocal {
 		c.networkController.NotifyNetworkRefChange(networkName, node)
@@ -820,11 +830,45 @@ func (c *nadController) DeRegisterNADReconciler(id uint64) {
 	delete(c.reconcilers, id)
 }
 
+// RegisterNetworkRefReconciler registers a reconciler to receive node+network activity changes.
+func (c *nadController) RegisterNetworkRefReconciler(r NetworkRefReconciler) uint64 {
+	c.Lock()
+	defer c.Unlock()
+	if c.networkRefReconcilers == nil {
+		c.networkRefReconcilers = map[uint64]networkRefReconcilerRegistration{}
+	}
+	c.nextNetworkRefReconcilerID++
+	id := c.nextNetworkRefReconcilerID
+	c.networkRefReconcilers[id] = networkRefReconcilerRegistration{id: id, r: r}
+	return id
+}
+
+// DeRegisterNetworkRefReconciler removes a previously registered network-ref reconciler by ID.
+func (c *nadController) DeRegisterNetworkRefReconciler(id uint64) {
+	c.Lock()
+	defer c.Unlock()
+	if _, ok := c.networkRefReconcilers[id]; !ok {
+		return
+	}
+	delete(c.networkRefReconcilers, id)
+}
+
 // notifyReconcilers enqueues the NAD key to all registered reconcilers
 // Must be called with nadController Mutex locked
 func (c *nadController) notifyReconcilers(key string) {
 	for _, entry := range c.reconcilers {
 		entry.r.Reconcile(key)
+	}
+}
+
+func (c *nadController) notifyNetworkRefReconcilers(node, networkName string) {
+	if node == "" || networkName == "" {
+		return
+	}
+	c.RLock()
+	defer c.RUnlock()
+	for _, entry := range c.networkRefReconcilers {
+		entry.r.Reconcile(node, networkName)
 	}
 }
 

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -481,6 +481,11 @@ func (c *nadController) reconcileNetworkActivity(networkNames []string, changedN
 		if c.usesLocalDynamicFiltering() {
 			active = c.NodeHasNetwork(c.filterNADsOnNode, networkName)
 			if !active && changedNADActive && networkName == changedNetworkName {
+				// NodeHasNetwork is authoritative once nadsByNetwork
+				// includes this NAD. If the tracker event beat syncNAD,
+				// the changed active event is the only current signal for
+				// this network; bootstrap it as active so we do not start a
+				// stale removal timer.
 				active = true
 			}
 		}
@@ -1261,6 +1266,12 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 		}
 	}
 	if shouldNetworkExist {
+		if c.usesLocalDynamicFiltering() {
+			// If this sync observes the locally filtered NAD should render,
+			// clear any stale removal timer left by a reordered or missed
+			// activity notification.
+			delete(c.markedForRemoval, key)
+		}
 		// ensure the network is associated with the NAD
 		ensureNetwork.AddNADs(key)
 		// reconcile the network

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -409,14 +409,19 @@ func (c *nadController) OnNetworkRefChange(node, nadNamespacedName string, activ
 
 	isLocal := node == c.filterNADsOnNode
 	networkName := nadNetwork.GetNetworkName()
-	c.notifyNetworkRefReconcilers(node, networkName)
+	affectedNetworks := c.getNetworkAndConnectedNetworks(networkName)
+	for _, affectedNetwork := range affectedNetworks {
+		c.notifyNetworkRefReconcilers(node, affectedNetwork)
+	}
 	// Enqueue a network reconcile for remote nodes (non-blocking).
 	if !isLocal {
-		c.networkController.NotifyNetworkRefChange(networkName, node)
+		for _, affectedNetwork := range affectedNetworks {
+			c.networkController.NotifyNetworkRefChange(affectedNetwork, node)
+		}
 	}
 	// Let the NAD controller handle lifecycle/teardown decisions asynchronously for local networks only.
 	if isLocal {
-		c.reconcileNetworkActivity(c.getNetworkAndConnectedNetworks(networkName), active, networkName, nadNamespacedName)
+		c.reconcileNetworkActivity(affectedNetworks, active, networkName, nadNamespacedName)
 	}
 
 }

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -99,10 +99,11 @@ type nadController struct {
 
 	markedForRemoval map[string]time.Time
 
-	// filterNADsOnNode is used by Dynamic UDN and refers the node name for which we consider that node local to
-	// where OVN-Kubernetes is running.
-	// For node/zone it is the name of the local node.
-	// For cluster-manager it is empty.
+	// filterNADsOnNode is the node identity used for local Dynamic UDN NAD
+	// rendering decisions. When set, this controller only renders a dynamic UDN
+	// NAD if the network is active for this node. Empty means this controller is
+	// cluster-scoped and does not locally filter NAD rendering, even when Dynamic
+	// UDN allocation is enabled.
 	filterNADsOnNode string
 
 	podTracker      *PodTrackerController
@@ -224,6 +225,14 @@ func newController(
 	)
 
 	return c, nil
+}
+
+// usesLocalDynamicFiltering reports whether this controller instance should
+// gate local NAD rendering on Dynamic UDN node activity. Cluster-scoped
+// instances keep all NADs rendered and leave per-node allocation decisions to
+// their network controllers.
+func (c *nadController) usesLocalDynamicFiltering() bool {
+	return c.filterNADsOnNode != ""
 }
 
 func (c *nadController) nodeHasDirectNAD(node, nad string) bool {
@@ -407,7 +416,7 @@ func (c *nadController) OnNetworkRefChange(node, nadNamespacedName string, activ
 		return
 	}
 
-	isLocal := node == c.filterNADsOnNode
+	isLocal := c.usesLocalDynamicFiltering() && node == c.filterNADsOnNode
 	networkName := nadNetwork.GetNetworkName()
 	affectedNetworks := c.getNetworkAndConnectedNetworks(networkName)
 	for _, affectedNetwork := range affectedNetworks {
@@ -453,7 +462,6 @@ func (c *nadController) reconcileNetworkActivity(networkNames []string, changedN
 		return
 	}
 
-	seenNADs := sets.New[string]()
 	for _, networkName := range networkNames {
 		if networkName == "" {
 			continue
@@ -470,7 +478,7 @@ func (c *nadController) reconcileNetworkActivity(networkNames []string, changedN
 		}
 
 		active := false
-		if c.filterNADsOnNode != "" {
+		if c.usesLocalDynamicFiltering() {
 			active = c.NodeHasNetwork(c.filterNADsOnNode, networkName)
 			if !active && changedNADActive && networkName == changedNetworkName {
 				active = true
@@ -478,11 +486,7 @@ func (c *nadController) reconcileNetworkActivity(networkNames []string, changedN
 		}
 
 		for nadKey := range nadKeys {
-			if seenNADs.Has(nadKey) {
-				continue
-			}
-			seenNADs.Insert(nadKey)
-			if c.filterNADsOnNode != "" {
+			if c.usesLocalDynamicFiltering() {
 				c.updateNADState(nadKey, active)
 				continue
 			}
@@ -491,7 +495,7 @@ func (c *nadController) reconcileNetworkActivity(networkNames []string, changedN
 	}
 }
 
-// filter should only be called if cm.filterNADsOnNode is set
+// filter should only be called when this controller uses local Dynamic UDN filtering.
 func (c *nadController) filter(nad *nettypes.NetworkAttachmentDefinition) (bool, error) {
 	if !nadRequiresDynamicFiltering(nad) {
 		return false, nil
@@ -1247,7 +1251,7 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 	}
 
 	shouldNetworkExist := true
-	if c.filterNADsOnNode != "" {
+	if c.usesLocalDynamicFiltering() {
 		shouldFilter, err := c.filter(nad)
 		if err != nil {
 			return fmt.Errorf("%s: failed filtering NAD %s: %w", c.name, key, err)

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -98,6 +98,11 @@ type nadController struct {
 	nadClient           nadclientset.Interface
 
 	markedForRemoval map[string]time.Time
+	// dynamicallyRemovedNADs tracks NADs that still exist in the informer but
+	// have already been locally removed after their Dynamic UDN inactivity grace
+	// period expired. This prevents repeated local delete scheduling while the
+	// NAD remains inactive.
+	dynamicallyRemovedNADs sets.Set[string]
 
 	// filterNADsOnNode is the node identity used for local Dynamic UDN NAD
 	// rendering decisions. When set, this controller only renders a dynamic UDN
@@ -135,23 +140,24 @@ func newController(
 ) (*nadController, error) {
 	networkController := newNetworkController(name, zone, node, cm, wf)
 	c := &nadController{
-		name:                  fmt.Sprintf("[%s NAD controller]", name),
-		stopChan:              make(chan struct{}),
-		recorder:              recorder,
-		nadLister:             wf.NADInformer().Lister(),
-		nodeLister:            wf.NodeCoreInformer().Lister(),
-		networkController:     networkController,
-		reconcilers:           map[uint64]reconcilerRegistration{},
-		networkRefReconcilers: map[uint64]networkRefReconcilerRegistration{},
-		nads:                  map[string]string{},
-		nadsByNetwork:         map[string]sets.Set[string]{},
-		dynamicFilterNADs:     map[string]bool{},
-		cncSelectedNetworks:   map[string]sets.Set[string]{},
-		cncNetworkIDs:         map[string]sets.Set[int]{},
-		cncsByNetworkID:       map[int]sets.Set[string]{},
-		cncConnectedNetworks:  map[string]sets.Set[string]{},
-		primaryNADs:           map[string]string{},
-		markedForRemoval:      map[string]time.Time{},
+		name:                   fmt.Sprintf("[%s NAD controller]", name),
+		stopChan:               make(chan struct{}),
+		recorder:               recorder,
+		nadLister:              wf.NADInformer().Lister(),
+		nodeLister:             wf.NodeCoreInformer().Lister(),
+		networkController:      networkController,
+		reconcilers:            map[uint64]reconcilerRegistration{},
+		networkRefReconcilers:  map[uint64]networkRefReconcilerRegistration{},
+		nads:                   map[string]string{},
+		nadsByNetwork:          map[string]sets.Set[string]{},
+		dynamicFilterNADs:      map[string]bool{},
+		cncSelectedNetworks:    map[string]sets.Set[string]{},
+		cncNetworkIDs:          map[string]sets.Set[int]{},
+		cncsByNetworkID:        map[int]sets.Set[string]{},
+		cncConnectedNetworks:   map[string]sets.Set[string]{},
+		primaryNADs:            map[string]string{},
+		markedForRemoval:       map[string]time.Time{},
+		dynamicallyRemovedNADs: sets.New[string](),
 	}
 	networkController.getNADKeysForNetwork = c.GetNADKeysForNetwork
 
@@ -430,7 +436,11 @@ func (c *nadController) OnNetworkRefChange(node, nadNamespacedName string, activ
 	}
 	// Let the NAD controller handle lifecycle/teardown decisions asynchronously for local networks only.
 	if isLocal {
-		c.reconcileNetworkActivity(affectedNetworks, active, networkName, nadNamespacedName)
+		// Tracker events can arrive before syncNAD has populated nadsByNetwork
+		// for this NAD. Requeue the changed key directly, then requeue any
+		// already-known NADs for this network and its CNC-connected peers.
+		c.reconcile(nadNamespacedName)
+		c.reconcileNetworkActivity(affectedNetworks)
 	}
 
 }
@@ -452,12 +462,10 @@ func (c *nadController) getNetworkAndConnectedNetworks(networkName string) []str
 	return networks
 }
 
-// reconcileNetworkActivity updates Dynamic UDN removal state and requeues NAD
-// sync for all NADs belonging to the provided networks. changedNADActive is
-// used only for changedNADKey's own network, preserving direct activity before
-// NAD/network caches know about the key while still deriving CNC peer activity
-// from the current adjacency snapshot.
-func (c *nadController) reconcileNetworkActivity(networkNames []string, changedNADActive bool, changedNetworkName, changedNADKey string) {
+// reconcileNetworkActivity requeues NAD sync for all NADs belonging to the
+// provided networks. syncNAD recomputes current activity and updates local
+// Dynamic UDN removal state.
+func (c *nadController) reconcileNetworkActivity(networkNames []string) {
 	if len(networkNames) == 0 {
 		return
 	}
@@ -466,35 +474,12 @@ func (c *nadController) reconcileNetworkActivity(networkNames []string, changedN
 		if networkName == "" {
 			continue
 		}
-		nadKeys := sets.New[string](c.GetNADKeysForNetwork(networkName)...)
-		if networkName == changedNetworkName && changedNADKey != "" {
-			// Tracker events can arrive before syncNAD has populated
-			// nadsByNetwork for this NAD. Include the changed key so the
-			// first activity event still requeues the NAD.
-			nadKeys.Insert(changedNADKey)
-		}
+		nadKeys := c.GetNADKeysForNetwork(networkName)
 		if len(nadKeys) == 0 {
 			continue
 		}
 
-		active := false
-		if c.usesLocalDynamicFiltering() {
-			active = c.NodeHasNetwork(c.filterNADsOnNode, networkName)
-			if !active && changedNADActive && networkName == changedNetworkName {
-				// NodeHasNetwork is authoritative once nadsByNetwork
-				// includes this NAD. If the tracker event beat syncNAD,
-				// the changed active event is the only current signal for
-				// this network; bootstrap it as active so we do not start a
-				// stale removal timer.
-				active = true
-			}
-		}
-
-		for nadKey := range nadKeys {
-			if c.usesLocalDynamicFiltering() {
-				c.updateNADState(nadKey, active)
-				continue
-			}
+		for _, nadKey := range nadKeys {
 			c.reconcile(nadKey)
 		}
 	}
@@ -766,7 +751,7 @@ func (c *nadController) syncAllCNCs() error {
 	networksToReconcile := c.updateCNCConnectivityLocked()
 	c.Unlock()
 
-	c.reconcileNetworkActivity(networksToReconcile.UnsortedList(), false, "", "")
+	c.reconcileNetworkActivity(networksToReconcile.UnsortedList())
 	return nil
 }
 
@@ -797,7 +782,7 @@ func (c *nadController) syncCNC(key string) error {
 	networksToReconcile := c.updateCNCConnectivityLocked()
 	c.Unlock()
 
-	c.reconcileNetworkActivity(networksToReconcile.UnsortedList(), false, "", "")
+	c.reconcileNetworkActivity(networksToReconcile.UnsortedList())
 	return nil
 }
 
@@ -890,24 +875,14 @@ func (c *nadController) reconcile(key string) {
 	c.controller.Reconcile(key)
 }
 
-// updateNADState enqueues a sync for a given NAD.
-// "active" defines if the network is actively being used by a dynamic resource
-//   - For local events, we either want to wait for grace period before tearing down an inactive network
-//     or clear any removal timer, but both conditions should lead to the network being reconciled (nad sync)
-func (c *nadController) updateNADState(key string, active bool) {
-	if active { // if local and active, clear the mark for removal
-		c.removeMarkedForRemoval(key)
-	} else { // inactive start timer for removal
-		c.setMarkedForRemoval(key)
+// setMarkedForRemovalLocked starts the Dynamic UDN inactivity grace period for
+// a NAD that is currently filtered from local rendering.
+// Caller must hold nadController lock.
+func (c *nadController) setMarkedForRemovalLocked(key string) {
+	if c.dynamicallyRemovedNADs.Has(key) {
+		return
 	}
-	// always requeue to nad controller to syncNAD again
-	c.controller.Reconcile(key)
-}
-
-func (c *nadController) setMarkedForRemoval(key string) {
-	c.Lock()
 	if _, ok := c.markedForRemoval[key]; ok {
-		c.Unlock()
 		return
 	}
 	if c.markedForRemoval == nil {
@@ -915,7 +890,6 @@ func (c *nadController) setMarkedForRemoval(key string) {
 	}
 	removalTime := time.Now().Add(config.OVNKubernetesFeature.UDNDeletionGracePeriod)
 	c.markedForRemoval[key] = removalTime
-	c.Unlock()
 
 	// ensure we reconcile later
 	stopCh := c.stopChan
@@ -941,10 +915,14 @@ func (c *nadController) setMarkedForRemoval(key string) {
 	}()
 }
 
-func (c *nadController) removeMarkedForRemoval(key string) {
-	c.Lock()
-	defer c.Unlock()
+// clearDynamicRemovalStateLocked clears pending or completed local dynamic
+// removal state for a NAD that should render again or no longer exists.
+// Caller must hold nadController lock.
+func (c *nadController) clearDynamicRemovalStateLocked(key string) {
 	delete(c.markedForRemoval, key)
+	if c.dynamicallyRemovedNADs != nil {
+		c.dynamicallyRemovedNADs.Delete(key)
+	}
 }
 
 func (c *nadController) syncAll() (err error) {
@@ -1079,7 +1057,15 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 	}
 
 	deleteTime, setforDeletion := c.markedForRemoval[key]
-	if setforDeletion && time.Now().After(deleteTime) {
+	removalExpired := setforDeletion && time.Now().After(deleteTime)
+	if removalExpired && c.usesLocalDynamicFiltering() && c.nodeHasNetworkNoLock(c.filterNADsOnNode, previousNetworkName) {
+		// Activity may have returned while the grace-period reconcile was still
+		// queued. Since syncNAD is now the source of truth for activity state,
+		// clear the stale timer instead of honoring the expired edge.
+		c.clearDynamicRemovalStateLocked(key)
+		removalExpired = false
+	}
+	if removalExpired {
 		// Grace period expired. Force a local teardown, but keep caches aligned to informer state.
 		klog.Infof("%s: NAD %q: marked for deletion and time has expired, will remove locally", c.name, key)
 		dynamicDelete = nad != nil
@@ -1088,6 +1074,12 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 		defer func() {
 			if syncErr == nil {
 				delete(c.markedForRemoval, key)
+				if dynamicDelete {
+					if c.dynamicallyRemovedNADs == nil {
+						c.dynamicallyRemovedNADs = sets.New[string]()
+					}
+					c.dynamicallyRemovedNADs.Insert(key)
+				}
 			}
 		}()
 	}
@@ -1212,7 +1204,7 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 		// On a true delete (incoming nad nil or expired grace period) we must clean caches,
 		// except for dynamicDelete where we keep informer-derived state.
 		if !dynamicDelete {
-			delete(c.markedForRemoval, key)
+			c.clearDynamicRemovalStateLocked(key)
 			// clean up primary mapping even if we never had an oldNetwork rendered
 			if c.primaryNADs[namespace] == key {
 				delete(c.primaryNADs, namespace)
@@ -1257,21 +1249,25 @@ func (c *nadController) syncNAD(key string, nad *nettypes.NetworkAttachmentDefin
 
 	shouldNetworkExist := true
 	if c.usesLocalDynamicFiltering() {
+		// IMPORTANT: nad/network caches should be updated before
+		// filtering the nad. Asynchronous routines like trackers
+		// depend on cache state to enqueue keys. Trackers track
+		// filtering, and filter relies on the trackers. Trackers
+		// enqueue keys and rely on nad/network caches for CNC enqueuing.
+		// Therefore with this dual dependency we must ensure ordering is correct
+		// to avoid races between the two.
 		shouldFilter, err := c.filter(nad)
 		if err != nil {
 			return fmt.Errorf("%s: failed filtering NAD %s: %w", c.name, key, err)
 		}
 		if shouldFilter {
+			c.setMarkedForRemovalLocked(key)
 			shouldNetworkExist = false
+		} else {
+			c.clearDynamicRemovalStateLocked(key)
 		}
 	}
 	if shouldNetworkExist {
-		if c.usesLocalDynamicFiltering() {
-			// If this sync observes the locally filtered NAD should render,
-			// clear any stale removal timer left by a reordered or missed
-			// activity notification.
-			delete(c.markedForRemoval, key)
-		}
 		// ensure the network is associated with the NAD
 		ensureNetwork.AddNADs(key)
 		// reconcile the network

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -1027,6 +1027,7 @@ func TestNetworkGracePeriodCleanup(t *testing.T) {
 	// Enable segmentation and grace period
 	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
 	config.OVNKubernetesFeature.UDNDeletionGracePeriod = 2 * time.Second // short grace period for test
 	tcm := &testControllerManager{
 		controllers: map[string]NetworkController{},
@@ -1036,6 +1037,9 @@ func TestNetworkGracePeriodCleanup(t *testing.T) {
 	}
 	fakeClient := util.GetOVNClientset().GetClusterManagerClientset()
 	fakeCtrl := &controller.FakeController{}
+	nadKey := util.GetNADName("test", "nad1")
+	stopCh := make(chan struct{})
+	defer close(stopCh)
 	nadController := &nadController{
 		nads:                map[string]string{},
 		primaryNADs:         map[string]string{},
@@ -1046,6 +1050,15 @@ func TestNetworkGracePeriodCleanup(t *testing.T) {
 		namespaceLister:     &fakeNamespaceLister{},
 		markedForRemoval:    map[string]time.Time{},
 		controller:          fakeCtrl,
+		filterNADsOnNode:    "node1",
+		stopChan:            stopCh,
+		podTracker: &PodTrackerController{
+			nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+				"node1": {
+					nadKey: {"test/pod-a": {}},
+				},
+			},
+		},
 	}
 	g.Expect(nadController.networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
 	g.Expect(nadController.networkController.Start()).To(gomega.Succeed())
@@ -1061,18 +1074,23 @@ func TestNetworkGracePeriodCleanup(t *testing.T) {
 		Role:    types.NetworkRolePrimary,
 		MTU:     1400,
 	}
-	netConf.NADName = util.GetNADName("test", "nad1")
+	netConf.NADName = nadKey
 	nad, err := buildNADWithAnnotations("nad1", "test", netConf, map[string]string{
 		types.OvnNetworkIDAnnotation: "1",
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nad.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
 	// Create the NAD in the fake client so syncNAD can find it
 	_, err = fakeClient.NetworkAttchDefClient.
 		K8sCniCncfIoV1().
 		NetworkAttachmentDefinitions(nad.Namespace).
 		Create(context.Background(), nad, metav1.CreateOptions{})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	err = nadController.syncNAD("test/nad1", nad)
+	err = nadController.syncNAD(nadKey, nad)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	netInfo, err := util.NewNetInfo(netConf)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -1088,14 +1106,9 @@ func TestNetworkGracePeriodCleanup(t *testing.T) {
 	fakeCtrl.Unlock()
 	// --- Step 2: Mark as inactive ---
 	// This triggers the grace-period timer, not immediate deletion.
-	nadController.updateNADState(util.GetNADName(nad.Namespace, nad.Name), false)
-	// updateNADState() also requeues immediately; capture that baseline first.
-	g.Eventually(func() int {
-		fakeCtrl.Lock()
-		defer fakeCtrl.Unlock()
-		return len(fakeCtrl.Reconciles)
-	}).WithTimeout(1 * time.Second).Should(gomega.Equal(numberOfReconciles + 1))
-	reconcilesAfterImmediate := numberOfReconciles + 1
+	nadController.podTracker.nodeNADToPodCache = map[string]map[string]map[string]struct{}{}
+	err = nadController.syncNAD(nadKey, nad)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
 	// --- Step 3: Verify that within the grace period, cleanup has NOT happened ---
 	g.Consistently(func() []string {
 		tcm.Lock()
@@ -1108,7 +1121,7 @@ func TestNetworkGracePeriodCleanup(t *testing.T) {
 		fakeCtrl.Lock()
 		defer fakeCtrl.Unlock()
 		return len(fakeCtrl.Reconciles)
-	}).WithTimeout(5 * time.Second).Should(gomega.Equal(reconcilesAfterImmediate + 1))
+	}).WithTimeout(5 * time.Second).Should(gomega.Equal(numberOfReconciles + 1))
 }
 
 func TestFilteredNADDeleteReleasesNetworkID(t *testing.T) {
@@ -2347,6 +2360,129 @@ func TestSyncNADClearsStaleRemovalMarkWhenDynamicNetworkActive(t *testing.T) {
 	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(key))
 }
 
+func TestSyncNADClearsExpiredRemovalMarkWhenDynamicNetworkActive(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	key := "ns1/nad-a"
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	g.Expect(networkIDAllocator.ReserveID("net-a", 1)).To(gomega.Succeed())
+
+	netConf := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  key,
+	}
+	nad, err := buildNADWithAnnotations("nad-a", "ns1", netConf, map[string]string{
+		types.OvnNetworkIDAnnotation: "1",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nad.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+
+	nc := &nadController{
+		controller:         &controller.FakeController{},
+		networkController:  newNetworkController("test-nad", "", "", nil, nil),
+		nads:               map[string]string{key: "net-a"},
+		nadsByNetwork:      map[string]sets.Set[string]{"net-a": sets.New[string](key)},
+		dynamicFilterNADs:  map[string]bool{key: true},
+		primaryNADs:        map[string]string{"ns1": key},
+		networkIDAllocator: networkIDAllocator,
+		filterNADsOnNode:   "node1",
+		podTracker: &PodTrackerController{
+			nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+				"node1": {
+					key: {"ns1/pod-a": {}},
+				},
+			},
+		},
+		markedForRemoval:       map[string]time.Time{key: time.Now().Add(-time.Minute)},
+		dynamicallyRemovedNADs: sets.New[string](),
+		cncConnectedNetworks:   map[string]sets.Set[string]{},
+	}
+
+	g.Expect(nc.syncNAD(key, nad)).To(gomega.Succeed())
+
+	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(key))
+	g.Expect(nc.dynamicallyRemovedNADs.Has(key)).To(gomega.BeFalse())
+	g.Expect(nc.networkController.getNetwork("net-a")).ToNot(gomega.BeNil())
+}
+
+func TestSyncNADDoesNotRescheduleAlreadyDynamicallyRemovedNAD(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.UDNDeletionGracePeriod = time.Hour
+
+	key := "ns1/nad-a"
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	g.Expect(networkIDAllocator.ReserveID("net-a", 1)).To(gomega.Succeed())
+
+	netConf := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  key,
+	}
+	nad, err := buildNADWithAnnotations("nad-a", "ns1", netConf, map[string]string{
+		types.OvnNetworkIDAnnotation: "1",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nad.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+	netInfo, err := util.NewNetInfo(netConf)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	networkController := newNetworkController("test-nad", "", "", nil, nil)
+	mutableNetInfo := util.NewMutableNetInfo(netInfo)
+	mutableNetInfo.SetNADs(key)
+	networkController.setNetwork("net-a", mutableNetInfo)
+
+	nc := &nadController{
+		controller:             &controller.FakeController{},
+		networkController:      networkController,
+		nads:                   map[string]string{key: "net-a"},
+		nadsByNetwork:          map[string]sets.Set[string]{"net-a": sets.New[string](key)},
+		dynamicFilterNADs:      map[string]bool{key: true},
+		primaryNADs:            map[string]string{"ns1": key},
+		networkIDAllocator:     networkIDAllocator,
+		filterNADsOnNode:       "node1",
+		podTracker:             &PodTrackerController{nodeNADToPodCache: map[string]map[string]map[string]struct{}{}},
+		markedForRemoval:       map[string]time.Time{key: time.Now().Add(-time.Minute)},
+		dynamicallyRemovedNADs: sets.New[string](),
+		cncConnectedNetworks:   map[string]sets.Set[string]{},
+	}
+
+	g.Expect(nc.syncNAD(key, nad)).To(gomega.Succeed())
+	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(key))
+	g.Expect(nc.dynamicallyRemovedNADs.Has(key)).To(gomega.BeTrue())
+	g.Expect(nc.networkController.getNetwork("net-a")).To(gomega.BeNil())
+
+	g.Expect(nc.syncNAD(key, nad)).To(gomega.Succeed())
+	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(key))
+	g.Expect(nc.dynamicallyRemovedNADs.Has(key)).To(gomega.BeTrue())
+}
+
 func TestOnNetworkRefChangeNotifiesNetworkRefReconcilers(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
@@ -2632,8 +2768,29 @@ func TestOnNetworkRefChangeClearsCNCConnectedRemovalMarks(t *testing.T) {
 		Controller: ptrTo(true),
 	}}
 
+	netConfB := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-b",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRoleSecondary,
+		NADName:  "ns1/nad-b",
+	}
+	nadB, err := buildNADWithAnnotations("nad-b", "ns1", netConfB, map[string]string{
+		types.OvnNetworkIDAnnotation: "2",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadB.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-b",
+		Controller: ptrTo(true),
+	}}
+
 	keyA := util.GetNADName(nadA.Namespace, nadA.Name)
-	keyB := "ns1/nad-b"
+	keyB := util.GetNADName(nadB.Namespace, nadB.Name)
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
 	podTracker := &PodTrackerController{
 		nodeNADToPodCache: map[string]map[string]map[string]struct{}{
 			"node1": {
@@ -2642,15 +2799,15 @@ func TestOnNetworkRefChangeClearsCNCConnectedRemovalMarks(t *testing.T) {
 		},
 	}
 	nc := &nadController{
-		controller:       &controller.FakeController{},
-		filterNADsOnNode: "node1",
-		podTracker:       podTracker,
-		networkController: &networkController{
-			networks:           map[string]util.MutableNetInfo{},
-			networkControllers: map[string]*networkControllerState{},
-		},
+		controller:         &controller.FakeController{},
+		filterNADsOnNode:   "node1",
+		podTracker:         podTracker,
+		networkController:  newNetworkController("test-nad", "", "", nil, nil),
+		networkIDAllocator: networkIDAllocator,
+		primaryNADs:        map[string]string{},
 		nadLister: &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{
 			nadA.Name: nadA,
+			nadB.Name: nadB,
 		}},
 		nads: map[string]string{
 			keyA: "net-a",
@@ -2674,6 +2831,7 @@ func TestOnNetworkRefChangeClearsCNCConnectedRemovalMarks(t *testing.T) {
 	}
 
 	nc.OnNetworkRefChange("node1", keyA, true)
+	g.Expect(nc.syncNAD(keyB, nadB)).To(gomega.Succeed())
 
 	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(keyB))
 }
@@ -2705,8 +2863,29 @@ func TestOnNetworkRefChangeMarksCNCConnectedNetworksInactive(t *testing.T) {
 		Controller: ptrTo(true),
 	}}
 
+	netConfB := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-b",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRoleSecondary,
+		NADName:  "ns1/nad-b",
+	}
+	nadB, err := buildNADWithAnnotations("nad-b", "ns1", netConfB, map[string]string{
+		types.OvnNetworkIDAnnotation: "2",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadB.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-b",
+		Controller: ptrTo(true),
+	}}
+
 	keyA := util.GetNADName(nadA.Namespace, nadA.Name)
-	keyB := "ns1/nad-b"
+	keyB := util.GetNADName(nadB.Namespace, nadB.Name)
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	nc := &nadController{
@@ -2715,12 +2894,12 @@ func TestOnNetworkRefChangeMarksCNCConnectedNetworksInactive(t *testing.T) {
 		podTracker: &PodTrackerController{
 			nodeNADToPodCache: map[string]map[string]map[string]struct{}{},
 		},
-		networkController: &networkController{
-			networks:           map[string]util.MutableNetInfo{},
-			networkControllers: map[string]*networkControllerState{},
-		},
+		networkController:  newNetworkController("test-nad", "", "", nil, nil),
+		networkIDAllocator: networkIDAllocator,
+		primaryNADs:        map[string]string{},
 		nadLister: &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{
 			nadA.Name: nadA,
+			nadB.Name: nadB,
 		}},
 		nads: map[string]string{
 			keyA: "net-a",
@@ -2743,6 +2922,8 @@ func TestOnNetworkRefChangeMarksCNCConnectedNetworksInactive(t *testing.T) {
 	}
 
 	nc.OnNetworkRefChange("node1", keyA, false)
+	g.Expect(nc.syncNAD(keyA, nadA)).To(gomega.Succeed())
+	g.Expect(nc.syncNAD(keyB, nadB)).To(gomega.Succeed())
 
 	g.Expect(nc.markedForRemoval).To(gomega.HaveKey(keyA))
 	g.Expect(nc.markedForRemoval).To(gomega.HaveKey(keyB))
@@ -2776,6 +2957,8 @@ func TestOnNetworkRefChangeKeepsNADActiveWhenAnotherTrackerStillReferencesIt(t *
 	}}
 
 	key := util.GetNADName(nad.Namespace, nad.Name)
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	nc := &nadController{
@@ -2794,10 +2977,9 @@ func TestOnNetworkRefChangeKeepsNADActiveWhenAnotherTrackerStillReferencesIt(t *
 		egressIPTracker: &EgressIPTrackerController{
 			cache: map[string]map[string]struct{}{},
 		},
-		networkController: &networkController{
-			networks:           map[string]util.MutableNetInfo{},
-			networkControllers: map[string]*networkControllerState{},
-		},
+		networkController:  newNetworkController("test-nad", "", "", nil, nil),
+		networkIDAllocator: networkIDAllocator,
+		primaryNADs:        map[string]string{},
 		nadLister: &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{
 			nad.Name: nad,
 		}},
@@ -2818,11 +3000,12 @@ func TestOnNetworkRefChangeKeepsNADActiveWhenAnotherTrackerStillReferencesIt(t *
 	}
 
 	nc.OnNetworkRefChange("node1", key, false)
+	g.Expect(nc.syncNAD(key, nad)).To(gomega.Succeed())
 
 	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(key))
 }
 
-func TestReconcileNetworkActivityUsesCurrentCNCConnectivity(t *testing.T) {
+func TestReconcileNetworkActivityRequeuesKnownNADs(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
@@ -2861,16 +3044,17 @@ func TestReconcileNetworkActivityUsesCurrentCNCConnectivity(t *testing.T) {
 		cncConnectedNetworks: map[string]sets.Set[string]{},
 	}
 
-	// Simulate OnNetworkRefChange racing with CNC removal: the caller captured
-	// net-b in an older connected-network snapshot, but current CNC adjacency
-	// no longer connects net-a and net-b. Only net-a should be treated active.
-	nc.reconcileNetworkActivity([]string{"net-a", "net-b"}, true, "net-a", keyA)
+	nc.reconcileNetworkActivity([]string{"net-a", "net-b"})
 
-	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(keyA))
-	g.Expect(nc.markedForRemoval).To(gomega.HaveKey(keyB))
+	fakeController := nc.controller.(*controller.FakeController)
+	fakeController.Lock()
+	reconciles := append([]string(nil), fakeController.Reconciles...)
+	fakeController.Unlock()
+	g.Expect(reconciles).To(gomega.ContainElements("Reconcile:"+keyA, "Reconcile:"+keyB))
+	g.Expect(nc.markedForRemoval).To(gomega.BeEmpty())
 }
 
-func TestSyncCNCEffectiveActivityUpdatesRemovalMarks(t *testing.T) {
+func TestSyncCNCRequeuesAffectedNetworkNADs(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
@@ -2927,7 +3111,6 @@ func TestSyncCNCEffectiveActivityUpdatesRemovalMarks(t *testing.T) {
 
 	g.Expect(nc.syncAllCNCs()).To(gomega.Succeed())
 
-	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(keyB))
 	fakeController.Lock()
 	reconciles := append([]string(nil), fakeController.Reconciles...)
 	fakeController.Unlock()

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -2290,6 +2290,63 @@ func TestSyncNADNotFilteredWhenCNCConnectedNetworkActive(t *testing.T) {
 	g.Expect(nc.networkController.getNetwork("net-b")).ToNot(gomega.BeNil())
 }
 
+func TestSyncNADClearsStaleRemovalMarkWhenDynamicNetworkActive(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	key := "ns1/nad-a"
+	podTracker := &PodTrackerController{
+		nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+			"node1": {
+				key: {"ns1/pod-a": {}},
+			},
+		},
+	}
+
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+
+	nc := &nadController{
+		networkController:    newNetworkController("test-nad", "", "", nil, nil),
+		nads:                 map[string]string{},
+		nadsByNetwork:        map[string]sets.Set[string]{},
+		dynamicFilterNADs:    map[string]bool{},
+		primaryNADs:          map[string]string{},
+		networkIDAllocator:   networkIDAllocator,
+		filterNADsOnNode:     "node1",
+		podTracker:           podTracker,
+		markedForRemoval:     map[string]time.Time{key: time.Now().Add(time.Hour)},
+		cncConnectedNetworks: map[string]sets.Set[string]{},
+	}
+
+	netConf := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  key,
+	}
+	nad, err := buildNADWithAnnotations("nad-a", "ns1", netConf, map[string]string{
+		types.OvnNetworkIDAnnotation: "1",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nad.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+
+	g.Expect(nc.syncNAD(key, nad)).To(gomega.Succeed())
+
+	g.Expect(nc.networkController.getNetwork("net-a")).ToNot(gomega.BeNil())
+	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(key))
+}
+
 func TestOnNetworkRefChangeNotifiesNetworkRefReconcilers(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -168,6 +168,26 @@ type testNetworkController struct {
 	handleRefChange func(node string, active bool)
 }
 
+type testNetworkRefReconciler struct {
+	updates chan struct {
+		node        string
+		networkName string
+	}
+}
+
+func (tr *testNetworkRefReconciler) Reconcile(node, networkName string) {
+	if tr == nil || tr.updates == nil {
+		return
+	}
+	tr.updates <- struct {
+		node        string
+		networkName string
+	}{
+		node:        node,
+		networkName: networkName,
+	}
+}
+
 func (tnc *testNetworkController) Start(context.Context) error {
 	tnc.tcm.Lock()
 	defer tnc.tcm.Unlock()
@@ -2165,9 +2185,14 @@ func TestOnNetworkRefChangeReconcilesCNCConnectedNetworks(t *testing.T) {
 	g.Expect(controller.Start(nadSyncController)).To(gomega.Succeed())
 	defer controller.Stop(nadSyncController)
 
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	g.Expect(networkIDAllocator.ReserveID("net-a", 7)).To(gomega.Succeed())
+
 	nc := &nadController{
-		controller:       nadSyncController,
-		filterNADsOnNode: "node1",
+		controller:         nadSyncController,
+		filterNADsOnNode:   "node1",
+		networkIDAllocator: networkIDAllocator,
 		nadLister: &fakeNADLister{
 			nads: map[string]*nettypes.NetworkAttachmentDefinition{
 				nadA.Name: nadA,
@@ -2244,10 +2269,10 @@ func TestSyncNADNotFilteredWhenCNCConnectedNetworkActive(t *testing.T) {
 			Type: "ovn-k8s-cni-overlay",
 		},
 		Topology: types.Layer3Topology,
-		Role:     types.NetworkRolePrimary,
-		NADName:  "ns2/nad-b",
+		Role:     types.NetworkRoleSecondary,
+		NADName:  "ns1/nad-b",
 	}
-	nadB, err := buildNADWithAnnotations("nad-b", "ns2", netConfB, map[string]string{
+	nadB, err := buildNADWithAnnotations("nad-b", "ns1", netConfB, map[string]string{
 		types.OvnNetworkIDAnnotation: "2",
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -2263,6 +2288,72 @@ func TestSyncNADNotFilteredWhenCNCConnectedNetworkActive(t *testing.T) {
 	// net-b must be rendered (not filtered) because net-a is active on this
 	// node and net-b is CNC-connected to net-a.
 	g.Expect(nc.networkController.getNetwork("net-b")).ToNot(gomega.BeNil())
+}
+
+func TestOnNetworkRefChangeNotifiesNetworkRefReconcilers(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	netConf := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "udn-net",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns1/primary",
+	}
+	nad, err := buildNAD("primary", "ns1", netConf)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nad.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn",
+		Controller: ptrTo(true),
+	}}
+
+	nadSyncController := controller.NewController(
+		"test-nad-sync-controller-for-network-ref",
+		&controller.ControllerConfig[string]{
+			RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+			Reconcile: func(string) error {
+				return nil
+			},
+			Threadiness: 1,
+		},
+	)
+	g.Expect(controller.Start(nadSyncController)).To(gomega.Succeed())
+	defer controller.Stop(nadSyncController)
+
+	nc := &nadController{
+		controller:            nadSyncController,
+		filterNADsOnNode:      "node1",
+		networkIDAllocator:    id.NewIDAllocator("NetworkIDs", MaxNetworks),
+		nadLister:             &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{nad.Name: nad}},
+		networkRefReconcilers: map[uint64]networkRefReconcilerRegistration{},
+	}
+	g.Expect(nc.networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+
+	refReconciler := &testNetworkRefReconciler{
+		updates: make(chan struct {
+			node        string
+			networkName string
+		}, 1),
+	}
+	id := nc.RegisterNetworkRefReconciler(refReconciler)
+	g.Expect(id).ToNot(gomega.BeZero())
+
+	nc.OnNetworkRefChange("node1", util.GetNADName(nad.Namespace, nad.Name), true)
+
+	g.Eventually(refReconciler.updates, time.Second).Should(gomega.Receive(gomega.Equal(struct {
+		node        string
+		networkName string
+	}{
+		node:        "node1",
+		networkName: "udn-net",
+	})))
 }
 
 func TestOnNetworkRefChangeRendersCNCConnectedNetworksWhenNodeBecomesActive(t *testing.T) {

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -2691,6 +2691,80 @@ func TestOnNetworkRefChangeMarksCNCConnectedNetworksInactive(t *testing.T) {
 	g.Expect(nc.markedForRemoval).To(gomega.HaveKey(keyB))
 }
 
+func TestOnNetworkRefChangeKeepsNADActiveWhenAnotherTrackerStillReferencesIt(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.UDNDeletionGracePeriod = time.Hour
+
+	netConf := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns1/nad-a",
+	}
+	nad, err := buildNADWithAnnotations("nad-a", "ns1", netConf, map[string]string{
+		types.OvnNetworkIDAnnotation: "1",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nad.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+
+	key := util.GetNADName(nad.Namespace, nad.Name)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	nc := &nadController{
+		controller:       &controller.FakeController{},
+		filterNADsOnNode: "node1",
+		podTracker: &PodTrackerController{
+			nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+				"node1": {
+					key: {"ns1/pod-a": {}},
+				},
+			},
+		},
+		// The egress tracker has already removed its local ref before calling
+		// OnNetworkRefChange(active=false); the pod tracker still keeps this
+		// NAD active on the node.
+		egressIPTracker: &EgressIPTrackerController{
+			cache: map[string]map[string]struct{}{},
+		},
+		networkController: &networkController{
+			networks:           map[string]util.MutableNetInfo{},
+			networkControllers: map[string]*networkControllerState{},
+		},
+		nadLister: &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{
+			nad.Name: nad,
+		}},
+		nads: map[string]string{
+			key: "net-a",
+		},
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string](key),
+		},
+		dynamicFilterNADs: map[string]bool{
+			key: true,
+		},
+		markedForRemoval: map[string]time.Time{
+			key: time.Now().Add(time.Hour),
+		},
+		stopChan:             stopCh,
+		cncConnectedNetworks: map[string]sets.Set[string]{},
+	}
+
+	nc.OnNetworkRefChange("node1", key, false)
+
+	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(key))
+}
+
 func TestReconcileNetworkActivityUsesCurrentCNCConnectivity(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -2356,6 +2356,82 @@ func TestOnNetworkRefChangeNotifiesNetworkRefReconcilers(t *testing.T) {
 	})))
 }
 
+func TestOnNetworkRefChangeNotifiesConnectedNetworkRefReconcilers(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	netConfA := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns1/nad-a",
+	}
+	nadA, err := buildNAD("nad-a", "ns1", netConfA)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadA.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+
+	nadSyncController := controller.NewController(
+		"test-nad-sync-controller-for-connected-network-ref",
+		&controller.ControllerConfig[string]{
+			RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+			Reconcile: func(string) error {
+				return nil
+			},
+			Threadiness: 1,
+		},
+	)
+	g.Expect(controller.Start(nadSyncController)).To(gomega.Succeed())
+	defer controller.Stop(nadSyncController)
+
+	nc := &nadController{
+		controller:            nadSyncController,
+		filterNADsOnNode:      "local-node",
+		networkController:     newNetworkController("", "", "", nil, nil),
+		networkIDAllocator:    id.NewIDAllocator("NetworkIDs", MaxNetworks),
+		nadLister:             &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{nadA.Name: nadA}},
+		networkRefReconcilers: map[uint64]networkRefReconcilerRegistration{},
+		cncConnectedNetworks: map[string]sets.Set[string]{
+			"net-a": sets.New[string]("net-b"),
+			"net-b": sets.New[string]("net-a"),
+		},
+	}
+	g.Expect(nc.networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+
+	refReconciler := &testNetworkRefReconciler{
+		updates: make(chan struct {
+			node        string
+			networkName string
+		}, 2),
+	}
+	id := nc.RegisterNetworkRefReconciler(refReconciler)
+	g.Expect(id).ToNot(gomega.BeZero())
+
+	nc.OnNetworkRefChange("remote-node", util.GetNADName(nadA.Namespace, nadA.Name), true)
+
+	received := sets.New[string]()
+	g.Eventually(func() []string {
+		for {
+			select {
+			case update := <-refReconciler.updates:
+				g.Expect(update.node).To(gomega.Equal("remote-node"))
+				received.Insert(update.networkName)
+			default:
+				return received.UnsortedList()
+			}
+		}
+	}, time.Second).Should(gomega.ConsistOf("net-a", "net-b"))
+}
+
 func TestOnNetworkRefChangeRendersCNCConnectedNetworksWhenNodeBecomesActive(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
@@ -2828,6 +2904,152 @@ func TestOnNetworkRefChangeNotifiesNetworkController(t *testing.T) {
 			g.Expect(callCount).To(gomega.Equal(1))
 			g.Expect(gotNode).To(gomega.Equal(nodeName))
 			g.Expect(gotActive).To(gomega.Equal(tt.nodeHasNetworkActive))
+		})
+	}
+}
+
+func TestOnNetworkRefChangeNotifiesConnectedRemoteNetworkControllers(t *testing.T) {
+	tests := []struct {
+		name           string
+		notifyActive   bool
+		directRef      bool
+		expectedActive bool
+	}{
+		{
+			name:           "connected networks become active",
+			notifyActive:   true,
+			directRef:      true,
+			expectedActive: true,
+		},
+		{
+			name:           "connected networks become inactive",
+			notifyActive:   false,
+			directRef:      false,
+			expectedActive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			err := config.PrepareTestConfig()
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+			config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+
+			keyA := "ns1/nad-a"
+			keyB := "ns1/nad-b"
+			netConfA := &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					Name: "net-a",
+					Type: "ovn-k8s-cni-overlay",
+				},
+				Topology: types.Layer3Topology,
+				Role:     types.NetworkRolePrimary,
+				NADName:  keyA,
+			}
+			nadA, err := buildNAD("nad-a", "ns1", netConfA)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			nadA.OwnerReferences = []metav1.OwnerReference{{
+				Kind:       "UserDefinedNetwork",
+				Name:       "udn-a",
+				Controller: ptrTo(true),
+			}}
+			netConfB := &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					Name: "net-b",
+					Type: "ovn-k8s-cni-overlay",
+				},
+				Topology: types.Layer3Topology,
+				Role:     types.NetworkRoleSecondary,
+				NADName:  keyB,
+			}
+			nadB, err := buildNAD("nad-b", "ns1", netConfB)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			nadB.OwnerReferences = []metav1.OwnerReference{{
+				Kind:       "UserDefinedNetwork",
+				Name:       "udn-b",
+				Controller: ptrTo(true),
+			}}
+
+			podTracker := &PodTrackerController{
+				nodeNADToPodCache: map[string]map[string]map[string]struct{}{},
+			}
+			if tt.directRef {
+				podTracker.nodeNADToPodCache["remote-node"] = map[string]map[string]struct{}{
+					keyA: {"ns1/pod-a": {}},
+				}
+			}
+
+			tcm := &testControllerManager{
+				controllers: map[string]NetworkController{},
+				defaultNetwork: &testNetworkController{
+					ReconcilableNetInfo: &util.DefaultNetInfo{},
+				},
+			}
+			networkController := newNetworkController("", "", "", tcm, nil)
+			nc := &nadController{
+				filterNADsOnNode:   "local-node",
+				podTracker:         podTracker,
+				nads:               map[string]string{keyA: "net-a", keyB: "net-b"},
+				nadsByNetwork:      map[string]sets.Set[string]{"net-a": sets.New[string](keyA), "net-b": sets.New[string](keyB)},
+				dynamicFilterNADs:  map[string]bool{keyA: true, keyB: true},
+				primaryNADs:        map[string]string{},
+				networkController:  networkController,
+				networkIDAllocator: id.NewIDAllocator("NetworkIDs", MaxNetworks),
+				nadLister:          &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{nadA.Name: nadA, nadB.Name: nadB}},
+				cncConnectedNetworks: map[string]sets.Set[string]{
+					"net-a": sets.New[string]("net-b"),
+					"net-b": sets.New[string]("net-a"),
+				},
+			}
+			nc.networkController.nodeHasNetwork = nc.NodeHasNetwork
+			g.Expect(nc.networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+
+			nadNetworkA, err := util.ParseNADInfo(nadA)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			mutableNetInfoA := util.NewMutableNetInfo(nadNetworkA)
+			mutableNetInfoA.SetNADs(keyA)
+			nc.networkController.setNetwork("net-a", mutableNetInfoA)
+
+			nadNetworkB, err := util.ParseNADInfo(nadB)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			mutableNetInfoB := util.NewMutableNetInfo(nadNetworkB)
+			mutableNetInfoB.SetNADs(keyB)
+			nc.networkController.setNetwork("net-b", mutableNetInfoB)
+
+			callCount := map[string]int{}
+			gotNode := map[string]string{}
+			gotActive := map[string]bool{}
+			for _, networkName := range []string{"net-a", "net-b"} {
+				networkName := networkName
+				nadNetwork := nadNetworkA
+				if networkName == "net-b" {
+					nadNetwork = nadNetworkB
+				}
+				nc.networkController.networkControllers[networkName] = &networkControllerState{
+					controller: &testNetworkController{
+						ReconcilableNetInfo: util.NewReconcilableNetInfo(nadNetwork),
+						tcm:                 tcm,
+						handleRefChange: func(node string, active bool) {
+							callCount[networkName]++
+							gotNode[networkName] = node
+							gotActive[networkName] = active
+						},
+					},
+				}
+			}
+
+			nc.OnNetworkRefChange("remote-node", keyA, tt.notifyActive)
+			g.Expect(nc.networkController.syncNetwork("net-a")).To(gomega.Succeed())
+			g.Expect(nc.networkController.syncNetwork("net-b")).To(gomega.Succeed())
+
+			for _, networkName := range []string{"net-a", "net-b"} {
+				g.Expect(callCount[networkName]).To(gomega.Equal(1), "network %s", networkName)
+				g.Expect(gotNode[networkName]).To(gomega.Equal("remote-node"), "network %s", networkName)
+				g.Expect(gotActive[networkName]).To(gomega.Equal(tt.expectedActive), "network %s", networkName)
+			}
 		})
 	}
 }

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -31,6 +31,7 @@ import (
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
+	networkconnectv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -314,6 +315,25 @@ func (f *fakeNADLister) NetworkAttachmentDefinitions(_ string) nadlisters.Networ
 	return &fakeNADNamespaceLister{nads: f.nads}
 }
 
+type fakeCNCLister struct {
+	cncs map[string]*networkconnectv1.ClusterNetworkConnect
+}
+
+func (f *fakeCNCLister) List(_ labels.Selector) ([]*networkconnectv1.ClusterNetworkConnect, error) {
+	result := []*networkconnectv1.ClusterNetworkConnect{}
+	for _, cnc := range f.cncs {
+		result = append(result, cnc)
+	}
+	return result, nil
+}
+
+func (f *fakeCNCLister) Get(name string) (*networkconnectv1.ClusterNetworkConnect, error) {
+	if cnc, ok := f.cncs[name]; ok {
+		return cnc, nil
+	}
+	return nil, apierrors.NewNotFound(networkconnectv1.Resource("clusternetworkconnect"), name)
+}
+
 type testControllerManager struct {
 	sync.Mutex
 
@@ -397,6 +417,19 @@ func TestNADController(t *testing.T) {
 		cm := &nadController{
 			filterNADsOnNode: "node1",
 			podTracker:       pt,
+			nads: map[string]string{
+				"ns1/nad1": "network1",
+				"ns2/nad2": "network2",
+			},
+			nadsByNetwork: map[string]sets.Set[string]{
+				"network1": sets.New[string]("ns1/nad1"),
+				"network2": sets.New[string]("ns2/nad2"),
+			},
+			dynamicFilterNADs: map[string]bool{
+				"ns1/nad1": true,
+				"ns2/nad2": true,
+			},
+			cncConnectedNetworks: map[string]sets.Set[string]{},
 		}
 
 		tests := []struct {
@@ -1817,6 +1850,790 @@ func buildNADWithAnnotations(name, namespace string, network *ovncnitypes.NetCon
 	}
 	nad.Annotations = annotations
 	return nad, nil
+}
+
+func TestNodeHasNetworkIncludesCNCConnectivity(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+
+	podTracker := &PodTrackerController{
+		nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+			"node1": {
+				"ns1/nad-a": {"pod-a": {}},
+			},
+		},
+	}
+
+	nc := &nadController{
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string]("ns1/nad-a"),
+			"net-b": sets.New[string]("ns1/nad-b"),
+		},
+		dynamicFilterNADs: map[string]bool{
+			"ns1/nad-a": true,
+			"ns1/nad-b": true,
+		},
+		cncConnectedNetworks: map[string]sets.Set[string]{
+			"net-b": sets.New[string]("net-a"),
+		},
+		podTracker: podTracker,
+	}
+
+	g.Expect(nc.NodeHasNetwork("node1", "net-a")).To(gomega.BeTrue())
+	g.Expect(nc.NodeHasNetwork("node1", "net-b")).To(gomega.BeTrue())
+	g.Expect(nc.NodeHasNetwork("node1", "net-c")).To(gomega.BeFalse())
+}
+
+func TestSyncCNCIncludesClusterIPServiceConnectivity(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	g.Expect(networkIDAllocator.ReserveID("net-a", 1)).To(gomega.Succeed())
+	g.Expect(networkIDAllocator.ReserveID("net-b", 2)).To(gomega.Succeed())
+
+	cnc := &networkconnectv1.ClusterNetworkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cnc-services",
+			Annotations: map[string]string{
+				"k8s.ovn.org/network-connect-subnet": `{"layer3_1":{"ipv4":"192.168.0.0/24"},"layer3_2":{"ipv4":"192.168.1.0/24"}}`,
+			},
+		},
+		Spec: networkconnectv1.ClusterNetworkConnectSpec{
+			Connectivity: []networkconnectv1.ConnectivityType{
+				networkconnectv1.ServiceNetwork,
+			},
+		},
+	}
+
+	nc := &nadController{
+		networkIDAllocator: networkIDAllocator,
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string](),
+			"net-b": sets.New[string](),
+		},
+		cncConnectedNetworks: map[string]sets.Set[string]{},
+		cncLister: &fakeCNCLister{
+			cncs: map[string]*networkconnectv1.ClusterNetworkConnect{
+				cnc.Name: cnc,
+			},
+		},
+	}
+
+	g.Expect(nc.syncAllCNCs()).To(gomega.Succeed())
+	g.Expect(nc.cncConnectedNetworks["net-a"].Has("net-b")).To(gomega.BeTrue())
+	g.Expect(nc.cncConnectedNetworks["net-b"].Has("net-a")).To(gomega.BeTrue())
+}
+
+func TestSyncCNCSyncsOnlyRequestedCNC(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	for networkName, networkID := range map[string]int{
+		"net-a": 1,
+		"net-b": 2,
+		"net-c": 3,
+		"net-d": 4,
+	} {
+		g.Expect(networkIDAllocator.ReserveID(networkName, networkID)).To(gomega.Succeed())
+	}
+
+	cncAB := &networkconnectv1.ClusterNetworkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cnc-ab",
+			Annotations: map[string]string{
+				"k8s.ovn.org/network-connect-subnet": `{"layer3_1":{"ipv4":"192.168.0.0/24"},"layer3_2":{"ipv4":"192.168.1.0/24"}}`,
+			},
+		},
+	}
+	cncCD := &networkconnectv1.ClusterNetworkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cnc-cd",
+			Annotations: map[string]string{
+				"k8s.ovn.org/network-connect-subnet": `{"layer3_3":{"ipv4":"192.168.2.0/24"},"layer3_4":{"ipv4":"192.168.3.0/24"}}`,
+			},
+		},
+	}
+
+	nc := &nadController{
+		networkIDAllocator: networkIDAllocator,
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string](),
+			"net-b": sets.New[string](),
+			"net-c": sets.New[string](),
+			"net-d": sets.New[string](),
+		},
+		cncSelectedNetworks:  map[string]sets.Set[string]{},
+		cncConnectedNetworks: map[string]sets.Set[string]{},
+		cncLister: &fakeCNCLister{
+			cncs: map[string]*networkconnectv1.ClusterNetworkConnect{
+				cncAB.Name: cncAB,
+				cncCD.Name: cncCD,
+			},
+		},
+	}
+
+	g.Expect(nc.syncCNC(cncAB.Name)).To(gomega.Succeed())
+
+	g.Expect(nc.cncConnectedNetworks["net-a"].Has("net-b")).To(gomega.BeTrue())
+	g.Expect(nc.cncConnectedNetworks["net-b"].Has("net-a")).To(gomega.BeTrue())
+	g.Expect(nc.cncConnectedNetworks).ToNot(gomega.HaveKey("net-c"))
+	g.Expect(nc.cncConnectedNetworks).ToNot(gomega.HaveKey("net-d"))
+}
+
+func TestSyncCNCIndexesUnresolvedNetworkIDs(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	reconcileCh := make(chan string, 1)
+	cncReconciler := controller.NewController(
+		"test-unresolved-cnc-index-reconciler",
+		&controller.ControllerConfig[networkconnectv1.ClusterNetworkConnect]{
+			RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+			Reconcile: func(key string) error {
+				reconcileCh <- key
+				return nil
+			},
+			Threadiness: 1,
+		},
+	)
+	g.Expect(controller.Start(cncReconciler)).To(gomega.Succeed())
+	defer controller.Stop(cncReconciler)
+
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+
+	cnc := &networkconnectv1.ClusterNetworkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cnc-waiting",
+			Annotations: map[string]string{
+				"k8s.ovn.org/network-connect-subnet": `{"layer3_7":{"ipv4":"192.168.0.0/24"}}`,
+			},
+		},
+	}
+	nc := &nadController{
+		cncController:      cncReconciler,
+		networkIDAllocator: networkIDAllocator,
+		nadsByNetwork:      map[string]sets.Set[string]{},
+		cncLister: &fakeCNCLister{
+			cncs: map[string]*networkconnectv1.ClusterNetworkConnect{
+				cnc.Name: cnc,
+			},
+		},
+	}
+
+	g.Expect(nc.syncCNC(cnc.Name)).To(gomega.Succeed())
+	g.Expect(nc.cncConnectedNetworks).To(gomega.BeEmpty())
+	g.Expect(nc.cncsByNetworkID[7].Has(cnc.Name)).To(gomega.BeTrue())
+
+	nc.reconcileCNCsForNetworkIDs(7)
+
+	g.Eventually(reconcileCh, time.Second).Should(gomega.Receive(gomega.Equal(cnc.Name)))
+}
+
+func TestSyncCNCDeletePreservesOtherConnectivity(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	for networkName, networkID := range map[string]int{
+		"net-a": 1,
+		"net-b": 2,
+		"net-c": 3,
+	} {
+		g.Expect(networkIDAllocator.ReserveID(networkName, networkID)).To(gomega.Succeed())
+	}
+
+	cncAB := &networkconnectv1.ClusterNetworkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cnc-ab",
+			Annotations: map[string]string{
+				"k8s.ovn.org/network-connect-subnet": `{"layer3_1":{"ipv4":"192.168.0.0/24"},"layer3_2":{"ipv4":"192.168.1.0/24"}}`,
+			},
+		},
+	}
+	cncBC := &networkconnectv1.ClusterNetworkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cnc-bc",
+			Annotations: map[string]string{
+				"k8s.ovn.org/network-connect-subnet": `{"layer3_2":{"ipv4":"192.168.2.0/24"},"layer3_3":{"ipv4":"192.168.3.0/24"}}`,
+			},
+		},
+	}
+	cncLister := &fakeCNCLister{
+		cncs: map[string]*networkconnectv1.ClusterNetworkConnect{
+			cncAB.Name: cncAB,
+			cncBC.Name: cncBC,
+		},
+	}
+
+	nc := &nadController{
+		networkIDAllocator: networkIDAllocator,
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string](),
+			"net-b": sets.New[string](),
+			"net-c": sets.New[string](),
+		},
+		cncConnectedNetworks: map[string]sets.Set[string]{},
+		cncLister:            cncLister,
+	}
+
+	g.Expect(nc.syncAllCNCs()).To(gomega.Succeed())
+	g.Expect(nc.cncConnectedNetworks["net-a"].Has("net-b")).To(gomega.BeTrue())
+	g.Expect(nc.cncConnectedNetworks["net-b"].Has("net-c")).To(gomega.BeTrue())
+
+	delete(cncLister.cncs, cncAB.Name)
+	g.Expect(nc.syncCNC(cncAB.Name)).To(gomega.Succeed())
+
+	g.Expect(nc.cncConnectedNetworks["net-b"].Has("net-c")).To(gomega.BeTrue())
+	g.Expect(nc.cncConnectedNetworks["net-c"].Has("net-b")).To(gomega.BeTrue())
+	g.Expect(nc.cncConnectedNetworks["net-a"].Has("net-b")).To(gomega.BeFalse())
+	g.Expect(nc.cncsByNetworkID).ToNot(gomega.HaveKey(1))
+	g.Expect(nc.cncsByNetworkID[2].Has(cncAB.Name)).To(gomega.BeFalse())
+	g.Expect(nc.cncsByNetworkID[2].Has(cncBC.Name)).To(gomega.BeTrue())
+}
+
+func TestReconcileCNCsForNetworkIDsTargetsMatchingCNCs(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	reconcileCh := make(chan string, 4)
+	cncReconciler := controller.NewController(
+		"test-targeted-cnc-reconciler",
+		&controller.ControllerConfig[networkconnectv1.ClusterNetworkConnect]{
+			RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+			Reconcile: func(key string) error {
+				reconcileCh <- key
+				return nil
+			},
+			Threadiness: 1,
+		},
+	)
+	g.Expect(controller.Start(cncReconciler)).To(gomega.Succeed())
+	defer controller.Stop(cncReconciler)
+
+	nc := &nadController{
+		cncController: cncReconciler,
+		cncsByNetworkID: map[int]sets.Set[string]{
+			7: sets.New[string]("cnc-match"),
+			9: sets.New[string]("cnc-other"),
+		},
+	}
+
+	nc.reconcileCNCsForNetworkIDs(7)
+
+	g.Eventually(reconcileCh, time.Second).Should(gomega.Receive(gomega.Equal("cnc-match")))
+	g.Consistently(reconcileCh, 200*time.Millisecond).ShouldNot(gomega.Receive())
+}
+
+func TestOnNetworkRefChangeReconcilesCNCConnectedNetworks(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	netConfA := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns1/nad-a",
+	}
+	nadA, err := buildNAD("nad-a", "ns1", netConfA)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadA.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+
+	reconcileCh := make(chan string, 8)
+	nadSyncController := controller.NewController(
+		"test-nad-sync-controller",
+		&controller.ControllerConfig[string]{
+			RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+			Reconcile: func(key string) error {
+				reconcileCh <- key
+				return nil
+			},
+			Threadiness: 1,
+		},
+	)
+	g.Expect(controller.Start(nadSyncController)).To(gomega.Succeed())
+	defer controller.Stop(nadSyncController)
+
+	nc := &nadController{
+		controller:       nadSyncController,
+		filterNADsOnNode: "node1",
+		nadLister: &fakeNADLister{
+			nads: map[string]*nettypes.NetworkAttachmentDefinition{
+				nadA.Name: nadA,
+			},
+		},
+		networkController: &networkController{
+			networks:           map[string]util.MutableNetInfo{},
+			networkControllers: map[string]*networkControllerState{},
+		},
+		nads: map[string]string{
+			"ns1/nad-a": "net-a",
+			"ns1/nad-b": "net-b",
+		},
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string]("ns1/nad-a"),
+			"net-b": sets.New[string]("ns1/nad-b"),
+		},
+		cncConnectedNetworks: map[string]sets.Set[string]{
+			"net-a": sets.New[string]("net-b"),
+		},
+	}
+
+	nc.OnNetworkRefChange("node1", "ns1/nad-a", true)
+
+	received := sets.New[string]()
+	g.Eventually(func() []string {
+		for {
+			select {
+			case key := <-reconcileCh:
+				received.Insert(key)
+			default:
+				return received.UnsortedList()
+			}
+		}
+	}, time.Second).Should(gomega.ConsistOf("ns1/nad-a", "ns1/nad-b"))
+}
+
+func TestSyncNADNotFilteredWhenCNCConnectedNetworkActive(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	podTracker := &PodTrackerController{
+		nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+			"node1": {
+				"ns1/nad-a": {"pod-a": {}},
+			},
+		},
+	}
+
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	g.Expect(networkIDAllocator.ReserveID("net-a", 1)).To(gomega.Succeed())
+
+	nc := &nadController{
+		networkController:  newNetworkController("test-nad", "", "", nil, nil),
+		nads:               map[string]string{"ns1/nad-a": "net-a"},
+		nadsByNetwork:      map[string]sets.Set[string]{"net-a": sets.New[string]("ns1/nad-a")},
+		dynamicFilterNADs:  map[string]bool{"ns1/nad-a": true},
+		primaryNADs:        map[string]string{},
+		networkIDAllocator: networkIDAllocator,
+		filterNADsOnNode:   "node1",
+		podTracker:         podTracker,
+		cncConnectedNetworks: map[string]sets.Set[string]{
+			"net-b": sets.New[string]("net-a"),
+		},
+	}
+
+	netConfB := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-b",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns2/nad-b",
+	}
+	nadB, err := buildNADWithAnnotations("nad-b", "ns2", netConfB, map[string]string{
+		types.OvnNetworkIDAnnotation: "2",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadB.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-b",
+		Controller: ptrTo(true),
+	}}
+
+	nadKey := util.GetNADName(nadB.Namespace, nadB.Name)
+	g.Expect(nc.syncNAD(nadKey, nadB)).To(gomega.Succeed())
+
+	// net-b must be rendered (not filtered) because net-a is active on this
+	// node and net-b is CNC-connected to net-a.
+	g.Expect(nc.networkController.getNetwork("net-b")).ToNot(gomega.BeNil())
+}
+
+func TestOnNetworkRefChangeRendersCNCConnectedNetworksWhenNodeBecomesActive(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	netConfA := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns1/nad-a",
+	}
+	nadA, err := buildNADWithAnnotations("nad-a", "ns1", netConfA, map[string]string{
+		types.OvnNetworkIDAnnotation: "1",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadA.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+
+	netConfB := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-b",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRoleSecondary,
+		NADName:  "ns1/nad-b",
+	}
+	nadB, err := buildNADWithAnnotations("nad-b", "ns1", netConfB, map[string]string{
+		types.OvnNetworkIDAnnotation: "2",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadB.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-b",
+		Controller: ptrTo(true),
+	}}
+
+	podTracker := &PodTrackerController{
+		nodeNADToPodCache: map[string]map[string]map[string]struct{}{},
+	}
+
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+
+	var nc *nadController
+	nadSyncController := controller.NewController(
+		"test-nad-sync-controller",
+		&controller.ControllerConfig[string]{
+			RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+			Reconcile: func(key string) error {
+				namespace, name, err := cache.SplitMetaNamespaceKey(key)
+				if err != nil {
+					return err
+				}
+				nad, err := nc.nadLister.NetworkAttachmentDefinitions(namespace).Get(name)
+				if apierrors.IsNotFound(err) {
+					nad = nil
+					err = nil
+				}
+				if err != nil {
+					return err
+				}
+				return nc.syncNAD(key, nad)
+			},
+			Threadiness: 1,
+		},
+	)
+	g.Expect(controller.Start(nadSyncController)).To(gomega.Succeed())
+	defer controller.Stop(nadSyncController)
+
+	nc = &nadController{
+		controller:         nadSyncController,
+		filterNADsOnNode:   "node1",
+		podTracker:         podTracker,
+		networkController:  newNetworkController("test-nad", "", "", nil, nil),
+		networkIDAllocator: networkIDAllocator,
+		nads:               map[string]string{},
+		nadsByNetwork:      map[string]sets.Set[string]{},
+		primaryNADs:        map[string]string{},
+		nadLister:          &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{"nad-a": nadA, "nad-b": nadB}},
+		cncConnectedNetworks: map[string]sets.Set[string]{
+			"net-a": sets.New[string]("net-b"),
+			"net-b": sets.New[string]("net-a"),
+		},
+	}
+
+	keyA := util.GetNADName(nadA.Namespace, nadA.Name)
+	keyB := util.GetNADName(nadB.Namespace, nadB.Name)
+
+	// Initially no local refs: both networks stay filtered.
+	g.Expect(nc.syncNAD(keyA, nadA)).To(gomega.Succeed())
+	g.Expect(nc.syncNAD(keyB, nadB)).To(gomega.Succeed())
+	g.Expect(nc.networkController.getNetwork("net-a")).To(gomega.BeNil())
+	g.Expect(nc.networkController.getNetwork("net-b")).To(gomega.BeNil())
+
+	// A local pod on net-a should trigger reconciliation of both A and
+	// CNC-connected B, and both should render.
+	podTracker.cacheMutex.Lock()
+	podTracker.nodeNADToPodCache["node1"] = map[string]map[string]struct{}{
+		keyA: {"ns1/pod-a": {}},
+	}
+	podTracker.cacheMutex.Unlock()
+
+	nc.OnNetworkRefChange("node1", keyA, true)
+
+	g.Eventually(func() bool { return nc.networkController.getNetwork("net-a") != nil }, time.Second).Should(gomega.BeTrue())
+	g.Eventually(func() bool { return nc.networkController.getNetwork("net-b") != nil }, time.Second).Should(gomega.BeTrue())
+}
+
+func TestOnNetworkRefChangeClearsCNCConnectedRemovalMarks(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	netConfA := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns1/nad-a",
+	}
+	nadA, err := buildNADWithAnnotations("nad-a", "ns1", netConfA, map[string]string{
+		types.OvnNetworkIDAnnotation: "1",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadA.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+
+	keyA := util.GetNADName(nadA.Namespace, nadA.Name)
+	keyB := "ns1/nad-b"
+	podTracker := &PodTrackerController{
+		nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+			"node1": {
+				keyA: {"ns1/pod-a": {}},
+			},
+		},
+	}
+	nc := &nadController{
+		controller:       &controller.FakeController{},
+		filterNADsOnNode: "node1",
+		podTracker:       podTracker,
+		networkController: &networkController{
+			networks:           map[string]util.MutableNetInfo{},
+			networkControllers: map[string]*networkControllerState{},
+		},
+		nadLister: &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{
+			nadA.Name: nadA,
+		}},
+		nads: map[string]string{
+			keyA: "net-a",
+			keyB: "net-b",
+		},
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string](keyA),
+			"net-b": sets.New[string](keyB),
+		},
+		dynamicFilterNADs: map[string]bool{
+			keyA: true,
+			keyB: true,
+		},
+		markedForRemoval: map[string]time.Time{
+			keyB: time.Now().Add(time.Hour),
+		},
+		cncConnectedNetworks: map[string]sets.Set[string]{
+			"net-a": sets.New[string]("net-b"),
+			"net-b": sets.New[string]("net-a"),
+		},
+	}
+
+	nc.OnNetworkRefChange("node1", keyA, true)
+
+	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(keyB))
+}
+
+func TestOnNetworkRefChangeMarksCNCConnectedNetworksInactive(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.UDNDeletionGracePeriod = time.Hour
+
+	netConfA := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net-a",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns1/nad-a",
+	}
+	nadA, err := buildNADWithAnnotations("nad-a", "ns1", netConfA, map[string]string{
+		types.OvnNetworkIDAnnotation: "1",
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadA.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "UserDefinedNetwork",
+		Name:       "udn-a",
+		Controller: ptrTo(true),
+	}}
+
+	keyA := util.GetNADName(nadA.Namespace, nadA.Name)
+	keyB := "ns1/nad-b"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	nc := &nadController{
+		controller:       &controller.FakeController{},
+		filterNADsOnNode: "node1",
+		podTracker: &PodTrackerController{
+			nodeNADToPodCache: map[string]map[string]map[string]struct{}{},
+		},
+		networkController: &networkController{
+			networks:           map[string]util.MutableNetInfo{},
+			networkControllers: map[string]*networkControllerState{},
+		},
+		nadLister: &fakeNADLister{nads: map[string]*nettypes.NetworkAttachmentDefinition{
+			nadA.Name: nadA,
+		}},
+		nads: map[string]string{
+			keyA: "net-a",
+			keyB: "net-b",
+		},
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string](keyA),
+			"net-b": sets.New[string](keyB),
+		},
+		dynamicFilterNADs: map[string]bool{
+			keyA: true,
+			keyB: true,
+		},
+		markedForRemoval: map[string]time.Time{},
+		stopChan:         stopCh,
+		cncConnectedNetworks: map[string]sets.Set[string]{
+			"net-a": sets.New[string]("net-b"),
+			"net-b": sets.New[string]("net-a"),
+		},
+	}
+
+	nc.OnNetworkRefChange("node1", keyA, false)
+
+	g.Expect(nc.markedForRemoval).To(gomega.HaveKey(keyA))
+	g.Expect(nc.markedForRemoval).To(gomega.HaveKey(keyB))
+}
+
+func TestReconcileNetworkActivityUsesCurrentCNCConnectivity(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.UDNDeletionGracePeriod = time.Hour
+
+	keyA := "ns1/nad-a"
+	keyB := "ns1/nad-b"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	nc := &nadController{
+		controller:       &controller.FakeController{},
+		filterNADsOnNode: "node1",
+		podTracker: &PodTrackerController{
+			nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+				"node1": {
+					keyA: {"ns1/pod-a": {}},
+				},
+			},
+		},
+		nads: map[string]string{
+			keyA: "net-a",
+			keyB: "net-b",
+		},
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string](keyA),
+			"net-b": sets.New[string](keyB),
+		},
+		dynamicFilterNADs: map[string]bool{
+			keyA: true,
+			keyB: true,
+		},
+		markedForRemoval:     map[string]time.Time{},
+		stopChan:             stopCh,
+		cncConnectedNetworks: map[string]sets.Set[string]{},
+	}
+
+	// Simulate OnNetworkRefChange racing with CNC removal: the caller captured
+	// net-b in an older connected-network snapshot, but current CNC adjacency
+	// no longer connects net-a and net-b. Only net-a should be treated active.
+	nc.reconcileNetworkActivity([]string{"net-a", "net-b"}, true, "net-a", keyA)
+
+	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(keyA))
+	g.Expect(nc.markedForRemoval).To(gomega.HaveKey(keyB))
+}
+
+func TestSyncCNCEffectiveActivityUpdatesRemovalMarks(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableDynamicUDNAllocation = true
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	keyA := "ns1/nad-a"
+	keyB := "ns1/nad-b"
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	g.Expect(networkIDAllocator.ReserveID("net-a", 1)).To(gomega.Succeed())
+	g.Expect(networkIDAllocator.ReserveID("net-b", 2)).To(gomega.Succeed())
+
+	cnc := &networkconnectv1.ClusterNetworkConnect{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cnc-ab",
+			Annotations: map[string]string{
+				"k8s.ovn.org/network-connect-subnet": `{"layer3_1":{"ipv4":"192.168.0.0/24"},"layer3_2":{"ipv4":"192.168.1.0/24"}}`,
+			},
+		},
+	}
+	fakeController := &controller.FakeController{}
+	nc := &nadController{
+		controller:         fakeController,
+		filterNADsOnNode:   "node1",
+		networkIDAllocator: networkIDAllocator,
+		podTracker: &PodTrackerController{
+			nodeNADToPodCache: map[string]map[string]map[string]struct{}{
+				"node1": {
+					keyA: {"ns1/pod-a": {}},
+				},
+			},
+		},
+		nads: map[string]string{
+			keyA: "net-a",
+			keyB: "net-b",
+		},
+		nadsByNetwork: map[string]sets.Set[string]{
+			"net-a": sets.New[string](keyA),
+			"net-b": sets.New[string](keyB),
+		},
+		dynamicFilterNADs: map[string]bool{
+			keyA: true,
+			keyB: true,
+		},
+		markedForRemoval:     map[string]time.Time{keyB: time.Now().Add(time.Hour)},
+		cncConnectedNetworks: map[string]sets.Set[string]{},
+		cncLister: &fakeCNCLister{
+			cncs: map[string]*networkconnectv1.ClusterNetworkConnect{
+				cnc.Name: cnc,
+			},
+		},
+	}
+
+	g.Expect(nc.syncAllCNCs()).To(gomega.Succeed())
+
+	g.Expect(nc.markedForRemoval).ToNot(gomega.HaveKey(keyB))
+	fakeController.Lock()
+	reconciles := append([]string(nil), fakeController.Reconciles...)
+	fakeController.Unlock()
+	g.Expect(reconciles).To(gomega.ContainElements("Reconcile:"+keyA, "Reconcile:"+keyB))
 }
 
 func TestOnNetworkRefChangeNotifiesNetworkController(t *testing.T) {

--- a/go-controller/pkg/networkmanager/networkmanager_suite_test.go
+++ b/go-controller/pkg/networkmanager/networkmanager_suite_test.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package networkmanager
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Disable WatchListClient feature gate for tests.
+	// Fake clientsets from third-party libraries don't yet support WatchList semantics
+	// introduced in K8s 1.35, causing informers to hang waiting for bookmark events.
+	// See: https://github.com/kubernetes/kubernetes/issues/135895
+	os.Setenv("KUBE_FEATURE_WatchListClient", "false")
+	os.Exit(m.Run())
+}

--- a/go-controller/pkg/ovn/controller/networkconnect/controller.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller.go
@@ -5,7 +5,9 @@ package networkconnect
 
 import (
 	"fmt"
+	"net"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,7 +36,8 @@ import (
 )
 
 const (
-	controllerName = "ovnkube-network-connect-controller"
+	controllerName         = "ovnkube-network-connect-controller"
+	networkRefKeySeparator = "/"
 )
 
 // Controller manages network connectivity between (C)UDNs based on ClusterNetworkConnect CRs.
@@ -77,12 +80,22 @@ type Controller struct {
 	nadReconcilerID uint64
 	// serviceController handles Service events (for ServiceNetwork connectivity)
 	serviceController controllerutil.Controller
+	// networkRefQueue handles node+network activity-triggered CNC requeues
+	networkRefQueue controllerutil.Reconciler
+	// networkRefReconciler receives node+network activity notifications from networkmanager
+	networkRefReconciler   networkmanager.NetworkRefReconciler
+	networkRefReconcilerID uint64
 
 	// Single global lock protecting all controller state
 	sync.RWMutex
 
 	// cncCache holds the state for each CNC keyed by CNC name
 	cncCache map[string]*networkConnectState
+
+	// cncNetworkIDs tracks desired owner network IDs from each CNC's subnet annotation.
+	cncNetworkIDs map[string]sets.Set[int]
+	// cncsByNetworkID indexes CNCs by desired owner network ID for targeted requeues.
+	cncsByNetworkID map[int]sets.Set[string]
 
 	// localZoneNode is the node in this controller's zone.
 	// We only support 1 node per zone for this feature.
@@ -105,6 +118,13 @@ type networkConnectState struct {
 	// podNetworkConnectEnabled tracks whether PodNetwork connectivity is enabled
 	// Used to determine if partial connectivity (service without pod) was active.
 	podNetworkConnectEnabled bool
+}
+
+type networkRefReconcilerFunc func(node, networkName string)
+
+// Reconcile adapts a plain function to the NetworkRefReconciler interface.
+func (f networkRefReconcilerFunc) Reconcile(node, networkName string) {
+	f(node, networkName)
 }
 
 // NewController creates a new network connect controller for ovnkube-controller.
@@ -130,6 +150,8 @@ func NewController(
 		networkManager:    networkManager,
 		addressSetFactory: addressset.NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode),
 		cncCache:          make(map[string]*networkConnectState),
+		cncNetworkIDs:     make(map[string]sets.Set[int]),
+		cncsByNetworkID:   make(map[int]sets.Set[string]),
 	}
 
 	cncCfg := &controllerutil.ControllerConfig[networkconnectv1.ClusterNetworkConnect]{
@@ -170,6 +192,26 @@ func NewController(
 		"ovnkube-network-connect-nad",
 		nadReconcilerConfig,
 	)
+	networkRefReconcilerConfig := &controllerutil.ReconcilerConfig{
+		RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
+		Reconcile:   c.syncNetworkRef,
+		Threadiness: 1,
+		MaxAttempts: controllerutil.InfiniteAttempts,
+	}
+	c.networkRefQueue = controllerutil.NewReconciler(
+		"ovnkube-network-connect-network-ref",
+		networkRefReconcilerConfig,
+	)
+	networkRefQueue := c.networkRefQueue
+	c.networkRefReconciler = networkRefReconcilerFunc(func(node, networkName string) {
+		if node == "" || networkName == "" || networkRefQueue == nil {
+			return
+		}
+		// Network manager notifies with semantic node+network values. Adapt
+		// them to the CNC controller's string-keyed workqueue locally so the
+		// queue key format stays private to this controller.
+		networkRefQueue.Reconcile(networkRefKey(node, networkName))
+	})
 
 	serviceCfg := &controllerutil.ControllerConfig[corev1.Service]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -193,26 +235,34 @@ func NewController(
 func (c *Controller) Start() (err error) {
 	klog.Infof("Starting ovnkube network connect controller for zone %s", c.zone)
 	initialSync := func() error { return c.repairStaleCNCs() }
-	if c.nadReconciler == nil {
-		return controllerutil.StartWithInitialSync(initialSync,
-			c.cncController,
-			c.nodeController,
-			c.serviceController,
-		)
-	}
-	c.nadReconcilerID = c.networkManager.RegisterNADReconciler(c.nadReconciler)
-	defer func() {
-		if err != nil {
-			c.networkManager.DeRegisterNADReconciler(c.nadReconcilerID)
-			c.nadReconcilerID = 0
-		}
-	}()
-	return controllerutil.StartWithInitialSync(initialSync,
+	controllers := []controllerutil.Reconciler{
 		c.cncController,
 		c.nodeController,
-		c.nadReconciler,
 		c.serviceController,
-	)
+	}
+	if c.nadReconciler != nil {
+		c.nadReconcilerID = c.networkManager.RegisterNADReconciler(c.nadReconciler)
+		controllers = append(controllers, c.nadReconciler)
+	}
+	if c.networkRefReconciler != nil {
+		c.networkRefReconcilerID = c.networkManager.RegisterNetworkRefReconciler(c.networkRefReconciler)
+		if c.networkRefQueue != nil {
+			controllers = append(controllers, c.networkRefQueue)
+		}
+	}
+	defer func() {
+		if err != nil {
+			if c.nadReconcilerID != 0 {
+				c.networkManager.DeRegisterNADReconciler(c.nadReconcilerID)
+				c.nadReconcilerID = 0
+			}
+			if c.networkRefReconcilerID != 0 {
+				c.networkManager.DeRegisterNetworkRefReconciler(c.networkRefReconcilerID)
+				c.networkRefReconcilerID = 0
+			}
+		}
+	}()
+	return controllerutil.StartWithInitialSync(initialSync, controllers...)
 }
 
 // Stop stops the controller.
@@ -220,63 +270,169 @@ func (c *Controller) Stop() {
 	if c.nadReconcilerID != 0 {
 		c.networkManager.DeRegisterNADReconciler(c.nadReconcilerID)
 	}
-	if c.nadReconciler != nil {
-		controllerutil.Stop(
-			c.cncController,
-			c.nodeController,
-			c.nadReconciler,
-			c.serviceController,
-		)
-	} else {
-		controllerutil.Stop(
-			c.cncController,
-			c.nodeController,
-			c.serviceController,
-		)
+	if c.networkRefReconcilerID != 0 {
+		c.networkManager.DeRegisterNetworkRefReconciler(c.networkRefReconcilerID)
 	}
+	controllers := []controllerutil.Reconciler{
+		c.cncController,
+		c.nodeController,
+		c.serviceController,
+	}
+	if c.nadReconciler != nil {
+		controllers = append(controllers, c.nadReconciler)
+	}
+	if c.networkRefQueue != nil {
+		controllers = append(controllers, c.networkRefQueue)
+	}
+	controllerutil.Stop(controllers...)
 	c.nadReconciler = nil
 	c.nadReconcilerID = 0
+	c.networkRefQueue = nil
+	c.networkRefReconciler = nil
+	c.networkRefReconcilerID = 0
 	klog.Infof("Stopped ovnkube network connect controller for zone %s", c.zone)
 }
 
+// networkRefKey builds the queue key used for deferred node+network activity
+// processing. The network name is used instead of ID because activity can be
+// observed before NAD reconciliation has resolved the ID locally.
+func networkRefKey(node, networkName string) string {
+	return node + networkRefKeySeparator + networkName
+}
+
+// parseNetworkRefKey decodes a queue key back into node and network name.
+func parseNetworkRefKey(key string) (string, string, error) {
+	idx := strings.LastIndex(key, networkRefKeySeparator)
+	if idx <= 0 || idx == len(key)-1 {
+		return "", "", fmt.Errorf("invalid network-ref key %q", key)
+	}
+	node := key[:idx]
+	return node, key[idx+1:], nil
+}
+
+func (c *Controller) syncNetworkRef(key string) error {
+	if c.networkManager == nil {
+		return nil
+	}
+	_, networkName, err := parseNetworkRefKey(key)
+	if err != nil {
+		klog.Warningf("Skipping invalid network-ref key %q: %v", key, err)
+		return nil
+	}
+
+	c.reconcileCNCsForNetworkIDs(c.networkIDsForNetworkName(networkName)...)
+	return nil
+}
+
 func (c *Controller) syncNAD(key string) error {
-	if c.nadLister == nil || c.networkManager == nil {
+	if c.networkManager == nil {
 		return nil
 	}
 	nadNetwork := c.networkManager.GetNetInfoForNADKey(key)
-	if nadNetwork == nil {
+	if nadNetwork != nil {
+		// Common path: the NAD's network is rendered, so we can requeue
+		// CNCs directly by its network ID without scanning the CNC index.
+		networkID := nadNetwork.GetNetworkID()
+		if networkID == types.InvalidID {
+			return nil
+		}
+		c.reconcileCNCsForNetworkIDs(networkID)
 		return nil
 	}
-	networkID := nadNetwork.GetNetworkID()
-	if networkID == types.InvalidID {
-		return nil
-	}
-	cncs, err := c.cncLister.List(labels.Everything())
-	if err != nil {
-		return err
-	}
-	for _, cnc := range cncs {
-		subnets, err := util.ParseNetworkConnectSubnetAnnotation(cnc)
-		if err != nil {
-			klog.Warningf("Failed parsing CNC %s subnet annotation: %v", cnc.Name, err)
+
+	// Dynamic UDN can know a NAD-to-network mapping while the network is
+	// filtered and therefore absent from networkController. Fall back to the
+	// network name and resolve matching indexed CNC network IDs.
+	networkName := c.networkManager.GetNetworkNameForNADKey(key)
+	c.reconcileCNCsForNetworkIDs(c.networkIDsForNetworkName(networkName)...)
+	return nil
+}
+
+func networkIDsFromAllocatedSubnets(allocatedSubnets map[string][]*net.IPNet) sets.Set[int] {
+	networkIDs := sets.New[int]()
+	for owner := range allocatedSubnets {
+		_, ownerNetworkID, err := util.ParseNetworkOwner(owner)
+		if err != nil || ownerNetworkID == types.InvalidID {
 			continue
 		}
-		shouldReconcile := false
-		for owner := range subnets {
-			_, ownerNetworkID, err := util.ParseNetworkOwner(owner)
-			if err != nil {
-				continue
-			}
-			if ownerNetworkID == networkID {
-				shouldReconcile = true
-				break
-			}
-		}
-		if shouldReconcile {
-			c.cncController.Reconcile(cnc.Name)
+		networkIDs.Insert(ownerNetworkID)
+	}
+	return networkIDs
+}
+
+func (c *Controller) networkIDsForNetworkName(networkName string) []int {
+	if c.networkManager == nil || networkName == "" {
+		return nil
+	}
+
+	c.RLock()
+	indexedNetworkIDs := make([]int, 0, len(c.cncsByNetworkID))
+	for networkID := range c.cncsByNetworkID {
+		indexedNetworkIDs = append(indexedNetworkIDs, networkID)
+	}
+	c.RUnlock()
+
+	matchingNetworkIDs := sets.New[int]()
+	for _, networkID := range indexedNetworkIDs {
+		netInfo := c.networkManager.GetNetworkByID(networkID)
+		if netInfo != nil && netInfo.GetNetworkName() == networkName {
+			matchingNetworkIDs.Insert(networkID)
 		}
 	}
-	return nil
+	return matchingNetworkIDs.UnsortedList()
+}
+
+// updateCNCNetworkIDsLocked refreshes the desired network ID reverse index for a CNC.
+// Caller must hold c.Lock().
+func (c *Controller) updateCNCNetworkIDsLocked(cncName string, networkIDs sets.Set[int]) {
+	if c.cncNetworkIDs == nil {
+		c.cncNetworkIDs = map[string]sets.Set[int]{}
+	}
+	if c.cncsByNetworkID == nil {
+		c.cncsByNetworkID = map[int]sets.Set[string]{}
+	}
+
+	for networkID := range c.cncNetworkIDs[cncName] {
+		indexedCNCs := c.cncsByNetworkID[networkID]
+		indexedCNCs.Delete(cncName)
+		if len(indexedCNCs) == 0 {
+			delete(c.cncsByNetworkID, networkID)
+		}
+	}
+
+	if networkIDs == nil {
+		delete(c.cncNetworkIDs, cncName)
+		return
+	}
+
+	c.cncNetworkIDs[cncName] = networkIDs
+	for networkID := range networkIDs {
+		indexedCNCs := c.cncsByNetworkID[networkID]
+		if indexedCNCs == nil {
+			indexedCNCs = sets.New[string]()
+			c.cncsByNetworkID[networkID] = indexedCNCs
+		}
+		indexedCNCs.Insert(cncName)
+	}
+}
+
+func (c *Controller) reconcileCNCsForNetworkIDs(networkIDs ...int) {
+	if c.cncController == nil || len(networkIDs) == 0 {
+		return
+	}
+
+	cncsToReconcile := sets.New[string]()
+	c.RLock()
+	for _, networkID := range networkIDs {
+		for cncName := range c.cncsByNetworkID[networkID] {
+			cncsToReconcile.Insert(cncName)
+		}
+	}
+	c.RUnlock()
+
+	for cncName := range cncsToReconcile {
+		c.cncController.Reconcile(cncName)
+	}
 }
 
 // cncNeedsUpdate determines if a CNC update requires reconciliation.
@@ -578,6 +734,13 @@ func (c *Controller) syncCNC(cnc *networkconnectv1.ClusterNetworkConnect) error 
 		}
 		c.cncCache[cnc.Name] = cncState
 	}
+	allocatedSubnets, err := util.ParseNetworkConnectSubnetAnnotation(cnc)
+	if err != nil {
+		c.updateCNCNetworkIDsLocked(cnc.Name, nil)
+		return fmt.Errorf("failed to parse subnet annotation for CNC %s: %w", cnc.Name, err)
+	}
+	c.updateCNCNetworkIDsLocked(cnc.Name, networkIDsFromAllocatedSubnets(allocatedSubnets))
+
 	// STEP1: Create the connect router for the CNC using tunnel ID from CNC annotation
 	// This is always a one time operation - Every CNC has exactly one connect router.
 	// tunnelID is set by cluster manager during CNC creation and is considered immutable
@@ -599,10 +762,6 @@ func (c *Controller) syncCNC(cnc *networkconnectv1.ClusterNetworkConnect) error 
 		}
 		cncState.tunnelID = tunnelID
 	}
-	allocatedSubnets, err := util.ParseNetworkConnectSubnetAnnotation(cnc)
-	if err != nil {
-		return fmt.Errorf("failed to parse subnet annotation for CNC %s: %w", cnc.Name, err)
-	}
 
 	if err := c.syncNetworkConnections(cnc, allocatedSubnets); err != nil {
 		return fmt.Errorf("failed to sync network connections for CNC %s: %v", cnc.Name, err)
@@ -613,6 +772,7 @@ func (c *Controller) syncCNC(cnc *networkconnectv1.ClusterNetworkConnect) error 
 // cleanupCNC removes OVN resources for a deleted CNC.
 func (c *Controller) cleanupCNC(cncName string) error {
 	klog.V(4).Infof("Cleaning up CNC %s", cncName)
+	c.updateCNCNetworkIDsLocked(cncName, nil)
 
 	cncState, exists := c.cncCache[cncName]
 	if !exists {

--- a/go-controller/pkg/ovn/controller/networkconnect/controller_components_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller_components_test.go
@@ -5,13 +5,11 @@ package networkconnect
 
 import (
 	"context"
-	"fmt"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
 
-	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 
@@ -21,9 +19,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	networkconnectv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/clusternetworkconnect/v1"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
+	crdtypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -144,15 +143,15 @@ func TestCNCNeedsUpdate(t *testing.T) {
 			name: "network selectors changed - CUDN selector added",
 			oldObj: &networkconnectv1.ClusterNetworkConnect{
 				Spec: networkconnectv1.ClusterNetworkConnectSpec{
-					NetworkSelectors: []types.NetworkSelector{},
+					NetworkSelectors: []crdtypes.NetworkSelector{},
 				},
 			},
 			newObj: &networkconnectv1.ClusterNetworkConnect{
 				Spec: networkconnectv1.ClusterNetworkConnectSpec{
-					NetworkSelectors: []types.NetworkSelector{
+					NetworkSelectors: []crdtypes.NetworkSelector{
 						{
-							NetworkSelectionType: types.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &types.ClusterUserDefinedNetworkSelector{
+							NetworkSelectionType: crdtypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &crdtypes.ClusterUserDefinedNetworkSelector{
 								NetworkSelector: metav1.LabelSelector{
 									MatchLabels: map[string]string{"app": "test"},
 								},
@@ -167,10 +166,10 @@ func TestCNCNeedsUpdate(t *testing.T) {
 			name: "network selectors changed - PUDN selector label changed",
 			oldObj: &networkconnectv1.ClusterNetworkConnect{
 				Spec: networkconnectv1.ClusterNetworkConnectSpec{
-					NetworkSelectors: []types.NetworkSelector{
+					NetworkSelectors: []crdtypes.NetworkSelector{
 						{
-							NetworkSelectionType: types.PrimaryUserDefinedNetworks,
-							PrimaryUserDefinedNetworkSelector: &types.PrimaryUserDefinedNetworkSelector{
+							NetworkSelectionType: crdtypes.PrimaryUserDefinedNetworks,
+							PrimaryUserDefinedNetworkSelector: &crdtypes.PrimaryUserDefinedNetworkSelector{
 								NamespaceSelector: metav1.LabelSelector{
 									MatchLabels: map[string]string{"env": "dev"},
 								},
@@ -181,10 +180,10 @@ func TestCNCNeedsUpdate(t *testing.T) {
 			},
 			newObj: &networkconnectv1.ClusterNetworkConnect{
 				Spec: networkconnectv1.ClusterNetworkConnectSpec{
-					NetworkSelectors: []types.NetworkSelector{
+					NetworkSelectors: []crdtypes.NetworkSelector{
 						{
-							NetworkSelectionType: types.PrimaryUserDefinedNetworks,
-							PrimaryUserDefinedNetworkSelector: &types.PrimaryUserDefinedNetworkSelector{
+							NetworkSelectionType: crdtypes.PrimaryUserDefinedNetworks,
+							PrimaryUserDefinedNetworkSelector: &crdtypes.PrimaryUserDefinedNetworkSelector{
 								NamespaceSelector: metav1.LabelSelector{
 									MatchLabels: map[string]string{"env": "prod"},
 								},
@@ -199,10 +198,10 @@ func TestCNCNeedsUpdate(t *testing.T) {
 			name: "network selectors unchanged",
 			oldObj: &networkconnectv1.ClusterNetworkConnect{
 				Spec: networkconnectv1.ClusterNetworkConnectSpec{
-					NetworkSelectors: []types.NetworkSelector{
+					NetworkSelectors: []crdtypes.NetworkSelector{
 						{
-							NetworkSelectionType: types.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &types.ClusterUserDefinedNetworkSelector{
+							NetworkSelectionType: crdtypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &crdtypes.ClusterUserDefinedNetworkSelector{
 								NetworkSelector: metav1.LabelSelector{
 									MatchLabels: map[string]string{"app": "test"},
 								},
@@ -213,10 +212,10 @@ func TestCNCNeedsUpdate(t *testing.T) {
 			},
 			newObj: &networkconnectv1.ClusterNetworkConnect{
 				Spec: networkconnectv1.ClusterNetworkConnectSpec{
-					NetworkSelectors: []types.NetworkSelector{
+					NetworkSelectors: []crdtypes.NetworkSelector{
 						{
-							NetworkSelectionType: types.ClusterUserDefinedNetworks,
-							ClusterUserDefinedNetworkSelector: &types.ClusterUserDefinedNetworkSelector{
+							NetworkSelectionType: crdtypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &crdtypes.ClusterUserDefinedNetworkSelector{
 								NetworkSelector: metav1.LabelSelector{
 									MatchLabels: map[string]string{"app": "test"},
 								},
@@ -493,119 +492,154 @@ func TestController_reconcileNode(t *testing.T) {
 // TestController_syncNAD tests that syncNAD requeues CNCs matching the NAD network ID.
 func TestController_syncNAD(t *testing.T) {
 	g := gomega.NewWithT(t)
-	setupTestConfig(true, true)
-
-	fakeClientset := util.GetOVNClientset().GetOVNKubeControllerClientset()
-
 	networkID := 7
-	ownerKey := fmt.Sprintf("layer3_%d", networkID)
-	cnc := &networkconnectv1.ClusterNetworkConnect{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cnc1",
-			Annotations: map[string]string{
-				"k8s.ovn.org/network-connect-subnet": fmt.Sprintf("{\"%s\":{\"ipv4\":\"192.168.0.0/24\"}}", ownerKey),
-			},
+	nadKey := "ns1/nad1"
+	netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "net1",
+			Type: "ovn-k8s-cni-overlay",
 		},
-	}
-	_, err := fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Create(
-		context.Background(), cnc, metav1.CreateOptions{})
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-
-	nadConfig := `{"cniVersion":"1.1.0","name":"net1","type":"ovn-k8s-cni-overlay","topology":"layer3","role":"primary","netAttachDefName":"ns1/nad1"}`
-	nad := &nettypes.NetworkAttachmentDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "ns1",
-			Name:      "nad1",
-			Annotations: map[string]string{
-				"k8s.ovn.org/network-id": strconv.Itoa(networkID),
-			},
-		},
-		Spec: nettypes.NetworkAttachmentDefinitionSpec{
-			Config: nadConfig,
-		},
-	}
-	_, err = fakeClientset.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nad.Namespace).Create(
-		context.Background(), nad, metav1.CreateOptions{})
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-
-	nadKey := util.GetNADName(nad.Namespace, nad.Name)
-	netInfo, err := util.ParseNADInfo(nad)
+		Topology: ovntypes.Layer3Topology,
+		Role:     ovntypes.NetworkRolePrimary,
+		NADName:  nadKey,
+	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	mutableNetInfo := util.NewMutableNetInfo(netInfo)
 	mutableNetInfo.AddNADs(nadKey)
 	mutableNetInfo.SetNetworkID(networkID)
 
-	wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClientset)
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-
-	err = wf.Start()
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-	defer wf.Shutdown()
-
-	// Wait for informer caches to sync
-	syncCtx, syncCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer syncCancel()
-	synced := cache.WaitForCacheSync(
-		syncCtx.Done(),
-		wf.ClusterNetworkConnectInformer().Informer().HasSynced,
-		wf.NADInformer().Informer().HasSynced,
-	)
-	g.Expect(synced).To(gomega.BeTrue(), "informer caches should sync")
-
-	// Track reconciled CNCs
-	reconciledCNCs := sets.New[string]()
-	reconciledMutex := sync.Mutex{}
-
-	// Create controller with listers from watch factory
+	cncController := &controllerutil.FakeController{}
 	c := &Controller{
-		cncLister: wf.ClusterNetworkConnectInformer().Lister(),
-		nadLister: wf.NADInformer().Lister(),
 		networkManager: &networkmanager.FakeNetworkManager{
 			NADNetworks: map[string]util.NetInfo{
 				nadKey: mutableNetInfo,
 			},
 		},
+		cncController: cncController,
 	}
+	c.Lock()
+	c.updateCNCNetworkIDsLocked("cnc1", sets.New(networkID))
+	c.updateCNCNetworkIDsLocked("cnc2", sets.New(99))
+	c.updateCNCNetworkIDsLocked("cnc3", sets.New(networkID, 99))
+	c.Unlock()
 
-	// Create CNC controller with custom reconcile function that tracks calls
-	cncCfg := &controllerutil.ControllerConfig[networkconnectv1.ClusterNetworkConnect]{
-		RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
-		Informer:    wf.ClusterNetworkConnectInformer().Informer(),
-		Lister:      wf.ClusterNetworkConnectInformer().Lister().List,
-		Reconcile: func(key string) error {
-			reconciledMutex.Lock()
-			defer reconciledMutex.Unlock()
-			reconciledCNCs.Insert(key)
-			return nil
+	err = c.syncNAD(nadKey)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(cncController.Reconciles).To(gomega.ConsistOf("Reconcile:cnc1", "Reconcile:cnc3"))
+}
+
+// TestController_syncNetworkRef tests that syncNetworkRef requeues CNCs matching the network ID.
+func TestController_syncNetworkRef(t *testing.T) {
+	g := gomega.NewWithT(t)
+	networkID := 11
+	networkName := "blue-net"
+	netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: networkName,
+			Type: "ovn-k8s-cni-overlay",
 		},
-		ObjNeedsUpdate: cncNeedsUpdate,
-		Threadiness:    1,
+		Topology: ovntypes.Layer3Topology,
+		Role:     ovntypes.NetworkRoleSecondary,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadNetwork := util.NewMutableNetInfo(netInfo)
+	nadNetwork.SetNetworkID(networkID)
+
+	cncController := &controllerutil.FakeController{}
+	c := &Controller{
+		cncController:  cncController,
+		networkManager: &networkmanager.FakeNetworkManager{NADNetworks: map[string]util.NetInfo{"ns1/nad1": nadNetwork}},
 	}
-	c.cncController = controllerutil.NewController("test-cnc-controller", cncCfg)
+	c.Lock()
+	c.updateCNCNetworkIDsLocked("cnc1", sets.New(networkID))
+	c.updateCNCNetworkIDsLocked("cnc2", sets.New(99))
+	c.updateCNCNetworkIDsLocked("cnc3", sets.New(networkID, 99))
+	c.Unlock()
 
-	err = controllerutil.Start(c.cncController)
+	err = c.syncNetworkRef(networkRefKey("node1", networkName))
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	defer controllerutil.Stop(c.cncController)
+	g.Expect(cncController.Reconciles).To(gomega.ConsistOf("Reconcile:cnc1", "Reconcile:cnc3"))
 
-	// Wait for initial sync, then clear recorded reconciliations
-	g.Eventually(func() int {
-		reconciledMutex.Lock()
-		defer reconciledMutex.Unlock()
-		return reconciledCNCs.Len()
-	}).Should(gomega.BeNumerically(">=", 1))
-	reconciledMutex.Lock()
-	reconciledCNCs = sets.New[string]()
-	reconciledMutex.Unlock()
-
-	err = c.syncNAD("ns1/nad1")
+	err = c.syncNetworkRef(networkRefKey("node1", "missing-net"))
 	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(cncController.Reconciles).To(gomega.ConsistOf("Reconcile:cnc1", "Reconcile:cnc3"))
+}
 
-	// Verify CNC was requeued
-	g.Eventually(func() []string {
-		reconciledMutex.Lock()
-		defer reconciledMutex.Unlock()
-		return reconciledCNCs.UnsortedList()
-	}).Should(gomega.ConsistOf("cnc1"))
+type filteredNADNetworkManager struct {
+	networkmanager.FakeNetworkManager
+	nadNetworkNames map[string]string
+}
+
+func (fnm *filteredNADNetworkManager) GetNetInfoForNADKey(string) util.NetInfo {
+	return nil
+}
+
+func (fnm *filteredNADNetworkManager) GetNetworkNameForNADKey(nadKey string) string {
+	return fnm.nadNetworkNames[nadKey]
+}
+
+func TestController_syncNADRequeuesCNCForFilteredNAD(t *testing.T) {
+	g := gomega.NewWithT(t)
+	networkID := 11
+	networkName := "blue-net"
+	nadKey := "ns1/nad1"
+	netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: networkName,
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: ovntypes.Layer3Topology,
+		Role:     ovntypes.NetworkRoleSecondary,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	nadNetwork := util.NewMutableNetInfo(netInfo)
+	nadNetwork.SetNetworkID(networkID)
+
+	cncController := &controllerutil.FakeController{}
+	c := &Controller{
+		cncController: cncController,
+		networkManager: &filteredNADNetworkManager{
+			FakeNetworkManager: networkmanager.FakeNetworkManager{
+				NADNetworks: map[string]util.NetInfo{nadKey: nadNetwork},
+			},
+			nadNetworkNames: map[string]string{nadKey: networkName},
+		},
+	}
+	c.Lock()
+	c.updateCNCNetworkIDsLocked("cnc1", sets.New(networkID))
+	c.updateCNCNetworkIDsLocked("cnc2", sets.New(99))
+	c.Unlock()
+
+	err = c.syncNAD(nadKey)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(cncController.Reconciles).To(gomega.ConsistOf("Reconcile:cnc1"))
+}
+
+func TestController_UpdateCNCNetworkIDsLocked(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	c := &Controller{}
+	c.Lock()
+	c.updateCNCNetworkIDsLocked("cnc1", sets.New(7, 8))
+	c.updateCNCNetworkIDsLocked("cnc2", sets.New(8))
+	c.Unlock()
+	g.Expect(c.cncNetworkIDs["cnc1"]).To(gomega.Equal(sets.New(7, 8)))
+	g.Expect(c.cncsByNetworkID[7]).To(gomega.Equal(sets.New("cnc1")))
+	g.Expect(c.cncsByNetworkID[8]).To(gomega.Equal(sets.New("cnc1", "cnc2")))
+
+	c.Lock()
+	c.updateCNCNetworkIDsLocked("cnc1", sets.New(9))
+	c.Unlock()
+	g.Expect(c.cncNetworkIDs["cnc1"]).To(gomega.Equal(sets.New(9)))
+	g.Expect(c.cncsByNetworkID).ToNot(gomega.HaveKey(7))
+	g.Expect(c.cncsByNetworkID[8]).To(gomega.Equal(sets.New("cnc2")))
+	g.Expect(c.cncsByNetworkID[9]).To(gomega.Equal(sets.New("cnc1")))
+
+	c.Lock()
+	c.updateCNCNetworkIDsLocked("cnc2", nil)
+	c.Unlock()
+	g.Expect(c.cncNetworkIDs).ToNot(gomega.HaveKey("cnc2"))
+	g.Expect(c.cncsByNetworkID).ToNot(gomega.HaveKey(8))
 }
 
 // Test for serviceNeedsUpdate function

--- a/go-controller/pkg/ovn/controller/networkconnect/controller_suite_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller_suite_test.go
@@ -4,11 +4,21 @@
 package networkconnect
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func TestMain(m *testing.M) {
+	// Disable WatchListClient feature gate for tests.
+	// Fake clientsets from third-party libraries don't yet support WatchList semantics
+	// introduced in K8s 1.35, causing informers to hang waiting for bookmark events.
+	// See: https://github.com/kubernetes/kubernetes/issues/135895
+	os.Setenv("KUBE_FEATURE_WatchListClient", "false")
+	os.Exit(m.Run())
+}
 
 func TestNetworkConnectController(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/go-controller/pkg/ovn/controller/networkconnect/controller_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/controller_test.go
@@ -2755,6 +2755,117 @@ var _ = Describe("OVNKube Network Connect Controller Integration Tests", func() 
 					}).WithTimeout(5 * time.Second).Should(Succeed())
 				})
 
+				It("should create remote ports and routes when a remote node becomes active via network ref event", func() {
+					zoneName = "node1"
+					network := testNetwork{
+						name:         "remote-activate-net",
+						id:           1,
+						topologyType: ovntypes.Layer3Topology,
+						subnets:      []string{"10.128.0.0/14/23", "fd00:10:128::/48/64"},
+					}
+					nodes := []testNode{
+						{name: "node1", id: 1, zone: "node1", nodeSubnets: map[string]subnetPair{
+							"remote-activate-net": {"10.128.1.0/24", "fd00:10:128:1::/64"},
+						}},
+						{name: "node2", id: 2, zone: "node2", nodeSubnets: map[string]subnetPair{
+							"remote-activate-net": {"10.128.2.0/24", "fd00:10:128:2::/64"},
+						}},
+					}
+
+					initialDB := createInitialDBWithRouters([]testNetwork{network})
+					initialDB = append(initialDB, &nbdb.Copp{
+						UUID: "copp-uuid",
+						Name: ovntypes.DefaultCOPPName,
+					})
+
+					var err error
+					nbClient, testCtx, err = libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+						NBData: initialDB,
+					}, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					var nodeObjs []runtime.Object
+					for _, n := range nodes {
+						nodeObjs = append(nodeObjs, createTestNode(n))
+					}
+					fakeClientset = util.GetOVNClientset(nodeObjs...).GetOVNKubeControllerClientset()
+
+					wf, err = factory.NewOVNKubeControllerWatchFactory(fakeClientset)
+					Expect(err).NotTo(HaveOccurred())
+					err = wf.Start()
+					Expect(err).NotTo(HaveOccurred())
+
+					netInfo, err := createNetInfo(network)
+					Expect(err).NotTo(HaveOccurred())
+					nm := &testNetworkManager{
+						FakeNetworkManager: networkmanager.FakeNetworkManager{
+							PrimaryNetworks: map[string]util.NetInfo{
+								network.name: netInfo,
+							},
+						},
+						nodeHas: map[string]map[string]bool{
+							"node1": {network.name: true},
+							"node2": {network.name: false},
+						},
+					}
+
+					controller = NewController(zoneName, nbClient, wf, nm)
+					err = controller.Start()
+					Expect(err).NotTo(HaveOccurred())
+
+					subnetAnnotation := buildConnectSubnetAnnotation(map[string]subnetPair{
+						"layer3_1": {"192.168.0.0/24", "fd00:192:168::/64"},
+					})
+					cnc := createTestCNC("remote-activate-cnc", 1600, defaultConnectSubnets(), subnetAnnotation)
+
+					_, err = fakeClientset.NetworkConnectClient.K8sV1().ClusterNetworkConnects().Create(
+						context.Background(), cnc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(func() error {
+						return verifyConnectRouter(nbClient, "remote-activate-cnc", 1600)
+					}).WithTimeout(5 * time.Second).Should(Succeed())
+
+					// Remote node2 starts inactive, so its port/routes should not exist yet.
+					Consistently(func() error {
+						return verifyRouterStaticRoutesCount(nbClient, getConnectRouterName("remote-activate-cnc"),
+							"remote-activate-cnc", network.id, 2, 0)
+					}).WithTimeout(2 * time.Second).Should(Succeed())
+
+					remoteConnectPort := getConnectRouterToNetworkRouterPortName("remote-activate-cnc", network.name, "node2")
+					Consistently(func() error {
+						_, err := libovsdbops.GetLogicalRouterPort(nbClient, &nbdb.LogicalRouterPort{Name: remoteConnectPort})
+						if err == nil {
+							return fmt.Errorf("remote port %s unexpectedly exists", remoteConnectPort)
+						}
+						return nil
+					}).WithTimeout(2 * time.Second).Should(Succeed())
+
+					// Mark node2 active and drive the registered network-ref callback.
+					nm.nodeHas["node2"][network.name] = true
+					Expect(nm.NetworkRefReconcilers).To(HaveLen(1))
+					controller.networkRefReconciler.Reconcile("node2", network.name)
+
+					// The queued network-ref reconcile should requeue the CNC and program
+					// the previously missing remote node topology.
+					Eventually(func() error {
+						return verifyRouterPortIsRemote(nbClient, remoteConnectPort,
+							getExpectedPortTunnelKey("192.168.0.0/24", "fd00:192:168::/64", ovntypes.Layer3Topology, 2))
+					}).WithTimeout(5 * time.Second).Should(Succeed())
+
+					expectedPerIPFamily := 0
+					if config.IPv4Mode {
+						expectedPerIPFamily++
+					}
+					if config.IPv6Mode {
+						expectedPerIPFamily++
+					}
+					Eventually(func() error {
+						return verifyRouterStaticRoutesCount(nbClient, getConnectRouterName("remote-activate-cnc"),
+							"remote-activate-cnc", network.id, 2, expectedPerIPFamily)
+					}).WithTimeout(5 * time.Second).Should(Succeed())
+				})
+
 				It("should create ports for all nodes when multiple networks are connected", func() {
 					// Setup with 1 Layer3 and 1 Layer2 network and 2 nodes (1 local, 1 remote)
 					zoneName = "node1"

--- a/go-controller/pkg/ovn/controller/networkconnect/topology.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/topology.go
@@ -327,13 +327,11 @@ func (c *Controller) syncNetworkConnections(cnc *networkconnectv1.ClusterNetwork
 			}
 		}
 
-		// Ensure static routes on the connect router. For Layer2, skip when the local network is inactive.
-		if netInfo.TopologyType() != ovntypes.Layer2Topology || localActive {
-			createOps, err = c.ensureStaticRoutesOps(createOps, cnc, netInfo, subnets, allNodes)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("CNC %s: failed to ensure static routes for network %s: %w", cncName, netInfo.GetNetworkName(), err))
-				continue
-			}
+		// Ensure static routes on the connect router.
+		createOps, err = c.ensureStaticRoutesOps(createOps, cnc, netInfo, subnets, allNodes, localActive)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("CNC %s: failed to ensure static routes for network %s: %w", cncName, netInfo.GetNetworkName(), err))
+			continue
 		}
 
 		// If ServiceNetwork is enabled, add this network's LBs to the CNC's LBG
@@ -707,7 +705,8 @@ func (c *Controller) ensureConnectPortsOps(ops []ovsdb.Operation, cnc *networkco
 	}
 
 	if netInfo.TopologyType() == ovntypes.Layer3Topology {
-		// For Layer3 networks, create ports for all nodes
+		// For Layer3 networks, reconcile ports for each node based on
+		// per-node network activity.
 		for _, node := range nodes {
 			nodeID, err := util.GetNodeID(node)
 			if err != nil {
@@ -732,9 +731,10 @@ func (c *Controller) ensureConnectPortsOps(ops []ovsdb.Operation, cnc *networkco
 			networkPortName := getNetworkRouterToConnectRouterPortName(networkName, node.Name, cncName)
 
 			isLocalNode := util.GetNodeZone(node) == c.zone
+			nodeActive := c.networkManager.NodeHasNetwork(node.Name, networkName)
 
 			if isLocalNode {
-				if !localActive {
+				if !nodeActive {
 					ops, err = libovsdbops.DeleteLogicalRouterPortWithPredicateOps(c.nbClient, ops, connectRouterName,
 						func(item *nbdb.LogicalRouterPort) bool {
 							return item.Name == connectPortName
@@ -763,6 +763,23 @@ func (c *Controller) ensureConnectPortsOps(ops []ovsdb.Operation, cnc *networkco
 					return nil, fmt.Errorf("failed to create network router port ops %s: %v", networkPortName, err)
 				}
 			} else {
+				if !nodeActive {
+					ops, err = libovsdbops.DeleteLogicalRouterPortWithPredicateOps(c.nbClient, ops, connectRouterName,
+						func(item *nbdb.LogicalRouterPort) bool {
+							return item.Name == connectPortName
+						})
+					if err != nil {
+						return nil, fmt.Errorf("failed to delete remote connect router port ops %s: %v", connectPortName, err)
+					}
+					ops, err = libovsdbops.DeleteLogicalRouterPortWithPredicateOps(c.nbClient, ops, networkRouterName,
+						func(item *nbdb.LogicalRouterPort) bool {
+							return item.Name == networkPortName
+						})
+					if err != nil {
+						return nil, fmt.Errorf("failed to delete network router port ops %s: %v", networkPortName, err)
+					}
+					continue
+				}
 				// Remote node: create only the connect-router side port with requested-chassis set
 				// This makes the port type: remote in SB, enabling cross-zone tunneling
 				chassisID, err := util.ParseNodeChassisIDAnnotation(node)
@@ -1034,12 +1051,13 @@ func (c *Controller) createRoutingPoliciesOps(ops []ovsdb.Operation, dstNetworkI
 
 // ensureStaticRoutesOps returns ops to create static routes on the connect router for reaching network subnets.
 func (c *Controller) ensureStaticRoutesOps(ops []ovsdb.Operation, cnc *networkconnectv1.ClusterNetworkConnect,
-	netInfo util.NetInfo, subnets []*net.IPNet, nodes []*corev1.Node) ([]ovsdb.Operation, error) {
+	netInfo util.NetInfo, subnets []*net.IPNet, nodes []*corev1.Node, localActive bool) ([]ovsdb.Operation, error) {
 	cncName := cnc.Name
 	networkName := netInfo.GetNetworkName()
 	connectRouterName := getConnectRouterName(cncName)
 
 	networkID := netInfo.GetNetworkID()
+	var err error
 
 	// Get the network's pod subnets
 	podSubnets := netInfo.Subnets()
@@ -1049,6 +1067,19 @@ func (c *Controller) ensureStaticRoutesOps(ops []ovsdb.Operation, cnc *networkco
 		for _, node := range nodes {
 			nodeID, err := util.GetNodeID(node)
 			if err != nil {
+				continue
+			}
+			nodeActive := c.networkManager.NodeHasNetwork(node.Name, networkName)
+			if !nodeActive {
+				ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, connectRouterName,
+					func(item *nbdb.LogicalRouterStaticRoute) bool {
+						return item.ExternalIDs[libovsdbops.ObjectNameKey.String()] == cncName &&
+							item.ExternalIDs[libovsdbops.NetworkIDKey.String()] == strconv.Itoa(networkID) &&
+							item.ExternalIDs[libovsdbops.NodeIDKey.String()] == strconv.Itoa(nodeID)
+					})
+				if err != nil {
+					return nil, fmt.Errorf("failed to delete static route ops for inactive node %s: %v", node.Name, err)
+				}
 				continue
 			}
 
@@ -1074,6 +1105,18 @@ func (c *Controller) ensureStaticRoutesOps(ops []ovsdb.Operation, cnc *networkco
 		}
 	}
 	if netInfo.TopologyType() == ovntypes.Layer2Topology {
+		if !localActive {
+			ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, connectRouterName,
+				func(item *nbdb.LogicalRouterStaticRoute) bool {
+					return item.ExternalIDs[libovsdbops.ObjectNameKey.String()] == cncName &&
+						item.ExternalIDs[libovsdbops.NetworkIDKey.String()] == strconv.Itoa(networkID)
+				})
+			if err != nil {
+				return nil, fmt.Errorf("failed to delete static route ops for inactive Layer2 network %s: %v", networkName, err)
+			}
+			return ops, nil
+		}
+
 		// For Layer2, create a single route to the network's subnets
 		portPairInfo, err := GetP2PAddresses(subnets, 0)
 		if err != nil {

--- a/go-controller/pkg/ovn/controller/networkconnect/topology_test.go
+++ b/go-controller/pkg/ovn/controller/networkconnect/topology_test.go
@@ -43,11 +43,15 @@ func chassisIDForNode(nodeName string) string {
 
 type testNetworkManager struct {
 	networkmanager.FakeNetworkManager
-	nodeHas map[string]bool
+	nodeHas map[string]map[string]bool
 }
 
-func (t *testNetworkManager) NodeHasNetwork(_ string, networkName string) bool {
-	return t.nodeHas[networkName]
+func (t *testNetworkManager) NodeHasNetwork(node, networkName string) bool {
+	networks, ok := t.nodeHas[node]
+	if !ok {
+		return false
+	}
+	return networks[networkName]
 }
 
 func TestGetConnectRouterName(t *testing.T) {
@@ -711,6 +715,15 @@ func TestEnsureConnectPortsOps(t *testing.T) {
 			c := &Controller{
 				nbClient: nbClient,
 				zone:     tt.zone,
+				networkManager: &testNetworkManager{
+					nodeHas: func() map[string]map[string]bool {
+						nodeHas := map[string]map[string]bool{}
+						for _, node := range tt.nodes {
+							nodeHas[node.Name] = map[string]bool{tt.networkName: true}
+						}
+						return nodeHas
+					}(),
+				},
 			}
 
 			cnc := &networkconnectv1.ClusterNetworkConnect{
@@ -765,6 +778,84 @@ func TestEnsureConnectPortsOps(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEnsureConnectPortsOpsDeletesInactiveLayer3RemoteNodePorts(t *testing.T) {
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			&nbdb.LogicalRouter{
+				UUID:  "connect-router-uuid",
+				Name:  "connect_router_test-cnc",
+				Ports: []string{"connect-port-uuid"},
+			},
+			&nbdb.LogicalRouter{
+				UUID:  "network-router-uuid",
+				Name:  "cluster-router_test-network",
+				Ports: []string{"network-port-uuid"},
+			},
+			&nbdb.LogicalRouterPort{
+				UUID: "connect-port-uuid",
+				Name: ovntypes.ConnectRouterToRouterPrefix + "test-cnc_test-network_node2",
+			},
+			&nbdb.LogicalRouterPort{
+				UUID: "network-port-uuid",
+				Name: ovntypes.RouterToConnectRouterPrefix + "test-network_node2_test-cnc",
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	defer cleanup.Cleanup()
+
+	c := &Controller{
+		nbClient: nbClient,
+		zone:     "node1",
+		networkManager: &testNetworkManager{
+			nodeHas: map[string]map[string]bool{
+				"node2": {"test-network": false},
+			},
+		},
+	}
+
+	cnc := &networkconnectv1.ClusterNetworkConnect{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cnc"},
+		Spec: networkconnectv1.ClusterNetworkConnectSpec{
+			ConnectSubnets: []networkconnectv1.ConnectSubnet{
+				{CIDR: "192.168.0.0/16", NetworkPrefix: 24},
+			},
+		},
+	}
+
+	netInfo := &mocks.NetInfo{}
+	netInfo.On("GetNetworkName").Return("test-network")
+	netInfo.On("GetNetworkID").Return(1)
+	netInfo.On("TopologyType").Return(ovntypes.Layer3Topology)
+	netInfo.On("GetNetworkScopedClusterRouterName").Return("cluster-router_test-network")
+
+	nodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-id": "2",
+					util.OvnNodeChassisID: chassisIDForNode("node2"),
+					util.OvnNodeZoneName:  "node2",
+				},
+			},
+		},
+	}
+
+	ops, err := c.ensureConnectPortsOps(nil, cnc, netInfo, []*net.IPNet{ovntest.MustParseIPNet("192.168.0.0/24")}, nodes, true)
+	require.NoError(t, err)
+	_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+	require.NoError(t, err)
+
+	connectRouter, err := libovsdbops.GetLogicalRouter(nbClient, &nbdb.LogicalRouter{Name: "connect_router_test-cnc"})
+	require.NoError(t, err)
+	assert.Empty(t, connectRouter.Ports)
+
+	networkRouter, err := libovsdbops.GetLogicalRouter(nbClient, &nbdb.LogicalRouter{Name: "cluster-router_test-network"})
+	require.NoError(t, err)
+	assert.Empty(t, networkRouter.Ports)
 }
 
 func TestCleanupNetworkConnections(t *testing.T) {
@@ -915,26 +1006,45 @@ func TestSyncNetworkConnectionsInactiveNetwork(t *testing.T) {
 
 	fakeClientset := util.GetOVNClientset().GetOVNKubeControllerClientset()
 
-	nodeSubnets := map[string]string{
+	node1Subnets := map[string]string{
 		"netA": "10.0.0.0/24",
 		"netB": "10.1.0.0/24",
 	}
-	subnetsBytes, err := json.Marshal(nodeSubnets)
+	node2Subnets := map[string]string{
+		"netA": "10.0.1.0/24",
+		"netB": "10.1.1.0/24",
+	}
+	node1SubnetsBytes, err := json.Marshal(node1Subnets)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	node2SubnetsBytes, err := json.Marshal(node2Subnets)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	// Seed a local node with per-network subnets and required annotations.
-	node := &corev1.Node{
+	// Seed local and remote nodes with per-network subnets and required annotations.
+	node1 := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 			Annotations: map[string]string{
 				util.OvnNodeZoneName:       "zone1",
 				util.OvnNodeID:             "1",
 				util.OvnNodeChassisID:      chassisIDForNode("node1"),
-				"k8s.ovn.org/node-subnets": string(subnetsBytes),
+				"k8s.ovn.org/node-subnets": string(node1SubnetsBytes),
 			},
 		},
 	}
-	_, err = fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				util.OvnNodeZoneName:       "zone2",
+				util.OvnNodeID:             "2",
+				util.OvnNodeChassisID:      chassisIDForNode("node2"),
+				"k8s.ovn.org/node-subnets": string(node2SubnetsBytes),
+			},
+		},
+	}
+	_, err = fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node1, metav1.CreateOptions{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node2, metav1.CreateOptions{})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// Start node informer so getNodeSubnet can resolve node annotations.
@@ -971,7 +1081,7 @@ func TestSyncNetworkConnectionsInactiveNetwork(t *testing.T) {
 		{CIDR: ovntest.MustParseIPNet("10.1.0.0/16")},
 	})
 
-	// netA is active locally, netB is inactive initially.
+	// netA is active locally, netB is inactive locally but active on node2.
 	networks := map[string]util.NetInfo{
 		"netA": networkA,
 		"netB": networkB,
@@ -980,9 +1090,15 @@ func TestSyncNetworkConnectionsInactiveNetwork(t *testing.T) {
 		FakeNetworkManager: networkmanager.FakeNetworkManager{
 			PrimaryNetworks: networks,
 		},
-		nodeHas: map[string]bool{
-			"netA": true,
-			"netB": false,
+		nodeHas: map[string]map[string]bool{
+			"node1": {
+				"netA": true,
+				"netB": false,
+			},
+			"node2": {
+				"netA": false,
+				"netB": true,
+			},
 		},
 	}
 
@@ -1002,7 +1118,7 @@ func TestSyncNetworkConnectionsInactiveNetwork(t *testing.T) {
 		zone:           "zone1",
 		nodeLister:     wf.NodeCoreInformer().Lister(),
 		networkManager: nm,
-		localZoneNode:  node,
+		localZoneNode:  node1,
 		cncCache: map[string]*networkConnectState{
 			cncName: {
 				name:              cncName,
@@ -1027,7 +1143,7 @@ func TestSyncNetworkConnectionsInactiveNetwork(t *testing.T) {
 		util.ComputeNetworkOwner(ovntypes.Layer3Topology, 2): {ovntest.MustParseIPNet("192.168.1.0/24")},
 	}
 
-	// First sync: netB inactive, so only remote/static programming is expected.
+	// First sync: netB inactive locally, but active remotely on node2.
 	err = c.syncNetworkConnections(cnc, allocatedSubnets)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -1038,21 +1154,22 @@ func TestSyncNetworkConnectionsInactiveNetwork(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(policies).ToNot(gomega.BeEmpty())
 
-	// Static routes for netB should be programmed on the connect router.
+	// Static routes for netB should be programmed for the remote active node only.
 	routes, err := libovsdbops.FindLogicalRouterStaticRoutesWithPredicate(nbClient, func(item *nbdb.LogicalRouterStaticRoute) bool {
 		return item.ExternalIDs[libovsdbops.ObjectNameKey.String()] == cncName &&
-			item.ExternalIDs[libovsdbops.NetworkIDKey.String()] == "2"
+			item.ExternalIDs[libovsdbops.NetworkIDKey.String()] == "2" &&
+			item.ExternalIDs[libovsdbops.NodeIDKey.String()] == "2"
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(routes).ToNot(gomega.BeEmpty())
-	portPairInfo, err := GetP2PAddresses(allocatedSubnets[util.ComputeNetworkOwner(ovntypes.Layer3Topology, 2)], 1)
+	portPairInfo, err := GetP2PAddresses(allocatedSubnets[util.ComputeNetworkOwner(ovntypes.Layer3Topology, 2)], 2)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	expectedNexthops := util.IPNetsToIPs(portPairInfo.networkPortIPs)
 	g.Expect(expectedNexthops).ToNot(gomega.BeEmpty())
 
 	foundRoute := false
 	for _, route := range routes {
-		if route.IPPrefix == "10.1.0.0/24" {
+		if route.IPPrefix == "10.1.1.0/24" {
 			g.Expect(route.Nexthop).To(gomega.Equal(expectedNexthops[0].String()))
 			foundRoute = true
 			break
@@ -1060,22 +1177,44 @@ func TestSyncNetworkConnectionsInactiveNetwork(t *testing.T) {
 	}
 	g.Expect(foundRoute).To(gomega.BeTrue())
 
-	// No local router port should be created for inactive netB.
+	// No local router port should be created for inactive local netB.
 	ports, err := libovsdbops.FindLogicalRouterPortWithPredicate(nbClient, func(item *nbdb.LogicalRouterPort) bool {
-		return item.ExternalIDs[libovsdbops.NetworkIDKey.String()] == "2" &&
-			item.ExternalIDs[libovsdbops.RouterNameKey.String()] == "cluster-router_netB"
+		return item.Name == getNetworkRouterToConnectRouterPortName("netB", "node1", cncName)
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(ports).To(gomega.BeEmpty())
 
-	// Activate netB and re-sync: local router ports and policies should now be created.
-	nm.nodeHas["netB"] = true
+	// Remote connect-router port for active node2 should exist.
+	_, err = libovsdbops.GetLogicalRouterPort(nbClient, &nbdb.LogicalRouterPort{
+		Name: getConnectRouterToNetworkRouterPortName(cncName, "netB", "node2"),
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Deactivate remote netB and re-sync: remote routes and remote connect port should be removed.
+	nm.nodeHas["node2"]["netB"] = false
+	err = c.syncNetworkConnections(cnc, allocatedSubnets)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	routes, err = libovsdbops.FindLogicalRouterStaticRoutesWithPredicate(nbClient, func(item *nbdb.LogicalRouterStaticRoute) bool {
+		return item.ExternalIDs[libovsdbops.ObjectNameKey.String()] == cncName &&
+			item.ExternalIDs[libovsdbops.NetworkIDKey.String()] == "2" &&
+			item.ExternalIDs[libovsdbops.NodeIDKey.String()] == "2"
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(routes).To(gomega.BeEmpty())
+
+	_, err = libovsdbops.GetLogicalRouterPort(nbClient, &nbdb.LogicalRouterPort{
+		Name: getConnectRouterToNetworkRouterPortName(cncName, "netB", "node2"),
+	})
+	g.Expect(err).To(gomega.HaveOccurred())
+
+	// Activate local netB and re-sync: local router ports and reverse policies should be created.
+	nm.nodeHas["node1"]["netB"] = true
 	err = c.syncNetworkConnections(cnc, allocatedSubnets)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	ports, err = libovsdbops.FindLogicalRouterPortWithPredicate(nbClient, func(item *nbdb.LogicalRouterPort) bool {
-		return item.ExternalIDs[libovsdbops.NetworkIDKey.String()] == "2" &&
-			item.ExternalIDs[libovsdbops.RouterNameKey.String()] == "cluster-router_netB"
+		return item.Name == getNetworkRouterToConnectRouterPortName("netB", "node1", cncName)
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(ports).ToNot(gomega.BeEmpty())
@@ -2102,6 +2241,15 @@ func TestEnsureStaticRoutesOps(t *testing.T) {
 				nbClient:   nbClient,
 				zone:       tt.zone,
 				nodeLister: wf.NodeCoreInformer().Lister(),
+				networkManager: &testNetworkManager{
+					nodeHas: func() map[string]map[string]bool {
+						nodeHas := map[string]map[string]bool{}
+						for _, node := range tt.nodes {
+							nodeHas[node.name] = map[string]bool{tt.networkName: true}
+						}
+						return nodeHas
+					}(),
+				},
 			}
 
 			cnc := &networkconnectv1.ClusterNetworkConnect{
@@ -2116,7 +2264,7 @@ func TestEnsureStaticRoutesOps(t *testing.T) {
 				nodes = append(nodes, node)
 			}
 
-			ops, err := c.ensureStaticRoutesOps(nil, cnc, netInfo, tt.connectSubnets, nodes)
+			ops, err := c.ensureStaticRoutesOps(nil, cnc, netInfo, tt.connectSubnets, nodes, true)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -3797,4 +3945,137 @@ func TestCleanupPartialConnectivity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEnsureStaticRoutesOpsDeletesInactiveLayer3RemoteNodeRoutes(t *testing.T) {
+	fakeClientset := util.GetOVNClientset().GetOVNKubeControllerClientset()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				"k8s.ovn.org/node-id": "2",
+			},
+		},
+	}
+	_, err := fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClientset)
+	require.NoError(t, err)
+	err = wf.Start()
+	require.NoError(t, err)
+	defer wf.Shutdown()
+
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer syncCancel()
+	synced := cache.WaitForCacheSync(syncCtx.Done(), wf.NodeCoreInformer().Informer().HasSynced)
+	require.True(t, synced, "informer caches should sync")
+
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			&nbdb.LogicalRouter{
+				UUID:         "connect-router-uuid",
+				Name:         "connect_router_test-cnc",
+				StaticRoutes: []string{"route-uuid"},
+			},
+			&nbdb.LogicalRouterStaticRoute{
+				UUID:     "route-uuid",
+				IPPrefix: "10.128.2.0/24",
+				Nexthop:  "192.168.0.3",
+				ExternalIDs: map[string]string{
+					libovsdbops.ObjectNameKey.String(): "test-cnc",
+					libovsdbops.NetworkIDKey.String():  "1",
+					libovsdbops.NodeIDKey.String():     "2",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	defer cleanup.Cleanup()
+
+	netInfo := &mocks.NetInfo{}
+	netInfo.On("GetNetworkName").Return("test-network")
+	netInfo.On("GetNetworkID").Return(1)
+	netInfo.On("TopologyType").Return(ovntypes.Layer3Topology)
+	netInfo.On("Subnets").Return([]config.CIDRNetworkEntry{{CIDR: ovntest.MustParseIPNet("10.128.0.0/16")}})
+
+	c := &Controller{
+		nbClient:   nbClient,
+		zone:       "node1",
+		nodeLister: wf.NodeCoreInformer().Lister(),
+		networkManager: &testNetworkManager{
+			nodeHas: map[string]map[string]bool{
+				"node2": {"test-network": false},
+			},
+		},
+	}
+
+	listerNode, err := wf.NodeCoreInformer().Lister().Get("node2")
+	require.NoError(t, err)
+
+	ops, err := c.ensureStaticRoutesOps(
+		nil,
+		&networkconnectv1.ClusterNetworkConnect{ObjectMeta: metav1.ObjectMeta{Name: "test-cnc"}},
+		netInfo,
+		[]*net.IPNet{ovntest.MustParseIPNet("192.168.0.0/24")},
+		[]*corev1.Node{listerNode},
+		true,
+	)
+	require.NoError(t, err)
+	_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+	require.NoError(t, err)
+
+	router, err := libovsdbops.GetLogicalRouter(nbClient, &nbdb.LogicalRouter{Name: "connect_router_test-cnc"})
+	require.NoError(t, err)
+	assert.Empty(t, router.StaticRoutes)
+}
+
+func TestEnsureStaticRoutesOpsDeletesInactiveLayer2Routes(t *testing.T) {
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			&nbdb.LogicalRouter{
+				UUID:         "connect-router-uuid",
+				Name:         "connect_router_test-cnc",
+				StaticRoutes: []string{"route-uuid"},
+			},
+			&nbdb.LogicalRouterStaticRoute{
+				UUID:     "route-uuid",
+				IPPrefix: "10.200.0.0/24",
+				Nexthop:  "192.168.0.1",
+				ExternalIDs: map[string]string{
+					libovsdbops.ObjectNameKey.String(): "test-cnc",
+					libovsdbops.NetworkIDKey.String():  "1",
+					libovsdbops.NodeIDKey.String():     "0",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	defer cleanup.Cleanup()
+
+	netInfo := &mocks.NetInfo{}
+	netInfo.On("GetNetworkName").Return("test-l2-network")
+	netInfo.On("GetNetworkID").Return(1)
+	netInfo.On("TopologyType").Return(ovntypes.Layer2Topology)
+	netInfo.On("Subnets").Return([]config.CIDRNetworkEntry{{CIDR: ovntest.MustParseIPNet("10.200.0.0/24")}})
+
+	c := &Controller{
+		nbClient: nbClient,
+	}
+
+	ops, err := c.ensureStaticRoutesOps(
+		nil,
+		&networkconnectv1.ClusterNetworkConnect{ObjectMeta: metav1.ObjectMeta{Name: "test-cnc"}},
+		netInfo,
+		[]*net.IPNet{ovntest.MustParseIPNet("192.168.0.0/31")},
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+	require.NoError(t, err)
+
+	router, err := libovsdbops.GetLogicalRouter(nbClient, &nbdb.LogicalRouter{Name: "connect_router_test-cnc"})
+	require.NoError(t, err)
+	assert.Empty(t, router.StaticRoutes)
 }

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -25,6 +25,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
 )
 
@@ -386,6 +387,98 @@ func getCNCAnnotations(cncName string) (map[string]string, error) {
 		return nil, err
 	}
 	return annotations, nil
+}
+
+func getCNCNetworkIDForTopology(cncName, topology string) string {
+	prefix := strings.ToLower(topology) + "_"
+	var networkID string
+	Eventually(func(g Gomega) {
+		annotations, err := getCNCAnnotations(cncName)
+		g.Expect(err).NotTo(HaveOccurred())
+		subnetAnnotation := annotations[ovnNetworkConnectSubnetAnnotation]
+		var subnets map[string]cncAnnotationSubnet
+		g.Expect(json.Unmarshal([]byte(subnetAnnotation), &subnets)).To(Succeed())
+
+		foundID := ""
+		for owner := range subnets {
+			if strings.HasPrefix(owner, prefix) {
+				foundID = strings.TrimPrefix(owner, prefix)
+				break
+			}
+		}
+		g.Expect(foundID).NotTo(BeEmpty(), "CNC %s should have a %s owner key", cncName, topology)
+		networkID = foundID
+	}, 60*time.Second, 2*time.Second).Should(Succeed())
+	return networkID
+}
+
+func getNodeIDAnnotation(cs clientset.Interface, nodeName string) string {
+	node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	nodeID := node.Annotations["k8s.ovn.org/node-id"]
+	Expect(nodeID).NotTo(BeEmpty(), "node %s should have k8s.ovn.org/node-id annotation", nodeName)
+	return nodeID
+}
+
+func findOVNNBDBPod(cs clientset.Interface, ovnNamespace string) (*corev1.Pod, error) {
+	pods, err := cs.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "ovn-db-pod=true"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list OVN DB pods: %w", err)
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		for _, container := range pod.Spec.Containers {
+			if container.Name == "nb-ovsdb" {
+				return pod, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no running OVN DB pod with nb-ovsdb container found in namespace %s", ovnNamespace)
+}
+
+func runOVNNBCTL(f *framework.Framework, cs clientset.Interface, args ...string) (string, error) {
+	ovnNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+	dbPod, err := findOVNNBDBPod(cs, ovnNamespace)
+	if err != nil {
+		return "", err
+	}
+	cmd := append([]string{"ovn-nbctl"}, args...)
+	stdout, stderr, err := ExecCommandInContainerWithFullOutput(f, ovnNamespace, dbPod.Name, "nb-ovsdb", cmd...)
+	if err != nil {
+		return stdout, fmt.Errorf("failed running ovn-nbctl %v on %s/%s: %w, stderr: %s", args, ovnNamespace, dbPod.Name, err, stderr)
+	}
+	return strings.TrimSpace(stdout), nil
+}
+
+func findCNCNodeOVNObjects(f *framework.Framework, cs clientset.Interface, table, columns, cncName, networkID, nodeID string) (string, error) {
+	return runOVNNBCTL(f, cs,
+		"--data=bare",
+		"--no-heading",
+		"--columns="+columns,
+		"find", table,
+		fmt.Sprintf("external_ids:k8s.ovn.org/name=%s", cncName),
+		fmt.Sprintf("external_ids:network-id=%s", networkID),
+		fmt.Sprintf("external_ids:node-id=%s", nodeID),
+	)
+}
+
+func verifyCNCNodeOVNObjects(f *framework.Framework, cs clientset.Interface, cncName, networkID, nodeID string, expectPresent bool) {
+	Eventually(func(g Gomega) {
+		ports, err := findCNCNodeOVNObjects(f, cs, "Logical_Router_Port", "name", cncName, networkID, nodeID)
+		g.Expect(err).NotTo(HaveOccurred())
+		routes, err := findCNCNodeOVNObjects(f, cs, "Logical_Router_Static_Route", "ip_prefix,nexthop", cncName, networkID, nodeID)
+		g.Expect(err).NotTo(HaveOccurred())
+		if expectPresent {
+			g.Expect(ports).NotTo(BeEmpty(), "expected CNC %s L3 router ports for network ID %s node ID %s", cncName, networkID, nodeID)
+			g.Expect(routes).NotTo(BeEmpty(), "expected CNC %s L3 static routes for network ID %s node ID %s", cncName, networkID, nodeID)
+			return
+		}
+		g.Expect(ports).To(BeEmpty(), "expected CNC %s L3 router ports for network ID %s node ID %s to be removed", cncName, networkID, nodeID)
+		g.Expect(routes).To(BeEmpty(), "expected CNC %s L3 static routes for network ID %s node ID %s to be removed", cncName, networkID, nodeID)
+	}, 60*time.Second, 2*time.Second).Should(Succeed())
 }
 
 // getCNCTunnelID gets CNC tunnel ID from annotations
@@ -2489,6 +2582,18 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 		return "other"
 	}
 
+	// checkPingConnectivity checks ICMP reachability from one pod to an IP.
+	// It uses ping6 for IPv6 destinations.
+	checkPingConnectivity := func(fromNamespace, fromPodName, toIP string) error {
+		pingCmd := "ping"
+		if ip := net.ParseIP(toIP); ip != nil && ip.To4() == nil {
+			pingCmd = "ping6"
+		}
+		_, err := e2ekubectl.RunKubectl(fromNamespace, "exec", fromPodName, "--",
+			pingCmd, "-c", "3", "-W", "2", toIP)
+		return err
+	}
+
 	// verifyCrossNetworkConnectivity verifies connectivity from a set of pods to another set
 	// Supports dual-stack by testing all IPs for each pod
 	// Uses Eventually for expected success
@@ -2980,6 +3085,123 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			verifyFullMeshConnectivity(srcPods, podIPs, true)
 
 			By("Test completed successfully - CNC lifecycle validated")
+		})
+	})
+
+	Context("Dynamic UDN allocation", func() {
+		const nodeHostnameKey = "kubernetes.io/hostname"
+
+		It("should connect cross-node L3 and L2 UDN pods through CNC when dynamic UDN allocation is enabled", func() {
+			if !isDynamicUDNEnabled() {
+				Skip("test requires DYNAMIC_UDN_ALLOCATION=true")
+			}
+
+			testID := rand.String(5)
+			cncName := generateCNCName()
+			l3UDNName := "blue-udn"
+			l2UDNName := "green-udn"
+			l3Namespace := fmt.Sprintf("blue-ns-%s", testID)
+			l2Namespace := fmt.Sprintf("green-ns-%s", testID)
+			udnLabel := map[string]string{"cnc-test": testID}
+
+			nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), cs, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(nodes.Items)).To(BeNumerically(">=", 2), "test requires at least 2 schedulable nodes")
+			node1Name, node2Name := nodes.Items[0].Name, nodes.Items[1].Name
+
+			var l3PodNode1, l3PodNode2, l2Pod *corev1.Pod
+
+			DeferCleanup(func() {
+				deleteCNC(cncName)
+				if l3PodNode1 != nil {
+					_ = cs.CoreV1().Pods(l3PodNode1.Namespace).Delete(context.Background(), l3PodNode1.Name, metav1.DeleteOptions{})
+				}
+				if l3PodNode2 != nil {
+					_ = cs.CoreV1().Pods(l3PodNode2.Namespace).Delete(context.Background(), l3PodNode2.Name, metav1.DeleteOptions{})
+				}
+				if l2Pod != nil {
+					_ = cs.CoreV1().Pods(l2Pod.Namespace).Delete(context.Background(), l2Pod.Name, metav1.DeleteOptions{})
+				}
+				deleteUDN(l3Namespace, l3UDNName)
+				deleteUDN(l2Namespace, l2UDNName)
+				deleteNamespace(cs, l3Namespace)
+				deleteNamespace(cs, l2Namespace)
+			})
+
+			By("Creating two UDN namespaces selected by the same CNC")
+			createUDNNamespaceWithName(cs, l3Namespace, udnLabel)
+			createUDNNamespaceWithName(cs, l2Namespace, udnLabel)
+
+			By("Creating the L3 and L2 UDNs")
+			createLayer3PrimaryUDNWithSubnets(cs, l3Namespace, l3UDNName, "10.140.0.0/16", "2014:100:600::0/60")
+			createLayer2PrimaryUDNWithSubnets(cs, l2Namespace, l2UDNName, "10.141.0.0/16", "2014:100:700::0/60")
+
+			By("Waiting for both UDNs to be ready")
+			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, l3Namespace, l3UDNName), 60*time.Second, time.Second).Should(Succeed())
+			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, l2Namespace, l2UDNName), 60*time.Second, time.Second).Should(Succeed())
+
+			By("Creating the CNC before either node becomes active for the selected UDNs")
+			createOrUpdateCNC(cs, cncName, nil, udnLabel)
+
+			By("Verifying the CNC selected both UDNs")
+			verifyCNCHasBothAnnotations(cncName)
+			verifyCNCSubnetAnnotationNetworkCount(cncName, 2)
+			l3NetworkID := getCNCNetworkIDForTopology(cncName, "layer3")
+			node1ID := getNodeIDAnnotation(cs, node1Name)
+			node2ID := getNodeIDAnnotation(cs, node2Name)
+
+			By(fmt.Sprintf("Creating an L3 pod on %s", node1Name))
+			l3PodNode1Config := httpServerPodConfig("blue-pod-node1", l3Namespace)
+			l3PodNode1Config.nodeSelector = map[string]string{nodeHostnameKey: node1Name}
+			l3PodNode1 = runUDNPod(cs, l3Namespace, l3PodNode1Config, nil)
+
+			By(fmt.Sprintf("Creating a second L3 pod on %s", node2Name))
+			l3PodNode2Config := httpServerPodConfig("blue-pod-node2", l3Namespace)
+			l3PodNode2Config.nodeSelector = map[string]string{nodeHostnameKey: node2Name}
+			l3PodNode2 = runUDNPod(cs, l3Namespace, l3PodNode2Config, nil)
+
+			By(fmt.Sprintf("Creating an L2 pod on %s", node2Name))
+			l2PodConfig := httpServerPodConfig("green-pod", l2Namespace)
+			l2PodConfig.nodeSelector = map[string]string{nodeHostnameKey: node2Name}
+			l2Pod = runUDNPod(cs, l2Namespace, l2PodConfig, nil)
+
+			l3PodNode1IPs := getPrimaryNetworkPodIPs(l3Namespace, l3PodNode1.Name, l3UDNName)
+			l3PodNode2IPs := getPrimaryNetworkPodIPs(l3Namespace, l3PodNode2.Name, l3UDNName)
+			l2PodIPs := getPrimaryNetworkPodIPs(l2Namespace, l2Pod.Name, l2UDNName)
+
+			By("Verifying the cross-node L3 and L2 pods can ping each other through the CNC")
+			for _, l2PodIP := range l2PodIPs {
+				Eventually(func() error {
+					return checkPingConnectivity(l3PodNode1.Namespace, l3PodNode1.Name, l2PodIP)
+				}, 30*time.Second, 2*time.Second).Should(Succeed(),
+					fmt.Sprintf("expected %s/%s to ping %s", l3PodNode1.Namespace, l3PodNode1.Name, l2PodIP))
+			}
+			for _, l3PodIP := range l3PodNode1IPs {
+				Eventually(func() error {
+					return checkPingConnectivity(l2Pod.Namespace, l2Pod.Name, l3PodIP)
+				}, 30*time.Second, 2*time.Second).Should(Succeed(),
+					fmt.Sprintf("expected %s/%s to ping %s", l2Pod.Namespace, l2Pod.Name, l3PodIP))
+			}
+
+			By("Verifying CNC created L3 node-specific OVN state for both active L3 nodes")
+			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node1ID, true)
+			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node2ID, true)
+
+			By(fmt.Sprintf("Deleting the L3 pod on %s to make that node inactive for the L3 UDN", node1Name))
+			Expect(deletePodWithWait(context.Background(), cs, l3PodNode1)).To(Succeed())
+			l3PodNode1 = nil
+
+			By("Verifying the remaining L3 pod is still reachable through the CNC")
+			for _, l3PodIP := range l3PodNode2IPs {
+				Eventually(func() error {
+					return checkPingConnectivity(l2Pod.Namespace, l2Pod.Name, l3PodIP)
+				}, 30*time.Second, 2*time.Second).Should(Succeed(),
+					fmt.Sprintf("expected %s/%s to ping remaining L3 pod IP %s", l2Pod.Namespace, l2Pod.Name, l3PodIP))
+			}
+
+			By("Verifying CNC removed L3 node-specific OVN state for the inactive node only")
+			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node1ID, false)
+			verifyCNCNodeOVNObjects(f, cs, cncName, l3NetworkID, node2ID, true)
 		})
 	})
 

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -3496,9 +3496,6 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 		   7. Delete CNC-2, verify all services isolated
 		*/
 		It("should maintain non-transitive service connectivity when a network is selected by multiple CNCs", func() {
-			if isDynamicUDNEnabled() {
-				Skip("Service connectivity with dynamic UDN allocation is not yet supported, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5963")
-			}
 			// Same topology as above but with ServiceNetwork enabled:
 			// CNC-1: blue + red, CNC-2: blue + green
 			// Verify service VIPs work cross-network and survive CNC-1 deletion
@@ -3736,9 +3733,6 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 		   7. Delete CNC-2, verify all services isolated
 		*/
 		It("should maintain service connectivity when both CNCs select the exact same networks", func() {
-			if isDynamicUDNEnabled() {
-				Skip("Service connectivity with dynamic UDN allocation is not yet supported, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5963")
-			}
 			// Both CNCs select the same 2 networks with ServiceNetwork
 			// Deleting one CNC should not break the other's service connectivity
 
@@ -4000,9 +3994,6 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 		}
 
 		BeforeEach(func() {
-			if isDynamicUDNEnabled() {
-				Skip("Service connectivity with dynamic UDN allocation is not yet supported, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5963")
-			}
 			// Get 2 schedulable nodes for cross-node testing
 			nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), cs, 2)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- Adds CNC tracker in NAD controller to influence Dynamic UDN Network active/inactive states. Networks are now active that are selected by CNC and that CNC has at least 1 active network on a node.
- Adds new API to register with NAD controller for network related events for nodes when they go active/inactive
- CNC controller subscribes to this new API, then reconciles when networks go active on a remote node
- Layer 3 remote routes/ports are filtered if nodes are inactive

Fixes #5963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ClusterNetworkConnect support and a network-ref reconciliation mechanism to detect and notify when nodes gain/lose network connectivity.
  * Integrated network-ref plumbing into controllers to trigger reconcilation workflows for affected networks.

* **Improvements**
  * Controllers now proactively remove stale per-node ports and routes when a node is no longer active for a network.

* **Tests**
  * Added unit and end-to-end tests for ClusterNetworkConnect, network-ref reconciliation, and dynamic user-defined network connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->