### PR TITLE
Use GinkgoHelper in ovntesting.OnSupportedPlatformsIt()

### DIFF
--- a/go-controller/pkg/testing/testing.go
+++ b/go-controller/pkg/testing/testing.go
@@ -12,6 +12,7 @@ import (
 // tests that are unable to execute in certain environments. Such as those without
 // root or cap_net_admin privileges
 func OnSupportedPlatformsIt(description string, f interface{}) {
+	ginkgo.GinkgoHelper()
 	if !NoRoot() {
 		ginkgo.It(description, f)
 	} else {


### PR DESCRIPTION
Currently, every test that uses `ovntesting.OnSupportedPlatformsIt()` shows up as being located at `go-controller/pkg/testing/testing.go:16` in the logs:

```
UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Gateway functionality ensure UDNGateway and VRFManager and IPRulesManager are invoked for Primary UDNs when feature gate is ON
/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/testing.go:16
```

calling `ginkgo.GinkgoHelper()` fixes the logging to ignore that function and report the parent file/line number:

```
UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Gateway functionality ensure UDNGateway and VRFManager and IPRulesManager are invoked for Primary UDNs when feature gate is ON
/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/user_defined_node_network_controller_test.go:267
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test helper function identification for improved test reporting and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->