### PR TITLE
Fix BGP e2e reliability: retry FRRConfiguration apply and add configurable max-pods for KIND

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1643,6 +1643,7 @@ create_kind_cluster() {
   ovn_num_worker=${KIND_NUM_WORKER} \
   kind_num_infra=${KIND_NUM_INFRA} \
   cluster_log_level=${KIND_CLUSTER_LOGLEVEL:-4} \
+  kind_max_pods=${KIND_MAX_PODS:-250} \
   jinjanate "${KIND_CONFIG}" -o "${KIND_CONFIG_LCL}"
 
   # Create KIND cluster. For additional debug, add '--verbosity <int>': 0 None .. 3 Debug

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -41,11 +41,13 @@ kubeadmConfigPatches:
   nodeRegistration:
     kubeletExtraArgs:
       "v": "{{ cluster_log_level }}"
+      "max-pods": "{{ kind_max_pods | default(250) }}"
   ---
   kind: JoinConfiguration
   nodeRegistration:
     kubeletExtraArgs:
       "v": "{{ cluster_log_level }}"
+      "max-pods": "{{ kind_max_pods | default(250) }}"
 nodes:
  - role: control-plane
    kubeadmConfigPatches:

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -2969,10 +2969,12 @@ func runBGPNetworkAndServer(
 		return fmt.Errorf("failed to generate FRR-k8s configuration: %w", err)
 	}
 	ictx.AddCleanUpFn(func() error { return os.RemoveAll(frrK8sConfig) })
-	_, err = e2ekubectl.RunKubectl(deploymentconfig.Get().FRRK8sNamespace(), "create", "-f", frrK8sConfig)
-	if err != nil {
-		return fmt.Errorf("failed to apply FRRConfiguration: %w", err)
-	}
+	// Retry FRRConfiguration apply: the frr-k8s validation webhook may not be ready
+	// immediately (e.g., after cluster startup), causing "context deadline exceeded".
+	gomega.Eventually(func(g gomega.Gomega) {
+		_, err = e2ekubectl.RunKubectl(deploymentconfig.Get().FRRK8sNamespace(), "apply", "-f", frrK8sConfig)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to apply FRRConfiguration")
+	}, 60*time.Second, 5*time.Second).Should(gomega.Succeed())
 	ictx.AddCleanUpFn(func() error {
 		_, err = e2ekubectl.RunKubectl(deploymentconfig.Get().FRRK8sNamespace(), "delete", "-f", frrK8sConfig)
 		if err != nil {
@@ -3032,8 +3034,12 @@ func createNamespaceWithPrimaryNetworkOfType(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create namespace: %w", err)
 	}
+	namespaceName := namespace.Name
 	ictx.AddCleanUpFn(func() error {
-		return f.ClientSet.CoreV1().Namespaces().Delete(context.Background(), namespace.Name, metav1.DeleteOptions{})
+		if f == nil || f.ClientSet == nil {
+			return nil
+		}
+		return f.ClientSet.CoreV1().Namespaces().Delete(context.Background(), namespaceName, metav1.DeleteOptions{})
 	})
 
 	// just creating a namespace with default network, return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

This PR improves BGP e2e test reliability. The VRF-Lite test setup
improvements (BeforeAll, shorter timeouts, dynamic subnets, etc.) were
landed upstream in the meantime, so this PR now focuses on the remaining
reliability fixes not yet in tree.

Files changed:
- `contrib/kind-common.sh` – add `KIND_MAX_PODS` variable (default 250)
- `contrib/kind.yaml.j2` – add `max-pods` kubelet arg for control-plane and worker nodes
- `test/e2e/route_advertisements.go` – BGP e2e reliability fixes

### 1. Kind cluster configuration (`contrib/kind-common.sh`, `contrib/kind.yaml.j2`)

Configurable max-pods for kind nodes: Introduces `KIND_MAX_PODS` (default 250) so the
kubelet `max-pods` can be tuned for VRF-Lite/BGP tests that need more pods per node.

### 2. BGP e2e reliability fixes (`test/e2e/route_advertisements.go`)

- **Retry FRRConfiguration apply on frr-k8s webhook timeout**: Wraps `RunKubectl`
  in `gomega.Eventually` (60s, 5s) and uses `"apply"` instead of `"create"` so
  retries succeed if the resource was already partially created. Handles transient
  `context deadline exceeded` errors when the frr-k8s validation webhook is not
  ready yet.

- **Guard namespace cleanup against nil framework pointer**: Captures
  `namespace.Name` into a local variable before the cleanup closure (avoiding
  stale reference) and adds a nil check for `f`/`f.ClientSet` to prevent panics
  during cleanup after test framework teardown.

Fixes #

## Additional Information for reviewers

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated KIND cluster configuration to support configurable maximum pods per node (defaults to 250).
  * Added automatic retry logic (60-second timeout) for configuration application to handle webhook initialization timing.

* **Bug Fixes**
  * Improved resource cleanup error handling to prevent nil-pointer dereferences in failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->