### PR TITLE
Make Kubelet CRI operation timeout tunable

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -29,8 +29,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-const kubeletDefaultCRIOperationTimeout = 2 * time.Minute
-
 // *** The Server is PRIVATE API between OVN components and may be
 // changed at any time.  It is in no way a supported interface or API. ***
 //
@@ -169,8 +167,7 @@ func cniRequestToPodRequest(cr *Request) (*PodRequest, error) {
 
 	// STATUS requests do not carry pod-specific context. Return early after validating config.
 	if req.Command == CNIStatus {
-		// Match the Kubelet default CRI operation timeout of 2m.
-		req.ctx, req.cancel = context.WithTimeout(context.Background(), kubeletDefaultCRIOperationTimeout)
+		req.ctx, req.cancel = context.WithTimeout(context.Background(), time.Duration(config.Default.KubeletCRIOperationTimeout)*time.Second)
 		return req, nil
 	}
 
@@ -236,8 +233,7 @@ func cniRequestToPodRequest(cr *Request) (*PodRequest, error) {
 		}
 	}
 
-	// Match the Kubelet default CRI operation timeout of 2m.
-	req.ctx, req.cancel = context.WithTimeout(context.Background(), kubeletDefaultCRIOperationTimeout)
+	req.ctx, req.cancel = context.WithTimeout(context.Background(), time.Duration(config.Default.KubeletCRIOperationTimeout)*time.Second)
 	return req, nil
 }
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -103,6 +103,7 @@ var (
 		Zone:                         types.OvnDefaultZone,
 		RawUDNAllowedDefaultServices: "default/kubernetes,kube-system/kube-dns",
 		Transport:                    "",
+		KubeletCRIOperationTimeout:   types.DefaultKubeletCRIOperationTimeout,
 	}
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
@@ -369,6 +370,10 @@ type DefaultConfig struct {
 	// Accepts: "" (empty, uses OVN default overlay) or "no-overlay".
 	// Defaults to "" (empty).
 	Transport string `gcfg:"transport"`
+
+	// KubeletCRIOperationTimeout is the timeout for kubelet CRI operation, may be useful
+	// to increase for high-scale clusters. Default value is 2 minutes.
+	KubeletCRIOperationTimeout uint `gcfg:"kubelet-cri-operation-timeout"`
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -1052,6 +1057,12 @@ var CommonFlags = []cli.Flag{
 		Name:        "enable-multicast",
 		Usage:       "Adds multicast support. Valid only with --init-master option.",
 		Destination: &EnableMulticast,
+	},
+	&cli.UintFlag{
+		Name:        "kubelet-cri-operation-timeout",
+		Usage:       "KubeletCRIOperationTimeout is the timeout for kubelet CRI operation, may be useful to increase for high-scale clusters. Default value is 2 minutes.",
+		Destination: &cliConfig.Default.KubeletCRIOperationTimeout,
+		Value:       Default.KubeletCRIOperationTimeout,
 	},
 	// Logging options
 	&cli.IntFlag{
@@ -2606,6 +2617,10 @@ func buildDefaultConfig(cli, file *config) error {
 
 	if Default.Zone == "" {
 		Default.Zone = types.OvnDefaultZone
+	}
+
+	if Default.KubeletCRIOperationTimeout == 0 {
+		Default.KubeletCRIOperationTimeout = types.DefaultKubeletCRIOperationTimeout
 	}
 
 	return nil

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -352,4 +352,7 @@ const (
 	// management port.
 	NFTMgmtPortNoSNATSubnetsV4 = "mgmtport-no-snat-subnets-v4"
 	NFTMgmtPortNoSNATSubnetsV6 = "mgmtport-no-snat-subnets-v6"
+
+	// DefaultKubeletCRIOperationTimeout is the default timeout for kubelet CRI operation.
+	DefaultKubeletCRIOperationTimeout = 120 // in seconds
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

In large clusters, the kubelet CRI operation timeout value may need to be increased to allow ovn-controller more time to create the openlow rules in OVS. This PR adds a config knob to adjust this value. The dafault value is set to the previous constant value of 2 minutes. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubelet CRI operation timeout is now configurable (default: 120 seconds) via config and a new CLI flag, replacing the prior fixed 2-minute value.

* **Bug Fixes / Behavior**
  * CNI status processing and final pod request handling now consistently use the configured timeout, preventing mismatched timeouts and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->