### PR TITLE
Bump MetalLB to 0.15.3; Bump FRR to 10.5.3+; e2e: do not skip frr service coredumps

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1134,7 +1134,7 @@ get_kubevirt_release_url() {
 
 readonly FRR_K8S_VERSION=v0.0.21
 readonly FRR_K8S_UPSTREAM_FRR_IMAGE=quay.io/frrouting/frr:10.4.1
-readonly FRR_DEPLOYED_IMAGE=quay.io/frrouting/frr:10.4.3
+readonly FRR_DEPLOYED_IMAGE=quay.io/frrouting/frr:10.5.3
 # Override to test newer FRR builds in the in-cluster frr-k8s daemonset
 # without changing the pinned frr-k8s release.
 FRR_K8S_FRR_IMAGE=${FRR_K8S_FRR_IMAGE:-${FRR_DEPLOYED_IMAGE}}
@@ -1161,10 +1161,13 @@ clone_frr() {
     # https://github.com/FRRouting/frr/pull/15714).
     #
     # Bump to 10.4.1 for upstream demo was posted here: https://github.com/metallb/frr-k8s/pull/404
-    # We bump further to 10.4.3 to include additional fixes for EVPN:
+    # We bump further to 10.5.3 to include additional fixes for EVPN and coredumps:
     # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3907335193
     # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3898408592
     # https://github.com/FRRouting/frr/pull/20496
+    #
+    # Note: 10.5.3 is aligned with current metallb trunk:
+    # https://github.com/metallb/metallb/pull/2993
     replace_in_file_or_exit \
       hack/demo/demo.sh \
       "${FRR_K8S_UPSTREAM_FRR_IMAGE}" \

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -514,12 +514,7 @@ install_ingress() {
 
 METALLB_DIR="/tmp/metallb"
 install_metallb() {
-  # Using latest v0.14.9 as the commit we were using would not build and this
-  # version is the one having least issues for dual stack. However tests might
-  # have to workaround these two outstanding issue until fixed
-  # https://github.com/metallb/metallb/issues/2723
-  # https://github.com/metallb/metallb/issues/2724
-  local metallb_version=v0.14.9
+  local metallb_version=v0.15.3
   mkdir -p /tmp/metallb
   local builddir
   builddir=$(mktemp -d "${METALLB_DIR}/XXXXXX")
@@ -533,18 +528,7 @@ install_metallb() {
   # when using 'kind load' command however metallb builds and uses older
   # incompatible kind version patch it so that it uses our own kind install
   # instead of their build
-  patch tasks.py << 'EOF'
-@@ -29,7 +29,7 @@ extra_network = "network2"
--controller_gen_version = "v0.16.3"
-+controller_gen_version = "v0.19.0"
- build_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "build")
- kubectl_path = os.path.join(build_path, "kubectl")
--kind_path = os.path.join(build_path, "kind")
-+kind_path = "kind"
- ginkgo_path = os.path.join(build_path, "bin", "ginkgo")
- controller_gen_path = os.path.join(build_path, "bin", "controller-gen")
- kubectl_version = "v1.31.0"
-EOF
+  sed -i 's|kind_path = os.path.join(build_path, "kind")|kind_path = "kind"|' tasks.py
 
   pip install -r dev-env/requirements.txt
 

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1133,6 +1133,12 @@ get_kubevirt_release_url() {
 }
 
 readonly FRR_K8S_VERSION=v0.0.21
+readonly FRR_K8S_UPSTREAM_FRR_IMAGE=quay.io/frrouting/frr:10.4.1
+readonly FRR_DEPLOYED_IMAGE=quay.io/frrouting/frr:10.4.3
+# Override to test newer FRR builds in the in-cluster frr-k8s daemonset
+# without changing the pinned frr-k8s release.
+FRR_K8S_FRR_IMAGE=${FRR_K8S_FRR_IMAGE:-${FRR_DEPLOYED_IMAGE}}
+readonly FRR_EXTERNAL_DEMO_IMAGE=${FRR_DEPLOYED_IMAGE}
 readonly FRR_TMP_DIR=$(mktemp -d -u)
 
 clone_frr() {
@@ -1161,8 +1167,8 @@ clone_frr() {
     # https://github.com/FRRouting/frr/pull/20496
     replace_in_file_or_exit \
       hack/demo/demo.sh \
-      'quay.io/frrouting/frr:10.4.1' \
-      'quay.io/frrouting/frr:10.4.3'
+      "${FRR_K8S_UPSTREAM_FRR_IMAGE}" \
+      "${FRR_EXTERNAL_DEMO_IMAGE}"
 
     popd
 
@@ -1343,6 +1349,7 @@ install_frr_k8s() {
   clone_frr
 
   # apply frr-k8s
+
   # The all-in-one manifest is only consumed here (deploy_frr_external_container
   # uses CRDs and the demo scripts, not this manifest), so the fix lives here
   # rather than in clone_frr. This covers both kind.sh and kind-helm.sh since
@@ -1355,10 +1362,12 @@ install_frr_k8s() {
   # REVERT ME: when https://github.com/metallb/metallb/issues/2619 is fixed
   sed -i 's|gcr.io/kubebuilder/kube-rbac-proxy|registry.k8s.io/kubebuilder/kube-rbac-proxy|g' \
     "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml
-  # Bump frr in frr-k8s to 10.4.3 to consume the following fix
-  # https://github.com/FRRouting/frr/pull/20496
-  sed -i 's|quay.io/frrouting/frr:[0-9.]*|quay.io/frrouting/frr:10.4.3|g' \
-    "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml
+
+  replace_in_file_or_exit \
+    "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml \
+    "${FRR_K8S_UPSTREAM_FRR_IMAGE}" \
+    "${FRR_K8S_FRR_IMAGE}"
+
   if [ "${bgp_port}" -ne 0 ]; then
     local frr_yaml="${FRR_TMP_DIR}/frr-k8s/config/all-in-one/frr-k8s.yaml"
     grep -q 'bgpd_options=.*-p 0' "$frr_yaml" || {

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -513,6 +513,40 @@ install_ingress() {
 }
 
 METALLB_DIR="/tmp/metallb"
+
+align_metallb_pool_with_ip_family() {
+  # In single-stack jobs, dev-env can provide dual-stack addresses, which
+  # causes withdraw/announce churn and flaky connectivity checks.
+  if [ "$PLATFORM_IPV4_SUPPORT" == "$PLATFORM_IPV6_SUPPORT" ]; then
+    return
+  fi
+
+  local pool_json filtered_addresses_json matched_count
+  pool_json=$(kubectl -n metallb-system get ipaddresspool dev-env-bgp -o json 2>/dev/null || true)
+  if [ -z "${pool_json}" ]; then
+    echo "Failed to read dev-env-bgp pool"
+    kubectl -n metallb-system get ipaddresspool dev-env-bgp -o yaml || true
+    exit 1
+  fi
+
+  filtered_addresses_json=$(echo "${pool_json}" | jq -c \
+    --arg ipv4 "${PLATFORM_IPV4_SUPPORT}" \
+    --arg ipv6 "${PLATFORM_IPV6_SUPPORT}" '
+    .spec.addresses
+    | if $ipv6 == "true" and $ipv4 != "true" then map(select(test(":")))
+      elif $ipv4 == "true" and $ipv6 != "true" then map(select(test(":") | not))
+      else .
+      end
+  ')
+  matched_count=$(echo "${filtered_addresses_json}" | jq 'length')
+  if [ "${matched_count}" -eq 0 ]; then
+    echo "Failed to derive family-matching addresses from dev-env-bgp pool: $(echo "${pool_json}" | jq -c '.spec.addresses')"
+    exit 1
+  fi
+  kubectl -n metallb-system patch ipaddresspool dev-env-bgp --type='merge' \
+    -p "{\"spec\":{\"addresses\":${filtered_addresses_json}}}"
+}
+
 install_metallb() {
   local metallb_version=v0.15.3
   mkdir -p /tmp/metallb
@@ -545,6 +579,8 @@ install_metallb() {
   fi
   # Override GOBIN until https://github.com/metallb/metallb/issues/2218 is fixed.
   GOBIN="" inv dev-env -n ovn -b frr -p bgp -i "${ip_family}"
+
+  align_metallb_pool_with_ip_family
 
   $OCI_BIN network rm -f clientnet
   $OCI_BIN network create --subnet="${METALLB_CLIENT_NET_SUBNET_IPV4}" ${ipv6_network} --driver bridge clientnet

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -38,6 +38,35 @@ if_error_exit() {
     fi
 }
 
+replace_in_file_or_exit() {
+  local file="$1"
+  local needle="$2"
+  local replacement="$3"
+  local escaped_needle escaped_replacement
+
+  escaped_needle=$(escape_sed_replacement "$needle")
+  escaped_replacement=$(escape_sed_replacement "$replacement")
+
+  if ! grep -Fq -- "$needle" "$file"; then
+    echo "Expected to replace pattern in ${file}, but it was not found: ${needle}" >&2
+    exit 1
+  fi
+
+  if ! sed -i "s|${escaped_needle}|${escaped_replacement}|g" "$file"; then
+    echo "Failed to update ${file}" >&2
+    exit 1
+  fi
+
+  if grep -Fq -- "$needle" "$file"; then
+    echo "Pattern still present in ${file} after replacement: ${needle}" >&2
+    exit 1
+  fi
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed 's/[\\|&]/\\&/g'
+}
+
 set_common_default_params() {
   # KIND/cluster params
   KIND_CREATE=${KIND_CREATE:-true}
@@ -562,7 +591,10 @@ install_metallb() {
   # when using 'kind load' command however metallb builds and uses older
   # incompatible kind version patch it so that it uses our own kind install
   # instead of their build
-  sed -i 's|kind_path = os.path.join(build_path, "kind")|kind_path = "kind"|' tasks.py
+  replace_in_file_or_exit \
+    tasks.py \
+    'kind_path = os.path.join(build_path, "kind")' \
+    'kind_path = "kind"'
 
   pip install -r dev-env/requirements.txt
 
@@ -1127,7 +1159,10 @@ clone_frr() {
     # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3907335193
     # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3898408592
     # https://github.com/FRRouting/frr/pull/20496
-    sed -i 's|quay.io/frrouting/frr:[0-9.]*|quay.io/frrouting/frr:10.4.3|g' hack/demo/demo.sh
+    replace_in_file_or_exit \
+      hack/demo/demo.sh \
+      'quay.io/frrouting/frr:10.4.1' \
+      'quay.io/frrouting/frr:10.4.3'
 
     popd
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,15 +13,12 @@ DUALSTACK_CONVERSION?=false
 # Coredump detection settings
 # Directory where kind clusters store coredumps
 COREDUMP_DIR?=/tmp/kind/logs/coredumps
-# Processes to skip when checking for coredumps (pipe-separated for grep)
-# https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5782
-SKIPPED_COREDUMPS?=zebra|bgpd|mgmtd|bfdd
 
-# Check for coredumps and fail if any are found (excluding skipped processes)
+# Check for coredumps and fail if any are found
 # Usage: $(call check-coredumps)
 define check-coredumps
 	@if [ -d "$(COREDUMP_DIR)" ]; then \
-		coredumps=$$(find "$(COREDUMP_DIR)" -maxdepth 1 -type f 2>/dev/null | grep -v -E '$(SKIPPED_COREDUMPS)' || true); \
+		coredumps=$$(find "$(COREDUMP_DIR)" -maxdepth 1 -type f 2>/dev/null); \
 		if [ -n "$$coredumps" ]; then \
 			echo "ERROR: Coredumps found:"; \
 			echo "$$coredumps"; \

--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -23,6 +23,7 @@ var (
 	nginx                 = "nginx:1"
 	metallbLBService      = "quay.io/itssurya/dev-images:metallb-lbservice"
 	udpServerSrcIPPrinter = "quay.io/itssurya/dev-images:udp-server-srcip-printer"
+	frr                   = "quay.io/frrouting/frr:10.4.3"
 
 	extraImages []string
 )
@@ -45,6 +46,9 @@ func init() {
 	}
 	if udpServerOverride := os.Getenv("UDP_SERVER_SRCIP_PRINTER_IMAGE"); udpServerOverride != "" {
 		udpServerSrcIPPrinter = udpServerOverride
+	}
+	if frrOverride := os.Getenv("FRR_IMAGE"); frrOverride != "" {
+		frr = frrOverride
 	}
 }
 
@@ -70,6 +74,10 @@ func MetalLBLBService() string {
 
 func UDPServerSrcIPPrinter() string {
 	return udpServerSrcIPPrinter
+}
+
+func FRR() string {
+	return frr
 }
 
 // Add registers images that are needed by a test suite. Call from init()

--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -23,7 +23,7 @@ var (
 	nginx                 = "nginx:1"
 	metallbLBService      = "quay.io/itssurya/dev-images:metallb-lbservice"
 	udpServerSrcIPPrinter = "quay.io/itssurya/dev-images:udp-server-srcip-printer"
-	frr                   = "quay.io/frrouting/frr:10.4.3"
+	frr                   = "quay.io/frrouting/frr:10.5.3"
 
 	extraImages []string
 )

--- a/test/e2e/reporter.go
+++ b/test/e2e/reporter.go
@@ -205,10 +205,17 @@ func rawDump(exec Executor, filesToDump ...string) (string, error) {
 	}
 	res += out
 
-	res += "####### Routes published by BGP Speakers\n"
+	res += "####### Routes published by BGP Speakers (IPv4)\n"
 	out, err = exec.Exec("vtysh", "-c", "show ip bgp detail")
 	if err != nil {
 		allerrs = errors.Wrapf(allerrs, "\nFailed exec show ip bgp detail: %v", err)
+	}
+	res += out
+
+	res += "####### Routes published by BGP Speakers (IPv6)\n"
+	out, err = exec.Exec("vtysh", "-c", "show bgp ipv6 unicast detail")
+	if err != nil {
+		allerrs = errors.Wrapf(allerrs, "\nFailed exec show bgp ipv6 unicast detail: %v", err)
 	}
 	res += out
 
@@ -216,6 +223,13 @@ func rawDump(exec Executor, filesToDump ...string) (string, error) {
 	out, err = exec.Exec("bash", "-c", "ip route show")
 	if err != nil {
 		allerrs = errors.Wrapf(allerrs, "\nFailed exec ip route show: %v", err)
+	}
+	res += out
+
+	res += "####### ip -6 route show\n"
+	out, err = exec.Exec("bash", "-c", "ip -6 route show")
+	if err != nil {
+		allerrs = errors.Wrapf(allerrs, "\nFailed exec ip -6 route show: %v", err)
 	}
 	res += out
 

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -62,6 +62,12 @@ const (
 	netexecPort            = 8080
 )
 
+func init() {
+	if os.Getenv("ENABLE_ROUTE_ADVERTISEMENTS") == "true" {
+		images.Add(images.FRR())
+	}
+}
+
 var _ = ginkgo.Describe("BGP: When default podNetwork is advertised", feature.RouteAdvertisements, func() {
 	var serverContainerIPs []string
 	var frrContainerIPv4, frrContainerIPv6 string
@@ -2761,8 +2767,6 @@ type templateInputFRR struct {
 var ratestdata embed.FS
 var tmplDir = filepath.Join("testdata", "routeadvertisements")
 
-const frrImage = "quay.io/frrouting/frr:10.4.3"
-
 // generateFRRConfiguration to establish a BGP session towards the provided
 // neighbors in the network's VRF configured to advertised the provided
 // networks. Returns a temporary directory where the configuration is generated.
@@ -2916,7 +2920,7 @@ func runBGPNetworkAndServer(
 	ictx.AddCleanUpFn(func() error { return os.RemoveAll(frrConfig) })
 	frr := infraapi.ExternalContainer{
 		Name:        networkName + "-frr",
-		Image:       frrImage,
+		Image:       images.FRR(),
 		Network:     bgpPeerNetwork,
 		RuntimeArgs: []string{"--volume", frrConfig + ":" + filepath.Join(filepath.FromSlash("/"), "etc", "frr")},
 	}

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1903,6 +1903,18 @@ metadata:
 		e2ekubectl.RunKubectlOrDie("default", "label", "node", nonBackendNodeName, "k8s.ovn.org/egress-assignable-")
 	})
 
+	tryWgetLoadBalancer := func(externalContainer infraapi.ExternalContainer, svcLoadBalancerIP string) {
+		err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+			_, err := wgetInExternalContainer(externalContainer, svcLoadBalancerIP, endpointHTTPPort, "big.iso")
+			if err != nil {
+				framework.Logf("retrying wget to %s: %v", svcLoadBalancerIP, err)
+				return false, nil
+			}
+			return true, nil
+		})
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+	}
+
 	ginkgo.It("Should ensure connectivity works on an external service when mtu changes in intermediate node", func() {
 		err := WaitForServingAndReadyServiceEndpointsNum(context.TODO(), f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*180)
 		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an endpoint, err: %v", svcName, err))
@@ -2155,8 +2167,7 @@ spec:
 
 		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 		externalContainer := infraapi.ExternalContainer{Name: externalClientContainerName}
-		_, err = wgetInExternalContainer(externalContainer, svcLoadBalancerIP, endpointHTTPPort, "big.iso")
-		framework.ExpectNoError(err, "failed to curl load balancer service")
+		tryWgetLoadBalancer(externalContainer, svcLoadBalancerIP)
 
 		ginkgo.By("patching service " + svcName + " to allocateLoadBalancerNodePorts=false and externalTrafficPolicy=local")
 
@@ -2299,8 +2310,7 @@ spec:
 
 		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 		externalContainer := infraapi.ExternalContainer{Name: externalClientContainerName}
-		_, err = wgetInExternalContainer(externalContainer, svcLoadBalancerIP, endpointHTTPPort, "big.iso")
-		framework.ExpectNoError(err, "failed to curl load balancer service")
+		tryWgetLoadBalancer(externalContainer, svcLoadBalancerIP)
 
 		// Patch the service to use named ports.
 		ginkgo.By("patching service " + svcName + " to named ports")
@@ -2324,8 +2334,7 @@ spec:
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of nftables elements, err: %v", err)
 		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 		externalContainer = infraapi.ExternalContainer{Name: externalClientContainerName}
-		_, err = wgetInExternalContainer(externalContainer, svcLoadBalancerIP, endpointHTTPPort, "big.iso")
-		framework.ExpectNoError(err, "failed to curl load balancer service")
+		tryWgetLoadBalancer(externalContainer, svcLoadBalancerIP)
 
 		// Patch the service to use allocateLoadBalancerNodeProts=false and externalTrafficPolicy=local.
 		ginkgo.By("patching service " + svcName + " to allocateLoadBalancerNodePorts=false and externalTrafficPolicy=local")
@@ -2357,8 +2366,7 @@ spec:
 
 		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 
-		_, err = wgetInExternalContainer(externalContainer, svcLoadBalancerIP, endpointHTTPPort, "big.iso")
-		framework.ExpectNoError(err, "failed to curl load balancer service")
+		tryWgetLoadBalancer(externalContainer, svcLoadBalancerIP)
 
 		pktSize := 60
 		if utilnet.IsIPv6String(svcLoadBalancerIP) {
@@ -2390,8 +2398,7 @@ spec:
 
 		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 
-		_, err = wgetInExternalContainer(externalContainer, svcLoadBalancerIP, endpointHTTPPort, "big.iso")
-		framework.ExpectNoError(err, "failed to curl load balancer service")
+		tryWgetLoadBalancer(externalContainer, svcLoadBalancerIP)
 
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(backendNodeName, 1, fmt.Sprintf("[1:%d] -A OVN-KUBE-ETP", pktSize)))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1995,10 +1995,14 @@ metadata:
 		numberOfETPRules := pokeNodeIPTableRules(backendNodeName, "OVN-KUBE-EXTERNALIP")
 		gomega.Expect(numberOfETPRules).To(gomega.Equal(5))
 
-		// curl the LB service from the client container to trigger BGP route advertisement
-		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 		primaryProviderNetwork, err := infraprovider.Get().PrimaryNetwork()
 		framework.ExpectNoError(err, "must fetch primary provider network")
+
+		ginkgo.By("waiting for BGP route to be installed on the FRR router")
+		waitForFRRBGPRoute(svcLoadBalancerIP, externalRouterContainerName, primaryProviderNetwork)
+
+		// curl the LB service from the client container to trigger BGP route advertisement
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 		externalContainer := infraapi.ExternalContainer{Name: "lbclient", Network: primaryProviderNetwork} // pre-created
 		_, err = wgetInExternalContainer(externalContainer, svcLoadBalancerIP, endpointHTTPPort, "big.iso")
 		framework.ExpectNoError(err, "failed to curl load balancer service")
@@ -2142,6 +2146,12 @@ spec:
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of nftables elements, err: %v", err)
 		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfNFTElements(backendNodeName, 0, "mgmtport-no-snat-nodeports"))
 		framework.ExpectNoError(err, "Couldn't fetch the correct number of nftables elements, err: %v", err)
+
+		primaryProviderNetwork, err := infraprovider.Get().PrimaryNetwork()
+		framework.ExpectNoError(err, "must get primary provider network")
+
+		ginkgo.By("waiting for BGP route to be installed on the FRR router")
+		waitForFRRBGPRoute(svcLoadBalancerIP, externalRouterContainerName, primaryProviderNetwork)
 
 		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " with backend pod " + backendName)
 		externalContainer := infraapi.ExternalContainer{Name: externalClientContainerName}
@@ -2701,6 +2711,26 @@ spec:
 		}
 	})
 })
+
+// waitForFRRBGPRoute waits for a BGP route for the given service VIP to be
+// installed in the external FRR router's kernel routing table.
+func waitForFRRBGPRoute(svcLoadBalancerIP string, frrContainerName string, providerNetwork infraapi.Network) {
+	ipVer := ""
+	if utilnet.IsIPv6String(svcLoadBalancerIP) {
+		ipVer = " -6"
+	}
+	cmd := strings.Split(fmt.Sprintf("ip%s route show %s", ipVer, svcLoadBalancerIP), " ")
+	frrContainer := infraapi.ExternalContainer{Name: frrContainerName, Network: providerNetwork}
+	gomega.Eventually(func() bool {
+		routes, err := infraprovider.Get().ExecExternalContainerCommand(frrContainer, cmd)
+		if err != nil {
+			framework.Logf("Failed to get routes from FRR: %v", err)
+			return false
+		}
+		framework.Logf("FRR routes for %s: %s", svcLoadBalancerIP, routes)
+		return strings.Contains(routes, "proto bgp")
+	}, 30*time.Second, 1*time.Second).Should(gomega.BeTrue(), "BGP route for %s was not installed on the FRR router", svcLoadBalancerIP)
+}
 
 func getNodeIP(c clientset.Interface, nodeName string) (string, error) {
 	node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1169,9 +1169,6 @@ func wrappedTestFramework(basename string) *framework.Framework {
 		logLocation := "/var/log"
 		coredumpDir := "/tmp/kind/logs/coredumps"
 		dbLocation := "/var/lib/openvswitch"
-		// https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5782
-		skippedCoredumps := []string{"zebra", "bgpd", "mgmtd", "bfdd"}
-
 		// Check for coredumps on host
 		var coredumpFiles []string
 		files, err := os.ReadDir(coredumpDir)
@@ -1180,14 +1177,7 @@ func wrappedTestFramework(basename string) *framework.Framework {
 				if file.IsDir() {
 					continue
 				}
-				fileName := file.Name()
-				if slices.ContainsFunc(skippedCoredumps, func(s string) bool {
-					return strings.Contains(fileName, s)
-				}) {
-					framework.Logf("Ignoring coredump for skipped process: %s", fileName)
-					continue
-				}
-				coredumpFiles = append(coredumpFiles, fileName)
+				coredumpFiles = append(coredumpFiles, file.Name())
 			}
 		}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Bump metallb to 0.15.3 that has 10.1+ FRR stack with necessary fixes for segfaults in Alpine env.

Bump FRR images to 10.5.3 to include more fixes for coredumps.

Fixes #5782
Fixes #5453

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Coredump handling simplified: all coredump files are now collected and reported (no exclusions) but no longer fail test execution.
  * Added wait logic in e2e tests to ensure BGP routes are present before contacting load‑balanced services.

* **Chores**
  * Networking/demo tooling updated: MetalLB and FRR versions bumped; installation/patching steps simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->