### PR TITLE
route advertisement: Init FRR factory for combined mode

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -292,6 +292,13 @@ func NewMasterWatchFactory(ovnClientset *util.OVNMasterClientset) (*WatchFactory
 		wf.vtepFactory.K8s().V1().VTEPs().Informer()
 	}
 
+	// Initialize FRR factory for Route Advertisement support in combined mode (cluster-manager + ovnkube-controller).
+	if util.IsRouteAdvertisementsEnabled() {
+		wf.frrFactory = frrinformerfactory.NewSharedInformerFactory(ovnClientset.FRRClient, resyncInterval)
+		// make sure shared informer is created for a factory, so on wf.frrFactory.Start() it is initialized and caches are synced.
+		wf.frrFactory.Api().V1beta1().FRRConfigurations().Informer()
+	}
+
 	return wf, nil
 }
 


### PR DESCRIPTION
## 📑 Description
Initialize FRR factories when running OVN-K in combined mode (cluster-manager + ovnkube-controller).
Otherwise, OVN-K will panic when using --init-master (combined mode deployment) trying to access FRR informer for RA controller.

## Additional Information for reviewers
N/A

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
Run combined mode OVN-K with route advertisement, for example MicroShift because it specifies `--init-master`.

Without the fix, OVN-K will panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x196ef40]

goroutine 10083 [running]:
github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory.(*WatchFactory).FRRConfigurationsInformer(0x4004e37e60?)
        /workspace/ovn-kubernetes/go-controller/pkg/factory/factory.go:1866 +0x20
github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/routeadvertisements.NewController({0x2e7d7b8, 0x40002db180}, 0x400086c640, 0x4000822fc0)
        /workspace/ovn-kubernetes/go-controller/pkg/clustermanager/routeadvertisements/controller.go:97 +0x54
github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager.NewClusterManager(0x4000822fc0, 0x0?, {0xffffd6805c8d, 0x3}, {0xffff4fddb118, 0x4000809940})
        /workspace/ovn-kubernetes/go-controller/pkg/clustermanager/clustermanager.go:192 +0x8b4
main.runOvnKube.func2()
        /workspace/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:474 +0x348
created by main.runOvnKube in goroutine 1
        /workspace/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:470 +0x220
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Initialized route advertisement and FRR configuration handling in combined mode to ensure routing components are prepared and relevant caches are initialized on start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->