### PR TITLE
Exclude webhook pods from being subject to the webhook

### DIFF
--- a/dist/templates/ovnkube-identity.yaml.j2
+++ b/dist/templates/ovnkube-identity.yaml.j2
@@ -120,6 +120,9 @@ webhooks:
       caBundle: {{ webhook_ca_bundle }}
     admissionReviewVersions: ['v1']
     sideEffects: None
+    matchConditions:
+      - name: skip-ovnkube-identity-self-pods
+        expression: '!(request.namespace == "ovn-kubernetes" && has(object.metadata.labels) && "name" in object.metadata.labels && object.metadata.labels["name"] == "ovnkube-identity")'
     rules:
       - operations: [ "UPDATE" ]
         apiGroups: ["*"]

--- a/helm/ovn-kubernetes/charts/ovnkube-identity/templates/webhook.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-identity/templates/webhook.yaml
@@ -47,6 +47,9 @@ webhooks:
       caBundle: {{ $ca.Cert | b64enc | quote }}
     admissionReviewVersions: ['v1']
     sideEffects: None
+    matchConditions:
+      - name: skip-ovnkube-identity-self-pods
+        expression: '!(request.namespace == "ovn-kubernetes" && has(object.metadata.labels) && "name" in object.metadata.labels && object.metadata.labels["name"] == "ovnkube-identity")'
     rules:
       - operations: [ "UPDATE" ]
         apiGroups: ["*"]


### PR DESCRIPTION
If all of the webhook pods go down, when a new one comes up and the status is attempted to be updated of the pod, KAPI will have no webhook to contact and updates will fail. We should exclude the webhook for the webhook pods.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pod admission webhook behavior to skip processing for the identity component’s own pod (identified by namespace and label), preventing the webhook from acting on that system pod. This reduces inadvertent webhook interactions, improves stability during component updates, and avoids self-targeting admission events in specific deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->