### PR TITLE
dpulease: fix lease ownerReference and log healthy recovery

### DIFF
--- a/go-controller/pkg/node/dpulease/manager.go
+++ b/go-controller/pkg/node/dpulease/manager.go
@@ -200,7 +200,12 @@ func (m *Manager) setStatus(reason string, ready bool) {
 	m.statusMu.Lock()
 	defer m.statusMu.Unlock()
 
-	if m.ready != ready || m.reason != reason {
+	prevReady := m.ready
+	prevReason := m.reason
+	if prevReady != ready || prevReason != reason {
+		if ready && !prevReady && prevReason != "" {
+			klog.V(4).Infof("DPU lease %s marked healthy", m.leaseName())
+		}
 		m.ready = ready
 		m.reason = reason
 	}
@@ -222,7 +227,7 @@ func (m *Manager) newLease(now metav1.MicroTime) *coordinationv1.Lease {
 					Name:               m.nodeName,
 					UID:                m.nodeUID,
 					Controller:         boolPtr(true),
-					BlockOwnerDeletion: boolPtr(true),
+					BlockOwnerDeletion: boolPtr(false),
 				},
 			},
 		},
@@ -259,28 +264,31 @@ func (m *Manager) updateLeaseSpec(lease *coordinationv1.Lease, now metav1.MicroT
 		}
 	}
 
-	if !m.hasOwnerRef(lease.OwnerReferences) {
+	ownerRefFound := false
+	for i := range lease.OwnerReferences {
+		ref := &lease.OwnerReferences[i]
+		if ref.Kind == "Node" && ref.Name == m.nodeName && ref.UID == m.nodeUID {
+			ownerRefFound = true
+			if ref.BlockOwnerDeletion == nil || *ref.BlockOwnerDeletion {
+				ref.BlockOwnerDeletion = boolPtr(false)
+				changed = true
+			}
+			break
+		}
+	}
+	if !ownerRefFound {
 		lease.OwnerReferences = append(lease.OwnerReferences, metav1.OwnerReference{
 			APIVersion:         "v1",
 			Kind:               "Node",
 			Name:               m.nodeName,
 			UID:                m.nodeUID,
 			Controller:         boolPtr(true),
-			BlockOwnerDeletion: boolPtr(true),
+			BlockOwnerDeletion: boolPtr(false),
 		})
 		changed = true
 	}
 
 	return changed
-}
-
-func (m *Manager) hasOwnerRef(refs []metav1.OwnerReference) bool {
-	for _, ref := range refs {
-		if ref.Kind == "Node" && ref.Name == m.nodeName && ref.UID == m.nodeUID {
-			return true
-		}
-	}
-	return false
 }
 
 func (m *Manager) isExpired(lease *coordinationv1.Lease) (bool, string) {

--- a/go-controller/pkg/node/dpulease/manager_test.go
+++ b/go-controller/pkg/node/dpulease/manager_test.go
@@ -162,6 +162,74 @@ func TestEnsureLeaseRetriesOnAlreadyExists(t *testing.T) {
 	g.Expect(*fetched.Spec.LeaseDurationSeconds).To(gomega.Equal(int32(20)))
 }
 
+func TestSetStatusTransitions(t *testing.T) {
+	g := gomega.NewWithT(t)
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker", UID: types.UID("nodeuid")}}
+	client := fake.NewSimpleClientset()
+	mgr := NewManager(client, "ovn-kubernetes", node, time.Second, 30*time.Second)
+
+	// After construction, manager should be ready (NewManager calls setStatus("", true))
+	ready, reason := mgr.Ready()
+	g.Expect(ready).To(gomega.BeTrue())
+	g.Expect(reason).To(gomega.BeEmpty())
+
+	// Transition to unhealthy
+	mgr.setStatus("lease expired", false)
+	ready, reason = mgr.Ready()
+	g.Expect(ready).To(gomega.BeFalse())
+	g.Expect(reason).To(gomega.Equal("lease expired"))
+
+	// Transition back to healthy (recovery)
+	mgr.setStatus("", true)
+	ready, reason = mgr.Ready()
+	g.Expect(ready).To(gomega.BeTrue())
+	g.Expect(reason).To(gomega.BeEmpty())
+
+	// Idempotent: setting same status again doesn't change anything
+	mgr.setStatus("", true)
+	ready, reason = mgr.Ready()
+	g.Expect(ready).To(gomega.BeTrue())
+	g.Expect(reason).To(gomega.BeEmpty())
+}
+
+func TestUpdateLeaseFixesBlockOwnerDeletion(t *testing.T) {
+	g := gomega.NewWithT(t)
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker", UID: types.UID("nodeuid")}}
+
+	// Simulate a lease created by old code with BlockOwnerDeletion: true
+	oldLease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ovn-dpu-worker",
+			Namespace: "ovn-kubernetes",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "Node",
+					Name:               "worker",
+					UID:                types.UID("nodeuid"),
+					Controller:         boolPtr(true),
+					BlockOwnerDeletion: boolPtr(true),
+				},
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       ptrToString(HolderIdentity),
+			LeaseDurationSeconds: ptrToInt32(40),
+		},
+	}
+	client := fake.NewSimpleClientset(oldLease)
+	mgr := NewManager(client, "ovn-kubernetes", node, 10*time.Second, 40*time.Second)
+
+	lease, err := mgr.EnsureLease(context.Background())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lease).NotTo(gomega.BeNil())
+
+	// Verify BlockOwnerDeletion was corrected to false
+	g.Expect(lease.OwnerReferences).To(gomega.HaveLen(1))
+	g.Expect(lease.OwnerReferences[0].UID).To(gomega.Equal(node.UID))
+	g.Expect(*lease.OwnerReferences[0].BlockOwnerDeletion).To(gomega.BeFalse())
+}
+
 func ptrToString(val string) *string {
 	return &val
 }


### PR DESCRIPTION
## Summary
- Set `blockOwnerDeletion` to `false` on the DPU lease ownerReference. The ovnkube-node service account typically lacks permission to set finalizers on Node objects, causing a crash when `blockOwnerDeletion` is `true`.
- Log at debug level when the DPU lease transitions from unhealthy back to healthy, matching the existing "marked unhealthy" warning for better observability. The log only fires on actual recovery, not on initial startup.

## Test plan
- [x] Unit tests pass (`PKGS=./pkg/node/dpulease/... make test`)
- [x] Verified in DPF cross-cluster deployment: lease creation succeeds without finalizer permission errors
- [x] Verified lease recovery log appears after DPU pod restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved lease health status reporting to reduce redundant logging and ensure accurate state transitions.
  * Fixed lease ownership handling to properly manage object lifecycle and prevent orphaned resources.

* **Tests**
  * Added comprehensive test coverage for status transition scenarios and ownership correction logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->