### PR TITLE
e2e: kubevirt: enforce max 2 seconds downtime during live migration

### DIFF
--- a/go-controller/pkg/testing/iperf/iperf.go
+++ b/go-controller/pkg/testing/iperf/iperf.go
@@ -1,0 +1,61 @@
+package iperf
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const TrafficDownIperfLog = "0.00 Bytes  0.00 bits/sec"
+
+// LogDowntime analyzes an iperf3 log (with epoch timestamps) and returns
+// the maximum number of consecutive seconds with zero traffic since startTime.
+// Lines before startTime are ignored. Lines without a valid epoch timestamp or
+// without " sec " are skipped.
+func LogDowntime(iperfLog string, startTime time.Time) (int, error) {
+	lines := strings.Split(strings.TrimSuffix(iperfLog, "\n"), "\n")
+
+	maxZeroTrafficLines := 0
+	zeroTrafficLines := 0
+	foundIntervalAfterStart := false
+	lastIntervalDown := false
+	for _, line := range lines {
+		if !strings.Contains(line, " sec ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		epoch, parseErr := strconv.ParseInt(fields[0], 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		lineTime := time.Unix(epoch, 0)
+		if lineTime.Before(startTime) {
+			continue
+		}
+		foundIntervalAfterStart = true
+		if strings.Contains(line, TrafficDownIperfLog) {
+			zeroTrafficLines++
+			if zeroTrafficLines > maxZeroTrafficLines {
+				maxZeroTrafficLines = zeroTrafficLines
+			}
+			lastIntervalDown = true
+		} else {
+			zeroTrafficLines = 0
+			lastIntervalDown = false
+		}
+	}
+
+	if !foundIntervalAfterStart {
+		return 0, fmt.Errorf("no interval after startTime %s yet", startTime)
+	}
+
+	if lastIntervalDown {
+		return 0, fmt.Errorf("traffic is still down")
+	}
+
+	return maxZeroTrafficLines, nil
+}

--- a/go-controller/pkg/testing/iperf/iperf_test.go
+++ b/go-controller/pkg/testing/iperf/iperf_test.go
@@ -1,0 +1,185 @@
+package iperf
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func iperfLine(epoch int64, interval, transfer, bitrate string) string {
+	return fmt.Sprintf("%d [  6] %s sec  %s  %s    0   2.00 MBytes", epoch, interval, transfer, bitrate)
+}
+
+func iperfZeroLine(epoch int64, interval string) string {
+	return fmt.Sprintf("%d [  6] %s sec  0.00 Bytes  0.00 bits/sec    0   1.30 KBytes", epoch, interval)
+}
+
+func TestLogDowntime(t *testing.T) {
+	baseEpoch := int64(1772800000)
+	startTime := time.Unix(baseEpoch, 0)
+
+	tests := []struct {
+		name             string
+		log              string
+		startTime        time.Time
+		expectedDowntime int
+		expectErr        bool
+		expectedErr      string
+	}{
+		{
+			name: "no downtime",
+			log: strings.Join([]string{
+				fmt.Sprintf("%d Connecting to host 10.0.0.1, port 5201", baseEpoch),
+				fmt.Sprintf("%d [ ID] Interval           Transfer     Bitrate         Retr  Cwnd", baseEpoch),
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfLine(baseEpoch+1, "1.00-2.00", "195 MBytes", "1.64 Gbits/sec"),
+				iperfLine(baseEpoch+2, "2.00-3.00", "210 MBytes", "1.76 Gbits/sec"),
+			}, "\n"),
+			startTime:        startTime,
+			expectedDowntime: 0,
+		},
+		{
+			name: "1 second downtime within limit",
+			log: strings.Join([]string{
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfLine(baseEpoch+1, "1.00-2.00", "195 MBytes", "1.64 Gbits/sec"),
+				iperfZeroLine(baseEpoch+2, "2.00-3.00"),
+				iperfLine(baseEpoch+3, "3.00-4.00", "180 MBytes", "1.51 Gbits/sec"),
+			}, "\n"),
+			startTime:        startTime,
+			expectedDowntime: 1,
+		},
+		{
+			name: "2 seconds downtime at limit",
+			log: strings.Join([]string{
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfZeroLine(baseEpoch+1, "1.00-2.00"),
+				iperfZeroLine(baseEpoch+2, "2.00-3.00"),
+				iperfLine(baseEpoch+3, "3.00-4.00", "180 MBytes", "1.51 Gbits/sec"),
+			}, "\n"),
+			startTime:        startTime,
+			expectedDowntime: 2,
+		},
+		{
+			name: "5 seconds downtime exceeds limit",
+			log: strings.Join([]string{
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfZeroLine(baseEpoch+1, "1.00-2.00"),
+				iperfZeroLine(baseEpoch+2, "2.00-3.00"),
+				iperfZeroLine(baseEpoch+3, "3.00-4.00"),
+				iperfZeroLine(baseEpoch+4, "4.00-5.00"),
+				iperfZeroLine(baseEpoch+5, "5.00-6.00"),
+				iperfLine(baseEpoch+6, "6.00-7.00", "180 MBytes", "1.51 Gbits/sec"),
+			}, "\n"),
+			startTime:        startTime,
+			expectedDowntime: 5,
+		},
+		{
+			name: "downtime before startTime is ignored",
+			log: strings.Join([]string{
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfZeroLine(baseEpoch+1, "1.00-2.00"),
+				iperfZeroLine(baseEpoch+2, "2.00-3.00"),
+				iperfZeroLine(baseEpoch+3, "3.00-4.00"),
+				iperfZeroLine(baseEpoch+4, "4.00-5.00"),
+				iperfZeroLine(baseEpoch+5, "5.00-6.00"),
+				iperfLine(baseEpoch+6, "6.00-7.00", "180 MBytes", "1.51 Gbits/sec"),
+				iperfLine(baseEpoch+7, "7.00-8.00", "190 MBytes", "1.59 Gbits/sec"),
+			}, "\n"),
+			startTime:        time.Unix(baseEpoch+6, 0),
+			expectedDowntime: 0,
+		},
+		{
+			name: "two downtime windows returns the max",
+			log: strings.Join([]string{
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfZeroLine(baseEpoch+1, "1.00-2.00"),
+				iperfZeroLine(baseEpoch+2, "2.00-3.00"),
+				iperfLine(baseEpoch+3, "3.00-4.00", "180 MBytes", "1.51 Gbits/sec"),
+				iperfZeroLine(baseEpoch+4, "4.00-5.00"),
+				iperfZeroLine(baseEpoch+5, "5.00-6.00"),
+				iperfZeroLine(baseEpoch+6, "6.00-7.00"),
+				iperfZeroLine(baseEpoch+7, "7.00-8.00"),
+				iperfLine(baseEpoch+8, "8.00-9.00", "190 MBytes", "1.59 Gbits/sec"),
+			}, "\n"),
+			startTime:        startTime,
+			expectedDowntime: 4,
+		},
+		{
+			name: "traffic still down returns error",
+			log: strings.Join([]string{
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfZeroLine(baseEpoch+1, "1.00-2.00"),
+				iperfZeroLine(baseEpoch+2, "2.00-3.00"),
+			}, "\n"),
+			startTime:   startTime,
+			expectErr:   true,
+			expectedErr: "traffic is still down",
+		},
+		{
+			name: "lines without timestamps are skipped",
+			log: strings.Join([]string{
+				"Connecting to host 10.0.0.1, port 5201",
+				"[ ID] Interval           Transfer     Bitrate         Retr  Cwnd",
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfLine(baseEpoch+1, "1.00-2.00", "195 MBytes", "1.64 Gbits/sec"),
+			}, "\n"),
+			startTime:        startTime,
+			expectedDowntime: 0,
+		},
+		{
+			name: "no interval after startTime yet",
+			log: strings.Join([]string{
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfLine(baseEpoch+1, "1.00-2.00", "195 MBytes", "1.64 Gbits/sec"),
+			}, "\n"),
+			startTime:   time.Unix(baseEpoch+10, 0),
+			expectErr:   true,
+			expectedErr: "no interval after startTime",
+		},
+		{
+			name: "only banners no intervals",
+			log: strings.Join([]string{
+				fmt.Sprintf("%d Connecting to host 10.0.0.1, port 5201", baseEpoch),
+				fmt.Sprintf("%d [ ID] Interval           Transfer     Bitrate         Retr  Cwnd", baseEpoch),
+			}, "\n"),
+			startTime:   startTime,
+			expectErr:   true,
+			expectedErr: "no interval after startTime",
+		},
+		{
+			name: "epoch zero startTime checks all lines",
+			log: strings.Join([]string{
+				iperfLine(baseEpoch, "0.00-1.00", "200 MBytes", "1.68 Gbits/sec"),
+				iperfZeroLine(baseEpoch+1, "1.00-2.00"),
+				iperfZeroLine(baseEpoch+2, "2.00-3.00"),
+				iperfZeroLine(baseEpoch+3, "3.00-4.00"),
+				iperfLine(baseEpoch+4, "4.00-5.00", "180 MBytes", "1.51 Gbits/sec"),
+			}, "\n"),
+			startTime:        time.Unix(0, 0).UTC(),
+			expectedDowntime: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			downtime, err := LogDowntime(tt.log, tt.startTime)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				if tt.expectedErr != "" && !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.expectedErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if downtime != tt.expectedDowntime {
+				t.Errorf("expected downtime %d, got %d", tt.expectedDowntime, downtime)
+			}
+		})
+	}
+}

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -20,6 +20,7 @@ import (
 	rav1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
 	crdtypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	iperftest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/iperf"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/diagnostics"
@@ -320,7 +321,7 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			polling := 15 * time.Second
 			for podName, serverPodIPs := range serverPodIPsByName {
 				for _, serverPodIP := range serverPodIPs {
-					output, err := virtClient.RunCommand(vmi, fmt.Sprintf("iperf3 -t 0 -c %[2]s --logfile /tmp/%[1]s_%[2]s_iperf3.log &", podName, serverPodIP), polling)
+					output, err := virtClient.RunCommand(vmi, fmt.Sprintf("iperf3 -t 0 --forceflush --timestamps='%%s ' -c %[2]s --logfile /tmp/%[1]s_%[2]s_iperf3.log &", podName, serverPodIP), polling)
 					if err != nil {
 						return fmt.Errorf("%s: %w", output, err)
 					}
@@ -329,37 +330,51 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			return nil
 		}
 
-		checkIperfTraffic = func(iperfLogFile string, execFn func(cmd string) (string, error), stage string) {
-			GinkgoHelper()
-			// Check the last line eventually show traffic flowing
-			Eventually(func() (string, error) {
+		checkIperfTraffic = func(iperfLogFile string, execFn func(cmd string) (string, error), startTime *time.Time, stage string) {
+			if startTime == nil {
+				// Legacy path: just check the last interval line shows traffic flowing
+				Eventually(func(g Gomega) {
+					iperfLog, err := execFn("cat " + iperfLogFile)
+					g.Expect(err).NotTo(HaveOccurred(), stage+": failed reading iperf3 log")
+					g.Expect(iperfLog).NotTo(ContainSubstring("iperf3: error"), stage+": "+iperfLogFile)
+
+					lastIntervalLine := ""
+					for _, line := range strings.Split(strings.TrimSuffix(iperfLog, "\n"), "\n") {
+						if strings.Contains(line, " sec ") {
+							lastIntervalLine = line
+						}
+					}
+					g.Expect(lastIntervalLine).NotTo(BeEmpty(), stage+": no iperf3 interval logged yet")
+					g.Expect(lastIntervalLine).NotTo(ContainSubstring(iperftest.TrafficDownIperfLog),
+						fmt.Sprintf("%s: last iperf3 interval shows zero traffic:\n%s", stage, lastIntervalLine))
+				}).
+					WithPolling(50*time.Millisecond).
+					WithTimeout(5*time.Second).
+					Should(Succeed(), stage+": failed checking iperf3 traffic at file "+iperfLogFile)
+				return
+			}
+
+			// Poll the iperf3 log until traffic resumes or downtime exceeds
+			// 2 seconds (each iperf3 line is a 1 second interval).
+			Eventually(func(g Gomega) {
 				iperfLog, err := execFn("cat " + iperfLogFile)
-				if err != nil {
-					return "", err
-				}
-				// Fail fast
-				Expect(iperfLog).NotTo(ContainSubstring("iperf3: error"), stage+": "+iperfLogFile)
-				// Remove last carriage return to properly split by new line.
-				iperfLog = strings.TrimSuffix(iperfLog, "\n")
-				iperfLogLines := strings.Split(iperfLog, "\n")
-				if len(iperfLogLines) == 0 {
-					return "", nil
-				}
-				lastIperfLogLine := iperfLogLines[len(iperfLogLines)-1]
-				return lastIperfLogLine, nil
+				g.Expect(err).NotTo(HaveOccurred(), stage+": failed reading iperf3 log")
+				g.Expect(iperfLog).NotTo(ContainSubstring("iperf3: error"), stage+": "+iperfLogFile)
+
+				maxDowntime, err := iperftest.LogDowntime(iperfLog, *startTime)
+				g.Expect(err).NotTo(HaveOccurred(), stage+": traffic should have resumed")
+
+				g.Expect(maxDowntime).To(BeNumerically("<=", 2),
+					fmt.Sprintf("%s: expected at most 2 seconds of zero traffic since migration start %s, got %d:\n%s",
+						stage, startTime, maxDowntime, iperfLog))
+
 			}).
 				WithPolling(50*time.Millisecond).
-				WithTimeout(2*time.Second).
-				Should(
-					SatisfyAll(
-						ContainSubstring(" sec "),
-						Not(ContainSubstring("0.00 Bytes  0.00 bits/sec")),
-					),
-					stage+": failed checking iperf3 traffic at file "+iperfLogFile,
-				)
+				WithTimeout(5*time.Second).
+				Should(Succeed(), stage+": failed checking iperf3 traffic at file "+iperfLogFile)
 		}
 
-		checkEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, stage string) {
+		checkEastWestIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, podIPsByName map[string][]string, migrationStart *time.Time, stage string) {
 			GinkgoHelper()
 			for podName, podIPs := range podIPsByName {
 				for _, podIP := range podIPs {
@@ -367,10 +382,11 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 					execFn := func(cmd string) (string, error) {
 						return virtClient.RunCommand(vmi, cmd, 2*time.Second)
 					}
-					checkIperfTraffic(iperfLogFile, execFn, stage)
+					checkIperfTraffic(iperfLogFile, execFn, migrationStart, stage)
 				}
 			}
 		}
+
 		startNorthSouthIperfTraffic = func(execFn execFnType, addresses []string, port int32, logPrefix, stage string) error {
 			GinkgoHelper()
 			Expect(addresses).NotTo(BeEmpty())
@@ -389,7 +405,7 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 				}
 
 				By(fmt.Sprintf("start from %s: %s", address, stage))
-				output, err = execFn(fmt.Sprintf("nohup iperf3 -t 0 -c %[1]s -p %[2]d --logfile %[3]s &", address, port, iperfLogFile))
+				output, err = execFn(fmt.Sprintf("nohup iperf3 -t 0 --forceflush --timestamps='%%s ' -c %[1]s -p %[2]d --logfile %[3]s &", address, port, iperfLogFile))
 				if err != nil {
 					return fmt.Errorf("failed at starting iperf3 in background %s: %w", output, err)
 				}
@@ -413,7 +429,7 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			return startNorthSouthIperfTraffic(execFn, addresses, port, "egress", stage)
 		}
 
-		checkNorthSouthIngressIperfTraffic = func(container infraapi.ExternalContainer, addresses []string, port int32, stage string) {
+		checkNorthSouthIngressIperfTraffic = func(container infraapi.ExternalContainer, addresses []string, port int32, migrationStart *time.Time, stage string) {
 			GinkgoHelper()
 			Expect(addresses).NotTo(BeEmpty())
 			for _, ip := range addresses {
@@ -421,11 +437,11 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 				execFn := func(cmd string) (string, error) {
 					return infraprovider.Get().ExecExternalContainerCommand(container, []string{"bash", "-c", cmd})
 				}
-				checkIperfTraffic(iperfLogFile, execFn, stage)
+				checkIperfTraffic(iperfLogFile, execFn, migrationStart, stage)
 			}
 		}
 
-		checkNorthSouthEgressIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, addresses []string, port int32, stage string) {
+		checkNorthSouthEgressIperfTraffic = func(vmi *kubevirtv1.VirtualMachineInstance, addresses []string, port int32, migrationStart *time.Time, stage string) {
 			GinkgoHelper()
 			Expect(addresses).NotTo(BeEmpty())
 			for _, ip := range addresses {
@@ -437,7 +453,7 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 					execFn := func(cmd string) (string, error) {
 						return virtClient.RunCommand(vmi, cmd, 5*time.Second)
 					}
-					checkIperfTraffic(iperfLogFile, execFn, stage)
+					checkIperfTraffic(iperfLogFile, execFn, migrationStart, stage)
 				}
 			}
 		}
@@ -612,6 +628,7 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 				return vmi.Status.MigrationState.Completed
 			}).WithPolling(time.Second).WithTimeout(20*time.Minute).Should(BeTrue(), "should complete migration")
 			Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
+			Expect(vmi.Status.MigrationState.StartTimestamp).NotTo(BeNil(), "should have a StartTimestamp")
 			Expect(vmi.Status.MigrationState.SourcePod).NotTo(BeEmpty())
 			Eventually(func() corev1.PodPhase {
 				sourcePod := &corev1.Pod{
@@ -695,6 +712,8 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			}).WithPolling(time.Second).WithTimeout(5 * time.Minute).Should(
 				Equal(kubevirtv1.MigrationFailed),
 			)
+			Expect(crClient.Get(context.TODO(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
+			Expect(vmi.Status.MigrationState).NotTo(BeNil(), "should have a MigrationState")
 		}
 
 		liveMigrateFailed = func(vmi *kubevirtv1.VirtualMachineInstance) {
@@ -1939,7 +1958,7 @@ ip route add %[3]s via %[4]s
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic before %s %s", td.resource.description, td.test.description))
 			Expect(startEastWestIperfTraffic(vmi, testPodsIPs, step)).To(Succeed(), step)
-			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
+			checkEastWestIperfTraffic(vmi, testPodsIPs, nil, step)
 
 			if td.role == udnv1.NetworkRolePrimary {
 				if isIPv6Supported(fr.ClientSet) && isInterconnectEnabled() {
@@ -1957,7 +1976,7 @@ ip route add %[3]s via %[4]s
 				output, err := virtClient.RunCommand(vmi, "/tmp/iperf-server.sh", time.Minute)
 				Expect(err).NotTo(HaveOccurred(), step+": "+output)
 				Expect(startNorthSouthIngressIperfTraffic(externalContainer, serverIPs, serverPort, step)).To(Succeed())
-				checkNorthSouthIngressIperfTraffic(externalContainer, serverIPs, serverPort, step)
+				checkNorthSouthIngressIperfTraffic(externalContainer, serverIPs, serverPort, nil, step)
 				checkNorthSouthEgressICMPTraffic(vmi, externalContainerIPs, step)
 				if td.ingress == "routed" {
 					_, err := infraprovider.Get().ExecExternalContainerCommand(externalContainer, []string{"bash", "-c", iperfServerScript})
@@ -1970,7 +1989,7 @@ ip route add %[3]s via %[4]s
 						})
 						Expect(err).NotTo(HaveOccurred(), step+": "+output)
 					}
-					checkNorthSouthEgressIperfTraffic(vmi, externalContainerIPs, iperf3DefaultPort, step)
+					checkNorthSouthEgressIperfTraffic(vmi, externalContainerIPs, iperf3DefaultPort, nil, step)
 				}
 			}
 
@@ -1990,6 +2009,7 @@ ip route add %[3]s via %[4]s
 				Should(ConsistOf(expectedAddresesAtGuest), step)
 
 			step = by(vmi.Name, fmt.Sprintf("Check east/west traffic after %s %s", td.resource.description, td.test.description))
+			var migrationStart *time.Time
 			if td.test.description == restart.description {
 				// At restart we need re-connect
 				Expect(startEastWestIperfTraffic(vmi, testPodsIPs, step)).To(Succeed(), step)
@@ -1998,14 +2018,16 @@ ip route add %[3]s via %[4]s
 					Expect(err).NotTo(HaveOccurred(), step+": "+output)
 					Expect(startNorthSouthIngressIperfTraffic(externalContainer, serverIPs, serverPort, step)).To(Succeed())
 				}
+			} else if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.StartTimestamp != nil {
+				migrationStart = &vmi.Status.MigrationState.StartTimestamp.Time
 			}
-			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
+			checkEastWestIperfTraffic(vmi, testPodsIPs, migrationStart, step)
 			if td.role == udnv1.NetworkRolePrimary {
 				step = by(vmi.Name, fmt.Sprintf("Check north/south traffic after %s %s", td.resource.description, td.test.description))
-				checkNorthSouthIngressIperfTraffic(externalContainer, serverIPs, serverPort, step)
+				checkNorthSouthIngressIperfTraffic(externalContainer, serverIPs, serverPort, migrationStart, step)
 				checkNorthSouthEgressICMPTraffic(vmi, externalContainerIPs, step)
 				if td.ingress == "routed" {
-					checkNorthSouthEgressIperfTraffic(vmi, externalContainerIPs, iperf3DefaultPort, step)
+					checkNorthSouthEgressIperfTraffic(vmi, externalContainerIPs, iperf3DefaultPort, migrationStart, step)
 				}
 			}
 
@@ -2362,7 +2384,7 @@ chpasswd: { expire: False }
 
 			step = by(vmi.Name, "Check east/west traffic before virtual machine instance live migration")
 			Expect(startEastWestIperfTraffic(vmi, testPodsIPs, step)).To(Succeed(), step)
-			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
+			checkEastWestIperfTraffic(vmi, testPodsIPs, nil, step)
 
 			by(vmi.Name, "Running live migration for virtual machine instance")
 			td(vmi)
@@ -2374,7 +2396,11 @@ chpasswd: { expire: False }
 			Expect(virtClient.LoginToFedora(vmi, "fedora", "fedora")).To(Succeed(), step)
 
 			step = by(vmi.Name, "Check east/west traffic after virtual machine instance live migration")
-			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
+			var migrationStart *time.Time
+			if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.StartTimestamp != nil {
+				migrationStart = &vmi.Status.MigrationState.StartTimestamp.Time
+			}
+			checkEastWestIperfTraffic(vmi, testPodsIPs, migrationStart, step)
 
 			By("Stop iperf3 traffic before force killing vm, so iperf3 server do not get stuck")
 			output, err = virtClient.RunCommand(vmi, "killall --wait iperf3", 5*time.Second)
@@ -2408,13 +2434,20 @@ chpasswd: { expire: False }
 
 			step = by(vmi.Name, "Restart iperf traffic after forcing a vm failure")
 			Expect(startEastWestIperfTraffic(vmi, testPodsIPs, step)).To(Succeed(), step)
-			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
+			checkEastWestIperfTraffic(vmi, testPodsIPs, nil, step)
 
 			by(vmi.Name, "Running live migration after forcing vm failure")
 			td(vmi)
 
+			// Update vmi status after live migration
+			Expect(crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
+
 			step = by(vmi.Name, "Check east/west traffic for failed virtual machine after live migration")
-			checkEastWestIperfTraffic(vmi, testPodsIPs, step)
+			var migrationStart2 *time.Time
+			if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.StartTimestamp != nil {
+				migrationStart2 = &vmi.Status.MigrationState.StartTimestamp.Time
+			}
+			checkEastWestIperfTraffic(vmi, testPodsIPs, migrationStart2, step)
 		},
 			Entry("after succeeded live migration", liveMigrateSucceed),
 			Entry("after failed live migration", liveMigrateFailed),


### PR DESCRIPTION
## Description

Instead of only checking the last iperf3 log line after live migration,
use iperf3 timestamps to inspect all intervals from migration start onward
and enforce a maximum of 2 seconds of zero traffic.

A new `iperf.LogDowntime(log, startTime)` helper parses lines with epoch
timestamps, counts max consecutive zero-traffic seconds after `startTime`,
and returns an error if traffic is still down. iperf3 is started with
`--forceflush --timestamps='%s '` to produce per-second lines with Unix
timestamps.

Post-migration checks poll `LogDowntime` and fail if downtime exceeds 2s.

## Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI

## How to verify

PR includes unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timestamp-based downtime analysis for iperf traffic monitoring during VM live migrations.
  * Propagation of migration start timestamps to traffic checks for timing-aware verification.
  * Extended timeouts and polling intervals with stricter downtime thresholds for more robust verification.

* **Tests**
  * Added comprehensive tests for downtime calculation covering multiple scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->