### PR TITLE
e2e: kubevirt: use netshoot image instead of iperf3

### DIFF
--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -15,7 +15,8 @@ var (
 	// pre-approve new images.
 	agnHost = image.GetE2EImage(image.Agnhost)
 	// FIXME: iperf3 image should not be retrieved from a users repo and should not have latest tag
-	iperf3 = "quay.io/sronanrh/iperf:latest"
+	iperf3   = "quay.io/sronanrh/iperf:latest"
+	netshoot = "ghcr.io/nicolaka/netshoot:v0.13"
 )
 
 func init() {
@@ -25,6 +26,9 @@ func init() {
 	if iperf3Override := os.Getenv("IPERF3_IMAGE"); iperf3Override != "" {
 		iperf3 = iperf3Override
 	}
+	if netshootOverride := os.Getenv("NETSHOOT_IMAGE"); netshootOverride != "" {
+		netshoot = netshootOverride
+	}
 }
 
 func AgnHost() string {
@@ -33,4 +37,8 @@ func AgnHost() string {
 
 func IPerf3() string {
 	return iperf3
+}
+
+func Netshoot() string {
+	return netshoot
 }

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1210,11 +1210,12 @@ passwd:
 		}
 
 		iperfServerScript = `
-#!/bin/bash -xe
-iface=$(ifconfig  |grep flags |grep -v "eth0\|lo" | sed "s/: .*//")
+#!/bin/bash
+set -xe
+iface=$(ip -o link show | awk -F': ' '{print $2}' | grep -v "eth0\|lo" | head -1| sed "s#@.*##")
 iface=${iface:-eth0}
 
-ipv4=$(ifconfig $iface | grep "inet "|awk '{print $2}'| sed "s#/.*##")
+ipv4=$(ip -4 addr show dev $iface | awk '/inet / {print $2}' | sed "s#/.*##")
 if [ "$ipv4" != "" ]; then
 	iperf3 -s -D --bind $ipv4 --logfile /tmp/test_${ipv4}_iperf3.log
 	sleep 1
@@ -1226,7 +1227,7 @@ fi
 
 cnt=0
 while [ "$ipv6" == "" -a $cnt -lt 10 ]; do
-	ipv6=$(ifconfig $iface | grep inet6 |grep -v fe80 |awk '{print $2}'| sed "s#/.*##")
+	ipv6=$(ip -6 addr show dev $iface | awk '/inet6/ && !/fe80/ {print $2}' | sed "s#/.*##")
 	sleep 1
 	cnt=$((cnt+1))
 done
@@ -1273,7 +1274,7 @@ fi
 					if nse != nil {
 						pod.Annotations = networkSelectionElements(*nse)
 					}
-					pod.Spec.Containers[0].Image = images.IPerf3()
+					pod.Spec.Containers[0].Image = images.Netshoot()
 					pod.Spec.Containers[0].Args = []string{iperfServerScript + "\n sleep infinity"}
 				})
 				if err != nil {
@@ -1854,9 +1855,9 @@ write_files:
 				externalContainerName := namespace + "-iperf"
 				externalContainerSpec := infraapi.ExternalContainer{
 					Name:    externalContainerName,
-					Image:   images.IPerf3(),
+					Image:   images.Netshoot(),
 					Network: providerNetwork,
-					CmdArgs: []string{"sleep infinity"},
+					CmdArgs: []string{"sleep", "infinity"},
 					ExtPort: externalContainerPort,
 				}
 				externalContainer, err = providerCtx.CreateExternalContainer(externalContainerSpec)
@@ -1881,7 +1882,6 @@ write_files:
 
 				output, err := infraprovider.Get().ExecExternalContainerCommand(externalContainer, []string{"bash", "-c", fmt.Sprintf(`
 set -xe
-dnf install -y iproute
 ip route add %[1]s via %[2]s
 ip route add %[3]s via %[4]s
 `, cidrIPv4, frrExternalContainerInterface.GetIPv4(), cidrIPv6, frrExternalContainerInterface.GetIPv6())})


### PR DESCRIPTION
## 📑 Description

Replace the iperf3 image with netshoot (`nicolaka/netshoot:v0.13`) in kubevirt e2e tests. The netshoot image includes both `iperf3` and the `ip` command, allowing us to replace `ifconfig` usage with `ip` commands and eliminating "ip command not found" warnings from the test infrastructure.

## Additional Information for reviewers

- Added `Netshoot()` image to `test/e2e/images/images.go` with `NETSHOOT_IMAGE` env var override
- Replaced `images.IPerf3()` with `images.Netshoot()` for kubevirt test pods and external containers
- Replaced `ifconfig` with `ip` commands in `iperfServerScript`:
  - Interface discovery: `ip -o link show` instead of `ifconfig | grep flags`
  - IPv4 extraction: `ip -4 addr show` instead of `ifconfig | grep "inet "`
  - IPv6 extraction: `ip -6 addr show` instead of `ifconfig | grep inet6`

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI

## How to verify it

Run the kubevirt e2e tests — the iperf3 server script should work without `ifconfig` and without "ip command not found" warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added support for a new netshoot test image and provisioning in end-to-end tests.
  * Enabled environment variable override for test container image selection.
  * Improved networking checks and startup validation for iperf servers (IPv4/IPv6 handling).
  * Updated container command argument handling for more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->