### PR TITLE
EVPN: Ensure VNIs are unique per vtep

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -83,6 +83,12 @@ func ipVRFKey(networkName string) string {
 	return networkName + "/ipvrf"
 }
 
+// vniKey identifies a VNI within a VTEP scope. VNIs must be unique per VTEP.
+type vniKey struct {
+	vtep string
+	vni  int32
+}
+
 type RenderNetAttachDefManifest func(obj client.Object, targetNamespace string, opts ...template.RenderOption) (*netv1.NetworkAttachmentDefinition, error)
 
 type networkInUseError struct {
@@ -126,6 +132,11 @@ type Controller struct {
 	// vidAllocator allocates cluster-wide VLAN IDs for EVPN networks.
 	// VIDs are allocated per network name and stored in the NAD config JSON.
 	vidAllocator id.Allocator
+
+	// reservedVNIs tracks (VTEP, VNI) → network name to ensure no two networks
+	// sharing the same VTEP use the same VNI.
+	reservedVNIs     map[vniKey]string
+	reservedVNIsLock sync.RWMutex
 
 	udnClient         userdefinednetworkclientset.Interface
 	udnLister         userdefinednetworklister.UserDefinedNetworkLister
@@ -179,6 +190,7 @@ func New(
 		networkManager:    networkManager,
 		namespaceTracker:  map[string]sets.Set[string]{},
 		vidAllocator:      vidAllocator,
+		reservedVNIs:      map[vniKey]string{},
 		eventRecorder:     eventRecorder,
 	}
 	udnCfg := &controller.ControllerConfig[userdefinednetworkv1.UserDefinedNetwork]{
@@ -402,9 +414,12 @@ func (c *Controller) recoverEVPNVIDsForCUDN(cudnName string) error {
 		return fmt.Errorf("network %s not found in NetworkManager cache", networkName)
 	}
 
+	if err := c.reserveVNIs(cudnName, netInfo.EVPNVTEPName(), netInfo.EVPNMACVRFVNI(), netInfo.EVPNIPVRFVNI()); err != nil {
+		return fmt.Errorf("failed to reserve VNIs for cudn %s: %w", cudnName, err)
+	}
+
 	macVRFVID := netInfo.EVPNMACVRFVID()
 	ipVRFVID := netInfo.EVPNIPVRFVID()
-
 	// Check if this network has EVPN VIDs allocated
 	if macVRFVID == 0 && ipVRFVID == 0 {
 		klog.V(4).Infof("EVPN CUDN %s has no VIDs allocated yet, skipping recovery", cudnName)
@@ -462,6 +477,40 @@ func (c *Controller) releaseVIDForNetwork(networkName string) {
 	ipVID := c.vidAllocator.ReleaseID(ipVRFKey(networkName))
 	if macVID >= 0 || ipVID >= 0 {
 		klog.V(4).Infof("Released VIDs for network %s: MAC-VRF=%d, IP-VRF=%d", networkName, macVID, ipVID)
+	}
+	c.releaseVNIs(networkName)
+}
+
+// reserveVNIs reserves VNIs for a network within a VTEP scope, ensuring no two
+// networks sharing the same VTEP use the same VNI.
+func (c *Controller) reserveVNIs(networkName, vtepName string, macVRFVNI, ipVRFVNI int32) error {
+	c.reservedVNIsLock.Lock()
+	defer c.reservedVNIsLock.Unlock()
+
+	var errs []error
+	for _, vni := range []int32{macVRFVNI, ipVRFVNI} {
+		if vni == 0 {
+			continue
+		}
+		key := vniKey{vtep: vtepName, vni: vni}
+		if owner, exists := c.reservedVNIs[key]; exists && owner != networkName {
+			errs = append(errs, fmt.Errorf("VNI %d on VTEP %q is already reserved by network %q", vni, vtepName, owner))
+			continue
+		}
+		c.reservedVNIs[key] = networkName
+	}
+	return errors.Join(errs...)
+}
+
+// releaseVNIs releases all VNIs owned by the given network.
+func (c *Controller) releaseVNIs(networkName string) {
+	c.reservedVNIsLock.Lock()
+	defer c.reservedVNIsLock.Unlock()
+
+	for vni, owner := range c.reservedVNIs {
+		if owner == networkName {
+			delete(c.reservedVNIs, vni)
+		}
 	}
 }
 

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -287,7 +287,7 @@ func (c *Controller) initializeController() error {
 		// Recovery failures are logged and the affected CUDNs are enqueued for reconciliation,
 		// but don't block startup - this prevents a DoS where a malicious NAD could
 		// crash the entire cluster-manager.
-		c.recoverEVPNVIDs(cudnNADs)
+		c.recoverEVPNIDs(cudnNADs)
 	}
 
 	return nil
@@ -351,7 +351,7 @@ func (c *Controller) initializeNamespaceTracker(cudnNADs cudnToNADs) {
 	}
 }
 
-// recoverEVPNVIDs recovers VID allocations from existing EVPN CUDNs using
+// recoverEVPNIDs recovers VID allocations and VNI reservations from existing EVPN CUDNs using
 // NetworkManager's cached NetInfo. NetworkManager has already processed all NADs
 // by the time this function is called (it starts before UDN controller).
 //
@@ -362,7 +362,7 @@ func (c *Controller) initializeNamespaceTracker(cudnNADs cudnToNADs) {
 //
 // If VID recovery fails for a CUDN (e.g., NetworkManager couldn't parse the NAD),
 // this logs an error and enqueues the CUDN for reconciliation.
-func (c *Controller) recoverEVPNVIDs(cudnNADs cudnToNADs) {
+func (c *Controller) recoverEVPNIDs(cudnNADs cudnToNADs) {
 	// Extract EVPN CUDNs with NADs into a slice for deterministic ordering.
 	evpnCUDNs := make([]*cudnWithNADs, 0, len(cudnNADs))
 	for _, entry := range cudnNADs {
@@ -390,7 +390,7 @@ func (c *Controller) recoverEVPNVIDs(cudnNADs cudnToNADs) {
 	})
 
 	for _, entry := range evpnCUDNs {
-		if err := c.recoverEVPNVIDsForCUDN(entry.cudn.Name); err != nil {
+		if err := c.recoverEVPNIDsForCUDN(entry.cudn.Name); err != nil {
 			klog.Errorf("VID recovery failed for EVPN CUDN %s: %v. "+
 				"The CUDN will be reconciled and existing NAD VIDs will be preserved if possible.",
 				entry.cudn.Name, err)
@@ -399,10 +399,10 @@ func (c *Controller) recoverEVPNVIDs(cudnNADs cudnToNADs) {
 	}
 }
 
-// recoverEVPNVIDsForCUDN attempts to recover VIDs for a single CUDN using NetworkManager's cache.
+// recoverEVPNIDsForCUDN attempts to recover VIDs and VNI reservations for a single CUDN using NetworkManager's cache.
 // Returns nil if VIDs were successfully recovered or if no VIDs are allocated yet.
 // Returns error if VID reservation fails (e.g., conflict with another network).
-func (c *Controller) recoverEVPNVIDsForCUDN(cudnName string) error {
+func (c *Controller) recoverEVPNIDsForCUDN(cudnName string) error {
 	networkName := util.GenerateCUDNNetworkName(cudnName)
 
 	// Use NetworkManager's cached NetInfo - it has already parsed the NAD
@@ -462,7 +462,7 @@ func (c *Controller) reserveRecoveredVIDs(networkName string, macVRFVID, ipVRFVI
 	return errors.Join(errs...)
 }
 
-// releaseVIDForNetwork releases the VIDs allocated for a network's VRFs.
+// releaseEVPNIDsForNetwork releases the VIDs and VNI reservations for a network's VRFs.
 //
 // NOTE: VID release is not synchronized with node-side dataplane cleanup.
 // In theory, a rapidly created new network could get the same VID while nodes
@@ -472,7 +472,7 @@ func (c *Controller) reserveRecoveredVIDs(networkName string, macVRFVID, ipVRFVI
 // The actual mitigation is on the node-side: nodes should check for VID conflicts
 // and refuse to configure a VID already in use by a different network, waiting
 // until the old network is cleaned up.
-func (c *Controller) releaseVIDForNetwork(networkName string) {
+func (c *Controller) releaseEVPNIDsForNetwork(networkName string) {
 	macVID := c.vidAllocator.ReleaseID(macVRFKey(networkName))
 	ipVID := c.vidAllocator.ReleaseID(ipVRFKey(networkName))
 	if macVID >= 0 || ipVID >= 0 {
@@ -951,7 +951,7 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 			delete(c.namespaceTracker, cudnName)
 			metrics.DecrementCUDNCount(role, topology)
 			metrics.DeleteDynamicUDNNodeCount(util.GenerateCUDNNetworkName(cudn.Name))
-			c.releaseVIDForNetwork(cudnName)
+			c.releaseEVPNIDsForNetwork(cudnName)
 		}
 
 		return nil, nil

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -188,8 +189,13 @@ func (c *Controller) allocateEVPNVIDsIfNeeded(obj client.Object) ([]template.Ren
 	}
 
 	networkName := obj.GetName()
-	var macVRFVID, ipVRFVID int
 
+	// ptr.Deref yields zero-value VRFConfig for nil VRFs, reserveVNIs skips VNI 0
+	if err := c.reserveVNIs(networkName, evpnCfg.VTEP, ptr.Deref(evpnCfg.MACVRF, userdefinednetworkv1.VRFConfig{}).VNI, ptr.Deref(evpnCfg.IPVRF, userdefinednetworkv1.VRFConfig{}).VNI); err != nil {
+		return nil, fmt.Errorf("failed to reserve VNIs: %w", err)
+	}
+
+	var macVRFVID, ipVRFVID int
 	// Allocate VID for MAC-VRF if present
 	if evpnCfg.MACVRF != nil {
 		vid, err := c.vidAllocator.AllocateID(macVRFKey(networkName))

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
@@ -45,9 +45,9 @@ func (c *Controller) updateNAD(obj client.Object, namespace string) (*netv1.Netw
 		return nil, fmt.Errorf("failed to get NetworkAttachmentDefinition %s/%s from cache: %v", namespace, obj.GetName(), err)
 	}
 
-	renderOpts, err := c.allocateEVPNVIDsIfNeeded(obj)
+	renderOpts, err := c.allocateEVPNIDsIfNeeded(obj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to allocate EVPN VIDs: %w", err)
+		return nil, fmt.Errorf("failed to allocate EVPN IDs: %w", err)
 	}
 
 	desiredNAD, err := c.renderNadFn(obj, namespace, renderOpts...)
@@ -165,14 +165,14 @@ func (c *Controller) deleteNAD(obj client.Object, namespace string) error {
 	return nil
 }
 
-// allocateEVPNVIDsIfNeeded checks if the object is an EVPN network and allocates VIDs if needed.
+// allocateEVPNIDsIfNeeded checks if the object is an EVPN network and allocates VIDs and reserves VNIs if needed.
 // Returns render options containing the allocated VIDs, or empty options for non-EVPN networks.
 // Returns an error if EVPN transport is requested but the feature flag is disabled.
 //
 // This function relies on the idempotency of AllocateID: if a VID was already allocated for a key
 // (either during recovery or a previous reconciliation), AllocateID returns the same VID.
 // This means VIDs are stable across reconciliations without needing to parse the existing NAD.
-func (c *Controller) allocateEVPNVIDsIfNeeded(obj client.Object) ([]template.RenderOption, error) {
+func (c *Controller) allocateEVPNIDsIfNeeded(obj client.Object) ([]template.RenderOption, error) {
 	spec := template.GetSpec(obj)
 	if spec.GetTransport() != userdefinednetworkv1.TransportOptionEVPN {
 		return nil, nil

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -490,7 +490,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should allocate VID for EVPN network NAD", func() {
 				testNs := testNamespace("evpn-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-cudn", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 				Expect(c.Run()).To(Succeed())
@@ -579,8 +579,8 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should allocate different VIDs for multiple EVPN networks", func() {
 				testNs := testNamespace("evpn-multi-test")
 				vtep := testVTEP("vtep-test")
-				cudn1 := testEVPNClusterUDN("evpn-cudn-1", vtep.Name, testNs.Name)
-				cudn2 := testEVPNClusterUDN("evpn-cudn-2", vtep.Name, testNs.Name)
+				cudn1 := testEVPNClusterUDN("evpn-cudn-1", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
+				cudn2 := testEVPNClusterUDN("evpn-cudn-2", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 300}}, testNs.Name)
 				cudn2.UID = "2" // Different UID for second CUDN
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn1, cudn2, testNs, vtep)
@@ -602,10 +602,64 @@ var _ = Describe("User Defined Network Controller", func() {
 				}).Should(Succeed())
 			})
 
+			It("should reject EVPN network with duplicate VNI on the same VTEP", func() {
+				testNs := testNamespace("evpn-vni-conflict-test")
+				vtep := testVTEP("vtep-test")
+				cudn1 := testEVPNClusterUDN("evpn-vni-1", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
+				cudn2 := testEVPNClusterUDN("evpn-vni-2", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
+				cudn2.UID = "2"
+
+				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn1, cudn2, testNs, vtep)
+				Expect(c.Run()).To(Succeed())
+
+				Eventually(func(g Gomega) {
+					cudn1Updated, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), "evpn-vni-1", metav1.GetOptions{})
+					g.Expect(err).NotTo(HaveOccurred())
+					cudn2Updated, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), "evpn-vni-2", metav1.GetOptions{})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					conditionsHaveVNIConflict := func(conditions []metav1.Condition) bool {
+						for _, c := range conditions {
+							if c.Type == "NetworkCreated" && c.Status == "False" && strings.Contains(c.Message, "VNI") {
+								return true
+							}
+						}
+						return false
+					}
+					cudn1Conflict := conditionsHaveVNIConflict(cudn1Updated.Status.Conditions)
+					cudn2Conflict := conditionsHaveVNIConflict(cudn2Updated.Status.Conditions)
+					g.Expect(cudn1Conflict || cudn2Conflict).To(BeTrue(), "one CUDN should report VNI conflict")
+				}).Should(Succeed())
+			})
+
+			It("should allow same VNI on different VTEPs", func() {
+				testNs := testNamespace("evpn-diff-vtep-test")
+				vtep1 := testVTEP("vtep-1")
+				vtep2 := testVTEP("vtep-2")
+				cudn1 := testEVPNClusterUDN("evpn-vtep1-net", &udnv1.EVPNConfig{VTEP: vtep1.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
+				cudn2 := testEVPNClusterUDN("evpn-vtep2-net", &udnv1.EVPNConfig{VTEP: vtep2.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
+				cudn2.UID = "2"
+
+				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn1, cudn2, testNs, vtep1, vtep2)
+				Expect(c.Run()).To(Succeed())
+
+				// Both NADs should be created successfully
+				Eventually(func(g Gomega) {
+					nad1, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(testNs.Name).Get(context.Background(), "evpn-vtep1-net", metav1.GetOptions{})
+					g.Expect(err).NotTo(HaveOccurred())
+					nad2, err := cs.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(testNs.Name).Get(context.Background(), "evpn-vtep2-net", metav1.GetOptions{})
+					g.Expect(err).NotTo(HaveOccurred())
+					vid1, _ := evpnVIDsFromNAD(nad1)
+					vid2, _ := evpnVIDsFromNAD(nad2)
+					g.Expect(vid1).To(BeNumerically(">", 0))
+					g.Expect(vid2).To(BeNumerically(">", 0))
+				}).Should(Succeed())
+			})
+
 			It("should release VID when EVPN CUDN is deleted", func() {
 				testNs := testNamespace("evpn-delete-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-delete-cudn", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-delete-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 				Expect(c.Run()).To(Succeed())
@@ -682,7 +736,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should preserve allocated VID when EVPN CUDN is updated", func() {
 				testNs := testNamespace("evpn-update-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-update-cudn", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-update-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 				Expect(c.Run()).To(Succeed())
@@ -717,10 +771,10 @@ var _ = Describe("User Defined Network Controller", func() {
 				// and a new VID is allocated.
 				testNs := testNamespace("evpn-all-corrupted-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-all-corrupted", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-all-corrupted", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				// Create a corrupted NAD owned by the CUDN - NetworkManager will fail to parse it
-				corruptedNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, vtep.Name, 0, 0)
+				corruptedNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, &ovncnitypes.EVPNConfig{VTEP: vtep.Name, MACVRF: &ovncnitypes.VRFConfig{VNI: 100}})
 				corruptedNAD.Spec.Config = `{"transport":"evpn", invalid json - corrupted`
 
 				// Use started NetworkManager - it will fail to parse the corrupted NAD
@@ -743,10 +797,10 @@ var _ = Describe("User Defined Network Controller", func() {
 				// Instead, the CUDN is enqueued for reconciliation and gets a new VID.
 				testNs := testNamespace("evpn-vid-conflict-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-conflict", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-conflict", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				// Create a NAD with VID 5 for MAC-VRF
-				existingNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, vtep.Name, 5, 0)
+				existingNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, &ovncnitypes.EVPNConfig{VTEP: vtep.Name, MACVRF: &ovncnitypes.VRFConfig{VNI: 100, VID: 5}})
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep, existingNAD)
 
@@ -776,7 +830,11 @@ var _ = Describe("User Defined Network Controller", func() {
 				cudn := testSymmetricIRBClusterUDN("evpn-ipvrf-conflict", vtep.Name, testNs.Name)
 
 				// Create a symmetric IRB NAD with both MAC-VRF (VID 3) and IP-VRF (VID 7)
-				existingNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, vtep.Name, 3, 7)
+				existingNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, &ovncnitypes.EVPNConfig{
+					VTEP:   vtep.Name,
+					MACVRF: &ovncnitypes.VRFConfig{VNI: 100, VID: 3},
+					IPVRF:  &ovncnitypes.VRFConfig{VNI: 200, VID: 7},
+				})
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep, existingNAD)
 
@@ -808,7 +866,11 @@ var _ = Describe("User Defined Network Controller", func() {
 				cudn := testSymmetricIRBClusterUDN("evpn-macvrf-conflict", vtep.Name, testNs.Name)
 
 				// Create a symmetric IRB NAD with both MAC-VRF (VID 3) and IP-VRF (VID 7)
-				existingNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, vtep.Name, 3, 7)
+				existingNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, &ovncnitypes.EVPNConfig{
+					VTEP:   vtep.Name,
+					MACVRF: &ovncnitypes.VRFConfig{VNI: 100, VID: 3},
+					IPVRF:  &ovncnitypes.VRFConfig{VNI: 200, VID: 7},
+				})
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep, existingNAD)
 
@@ -832,7 +894,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should not fail startup when CUDN exists but has no NADs yet", func() {
 				vtep := testVTEP("vtep-test")
 				// Create a CUDN without any NADs (namespace doesn't match selector)
-				cudnWithNoNADs := testEVPNClusterUDN("evpn-no-nads", vtep.Name, "nonexistent-ns")
+				cudnWithNoNADs := testEVPNClusterUDN("evpn-no-nads", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, "nonexistent-ns")
 
 				c = newTestControllerWithNetworkManager(renderNadStub(nil), cudnWithNoNADs, vtep)
 
@@ -848,10 +910,10 @@ var _ = Describe("User Defined Network Controller", func() {
 				// 2. UDN controller starts and recovers VIDs from NetworkManager's cache
 				testNs := testNamespace("evpn-nm-recovery-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-nm-recovery", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-nm-recovery", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				// Create an existing NAD with VID 42 (simulating a previous controller run)
-				existingNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, vtep.Name, 42, 0)
+				existingNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, &ovncnitypes.EVPNConfig{VTEP: vtep.Name, MACVRF: &ovncnitypes.VRFConfig{VNI: 100, VID: 42}})
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep, existingNAD)
 				Expect(c.Run()).To(Succeed())
@@ -870,17 +932,17 @@ var _ = Describe("User Defined Network Controller", func() {
 				vtep := testVTEP("vtep-test")
 
 				// Create two CUDNs with different creation timestamps and unique UIDs
-				olderCUDN := testEVPNClusterUDN("aaa-older-cudn", vtep.Name, testNs1.Name)
+				olderCUDN := testEVPNClusterUDN("aaa-older-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs1.Name)
 				olderCUDN.UID = "older-uid-1"
 				olderCUDN.CreationTimestamp = metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 
-				newerCUDN := testEVPNClusterUDN("zzz-newer-cudn", vtep.Name, testNs2.Name)
+				newerCUDN := testEVPNClusterUDN("zzz-newer-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 300}}, testNs2.Name)
 				newerCUDN.UID = "newer-uid-2"
 				newerCUDN.CreationTimestamp = metav1.NewTime(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
 
 				// Both NADs claim VID 42 - this simulates a conflict scenario
-				olderNAD := testEVPNClusterUdnNADOwnedByCUDN(olderCUDN, testNs1.Name, vtep.Name, 42, 0)
-				newerNAD := testEVPNClusterUdnNADOwnedByCUDN(newerCUDN, testNs2.Name, vtep.Name, 42, 0)
+				olderNAD := testEVPNClusterUdnNADOwnedByCUDN(olderCUDN, testNs1.Name, &ovncnitypes.EVPNConfig{VTEP: vtep.Name, MACVRF: &ovncnitypes.VRFConfig{VNI: 100, VID: 42}})
+				newerNAD := testEVPNClusterUdnNADOwnedByCUDN(newerCUDN, testNs2.Name, &ovncnitypes.EVPNConfig{VTEP: vtep.Name, MACVRF: &ovncnitypes.VRFConfig{VNI: 300, VID: 42}})
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest,
 					olderCUDN, newerCUDN, testNs1, testNs2, vtep, olderNAD, newerNAD)
@@ -905,7 +967,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should return error when VID pool is exhausted", func() {
 				testNs := testNamespace("evpn-exhaustion-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-exhaust-cudn", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-exhaust-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 
@@ -942,7 +1004,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should allocate VID after pool is freed up", func() {
 				testNs := testNamespace("evpn-free-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-free-cudn", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-free-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 
@@ -1006,7 +1068,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				const runtimeNsName = "runtime-ns-test"
 
 				// CUDN with selector matching a namespace that doesn't exist yet
-				cudn := testEVPNClusterUDN("evpn-runtime-cudn", vtep.Name, runtimeNsName)
+				cudn := testEVPNClusterUDN("evpn-runtime-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, runtimeNsName)
 
 				// Start controller - no NADs to recover, allocator empty for this key
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, vtep)
@@ -1043,7 +1105,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				// Namespace that doesn't exist at startup
 				const runtimeNsName = "runtime-conflict-test"
 
-				cudn := testEVPNClusterUDN("evpn-runtime-conflict", vtep.Name, runtimeNsName)
+				cudn := testEVPNClusterUDN("evpn-runtime-conflict", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, runtimeNsName)
 
 				// Start controller - no NADs to recover, allocator empty for this key
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, vtep)
@@ -1055,7 +1117,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 				// Create namespace and NAD with VID 42 at runtime (collision with another CUDN)
 				testNs := testNamespace(runtimeNsName)
-				runtimeNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, vtep.Name, 42, 0)
+				runtimeNAD := testEVPNClusterUdnNADOwnedByCUDN(cudn, testNs.Name, &ovncnitypes.EVPNConfig{VTEP: vtep.Name, MACVRF: &ovncnitypes.VRFConfig{VNI: 100, VID: 42}})
 
 				_, err := cs.KubeClient.CoreV1().Namespaces().Create(context.Background(), testNs, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1080,7 +1142,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				// existing VID takes precedence because ReserveID fails when key already has a VID.
 				testNs := testNamespace("evpn-vid-manual-change-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-manual-change-cudn", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-manual-change-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 				Expect(c.Run()).To(Succeed())
@@ -1112,7 +1174,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 			It("should report VTEPNotFound when EVPN CUDN references non-existent VTEP", func() {
 				testNs := testNamespace("evpn-vtep-missing-test")
-				cudn := testEVPNClusterUDN("evpn-vtep-missing", "default", testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-vtep-missing", &udnv1.EVPNConfig{VTEP: "default", MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs)
 				Expect(c.Run()).To(Succeed())
@@ -1137,7 +1199,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should create NAD when VTEP exists for EVPN CUDN", func() {
 				testNs := testNamespace("evpn-vtep-exists-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-vtep-exists", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-vtep-exists", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 				Expect(c.Run()).To(Succeed())
@@ -1164,7 +1226,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should automatically reconcile CUDN when VTEP is created after CUDN", func() {
 				testNs := testNamespace("evpn-vtep-transition-test")
 				vtepName := "default"
-				cudn := testEVPNClusterUDN("evpn-vtep-transition", vtepName, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-vtep-transition", &udnv1.EVPNConfig{VTEP: vtepName, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				// Start controller WITHOUT the VTEP - CUDN references non-existent VTEP
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs)
@@ -1219,7 +1281,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				nonEvpnCUDN.UID = "non-evpn-uid"
 
 				// Create an EVPN CUDN that references the VTEP
-				evpnCUDN := testEVPNClusterUDN("evpn-cudn", vtep.Name, testNs.Name)
+				evpnCUDN := testEVPNClusterUDN("evpn-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 				evpnCUDN.UID = "evpn-uid"
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, nonEvpnCUDN, evpnCUDN, testNs, vtep)
@@ -1240,7 +1302,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			It("should report VTEPNotFound when VTEP is deleted after CUDN creation", func() {
 				testNs := testNamespace("evpn-vtep-delete-test")
 				vtep := testVTEP("vtep-to-delete")
-				cudn := testEVPNClusterUDN("evpn-vtep-delete", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-vtep-delete", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 				Expect(c.Run()).To(Succeed())
@@ -1286,7 +1348,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 				testNs := testNamespace("evpn-disabled-test")
 				vtep := testVTEP("vtep-test")
-				cudn := testEVPNClusterUDN("evpn-disabled-cudn", vtep.Name, testNs.Name)
+				cudn := testEVPNClusterUDN("evpn-disabled-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 				c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 				Expect(c.Run()).To(Succeed())
@@ -2731,7 +2793,7 @@ func newRenderNadStub(nad *netv1.NetworkAttachmentDefinition, err error) RenderN
 	}
 }
 
-func testEVPNClusterUDN(name string, vtepName string, targetNamespaces ...string) *udnv1.ClusterUserDefinedNetwork {
+func testEVPNClusterUDN(name string, evpnCfg *udnv1.EVPNConfig, targetNamespaces ...string) *udnv1.ClusterUserDefinedNetwork {
 	return &udnv1.ClusterUserDefinedNetwork{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:     map[string]string{"k8s.ovn.org/user-defined-network": ""},
@@ -2754,35 +2816,26 @@ func testEVPNClusterUDN(name string, vtepName string, targetNamespaces ...string
 					Subnets: udnv1.DualStackCIDRs{"10.10.10.0/24"},
 				},
 				Transport: udnv1.TransportOptionEVPN,
-				EVPN: &udnv1.EVPNConfig{
-					VTEP: vtepName,
-					MACVRF: &udnv1.VRFConfig{
-						VNI: 100,
-					},
-				},
+				EVPN:      evpnCfg,
 			},
 		},
 	}
 }
 
-// testEVPNClusterUdnNADWithVIDs creates an EVPN NAD with specific MAC-VRF and IP-VRF VIDs.
-// Pass 0 for ipVID to create a MAC-VRF only NAD.
-func testEVPNClusterUdnNADWithVIDs(name, namespace, vtepName string, macVID, ipVID int) *netv1.NetworkAttachmentDefinition {
+// testEVPNClusterUdnNADWithEVPNCfg creates an EVPN NAD with the given EVPN configuration.
+func testEVPNClusterUdnNADWithEVPNCfg(name, namespace string, evpnCfg *ovncnitypes.EVPNConfig) *netv1.NetworkAttachmentDefinition {
 	nad := testClusterUdnNAD(name, namespace)
-	if ipVID > 0 {
-		// Symmetric IRB (both MAC-VRF and IP-VRF)
-		nad.Spec.Config = fmt.Sprintf(`{"cniVersion":"1.1.0","name":"cluster_udn_%s","type":"ovn-k8s-cni-overlay","netAttachDefName":"%s/%s","topology":"layer2","role":"primary","subnets":"10.10.0.0/16","transport":"evpn","evpn":{"vtep":"%s","macVRF":{"vni":100,"vid":%d},"ipVRF":{"vni":200,"vid":%d}}}`, name, namespace, name, vtepName, macVID, ipVID)
-	} else {
-		// MAC-VRF only
-		nad.Spec.Config = fmt.Sprintf(`{"cniVersion":"1.1.0","name":"cluster_udn_%s","type":"ovn-k8s-cni-overlay","netAttachDefName":"%s/%s","topology":"layer2","role":"primary","subnets":"10.10.0.0/16","transport":"evpn","evpn":{"vtep":"%s","macVRF":{"vni":100,"vid":%d}}}`, name, namespace, name, vtepName, macVID)
+	evpnJSON, err := json.Marshal(evpnCfg)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal EVPN config: %v", err))
 	}
+	nad.Spec.Config = fmt.Sprintf(`{"cniVersion":"1.1.0","name":"cluster_udn_%s","type":"ovn-k8s-cni-overlay","netAttachDefName":"%s/%s","topology":"layer2","role":"primary","subnets":"10.10.0.0/16","transport":"evpn","evpn":%s}`, name, namespace, name, evpnJSON)
 	return nad
 }
 
-// testEVPNClusterUdnNADOwnedByCUDN creates an EVPN NAD with specific VIDs and sets up
-// the OwnerReferences to indicate ownership by the given CUDN.
-func testEVPNClusterUdnNADOwnedByCUDN(cudn *udnv1.ClusterUserDefinedNetwork, namespace, vtepName string, macVID, ipVID int) *netv1.NetworkAttachmentDefinition {
-	nad := testEVPNClusterUdnNADWithVIDs(cudn.Name, namespace, vtepName, macVID, ipVID)
+// testEVPNClusterUdnNADOwnedByCUDN creates an EVPN NAD owned by the given CUDN.
+func testEVPNClusterUdnNADOwnedByCUDN(cudn *udnv1.ClusterUserDefinedNetwork, namespace string, evpnCfg *ovncnitypes.EVPNConfig) *netv1.NetworkAttachmentDefinition {
+	nad := testEVPNClusterUdnNADWithEVPNCfg(cudn.Name, namespace, evpnCfg)
 	nad.OwnerReferences = []metav1.OwnerReference{
 		{
 			APIVersion:         "k8s.ovn.org/v1",
@@ -2797,73 +2850,22 @@ func testEVPNClusterUdnNADOwnedByCUDN(cudn *udnv1.ClusterUserDefinedNetwork, nam
 }
 
 func testSymmetricIRBClusterUDN(name string, vtepName string, targetNamespaces ...string) *udnv1.ClusterUserDefinedNetwork {
-	return &udnv1.ClusterUserDefinedNetwork{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels:     map[string]string{"k8s.ovn.org/user-defined-network": ""},
-			Finalizers: []string{"k8s.ovn.org/user-defined-network-protection"},
-			Name:       name,
-			UID:        "1",
-		},
-		Spec: udnv1.ClusterUserDefinedNetworkSpec{
-			NamespaceSelector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
-				{
-					Key:      corev1.LabelMetadataName,
-					Operator: metav1.LabelSelectorOpIn,
-					Values:   targetNamespaces,
-				},
-			}},
-			Network: udnv1.NetworkSpec{
-				Topology: udnv1.NetworkTopologyLayer2,
-				Layer2: &udnv1.Layer2Config{
-					Role:    udnv1.NetworkRoleSecondary,
-					Subnets: udnv1.DualStackCIDRs{"10.10.10.0/24"},
-				},
-				Transport: udnv1.TransportOptionEVPN,
-				EVPN: &udnv1.EVPNConfig{
-					VTEP: vtepName,
-					MACVRF: &udnv1.VRFConfig{
-						VNI: 100,
-					},
-					IPVRF: &udnv1.VRFConfig{
-						VNI: 200,
-					},
-				},
-			},
-		},
-	}
+	return testEVPNClusterUDN(name, &udnv1.EVPNConfig{
+		VTEP:   vtepName,
+		MACVRF: &udnv1.VRFConfig{VNI: 100},
+		IPVRF:  &udnv1.VRFConfig{VNI: 200},
+	}, targetNamespaces...)
 }
 
 func testEVPNIPVRFClusterUDN(name string, vtepName string, targetNamespaces ...string) *udnv1.ClusterUserDefinedNetwork {
-	return &udnv1.ClusterUserDefinedNetwork{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels:     map[string]string{"k8s.ovn.org/user-defined-network": ""},
-			Finalizers: []string{"k8s.ovn.org/user-defined-network-protection"},
-			Name:       name,
-			UID:        "1",
-		},
-		Spec: udnv1.ClusterUserDefinedNetworkSpec{
-			NamespaceSelector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
-				{
-					Key:      corev1.LabelMetadataName,
-					Operator: metav1.LabelSelectorOpIn,
-					Values:   targetNamespaces,
-				},
-			}},
-			Network: udnv1.NetworkSpec{
-				Topology: udnv1.NetworkTopologyLayer3,
-				Layer3: &udnv1.Layer3Config{
-					Role: udnv1.NetworkRoleSecondary,
-				},
-				Transport: udnv1.TransportOptionEVPN,
-				EVPN: &udnv1.EVPNConfig{
-					VTEP: vtepName,
-					IPVRF: &udnv1.VRFConfig{
-						VNI: 200,
-					},
-				},
-			},
-		},
-	}
+	cudn := testEVPNClusterUDN(name, &udnv1.EVPNConfig{
+		VTEP:  vtepName,
+		IPVRF: &udnv1.VRFConfig{VNI: 200},
+	}, targetNamespaces...)
+	cudn.Spec.Network.Topology = udnv1.NetworkTopologyLayer3
+	cudn.Spec.Network.Layer2 = nil
+	cudn.Spec.Network.Layer3 = &udnv1.Layer3Config{Role: udnv1.NetworkRoleSecondary}
+	return cudn
 }
 
 func testVTEP(name string) *vtepv1.VTEP {

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -993,7 +993,7 @@ var _ = Describe("User Defined Network Controller", func() {
 					Type:    "NetworkCreated",
 					Status:  "False",
 					Reason:  "NetworkAttachmentDefinitionSyncError",
-					Message: "failed to allocate EVPN VIDs: failed to allocate VID for MAC-VRF: failed to allocate the id for the resource evpn-exhaust-cudn/macvrf",
+					Message: "failed to allocate EVPN IDs: failed to allocate VID for MAC-VRF: failed to allocate the id for the resource evpn-exhaust-cudn/macvrf",
 				}}), "should report VID allocation failure in status")
 
 				// Verify NAD was not created


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VNI reservation to prevent VNI conflicts per VTEP; reservations are recovered on startup and released during network cleanup.
  * CRD validation added: macVRF and ipVRF must use different VNIs.

* **Tests**
  * Expanded EVPN test coverage for VNI conflicts, startup recovery, deterministic allocation, VTEP changes, and the equal‑VNI invalid case; tests modernized to use a unified EVPN config input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->