### PR TITLE
Pass node name to Route Import manager

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -529,7 +529,8 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 				libovsdbOvnNBClient,
 				libovsdbOvnSBClient,
 				eventRecorder,
-				wg)
+				wg,
+				runMode.identity)
 			if err != nil {
 				controllerErr = fmt.Errorf("failed to initialize network controller: %w", err)
 				return

--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -245,7 +245,7 @@ func (cm *ControllerManager) CleanupStaleNetworks(validNetworks ...util.NetInfo)
 // NewControllerManager creates a new ovnkube controller manager to manage all the controller for all networks
 func NewControllerManager(ovnClient *util.OVNClientset, wf *factory.WatchFactory,
 	libovsdbOvnNBClient libovsdbclient.Client, libovsdbOvnSBClient libovsdbclient.Client,
-	recorder record.EventRecorder, wg *sync.WaitGroup) (*ControllerManager, error) {
+	recorder record.EventRecorder, wg *sync.WaitGroup, identity string) (*ControllerManager, error) {
 	podRecorder := metrics.NewPodRecorder()
 
 	stopCh := make(chan struct{})
@@ -288,7 +288,7 @@ func NewControllerManager(ovnClient *util.OVNClientset, wf *factory.WatchFactory
 		if !config.OVNKubernetesFeature.EnableInterconnect {
 			return nil, fmt.Errorf("RouteAdvertisements can only be used if Interconnect is enabled")
 		}
-		cm.routeImportManager = routeimport.New(config.Default.Zone, cm.nbClient)
+		cm.routeImportManager = routeimport.New(identity, cm.nbClient)
 	}
 
 	return cm, nil


### PR DESCRIPTION
## 📑 Description
When OVN-K runs in OVNKubeController mode, the ControllerManager creates RouteImportManager with `node` parameter being `config.Default.Zone` which is `global`.
For `--init-master` (combined mode) deployments, it means that the RouteImport manager will fail to access the Gateway Router (looks for `GR_global`, instead it's `GR_$nodeName`) therefore received routes are not installed in the Gateway Router:
```
E0305 16:04:32.767823  768545 controller.go:258] Controller RouteImport: error found while processing default: failed to get routes from OVN: failed to get routes from router GR_global: failed to get router: GR_global, error: object not found
```


## Additional Information for reviewers

Also, for what it's worth: when running in Cluster Manager mode, the cluster manager is given the `runMode.identity`.

Providing `--zone $nodeName` to ovnkube does not solve the problem, because following error is being logged and ovnkube doesn't become ready:
```
I0305 16:06:13.685642  770469 ovs.go:167] Exec(32): /usr/bin/ovn-sbctl --timeout=15 --no-leader-only get SB_Global . options:name
I0305 16:06:13.688530  770469 ovs.go:170] Exec(32): stdout: ""
I0305 16:06:13.688544  770469 ovs.go:171] Exec(32): stderr: "ovn-sbctl: no key \"name\" in SB_Global record \".\" column options\n"
```

Eventually, ovnkube exits:
```
F0305 16:10:59.930808  770469 ovnkube.go:147] failed to run ovnkube: [failed to start network controller: failed to start default ovnkube-controller - OVN NBDB zone global does not match the configured zone "dev": errors: context deadline exceeded, config zone dev different from NBDB zone global, failed to start node network controller: failed to init default node network controller: timed out waiting for the node zone dev to match the OVN Southbound db zone, err: context canceled, err1: node dev zone dev mismatch with the Southbound zone global]
```

Perhaps it's the way OVN-K on MicroShift is being initialized.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Controller manager initialization now accepts and propagates an identity parameter for configuration.
  * Route advertisement/import behavior updated to use identity-based settings instead of zone-based configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->