### PR TITLE
fix: add short names for (c)udn

### DIFF
--- a/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_clusteruserdefinednetworks.yaml.j2
@@ -11,6 +11,8 @@ spec:
     kind: ClusterUserDefinedNetwork
     listKind: ClusterUserDefinedNetworkList
     plural: clusteruserdefinednetworks
+    shortNames:
+    - cudn
     singular: clusteruserdefinednetwork
   scope: Cluster
   versions:

--- a/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
+++ b/dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2
@@ -11,6 +11,8 @@ spec:
     kind: UserDefinedNetwork
     listKind: UserDefinedNetworkList
     plural: userdefinednetworks
+    shortNames:
+    - udn
     singular: userdefinednetwork
   scope: Namespaced
   versions:

--- a/go-controller/pkg/crd/userdefinednetwork/v1/cudn.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/cudn.go
@@ -7,7 +7,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=clusteruserdefinednetworks,scope=Cluster
+// +kubebuilder:resource:path=clusteruserdefinednetworks,scope=Cluster,shortName=cudn
 // +kubebuilder:singular=clusteruserdefinednetwork
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/go-controller/pkg/crd/userdefinednetwork/v1/udn.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/udn.go
@@ -6,7 +6,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 //
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=userdefinednetworks,scope=Namespaced
+// +kubebuilder:resource:path=userdefinednetworks,scope=Namespaced,shortName=udn
 // +kubebuilder:singular=userdefinednetwork
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

typing clusteruserdefinednetwork is getting old fast :)
seems that cudn and udn would be much nicer for all users.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shorthand aliases for two Custom Resource Definitions: "cudn" and "udn", enabling faster kubectl commands and shorter configuration references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->