### PR TITLE
narrow test case match string for "Network Segmentation: Preconfigured Layer2 UDN" test cases

### DIFF
--- a/test/e2e/network_segmentation_preconfigured_layer2.go
+++ b/test/e2e/network_segmentation_preconfigured_layer2.go
@@ -167,7 +167,7 @@ var _ = Describe("Network Segmentation: Preconfigured Layer2 UDN", feature.Netwo
 				reservedCIDRs: "172.16.0.10/30",
 			},
 			expectedError: ContainSubstring(
-				"Invalid value: reservedSubnets must be a masked network address (no host bits set)",
+				"reservedSubnets must be a masked network address (no host bits set)",
 			),
 		}),
 		Entry("Layer2 with unmasked IPv6 reserved subnets", invalidAPITestConfig{
@@ -179,7 +179,7 @@ var _ = Describe("Network Segmentation: Preconfigured Layer2 UDN", feature.Netwo
 				reservedCIDRs: "2014:100:200::88/122",
 			},
 			expectedError: ContainSubstring(
-				"Invalid value: reservedSubnets must be a masked network address (no host bits set)",
+				"reservedSubnets must be a masked network address (no host bits set)",
 			),
 		}),
 		Entry("Layer2 with unmasked IPv4 infrastructure subnets", invalidAPITestConfig{
@@ -191,7 +191,7 @@ var _ = Describe("Network Segmentation: Preconfigured Layer2 UDN", feature.Netwo
 				infrastructureCIDRs: "172.16.0.10/30",
 			},
 			expectedError: ContainSubstring(
-				"Invalid value: infrastructureSubnets must be a masked network address (no host bits set)",
+				"infrastructureSubnets must be a masked network address (no host bits set)",
 			),
 		}),
 		Entry("Layer2 with unmasked IPv6 infrastructure subnets", invalidAPITestConfig{
@@ -203,7 +203,7 @@ var _ = Describe("Network Segmentation: Preconfigured Layer2 UDN", feature.Netwo
 				infrastructureCIDRs: "2014:100:200::88/122",
 			},
 			expectedError: ContainSubstring(
-				"Invalid value: infrastructureSubnets must be a masked network address (no host bits set)",
+				"infrastructureSubnets must be a masked network address (no host bits set)",
 			),
 		}),
 	)


### PR DESCRIPTION
k8s 1.35 has updated [0] the error string for some validations. this will still work with 1.34 and continue to work when we bump to 1.35

[0] https://github.com/kubernetes/kubernetes/pull/133832/changes/a67468717c3c366ed182d6a3dc46ca2b7b1af81c

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Relaxed error-message matching in Layer2 preconfigured network segmentation tests: removed the strict expectation of a leading 'Invalid value: "object":' prefix when validating errors for reserved and infrastructure subnet scenarios, making tests more robust and consistent without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->