### PR TITLE
Bump Fedora to 44 and OVN to ovn-25.09.2-2.fc44

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -31,7 +31,7 @@ RUN cd ovn-kubernetes/dist/images && \
 #############################################
 # Stage to get OVN and OVS RPMs from source #
 #############################################
-FROM quay.io/fedora/fedora:42 AS ovnbuilder
+FROM quay.io/fedora/fedora:44 AS ovnbuilder
 USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
@@ -94,8 +94,8 @@ RUN git log -n 1
 ########################################
 # Stage to download OVN RPMs from koji #
 ########################################
-FROM quay.io/fedora/fedora:42 AS kojidownloader
-ARG ovnver=ovn-25.09.2-2.fc42
+FROM quay.io/fedora/fedora:44 AS kojidownloader
+ARG ovnver=ovn-25.09.2-2.fc44
 
 USER root
 
@@ -115,14 +115,14 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] || [ -z "$TARGETPLATFORM" ] ; then 
 ######################################
 # Stage to copy OVN RPMs from source #
 ######################################
-FROM quay.io/fedora/fedora:42 AS source
+FROM quay.io/fedora/fedora:44 AS source
 COPY --from=ovnbuilder /root/ovn/rpm/rpmbuild/RPMS/x86_64/*.rpm /
 COPY --from=ovnbuilder /root/ovs/rpm/rpmbuild/RPMS/x86_64/*.rpm /
 
 ####################################
 # Stage to copy OVN RPMs from koji #
 ####################################
-FROM quay.io/fedora/fedora:42 AS koji
+FROM quay.io/fedora/fedora:44 AS koji
 
 COPY --from=kojidownloader /*.rpm /
 


### PR DESCRIPTION
Koji deleted fc42 builds, only fc44 packages are available.

https://koji.fedoraproject.org/koji/buildinfo?buildID=2873920

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
