### PR TITLE
EVPN test: add multicast e2e for EVPN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -517,7 +517,7 @@ jobs:
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
       OVN_HYBRID_OVERLAY_ENABLE: ${{ (matrix.target == 'control-plane' || matrix.target == 'control-plane-helm') && (matrix.ipfamily == 'ipv4' || matrix.ipfamily == 'dualstack' ) }}
-      OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || startsWith(matrix.target, 'network-segmentation') || startsWith(matrix.target, 'bgp') }}"
+      OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || startsWith(matrix.target, 'network-segmentation') || startsWith(matrix.target, 'bgp') || startsWith(matrix.target, 'evpn')}}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || startsWith(matrix.target, 'bgp') }}"
       OVN_HA: "${{ matrix.ha == 'HA' }}"
       OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws == 'noSnatGW' }}"

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -514,6 +514,22 @@ func (oc *Layer2UserDefinedNetworkController) init() error {
 			return fmt.Errorf("failed to create cluster port groups for network %q: %w", oc.GetNetworkName(), err)
 		}
 
+		// Add the MACVRF port to ClusterRtrPortGroupNameBase so the
+		// AllowInterNode multicast ACL permits multicast traffic to/from
+		// the EVPN fabric.
+		if oc.multicastSupport && oc.Transport() == types.NetworkTransportEVPN {
+			macvrfportName := util.GetMACVRFPortName(oc.GetNetworkScopedSwitchName(types.OVNLayer2Switch))
+			lsp := &nbdb.LogicalSwitchPort{Name: macvrfportName}
+			lsp, err = libovsdbops.GetLogicalSwitchPort(oc.nbClient, lsp)
+			if err != nil {
+				return fmt.Errorf("failed to get MACVRF port %s: %w", macvrfportName, err)
+			}
+			if err := libovsdbops.AddPortsToPortGroup(oc.nbClient,
+				oc.getClusterPortGroupName(types.ClusterRtrPortGroupNameBase), lsp.UUID); err != nil {
+				return fmt.Errorf("failed to add MACVRF port to router port group for multicast: %w", err)
+			}
+		}
+
 		if err := oc.syncDefaultMulticastPolicies(); err != nil {
 			return fmt.Errorf("failed to sync default multicast policies for network %q: %w", oc.GetNetworkName(), err)
 		}

--- a/test/e2e/multicast.go
+++ b/test/e2e/multicast.go
@@ -59,15 +59,17 @@ var _ = ginkgo.Describe("Multicast", feature.Multicast, func() {
 		})
 
 		ginkgo.It("should be able to send multicast UDP traffic between nodes", func() {
-			testMulticastUDPTraffic(fr, clientNodeInfo, serverNodeInfo, defaultPodInterface)
+			err := testMulticastUDPTraffic(fr, clientNodeInfo, serverNodeInfo, defaultPodInterface)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 		ginkgo.It("should be able to receive multicast IGMP query", func() {
-			testMulticastIGMPQuery(fr, clientNodeInfo, serverNodeInfo)
+			err := testMulticastIGMPQuery(fr, clientNodeInfo, serverNodeInfo)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})
 })
 
-func testMulticastUDPTraffic(fr *framework.Framework, clientNodeInfo, serverNodeInfo nodeInfo, iface string) {
+func testMulticastUDPTraffic(fr *framework.Framework, clientNodeInfo, serverNodeInfo nodeInfo, iface string) error {
 	ginkgo.GinkgoHelper()
 	const (
 		mcastSource  = "pod-client"
@@ -138,10 +140,16 @@ func testMulticastUDPTraffic(fr *framework.Framework, clientNodeInfo, serverNode
 	e2epod.NewPodClient(fr).CreateSync(context.TODO(), mcastServerPod3)
 
 	ginkgo.By("checking if pod server1 received multicast traffic")
-	gomega.Eventually(func() (string, error) {
-		return e2epod.GetPodLogs(context.TODO(), fr.ClientSet, ns, mcastServer1, mcastServer1)
-	},
-		30*time.Second, 1*time.Second).Should(gomega.ContainSubstring("connected"))
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
+		logs, err := e2epod.GetPodLogs(context.TODO(), fr.ClientSet, ns, mcastServer1, mcastServer1)
+		if err != nil {
+			return false, nil
+		}
+		return strings.Contains(logs, "connected"), nil
+	})
+	if err != nil {
+		return fmt.Errorf("server1 did not receive multicast traffic: %w", err)
+	}
 
 	ginkgo.By("checking if pod server2 does not received multicast traffic")
 	gomega.Eventually(func() (string, error) {
@@ -150,14 +158,21 @@ func testMulticastUDPTraffic(fr *framework.Framework, clientNodeInfo, serverNode
 		30*time.Second, 1*time.Second).ShouldNot(gomega.ContainSubstring("connected"))
 
 	ginkgo.By("checking if pod server3 received multicast traffic")
-	gomega.Eventually(func() (string, error) {
-		return e2epod.GetPodLogs(context.TODO(), fr.ClientSet, ns, mcastServer3, mcastServer3)
-	},
-		30*time.Second, 1*time.Second).Should(gomega.ContainSubstring("connected"))
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
+		logs, err := e2epod.GetPodLogs(context.TODO(), fr.ClientSet, ns, mcastServer3, mcastServer3)
+		if err != nil {
+			return false, nil
+		}
+		return strings.Contains(logs, "connected"), nil
+	})
+	if err != nil {
+		return fmt.Errorf("server3 did not receive multicast traffic: %w", err)
+	}
 
+	return nil
 }
 
-func testMulticastIGMPQuery(f *framework.Framework, clientNodeInfo, serverNodeInfo nodeInfo) {
+func testMulticastIGMPQuery(f *framework.Framework, clientNodeInfo, serverNodeInfo nodeInfo) error {
 	ginkgo.GinkgoHelper()
 	const (
 		mcastGroup           string = "224.1.1.1"
@@ -211,9 +226,18 @@ func testMulticastIGMPQuery(f *framework.Framework, clientNodeInfo, serverNodeIn
 	ginkgo.By("verifying that the IGMP query has been received")
 	// ovn-k leaves both mcast_idle_timeout and mcast_query_interval to default which means that
 	// ovn-controller will send IGMP queries every 150 seconds.
-	gomega.Eventually(func() (string, error) {
-		return e2ekubectl.RunKubectl(f.Namespace.Name, "exec", multicastListenerPod, "--", "/bin/bash", "-c", fmt.Sprintf("grep igmp %s", tcpdumpFileName))
-	}, 2*150*time.Second, 5*time.Second).Should(gomega.ContainSubstring("igmp"), "Failed to retrieve multicast IGMP query within the expected time")
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*150*time.Second, true, func(context.Context) (bool, error) {
+		output, err := e2ekubectl.RunKubectl(f.Namespace.Name, "exec", multicastListenerPod, "--", "/bin/bash", "-c", fmt.Sprintf("grep igmp %s", tcpdumpFileName))
+		if err != nil {
+			return false, nil
+		}
+		return strings.Contains(output, "igmp"), nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to receive multicast IGMP query within the expected time: %w", err)
+	}
+
+	return nil
 }
 
 func enableMulticastForNamespace(fr *framework.Framework) {

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -904,7 +904,8 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 					metav1.CreateOptions{},
 				)
 				framework.ExpectNoError(err)
-				testMulticastUDPTraffic(f, clientNodeInfo, serverNodeInfo, udnPodInterface)
+				err = testMulticastUDPTraffic(f, clientNodeInfo, serverNodeInfo, udnPodInterface)
+				Expect(err).NotTo(HaveOccurred())
 			},
 				ginkgo.Entry("with primary layer3 UDN", networkAttachmentConfigParams{
 					name:     nadName,
@@ -939,7 +940,8 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 					metav1.CreateOptions{},
 				)
 				framework.ExpectNoError(err)
-				testMulticastIGMPQuery(f, clientNodeInfo, serverNodeInfo)
+				err = testMulticastIGMPQuery(f, clientNodeInfo, serverNodeInfo)
+				Expect(err).NotTo(HaveOccurred())
 			},
 				ginkgo.Entry("with primary layer3 UDN", networkAttachmentConfigParams{
 					name:     nadName,

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -2699,6 +2699,95 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		},
 		networksToTest,
 	)
+
+	evpnNetworks := []ginkgo.TableEntry{
+		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF", feature.EVPN, layer3IPVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF", feature.EVPN, layer2MACVRFNetworkSpecGen),
+		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF", feature.EVPN, layer2MACVRFIPVRFNetworkSpecGen),
+	}
+
+	ginkgo.DescribeTableSubtree("with multicast feature enabled for namespace",
+		func(networkSpecGen func() *udnv1.NetworkSpec) {
+			var (
+				clientNodeInfo, serverNodeInfo nodeInfo
+				testNamespace                  *corev1.Namespace
+			)
+
+			ginkgo.BeforeEach(func() {
+				nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 2)
+				framework.ExpectNoError(err)
+				if len(nodes.Items) < 2 {
+					e2eskipper.Skipf(
+						"Test requires >= 2 Ready nodes, but there are only %v nodes",
+						len(nodes.Items))
+				}
+
+				ips := e2enode.CollectAddresses(nodes, corev1.NodeInternalIP)
+
+				clientNodeInfo = nodeInfo{
+					name:   nodes.Items[0].Name,
+					nodeIP: ips[0],
+				}
+
+				serverNodeInfo = nodeInfo{
+					name:   nodes.Items[1].Name,
+					nodeIP: ips[1],
+				}
+
+				networkSpec := networkSpecGen()
+				// Match subnets by IP families
+				switch {
+				case networkSpec.Layer3 != nil:
+					networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
+				case networkSpec.Layer2 != nil:
+					networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
+				}
+
+				testNamespace, _ = configureNetworkWithInfra(
+					f,
+					ictx,
+					testBaseName,
+					ipFamilySet,
+					testNetworkName,
+					cudnAdvertisedEVPN,
+					networkSpec,
+				)
+				f.Namespace = testNamespace
+
+				ginkgo.By("Enabling multicast for namespace")
+				enableMulticastForNamespace(f)
+			})
+
+			ginkgo.It("handle multicast UDP traffic", func() {
+				networkSpec := networkSpecGen()
+				isLayer3 := networkSpec.Topology == udnv1.NetworkTopologyLayer3
+
+				ginkgo.By("send multicast UDP traffic between nodes")
+				err := testMulticastUDPTraffic(f, clientNodeInfo, serverNodeInfo, udnPodInterface)
+				if isLayer3 {
+					gomega.Expect(err).To(gomega.HaveOccurred(), fmt.Sprintf("multicast UDP traffic should fail on %s network", networkSpec.Topology))
+				} else {
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("multicast UDP traffic should work on %s network", networkSpec.Topology))
+				}
+			})
+
+			ginkgo.It("handle multicast IGMP query", func() {
+				networkSpec := networkSpecGen()
+				isLayer3 := networkSpec.Topology == udnv1.NetworkTopologyLayer3
+
+				ginkgo.By("receive multicast IGMP query")
+				if isLayer3 {
+					err := testMulticastIGMPQuery(f, clientNodeInfo, serverNodeInfo)
+					gomega.Expect(err).To(gomega.HaveOccurred(), fmt.Sprintf("multicast IGMP query should fail on %s network", networkSpec.Topology))
+				} else {
+					// TODO: this test is broken, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5309
+					//err := testMulticastIGMPQuery(f, clientNodeInfo, serverNodeInfo)
+					//gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("multicast IGMP query should work on %s EVPN network", networkSpec.Topology))
+				}
+			})
+		},
+		evpnNetworks,
+	)
 })
 
 // routeAdvertisementsReadyFunc returns a function that checks for the


### PR DESCRIPTION
Add multicast UDP traffic and IGMP query tests for EVPN across Layer2 (MAC-VRF + MAC-VRF and IP-VRF) and Layer3 (IP-VRF) topologies. Refactor multicast test functions to return errors for conditional validation.

- Extract setupEVPNInfrastructure helper for test reuse
- Add multicast tests for Layer2 MAC-VRF, Layer2 MAC-VRF+IP-VRF, and Layer3 IP-VRF
- Refactor testMulticastUDPTraffic and testMulticastIGMPQuery to return errors

based on #6068 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing**
  * Improved multicast test reliability through enhanced error handling and detection
  * Added multicast test coverage for EVPN configurations with multiple topology variants

* **Features**
  * Multicast functionality is now validated for EVPN network environments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->