### PR TITLE
Add ovnkube-identity support for DPUs

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -451,6 +451,12 @@ while [ "$1" != "" ]; do
   --dpuhost-cluster-k8s-cacert)
     DPUHOST_CLUSTER_K8S_CACERT=$value
     ;;
+  --generate-dpu-host-csr)
+    GENERATE_DPU_HOST_CSR=$VALUE
+    ;;
+  --dpu-host-in-cluster)
+    DPU_HOST_IN_CLUSTER=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -684,6 +690,12 @@ echo "ovn_nohostsubnet_label: ${ovn_nohostsubnet_label}"
 
 ovn_disable_requestedchassis=${OVN_DISABLE_REQUESTEDCHASSIS}
 echo "ovn_disable_requestedchassis: ${ovn_disable_requestedchassis}"
+
+dpu_host_in_cluster=${DPU_HOST_IN_CLUSTER:-"false"}
+echo "dpu_host_in_cluster: ${dpu_host_in_cluster}"
+
+generate_dpu_host_csr=${GENERATE_DPU_HOST_CSR:-"false"}
+echo "generate_dpu_host_csr: ${generate_dpu_host_csr}"
 
 ovn_image=${ovnkube_image} \
   ovnkube_compact_mode_enable=${ovnkube_compact_mode_enable} \
@@ -1177,6 +1189,7 @@ ovn_image=${ovnkube_image} \
   dpuhost_cluster_k8s_cacert_data=${dpuhost_cluster_k8s_cacert_data} \
   dpuhost_cluster_k8s_token_file=${dpuhost_cluster_k8s_token_file} \
   dpuhost_cluster_k8s_cacert=${dpuhost_cluster_k8s_cacert} \
+  generate_dpu_host_csr=${generate_dpu_host_csr} \
   jinjanate ../templates/ovnkube-single-node-zone-dpu.yaml.j2 -o ${output_dir}/ovnkube-single-node-zone-dpu.yaml
 
 ovn_image=${ovnkube_image} \
@@ -1317,6 +1330,7 @@ net_cidr=${net_cidr} svc_cidr=${svc_cidr} \
 
 ovn_enable_interconnect=${ovn_enable_interconnect} \
 ovn_enable_ovnkube_identity=${ovn_enable_ovnkube_identity} \
+dpu_host_in_cluster=${dpu_host_in_cluster} \
 ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
 ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
   jinjanate ../templates/rbac-ovnkube-node.yaml.j2 -o ${output_dir}/rbac-ovnkube-node.yaml

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -86,6 +86,7 @@ fi
 # OVNKUBE_NODE_MGMT_PORT_NETDEV - ovnkube node management port netdev.
 # OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME - ovnkube node management port device plugin resource
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node. mandatory in case ovnkube-node-mode=="dpu"
+# GENERATE_DPU_HOST_CSR - when true, DPU node uses K8s token and CAcert to obtain a client cert for the host cluster via CSR
 # OVN_HOST_NETWORK_NAMESPACE - namespace to classify host network traffic for applying network policies
 # OVN_DISABLE_FORWARDING - disable forwarding on OVNK controlled interfaces
 # OVN_ENABLE_MULTI_EXTERNAL_GATEWAY - enable multi external gateway for ovn-kubernetes
@@ -2394,6 +2395,7 @@ ovnkube-controller-with-node() {
     [[ -n ${K8S_TOKEN_FILE} ]] && cluster_access_opts+="--k8s-token-file=${K8S_TOKEN_FILE} "
     [[ -n ${K8S_CACERT_DATA} ]] && cluster_access_opts+="--k8s-cacert-data=${K8S_CACERT_DATA} "
     [[ -n ${K8S_CACERT} ]] && cluster_access_opts+="--k8s-cacert=${K8S_CACERT} "
+    [[ "${GENERATE_DPU_HOST_CSR}" == "true" ]] && cluster_access_opts+="--generate-dpu-host-csr "
   fi
 
   echo "=============== ovnkube-controller-with-node --init-ovnkube-controller-with-node=========="

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -177,14 +177,12 @@ spec:
               name: ovn-config
               key: routable_mtu
               optional: true
-       {%-if ovnkube_app_name=="ovnkube-node-dpu" %}
-        - name: K8S_NODE_DPU
-       {%- else %}
+       {%-if ovnkube_app_name!="ovnkube-node-dpu" %}
         - name: K8S_NODE
-       {%- endif %}
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+       {%- endif %}
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:
@@ -371,14 +369,12 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
-       {%- if ovnkube_app_name=="ovnkube-node-dpu" %}
-        - name: K8S_NODE_DPU
-       {%- else %}
+        {%- if ovnkube_app_name!="ovnkube-node-dpu" %}
         - name: K8S_NODE
-       {%- endif %}
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        {%- endif %}
         - name: OVN_KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:

--- a/dist/templates/ovnkube-single-node-zone-dpu.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone-dpu.yaml.j2
@@ -310,6 +310,8 @@ spec:
           value: "{{ dpuhost_cluster_k8s_token_file }}"
         - name: K8S_CACERT
           value: "{{ dpuhost_cluster_k8s_cacert }}"
+        - name: GENERATE_DPU_HOST_CSR
+          value: "{{ generate_dpu_host_csr }}"
         - name: OVN_MTU
           value: "{{ mtu_value }}"
         - name: OVN_GATEWAY_MODE

--- a/dist/templates/rbac-ovnkube-node.yaml.j2
+++ b/dist/templates/rbac-ovnkube-node.yaml.j2
@@ -5,7 +5,9 @@ metadata:
     namespace: ovn-kubernetes
 
 # When ovn_enable_ovnkube_identity is true, an ovnkube-node process will identify as a user in a system:ovn-nodes group,
-# not the ovnkube-node serviceAccount
+# not the ovnkube-node serviceAccount.
+# DPUs will initially present ovnkube-node serviceAccount to request CSR, but after approval identify as a user in a
+# separate system:ovn-node-dpus group and reference dpu host node name.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -20,6 +22,11 @@ subjects:
     - kind: Group
       name: system:ovn-nodes
       apiGroup: rbac.authorization.k8s.io
+    {% if (dpu_host_in_cluster | default("false")) == "true" -%}
+    - kind: Group
+      name: system:ovn-node-dpus
+      apiGroup: rbac.authorization.k8s.io
+    {% endif -%}
     {% else %}
     - kind: ServiceAccount
       name: ovnkube-node
@@ -60,6 +67,11 @@ subjects:
     - kind: Group
       name: system:ovn-nodes
       apiGroup: rbac.authorization.k8s.io
+    {% if (dpu_host_in_cluster | default("false")) == "true" -%}
+    - kind: Group
+      name: system:ovn-node-dpus
+      apiGroup: rbac.authorization.k8s.io
+    {% endif -%}
     {% else %}
     - kind: ServiceAccount
       name: ovnkube-node
@@ -84,6 +96,11 @@ subjects:
     - kind: Group
       name: system:ovn-nodes
       apiGroup: rbac.authorization.k8s.io
+    {% if (dpu_host_in_cluster | default("false")) == "true" -%}
+    - kind: Group
+      name: system:ovn-node-dpus
+      apiGroup: rbac.authorization.k8s.io
+    {% endif -%}
     {% else %}
     - kind: ServiceAccount
       name: ovnkube-node
@@ -109,6 +126,37 @@ subjects:
       name: ovnkube-node
       namespace: ovn-kubernetes
 
+
+# When ovnkube-identity is enabled DPU needs token/CA for ovnkube-node SA to create CSRs and hence require CSR permissions in addition
+{% if ovn_enable_ovnkube_identity == "true" and (dpu_host_in_cluster | default("false")) == "true" -%}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-node-csr-bootstrap
+rules:
+    - apiGroups: ["certificates.k8s.io"]
+      resources:
+          - certificatesigningrequests
+      verbs:
+        - create
+        - get
+        - list
+        - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-node-csr-bootstrap
+roleRef:
+    name: ovnkube-node-csr-bootstrap
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-node
+      namespace: ovn-kubernetes
+{% endif %}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -237,6 +285,8 @@ rules:
           - create
           {%- endif %}
 
+# ovnkube-node-dpu-leases is required only when ovnkube-node-dpu-host is in the cluster
+{% if (dpu_host_in_cluster | default("false")) == "true" -%}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -251,6 +301,9 @@ subjects:
     {% if ovn_enable_ovnkube_identity == "true" -%}
     - kind: Group
       name: system:ovn-nodes
+      apiGroup: rbac.authorization.k8s.io
+    - kind: Group
+      name: system:ovn-node-dpus
       apiGroup: rbac.authorization.k8s.io
     {% else %}
     - kind: ServiceAccount
@@ -269,3 +322,4 @@ rules:
       resources:
           - leases
       verbs: [ "get", "create", "update" ]
+{%- endif %}

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -290,6 +290,11 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 		return fmt.Errorf("failed to initialize exec helper: %v", err)
 	}
 
+	runMode, err := determineOvnkubeRunMode(ctx)
+	if err != nil {
+		return err
+	}
+
 	ovnKubeStartWg := &sync.WaitGroup{}
 	defer func() {
 		// make sure everything stops and wait
@@ -297,24 +302,17 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 		ovnKubeStartWg.Wait()
 	}()
 
-	if config.Kubernetes.BootstrapKubeconfig != "" {
-		// In the case of dpus K8S_NODE will be set to dpu host's name
-		var csrNodeName string
-		if config.OvnKubeNode.Mode == types.NodeModeDPU {
-			csrNodeName = os.Getenv("K8S_NODE_DPU")
-		} else {
-			csrNodeName = os.Getenv("K8S_NODE")
+	if config.Kubernetes.BootstrapKubeconfig != "" || (config.OvnKubeNode.Mode == types.NodeModeDPU && config.Kubernetes.GenerateDPUHostCSR) {
+		// csrNodeName is the node identity passed in from init script. For DPU it will be set to DPU host node name.
+		csrNodeName := runMode.identity
+		if csrNodeName == "" {
+			return fmt.Errorf("node identity (K8S_NODE) is not set")
 		}
-		if err := util.StartNodeCertificateManager(ctx.Context, ovnKubeStartWg, csrNodeName, &config.Kubernetes); err != nil {
+		if err := util.StartNodeCertificateManager(ctx.Context, ovnKubeStartWg, csrNodeName, config.OvnKubeNode.Mode == types.NodeModeDPU, &config.Kubernetes); err != nil {
 			return fmt.Errorf("failed to start the node certificate manager: %w", err)
 		}
 	}
 	ovnClientset, err := util.NewOVNClientset(&config.Kubernetes)
-	if err != nil {
-		return err
-	}
-
-	runMode, err := determineOvnkubeRunMode(ctx)
 	if err != nil {
 		return err
 	}

--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
@@ -103,7 +103,7 @@ func runHybridOverlay(ctx *cli.Context) error {
 	wg := &sync.WaitGroup{}
 	clientCfg := config.Kubernetes
 	if config.Kubernetes.BootstrapKubeconfig != "" {
-		if err := util.StartNodeCertificateManager(ctx.Context, wg, nodeName, &config.Kubernetes); err != nil {
+		if err := util.StartNodeCertificateManager(ctx.Context, wg, nodeName, false, &config.Kubernetes); err != nil {
 			return fmt.Errorf("failed to start the node certificate manager: %w", err)
 		}
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -440,6 +440,7 @@ type KubernetesConfig struct {
 	APIServer               string `gcfg:"apiserver"`
 	Token                   string `gcfg:"token"`
 	TokenFile               string `gcfg:"tokenFile"`
+	GenerateDPUHostCSR      bool   `gcfg:"generate-dpu-host-csr"`
 	CompatServiceCIDR       string `gcfg:"service-cidr"`
 	RawServiceCIDRs         string `gcfg:"service-cidrs"`
 	ServiceCIDRs            []*net.IPNet
@@ -1408,6 +1409,11 @@ var K8sFlags = []cli.Flag{
 		Name:        "k8s-token-file",
 		Usage:       "the path to Kubernetes API token. If set, it is periodically read and takes precedence over k8s-token",
 		Destination: &cliConfig.Kubernetes.TokenFile,
+	},
+	&cli.BoolFlag{
+		Name:        "generate-dpu-host-csr",
+		Usage:       "when true, DPU node uses k8s token and CACert to obtain a client cert for the DPU Host cluster via CSR",
+		Destination: &cliConfig.Kubernetes.GenerateDPUHostCSR,
 	},
 	&cli.StringFlag{
 		Name:        "ovn-config-namespace",

--- a/go-controller/pkg/csrapprover/approver.go
+++ b/go-controller/pkg/csrapprover/approver.go
@@ -28,6 +28,7 @@ import (
 const (
 	ControllerName = "ovnkube-csr-approver-controller"
 	NamePrefix     = "system:ovn-node"
+	NamePrefixDPU  = "system:ovn-node-dpu"
 	MaxDuration    = time.Hour * 24 * 365
 )
 
@@ -74,7 +75,7 @@ func InitCSRAcceptanceConditions(fileName string) (conditions []CSRAcceptanceCon
 		}
 	}
 
-	conditions = append([]CSRAcceptanceCondition{DefaultCSRAcceptanceCondition}, conditions...)
+	conditions = append([]CSRAcceptanceCondition{DefaultCSRAcceptanceCondition, DPUCSRAcceptanceCondition}, conditions...)
 	// initialize Sets from slices
 	for i, v := range conditions {
 		conditions[i].groupsSet = sets.New[string](v.Groups...)
@@ -91,6 +92,16 @@ var (
 		Groups:           []string{"system:nodes", "system:ovn-nodes", "system:authenticated"},
 		UserPrefixes:     []string{"system:node", NamePrefix},
 		Default:          true,
+	}
+	// DPU CSRs
+	// (1) Initial CSR will use SA token and have Username like system:serviceaccount:ovn-kubernetes:ovnkube-node
+	// (2) Renewal of DPU certs will use system:ovn-node-dpus group while referencing DPU Host nodename
+	DPUCSRAcceptanceCondition = CSRAcceptanceCondition{
+		CommonNamePrefix: NamePrefixDPU,
+		Organizations:    []string{"system:ovn-node-dpus"},
+		Groups:           []string{"system:serviceaccounts", "system:serviceaccounts:ovn-kubernetes", "system:authenticated", "system:ovn-node-dpus"},
+		UserPrefixes:     []string{"system:serviceaccount", NamePrefixDPU},
+		Default:          false,
 	}
 	Usages = sets.New[certificatesv1.KeyUsage](
 		certificatesv1.UsageDigitalSignature,
@@ -269,17 +280,51 @@ func (c *OVNKubeCSRController) Reconcile(ctx context.Context, request reconcile.
 }
 
 func (c *CSRAcceptanceCondition) validateCSR(req *certificatesv1.CertificateSigningRequest, x509CSR *x509.CertificateRequest, acceptUsages sets.Set[certificatesv1.KeyUsage]) error {
-
-	// expected username format: userPrefix:nodeName
-	// example: system:ovn-node:ovn-worker2
-	i := strings.LastIndex(req.Spec.Username, ":")
-	if i == -1 || i == len(req.Spec.Username)-1 {
-		return fmt.Errorf("failed to parse the username: %s", req.Spec.Username)
-	}
-	prefix := req.Spec.Username[:i]
-	nodeName := req.Spec.Username[i+1:]
-	if !c.userPrefixesSet.Has(prefix) {
-		return fmt.Errorf("CSR %q was created by an unexpected user: %q", req.Name, req.Spec.Username)
+	// For DPU two cases need to be handled since initial CSR and cert renewal have different usernames.
+	// Initial CSR with SA token bootstrap: Username is SA (e.g. system:serviceaccount:ovn-kubernetes:ovnkube-node), nodeName has to be derived from CSR CN.
+	// Cert renewal: Username is system:ovn-node-dpu:<dpu host nodeName>, nodeName has to be derived from Username.
+	var nodeName string
+	if c.CommonNamePrefix == NamePrefixDPU {
+		if !strings.HasPrefix(x509CSR.Subject.CommonName, c.CommonNamePrefix+":") {
+			return fmt.Errorf("CSR %q common name %q does not have expected prefix %q", req.Name, x509CSR.Subject.CommonName, c.CommonNamePrefix+":")
+		}
+		cnNodeName := strings.TrimPrefix(x509CSR.Subject.CommonName, c.CommonNamePrefix+":")
+		if strings.HasPrefix(req.Spec.Username, NamePrefixDPU+":") {
+			// Cert renewal: nodeName from Username
+			nodeName = strings.TrimPrefix(req.Spec.Username, NamePrefixDPU+":")
+			if nodeName != cnNodeName {
+				return fmt.Errorf("CSR %q username node %q does not match common name node %q", req.Name, nodeName, cnNodeName)
+			}
+		} else {
+			// Token bootstrap: nodeName from CSR CN; require request from service account
+			nodeName = cnNodeName
+			var hasAllowedPrefix bool
+			for _, p := range c.UserPrefixes {
+				// Skip system:ovn-node-dpu prefix in Token bootstrap path (only allow service account)
+				if p == NamePrefixDPU {
+					continue
+				}
+				if strings.HasPrefix(req.Spec.Username, p+":") {
+					hasAllowedPrefix = true
+					break
+				}
+			}
+			if !hasAllowedPrefix {
+				return fmt.Errorf("CSR %q was created by an unexpected user: %q (expected prefix in %v)", req.Name, req.Spec.Username, c.UserPrefixes)
+			}
+		}
+	} else {
+		// For non DPU, expected username format: userPrefix:nodeName
+		// example: system:ovn-node:ovn-worker2
+		i := strings.LastIndex(req.Spec.Username, ":")
+		if i == -1 || i == len(req.Spec.Username)-1 {
+			return fmt.Errorf("failed to parse the username: %s", req.Spec.Username)
+		}
+		prefix := req.Spec.Username[:i]
+		nodeName = req.Spec.Username[i+1:]
+		if !c.userPrefixesSet.Has(prefix) {
+			return fmt.Errorf("CSR %q was created by an unexpected user: %q", req.Name, req.Spec.Username)
+		}
 	}
 
 	if errs := validation.IsDNS1123Subdomain(nodeName); len(errs) != 0 {

--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	hotypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -73,25 +74,57 @@ var hybridOverlayNodeAnnotationChecks = map[string]checkNodeAnnot{
 	hotypes.HybridOverlayDRIP:  nil,
 }
 
+// dpuNodeAnnotationChecks holds annotations allowed for ovnkube-node-dpu:<nodeName> when updating
+// the DPU-host node belonging to it.
+var dpuNodeAnnotationChecks = map[string]checkNodeAnnot{
+	util.OvnNodeZoneName: func(v annotationChange, nodeName string) error {
+		if (v.action == added || v.action == changed) &&
+			(v.value == types.OvnDefaultZone || v.value == nodeName) {
+			return nil
+		}
+		return fmt.Errorf("%s can only be set to %s or %s, it cannot be removed", util.OvnNodeZoneName, types.OvnDefaultZone, nodeName)
+	},
+	util.OVNNodeEncapIPs:        nil,
+	util.OvnNodeIfAddr:          nil,
+	util.OvnNodeL3GatewayConfig: nil,
+	util.OvnNodeChassisID: func(v annotationChange, _ string) error {
+		if v.action == removed {
+			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)
+		}
+		if v.action == changed {
+			return fmt.Errorf("%s cannot be changed once set", util.OvnNodeChassisID)
+		}
+		return nil
+	},
+	util.OvnNodeGatewayMtuSupport: nil,
+}
+
 type NodeAdmission struct {
-	annotationChecks  map[string]checkNodeAnnot
-	annotationKeys    sets.Set[string]
-	extraAllowedUsers sets.Set[string]
+	annotationChecks    map[string]checkNodeAnnot
+	annotationKeys      sets.Set[string]
+	dpuAnnotationChecks map[string]checkNodeAnnot
+	dpuAnnotationKeys   sets.Set[string]
+	extraAllowedUsers   sets.Set[string]
 }
 
 func NewNodeAdmissionWebhook(enableInterconnect, enableHybridOverlay bool, extraAllowedUsers ...string) *NodeAdmission {
 	checks := make(map[string]checkNodeAnnot)
 	maps.Copy(checks, commonNodeAnnotationChecks)
+	dpuChecks := make(map[string]checkNodeAnnot)
+	maps.Copy(dpuChecks, dpuNodeAnnotationChecks)
 	if enableInterconnect {
 		maps.Copy(checks, interconnectNodeAnnotationChecks)
+		maps.Copy(dpuChecks, interconnectNodeAnnotationChecks)
 	}
 	if enableHybridOverlay {
 		maps.Copy(checks, hybridOverlayNodeAnnotationChecks)
 	}
 	return &NodeAdmission{
-		annotationChecks:  checks,
-		annotationKeys:    sets.New[string](maps.Keys(checks)...),
-		extraAllowedUsers: sets.New[string](extraAllowedUsers...),
+		annotationChecks:    checks,
+		annotationKeys:      sets.New[string](maps.Keys(checks)...),
+		dpuAnnotationChecks: dpuChecks,
+		dpuAnnotationKeys:   sets.New[string](maps.Keys(dpuChecks)...),
+		extraAllowedUsers:   sets.New[string](extraAllowedUsers...),
 	}
 }
 
@@ -114,6 +147,18 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 		return nil, err
 	}
 	nodeName, isOVNKubeNode := ovnkubeNodeIdentity(req.UserInfo)
+	isDPU := isOVNKubeNode && strings.HasPrefix(req.UserInfo.Username, csrapprover.NamePrefixDPU+":")
+
+	// For ovnkube-node-dpu use only DPU-allowed annotations; otherwise use the full allowed set
+	var effectiveKeys sets.Set[string]
+	var effectiveChecks map[string]checkNodeAnnot
+	if isDPU {
+		effectiveKeys = p.dpuAnnotationKeys
+		effectiveChecks = p.dpuAnnotationChecks
+	} else {
+		effectiveKeys = p.annotationKeys
+		effectiveChecks = p.annotationChecks
+	}
 
 	changes := mapDiff(oldNode.Annotations, newNode.Annotations)
 	changedKeys := maps.Keys(changes)
@@ -137,7 +182,7 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 	}
 
 	for _, key := range changedKeys {
-		if check := p.annotationChecks[key]; check != nil {
+		if check := effectiveChecks[key]; check != nil {
 			if err := check(changes[key], nodeName); err != nil {
 				return nil, fmt.Errorf("user: %q is not allowed to set %s on node %q: %v", req.UserInfo.Username, key, newNode.Name, err)
 			}
@@ -150,15 +195,20 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 		return nil, nil
 	}
 
-	if newNode.Name != nodeName {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to modify nodes %q annotations", nodeName, newNode.Name)
+	identityDescription := "ovnkube-node on node"
+	if isDPU {
+		identityDescription = "ovnkube-node-dpu for node"
 	}
 
-	// ovnkube-node is not allowed to change annotations outside of it's scope
-	if !p.annotationKeys.HasAll(changedKeys...) {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to set the following annotations: %v",
+	if newNode.Name != nodeName {
+		return nil, fmt.Errorf("%s: %q is not allowed to modify annotations on node %q", identityDescription, nodeName, newNode.Name)
+	}
+
+	// ovnkube-node / ovnkube-node-dpu is not allowed to change annotations outside of its scope
+	if !effectiveKeys.HasAll(changedKeys...) {
+		return nil, fmt.Errorf("%s: %q is not allowed to set the following annotations: %v", identityDescription,
 			nodeName,
-			sets.New[string](changedKeys...).Difference(p.annotationKeys).UnsortedList())
+			sets.New[string](changedKeys...).Difference(effectiveKeys).UnsortedList())
 	}
 
 	// Verify that nothing but the annotations changed.
@@ -188,7 +238,7 @@ func (p NodeAdmission) ValidateUpdate(ctx context.Context, oldNode, newNode *cor
 	}
 	if !apiequality.Semantic.DeepEqual(oldNodeShallowCopy.ObjectMeta, newNodeShallowCopy.ObjectMeta) ||
 		!apiequality.Semantic.DeepEqual(oldNodeShallowCopy.Status, newNodeShallowCopy.Status) {
-		return nil, fmt.Errorf("ovnkube-node on node: %q is not allowed to modify anything other than annotations", nodeName)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify anything other than annotations", identityDescription, nodeName)
 	}
 
 	return nil, nil

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -50,8 +50,13 @@ func TestNewNodeAdmissionWebhook(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewNodeAdmissionWebhook(tt.enableInterconnect, tt.enableHybridOverlay); !got.annotationKeys.HasAll(tt.expectedKeys...) {
+			got := NewNodeAdmissionWebhook(tt.enableInterconnect, tt.enableHybridOverlay)
+			if !got.annotationKeys.HasAll(tt.expectedKeys...) {
 				t.Errorf("NewNodeAdmissionWebhook() = %v, want %v", got.annotationKeys, tt.expectedKeys)
+			}
+			// DPU webhook must always have the DPU-allowed node annotation keys
+			if !got.dpuAnnotationKeys.HasAll(maps.Keys(dpuNodeAnnotationChecks)...) {
+				t.Errorf("NewNodeAdmissionWebhook() dpuAnnotationKeys = %v, want all of %v", got.dpuAnnotationKeys, maps.Keys(dpuNodeAnnotationChecks))
 			}
 		})
 	}
@@ -148,7 +153,7 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 					Annotations: map[string]string{util.OVNNodeHostCIDRs: "new"},
 				},
 			},
-			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify nodes %q annotations", nodeName+"_rougeOne", nodeName),
+			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify annotations on node %q", nodeName+"_rougeOne", nodeName),
 		},
 		{
 			name: "ovnkube-node cannot modify annotations that do not belong to it",
@@ -188,6 +193,65 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 					Name:        nodeName,
 					Annotations: map[string]string{util.OvnNodeChassisID: "chassisID"}},
 			},
+		},
+		{
+			name: "ovnkube-node-dpu can add annotation on its host node",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: "system:ovn-node-dpu:dpu-host",
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dpu-host",
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "dpu-host",
+					Annotations: map[string]string{util.OvnNodeChassisID: "chassisID"},
+				},
+			},
+		},
+		{
+			name: "ovnkube-node-dpu cannot add annotation on a host node that doesn't belong to it",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: "system:ovn-node-dpu:dpu-host",
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "another-dpu-host",
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "another-dpu-host",
+					Annotations: map[string]string{util.OvnNodeChassisID: "chassisID"},
+				},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node-dpu for node: %q is not allowed to modify annotations on node %q", "dpu-host", "another-dpu-host"),
+		},
+		{
+			name: "ovnkube-node-dpu cannot set annotations not in DPU allowed set",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: "system:ovn-node-dpu:" + nodeName,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OVNNodeHostCIDRs: "192.168.1.0/24"},
+				},
+			},
+			expectedErr: fmt.Errorf("ovnkube-node-dpu for node: %q is not allowed to set the following annotations: %v", nodeName, []string{util.OVNNodeHostCIDRs}),
 		},
 		{
 			name: "ovnkube-node cannot remove util.OvnNodeChassisID",

--- a/go-controller/pkg/ovnwebhook/podadmission.go
+++ b/go-controller/pkg/ovnwebhook/podadmission.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"golang.org/x/exp/maps"
 
@@ -14,6 +15,7 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -22,7 +24,7 @@ import (
 // checkPodAnnot defines additional checks for the allowed annotations
 type checkPodAnnot func(nodeLister listers.NodeLister, v annotationChange, pod *corev1.Pod, nodeName string) error
 
-// interconnectPodAnnotationChecks holds annotations allowed for ovnkube-node:<nodeName> users in IC environments
+// interconnectPodAnnotations holds annotations allowed for ovnkube-node:<nodeName> and ovnkube-node-dpu:<nodeName> users in IC environments.
 var interconnectPodAnnotations = map[string]checkPodAnnot{
 	util.OvnPodAnnotationName: func(nodeLister listers.NodeLister, v annotationChange, pod *corev1.Pod, nodeName string) error {
 		// Ignore kubevirt pods with live migration, the IP can cross node-subnet boundaries
@@ -128,6 +130,7 @@ func (p PodAdmission) ValidateUpdate(ctx context.Context, oldPod, newPod *corev1
 		return nil, err
 	}
 	isOVNKubeNode, podAdmission, nodeName := checkNodeIdentity(p.podAdmissions, req.UserInfo)
+	isDPU := isOVNKubeNode && strings.HasPrefix(req.UserInfo.Username, csrapprover.NamePrefixDPU+":")
 
 	changes := mapDiff(oldPod.Annotations, newPod.Annotations)
 	changedKeys := maps.Keys(changes)
@@ -174,18 +177,24 @@ func (p PodAdmission) ValidateUpdate(ctx context.Context, oldPod, newPod *corev1
 	if podAdmission != nil {
 		prefixName = podAdmission.CommonNamePrefix
 	}
+	identityDescription := prefixName + " on node"
+	if isDPU {
+		identityDescription = "ovnkube-node-dpu for node"
+	} else if strings.HasPrefix(req.UserInfo.Username, csrapprover.NamePrefix+":") {
+		identityDescription = "ovnkube-node on node"
+	}
 
 	if oldPod.Spec.NodeName != nodeName {
-		return nil, fmt.Errorf("%s on node: %q is not allowed to modify pods %q annotations", prefixName, nodeName, oldPod.Name)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify annotations on pod %q", identityDescription, nodeName, oldPod.Name)
 	}
 	if newPod.Spec.NodeName != nodeName {
-		return nil, fmt.Errorf("%s on node: %q is not allowed to modify pods %q annotations", prefixName, nodeName, newPod.Name)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify annotations on pod %q", identityDescription, nodeName, newPod.Name)
 	}
 
-	// ovnkube-node is not allowed to change annotations outside of it's scope
+	// ovnkube-node / ovnkube-node-dpu is not allowed to change annotations outside of its scope
 	if isOVNKubeNode && !p.annotationKeys.HasAll(changedKeys...) {
-		return nil, fmt.Errorf("%s on node: %q is not allowed to set the following annotations on pod: %q: %v",
-			prefixName, nodeName, newPod.Name,
+		return nil, fmt.Errorf("%s: %q is not allowed to set the following annotations on pod: %q: %v",
+			identityDescription, nodeName, newPod.Name,
 			sets.New[string](changedKeys...).Difference(p.annotationKeys).UnsortedList())
 	}
 
@@ -200,7 +209,7 @@ func (p PodAdmission) ValidateUpdate(ctx context.Context, oldPod, newPod *corev1
 	newPodShallowCopy.ManagedFields = nil
 	if !apiequality.Semantic.DeepEqual(oldPodShallowCopy.ObjectMeta, newPodShallowCopy.ObjectMeta) ||
 		!apiequality.Semantic.DeepEqual(oldPodShallowCopy.Status, newPodShallowCopy.Status) {
-		return nil, fmt.Errorf("%s on node: %q is not allowed to modify anything other than annotations", prefixName, nodeName)
+		return nil, fmt.Errorf("%s: %q is not allowed to modify anything other than annotations", identityDescription, nodeName)
 	}
 
 	return nil, nil

--- a/go-controller/pkg/ovnwebhook/podadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/podadmission_test.go
@@ -17,6 +17,7 @@ import (
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -135,7 +136,7 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},
-			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify pods %q annotations", nodeName+"_rougeOne", podName),
+			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify annotations on pod %q", nodeName+"_rougeOne", podName),
 		},
 		{
 			name: "ovnkube-node cannot modify pod annotations that do not belong to it",
@@ -327,6 +328,33 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        podName,
 					Annotations: map[string]string{util.DPUConnectionStatusAnnot: "new"},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+		},
+		{
+			name: "ovnkube-node-dpu can set DPUConnectionStatusAnnot on pod",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{"k8s.ovn.org/node-subnets": `{"default":"192.168.0.0/24"}`},
+				},
+			},
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: csrapprover.NamePrefixDPU + ":" + nodeName,
+				}},
+			}),
+			oldObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+			newObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{util.DPUConnectionStatusAnnot: `{"default":{"Status":"Ready","Reason":""}}`},
 				},
 				Spec: corev1.PodSpec{NodeName: nodeName},
 			},

--- a/go-controller/pkg/ovnwebhook/user.go
+++ b/go-controller/pkg/ovnwebhook/user.go
@@ -10,9 +10,8 @@ import (
 
 // checkNodeIdentity retrieves user name from UserInfo, based on given podAdmissions.
 func checkNodeIdentity(podAdmissions []PodAdmissionConditionOption, user authenticationv1.UserInfo) (bool, *PodAdmissionConditionOption, string) {
-	// check ovn prefix
-	if strings.HasPrefix(user.Username, csrapprover.NamePrefix) {
-		return true, nil, strings.TrimPrefix(user.Username, csrapprover.NamePrefix+":")
+	if nodeName, ok := ovnkubeNodeIdentity(user); ok {
+		return true, nil, nodeName
 	}
 
 	// check prefix in podAdmissions
@@ -25,12 +24,16 @@ func checkNodeIdentity(podAdmissions []PodAdmissionConditionOption, user authent
 	return false, nil, ""
 }
 
+// ovnkubeNodeIdentity returns the node name and true if the user is an ovnkube-node identity
+// (system:ovn-node:<nodeName> or system:ovn-node-dpu:<nodeName>) that is allowed to modify that node's annotations.
 func ovnkubeNodeIdentity(user authenticationv1.UserInfo) (string, bool) {
-	if !strings.HasPrefix(user.Username, csrapprover.NamePrefix) {
+	if strings.HasPrefix(user.Username, csrapprover.NamePrefixDPU+":") {
+		nodeName := strings.TrimPrefix(user.Username, csrapprover.NamePrefixDPU+":")
+		return nodeName, true
+	}
+	if !strings.HasPrefix(user.Username, csrapprover.NamePrefix+":") {
 		return "", false
 	}
-
-	// Trim prefix and the last colon
 	nodeName := strings.TrimPrefix(user.Username, csrapprover.NamePrefix+":")
 	return nodeName, true
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -152,10 +152,15 @@ type OVNClusterManagerClientset struct {
 }
 
 const (
-	certNamePrefix       = "ovnkube-client"
-	certCommonNamePrefix = "system:ovn-node"
-	certOrganization     = "system:ovn-nodes"
+	certNamePrefix          = "ovnkube-client"
+	certCommonNamePrefix    = "system:ovn-node"
+	certOrganization        = "system:ovn-nodes"
+	certCommonNamePrefixDPU = "system:ovn-node-dpu"
+	certOrganizationDPU     = "system:ovn-node-dpus"
 )
+
+// DefaultDPUHostCertDir is the default directory for storing the DPU's client certificate
+const DefaultDPUHostCertDir = "/var/run/ovn-kubernetes/dpu-host-cert"
 
 var (
 	certUsages = []certificatesv1.KeyUsage{certificatesv1.UsageDigitalSignature, certificatesv1.UsageClientAuth}
@@ -340,12 +345,18 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 }
 
 // StartNodeCertificateManager manages the creation and rotation of the node-specific client certificate.
-// When there is no existing certificate, it will use the BootstrapKubeconfig kubeconfig to create a CSR and it will
-// wait for the certificate before returning.
-func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeName string, conf *config.KubernetesConfig) error {
+// When there is no existing certificate, it will use the BootstrapKubeconfig kubeconfig (or, for DPU
+// nodes, token+CA when BootstrapKubeconfig is empty) to create a CSR and wait for the certificate before returning.
+// useDPUIdentity should be true for DPUs to use system:ovn-node-dpu:<dpu host node> identity.
+func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeName string, useDPUIdentity bool, conf *config.KubernetesConfig) error {
 	if nodeName == "" {
 		return fmt.Errorf("the provided node name cannot be empty")
 	}
+
+	if useDPUIdentity && conf.CertDir == "" {
+		conf.CertDir = DefaultDPUHostCertDir
+	}
+
 	defaultKConfig, err := newKubernetesRestConfig(conf)
 	if err != nil {
 		return fmt.Errorf("unable to create kubernetes rest config, err: %v", err)
@@ -353,10 +364,34 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 	defaultKConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	defaultKConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
-	bootstrapKConfig, err := clientcmd.BuildConfigFromFlags("", conf.BootstrapKubeconfig)
-	if err != nil {
-		return fmt.Errorf("failed to load bootstrap kubeconfig from %s, err: %v", conf.BootstrapKubeconfig, err)
+	var bootstrapKConfig *rest.Config
+	if conf.BootstrapKubeconfig != "" {
+		bootstrapKConfig, err = clientcmd.BuildConfigFromFlags("", conf.BootstrapKubeconfig)
+		if err != nil {
+			return fmt.Errorf("failed to load bootstrap kubeconfig from %s, err: %v", conf.BootstrapKubeconfig, err)
+		}
+	} else if (conf.Token != "" || conf.TokenFile != "") && len(conf.CAData) > 0 && strings.HasPrefix(conf.APIServer, "https") {
+		bootstrapKConfig = &rest.Config{
+			Host:            conf.APIServer,
+			BearerToken:     conf.Token,
+			BearerTokenFile: conf.TokenFile,
+			TLSClientConfig: rest.TLSClientConfig{CAData: conf.CAData},
+		}
+	} else {
+		return fmt.Errorf("bootstrap kubeconfig or token and CACert with https apiserver is required for certificate manager")
 	}
+
+	// Use distinct identity for DPU to differentiate it from ovnkube-node identity on its associated dpu host, since node name
+	// on both will reference the same DPU host nodename
+	var commonNamePrefix, organization string
+	if useDPUIdentity {
+		commonNamePrefix = certCommonNamePrefixDPU
+		organization = certOrganizationDPU
+	} else {
+		commonNamePrefix = certCommonNamePrefix
+		organization = certOrganization
+	}
+
 	// If we have a valid certificate, use that to fetch CSRs.
 	// Otherwise, use the bootstrap credentials.
 	// https://github.com/kubernetes/kubernetes/blob/068ee321bc7bfe1c2cefb87fb4d9e5deea84fbc8/cmd/kubelet/app/server.go#L953-L963
@@ -373,10 +408,10 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 		return fmt.Errorf("failed to initialize the certificate store: %v", err)
 	}
 
-	// The CSR approver only accepts CSRs created by system:ovn-node:nodeName and system:node:nodeName.
-	// If the node name in the existing ovn-node certificate is different from the current node name,
-	// remove the certificate so the CSR will be created using the bootstrap kubeconfig using system:node:nodeName user.
-	certCommonName := fmt.Sprintf("%s:%s", certCommonNamePrefix, nodeName)
+	// The CSR approver only accepts CSRs created by system:ovn-node:nodeName and system:node:nodeName or for DPU system:ovn-node-dpu:nodeName.
+	// If the node name in the existing certificate is different from the current node name,
+	// remove the certificate so a new CSR will be created.
+	certCommonName := fmt.Sprintf("%s:%s", commonNamePrefix, nodeName)
 	currentCertFromFile, err := certificateStore.Current()
 	if err == nil && currentCertFromFile.Leaf != nil {
 		if currentCertFromFile.Leaf.Subject.CommonName != certCommonName {
@@ -409,7 +444,7 @@ func StartNodeCertificateManager(ctx context.Context, wg *sync.WaitGroup, nodeNa
 		Template: &x509.CertificateRequest{
 			Subject: pkix.Name{
 				CommonName:   certCommonName,
-				Organization: []string{certOrganization},
+				Organization: []string{organization},
 			},
 		},
 		RequestedCertificateLifetime: &conf.CertDuration,

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -156,10 +156,6 @@ spec:
               name: ovn-config
               key: routable_mtu
               optional: true
-        - name: K8S_NODE_DPU
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:
@@ -216,6 +212,8 @@ spec:
           value: {{ default "" .Values.global.extGatewayNetworkInterface | quote }}
         - name: OVN_ENABLE_OVNKUBE_IDENTITY
           value: {{ hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true | quote }}
+        - name: GENERATE_DPU_HOST_CSR
+          value: {{ hasKey .Values.global "generateDPUHostCSR" | ternary .Values.global.generateDPUHostCSR false | quote }}
         - name: OVN_SSL_ENABLE
           value: {{ include "isSslEnabled" . | quote }}
         - name: OVN_REMOTE_PROBE_INTERVAL
@@ -307,10 +305,6 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
-        - name: K8S_NODE_DPU
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: OVN_KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -314,6 +314,8 @@ spec:
           value: {{ default "" .Values.global.dpuHostClusterK8sTokenFile | quote }}
         - name: K8S_CACERT
           value: {{ default "" .Values.global.dpuHostClusterK8sCACert | quote }}
+        - name: GENERATE_DPU_HOST_CSR
+          value: {{ hasKey .Values.global "generateDPUHostCSR" | ternary .Values.global.generateDPUHostCSR false | quote }}
         - name: OVN_MTU
           value: {{ default "" .Values.global.mtu | quote }}
         - name: OVN_GATEWAY_MODE

--- a/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/templates/rbac-ovnkube-node.yaml
@@ -4,8 +4,12 @@ metadata:
     name: ovnkube-node
     namespace: ovn-kubernetes
 
+{{- $tags := (.Values.tags | default dict) }}
 # When ovn_enable_ovnkube_identity is true, an ovnkube-node process will identify as a user in a system:ovn-nodes group,
-# not the ovnkube-node serviceAccount
+# not the ovnkube-node serviceAccount.
+# DPUs will initially present ovnkube-node serviceAccount to request CSR, but after approval identify as a user in a
+# separate system:ovn-node-dpus group and reference dpu host node name.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -20,6 +24,11 @@ subjects:
     - kind: Group
       name: system:ovn-nodes
       apiGroup: rbac.authorization.k8s.io
+    {{- if not (eq (index $tags "ovnkube-node-dpu-host") false) }}
+    - kind: Group
+      name: system:ovn-node-dpus
+      apiGroup: rbac.authorization.k8s.io
+    {{- end }}
     {{- else }}
     - kind: ServiceAccount
       name: ovnkube-node
@@ -60,6 +69,11 @@ subjects:
     - kind: Group
       name: system:ovn-nodes
       apiGroup: rbac.authorization.k8s.io
+    {{- if not (eq (index $tags "ovnkube-node-dpu-host") false) }}
+    - kind: Group
+      name: system:ovn-node-dpus
+      apiGroup: rbac.authorization.k8s.io
+    {{- end }}
     {{- else }}
     - kind: ServiceAccount
       name: ovnkube-node
@@ -84,6 +98,11 @@ subjects:
     - kind: Group
       name: system:ovn-nodes
       apiGroup: rbac.authorization.k8s.io
+    {{- if not (eq (index $tags "ovnkube-node-dpu-host") false) }}
+    - kind: Group
+      name: system:ovn-node-dpus
+      apiGroup: rbac.authorization.k8s.io
+    {{- end }}
     {{- else }}
     - kind: ServiceAccount
       name: ovnkube-node
@@ -109,6 +128,36 @@ subjects:
       name: ovnkube-node
       namespace: ovn-kubernetes
 
+# When ovnkube-identity is enabled DPU needs token/CA for ovnkube-node SA to create CSRs and hence require CSR permissions in addition
+{{- if and (eq (hasKey .Values.global "enableOvnKubeIdentity" | ternary .Values.global.enableOvnKubeIdentity true) true) (not (eq (index $tags "ovnkube-node-dpu-host") false)) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: ovnkube-node-csr-bootstrap
+rules:
+    - apiGroups: ["certificates.k8s.io"]
+      resources:
+          - certificatesigningrequests
+      verbs:
+        - create
+        - get
+        - list
+        - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: ovnkube-node-csr-bootstrap
+roleRef:
+    name: ovnkube-node-csr-bootstrap
+    kind: ClusterRole
+    apiGroup: rbac.authorization.k8s.io
+subjects:
+    - kind: ServiceAccount
+      name: ovnkube-node
+      namespace: ovn-kubernetes
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -241,8 +290,7 @@ rules:
           - create
           {{- end }}
 
-{{- $tags := (.Values.tags | default dict) }}
-{{- if (index $tags "ovnkube-node-dpu-host") }}
+{{- if not (eq (index $tags "ovnkube-node-dpu-host") false) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -173,6 +173,8 @@ global:
   dpuHostClusterK8sTokenFile: ""
   # -- DPU Host cluster's Kubernetes Access Certs File
   dpuHostClusterK8sCACert: ""
+  # -- When true, token and certificate data from fields above will be used to obtain a client cert for the DPU host cluster via CSR
+  generateDPUHostCSR: false
   # -- DPU Host cluster's Network CIDR
   dpuHostClusterNetworkCIDR: 10.244.0.0/16/24
   # -- DPU Host cluster's Service CIDR


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR adds support for using ovnkube-identity with DPU.

DPUs are in a different cluster than the DPU-host nodes and use ovnkube-identity with token + CA (for ovnkube-node SA on DPU Host cluster) to obtain a client certificate for accessing the host cluster. They are identified as system:ovn-node-dpu:<dpu-host-node> in system:ovn-node-dpus, and the CSR approver accepts both initial (SA) and renewal (DPU identity) CSRs. The ovnkube-identity feature is enabled only on the DPU-Host cluster. generate-dpu-host-csr variable needs to be enabled on the DPU cluster for the DPUs to generate and renew the CSRs for performing operations on behalf of their DPU Host nodes. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flag and Helm values to let DPU nodes request host-cluster client certificates via CSR and use DPU-specific identities.
* **Bug Fixes / Behavior**
  * Certificate manager computes identity earlier, fails fast if missing, and supports DPU vs non-DPU CSR flows.
  * Admission and pod validation now recognize DPU identities and apply DPU-specific annotation rules/messages.
* **Security / RBAC**
  * Adds conditional CSR bootstrap RBAC and DPU-specific bindings when enabled.
* **Tests**
  * Added tests for DPU annotation admission scenarios.
* **Chores**
  * Exposed GENERATE_DPU_HOST_CSR env and removed legacy K8S_NODE_DPU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->