### PR TITLE
CUDN outboundSNAT implementation for both local and shared gateway mode

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
@@ -33,6 +33,7 @@ type SpecGetter interface {
 	GetLocalnet() *userdefinednetworkv1.LocalnetConfig
 	GetTransport() userdefinednetworkv1.TransportOption
 	GetEVPN() *userdefinednetworkv1.EVPNConfig
+	GetNoOverlay() *userdefinednetworkv1.NoOverlayConfig
 }
 
 func RenderNetAttachDefManifest(obj client.Object, targetNamespace string, opts ...RenderOption) (*netv1.NetworkAttachmentDefinition, error) {
@@ -203,6 +204,14 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter, opts *
 		netConfSpec.EVPN = renderEVPNConfig(spec, opts)
 	}
 
+	if spec.GetTransport() == userdefinednetworkv1.TransportOptionNoOverlay {
+		noOverlayCfg := spec.GetNoOverlay()
+		if noOverlayCfg != nil {
+			// Convert CRD SNATOption enum ("Enabled"/"Disabled") to internal format ("enabled"/"disabled")
+			netConfSpec.OutboundSNAT = strings.ToLower(string(noOverlayCfg.OutboundSNAT))
+		}
+	}
+
 	if netConfSpec.AllowPersistentIPs && !config.OVNKubernetesFeature.EnablePersistentIPs {
 		return nil, fmt.Errorf("allowPersistentIPs is set but persistentIPs is Disabled")
 	}
@@ -268,6 +277,9 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter, opts *
 
 	if netConfSpec.Transport != "" {
 		cniNetConf["transport"] = netConfSpec.Transport
+	}
+	if netConfSpec.OutboundSNAT != "" {
+		cniNetConf["outboundSNAT"] = netConfSpec.OutboundSNAT
 	}
 	if netConfSpec.EVPN != nil {
 		cniNetConf["evpn"] = netConfSpec.EVPN

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -85,6 +85,12 @@ type NetConf struct {
 	// When omitted, the default OVN overlay transport is used.
 	Transport string `json:"transport,omitempty"`
 
+	// OutboundSNAT configures SNAT behavior for outbound traffic from pods
+	// on user-defined networks in no-overlay mode.
+	// Valid values are "enabled" and "disabled".
+	// Only valid when Transport is "no-overlay".
+	OutboundSNAT string `json:"outboundSNAT,omitempty"`
+
 	// EVPNConfig contains configuration for EVPN mode.
 	// Only valid when Transport is "evpn".
 	EVPN *EVPNConfig `json:"evpn,omitempty"`

--- a/go-controller/pkg/crd/userdefinednetwork/v1/spec.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/spec.go
@@ -27,6 +27,11 @@ func (s *UserDefinedNetworkSpec) GetEVPN() *EVPNConfig {
 	return nil
 }
 
+func (s *UserDefinedNetworkSpec) GetNoOverlay() *NoOverlayConfig {
+	// UDN (namespace-scoped) does not support no-overlay transport
+	return nil
+}
+
 func (s *NetworkSpec) GetTopology() NetworkTopology {
 	return s.Topology
 }
@@ -49,4 +54,8 @@ func (s *NetworkSpec) GetTransport() TransportOption {
 
 func (s *NetworkSpec) GetEVPN() *EVPNConfig {
 	return s.EVPN
+}
+
+func (s *NetworkSpec) GetNoOverlay() *NoOverlayConfig {
+	return s.NoOverlay
 }

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -32,18 +32,24 @@ type BridgeUDNConfiguration struct {
 	NodeSubnets   []*net.IPNet
 	Advertised    atomic.Bool
 	ManagementIPs []*net.IPNet
+	// Transport mode for this network ("no-overlay", "evpn", or "" for default network)
+	Transport string
+	// OutboundSNAT setting for this network ("enabled", "disabled", or "")
+	OutboundSNAT string
 }
 
 func (netConfig *BridgeUDNConfiguration) ShallowCopy() *BridgeUDNConfiguration {
 	copy := &BridgeUDNConfiguration{
-		PatchPort:   netConfig.PatchPort,
-		OfPortPatch: netConfig.OfPortPatch,
-		MasqCTMark:  netConfig.MasqCTMark,
-		PktMark:     netConfig.PktMark,
-		V4MasqIPs:   netConfig.V4MasqIPs,
-		V6MasqIPs:   netConfig.V6MasqIPs,
-		Subnets:     netConfig.Subnets,
-		NodeSubnets: netConfig.NodeSubnets,
+		PatchPort:    netConfig.PatchPort,
+		OfPortPatch:  netConfig.OfPortPatch,
+		MasqCTMark:   netConfig.MasqCTMark,
+		PktMark:      netConfig.PktMark,
+		V4MasqIPs:    netConfig.V4MasqIPs,
+		V6MasqIPs:    netConfig.V6MasqIPs,
+		Subnets:      netConfig.Subnets,
+		NodeSubnets:  netConfig.NodeSubnets,
+		Transport:    netConfig.Transport,
+		OutboundSNAT: netConfig.OutboundSNAT,
 	}
 	copy.Advertised.Store(netConfig.Advertised.Load())
 	return copy
@@ -315,6 +321,8 @@ func (b *BridgeConfiguration) AddNetworkConfig(nInfo util.NetInfo, nodeSubnets, 
 			ManagementIPs: mgmtIPs,
 			Subnets:       nInfo.Subnets(),
 			NodeSubnets:   nodeSubnets,
+			Transport:     nInfo.Transport(),
+			OutboundSNAT:  nInfo.OutboundSNAT(),
 		}
 		netConfig.Advertised.Store(util.IsPodNetworkAdvertisedAtNode(nInfo, b.nodeName))
 

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -602,6 +602,18 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 		if ofPortPhys != "" {
 			for _, netConfig := range b.patchedNetConfigs() {
+				// table0, for UDN no-overlay networks, handle cross-node traffic
+				// that has already been SNATed to node IP by the gateway router.
+				if !netConfig.IsDefaultNetwork() && netConfig.Transport == types.NetworkTransportNoOverlay && config.Gateway.Mode == config.GatewayModeShared {
+					// In shared gateway mode, commit to conntrack and send directly to physical port.
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=99, in_port=%s, dl_src=%s, %s, nw_src=%s, "+
+							"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV4,
+							physicalIP.IP, config.Default.ConntrackZone,
+							netConfig.MasqCTMark, ofPortPhys))
+				}
+
 				// table0, packets coming from egressIP pods that have mark 1008 on them
 				// will be SNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
 				// SNATs these into egressIP prior to reaching external bridge.
@@ -703,6 +715,18 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 		if ofPortPhys != "" {
 			for _, netConfig := range b.patchedNetConfigs() {
+				// table0, for UDN no-overlay networks, handle cross-node traffic
+				// that has already been SNATed to node IP by the gateway router.
+				if !netConfig.IsDefaultNetwork() && netConfig.Transport == types.NetworkTransportNoOverlay && config.Gateway.Mode == config.GatewayModeShared {
+					// In shared gateway mode, commit to conntrack and send directly to physical port.
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=99, in_port=%s, dl_src=%s, %s, %s_src=%s, "+
+							"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV6,
+							protoPrefixV6, physicalIP.IP, config.Default.ConntrackZone,
+							netConfig.MasqCTMark, ofPortPhys))
+				}
+
 				// table0, packets coming from egressIP pods that have mark 1008 on them
 				// will be DNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
 				// DNATs these into egressIP prior to reaching external bridge.

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -999,13 +999,40 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 			}
 		}
 
-		snat := libovsdbops.BuildSNATWithMatch(
-			&masqIP.ManagementPort.IP,
-			localPodSubnet,
-			outputPort,
-			extIDs,
-			snatMatch,
-		)
+		// For noOverlay mode with outboundSNAT enabled in local gateway mode, add exempted_ext_ips
+		// to prevent SNATing pod-to-pod traffic within the same CUDN while still SNATing pod-to-external traffic.
+		// This SNAT is on ovn_cluster_router, which is used in local gateway mode.
+		var snat *nbdb.NAT
+		if bsnc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+			bsnc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
+			config.Gateway.Mode == config.GatewayModeLocal {
+			snatMatch = ""
+			v4UUID, v6UUID, err := getNoOverlaySNATExemptionAsUUID(bsnc.addressSetFactory, bsnc.GetNetInfo(), bsnc.controllerName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
+			}
+			// Use the appropriate UUID based on IP family
+			exemptedExtIPs := v4UUID
+			if ipFamily == utilnet.IPv6 {
+				exemptedExtIPs = v6UUID
+			}
+			snat = libovsdbops.BuildSNATWithExemptedExtIPs(
+				&masqIP.ManagementPort.IP,
+				localPodSubnet,
+				outputPort,
+				extIDs,
+				snatMatch,
+				exemptedExtIPs,
+			)
+		} else {
+			snat = libovsdbops.BuildSNATWithMatch(
+				&masqIP.ManagementPort.IP,
+				localPodSubnet,
+				outputPort,
+				extIDs,
+				snatMatch,
+			)
+		}
 		snats = append(snats, snat)
 	}
 

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -887,7 +887,13 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 		if util.IsNoOverlaySNATExemptionNeeded(gw.netInfo) {
 			// Get the no-overlay SNAT exemption address set UUIDs
 			addressSetFactory := addressset.NewOvnAddressSetFactory(gw.nbClient, config.IPv4Mode, config.IPv6Mode)
-			v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(addressSetFactory, gw.netInfo, types.DefaultNetworkControllerName)
+			// Use the correct controller name: default-network-controller for default network,
+			// <networkName>-network-controller for user-defined networks
+			controllerName := types.DefaultNetworkControllerName
+			if gw.netInfo.IsUserDefinedNetwork() {
+				controllerName = getNetworkControllerName(gw.netInfo.GetNetworkName())
+			}
+			v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(addressSetFactory, gw.netInfo, controllerName)
 			if err != nil {
 				return fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
 			}

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -495,6 +495,11 @@ func (oc *Layer3UserDefinedNetworkController) Cleanup() error {
 	cleanupLoadBalancerGroups(oc.nbClient, oc.GetNetInfo(),
 		oc.switchLoadBalancerGroupUUID, oc.clusterLoadBalancerGroupUUID, oc.routerLoadBalancerGroupUUID)
 
+	// Cleanup noOverlay SNAT exemption address set
+	if err := cleanupNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName); err != nil {
+		klog.Warningf("Failed to cleanup noOverlay SNAT exemption address set for network %s: %v", netName, err)
+	}
+
 	return nil
 }
 
@@ -757,6 +762,16 @@ func (oc *Layer3UserDefinedNetworkController) init() error {
 		oc.switchLoadBalancerGroupUUID = switchLBGroupUUID
 		oc.routerLoadBalancerGroupUUID = routerLBGroupUUID
 	}
+
+	// Initialize noOverlay SNAT exemption address set when using noOverlay transport with outboundSNAT enabled
+	// This is needed for both local and shared gateway modes
+	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled {
+		if _, err := initNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName); err != nil {
+			return fmt.Errorf("failed to initialize noOverlay SNAT exemption address set for network %s: %w", oc.GetNetworkName(), err)
+		}
+	}
+
 	return nil
 }
 
@@ -825,6 +840,21 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 	if nSyncs.syncNode { // do this only if it is a new node add
 		errors := oc.addAllPodsOnNode(node.Name)
 		errs = append(errs, errors...)
+	}
+
+	// Sync noOverlay SNAT exemption address set BEFORE gateway initialization
+	// This must happen before the gateway creates SNAT rules that reference the address set
+	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
+		(nSyncs.syncNode || nSyncs.syncGw) {
+		hostAddrs, err := util.GetNodeHostAddrs(node)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to get host addresses for node %s: %w", node.Name, err))
+		} else {
+			if err := syncNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName, hostAddrs); err != nil {
+				errs = append(errs, fmt.Errorf("failed to sync noOverlay SNAT exemption address set: %w", err))
+			}
+		}
 	}
 
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1402,6 +1402,160 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 		Expect(app.Run([]string{app.Name})).To(Succeed())
 	})
 
+	// Test 2: Verify SNAT with exempted_ext_ips is created on GR_<node> in SHARED gateway mode
+	It("creates SNAT with exempted address set in shared gateway mode on gateway router", func() {
+		// Step 1: Set config.Gateway.Mode = config.GatewayModeShared
+		config.Gateway.Mode = config.GatewayModeShared
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+		config.Default.Zone = testICZone
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16" // Broader subnet to accommodate network ID 2
+
+		app := cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		// Step 2: Create a Layer3 CUDN with no-overlay transport and outboundSNAT enabled
+		cudnNetInfo := userDefinedNetInfo{
+			netName:        userDefinedNetworkName,
+			nadName:        namespacedName(ns, nadName),
+			topology:       types.Layer3Topology,
+			clustersubnets: "10.100.0.0/16",
+			hostsubnets:    "10.100.1.0/24",
+			isPrimary:      true,
+			transport:      types.NetworkTransportNoOverlay,
+			outboundSNAT:   string(types.NoOverlaySNATEnabled),
+		}
+
+		app.Action = func(*cli.Context) error {
+			// Create NAD with no-overlay transport and outboundSNAT enabled
+			netConf := cudnNetInfo.netconf()
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			n := newUDNNamespace(ns)
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, cudnNetInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			podInfo := dummyTestPod(ns, cudnNetInfo)
+
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{Name: nodeName},
+					},
+				},
+				&corev1.NamespaceList{Items: []corev1.Namespace{*n}},
+				&corev1.NodeList{Items: []corev1.Node{}}, // Empty - will add node after watch starts
+				&corev1.PodList{Items: []corev1.Pod{*newMultiHomedPod(podInfo, cudnNetInfo)}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+			podInfo.populateLogicalSwitchCache(fakeOvn)
+
+			Expect(fakeOvn.networkManager.Start()).NotTo(HaveOccurred())
+			defer fakeOvn.networkManager.Stop()
+
+			// Step 3: Initialize the CUDN controller
+			fullL3UDNController := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(fullL3UDNController).ToNot(BeNil())
+			Expect(fullL3UDNController.init()).To(Succeed())
+
+			userDefinedNetController, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+
+			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
+
+			// Step 4: Create and advertise a pod on the CUDN to trigger gateway SNAT creation
+			By("Starting node watch on L3 UDN controller for shared gateway mode")
+			Expect(fakeOvn.registerUDNNodeHandler(userDefinedNetworkName)).To(Succeed())
+			Expect(userDefinedNetController.bnc.WatchPods()).To(Succeed())
+
+			By("Adding node to trigger gateway creation with SNAT+exemption")
+			// Add the node AFTER starting the watch so the watch catches the ADD event
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			By("Node created, gateway should be initialized")
+
+			// Wait for pod and gateway processing to complete
+			Eventually(func() error {
+				// Step 5: Query the OVN NB database to find NAT entries on GR_<nodeName>
+				gwRouterName := userDefinedNetController.bnc.GetNetInfo().GetNetworkScopedGWRouterName(nodeName)
+				lr := &nbdb.LogicalRouter{Name: gwRouterName}
+				lr, err = libovsdbops.GetLogicalRouter(fakeOvn.nbClient, lr)
+				if err != nil {
+					return fmt.Errorf("failed to get gateway router %s: %v", gwRouterName, err)
+				}
+
+				if len(lr.Nat) == 0 {
+					return fmt.Errorf("no NAT entries found on gateway router %s", gwRouterName)
+				}
+
+				// Step 6: Verify NAT entries have exempted_ext_ips set
+				foundSNATWithExemption := false
+				for _, natUUID := range lr.Nat {
+					nat := &nbdb.NAT{UUID: natUUID}
+					nat, err = libovsdbops.GetNAT(fakeOvn.nbClient, nat)
+					if err != nil {
+						continue
+					}
+
+					if nat.Type == nbdb.NATTypeSNAT && nat.ExemptedExtIPs != nil && *nat.ExemptedExtIPs != "" {
+						foundSNATWithExemption = true
+
+						// Get the address set to verify UUID and contents
+						dbIDs := libovsdbops.NewDbObjectIDs(
+							libovsdbops.AddressSetNoOverlaySNATExemption,
+							userDefinedNetController.bnc.controllerName,
+							map[libovsdbops.ExternalIDKey]string{
+								libovsdbops.ObjectNameKey: "no-overlay-snat-exemption",
+								libovsdbops.NetworkKey:    userDefinedNetController.bnc.GetNetworkName(),
+							},
+						)
+						as, err := fakeOvn.controller.addressSetFactory.GetAddressSet(dbIDs)
+						if err != nil {
+							return fmt.Errorf("failed to get address set: %v", err)
+						}
+
+						// Verify the NAT's ExemptedExtIPs field contains the actual address set UUID
+						v4UUID, v6UUID := as.GetASUUID()
+						expectedUUID := v4UUID // For IPv4 mode
+						if config.IPv6Mode && !config.IPv4Mode {
+							expectedUUID = v6UUID
+						}
+						if *nat.ExemptedExtIPs != expectedUUID {
+							return fmt.Errorf("NAT ExemptedExtIPs (%s) does not match address set UUID (%s)",
+								*nat.ExemptedExtIPs, expectedUUID)
+						}
+
+						// Verify the address set contains both cluster subnet and node host IP
+						ipv4Addrs, ipv6Addrs := as.GetAddresses()
+						allAddrs := append(ipv4Addrs, ipv6Addrs...)
+						expectedAddrs := []string{"10.100.0.0/16", "192.168.126.202"}
+						for _, expectedAddr := range expectedAddrs {
+							if !slices.Contains(allAddrs, expectedAddr) {
+								return fmt.Errorf("address set does not contain %s, has: %v", expectedAddr, allAddrs)
+							}
+						}
+						break
+					}
+				}
+
+				if !foundSNATWithExemption {
+					return fmt.Errorf("no SNAT with ExemptedExtIPs found on gateway router %s", gwRouterName)
+				}
+
+				return nil
+			}).WithTimeout(10 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+
+			return nil
+		}
+
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
 })
 
 func newPodWithPrimaryUDN(

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +47,8 @@ type userDefinedNetInfo struct {
 	allowPersistentIPs bool
 	ipamClaimReference string
 	hasEVPN            bool
+	transport          string // e.g., types.NetworkTransportNoOverlay
+	outboundSNAT       string // e.g., types.NoOverlaySNATEnabled
 }
 
 const (
@@ -1224,6 +1227,183 @@ var _ = Describe("Layer3 UDN Transport Mode - Interconnect", func() {
 	})
 })
 
+var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
+	var (
+		fakeOvn *FakeOVN
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		fakeOvn = NewFakeOVN(false)
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	// Test 1: Verify SNAT with exempted_ext_ips is created on ovn_cluster_router in LOCAL gateway mode
+	It("creates SNAT with exempted address set in local gateway mode on ovn-cluster-router", func() {
+		// Step 1: Set config.Gateway.Mode = config.GatewayModeLocal
+		By("Step 1: Setting up LOCAL gateway mode configuration")
+		config.Gateway.Mode = config.GatewayModeLocal
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+		config.Default.Zone = testICZone
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16" // Broader subnet to accommodate network ID 2
+
+		app := cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		// Step 2: Create a Layer3 CUDN with no-overlay transport and outboundSNAT enabled
+		By("Step 2: Creating Layer3 CUDN with no-overlay transport and outboundSNAT enabled")
+		cudnNetInfo := userDefinedNetInfo{
+			netName:        userDefinedNetworkName,
+			nadName:        namespacedName(ns, nadName),
+			topology:       types.Layer3Topology,
+			clustersubnets: "10.100.0.0/16",
+			hostsubnets:    "10.100.1.0/24",
+			isPrimary:      true,
+			transport:      types.NetworkTransportNoOverlay,
+			outboundSNAT:   string(types.NoOverlaySNATEnabled),
+		}
+
+		app.Action = func(*cli.Context) error {
+			// Create NAD with no-overlay transport and outboundSNAT enabled
+			netConf := cudnNetInfo.netconf()
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			n := newUDNNamespace(ns)
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, cudnNetInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			podInfo := dummyTestPod(ns, cudnNetInfo)
+
+			By("Starting fakeOvn with database setup (without node initially)")
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{Name: nodeName},
+					},
+				},
+				&corev1.NamespaceList{Items: []corev1.Namespace{*n}},
+				&corev1.NodeList{Items: []corev1.Node{}}, // Empty - will add node after watch starts
+				&corev1.PodList{Items: []corev1.Pod{*newMultiHomedPod(podInfo, cudnNetInfo)}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+			podInfo.populateLogicalSwitchCache(fakeOvn)
+
+			By("Starting network manager")
+			Expect(fakeOvn.networkManager.Start()).NotTo(HaveOccurred())
+			defer fakeOvn.networkManager.Stop()
+
+			// Step 3: Initialize the CUDN controller
+			By("Step 3: Initializing CUDN controller")
+			fullL3UDNController := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(fullL3UDNController).ToNot(BeNil())
+			Expect(fullL3UDNController.init()).To(Succeed())
+
+			userDefinedNetController, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+
+			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
+
+			// Step 4: Start watching nodes to trigger addUpdateLocalNodeEvent()
+			By("Starting node watch on L3 UDN controller")
+			Expect(fakeOvn.registerUDNNodeHandler(userDefinedNetworkName)).To(Succeed())
+
+			By("Adding node to trigger addUpdateLocalNodeEvent()")
+			// Add the node AFTER starting the watch so the watch catches the ADD event
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			By("Node created successfully")
+
+			// Wait for node processing to complete
+			By("Waiting for NAT entries to be created on ovn_cluster_router")
+			Eventually(func() error {
+				// Step 5: Query the OVN NB database to find NAT entries on the CUDN's ovn_cluster_router
+				clusterRouterName := userDefinedNetController.bnc.GetNetworkScopedClusterRouterName()
+
+				lr := &nbdb.LogicalRouter{Name: clusterRouterName}
+				lr, err = libovsdbops.GetLogicalRouter(fakeOvn.nbClient, lr)
+				if err != nil {
+					return fmt.Errorf("failed to get logical router %s: %v", clusterRouterName, err)
+				}
+
+				if len(lr.Nat) == 0 {
+					return fmt.Errorf("no NAT entries found on router %s", clusterRouterName)
+				}
+
+				// Step 6: Verify NAT entries have exempted_ext_ips set
+				foundSNATWithExemption := false
+				for _, natUUID := range lr.Nat {
+					nat := &nbdb.NAT{UUID: natUUID}
+					nat, err = libovsdbops.GetNAT(fakeOvn.nbClient, nat)
+					if err != nil {
+						continue
+					}
+
+					if nat.Type == nbdb.NATTypeSNAT && nat.ExemptedExtIPs != nil && *nat.ExemptedExtIPs != "" {
+						foundSNATWithExemption = true
+
+						// Get the address set to verify UUID and contents
+						dbIDs := libovsdbops.NewDbObjectIDs(
+							libovsdbops.AddressSetNoOverlaySNATExemption,
+							userDefinedNetController.bnc.controllerName,
+							map[libovsdbops.ExternalIDKey]string{
+								libovsdbops.ObjectNameKey: "no-overlay-snat-exemption",
+								libovsdbops.NetworkKey:    userDefinedNetworkName,
+							},
+						)
+						as, err := fakeOvn.controller.addressSetFactory.GetAddressSet(dbIDs)
+						if err != nil {
+							return fmt.Errorf("failed to get address set: %v", err)
+						}
+
+						// Verify the NAT's ExemptedExtIPs field contains the actual address set UUID
+						v4UUID, v6UUID := as.GetASUUID()
+						expectedUUID := v4UUID // For IPv4 mode
+						if config.IPv6Mode && !config.IPv4Mode {
+							expectedUUID = v6UUID
+						}
+						if *nat.ExemptedExtIPs != expectedUUID {
+							return fmt.Errorf("NAT ExemptedExtIPs (%s) does not match address set UUID (%s)",
+								*nat.ExemptedExtIPs, expectedUUID)
+						}
+
+						// Verify the address set contains both cluster subnet and node host IP
+						ipv4Addrs, ipv6Addrs := as.GetAddresses()
+						allAddrs := append(ipv4Addrs, ipv6Addrs...)
+						expectedAddrs := []string{"10.100.0.0/16", "192.168.126.202"}
+						for _, expectedAddr := range expectedAddrs {
+							if !slices.Contains(allAddrs, expectedAddr) {
+								return fmt.Errorf("address set does not contain %s, has: %v", expectedAddr, allAddrs)
+							}
+						}
+						break
+					}
+				}
+
+				if !foundSNATWithExemption {
+					return fmt.Errorf("no SNAT with ExemptedExtIPs found on router %s", clusterRouterName)
+				}
+
+				return nil
+			}).WithTimeout(5 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+
+			return nil
+		}
+
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
+
+})
+
 func newPodWithPrimaryUDN(
 	nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC, namespace string,
 	primaryUDNConfig userDefinedNetInfo,
@@ -1324,6 +1504,12 @@ func (sni *userDefinedNetInfo) netconf() *ovncnitypes.NetConf {
 
 	if sni.hasEVPN {
 		netconf.Transport = types.NetworkTransportEVPN
+	}
+	if sni.transport != "" {
+		netconf.Transport = sni.transport
+	}
+	if sni.outboundSNAT != "" {
+		netconf.OutboundSNAT = sni.outboundSNAT
 	}
 
 	return netconf

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -739,8 +739,9 @@ type userDefinedNetInfo struct {
 	defaultGatewayIPs   []net.IP
 	managementIPs       []net.IP
 
-	transport string
-	evpn      *ovncnitypes.EVPNConfig
+	transport    string
+	evpn         *ovncnitypes.EVPNConfig
+	outboundSNAT string
 }
 
 func (nInfo *userDefinedNetInfo) GetNetInfo() NetInfo {
@@ -878,8 +879,7 @@ func (nInfo *userDefinedNetInfo) Transport() string {
 
 // OutboundSNAT() string returns the outbound SNAT configuration for this network when using no-overlay transport.
 func (nInfo *userDefinedNetInfo) OutboundSNAT() string {
-	// TODO: implement per-network no-overlay outbound SNAT configuration
-	return ""
+	return nInfo.outboundSNAT
 }
 
 // EVPNVTEPName returns the name of the VTEP CR for EVPN
@@ -1069,6 +1069,9 @@ func (nInfo *userDefinedNetInfo) canReconcile(other NetInfo) bool {
 	if nInfo.EVPNIPVRFRouteTarget() != other.EVPNIPVRFRouteTarget() {
 		return false
 	}
+	if nInfo.OutboundSNAT() != other.OutboundSNAT() {
+		return false
+	}
 
 	lessCIDRNetworkEntry := func(a, b config.CIDRNetworkEntry) bool { return a.String() < b.String() }
 	if !cmp.Equal(nInfo.subnets, other.Subnets(), cmpopts.SortSlices(lessCIDRNetworkEntry)) {
@@ -1113,6 +1116,7 @@ func (nInfo *userDefinedNetInfo) copy() *userDefinedNetInfo {
 		managementIPs:         nInfo.managementIPs,
 		transport:             nInfo.transport,
 		evpn:                  nInfo.evpn,
+		outboundSNAT:          nInfo.outboundSNAT,
 	}
 	// copy mutables
 	c.mutableNetInfo.copyFrom(&nInfo.mutableNetInfo)
@@ -1138,6 +1142,7 @@ func newLayer3NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		mtu:            netconf.MTU,
 		transport:      netconf.Transport,
 		evpn:           netconf.EVPN,
+		outboundSNAT:   netconf.OutboundSNAT,
 		mutableNetInfo: mutableNetInfo{
 			id:   types.InvalidID,
 			nads: sets.Set[string]{},

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -743,6 +743,25 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				return condition.Reason
 			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
 
+			// Check CUDN TransportAccepted condition is True after RA is created
+			if cudnTemplate.Spec.Network.Transport != "" && cudnTemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
+				ginkgo.By("ensure CUDN TransportAccepted condition is True")
+				gomega.Eventually(func(g gomega.Gomega) {
+					cudnObj, err := f.DynamicClient.Resource(clusterUDNGVR).Get(context.Background(), cUDN.Name, metav1.GetOptions{}, "status")
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					conditions, err := getConditions(cudnObj)
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					for _, condition := range conditions {
+						if condition.Type == "TransportAccepted" {
+							g.Expect(string(condition.Status)).To(gomega.Equal("True"))
+							g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
+							return
+						}
+					}
+					g.Expect(false).To(gomega.BeTrue(), "TransportAccepted condition not found in CUDN %s", cUDN.Name)
+				}, 30*time.Second, time.Second).Should(gomega.Succeed())
+			}
+
 			gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
 
 			// -----------------               ------------------                         ---------------------
@@ -805,7 +824,14 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				}
 			}
 
-			ginkgo.By("queries to the external server are not SNATed (uses podIP)")
+			expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
+				cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+
+			if expectSNAT {
+				ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
+			} else {
+				ginkgo.By("queries to the external server are not SNATed (uses podIP)")
+			}
 			for _, serverContainerIP := range serverContainerIPs {
 				podIP, err := getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 0)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -825,23 +851,35 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 					framework.Poll,
 					60*time.Second)
 				framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-				if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
-					if isIPv4Supported(f.ClientSet) && isIPv6Supported(f.ClientSet) {
-						// for dualstack we need to fetch the IP at index1
-						// if singlestack IPV6 the original podIP at index0 is the correct one
-						// FIXME: This util call assumes the first index will always be the IPv4 address
-						// and second index will always be the IPv6 address
-						// which is not always the case.
-						podIP, err = getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 1)
+
+				if expectSNAT {
+					// When OutboundSNAT is enabled, traffic to external destinations
+					// is masqueraded to the node IP. Verify the source is NOT the pod IP.
+					sourceIP := strings.Split(stdout, ":")[0]
+					if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
+						sourceIP = strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
 					}
-					// For IPv6 addresses, need to handle the brackets in the output
-					outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
-					gomega.Expect(outputIP).To(gomega.Equal(podIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					gomega.Expect(sourceIP).NotTo(gomega.Equal(podIP),
+						fmt.Sprintf("Expected SNAT for pod %s but traffic was not SNATed, output: %v", echoClientPodName, stdout))
 				} else {
-					// Original IPv4 handling
-					gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(podIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
+						if isIPv4Supported(f.ClientSet) && isIPv6Supported(f.ClientSet) {
+							// for dualstack we need to fetch the IP at index1
+							// if singlestack IPV6 the original podIP at index0 is the correct one
+							// FIXME: This util call assumes the first index will always be the IPv4 address
+							// and second index will always be the IPv6 address
+							// which is not always the case.
+							podIP, err = getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 1)
+						}
+						// For IPv6 addresses, need to handle the brackets in the output
+						outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
+						gomega.Expect(outputIP).To(gomega.Equal(podIP),
+							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					} else {
+						// Original IPv4 handling
+						gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(podIP),
+							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					}
 				}
 			}
 		},
@@ -878,6 +916,106 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
 								NetworkSelector: metav1.LabelSelector{
 									MatchLabels: map[string]string{"bgp-udn-layer3-network": ""},
+								},
+							},
+						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
+					},
+				},
+			},
+		),
+		ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
+			&udnv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-",
+					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+				},
+				Spec: udnv1.ClusterUserDefinedNetworkSpec{
+					Network: udnv1.NetworkSpec{
+						Topology: udnv1.NetworkTopologyLayer3,
+						Layer3: &udnv1.Layer3Config{
+							Role: "Primary",
+							Subnets: []udnv1.Layer3Subnet{{
+								CIDR:       "103.103.0.0/16",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "2014:100:200::0/60",
+								HostSubnet: 64,
+							}},
+						},
+						Transport: udnv1.TransportOptionNoOverlay,
+						NoOverlay: &udnv1.NoOverlayConfig{
+							OutboundSNAT: udnv1.SNATEnabled,
+							Routing:      udnv1.RoutingUnmanaged,
+						},
+					},
+				},
+			},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+								},
+							},
+						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
+					},
+				},
+			},
+		),
+		ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+			&udnv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-",
+					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+				},
+				Spec: udnv1.ClusterUserDefinedNetworkSpec{
+					Network: udnv1.NetworkSpec{
+						Topology: udnv1.NetworkTopologyLayer3,
+						Layer3: &udnv1.Layer3Config{
+							Role: "Primary",
+							Subnets: []udnv1.Layer3Subnet{{
+								CIDR:       "103.103.0.0/16",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "2014:100:200::0/60",
+								HostSubnet: 64,
+							}},
+						},
+						Transport: udnv1.TransportOptionNoOverlay,
+						NoOverlay: &udnv1.NoOverlayConfig{
+							OutboundSNAT: udnv1.SNATDisabled,
+							Routing:      udnv1.RoutingUnmanaged,
+						},
+					},
+				},
+			},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
 								},
 							},
 						},
@@ -1166,6 +1304,27 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					}
 					return condition.Reason
 				}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
+
+				// Check CUDN TransportAccepted condition is True after RA is created
+				if cudnATemplate.Spec.Network.Transport != "" && cudnATemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
+					ginkgo.By("ensure CUDN TransportAccepted condition is True")
+					for _, cudnName := range []string{cudnA.Name, cudnB.Name} {
+						gomega.Eventually(func(g gomega.Gomega) {
+							cudnObj, err := f.DynamicClient.Resource(clusterUDNGVR).Get(context.Background(), cudnName, metav1.GetOptions{}, "status")
+							g.Expect(err).NotTo(gomega.HaveOccurred())
+							conditions, err := getConditions(cudnObj)
+							g.Expect(err).NotTo(gomega.HaveOccurred())
+							for _, condition := range conditions {
+								if condition.Type == "TransportAccepted" {
+									g.Expect(string(condition.Status)).To(gomega.Equal("True"))
+									g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
+									return
+								}
+							}
+							g.Expect(false).To(gomega.BeTrue(), "TransportAccepted condition not found in CUDN %s", cudnName)
+						}, 30*time.Second, time.Second).Should(gomega.Succeed())
+					}
+				}
 
 				ginkgo.By("ensure routes from UDNs are learned by the external FRR router")
 				serverContainerIPs := getBGPServerContainerIPs(f)
@@ -1849,6 +2008,59 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 			},
 		},
 	),
+	ginkgo.Entry("Layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+		&udnv1.ClusterUserDefinedNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "bgp-l3-noovl-unmgd-net-a",
+				Labels: map[string]string{"bgp-l3-noovl-unmgd-net-a": ""},
+			},
+			Spec: udnv1.ClusterUserDefinedNetworkSpec{
+				Network: udnv1.NetworkSpec{
+					Topology: udnv1.NetworkTopologyLayer3,
+					Layer3: &udnv1.Layer3Config{
+						Role: "Primary",
+						Subnets: []udnv1.Layer3Subnet{{
+							CIDR:       "102.102.0.0/16",
+							HostSubnet: 24,
+						}, {
+							CIDR:       "2013:100:200::0/60",
+							HostSubnet: 64,
+						}},
+					},
+					Transport: udnv1.TransportOptionNoOverlay,
+					NoOverlay: &udnv1.NoOverlayConfig{
+						OutboundSNAT: udnv1.SNATDisabled,
+						Routing:      udnv1.RoutingUnmanaged,
+					},
+				},
+			},
+		}, &udnv1.ClusterUserDefinedNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "bgp-l3-noovl-unmgd-net-b",
+				Labels: map[string]string{"bgp-l3-noovl-unmgd-net-b": ""},
+			},
+			Spec: udnv1.ClusterUserDefinedNetworkSpec{
+				Network: udnv1.NetworkSpec{
+					Topology: udnv1.NetworkTopologyLayer3,
+					Layer3: &udnv1.Layer3Config{
+						Role: "Primary",
+						Subnets: []udnv1.Layer3Subnet{{
+							CIDR:       "103.103.0.0/16",
+							HostSubnet: 24,
+						}, {
+							CIDR:       "2014:100:200::0/60",
+							HostSubnet: 64,
+						}},
+					},
+					Transport: udnv1.TransportOptionNoOverlay,
+					NoOverlay: &udnv1.NoOverlayConfig{
+						OutboundSNAT: udnv1.SNATDisabled,
+						Routing:      udnv1.RoutingUnmanaged,
+					},
+				},
+			},
+		},
+	),
 	ginkgo.Entry("Layer2",
 		&udnv1.ClusterUserDefinedNetwork{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2223,10 +2435,40 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			},
 		}
 	}
+	layer3NoOverlaySNATEnabledUnmanagedSpecGen := func() *udnv1.NetworkSpec {
+		return &udnv1.NetworkSpec{
+			Topology: udnv1.NetworkTopologyLayer3,
+			Layer3: &udnv1.Layer3Config{
+				Role:    udnv1.NetworkRolePrimary,
+				Subnets: randomL3CUDNSubnets(),
+			},
+			Transport: udnv1.TransportOptionNoOverlay,
+			NoOverlay: &udnv1.NoOverlayConfig{
+				OutboundSNAT: udnv1.SNATEnabled,
+				Routing:      udnv1.RoutingUnmanaged,
+			},
+		}
+	}
+	layer3NoOverlaySNATDisabledUnmanagedSpecGen := func() *udnv1.NetworkSpec {
+		return &udnv1.NetworkSpec{
+			Topology: udnv1.NetworkTopologyLayer3,
+			Layer3: &udnv1.Layer3Config{
+				Role:    udnv1.NetworkRolePrimary,
+				Subnets: randomL3CUDNSubnets(),
+			},
+			Transport: udnv1.TransportOptionNoOverlay,
+			NoOverlay: &udnv1.NoOverlayConfig{
+				OutboundSNAT: udnv1.SNATDisabled,
+				Routing:      udnv1.RoutingUnmanaged,
+			},
+		}
+	}
 
 	networksToTest := []ginkgo.TableEntry{
 		ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT enabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATEnabledUnmanagedSpecGen),
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT disabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATDisabledUnmanagedSpecGen),
 		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF", feature.EVPN, cudnAdvertisedEVPN, layer3IPVRFNetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF", feature.EVPN, cudnAdvertisedEVPN, layer2MACVRFNetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF", feature.EVPN, cudnAdvertisedEVPN, layer2MACVRFIPVRFNetworkSpecGen),
@@ -2236,6 +2478,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		func(testedNetworkType networkType, networkSpecGen func() *udnv1.NetworkSpec) {
 			var testNamespace *corev1.Namespace
 			var testPod *corev1.Pod
+			var networkSpec *udnv1.NetworkSpec
 
 			getSameNode := func() string {
 				return testPod.Spec.NodeName
@@ -2254,7 +2497,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			}
 
 			ginkgo.BeforeEach(func() {
-				networkSpec := networkSpecGen()
+				networkSpec = networkSpecGen()
 				switch {
 				case networkSpec.Layer3 != nil:
 					networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
@@ -2292,7 +2535,14 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						if !ipFamilySet.Has(family) {
 							e2eskipper.Skipf("IP family %v not supported", family)
 						}
-						ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+						expectSNAT := networkSpec.NoOverlay != nil &&
+							networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+
+						if expectSNAT {
+							ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
+						} else {
+							ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+						}
 						for _, externalServer := range externalServers {
 							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2315,8 +2565,26 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							)
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
 							gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-							framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
-							testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+							if expectSNAT {
+								framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
+								// When OutboundSNAT is enabled, pod-to-external traffic is masqueraded
+								// to the node IP. Verify the source is NOT the pod IP.
+								ip, err := e2epodoutput.RunHostCmdWithRetries(
+									testPod.Namespace,
+									testPod.Name,
+									fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
+									polling,
+									timeout,
+								)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								sourceIP, _, err := net.SplitHostPort(ip)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								gomega.Expect(sourceIP).NotTo(gomega.Equal(testPodIP),
+									fmt.Sprintf("Expected SNAT for pod %s but traffic was not SNATed, output: %v", testPod.Name, ip))
+							} else {
+								framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
+								testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+							}
 						}
 					},
 					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
@@ -2771,7 +3039,7 @@ const frrImage = "quay.io/frrouting/frr:10.4.2"
 // neighbors in the network's VRF configured to advertised the provided
 // networks. Returns a temporary directory where the configuration is generated.
 func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (directory string, err error) {
-	// parse configuration templates
+	// parse configuration templatesex
 	var templates *template.Template
 	templates, err = template.ParseFS(ratestdata, filepath.Join(tmplDir, "frr", "*.tmpl"))
 	if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
Add support for selective SNAT in ClusterUserDefinedNetworks (CUDN)
running in no-overlay transport mode with local gateway configuration.
This enables pod-to-external traffic to be SNATed while exempting
pod-to-pod and pod-to-node traffic.

Enable OutboundSNAT support for ClusterUserDefinedNetworks (CUDN) in
no-overlay transport mode with shared gateway configuration. SNAT rules
are created on per-node gateway routers (GR_<node>) with exempted
external IPs to skip SNAT for pod-to-pod traffic. 

Add NetworkAttachmentDefinition rendering logic for OutboundSNAT
configuration in ClusterUserDefinedNetworks (CUDN) using no-overlay
transport. This enables the CNI plugin to read outboundSNAT settings
from the NAD spec and configure data plane accordingly.

Extend NetInfo interface and CNI types to support OutboundSNAT
configuration for ClusterUserDefinedNetworks in no-overlay mode.
This enables OVN controllers to query outboundSNAT settings and
create appropriate SNAT rules with exempted external IPs.

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Based on https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5853 and also have commit https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6110/changes/ddfe6f35ac5d332d4f57acfe72c9c6b2a9b0bb51

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add outbound SNAT option (enabled/disabled) for user-defined no‑overlay networks; surfaced in network config and honored by LOCAL/SHARED gateways.
  * Transport validation now integrates RouteAdvertisements; NoOverlay/EVPN transports require accepted RouteAdvertisements to be marked accepted.
  * RouteAdvertisements notifier added to trigger network reconciliations when relevant RAs change.
  * No‑overlay route-import now imports kernel routes into the logical router (overlay routes remain ignored).

* **Tests**
  * New unit and e2e tests covering outbound SNAT behavior, exemption address‑sets, transport/RA validation, and route‑import differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->