### PR TITLE
Fix invalid characters in e2e artifact directory paths

### DIFF
--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -4276,7 +4276,7 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 		   17.   Verify pod-to-pod works cross-network again
 		   18.   Verify service connectivity FAILS cross-network, but works within same network
 		*/
-		It("pod and service connectivity through CNC connectivity types toggling [Feature:NetworkConnect]", func() {
+		It("pod and service connectivity through CNC connectivity types toggling", func() {
 			// Setup (Steps 1-4) completed in BeforeEach
 			// This test starts from Step 5
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1198,7 +1198,10 @@ func wrappedTestFramework(basename string) *framework.Framework {
 		dbs := []string{"ovnnb_db.db", "ovnsb_db.db"}
 		ovsdb := "conf.db"
 
-		testName := strings.Replace(ginkgo.CurrentSpecReport().LeafNodeText, " ", "_", -1)
+		testName := strings.Trim(
+			regexp.MustCompile(`[^A-Za-z0-9._-]+`).ReplaceAllString(ginkgo.CurrentSpecReport().LeafNodeText, "_"),
+			"_",
+		)
 		logDir := fmt.Sprintf("%s/e2e-dbs/%s-%s", logLocation, testName, f.UniqueName)
 		// grab all OVS and OVN dbs
 		nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})


### PR DESCRIPTION
The test name used for DB dump artifact directories was only replacing spaces with underscores, leaving colons and brackets intact. This caused artifact collection failures when the test name contained characters like [Feature:NetworkConnect].

Sanitize the test name by also replacing colons with underscores and stripping brackets. Additionally remove the redundant [Feature:NetworkConnect] tag from the CNC toggling test since the parent Describe already uses the proper feature.NetworkConnect Ginkgo label.


Made-with: Cursor

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed an internal feature tag from a connectivity test's display name to simplify test descriptions (no change to test behavior).
  * Improved test-name sanitization to replace disallowed characters and trim extraneous underscores, producing more consistent and reliable log directory names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->