### PR TITLE
Fix typo in EVPN ACL: use '&&' instead of '&' for logical AND in OVN match expression

### DIFF
--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -354,7 +354,7 @@ func getDenyARPAndNSOnMACVRF(controllerName, macvrfportName string, nodeLRPMAC n
 			),
 			types.DefaultDenyPriority,
 			fmt.Sprintf(
-				"outport==%q && eth.dst==%s && arp & arp.op==1 && arp.tpa==%s",
+				"outport==%q && eth.dst==%s && arp && arp.op==1 && arp.tpa==%s",
 				macvrfportName,
 				nodeLRPMAC.String(),
 				gwIfAddrv4.IP.String(),


### PR DESCRIPTION
Spotted by @dceara 
```
2026-03-11T10:33:23.078Z|00122|lflow|WARN|error parsing match "reg8[30..31] == 2 && reg0[10] == 1 && (outport=="macvrf-cluster_udn_evpn.l2_ovn_layer2_switch" && eth.dst==0a:58:0a:c8:00:01 && arp & arp.op==1 && arp.tpa==10.200.0.1)": `&' is only valid as part of `&&'.
```
I would like to defer adding a test to a separate pr as I think we need one with tcpdump proving we are dropping the ARPs.

cc: @jcaamano 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ARP traffic denial logic in secondary layer 2 network configurations to correctly evaluate ARP packets. This ensures ARP denial rules now work as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->