### PR TITLE
Handle start up panic with ovnk components

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -444,7 +445,7 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util.OVNClientset, eventRecorder record.EventRecorder) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("recovering from a panic in runOvnKube: %v", r)
+			err = formatRecoveredPanic("runOvnKube", r)
 		}
 	}()
 	startTime := time.Now()
@@ -470,6 +471,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		go func() {
 			defer cancel()
 			defer wg.Done()
+			defer recoverComponentPanic("cluster manager", &managerErr)
 
 			clusterManager, err := clustermanager.NewClusterManager(
 				ovnClientset.GetClusterManagerClientset(),
@@ -510,6 +512,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		go func() {
 			defer cancel()
 			defer wg.Done()
+			defer recoverComponentPanic("ovnkube controller", &controllerErr)
 
 			libovsdbOvnNBClient, err := libovsdb.NewNBClient(ctx.Done())
 			if err != nil {
@@ -565,6 +568,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		go func() {
 			defer cancel()
 			defer wg.Done()
+			defer recoverComponentPanic("node network controller", &nodeErr)
 
 			if config.Kubernetes.Token == "" {
 				nodeErr = fmt.Errorf("cannot initialize node without service account 'token'. Please provide one with --k8s-token argument")
@@ -684,6 +688,16 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	}
 
 	return nil
+}
+
+func recoverComponentPanic(component string, errp *error) {
+	if r := recover(); r != nil {
+		*errp = formatRecoveredPanic(component, r)
+	}
+}
+
+func formatRecoveredPanic(component string, recovered interface{}) error {
+	return fmt.Errorf("panic in %s: %v\n%s", component, recovered, debug.Stack())
 }
 
 // newWatchFactory returns the proper watch factory to use depending on the run

--- a/go-controller/cmd/ovnkube/ovnkube_test.go
+++ b/go-controller/cmd/ovnkube/ovnkube_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRecoverComponentPanicCapturesPanic(t *testing.T) {
+	var err error
+
+	func() {
+		defer recoverComponentPanic("cluster manager", &err)
+		panic("boom")
+	}()
+
+	if err == nil {
+		t.Fatal("expected panic to be converted to an error")
+	}
+	if !strings.Contains(err.Error(), "panic in cluster manager: boom") {
+		t.Fatalf("expected component panic in error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "goroutine ") {
+		t.Fatalf("expected stack trace in error, got %q", err.Error())
+	}
+}
+
+func TestRecoverComponentPanicIgnoresNormalReturn(t *testing.T) {
+	err := error(nil)
+
+	func() {
+		defer recoverComponentPanic("cluster manager", &err)
+	}()
+
+	if err != nil {
+		t.Fatalf("expected nil error when no panic occurs, got %v", err)
+	}
+}


### PR DESCRIPTION
When OVNK starts up components like ovnkube-cluster-manager it does so in a goroutine. If those top-level goroutines panic, we would not get the error message and stack output and instead a generic error code.

Note it does not handle panics from goroutines spawned by the top-level goroutines.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling in concurrent components to capture and report panics with full stack traces instead of silent termination.

* **Tests**
  * Added test coverage for panic recovery behavior in component operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->