### PR TITLE
CNI: reorder SR-IOV representor lifecycle to prevent CmdAdd/CmdDel race

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -472,11 +472,6 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 				return nil, nil, err
 			}
 		}
-		// 4. make sure it's not a port managed by OVS to avoid conflicts
-		_, err = ovsExec("--if-exists", "del-port", hostRepName)
-		if err != nil {
-			return nil, nil, err
-		}
 
 		hostIface.Name = hostRepName
 		link, err := util.GetNetLinkOps().LinkByName(hostIface.Name)
@@ -484,17 +479,12 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 			return nil, nil, err
 		}
 
-		err = util.GetNetLinkOps().LinkSetUp(link)
-		if err != nil {
-			return nil, nil, err
-		}
-
 		hostIface.Mac = link.Attrs().HardwareAddr.String()
-
-		// 5. set MTU on the representor
-		if err = util.GetNetLinkOps().LinkSetMTU(link, ifInfo.MTU); err != nil {
-			return nil, nil, fmt.Errorf("failed to set MTU on %s: %v", hostIface.Name, err)
-		}
+		// Do not bring the representor up or set MTU here. In full mode the representor must be
+		// added to br-int first, then brought up (and set MTU) in ConfigureOVS after the port
+		// is added to br-int. This avoids a race where an old pod's CmdDel could bring down the
+		// same VF representor and remove it from br-int after we brought the link up but before
+		// we added it to br-int.
 	}
 
 	return hostIface, contIface, nil
@@ -577,7 +567,7 @@ func ConfigureOVS(ctx context.Context, namespace, podName, podIfName, hostIfaceN
 		extId := extIds[0]
 		ifaceIDStr := util.GetExternalIDValByKey(extId, "iface-id")
 		nadKeyString := util.GetExternalIDValByKey(extId, types.NADExternalID)
-		// if NADExternalID does not exists, it is default network
+		// if NADExternalID does not exist, it is default network
 		if nadKeyString == "" {
 			nadKeyString = types.DefaultNetworkName
 		}
@@ -663,12 +653,27 @@ func ConfigureOVS(ctx context.Context, namespace, podName, podIfName, hostIfaceN
 		return err
 	}
 
-	if ifInfo.Ingress > 0 || ifInfo.Egress > 0 {
-		l, err := netlink.LinkByName(hostIfaceName)
-		if err != nil {
-			return fmt.Errorf("failed to find host veth interface %s: %v", hostIfaceName, err)
+	var link netlink.Link
+	if deviceID != "" || (ifInfo.Ingress > 0 || ifInfo.Egress > 0) {
+		if link, err = util.GetNetLinkOps().LinkByName(hostIfaceName); err != nil {
+			return fmt.Errorf("failed to find interface %s: %v", hostIfaceName, err)
 		}
-		err = netlink.LinkSetTxQLen(l, 1000)
+	}
+
+	if deviceID != "" {
+		// 4. set MTU on the representor
+		if err = util.GetNetLinkOps().LinkSetMTU(link, ifInfo.MTU); err != nil {
+			return fmt.Errorf("failed to set MTU on %s: %v", hostIfaceName, err)
+		}
+		// 5. if the interface is not up, set it to up
+		err = util.GetNetLinkOps().LinkSetUp(link)
+		if err != nil {
+			return fmt.Errorf("failed to set link UP on %s: %v", hostIfaceName, err)
+		}
+	}
+
+	if ifInfo.Ingress > 0 || ifInfo.Egress > 0 {
+		err = netlink.LinkSetTxQLen(link, 1000)
 		if err != nil {
 			return fmt.Errorf("failed to set host veth txqlen: %v", err)
 		}
@@ -920,13 +925,34 @@ func (pr *PodRequest) deletePodConntrack() {
 func (pr *PodRequest) deletePort(ifaceName, podNamespace, podName string) {
 	podDesc := fmt.Sprintf("%s/%s", podNamespace, podName)
 
+	var isVFDevice bool
+	link, err := util.GetNetLinkOps().LinkByName(ifaceName)
+	if err != nil {
+		klog.Warningf("Failed to find host-side link %s for pod %q: %v", ifaceName, podDesc, err)
+	} else if pr.CNIConf.DeviceID != "" {
+		isVFDevice = true
+	}
+
+	if isVFDevice {
+		// SR-IOV case: bring down the representor before removing from OVS.
+		// The device plugin can re-allocate a VF to a new pod before this
+		// CmdDel completes, causing the new pod's CmdAdd shim to run
+		// concurrently. By doing LinkSetDown before del-port, we eliminate
+		// the window where a racing CmdAdd could have its LinkSetUp or
+		// ConfigureOVS undone.
+		if err = util.GetNetLinkOps().LinkSetDown(link); err != nil {
+			klog.Warningf("Failed to bring down pod %q interface %s: %v", podDesc, ifaceName, err)
+		}
+	}
+
 	out, err := ovsExec("del-port", "br-int", ifaceName)
 	if err != nil && !strings.Contains(err.Error(), "no port named") {
 		// DEL should be idempotent; don't return an error just log it
 		klog.Warningf("Failed to delete pod %q OVS port %s: %v\n  %q", podDesc, ifaceName, err, string(out))
 	}
+
 	// skip deleting representor ports
-	if pr.CNIConf.DeviceID == "" {
+	if link != nil && !isVFDevice {
 		if err = util.LinkDelete(ifaceName); err != nil {
 			klog.Warningf("Failed to delete pod %q interface %s: %v", podDesc, ifaceName, err)
 		}

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -725,13 +725,6 @@ func TestSetupSriovInterface(t *testing.T) {
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-			},
-			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
-			},
-			runnerInstance: mockKexecIface,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
@@ -741,8 +734,8 @@ func TestSetupSriovInterface(t *testing.T) {
 				// The below two mock calls are needed for the moveIfToNetns() call that internally invokes them
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				{OnCallMethodName: "LinkSetNsFd", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
-				// The below mock call is needed for the LinkByName() invocation right after the renameLink() method
-				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
+				// The below mock call is for the LinkByName() of the host representor
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 			nsMockHelper: []ovntest.TestifyMockHelper{
 				// The below mock call is needed when moveIfToNetns() is called
@@ -752,7 +745,7 @@ func TestSetupSriovInterface(t *testing.T) {
 			},
 		},
 		{
-			desc:         "test code path when LinkSetMTU() fails",
+			desc:         "test success code path for non-DPU host mode",
 			inpNetNS:     mockNS,
 			inpContID:    "35b82dbe2c39768d9874861aee38cf569766d4855b525ae02bff2bfbda73392a",
 			inpIfaceName: "eth0",
@@ -762,14 +755,6 @@ func TestSetupSriovInterface(t *testing.T) {
 				NetdevName:    "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
-			errMatch:    fmt.Errorf("failed to set MTU on"),
-			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
-			},
-			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
-			},
-			runnerInstance: mockKexecIface,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
@@ -779,12 +764,8 @@ func TestSetupSriovInterface(t *testing.T) {
 				// The below two mock calls are needed for the moveIfToNetns() call that internally invokes them
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				{OnCallMethodName: "LinkSetNsFd", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
-				// The below mock call is needed for the LinkByName() invocation right after the renameLink() method
-				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
-				// The below mock call is self-explanatory and is for the LinkSetUp() method
-				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
-				// The below mock call is self-explanatory and is for the LinkSetMTU() method
-				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
+				// The below mock call is for the LinkByName() of the host representor
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 			},
 			nsMockHelper: []ovntest.TestifyMockHelper{
 				// The below mock call is needed when moveIfToNetns() is called
@@ -793,8 +774,8 @@ func TestSetupSriovInterface(t *testing.T) {
 				{OnCallMethodName: "Do", OnCallMethodArgType: []string{"func(ns.NetNS) error"}, RetArgList: []interface{}{nil}},
 			},
 			linkMockHelper: []ovntest.TestifyMockHelper{
-				// The below mock call is to retrieve the MAC address of host interface right before LinkSetMTU() method
-				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				// The below mock call is to retrieve the MAC address of the host representor
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "VFRepresentor", HardwareAddr: ovntest.MustParseMAC("0A:58:FD:98:00:01")}}},
 			},
 		},
 		{
@@ -1336,7 +1317,11 @@ func TestConfigureOVS(t *testing.T) {
 			sriovnetOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"enp1s0f0", nil}},
 			},
-			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{},
+			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+			},
 		},
 		{
 			desc:    "VF representor has no matching external_ids:ovn-pf-encap-ip-mapping",
@@ -1359,7 +1344,11 @@ func TestConfigureOVS(t *testing.T) {
 			sriovnetOpsMockHelper: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"enp999s0f0", nil}},
 			},
-			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{},
+			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+			},
 		},
 		{
 			desc:    "empty external_ids:ovn-pf-encap-ip-mapping",
@@ -1380,7 +1369,11 @@ func TestConfigureOVS(t *testing.T) {
 			pfEncapIp:             "", // ovs port added without encap-ip
 			execMock:              ovntest.NewFakeExec(),
 			sriovnetOpsMockHelper: []ovntest.TestifyMockHelper{},
-			netLinkOpsMockHelper:  []ovntest.TestifyMockHelper{},
+			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+			},
 		},
 		{
 			desc:    "ignore get SR-IOV uplink representor failure",
@@ -1407,7 +1400,89 @@ func TestConfigureOVS(t *testing.T) {
 					RetArgList:          []interface{}{"", fmt.Errorf("failed to lookup")},
 				},
 			},
-			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{},
+			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+			},
+		},
+		{
+			desc:    "LinkByName fails for VF representor after add-port",
+			podNs:   "ns-foo",
+			podName: "pod-bar",
+			vfRep:   "enp1s0f0_1",
+			ifInfo: &PodInterfaceInfo{
+				PodAnnotation: util.PodAnnotation{
+					IPs: []*net.IPNet{ipnet},
+				},
+				IsDPUHostMode: false,
+				NetName:       ovntypes.DefaultNetworkName,
+				NetdevName:    "enp1s0f0v1",
+				PodUID:        "xyz",
+			},
+			ovnPfEncapIpMapping: ovnPfEncapIpMapping,
+			errMatch:            fmt.Errorf("failed to find interface"),
+			pfEncapIp:           "10.0.0.1",
+			execMock:            ovntest.NewFakeExec(),
+			sriovnetOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"enp1s0f0", nil}},
+			},
+			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
+			},
+		},
+		{
+			desc:    "LinkSetMTU fails for VF representor after add-port",
+			podNs:   "ns-foo",
+			podName: "pod-bar",
+			vfRep:   "enp1s0f0_1",
+			ifInfo: &PodInterfaceInfo{
+				PodAnnotation: util.PodAnnotation{
+					IPs: []*net.IPNet{ipnet},
+				},
+				IsDPUHostMode: false,
+				NetName:       ovntypes.DefaultNetworkName,
+				NetdevName:    "enp1s0f0v1",
+				PodUID:        "xyz",
+			},
+			ovnPfEncapIpMapping: ovnPfEncapIpMapping,
+			errMatch:            fmt.Errorf("failed to set MTU on"),
+			pfEncapIp:           "10.0.0.1",
+			execMock:            ovntest.NewFakeExec(),
+			sriovnetOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"enp1s0f0", nil}},
+			},
+			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
+			},
+		},
+		{
+			desc:    "LinkSetUp fails for VF representor after add-port",
+			podNs:   "ns-foo",
+			podName: "pod-bar",
+			vfRep:   "enp1s0f0_1",
+			ifInfo: &PodInterfaceInfo{
+				PodAnnotation: util.PodAnnotation{
+					IPs: []*net.IPNet{ipnet},
+				},
+				IsDPUHostMode: false,
+				NetName:       ovntypes.DefaultNetworkName,
+				NetdevName:    "enp1s0f0v1",
+				PodUID:        "xyz",
+			},
+			ovnPfEncapIpMapping: ovnPfEncapIpMapping,
+			errMatch:            fmt.Errorf("failed to set link UP on"),
+			pfEncapIp:           "10.0.0.1",
+			execMock:            ovntest.NewFakeExec(),
+			sriovnetOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"enp1s0f0", nil}},
+			},
+			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
+			},
 		},
 	}
 

--- a/go-controller/pkg/node/base_node_network_controller_dpu.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu.go
@@ -282,28 +282,11 @@ func (bnnc *BaseNodeNetworkController) addRepPort(pod *corev1.Pod, dpuCD *util.D
 	}
 	klog.Infof("Port %s added to bridge br-int", vfRepName)
 
-	link, err := util.GetNetLinkOps().LinkByName(vfRepName)
-	if err != nil {
-		_ = bnnc.delRepPort(pod, dpuCD, vfRepName, nadKey)
-		return fmt.Errorf("failed to get link device for interface %s", vfRepName)
-	}
-
-	if err = util.GetNetLinkOps().LinkSetMTU(link, ifInfo.MTU); err != nil {
-		_ = bnnc.delRepPort(pod, dpuCD, vfRepName, nadKey)
-		return fmt.Errorf("failed to setup representor port. failed to set MTU for interface %s", vfRepName)
-	}
-
-	if err = util.GetNetLinkOps().LinkSetUp(link); err != nil {
-		_ = bnnc.delRepPort(pod, dpuCD, vfRepName, nadKey)
-		return fmt.Errorf("failed to setup representor port. failed to set link up for interface %s", vfRepName)
-	}
-
 	// Update connection-status annotation
 	// TODO(adrianc): we should update Status in case of error as well
 	connStatus := util.DPUConnectionStatus{Status: util.DPUConnectionStatusReady, Reason: ""}
 	err = bnnc.updatePodDPUConnStatusWithRetry(pod, &connStatus, nadKey)
 	if err != nil {
-		_ = util.GetNetLinkOps().LinkSetDown(link)
 		_ = bnnc.delRepPort(pod, dpuCD, vfRepName, nadKey)
 		return fmt.Errorf("failed to setup representor port. failed to set pod annotations. %v", err)
 	}

--- a/go-controller/pkg/node/base_node_network_controller_dpu_test.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu_test.go
@@ -317,65 +317,14 @@ var _ = Describe("Node DPU tests", func() {
 					Cmd:    genOfctlDumpFlowsCmd("table=0,in_port=1"),
 					Output: "non-empty-output",
 				})
-			})
-
-			Context("Fails if link configuration fails on", func() {
-				It("LinkByName()", func() {
-					netlinkOpsMock.On("LinkByName", vfRep).Return(nil, fmt.Errorf("failed to get link"))
-					// Mock ovs calls for cleanup
-					checkOVSPortPodInfo(execMock, vfRep, true, "15", "a8d09931", "default")
-					execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-						Cmd: genOVSDelPortCmd("pf0vf9"),
-					})
-
-					podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(&pod, nil)
-
-					err := dnnc.addRepPort(&pod, &scd, ifInfo, clientset)
-					Expect(err).To(HaveOccurred())
-					Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc())
-				})
-
-				It("LinkSetMTU()", func() {
-					netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
-					netlinkOpsMock.On("LinkSetMTU", vfLink, ifInfo.MTU).Return(fmt.Errorf("failed to set mtu"))
-					// Mock netlink/ovs calls for cleanup
-					checkOVSPortPodInfo(execMock, vfRep, true, "15", "a8d09931", "default")
-					netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
-					execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-						Cmd: genOVSDelPortCmd("pf0vf9"),
-					})
-
-					podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(&pod, nil)
-
-					err := dnnc.addRepPort(&pod, &scd, ifInfo, clientset)
-					Expect(err).To(HaveOccurred())
-					Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc())
-				})
-
-				It("LinkSetUp()", func() {
-					netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
-					netlinkOpsMock.On("LinkSetMTU", vfLink, ifInfo.MTU).Return(nil)
-					netlinkOpsMock.On("LinkSetUp", vfLink).Return(fmt.Errorf("failed to set link up"))
-					// Mock netlink/ovs calls for cleanup
-					checkOVSPortPodInfo(execMock, vfRep, true, "15", "a8d09931", "default")
-					netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
-					execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-						Cmd: genOVSDelPortCmd("pf0vf9"),
-					})
-
-					podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(&pod, nil)
-
-					err := dnnc.addRepPort(&pod, &scd, ifInfo, clientset)
-					Expect(err).To(HaveOccurred())
-					Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc())
-				})
+				// ConfigureOVS now calls LinkByName/LinkSetMTU/LinkSetUp when deviceID != ""
+				netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
+				netlinkOpsMock.On("LinkSetMTU", vfLink, ifInfo.MTU).Return(nil)
+				netlinkOpsMock.On("LinkSetUp", vfLink).Return(nil)
 			})
 
 			It("Sets dpu.connection-status pod annotation on success", func() {
 				var err error
-				netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
-				netlinkOpsMock.On("LinkSetMTU", vfLink, ifInfo.MTU).Return(nil)
-				netlinkOpsMock.On("LinkSetUp", vfLink).Return(nil)
 				dcs := util.DPUConnectionStatus{
 					Status: "Ready",
 				}
@@ -396,9 +345,6 @@ var _ = Describe("Node DPU tests", func() {
 
 			It("cleans up representor port if set pod annotation fails", func() {
 				var err error
-				netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
-				netlinkOpsMock.On("LinkSetMTU", vfLink, ifInfo.MTU).Return(nil)
-				netlinkOpsMock.On("LinkSetUp", vfLink).Return(nil)
 				dcs := util.DPUConnectionStatus{
 					Status: "Ready",
 				}


### PR DESCRIPTION
When kubelet deletes a pod, the SR-IOV device plugin can re-allocate the same VF before the old pod's CmdDel completes. The old pod's CmdDel shim then runs concurrently with the new pod's CmdAdd shim on the same representor.    On the setup side, move LinkSetUp and LinkSetMTU from setupSriovInterface (and DPU's addRepPort) into ConfigureOVS so they run immediately after add-port. This ensures the representor is only brought up once it is on br-int, closing the window where an old pod's CmdDel del-port could interfere. On the teardown side, reorder deletePort to call LinkSetDown before del-port, eliminate the window where a racing CmdAdd could have its link setup undone.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
  * More reliable SR-IOV port add/remove workflows with fewer race conditions and fewer spurious failures during port deletion.
  * Improved handling of interface state and MTU application to reduce transient networking glitches after attach/detach.

## Tests
  * Strengthened unit tests around SR-IOV representor behaviors to reduce regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->