### PR TITLE
Force fake iptables/nftables helpers at start of unit tests

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
-	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
@@ -411,7 +410,6 @@ var _ = Describe("SyncServices", func() {
 		config.Gateway.Mode = config.GatewayModeLocal
 		config.IPv4Mode = true
 		config.IPv6Mode = false
-		_ = nodenft.SetFakeNFTablesHelper()
 
 		fakeClient = &util.OVNNodeClientset{
 			KubeClient: fake.NewSimpleClientset(),

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -618,8 +618,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		_ = nodenft.SetFakeNFTablesHelper()
-
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
 		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, netInfo)
@@ -854,8 +852,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		_ = nodenft.SetFakeNFTablesHelper()
-
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
 		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, netInfo)
@@ -1059,9 +1055,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			wg.Wait()
 		}()
 		err = wf.Start()
-
-		_ = nodenft.SetFakeNFTablesHelper()
-
 		Expect(err).NotTo(HaveOccurred())
 
 		// Make Management port
@@ -1299,8 +1292,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		}()
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
-
-		_ = nodenft.SetFakeNFTablesHelper()
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
@@ -1750,7 +1741,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		defer func() {
 			wf.Shutdown()
 		}()
-		nodenft.SetFakeNFTablesHelper()
 		fNPW := initFakeNodePortWatcher()
 		fNPW.watchFactory = wf
 		// in-order to simulate a namespace with an Invalid UDN (when GetActiveNamespace is called), we add an entry

--- a/go-controller/pkg/node/managementport/port_suite_test.go
+++ b/go-controller/pkg/node/managementport/port_suite_test.go
@@ -8,9 +8,14 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func TestAdder(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
+	util.SetFakeIPTablesHelpers()
+	nodenft.SetFakeNFTablesHelper()
 	ginkgo.RunSpecs(t, "Management Port Suite")
 }

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
-	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	mgmtportmock "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
@@ -773,8 +772,6 @@ func configureKubeOVNContext(nodeName string, useNetlink bool) *testCtx {
 	Expect(err).NotTo(HaveOccurred())
 	err = tc.watchFactory.Start()
 	Expect(err).NotTo(HaveOccurred())
-
-	_ = nodenft.SetFakeNFTablesHelper()
 
 	mpmock := &mgmtportmock.Interface{}
 	mpmock.On("GetAddresses").Return([]*net.IPNet{tc.mgmtPortIP4, tc.mgmtPortIP6})

--- a/go-controller/pkg/node/node_suite_test.go
+++ b/go-controller/pkg/node/node_suite_test.go
@@ -8,6 +8,9 @@ import (
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -24,5 +27,7 @@ func TestNodeSuite(t *testing.T) {
 		t.Fatalf("Failed to disable WatchListClient feature gate: %v", err)
 	}
 	RegisterFailHandler(Fail)
+	util.SetFakeIPTablesHelpers()
+	nodenft.SetFakeNFTablesHelper()
 	RunSpecs(t, "Node Suite")
 }

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
-	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
@@ -315,8 +314,6 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 		nodeLister := v1mocks.NodeLister{}
 		nodeInformer.On("Lister").Return(&nodeLister)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
-		nodenft.SetFakeNFTablesHelper()
-		util.SetFakeIPTablesHelpers()
 
 		kubeFakeClient := fake.NewSimpleClientset(
 			&corev1.NodeList{


### PR DESCRIPTION
SetFakeIPTablesHelpers / SetFakeNFTablesHelper affect all tests that run after the function is called, not just the one that calls the function. Since we never want to use the real iptables/nftables from unit tests, call them at the start of testing to ensure that.

In particular, I think there are some tests that depend on the fact that a _different_ test will have called SetFakeIPTablesHelpers before they run. Or at least, I've seen this in some of the future PRs I'm working on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized fake network-helper initialization into core test suites to ensure consistent setup before running specs.
  * Removed redundant per-test fake helper calls across several tests, simplifying setup while preserving test behavior and outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->