### PR TITLE
Port config.DisableForwarding to nftables

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -12,18 +12,18 @@ OVN-Kubernetes allows to enable or disable IP forwarding for all traffic on OVN-
 By default forwarding is enabled and this allows host to forward traffic across OVN-Kubernetes managed interfaces.
 If forwarding is disabled then Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by cluster nodes.
 
-IP forwarding is implemented at cluster node level by modifying both iptables `FORWARD` chain and IP forwarding `sysctl` parameters. 
+IP forwarding is implemented at cluster node level by adding an nftables `forward` chain and modifying IP forwarding `sysctl` parameters.
 
 #### IPv4
 
 If forwarding is enabled(default) and it is desired to allow forwarding for traffic on unmanaged ovn-kubernetes interfaces, then system administrators need to set the following sysctl parameters on the desired interfaces or globally.
 OVN-Kubernetes already sets sysctl forwarding for interfaces it manages, such as the ovn-k8s-mp0 interface and the shared gateway bridge interface. An operator can be built to manage forwarding sysctl parameters based on forwarding mode.
-No extra iptables rules are added by OVN-Kubernetes to FORWARD chain while using this IP forwarding mode.
+No extra nftables rules are added by OVN-Kubernetes to the `forward` hook while using this IP forwarding mode.
 
 ```
 net.ipv4.ip_forward=1
 ```
-IP forwarding can be disabled either by setting `disable-forwarding` command line option to `true` while starting ovnkube or by setting `disable-forwarding` to `true` in config file. If forwarding is disabled the default policy for the [FORWARD iptables chain is set as DROP](#forwarding-rules) and system administrators can add use-case specific ACCEPT rules.
+IP forwarding can be disabled either by setting `disable-forwarding` command line option to `true` while starting ovnkube or by setting `disable-forwarding` to `true` in config file. If forwarding is disabled a [`forward`-hook chain with a default `drop` rule is created](#forwarding-rules) and system administrators can add use-case specific iptables/nftables rules to accept packets.
 
 When IP forwarding is disabled, following sysctl parameters are modified by OVN-Kubernetes to allow forwarding Kubernetes related traffic on OVN-Kubernetes managed bridge interfaces and management port interface.
 
@@ -87,41 +87,16 @@ It is not possible to configure the IPv6 forwarding per interface by setting the
 `net.ipv6.conf.IFNAME.forwarding` sysctl (it just configures the interface-specific Host/Router 
 behaviour). \
 Instead, the opposite approach is required where the global forwarding is always enabled and 
-the traffic is restricted through iptables.
+the traffic is restricted through iptables/nftables.
 
 #### Forwarding rules
 
-When the `disable-forwarding` parameter is configured specific iptables rules are added to
-the FORWARD chain to forward clusterNetwork and serviceNetwork traffic to their intended destinations.
-Additionally, the default policy for the FORWARD chain is set as `DROP`. Otherwise, the policy
-defaults to `ACCEPT` and no custom rules are added. This behavior is the same for both IPv6 and IPv4
-networks:
+When the `disable-forwarding` parameter is configured specific nftables rules are added to
+the `forward` hook to forward clusterNetwork and serviceNetwork traffic to their intended
+destinations, and to drop anything else.
 
-```
-# In IPv4 with disable-forwarding=true the FORWARD policy is set to DROP
-Chain FORWARD (policy DROP 0 packets, 0 bytes)
- pkts bytes target     prot opt in     out     source               destination         
-    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            169.254.169.1       
-    0     0 ACCEPT     0    --  *      *       169.254.169.1        0.0.0.0/0           
-    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            10.96.0.0/16        
-    0     0 ACCEPT     0    --  *      *       10.96.0.0/16         0.0.0.0/0           
-    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            10.244.0.0/16       
-    0     0 ACCEPT     0    --  *      *       10.244.0.0/16        0.0.0.0/0           
-    0     0 ACCEPT     0    --  ovn-k8s-mp0 *       0.0.0.0/0            0.0.0.0/0           
-    0     0 ACCEPT     0    --  *      ovn-k8s-mp0  0.0.0.0/0            0.0.0.0/0
-    
-# In IPv6 with disable-forwarding=true the FORWARD policy is set to DROP
-Chain FORWARD (policy DROP 0 packets, 0 bytes)
- pkts bytes target     prot opt in     out     source               destination         
-    0     0 ACCEPT     0    --  *      *       ::/0                 fd69::1             
-    0     0 ACCEPT     0    --  *      *       fd69::1              ::/0                
-    0     0 ACCEPT     0    --  *      *       ::/0                 fd00:10:96::/112    
-    0     0 ACCEPT     0    --  *      *       fd00:10:96::/112     ::/0                
-    0     0 ACCEPT     0    --  *      *       ::/0                 fd00:10:244::/48    
-    0     0 ACCEPT     0    --  *      *       fd00:10:244::/48     ::/0                
-    0     0 ACCEPT     0    --  ovn-k8s-mp0 *       ::/0                 ::/0                
-    0     0 ACCEPT     0    --  *      ovn-k8s-mp0  ::/0                 ::/0          
-```
+Otherwise, no changes are made to the nftables forwarding rules. This behavior is the same
+for both IPv6 and IPv4 networks.
 
 ### VLAN Config
 

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1576,8 +1576,9 @@ func DummyMasqueradeIPs() []net.IP {
 }
 
 // configureGlobalForwarding configures the global forwarding settings.
-// It sets the FORWARD policy to DROP/ACCEPT based on the config.Gateway.DisableForwarding value for all enabled IP families.
-// For IPv6 it additionally always enables the global forwarding.
+// Note that if config.Gateway.DisableForwarding is set we will also call
+// initExternalBridgeServiceForwardingRules() to create specific nftables
+// forwarding rules and block other forwarding at the netfilter level.
 func configureGlobalForwarding() error {
 	// Global forwarding works differently for IPv6:
 	//   conf/all/forwarding - BOOLEAN
@@ -1589,28 +1590,12 @@ func configureGlobalForwarding() error {
 	// It is not possible to configure the IPv6 forwarding per interface by
 	// setting the net.ipv6.conf.<ifname>.forwarding sysctl. Instead,
 	// the opposite approach is required where the global forwarding
-	// is enabled and an iptables rule is added to restrict it by default.
+	// is enabled and an nftables rule is added to restrict it by default.
 	if config.IPv6Mode {
 		if err := ip.EnableIP6Forward(); err != nil {
 			return fmt.Errorf("could not set the correct global forwarding value for ipv6:  %w", err)
 		}
 
-	}
-
-	for _, proto := range clusterIPTablesProtocols() {
-		ipt, err := util.GetIPTablesHelper(proto)
-		if err != nil {
-			return fmt.Errorf("failed to get the iptables helper: %w", err)
-		}
-
-		target := "ACCEPT"
-		if config.Gateway.DisableForwarding {
-			target = "DROP"
-
-		}
-		if err := ipt.ChangePolicy("filter", "FORWARD", target); err != nil {
-			return fmt.Errorf("failed to change the forward policy to %q: %w", target, err)
-		}
 	}
 	return nil
 }

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -92,6 +92,17 @@ add rule inet ovn-kubernetes ovn-kube-local-gw-masq ip saddr 169.254.169.1 masqu
 add rule inet ovn-kubernetes ovn-kube-local-gw-masq jump ovn-kube-pod-subnet-masq
 add chain inet ovn-kubernetes ovn-kube-pod-subnet-masq
 add rule inet ovn-kubernetes ovn-kube-pod-subnet-masq ip saddr 10.1.1.0/24 masquerade
+add chain inet ovn-kubernetes gateway-forward-local { type filter hook forward priority -1 ; }
+add rule inet ovn-kubernetes gateway-forward-local iifname "` + types.K8sMgmtIntfName + `" accept
+add rule inet ovn-kubernetes gateway-forward-local oifname "` + types.K8sMgmtIntfName + `" accept
+`
+
+// The additional rules expected if initExternalBridgeServiceForwardingRules() is called.
+const nftablesRulesForward = `
+add chain inet ovn-kubernetes gateway-forward { type filter hook forward priority 0 ; }
+add rule inet ovn-kubernetes gateway-forward ip saddr { 10.1.0.0/16, 169.254.169.1, 172.16.1.0/24 } accept
+add rule inet ovn-kubernetes gateway-forward ip daddr { 10.1.0.0/16, 169.254.169.1, 172.16.1.0/24 } accept
+add rule inet ovn-kubernetes gateway-forward drop
 `
 
 func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
@@ -1411,18 +1422,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				"OVN-KUBE-ETP": []string{},
 				"OVN-KUBE-ITP": []string{},
 			},
-			"filter": {
-				"FORWARD": []string{
-					"-d 169.254.169.1 -j ACCEPT",
-					"-s 169.254.169.1 -j ACCEPT",
-					"-d 172.16.1.0/24 -j ACCEPT",
-					"-s 172.16.1.0/24 -j ACCEPT",
-					"-d 10.1.0.0/16 -j ACCEPT",
-					"-s 10.1.0.0/16 -j ACCEPT",
-					"-i ovn-k8s-mp0 -j ACCEPT",
-					"-o ovn-k8s-mp0 -j ACCEPT",
-				},
-			},
+			"filter": {},
 			"mangle": {
 				"OUTPUT": []string{
 					"-j OVN-KUBE-ITP",
@@ -1431,10 +1431,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			},
 		}
 		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
-			Table: "filter",
-			Chain: "FORWARD",
-		}: "DROP"})
+		err = f4.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedTables = map[string]util.FakeTable{
@@ -1446,7 +1443,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		err = f6.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway
+		expectedNFT := nftablesRulesBase + nftablesRulesLocalGateway + nftablesRulesForward
 		if util.IsNetworkSegmentationSupportEnabled() {
 			expectedNFT += nftablesRulesUDN
 		}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1422,9 +1422,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 					"-i ovn-k8s-mp0 -j ACCEPT",
 					"-o ovn-k8s-mp0 -j ACCEPT",
 				},
-				"INPUT": []string{
-					"-i ovn-k8s-mp0 -m comment --comment from OVN to localhost -j ACCEPT",
-				},
 			},
 			"mangle": {
 				"OUTPUT": []string{

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -386,16 +386,6 @@ func getLocalGatewayFilterRules(ifname string, cidr *net.IPNet) []nodeipt.Rule {
 			},
 			Protocol: protocol,
 		},
-		{
-			Table: "filter",
-			Chain: "INPUT",
-			Args: []string{
-				"-i", ifname,
-				"-m", "comment", "--comment", "from OVN to localhost",
-				"-j", "ACCEPT",
-			},
-			Protocol: protocol,
-		},
 	}
 }
 

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -312,6 +312,11 @@ func getStaleMasqueradeIptablesRules(masqueradeIP net.IP) []nodeipt.Rule {
 		getMasqueradeIpTablesNATRules(masqueradeIP, getIPTablesProtocol(masqueradeIP.String()))...)
 }
 
+// delStaleMasqueradeIPTRules deletes all iptables rules that may have been added for a given masquerade IP.
+func delStaleMasqueradeIPTRules(masqueradeIP net.IP) error {
+	return deleteIptRules(getStaleMasqueradeIptablesRules(masqueradeIP))
+}
+
 func getMasqueradeIpTablesForwardRules(masqueradeIP net.IP, protocol iptables.Protocol) []nodeipt.Rule {
 	return []nodeipt.Rule{
 		{
@@ -349,18 +354,9 @@ func getMasqueradeIpTablesNATRules(masqueradeIP net.IP, protocol iptables.Protoc
 	}
 }
 
-// initExternalBridgeForwardingRules sets up iptables rules for br-* interface svc traffic forwarding
-// -A FORWARD -s 10.96.0.0/16 -j ACCEPT
-// -A FORWARD -d 10.96.0.0/16 -j ACCEPT
-// -A FORWARD -s 169.254.169.1 -j ACCEPT
-// -A FORWARD -d 169.254.169.1 -j ACCEPT
-func initExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
-	return insertIptRules(getGatewayForwardRules(cidrs))
-}
-
-// delExternalBridgeServiceForwardingRules removes iptables rules which might
+// delExternalBridgeServiceIPTForwardingRules removes iptables rules which might
 // have been added to disable forwarding
-func delExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
+func delExternalBridgeServiceIPTForwardingRules(cidrs []*net.IPNet) error {
 	return deleteIptRules(getGatewayForwardRules(cidrs))
 }
 
@@ -389,17 +385,9 @@ func getLocalGatewayFilterRules(ifname string, cidr *net.IPNet) []nodeipt.Rule {
 	}
 }
 
-// initLocalGatewayIPTFilterRules sets up iptables rules for interfaces
-func initLocalGatewayIPTFilterRules(ifname string, cidr *net.IPNet) error {
-	// Insert the filter table rules because they need to be evaluated BEFORE the DROP rules
-	// we have for forwarding. DO NOT change the ordering; specially important
-	// during SGW->LGW rollouts and restarts.
-	err := insertIptRules(getLocalGatewayFilterRules(ifname, cidr))
-	if err != nil {
-		return fmt.Errorf("unable to insert forwarding rules %v", err)
-	}
-	// NOTE: nftables masquerade rules are now handled separately in initLocalGatewayNFTNATRules
-	return nil
+// delLocalGatewayIPTFilterRules removes iptables rules for interfaces.
+func delLocalGatewayIPTFilterRules(ifname string, cidr *net.IPNet) error {
+	return deleteIptRules(getLocalGatewayFilterRules(ifname, cidr))
 }
 
 func addChaintoTable(ipt util.IPTablesHelper, tableName, chain string) {

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -22,12 +22,10 @@ func initLocalGateway(hostSubnets []*net.IPNet, mgmtPort managementport.Interfac
 		return nil
 	}
 
-	klog.Info("Adding iptables masquerading rules for new local gateway")
+	klog.Info("Adding nftables rules for new local gateway")
 
+	// Collect all CIDRs for masquerading rules
 	var allCIDRs []*net.IPNet
-	ifName := mgmtPort.GetInterfaceName()
-
-	// First pass: collect all CIDRs and setup iptables filter rules per interface
 	for _, hostSubnet := range hostSubnets {
 		// local gateway mode uses mp0 as default path for all ingress traffic into OVN
 		nextHop, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(hostSubnet), mgmtPort.GetAddresses())
@@ -35,22 +33,13 @@ func initLocalGateway(hostSubnets []*net.IPNet, mgmtPort managementport.Interfac
 			return fmt.Errorf("failed to find management port address: %w", err)
 		}
 
-		// add iptables masquerading for mp0 to exit the host for egress
 		cidr := nextHop.IP.Mask(nextHop.Mask)
 		cidrNet := &net.IPNet{IP: cidr, Mask: nextHop.Mask}
 		allCIDRs = append(allCIDRs, cidrNet)
-
-		// Setup iptables filter rules for this interface/CIDR
-		if err := initLocalGatewayIPTFilterRules(ifName, cidrNet); err != nil {
-			return fmt.Errorf("failed to add local NAT rules for: %s, err: %v", ifName, err)
-		}
 	}
 
-	// setup nftables masquerade rules for all CIDRs (v4, v6 or dualstack)
-	if len(allCIDRs) > 0 {
-		if err := initLocalGatewayNFTNATRules(allCIDRs...); err != nil {
-			return fmt.Errorf("failed to setup nftables masquerade rules: %w", err)
-		}
+	if err := initLocalGatewayRules(mgmtPort.GetInterfaceName(), allCIDRs); err != nil {
+		return fmt.Errorf("failed to setup nftables rules for local gateway: %w", err)
 	}
 
 	return nil

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -77,13 +77,8 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 
 	// Add or delete nftables rules based on DisableForwarding. This is
 	// to imitate addition or deletion of rules done in newNodePortWatcher().
-	var subnets []*net.IPNet
-	for _, subnet := range config.Default.ClusterSubnets {
-		subnets = append(subnets, subnet.CIDR)
-	}
-	subnets = append(subnets, config.Kubernetes.ServiceCIDRs...)
 	if config.Gateway.DisableForwarding {
-		if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
+		if err := initExternalBridgeServiceForwardingRules(); err != nil {
 			return fmt.Errorf("failed to add nftables forwarding rules for bridge %s: err %v", linkName, err)
 		}
 	} else {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -75,8 +75,8 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 	ipFullNet := net.IPNet{IP: ip, Mask: ipnet.Mask}
 	n.nodeIPManager.cidrs.Insert(ipFullNet.String())
 
-	// Add or delete iptables rules from FORWARD chain based on DisableForwarding. This is
-	// to imitate addition or deletion of iptales rules done in newNodePortWatcher().
+	// Add or delete nftables rules based on DisableForwarding. This is
+	// to imitate addition or deletion of rules done in newNodePortWatcher().
 	var subnets []*net.IPNet
 	for _, subnet := range config.Default.ClusterSubnets {
 		subnets = append(subnets, subnet.CIDR)
@@ -84,11 +84,11 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 	subnets = append(subnets, config.Kubernetes.ServiceCIDRs...)
 	if config.Gateway.DisableForwarding {
 		if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
-			return fmt.Errorf("failed to add accept rules in forwarding table for bridge %s: err %v", linkName, err)
+			return fmt.Errorf("failed to add nftables forwarding rules for bridge %s: err %v", linkName, err)
 		}
 	} else {
-		if err := delExternalBridgeServiceForwardingRules(subnets); err != nil {
-			return fmt.Errorf("failed to delete accept rules in forwarding table for bridge %s: err %v", linkName, err)
+		if err := delExternalBridgeServiceForwardingRules(); err != nil {
+			return fmt.Errorf("failed to delete nftables forwarding rules for bridge %s: err %v", linkName, err)
 		}
 	}
 
@@ -3540,7 +3540,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("disable-forwarding", func() {
-		It("adds or removes iptables rules upon change in forwarding mode", func() {
+		It("adds or removes nftables rules upon change in forwarding mode", func() {
 			app.Action = func(*cli.Context) error {
 				config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: ovntest.MustParseIPNet("10.1.0.0/16"), HostSubnetLength: 24}}
 				config.Kubernetes.ServiceCIDRs = ovntest.MustParseIPNets("172.16.1.0/24")
@@ -3558,104 +3558,21 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {
-						"FORWARD": []string{
-							"-d 169.254.169.1 -j ACCEPT",
-							"-s 169.254.169.1 -j ACCEPT",
-							"-d 172.16.1.0/24 -j ACCEPT",
-							"-s 172.16.1.0/24 -j ACCEPT",
-							"-d 10.1.0.0/16 -j ACCEPT",
-							"-s 10.1.0.0/16 -j ACCEPT",
-						},
-					},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
 
-				Expect(configureGlobalForwarding()).To(Succeed())
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
-					Table: "filter",
-					Chain: "FORWARD",
-				}: "DROP"})
-				Expect(err).NotTo(HaveOccurred())
-				expectedTables = map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables, nil)
+				expectedNFT := nftablesRulesBase + nftablesRulesForward
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
 
-				// Enable forwarding and test deletion of iptables rules from FORWARD chain
+				// Enable forwarding and test deletion of nftables forwarding rules
 				config.Gateway.DisableForwarding = false
 				fNPW.watchFactory = wf
 				Expect(configureGlobalForwarding()).To(Succeed())
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
-				expectedTables = map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-ETP",
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-						"OVN-KUBE-ETP":        []string{},
-						"OVN-KUBE-ITP":        []string{},
-					},
-					"filter": {
-						"FORWARD": []string{},
-					},
-					"mangle": {
-						"OUTPUT": []string{
-							"-j OVN-KUBE-ITP",
-						},
-						"OVN-KUBE-ITP": []string{},
-					},
-				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
-					Table: "filter",
-					Chain: "FORWARD",
-				}: "ACCEPT"})
+				expectedNFT = nftablesRulesBase
+				err = nodenft.MatchNFTRules(expectedNFT, nft.Dump())
 				Expect(err).NotTo(HaveOccurred())
-				expectedTables = map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-				f6 = iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables, nil)
-				Expect(err).NotTo(HaveOccurred())
+
 				return nil
 			}
 			err := app.Run([]string{app.Name})

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
@@ -437,7 +438,7 @@ func getUDNMasqueradeNFTRules(ipFamily utilnet.IPFamily) ([]*knftables.Rule, err
 
 // initLocalGatewayNFTNATRules sets up nftables rules for local gateway NAT functionality
 // This function supports dual-stack by accepting multiple CIDRs and generating rules for all IP families
-func initLocalGatewayNFTNATRules(cidrs ...*net.IPNet) error {
+func initLocalGatewayNFTNATRules(cidrs []*net.IPNet) error {
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
 		return fmt.Errorf("failed to get nftables helper: %w", err)
@@ -591,6 +592,183 @@ func delLocalGatewayPodSubnetNFTRules() error {
 
 	if err := nft.Run(context.TODO(), tx); err != nil && !knftables.IsNotFound(err) {
 		return fmt.Errorf("failed to delete pod subnet NAT rules: %w", err)
+	}
+
+	return nil
+}
+
+const (
+	// gatewayForwardChain is the chain used to configure forwarding rules when
+	// config.Gateway.DisableForwarding is true.
+	gatewayForwardChain = "gateway-forward"
+
+	// gatewayForwardLocalChain is the chain used to configure forwarding rules
+	// for local gateway mode.
+	gatewayForwardLocalChain = "gateway-forward-local"
+)
+
+// initExternalBridgeServiceForwardingRules is called when config.Gateway.DisableForwarding is
+// true, to set up allowed forwarding and deny other forwarding.
+func initExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("could not configure bridge forwarding: %w", err)
+	}
+
+	tx := nft.NewTransaction()
+	tx.Add(&knftables.Chain{
+		Name: gatewayForwardChain,
+
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.ForwardHook),
+		Priority: knftables.PtrTo(knftables.FilterPriority),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: gatewayForwardChain,
+	})
+
+	v4CIDRset := sets.New[string]()
+	v6CIDRset := sets.New[string]()
+	for _, cidr := range cidrs {
+		switch utilnet.IPFamilyOfCIDR(cidr) {
+		case utilnet.IPv4:
+			v4CIDRset.Insert(cidr.String())
+		case utilnet.IPv6:
+			v6CIDRset.Insert(cidr.String())
+		}
+	}
+
+	if len(v4CIDRset) > 0 {
+		v4CIDRset.Insert(config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String())
+		v4CIDRs := strings.Join(sets.List(v4CIDRset), ", ")
+
+		tx.Add(&knftables.Rule{
+			Chain: gatewayForwardChain,
+			Rule: knftables.Concat(
+				"ip saddr", "{", v4CIDRs, "}",
+				"accept",
+			),
+		})
+		tx.Add(&knftables.Rule{
+			Chain: gatewayForwardChain,
+			Rule: knftables.Concat(
+				"ip daddr", "{", v4CIDRs, "}",
+				"accept",
+			),
+		})
+	}
+
+	if len(v6CIDRset) > 0 {
+		v6CIDRset.Insert(config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String())
+		v6CIDRs := strings.Join(sets.List(v6CIDRset), ", ")
+
+		tx.Add(&knftables.Rule{
+			Chain: gatewayForwardChain,
+			Rule: knftables.Concat(
+				"ip6 saddr", "{", v6CIDRs, "}",
+				"accept",
+			),
+		})
+		tx.Add(&knftables.Rule{
+			Chain: gatewayForwardChain,
+			Rule: knftables.Concat(
+				"ip6 daddr", "{", v6CIDRs, "}",
+				"accept",
+			),
+		})
+	}
+
+	tx.Add(&knftables.Rule{
+		Chain: gatewayForwardChain,
+		Rule:  "drop",
+	})
+
+	err = nft.Run(context.TODO(), tx)
+	if err != nil {
+		return fmt.Errorf("could not configure bridge forwarding: %w", err)
+	}
+
+	// If there are legacy IPTables rules left around, clean them up, ignoring errors.
+	_ = delStaleMasqueradeIPTRules(config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP)
+	_ = delStaleMasqueradeIPTRules(config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP)
+
+	return nil
+}
+
+// delExternalBridgeServiceForwardingRules removes nftables rules which might
+// have been added to configure forwarding
+func delExternalBridgeServiceForwardingRules() error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("could not unconfigure bridge forwarding: %w", err)
+	}
+
+	tx := nft.NewTransaction()
+	tx.Delete(&knftables.Chain{Name: gatewayForwardChain})
+	err = nft.Run(context.TODO(), tx)
+	if err != nil && !knftables.IsNotFound(err) {
+		return fmt.Errorf("could not unconfigure bridge forwarding: %w", err)
+	}
+
+	return nil
+}
+
+// initLocalGatewayForwardRules sets up nftables forwarding rules specific to local
+// gateway mode
+func initLocalGatewayForwardRules(ifname string) error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("could not configure local gateway rules: %w", err)
+	}
+
+	tx := nft.NewTransaction()
+	tx.Add(&knftables.Chain{
+		Name: gatewayForwardLocalChain,
+
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.ForwardHook),
+		Priority: knftables.PtrTo(knftables.FilterPriority + "-1"),
+	})
+	tx.Flush(&knftables.Chain{
+		Name: gatewayForwardLocalChain,
+	})
+
+	quotedName := fmt.Sprintf("%q", ifname)
+	tx.Add(&knftables.Rule{
+		Chain: gatewayForwardLocalChain,
+		Rule: knftables.Concat(
+			"iifname", quotedName,
+			"accept",
+		),
+	})
+	tx.Add(&knftables.Rule{
+		Chain: gatewayForwardLocalChain,
+		Rule: knftables.Concat(
+			"oifname", quotedName,
+			"accept",
+		),
+	})
+
+	err = nft.Run(context.TODO(), tx)
+	if err != nil {
+		return fmt.Errorf("could not configure local gateway rules: %w", err)
+	}
+	return nil
+}
+
+// initLocalGatewayRules sets up all nftables rules specific to local gateway mode.
+func initLocalGatewayRules(ifname string, cidrs []*net.IPNet) error {
+	if err := initLocalGatewayNFTNATRules(cidrs); err != nil {
+		return err
+	}
+	if err := initLocalGatewayForwardRules(ifname); err != nil {
+		return err
+	}
+
+	// If there are legacy IPTables rules left around, clean them up, ignoring errors.
+	_ = delExternalBridgeServiceIPTForwardingRules(cidrs)
+	for _, cidr := range cidrs {
+		_ = delLocalGatewayIPTFilterRules(ifname, cidr)
 	}
 
 	return nil

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -609,7 +609,7 @@ const (
 
 // initExternalBridgeServiceForwardingRules is called when config.Gateway.DisableForwarding is
 // true, to set up allowed forwarding and deny other forwarding.
-func initExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
+func initExternalBridgeServiceForwardingRules() error {
 	nft, err := nodenft.GetNFTablesHelper()
 	if err != nil {
 		return fmt.Errorf("could not configure bridge forwarding: %w", err)
@@ -626,6 +626,12 @@ func initExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
 	tx.Flush(&knftables.Chain{
 		Name: gatewayForwardChain,
 	})
+
+	var cidrs []*net.IPNet
+	for _, subnet := range config.Default.ClusterSubnets {
+		cidrs = append(cidrs, subnet.CIDR)
+	}
+	cidrs = append(cidrs, config.Kubernetes.ServiceCIDRs...)
 
 	v4CIDRset := sets.New[string]()
 	v6CIDRset := sets.New[string]()

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1847,13 +1847,8 @@ func newNodePortWatcher(
 			}
 		}
 
-		var subnets []*net.IPNet
-		for _, subnet := range config.Default.ClusterSubnets {
-			subnets = append(subnets, subnet.CIDR)
-		}
-		subnets = append(subnets, config.Kubernetes.ServiceCIDRs...)
 		if config.Gateway.DisableForwarding {
-			if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
+			if err := initExternalBridgeServiceForwardingRules(); err != nil {
 				return nil, fmt.Errorf("failed to add accept rules in forwarding table for bridge %s: err %v", gwBridge.GetGatewayIface(), err)
 			}
 		} else {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1857,7 +1857,7 @@ func newNodePortWatcher(
 				return nil, fmt.Errorf("failed to add accept rules in forwarding table for bridge %s: err %v", gwBridge.GetGatewayIface(), err)
 			}
 		} else {
-			if err := delExternalBridgeServiceForwardingRules(subnets); err != nil {
+			if err := delExternalBridgeServiceForwardingRules(); err != nil {
 				return nil, fmt.Errorf("failed to delete accept rules in forwarding table for bridge %s: err %v", gwBridge.GetGatewayIface(), err)
 			}
 		}
@@ -2290,7 +2290,6 @@ func deleteStaleMasqueradeResources(bridgeName, nodeName string, wf factory.Node
 // struct and netlink.Link:
 // - neighbour object for IPv4 and IPv6 OVNMasqueradeIP and DummyNextHopMasqueradeIP.
 // - masquerade route added by addMasqueradeRoute function while starting up the gateway.
-// - iptables rules created for masquerade subnet based on ipForwarding and Gateway mode.
 // - stale HostMasqueradeIP address from gateway bridge
 func deleteMasqueradeResources(link netlink.Link, staleMasqueradeIPs *config.MasqueradeIPsConfig) error {
 	var subnets []*net.IPNet
@@ -2320,10 +2319,6 @@ func deleteMasqueradeResources(link netlink.Link, staleMasqueradeIPs *config.Mas
 		}
 		subnets = append(subnets, masqIPNet)
 		neighborIPs = append(neighborIPs, staleMasqueradeIPs.V4OVNMasqueradeIP, staleMasqueradeIPs.V4DummyNextHopMasqueradeIP)
-		if err := nodeipt.DelRules(getStaleMasqueradeIptablesRules(staleMasqueradeIPs.V4OVNMasqueradeIP)); err != nil {
-			aggregatedErrors = append(aggregatedErrors,
-				fmt.Errorf("failed to delete forwarding iptables rules for stale masquerade subnet %s: ", err))
-		}
 	}
 
 	if config.IPv6Mode && staleMasqueradeIPs.V6HostMasqueradeIP != nil {
@@ -2344,9 +2339,6 @@ func deleteMasqueradeResources(link netlink.Link, staleMasqueradeIPs *config.Mas
 		}
 		subnets = append(subnets, masqIPNet)
 		neighborIPs = append(neighborIPs, staleMasqueradeIPs.V6OVNMasqueradeIP, staleMasqueradeIPs.V6DummyNextHopMasqueradeIP)
-		if err := nodeipt.DelRules(getStaleMasqueradeIptablesRules(staleMasqueradeIPs.V6OVNMasqueradeIP)); err != nil {
-			return fmt.Errorf("failed to delete forwarding iptables rules for stale masquerade subnet %s: ", err)
-		}
 	}
 
 	for _, ip := range neighborIPs {

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
-	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
@@ -356,7 +355,6 @@ var _ = Describe("SyncServices", func() {
 		config.Gateway.Mode = config.GatewayModeLocal
 		config.IPv4Mode = true
 		config.IPv6Mode = false
-		_ = nodenft.SetFakeNFTablesHelper()
 
 		fakeClient = &util.OVNNodeClientset{
 			KubeClient: fake.NewSimpleClientset(),

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -613,8 +613,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		_ = nodenft.SetFakeNFTablesHelper()
-
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
 		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, netInfo)
@@ -845,8 +843,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		_ = nodenft.SetFakeNFTablesHelper()
-
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
 		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, netInfo)
@@ -1046,9 +1042,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 			wg.Wait()
 		}()
 		err = wf.Start()
-
-		_ = nodenft.SetFakeNFTablesHelper()
-
 		Expect(err).NotTo(HaveOccurred())
 
 		// Make Management port
@@ -1282,8 +1275,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		}()
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
-
-		_ = nodenft.SetFakeNFTablesHelper()
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
@@ -1729,7 +1720,6 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		defer func() {
 			wf.Shutdown()
 		}()
-		nodenft.SetFakeNFTablesHelper()
 		fNPW := initFakeNodePortWatcher()
 		fNPW.watchFactory = wf
 		// in-order to simulate a namespace with an Invalid UDN (when GetActiveNamespace is called), we add an entry

--- a/go-controller/pkg/node/managementport/port_suite_test.go
+++ b/go-controller/pkg/node/managementport/port_suite_test.go
@@ -5,9 +5,14 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func TestAdder(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
+	util.SetFakeIPTablesHelpers()
+	nodenft.SetFakeNFTablesHelper()
 	ginkgo.RunSpecs(t, "Management Port Suite")
 }

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
-	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	mgmtportmock "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
 	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
@@ -659,8 +658,6 @@ func configureKubeOVNContext(nodeName string, useNetlink bool) *testCtx {
 	Expect(err).NotTo(HaveOccurred())
 	err = tc.watchFactory.Start()
 	Expect(err).NotTo(HaveOccurred())
-
-	_ = nodenft.SetFakeNFTablesHelper()
 
 	mpmock := &mgmtportmock.Interface{}
 	mpmock.On("GetAddresses").Return([]*net.IPNet{tc.mgmtPortIP4, tc.mgmtPortIP6})

--- a/go-controller/pkg/node/node_suite_test.go
+++ b/go-controller/pkg/node/node_suite_test.go
@@ -5,6 +5,9 @@ import (
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -21,5 +24,7 @@ func TestNodeSuite(t *testing.T) {
 		t.Fatalf("Failed to disable WatchListClient feature gate: %v", err)
 	}
 	RegisterFailHandler(Fail)
+	util.SetFakeIPTablesHelpers()
+	nodenft.SetFakeNFTablesHelper()
 	RunSpecs(t, "Node Suite")
 }

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
-	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
@@ -302,8 +301,6 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 		nodeLister := v1mocks.NodeLister{}
 		nodeInformer.On("Lister").Return(&nodeLister)
 		nodeLister.On("Get", mock.AnythingOfType("string")).Return(node, nil)
-		nodenft.SetFakeNFTablesHelper()
-		util.SetFakeIPTablesHelpers()
 
 		kubeFakeClient := fake.NewSimpleClientset(
 			&corev1.NodeList{


### PR DESCRIPTION
Four commits here:
- An adjustment to the unit tests, from #6037
- Another adjustment to the unit tests, from #6107 
- Removing the `-A INPUT -i ovn-k8s-mp0 -j ACCEPT` iptables rule, which doesn't work if your system firewall is using nftables anyway. (If your firewall is dropping ovn-k traffic, you need to fix your firewall.)
- The actual porting of the rules associated with `config.DisableForwarding`

In iptables, we have to share the `FORWARD` chain with other users, so it's hard to ensure that our `DROP` rule reliably ends up at the end of the chain, so instead the iptables code set the "default policy" of the chain to `DROP`. In nftables we don't have to worry about that; nobody else is going to be adding rules to our chain, so we can just have a catch-all `drop` rule at the end rather than needing to change the policy for for unmatched packets.

This leaves around code to clean up old iptables forwarding rules for now, so it should handle upgrades correctly (by deleting the iptables rules and replacing them with nftables ones). The restart case is a little simpler on nftables than on iptables because we just always rewrite the entire `gateway-forward` chain on startup, so we don't need any extra code in `deleteMasqueradeResources` to handle day 2 config changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated forwarding docs to reference nftables (forward hook) instead of iptables and clarified default drop/forwarding behavior for IPv4/IPv6.

* **Refactor**
  * Switched gateway and forwarding management to nftables, centralizing rule setup for local-gateway and external-bridge flows, adding dual‑stack forwarding chains, and removing legacy iptables init-style logic in favor of nftables-first handling with best-effort iptables cleanup.

* **Tests**
  * Updated tests and fixtures to expect nftables behavior and initialize nftables helpers; removed iptables-only assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->