### PR TITLE
Fixes network controller leaking goroutines on failed start

### DIFF
--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -172,6 +172,9 @@ func (tnc *testNetworkController) Start(context.Context) error {
 	defer tnc.tcm.Unlock()
 	fmt.Printf("starting network: %s\n", testNetworkKey(tnc))
 	tnc.tcm.started = append(tnc.tcm.started, testNetworkKey(tnc))
+	if tnc.tcm.raiseErrorWhenStartingController != nil {
+		return tnc.tcm.raiseErrorWhenStartingController
+	}
 	return nil
 }
 
@@ -322,6 +325,7 @@ type testControllerManager struct {
 	cleaned []string
 
 	raiseErrorWhenCreatingController error
+	raiseErrorWhenStartingController error
 
 	valid []util.NetInfo
 }

--- a/go-controller/pkg/networkmanager/network_controller.go
+++ b/go-controller/pkg/networkmanager/network_controller.go
@@ -470,6 +470,7 @@ func (c *networkController) ensureNetwork(network util.MutableNetInfo) error {
 
 	err = nc.Start(context.Background())
 	if err != nil {
+		nc.Stop()
 		return fmt.Errorf("failed to start network %s: %w", networkName, err)
 	}
 	c.setNetworkState(network.GetNetworkName(), &networkControllerState{controller: nc})

--- a/go-controller/pkg/networkmanager/network_controller_test.go
+++ b/go-controller/pkg/networkmanager/network_controller_test.go
@@ -2,6 +2,7 @@ package networkmanager
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -401,4 +402,51 @@ func TestNetworkControllerClearsPendingNetworkRefOnDelete(t *testing.T) {
 	err = nm.syncNetwork(networkName)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(followupCalls).To(gomega.Equal(0))
+}
+
+func TestNetworkControllerStopsNetworkOnStartFailure(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	t.Cleanup(func() {
+		g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	})
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableRouteAdvertisements = false
+
+	netConf := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "udn-net",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer3Topology,
+		Role:     types.NetworkRolePrimary,
+		NADName:  "ns1/primary",
+		Subnets:  "10.128.0.0/14",
+	}
+	netInfo, err := util.NewNetInfo(netConf)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	tcm := &testControllerManager{
+		controllers: map[string]NetworkController{},
+		defaultNetwork: &testNetworkController{
+			ReconcilableNetInfo: &util.DefaultNetInfo{},
+		},
+		raiseErrorWhenStartingController: fmt.Errorf("start failed"),
+	}
+	nm := newNetworkController("", "", "", tcm, nil)
+
+	mutableNetInfo := util.NewMutableNetInfo(netInfo)
+	mutableNetInfo.SetNADs(netConf.NADName)
+	networkName := mutableNetInfo.GetNetworkName()
+	nm.setNetwork(networkName, mutableNetInfo)
+
+	err = nm.syncNetwork(networkName)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("failed to start network"))
+
+	tcm.Lock()
+	defer tcm.Unlock()
+	expectedNetworkKey := testNetworkKey(netInfo)
+	g.Expect(tcm.started).To(gomega.Equal([]string{expectedNetworkKey}))
+	g.Expect(tcm.stopped).To(gomega.Equal([]string{expectedNetworkKey}))
 }


### PR DESCRIPTION
When a UDN controller starts up it launches goroutines. If the oc.run() fails it is possible that goroutines are leaked because Stop is never called.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of network controller startup failures to ensure proper resource cleanup

* **Tests**
  * Enhanced test infrastructure to support startup failure simulation
  * Added comprehensive test coverage for failure and cleanup scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->