### PR TITLE
Support nodeSelector in AddressSetManager

### DIFF
--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -307,7 +307,7 @@ func NewControllerManager(ovnClient *util.OVNClientset, wf *factory.WatchFactory
 		cm.routeImportManager = routeimport.New(config.Default.Zone, cm.nbClient)
 	}
 	cm.addressSetManager = addresssetmanager.NewAddressSetManager(cm.watchFactory.PodCoreInformer(),
-		cm.watchFactory.NamespaceInformer(), cm.nbClient, cm.networkManager.Interface().GetNetworkNameForNADKey)
+		cm.watchFactory.NamespaceInformer(), cm.watchFactory.NodeCoreInformer(), cm.nbClient, cm.networkManager.Interface().GetNetworkNameForNADKey)
 
 	return cm, nil
 }

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,12 +39,17 @@ type podSelectorAddressSet struct {
 	namespaceSelector labels.Selector
 	// namespace is used when namespaceSelector is nil to set static namespace
 	namespace string
+	// nodeSelector decides which nodes' pods should be added to the address set; nil means all nodes
+	nodeSelector labels.Selector
 
 	addressSet addressset.AddressSet
 
 	// selectedNamespaces is a cache for namespaces that were selected by this address set during the last reconciliation
 	// used to optimize events processing.
 	selectedNamespaces sets.Set[string]
+	// selectedNodes is a cache for nodes that were selected by this address set during the last reconciliation
+	// used to optimize node event processing. Only set when nodeSelector is non-nil.
+	selectedNodes sets.Set[string]
 
 	// network-specific fields
 	controllerName string
@@ -67,9 +73,11 @@ type AddressSetManager struct {
 
 	podLister       listers.PodLister
 	namespaceLister listers.NamespaceLister
+	nodeLister      listers.NodeLister
 
 	podController        controller.Controller
 	nsController         controller.Controller
+	nodeController       controller.Controller
 	addressSetReconciler controller.Reconciler
 
 	// All network controllers are getting this function from the same networkmanager, so we can share it
@@ -77,7 +85,7 @@ type AddressSetManager struct {
 }
 
 func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInformer coreinformers.NamespaceInformer,
-	nbClient libovsdbclient.Client, getNetworkNameForNADKey func(nadKey string) string) *AddressSetManager {
+	nodeInformer coreinformers.NodeInformer, nbClient libovsdbclient.Client, getNetworkNameForNADKey func(nadKey string) string) *AddressSetManager {
 	m := &AddressSetManager{
 		name:                       "pod-selector-address-set-manager",
 		nbClient:                   nbClient,
@@ -87,6 +95,7 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 		addressSets:                syncmap.NewSyncMap[*podSelectorAddressSet](),
 		podLister:                  podInformer.Lister(),
 		namespaceLister:            namespaceInformer.Lister(),
+		nodeLister:                 nodeInformer.Lister(),
 		getNetworkNameForNADKey:    getNetworkNameForNADKey,
 	}
 	podCfg := &controller.ControllerConfig[corev1.Pod]{
@@ -111,7 +120,18 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 	}
 	m.nsController = controller.NewController[corev1.Namespace](m.name+"-namespace", nsCfg)
 
-	// addressSetReconciler is fed from the pod and namespace controllers
+	nodeCfg := &controller.ControllerConfig[corev1.Node]{
+		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+		Reconcile:      m.reconcileNode,
+		ObjNeedsUpdate: m.nodeNeedUpdate,
+		MaxAttempts:    controller.InfiniteAttempts,
+		Threadiness:    1,
+		Informer:       nodeInformer.Informer(),
+		Lister:         nodeInformer.Lister().List,
+	}
+	m.nodeController = controller.NewController[corev1.Node](m.name+"-node", nodeCfg)
+
+	// addressSetReconciler is fed from the pod, namespace and node controllers
 	m.addressSetReconciler = controller.NewReconciler(
 		m.name+"-addrset",
 		&controller.ReconcilerConfig{
@@ -126,30 +146,32 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 
 func (m *AddressSetManager) Start() error {
 	klog.Infof("Starting %s controller", m.name)
-	return controller.StartWithInitialSync(m.initialSync, m.podController, m.nsController, m.addressSetReconciler)
+	return controller.StartWithInitialSync(m.initialSync, m.podController, m.nsController, m.nodeController, m.addressSetReconciler)
 }
 
 func (m *AddressSetManager) Stop() {
 	klog.Infof("Stopping %s controller", m.name)
-	controller.Stop(m.podController, m.nsController, m.addressSetReconciler)
+	controller.Stop(m.podController, m.nsController, m.nodeController, m.addressSetReconciler)
 }
 
 func (m *AddressSetManager) initialSync() error {
 	return libovsdbutil.DeleteAddrSetsWithoutACLRefAnyController(libovsdbops.AddressSetPodSelector, m.nbClient)
 }
 
-// EnsureAddressSet returns address set for requested (podSelector, namespaceSelector, namespace).
+// EnsureAddressSet returns address set for requested (podSelector, namespaceSelector, namespace, nodeSelector).
 // If namespaceSelector is nil, namespace will be used with podSelector statically.
 // podSelector should not be nil, use metav1.LabelSelector{} to match all pods.
 // namespaceSelector can only be nil when namespace is set, use metav1.LabelSelector{} to match all namespaces.
+// nodeSelector is optional; nil means pods on all nodes are included.
 // podSelector = metav1.LabelSelector{} + static namespace may be replaced with namespace address set,
 // podSelector = metav1.LabelSelector{} + namespaceSelector may be replaced with a set of namespace address sets,
 // but both cases will work here too.
 //
 // backRef is the key that should be used for cleanup.
 // psAddrSetHashV4, psAddrSetHashV6 may be set to empty string if address set for that ipFamily wasn't created.
-func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector *metav1.LabelSelector,
+func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector,
 	namespace, backRef, controllerName string, netInfo util.NetInfo) (addrSetKey, psAddrSetHashV4, psAddrSetHashV6 string, err error) {
+	nodeSelector = normalizeNodeSelector(nodeSelector)
 	if podSelector == nil {
 		err = fmt.Errorf("pod selector is nil")
 		return
@@ -162,7 +184,7 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector *met
 		// namespace will be ignored in this case
 		namespace = ""
 	}
-	var nsSel, podSel labels.Selector
+	var nsSel, podSel, nodeSel labels.Selector
 	if namespaceSelector != nil {
 		nsSel, err = metav1.LabelSelectorAsSelector(namespaceSelector)
 		if err != nil {
@@ -176,12 +198,19 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector *met
 		err = fmt.Errorf("can't parse pod selector %v: %w", podSelector, err)
 		return
 	}
-	addrSetKey = getInternalKey(podSelector, namespaceSelector, namespace, controllerName)
+	if nodeSelector != nil {
+		nodeSel, err = metav1.LabelSelectorAsSelector(nodeSelector)
+		if err != nil {
+			err = fmt.Errorf("can't parse node selector %v: %w", nodeSelector, err)
+			return
+		}
+	}
+	addrSetKey = getInternalKey(podSelector, namespaceSelector, nodeSelector, namespace, controllerName)
 
 	err = m.addressSets.DoWithLock(addrSetKey, func(key string) error {
 		psAddrSet, found := m.addressSets.Load(key)
 		if !found {
-			addrSetDbIDs := GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector, namespace, controllerName)
+			addrSetDbIDs := GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector, nodeSelector, namespace, controllerName)
 			ipv4Mode, ipv6Mode := netInfo.IPMode()
 			var addrSet addressset.AddressSet
 			switch {
@@ -201,6 +230,7 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector *met
 				podSelector:       podSel,
 				namespaceSelector: nsSel,
 				namespace:         namespace,
+				nodeSelector:      nodeSel,
 				addressSet:        addrSet,
 				controllerName:    controllerName,
 				netInfo:           netInfo,
@@ -288,10 +318,11 @@ func (m *AddressSetManager) podNeedUpdate(old, new *corev1.Pod) bool {
 }
 
 func (m *AddressSetManager) reconcilePod(podKey string) error {
-	namespace, _, err := cache.SplitMetaNamespaceKey(podKey)
+	namespace, name, err := cache.SplitMetaNamespaceKey(podKey)
 	if err != nil {
 		return fmt.Errorf("failed to split meta namespace key %q: %v", podKey, err)
 	}
+	var pod *corev1.Pod
 	// only reconcile if this pod is in a namespace that is selected by an address set
 	// Get all existing keys, then lock address sets per key and check if they are affected.
 	// If the new keys are added, it will always call reconcile for that new key, so there is no race.
@@ -299,10 +330,29 @@ func (m *AddressSetManager) reconcilePod(podKey string) error {
 	existingAddrSets := m.addressSets.GetKeys()
 	for _, addrSetKey := range existingAddrSets {
 		// never returns error
-		_ = m.addressSets.DoWithLock(addrSetKey, func(addrSetKey string) error {
+		if err = m.addressSets.DoWithLock(addrSetKey, func(addrSetKey string) error {
 			addrSet, found := m.addressSets.Load(addrSetKey)
 			if !found {
 				// nothing to do
+				return nil
+			}
+			if addrSet.nodeSelector != nil {
+				if pod == nil {
+					pod, err = m.podLister.Pods(namespace).Get(name)
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							// pod deleted
+							pod = nil
+						} else {
+							return fmt.Errorf("failed to get pod %s in namespace %s: %v", name, namespace, err)
+						}
+					}
+				}
+				// check if pod's node matches address set's node selector
+				if pod == nil || addrSet.selectedNodes == nil || addrSet.selectedNodes.Has(pod.Spec.NodeName) {
+					m.addressSetReconciler.Reconcile(addrSetKey)
+					return nil
+				}
 				return nil
 			}
 			// only check address sets that have previously matched pod's namespace to avoid extra reconciliations
@@ -312,7 +362,9 @@ func (m *AddressSetManager) reconcilePod(podKey string) error {
 				return nil
 			}
 			return nil
-		})
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile address set %s for pod %s: %v", addrSetKey, podKey, err)
+		}
 	}
 	return nil
 }
@@ -367,6 +419,56 @@ func (m *AddressSetManager) reconcileNamespace(nsKey string) error {
 	return nil
 }
 
+func (m *AddressSetManager) nodeNeedUpdate(old, new *corev1.Node) bool {
+	if new == nil || old == nil {
+		return true
+	}
+	if !labels.Equals(new.Labels, old.Labels) {
+		// if node labels change, we need to reconcile address sets that use a node selector
+		return true
+	}
+	return false
+}
+
+func (m *AddressSetManager) reconcileNode(nodeKey string) error {
+	// find address sets that could be affected by this node event
+	// Get all existing keys, then lock address sets per key and check if they are affected.
+	// If the new keys are added, it will always call reconcile for that new key, so there is no race.
+	// If some keys are deleted, we just ignore it.
+	existingAddrSets := m.addressSets.GetKeys()
+	for _, addrSetKey := range existingAddrSets {
+		err := m.addressSets.DoWithLock(addrSetKey, func(addrSetKey string) error {
+			addrSet, _ := m.addressSets.Load(addrSetKey)
+			if addrSet == nil || addrSet.nodeSelector == nil || addrSet.nodeSelector.Empty() {
+				// nothing to do
+				return nil
+			}
+			// first find nodes that currently match this address set
+			currentlyMatchedNodes, err := m.getSelectedNodes(addrSet.nodeSelector)
+			if err != nil {
+				return err
+			}
+			if currentlyMatchedNodes.Has(nodeKey) {
+				// this node is relevant for this address set, reconcile
+				m.addressSetReconciler.Reconcile(addrSetKey)
+				return nil
+			}
+			// reconcile the address set if the node matches the previous selected nodes
+			previouslyMatchedNodes := addrSet.selectedNodes
+			// previouslyMatchedNodes == nil means the address set hasn't been reconciled yet, so need to reconcile
+			if previouslyMatchedNodes == nil || previouslyMatchedNodes.Has(nodeKey) {
+				m.addressSetReconciler.Reconcile(addrSetKey)
+				return nil
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to reconcile address set %s for node %s: %v", addrSetKey, nodeKey, err)
+		}
+	}
+	return nil
+}
+
 func (m *AddressSetManager) reconcileAddressSet(key string) error {
 	return m.addressSets.DoWithLock(key, func(key string) error {
 		psAddrSet, found := m.addressSets.Load(key)
@@ -413,6 +515,21 @@ func (m *AddressSetManager) reconcileAddressSet(key string) error {
 				}
 			}
 		}
+		// apply node selector filter if it's not empty
+		if psAddrSet.nodeSelector != nil && !psAddrSet.nodeSelector.Empty() {
+			selectedNodes, err := m.getSelectedNodes(psAddrSet.nodeSelector)
+			if err != nil {
+				return fmt.Errorf("failed to get selected nodes for address set %s: %v", key, err)
+			}
+			filtered := make([]*corev1.Pod, 0, len(pods))
+			for _, pod := range pods {
+				if pod.Spec.NodeName != "" && selectedNodes.Has(pod.Spec.NodeName) {
+					filtered = append(filtered, pod)
+				}
+			}
+			pods = filtered
+			psAddrSet.selectedNodes = selectedNodes
+		}
 		ips, err := m.getPodIPs(pods, psAddrSet.netInfo)
 		if err != nil {
 			return fmt.Errorf("failed to get pod IPs: %v", err)
@@ -451,6 +568,19 @@ func (m *AddressSetManager) getSelectedNamespaces(s *podSelectorAddressSet) (set
 	return matchedNamespaces, nil
 }
 
+// getSelectedNodes returns the set of node names that match the node selector.
+func (m *AddressSetManager) getSelectedNodes(nodeSelector labels.Selector) (sets.Set[string], error) {
+	nodes, err := m.nodeLister.List(nodeSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %v", err)
+	}
+	names := sets.New[string]()
+	for _, n := range nodes {
+		names.Insert(n.Name)
+	}
+	return names, nil
+}
+
 func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, netInfo util.NetInfo) ([]string, error) {
 	ips := []string{}
 	for _, pod := range pods {
@@ -473,8 +603,9 @@ func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, netInfo util.NetInfo) 
 	return ips, nil
 }
 
-func GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector *metav1.LabelSelector, namespace, controller string) *libovsdbops.DbObjectIDs {
-	addrsetKey := getPodSelectorKey(podSelector, namespaceSelector, namespace)
+func GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace, controller string) *libovsdbops.DbObjectIDs {
+	nodeSelector = normalizeNodeSelector(nodeSelector)
+	addrsetKey := getPodSelectorKey(podSelector, namespaceSelector, nodeSelector, namespace)
 	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetPodSelector, controller, map[libovsdbops.ExternalIDKey]string{
 		// pod selector address sets are cluster-scoped, only need name
 		libovsdbops.ObjectNameKey: addrsetKey,
@@ -547,11 +678,11 @@ func shortLabelSelectorString(sel *metav1.LabelSelector) string {
 
 // Since we have joined this manager for multiple controllers, we need to make keys unique across controllers.
 // In the db it is already achieved by using controller name in ExternalIDs, but for internal map we also need to add controller name
-func getInternalKey(podSelector, namespaceSelector *metav1.LabelSelector, namespace, controllerName string) string {
-	return controllerName + "_" + getPodSelectorKey(podSelector, namespaceSelector, namespace)
+func getInternalKey(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace, controllerName string) string {
+	return controllerName + "_" + getPodSelectorKey(podSelector, namespaceSelector, nodeSelector, namespace)
 }
 
-func getPodSelectorKey(podSelector, namespaceSelector *metav1.LabelSelector, namespace string) string {
+func getPodSelectorKey(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace string) string {
 	var namespaceKey string
 	if namespaceSelector == nil {
 		// namespace is static
@@ -559,5 +690,16 @@ func getPodSelectorKey(podSelector, namespaceSelector *metav1.LabelSelector, nam
 	} else {
 		namespaceKey = shortLabelSelectorString(namespaceSelector)
 	}
-	return namespaceKey + "_" + shortLabelSelectorString(podSelector)
+	key := namespaceKey + "_" + shortLabelSelectorString(podSelector)
+	if nodeSelector != nil {
+		key += "_" + shortLabelSelectorString(nodeSelector)
+	}
+	return key
+}
+
+func normalizeNodeSelector(sel *metav1.LabelSelector) *metav1.LabelSelector {
+	if sel != nil && len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0 {
+		return nil
+	}
+	return sel
 }

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -33,14 +33,14 @@ func getPolicyKeyWithKind(policy *knet.NetworkPolicy) string {
 
 func eventuallyExpectAddressSetsWithIP(asf *addressset.FakeAddressSetFactory, peer knet.NetworkPolicyPeer, namespace, ip string) {
 	if peer.PodSelector != nil {
-		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, namespace, controllerName)
+		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace, controllerName)
 		asf.EventuallyExpectAddressSetWithAddresses(dbIDs, []string{ip})
 	}
 }
 
 func eventuallyExpectEmptyAddressSetsExist(asf *addressset.FakeAddressSetFactory, peer knet.NetworkPolicyPeer, namespace string) {
 	if peer.PodSelector != nil {
-		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, namespace, controllerName)
+		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace, controllerName)
 		asf.EventuallyExpectEmptyAddressSetExist(dbIDs)
 	}
 }
@@ -89,14 +89,11 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		}
 	})
 
-	startAddrSetManager := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, pods []corev1.Pod) {
+	startAddrSetManagerWithNodes := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, pods []corev1.Pod, nodes []corev1.Node) {
 		clientSet = util.GetOVNClientset(
-			&corev1.NamespaceList{
-				Items: namespaces,
-			},
-			&corev1.PodList{
-				Items: pods,
-			},
+			&corev1.NamespaceList{Items: namespaces},
+			&corev1.PodList{Items: pods},
+			&corev1.NodeList{Items: nodes},
 		).GetOVNKubeControllerClientset()
 		var err error
 		wf, err = factory.NewOVNKubeControllerWatchFactory(clientSet)
@@ -105,12 +102,15 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		var libovsdbNBClient libovsdbclient.Client
 		libovsdbNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), libovsdbNBClient,
+		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
 			func(_ string) string { return "" })
-		// use fake factory for test
 		addressSetManager.addressSetFactoryV4 = asf
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	startAddrSetManager := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, pods []corev1.Pod) {
+		startAddrSetManagerWithNodes(dbSetup, namespaces, pods, nil)
 	}
 
 	ginkgo.It("validates selectors", func() {
@@ -131,29 +131,29 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		}
 		// try to add invalid peer
 		_, _, _, err := addressSetManager.EnsureAddressSet(
-			peer.PodSelector, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, peer.NamespaceSelector, nil, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("is not a valid label selector operator"))
 		// address set will not be created
-		peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, networkPolicy.Namespace, controllerName)
+		peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, networkPolicy.Namespace, controllerName)
 		asf.EventuallyExpectNoAddressSet(peerASIDs)
 
 		// add nil pod selector
 		_, _, _, err = addressSetManager.EnsureAddressSet(
-			nil, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
+			nil, peer.NamespaceSelector, nil, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("pod selector is nil"))
 		// address set will not be created
-		peerASIDs = GetPodSelectorAddrSetDbIDs(nil, peer.NamespaceSelector, networkPolicy.Namespace, controllerName)
+		peerASIDs = GetPodSelectorAddrSetDbIDs(nil, peer.NamespaceSelector, nil, networkPolicy.Namespace, controllerName)
 		asf.EventuallyExpectNoAddressSet(peerASIDs)
 
 		// namespace selector is nil and namespace is empty
 		_, _, _, err = addressSetManager.EnsureAddressSet(
-			peer.PodSelector, nil, "", getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, nil, nil, "", getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("namespace selector is nil and namespace is empty"))
 		// address set will not be created
-		peerASIDs = GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, "", controllerName)
+		peerASIDs = GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, nil, "", controllerName)
 		asf.EventuallyExpectNoAddressSet(peerASIDs)
 	})
 	ginkgo.It("creates one address set for multiple users with the same selector", func() {
@@ -166,14 +166,14 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 
 		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, nil)
 
-		_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, namespace1.Name,
+		_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nil, namespace1.Name,
 			"backref1", controllerName, &util.DefaultNetInfo{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, namespace1.Name,
+		_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nil, namespace1.Name,
 			"backref2", controllerName, &util.DefaultNetInfo{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, namespace1.Name, controllerName)
+		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name, controllerName)
 		asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
 		// expect peer address set only
 		asf.ExpectNumberOfAddressSets(1)
@@ -194,10 +194,10 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			startAddrSetManager(initialDB, []corev1.Namespace{namespace1, namespace2}, podsList)
 
 			_, _, _, err := addressSetManager.EnsureAddressSet(
-				peer.PodSelector, peer.NamespaceSelector, staticNamespace, "backRef", controllerName, &util.DefaultNetInfo{})
+				peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, "backRef", controllerName, &util.DefaultNetInfo{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// address set should be created and pod ips added
-			peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, staticNamespace, controllerName)
+			peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, controllerName)
 			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, addrSetIPs)
 		},
 		ginkgo.Entry("all pods from a static namespace", knet.NetworkPolicyPeer{
@@ -246,9 +246,9 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		}, namespaceName1, []string{ip3}),
 	)
 	ginkgo.It("on initial sync deletes unreferenced and leaves referenced address sets", func() {
-		unusedPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, "nsName", controllerName)
+		unusedPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", controllerName)
 		unusedPodSelAS, _ := addressset.GetTestDbAddrSets(unusedPodSelIDs, []string{"1.1.1.2"})
-		refNetpolIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, "nsName2", controllerName)
+		refNetpolIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName2", controllerName)
 		refNetpolAS, _ := addressset.GetTestDbAddrSets(refNetpolIDs, []string{"1.1.1.3"})
 		netpolACL := libovsdbops.BuildACL(
 			"netpolACL",
@@ -266,7 +266,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			types.DefaultACLTier,
 		)
 		netpolACL.UUID = "netpolACL-UUID"
-		refPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, "nsName3", controllerName)
+		refPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName3", controllerName)
 		refPodSelAS, _ := addressset.GetTestDbAddrSets(refPodSelIDs, []string{"1.1.1.4"})
 		podSelACL := libovsdbops.BuildACL(
 			"podSelACL",
@@ -322,7 +322,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, nil)
 
 		_, _, _, err := addressSetManager.EnsureAddressSet(
-			peer.PodSelector, peer.NamespaceSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Start a pod
@@ -371,7 +371,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		startAddrSetManager(initialDB, []corev1.Namespace{namespace1, namespace2}, nil)
 
 		_, _, _, err := addressSetManager.EnsureAddressSet(
-			peer.PodSelector, peer.NamespaceSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Start a pod
@@ -414,13 +414,143 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		backRef := "NetworkPolicy/namespace1/testpolicy"
 
 		_, _, _, err := addressSetManager.EnsureAddressSet(
-			peer.PodSelector, peer.NamespaceSelector, namespace1.Name, backRef, controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, backRef, controllerName, &util.DefaultNetInfo{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, namespace1.Name, controllerName)
+		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, controllerName)
 		asf.EventuallyExpectAddressSetWithAddresses(dbIDs, []string{ip1})
 
 		gomega.Expect(addressSetManager.CleanupForController(controllerName)).To(gomega.Succeed())
 		asf.EventuallyExpectNoAddressSet(dbIDs)
+	})
+
+	ginkgo.When("node selector is set", func() {
+		const (
+			nodeLabelKey         = "nodeType"
+			nodeTypeWorker       = "worker"
+			nodeTypeControlPlane = "control-plane"
+
+			podLabelKey = "app"
+			podAppVideo = "video"
+		)
+		node1 := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node1",
+				Labels: map[string]string{nodeLabelKey: nodeTypeWorker},
+			},
+		}
+		node2 := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node2",
+				Labels: map[string]string{nodeLabelKey: nodeTypeControlPlane},
+			},
+		}
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		pod1 := testing.NewPod(namespace1.Name, "pod1", "node1", ip1)
+		pod2 := testing.NewPod(namespace1.Name, "pod2", "node2", ip2)
+		podSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{podLabelKey: podAppVideo},
+		}
+		nodeSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{nodeLabelKey: nodeTypeWorker},
+		}
+		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelector, namespace1.Name, controllerName)
+
+		ginkgo.BeforeEach(func() {
+			startAddrSetManagerWithNodes(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*pod1}, []corev1.Node{node1})
+		})
+
+		ginkgo.It("same pod and namespace selector with different nodeSelector create different address sets", func() {
+			// add node2
+			_, err := clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// add pod2
+			_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Create(context.TODO(), pod2, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			podSelector := &metav1.LabelSelector{}
+			nodeSelWorker := &metav1.LabelSelector{MatchLabels: map[string]string{nodeLabelKey: nodeTypeWorker}}
+			nodeSelControlPlane := &metav1.LabelSelector{MatchLabels: map[string]string{nodeLabelKey: nodeTypeControlPlane}}
+			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelWorker, namespace1.Name, "backRef1", controllerName, &util.DefaultNetInfo{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelControlPlane, namespace1.Name, "backRef2", controllerName, &util.DefaultNetInfo{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			dbIDsWorker := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelWorker, namespace1.Name, controllerName)
+			dbIDsControlPlane := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelControlPlane, namespace1.Name, controllerName)
+			// expect 2 address sets with IPs populated
+			asf.EventuallyExpectAddressSetWithAddresses(dbIDsWorker, []string{ip1})
+			asf.EventuallyExpectAddressSetWithAddresses(dbIDsControlPlane, []string{ip2})
+			asf.ExpectNumberOfAddressSets(2)
+		})
+
+		ginkgo.It("doesn't add pod IP to address set if its labels don't match pod label selector", func() {
+			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Consistently(func(_ gomega.Gomega) {
+				asf.ExpectEmptyAddressSet(peerASIDs)
+			}).WithTimeout(500 * time.Millisecond).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("adds pod IP to address set if its labels match pod label selector", func() {
+			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod1Copy := pod1.DeepCopy()
+			pod1Copy.Labels = map[string]string{podLabelKey: podAppVideo}
+			_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), pod1Copy, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, []string{ip1})
+		})
+
+		ginkgo.It("adds pod IP to address set if its node labels match node label selector", func() {
+			specialNodeSelector := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					nodeLabelKey: "special-node",
+				},
+			}
+			podSelector := &metav1.LabelSelector{}
+			asID := GetPodSelectorAddrSetDbIDs(podSelector, nil, specialNodeSelector, namespace1.Name, controllerName)
+			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, specialNodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// expect the address set to be empty initially since nodeType "special-node" doesn't match "worker"
+			asf.EventuallyExpectEmptyAddressSetExist(asID)
+			// label the node as "special-node"
+			node1Copy := node1.DeepCopy()
+			node1Copy.Labels = map[string]string{nodeLabelKey: "special-node"}
+			_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), node1Copy, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// expect the address set to be populated
+			asf.EventuallyExpectAddressSetWithAddresses(asID, []string{ip1})
+		})
+
+		ginkgo.It("deletes pod IP from address set when pod is deleted", func() {
+			// label the pod to match the pod selector
+			pod1Copy := pod1.DeepCopy()
+			pod1Copy.Labels = map[string]string{podLabelKey: podAppVideo}
+			_, err := clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), pod1Copy, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, []string{ip1})
+			// delete the pod
+			err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Delete(context.TODO(), pod1.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+		})
+
+		ginkgo.It("deletes pod IP from address set when node label changes", func() {
+			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// add the pod to the address set
+			pod1Copy := pod1.DeepCopy()
+			pod1Copy.Labels = map[string]string{podLabelKey: podAppVideo}
+			_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), pod1Copy, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, []string{ip1})
+			// change the node label to not match the node selector
+			node1Copy := node1.DeepCopy()
+			node1Copy.Labels = map[string]string{nodeLabelKey: "control-plane"}
+			_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), node1Copy, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+		})
 	})
 })
 

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -1209,7 +1209,7 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 	}
 	// np.namespace will be used when fromJSON.NamespaceSelector = nil
 	asKey, ipv4as, ipv6as, err := bnc.addressSetManager.EnsureAddressSet(
-		podSelector, peer.NamespaceSelector, np.namespace, np.getKeyWithKind(), bnc.controllerName, bnc.GetNetInfo())
+		podSelector, peer.NamespaceSelector, nil, np.namespace, np.getKeyWithKind(), bnc.controllerName, bnc.GetNetInfo())
 	// even if GetPodSelectorAddressSet failed, add key for future cleanup or retry.
 	np.peerAddressSets = append(np.peerAddressSets, asKey)
 	if err != nil {

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -676,7 +676,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 			// Wait for netpols to appear
 			controllerName := l2Controller.controllerName
 			peer := netpol.Spec.Ingress[0].From[0]
-			dbIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, ns, controllerName)
+			dbIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, nil, ns, controllerName)
 			v4Hash, _ := addressset.GetHashNamesForAS(dbIDs)
 			Eventually(func(g Gomega) {
 				acls, err := libovsdbops.FindACLsWithPredicate(fakeOvn.nbClient, func(acl *nbdb.ACL) bool {

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			_, err = fakeOvn.asf.NewAddressSet(ns2, []string{"1.1.1.2"})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// netpol peer address set for existing netpol, should stay
-			netpol := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, "nsName", ovntypes.DefaultNetworkControllerName)
+			netpol := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", ovntypes.DefaultNetworkControllerName)
 			_, err = fakeOvn.asf.NewAddressSet(netpol, []string{"1.1.1.3"})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// egressQoS-owned address set, should stay

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -291,7 +291,7 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 		types.DefaultNetworkControllerName,
 	)
 	o.addressSetManager = addresssetmanager.NewAddressSetManager(o.watcher.PodCoreInformer(),
-		o.watcher.NamespaceInformer(), o.nbClient, o.networkManager.Interface().GetNetworkNameForNADKey)
+		o.watcher.NamespaceInformer(), o.watcher.NodeCoreInformer(), o.nbClient, o.networkManager.Interface().GetNetworkNameForNADKey)
 
 	if o.asf == nil {
 		o.eIPController.addressSetFactory = addressset.NewOvnAddressSetFactory(o.nbClient, config.IPv4Mode, config.IPv6Mode)

--- a/go-controller/pkg/ovn/policy_stale_test.go
+++ b/go-controller/pkg/ovn/policy_stale_test.go
@@ -152,7 +152,7 @@ func getStalePolicyACLs(gressIdx int, namespace, policyName string, peerNamespac
 				// nil pod selector is equivalent to empty pod selector, which selects all
 				podSelector = &metav1.LabelSelector{}
 			}
-			peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, namespace, controllerName)
+			peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, nil, namespace, controllerName)
 			asv4, _ := addressset.GetHashNamesForAS(peerIndex)
 			hashedASNames = append(hashedASNames, asv4)
 		}

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -277,7 +277,7 @@ func getGressACLs(gressIdx int, peers []knet.NetworkPolicyPeer, policyType knet.
 				// nil pod selector is equivalent to empty pod selector, which selects all
 				podSelector = &metav1.LabelSelector{}
 			}
-			peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, namespace, controllerName)
+			peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, nil, namespace, controllerName)
 			asv4, _ := addressset.GetHashNamesForAS(peerIndex)
 			hashedASNames = append(hashedASNames, asv4)
 		}
@@ -566,7 +566,7 @@ func getPortNetworkPolicy(policyName, namespace, labelName, labelVal string, tcp
 
 // buildNetworkPolicyPeerAddressSet builds the addresssets for the networkpolicy peer provided
 func buildNetworkPolicyPeerAddressSets(namespaceName string, peer knet.NetworkPolicyPeer, ips ...string) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	dbIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, namespaceName, types.DefaultNetworkControllerName)
+	dbIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespaceName, types.DefaultNetworkControllerName)
 	return addressset.GetTestDbAddrSets(dbIDs, ips)
 }
 
@@ -2633,7 +2633,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		asFactory = addressset.NewFakeAddressSetFactory(controllerName)
 		config.IPv4Mode = true
 		config.IPv6Mode = false
-		asIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, "nsName", types.DefaultNetworkControllerName)
+		asIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", types.DefaultNetworkControllerName)
 		gp := newGressPolicy(knet.PolicyTypeIngress, 0, "testing", "policy", controllerName,
 			false, &util.DefaultNetInfo{})
 		gp.hasPeerSelector = true


### PR DESCRIPTION
Enable address set to select pod IPs by nodeSelector



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address sets now support node selectors so policies can target workloads on specific nodes.
  * Address-set identities incorporate node selection, keeping sets distinct when node criteria differ.
  * Address sets are node-aware: node label changes trigger reconciliation and updates.

* **Bug Fixes**
  * Improved handling so pods are correctly added/removed from address sets when node membership changes.

* **Tests**
  * Expanded node-selector test coverage and added node-aware test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->