### PR TITLE
github actions: update actions version due to deprecation of nodejs 20

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Re-Test Action
         uses: ./.github/actions/retest-action

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,10 +35,10 @@ jobs:
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -112,7 +112,7 @@ jobs:
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: digests-fedora-${{ env.PLATFORM_PAIR }}
         path: /tmp/digests/*
@@ -126,7 +126,7 @@ jobs:
     needs: build-fedora
     steps:
     - name: Download digests
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: /tmp/digests
         pattern: digests-fedora-*
@@ -177,10 +177,10 @@ jobs:
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -252,7 +252,7 @@ jobs:
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: digests-ubuntu-${{ env.PLATFORM_PAIR }}
         path: /tmp/digests/*
@@ -266,7 +266,7 @@ jobs:
     needs: build-ubuntu
     steps:
     - name: Download digests
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: /tmp/digests
         pattern: digests-ubuntu-*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -55,7 +55,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -65,7 +65,7 @@ jobs:
           pip install $(mkdocs-get-deps)
       - run: mkdocs build --strict
       - name: Upload Artifact (Test)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-mkdocs-site
           path: ./site

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -107,7 +107,7 @@ jobs:
       METRICS_IP: "127.0.0.1"
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # Debug session for the performance test
     #- name: Setup tmate session
@@ -127,7 +127,7 @@ jobs:
         echo "sha=$PR_SHA" >> $GITHUB_OUTPUT
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.sha || github.sha }}
 
@@ -136,7 +136,7 @@ jobs:
       uses: ./.github/actions/diagnostics
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         cache: false
@@ -234,7 +234,7 @@ jobs:
         sudo systemctl restart docker
 
     - name: Download test-image-pr
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: test-image-pr
 
@@ -315,7 +315,7 @@ jobs:
     
     - name: Upload Prometheus installation logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: prometheus-install-logs-${{ matrix.perf-test }}-${{ github.run_id }}
         path: prometheus-install.log
@@ -373,21 +373,21 @@ jobs:
 
     - name: Upload performance report
       if: ${{ matrix.perf-test == 'kubelet-density-cni' || matrix.perf-test == 'udn-density-l2-noPods' || matrix.perf-test == 'cudn-density-l2-noPods' || matrix.perf-test == 'udn-density-l2-pods' || matrix.perf-test == 'cudn-density-l2-pods-netpol' || matrix.perf-test == 'udn-density-l2-pods-netpol' || matrix.perf-test == 'udn-density-l3-pods-netpol' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.perf-test }}-performance-report-${{ github.run_id }}
         path: /tmp/${{ matrix.perf-test }}/performance_report.md
 
     - name: Upload pprof data
       if: ${{ matrix.perf-test == 'kubelet-density-cni' || matrix.perf-test == 'udn-density-l2-noPods' || matrix.perf-test == 'cudn-density-l2-noPods' || matrix.perf-test == 'udn-density-l2-pods' || matrix.perf-test == 'cudn-density-l2-pods-netpol' || matrix.perf-test == 'udn-density-l2-pods-netpol' || matrix.perf-test == 'udn-density-l3-pods-netpol' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.perf-test }}-pprof-${{ github.run_id }}
         path: /tmp/${{ matrix.perf-test }}/pprof-data
 
     - name: Upload performance test data
       if: ${{ matrix.perf-test == 'kubelet-density-cni' || matrix.perf-test == 'udn-density-l2-noPods' || matrix.perf-test == 'cudn-density-l2-noPods' || matrix.perf-test == 'udn-density-l2-pods' || matrix.perf-test == 'cudn-density-l2-pods-netpol' || matrix.perf-test == 'udn-density-l2-pods-netpol' || matrix.perf-test == 'udn-density-l3-pods-netpol' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.perf-test }}-performance-test-data-${{ github.run_id }}
         path: /tmp/${{ matrix.perf-test }} 
@@ -400,7 +400,7 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.perf-test }}-kind-logs-${{ github.run_id }}
         path: /tmp/${{ matrix.perf-test }}/logs
@@ -458,13 +458,13 @@ jobs:
 
     - name: Check out code into the Go module directory
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event_name == 'issue_comment' && steps.pr_info.outputs.sha || github.sha }}
 
     - name: Set up Go
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         cache: false
@@ -509,7 +509,7 @@ jobs:
         cp ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR} ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
         gzip ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: test-image-pr
         path: ${{ env.CI_DIST_IMAGES_OUTPUT }}/${{ env.CI_IMAGE_PR_TAR }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -103,13 +103,13 @@ jobs:
     # only run the following steps if the base image was not found in the cache
     - name: Check out code into the Go module directory - from base branch
       if: steps.is_base_image_build_needed.outputs.BASE_IMAGE_RESTORED != 'true' && success()
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.base_ref || github.ref_name }}
 
     - name: Set up Go
       if: steps.is_base_image_build_needed.outputs.BASE_IMAGE_RESTORED != 'true' && success()
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -154,7 +154,7 @@ jobs:
         gzip ${CI_IMAGE_CACHE}${CI_IMAGE_BASE_TAR}
 
     # run the following always if none of the steps before failed
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: test-image-base
         path: ${{ env.CI_IMAGE_BASE_TAR }}
@@ -187,11 +187,11 @@ jobs:
     # only run the following steps if the PR image was not found in the cache
     - name: Check out code into the Go module directory - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -242,7 +242,7 @@ jobs:
         gzip ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
 
     # run the following if none of the previous steps failed
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: test-image-pr
         path: ${{ env.CI_DIST_IMAGES_OUTPUT }}/${{ env.CI_IMAGE_PR_TAR }}
@@ -252,10 +252,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -320,12 +320,12 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory - from Base branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
           ref: ${{ github.base_ref || github.ref_name }}
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -345,7 +345,7 @@ jobs:
       uses: ./.github/actions/free-disk-space
 
     - name: Download test-image-base
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: test-image-base
 
@@ -380,7 +380,7 @@ jobs:
         make -C test install-kind
 
     - name: Check out code into the Go module directory - from PR branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Export kind logs
       if: always()
@@ -394,13 +394,13 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
 
     - name: Download test-image-pr
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: test-image-pr
 
@@ -435,7 +435,7 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}-after-upgrade
         path: /tmp/kind/logs-kind-pr-branch
@@ -556,7 +556,7 @@ jobs:
       ENABLE_NO_OVERLAY_MANAGED_ROUTING: "${{ matrix.no-overlay == 'managed' }}"
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Runner Diagnostics
       if: always()
@@ -591,7 +591,7 @@ jobs:
         docker system info
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -653,7 +653,7 @@ jobs:
         sudo ufw disable
 
     - name: Download test-image-pr
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: test-image-pr
 
@@ -761,7 +761,7 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
@@ -794,14 +794,14 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Runner Diagnostics
       if: always()
       uses: ./.github/actions/diagnostics
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go-controller/go.mod'
         # Disabling cache to avoid warnings until these two issues are fixed
@@ -827,7 +827,7 @@ jobs:
         sudo ufw disable
 
     - name: Download test-image-pr
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: test-image-pr
 
@@ -886,7 +886,7 @@ jobs:
 
     - name: Upload kind logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
@@ -903,7 +903,7 @@ jobs:
 
     - name: Upload ovn dbs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kind-ovndbs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/ovndbs


### PR DESCRIPTION
go to Summary of any current CI run to check
Warning from the CI run:
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/download-artifact@v4, actions/setup-go@v5, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded GitHub Actions used across CI/CD workflows (checkout, Go setup, artifact upload/download and related action versions) to newer releases for improved stability and consistency.
  * Applied these version upgrades across multiple workflow jobs and platforms; no functional, build-command, or workflow-control changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->