### PR TITLE
  kubevirt: Support handling vm hostname field

### DIFF
--- a/go-controller/pkg/allocator/pod/macs.go
+++ b/go-controller/pkg/allocator/pod/macs.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"net"
 
-	kubevirtv1 "kubevirt.io/api/core/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -24,9 +22,9 @@ import (
 // macOwner compose the owner identifier reserved for MAC addresses management.
 // Returns "<ns>/<pod-name>" for regular pods and "<ns>/<vm-name>" for VMs.
 func macOwner(pod *corev1.Pod) string {
-	// Check if this is a VM pod and persistent IPs are enabled
-	if vmName, ok := pod.Labels[kubevirtv1.VirtualMachineNameLabel]; ok {
-		return fmt.Sprintf("%s/%s", pod.Namespace, vmName)
+	vmDescription, err := kubevirt.NewVMDescriptionFromPod(pod)
+	if err == nil && vmDescription != nil {
+		return vmDescription.Key().String()
 	}
 
 	// Default to pod-based identifier
@@ -43,10 +41,10 @@ func (allocator *PodAnnotationAllocator) ReleasePodReservedMacAddress(pod *corev
 	}
 
 	macOwnerID := macOwner(pod)
-	if vmKey := kubevirt.ExtractVMNameFromPod(pod); vmKey != nil {
+	if kubevirt.IsPodOwnedByVirtualMachine(pod) {
 		allVMPodsCompleted, err := kubevirt.AllVMPodsAreCompleted(allocator.podLister, pod)
 		if err != nil {
-			return fmt.Errorf("failed checking all VM %q pods are completed: %v", vmKey, err)
+			return fmt.Errorf("failed checking all VM %q pods are completed: %v", macOwnerID, err)
 		}
 		if !allVMPodsCompleted {
 			klog.V(5).Infof(`Retaining MAC address %q for owner %q on network %q because its in use by another VM pod`,

--- a/go-controller/pkg/clustermanager/pod/allocator_test.go
+++ b/go-controller/pkg/clustermanager/pod/allocator_test.go
@@ -20,6 +20,7 @@ import (
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,17 +51,21 @@ type testPod struct {
 	completed   bool
 	network     *nadapi.NetworkSelectionElement
 	labels      map[string]string
+	annotations map[string]string
 }
 
 func (p testPod) getPod(t *testing.T) *corev1.Pod {
 	t.Helper()
+	if p.annotations == nil {
+		p.annotations = map[string]string{}
+	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "pod",
 			UID:         apitypes.UID("pod"),
 			Namespace:   "namespace",
-			Annotations: map[string]string{},
 			Labels:      p.labels,
+			Annotations: p.annotations,
 		},
 		Spec: corev1.PodSpec{
 			HostNetwork: p.hostNetwork,
@@ -674,7 +679,13 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 					scheduled: true,
 					completed: true,
 					network:   &nadapi.NetworkSelectionElement{Namespace: "namespace", Name: "nad"},
-					labels:    map[string]string{"vm.kubevirt.io/name": "myvm"},
+					labels: map[string]string{
+						kubevirtv1.VirtualMachineNameLabel: "myvm",
+						kubevirtv1.AppLabel:                "virt-launcher",
+					},
+					annotations: map[string]string{
+						kubevirtv1.DomainAnnotation: "myvm",
+					},
 				},
 			},
 			expectMACRelease: &net.HardwareAddr{0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a},
@@ -713,7 +724,13 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 					scheduled: true,
 					completed: true,
 					network:   &nadapi.NetworkSelectionElement{Namespace: "namespace", Name: "nad"},
-					labels:    map[string]string{"vm.kubevirt.io/name": ""},
+					labels: map[string]string{
+						kubevirtv1.VirtualMachineNameLabel: "myvm",
+						kubevirtv1.AppLabel:                "virt-launcher",
+					},
+					annotations: map[string]string{
+						kubevirtv1.DomainAnnotation: "myvm",
+					},
 				},
 			},
 			newPodCopyRunning: true,
@@ -733,7 +750,13 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 					scheduled: true,
 					completed: true,
 					network:   &nadapi.NetworkSelectionElement{Namespace: "namespace", Name: "nad"},
-					labels:    map[string]string{"vm.kubevirt.io/name": "myvm"},
+					labels: map[string]string{
+						kubevirtv1.VirtualMachineNameLabel: "myvm",
+						kubevirtv1.AppLabel:                "virt-launcher",
+					},
+					annotations: map[string]string{
+						kubevirtv1.DomainAnnotation: "myvm",
+					},
 				},
 			},
 			expectError:     `failed to release pod "namespace/pod" mac "0a:0a:0a:0a:0a:0a": failed checking all VM "namespace/myvm" pods are completed: failed finding related pods for pod namespace/pod when checking if they are completed: test error`,
@@ -797,7 +820,13 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 				new: &testPod{
 					network:   &nadapi.NetworkSelectionElement{Namespace: "namespace", Name: "nad"},
 					scheduled: true,
-					labels:    map[string]string{"vm.kubevirt.io/name": "myvm"},
+					labels: map[string]string{
+						kubevirtv1.VirtualMachineNameLabel: "myvm",
+						kubevirtv1.AppLabel:                "virt-launcher",
+					},
+					annotations: map[string]string{
+						kubevirtv1.DomainAnnotation: "myvm",
+					},
 				},
 			},
 			expectAllocate: true,
@@ -814,7 +843,13 @@ func TestPodAllocator_reconcileForNAD(t *testing.T) {
 				new: &testPod{
 					scheduled: true, completed: true,
 					network: &nadapi.NetworkSelectionElement{Namespace: "namespace", Name: "nad"},
-					labels:  map[string]string{"vm.kubevirt.io/name": "myvm"},
+					labels: map[string]string{
+						kubevirtv1.VirtualMachineNameLabel: "myvm",
+						kubevirtv1.AppLabel:                "virt-launcher",
+					},
+					annotations: map[string]string{
+						kubevirtv1.DomainAnnotation: "myvm",
+					},
 				},
 			},
 			expectMACOwnerID: "namespace/myvm",

--- a/go-controller/pkg/kubevirt/dhcp.go
+++ b/go-controller/pkg/kubevirt/dhcp.go
@@ -75,11 +75,14 @@ func WithIPv6DNSServer(dnsServer string) func(*dhcpConfigs) {
 }
 
 func EnsureDHCPOptionsForLSP(controllerName string, nbClient libovsdbclient.Client, pod *corev1.Pod, ips []*net.IPNet, lsp *nbdb.LogicalSwitchPort, opts ...DHCPConfigsOpt) error {
-	vmKey := ExtractVMNameFromPod(pod)
-	if vmKey == nil {
+	vmDescription, err := NewVMDescriptionFromPod(pod)
+	if err != nil {
+		return fmt.Errorf("failed discovering vm description at pod %s/%s:%w", pod.Namespace, pod.Name, err)
+	}
+	if vmDescription == nil {
 		return fmt.Errorf("missing vm label at pod %s/%s", pod.Namespace, pod.Name)
 	}
-	dhcpConfigs, err := composeDHCPConfigs(controllerName, *vmKey, ips, opts...)
+	dhcpConfigs, err := composeDHCPConfigs(controllerName, vmDescription.Key(), ips, opts...)
 	if err != nil {
 		return fmt.Errorf("failed composing DHCP options: %v", err)
 	}
@@ -171,12 +174,15 @@ func composeDHCPOptions(controllerName string, vmKey ktypes.NamespacedName, dhcp
 }
 
 func DeleteDHCPOptions(nbClient libovsdbclient.Client, pod *corev1.Pod) error {
-	vmKey := ExtractVMNameFromPod(pod)
-	if vmKey == nil {
+	vmDescription, err := NewVMDescriptionFromPod(pod)
+	if err != nil {
+		return fmt.Errorf("failed discovering vm description at pod %s/%s:%w", pod.Namespace, pod.Name, err)
+	}
+	if vmDescription == nil {
 		return nil
 	}
 	if err := libovsdbops.DeleteDHCPOptionsWithPredicate(nbClient, func(item *nbdb.DHCPOptions) bool {
-		return item.ExternalIDs[string(libovsdbops.ObjectNameKey)] == vmKey.String()
+		return item.ExternalIDs[string(libovsdbops.ObjectNameKey)] == vmDescription.Key().String()
 	}); err != nil {
 		return err
 	}

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -12,9 +12,11 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/validate/content"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	v1 "k8s.io/client-go/listers/core/v1"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
@@ -29,6 +31,12 @@ import (
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/ndp"
+)
+
+var (
+	virtLauncherPodLabel = map[string]string{
+		kubevirtv1.AppLabel: "virt-launcher",
+	}
 )
 
 // DefaultGatewayReconciler is responsible for reconciling the default gateway
@@ -61,29 +69,17 @@ func IsPodLiveMigratable(pod *corev1.Pod) bool {
 	return ok
 }
 
-// TODO: remove adapter once all findVMRelatedPods usages transition to use PodLister
-type listPodsFn func(namespace string, selector metav1.LabelSelector) ([]*corev1.Pod, error)
-
 // findVMRelatedPods will return pods belong to the same vm annotated at pod and
 // filter out the one at the function argument
 func findVMRelatedPods(client *factory.WatchFactory, pod *corev1.Pod) ([]*corev1.Pod, error) {
-	return findVMRelatedPodsWithListerFn(client.GetPodsBySelector, pod)
-}
-
-func findVMRelatedPodsWithListerFn(listPodsFn listPodsFn, pod *corev1.Pod) ([]*corev1.Pod, error) {
-	vmName, ok := pod.Labels[kubevirtv1.VirtualMachineNameLabel]
-	if !ok {
-		return nil, nil
-	}
-	vmLabelSelector := metav1.LabelSelector{MatchLabels: map[string]string{kubevirtv1.VirtualMachineNameLabel: vmName}}
-	vmPods, err := listPodsFn(pod.Namespace, vmLabelSelector)
+	vmDescription, err := NewVMDescriptionFromPod(pod)
 	if err != nil {
 		return nil, err
 	}
-	if len(vmPods) == 0 {
-		return []*corev1.Pod{}, nil
+	vmPods, err := vmDescription.OwnedPods(client.PodCoreInformer().Lister())
+	if err != nil {
+		return nil, err
 	}
-
 	filteredOutVMPods := []*corev1.Pod{}
 	for _, vmPod := range vmPods {
 		// The purpose of this function is to return the "other" pods related
@@ -165,19 +161,17 @@ func EnsurePodAnnotationForVM(watchFactory *factory.WatchFactory, kube *kube.Kub
 }
 
 // AllVMPodsAreCompleted return true if all the vm pods are completed
-func AllVMPodsAreCompleted(podLister v1.PodLister, pod *corev1.Pod) (bool, error) {
+func AllVMPodsAreCompleted(podLister listersv1.PodLister, pod *corev1.Pod) (bool, error) {
 	if !util.PodCompleted(pod) {
 		return false, nil
 	}
 
-	f := func(namespace string, selector metav1.LabelSelector) ([]*corev1.Pod, error) {
-		s, err := metav1.LabelSelectorAsSelector(&selector)
-		if err != nil {
-			return nil, err
-		}
-		return podLister.Pods(namespace).List(s)
+	vmDescription, err := NewVMDescriptionFromPod(pod)
+	if err != nil {
+		return false, err
 	}
-	vmPods, err := findVMRelatedPodsWithListerFn(f, pod)
+
+	vmPods, err := vmDescription.OwnedPods(podLister)
 	if err != nil {
 		return false, fmt.Errorf("failed finding related pods for pod %s/%s when checking if they are completed: %v", pod.Namespace, pod.Name, err)
 	}
@@ -243,14 +237,93 @@ func nodeContainsPodSubnet(watchFactory *factory.WatchFactory, nodeName string, 
 	return false, nil
 }
 
-// ExtractVMNameFromPod returns namespace and name of vm backed up but the pod
-// for regular pods return nil
-func ExtractVMNameFromPod(pod *corev1.Pod) *ktypes.NamespacedName {
-	vmName, ok := pod.Labels[kubevirtv1.VirtualMachineNameLabel]
+// VMDescription holds the identity and ownership information for a KubeVirt
+// virtual machine derived from one of its virt-launcher pods. The key field
+// stores the namespaced name of the VM, and ownedPodsFn is a closure that
+// lists all pods belonging to the same VM via label or annotation selectors.
+type VMDescription struct {
+	key         ktypes.NamespacedName
+	ownedPodsFn func(podLister listersv1.PodLister) ([]*corev1.Pod, error)
+}
+
+func (vm VMDescription) Key() ktypes.NamespacedName {
+	return vm.key
+}
+
+func (vm VMDescription) OwnedPods(podLister listersv1.PodLister) ([]*corev1.Pod, error) {
+	return vm.ownedPodsFn(podLister)
+}
+
+func vmNameFromPod(pod *corev1.Pod) (string, error) {
+	vmName, ok := pod.Annotations[kubevirtv1.DomainAnnotation]
 	if !ok {
-		return nil
+		return "", fmt.Errorf("virtual machine pod %s/%s is missing the mandatory kubevirt annotation %s", pod.Namespace, pod.Name, kubevirtv1.DomainAnnotation)
 	}
-	return &ktypes.NamespacedName{Namespace: pod.Namespace, Name: vmName}
+	return vmName, nil
+}
+
+// nameToLabel truncates name to fit within the Kubernetes label value
+// maximum length of 63 characters (content.LabelValueMaxLength). If
+// name already fits, it is returned unchanged.
+func nameToLabel(name string) string {
+	if len(name) <= content.LabelValueMaxLength {
+		return name
+	}
+	return name[:content.LabelValueMaxLength]
+}
+
+// NewVMDescriptionFromPod builds a VMDescription from a virt-launcher pod.
+// Returns (nil, nil) if the pod is not owned by a virtual machine.
+// The VM name is extracted from the kubevirt domain annotation on the pod,
+// and the returned VMDescription.ownedPodsFn lists all sibling virt-launcher
+// pods belonging to the same VM. When the VM name label matches the
+// (possibly truncated) VM name, the lookup uses that label for efficiency;
+// otherwise it falls back to the generic virt-launcher label and filters
+// by the domain annotation to avoid false matches across VMs with long or
+// colliding names.
+func NewVMDescriptionFromPod(pod *corev1.Pod) (*VMDescription, error) {
+	if !IsPodOwnedByVirtualMachine(pod) {
+		return nil, nil
+	}
+
+	vmName, err := vmNameFromPod(pod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get VM name from pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	vmDescription := VMDescription{
+		key: ktypes.NamespacedName{Namespace: pod.Namespace, Name: vmName},
+	}
+
+	// By default filter pods first by "virt-launcher" pods
+	labelSelector := virtLauncherPodLabel
+
+	// if the label is the same (truncating it if is > 63 chars) search directly by label so we iterate less
+	vmNameLabel, ok := pod.Labels[kubevirtv1.VirtualMachineNameLabel]
+	if ok && nameToLabel(vmName) == vmNameLabel {
+		labelSelector = map[string]string{kubevirtv1.VirtualMachineNameLabel: vmNameLabel}
+	}
+
+	vmDescription.ownedPodsFn = func(podLister listersv1.PodLister) ([]*corev1.Pod, error) {
+		labelMatchedPods, err := podLister.Pods(vmDescription.key.Namespace).List(labels.SelectorFromSet(labelSelector))
+		if err != nil {
+			return nil, err
+		}
+		// Filter by DomainAnnotation to ensure we only include pods that actually belong to this VM
+		// (different VMs can have the same label if one VM's name matches another VM's hostname, or if vms names are very long but matches the truncated version of it)
+		ownedPods := []*corev1.Pod{}
+		for _, virtLauncherPod := range labelMatchedPods {
+			podVMName, err := vmNameFromPod(virtLauncherPod)
+			if err != nil {
+				return nil, err
+			}
+			if podVMName == vmDescription.key.Name {
+				ownedPods = append(ownedPods, virtLauncherPod)
+			}
+		}
+		return ownedPods, nil
+	}
+
+	return &vmDescription, nil
 }
 
 // CleanUpLiveMigratablePod remove routing and DHCP ovn related resources
@@ -304,10 +377,7 @@ func SyncVirtualMachines(nbClient libovsdbclient.Client, vms map[ktypes.Namespac
 func FindLiveMigratablePods(watchFactory *factory.WatchFactory) ([]*corev1.Pod, error) {
 	vmPods, err := watchFactory.GetAllPodsBySelector(
 		metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      kubevirtv1.VirtualMachineNameLabel,
-				Operator: metav1.LabelSelectorOpExists,
-			}},
+			MatchLabels: virtLauncherPodLabel,
 		},
 	)
 	if err != nil {
@@ -335,7 +405,14 @@ func allocateSyncMigratablePodIPs(watchFactory *factory.WatchFactory, lsManager 
 		return nil, "", nil, nil
 	}
 
-	vmKey := ExtractVMNameFromPod(pod)
+	vmDescription, err := NewVMDescriptionFromPod(pod)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	if vmDescription == nil {
+		return nil, "", nil, nil
+	}
+	vmKey := vmDescription.Key()
 
 	annotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadKey)
 	if err != nil {
@@ -345,13 +422,13 @@ func allocateSyncMigratablePodIPs(watchFactory *factory.WatchFactory, lsManager 
 	// If this zone do not own the subnet or the node that is passed
 	// do not match the switch, they should not be deallocated
 	if !zoneContainsPodSubnet || (nodeName != "" && switchName != nodeName) {
-		return vmKey, "", annotation, nil
+		return &vmKey, "", annotation, nil
 	}
 	expectedLogicalPortName, err := allocatePodIPsOnSwitch(pod, annotation, nadKey, switchName)
 	if err != nil {
-		return vmKey, "", nil, err
+		return &vmKey, "", nil, err
 	}
-	return vmKey, expectedLogicalPortName, annotation, nil
+	return &vmKey, expectedLogicalPortName, annotation, nil
 }
 
 // AllocateSyncMigratablePodIPsOnZone will refill ip pool in
@@ -391,7 +468,12 @@ func ZoneContainsPodSubnetOrUntracked(watchFactory *factory.WatchFactory, lsMana
 // IsPodOwnedByVirtualMachine returns true if the pod is own by a
 // kubevirt virtual machine, false otherwise.
 func IsPodOwnedByVirtualMachine(pod *corev1.Pod) bool {
-	return ExtractVMNameFromPod(pod) != nil
+	for k, v := range virtLauncherPodLabel {
+		if pod.Labels[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // IsPodAllowedForMigration determines whether a given pod is eligible for live migration
@@ -467,17 +549,17 @@ func (lm LiveMigrationStatus) IsTargetDomainReady() bool {
 //
 // Note: The function assumes that the pod is part of a VirtualMachine resource managed
 // by KubeVirt.
-func DiscoverLiveMigrationStatus(podLister v1.PodLister, pod *corev1.Pod) (*LiveMigrationStatus, error) {
-	vmKey := ExtractVMNameFromPod(pod)
-	if vmKey == nil {
-		return nil, nil
-	}
-
-	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{kubevirtv1.VirtualMachineNameLabel: vmKey.Name}})
+func DiscoverLiveMigrationStatus(podLister listersv1.PodLister, pod *corev1.Pod) (*LiveMigrationStatus, error) {
+	vmDescription, err := NewVMDescriptionFromPod(pod)
 	if err != nil {
 		return nil, err
 	}
-	vmPods, err := podLister.Pods(pod.Namespace).List(selector)
+
+	if vmDescription == nil {
+		return nil, nil
+	}
+
+	vmPods, err := vmDescription.OwnedPods(podLister)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/kubevirt/pod_test.go
+++ b/go-controller/pkg/kubevirt/pod_test.go
@@ -42,12 +42,22 @@ var _ = Describe("Kubevirt Pod", func() {
 	yetAnotherDuringMigrationKvTargetPod := runningKubevirtPod(t4)
 	readyMigrationKvTargetPod := domainReadyKubevirtPod(t4)
 
-	type testParams struct {
-		pods                    []corev1.Pod
-		expectedError           error
-		expectedMigrationStatus *LiveMigrationStatus
-	}
-	DescribeTable("DiscoverLiveMigrationStatus", func(params testParams) {
+	// Pods for hostname mismatch scenario (vm.kubevirt.io/name label != kubevirt.io/domain annotation)
+	hostnameVMName := "real-vm-name"
+	hostname := "shared-hostname"
+	runningKvSourcePodWithHostname := newKubevirtPodWithHostname(corev1.PodRunning, t0, hostnameVMName, hostname)
+	duringMigrationKvTargetPodWithHostname := newKubevirtPodWithHostname(corev1.PodRunning, t4, hostnameVMName, hostname)
+
+	// Pods for long VM name scenario (label truncated to 63 chars)
+	longVMName := "this-is-a-very-long-virtual-machine-name-that-exceeds-sixty-three-characters"
+	runningKvSourcePodWithLongName := newKubevirtPodWithLongName(corev1.PodRunning, t0, longVMName)
+	duringMigrationKvTargetPodWithLongName := newKubevirtPodWithLongName(corev1.PodRunning, t4, longVMName)
+
+	// Pods for colliding long VM names scenario (different VMs share the same truncated 63-char label)
+	collidingLongVMName := "this-is-a-very-long-virtual-machine-name-that-exceeds-sixty-three-characters-collider"
+	collidingVMPod := newKubevirtPodWithLongName(corev1.PodRunning, t2, collidingLongVMName)
+
+	initWatchFactory := func(pods []corev1.Pod) (*factory.WatchFactory, func()) {
 		Expect(config.PrepareTestConfig()).To(Succeed())
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
@@ -56,13 +66,23 @@ var _ = Describe("Kubevirt Pod", func() {
 		wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClient)
 		Expect(err).ToNot(HaveOccurred())
 
-		for _, pod := range params.pods {
+		for _, pod := range pods {
 			_, err := fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		Expect(wf.Start()).To(Succeed())
-		defer wf.Shutdown()
+		return wf, wf.Shutdown
+	}
+
+	type testParams struct {
+		pods                    []corev1.Pod
+		expectedError           error
+		expectedMigrationStatus *LiveMigrationStatus
+	}
+	DescribeTable("DiscoverLiveMigrationStatus", func(params testParams) {
+		wf, shutdown := initWatchFactory(params.pods)
+		defer shutdown()
 
 		currentPod := params.pods[0]
 		migrationStatus, err := DiscoverLiveMigrationStatus(wf.PodCoreInformer().Lister(), &currentPod)
@@ -188,23 +208,163 @@ var _ = Describe("Kubevirt Pod", func() {
 				expectedError: fmt.Errorf("unexpected live migration state at pods"),
 			},
 		),
+		Entry("discovers migration when VM has hostname configured (vmName label != domain annotation)",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePodWithHostname, duringMigrationKvTargetPodWithHostname},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePodWithHostname,
+					TargetPod: &duringMigrationKvTargetPodWithHostname,
+					State:     LiveMigrationInProgress,
+				},
+			},
+		),
+		Entry("discovers migration when VM name exceeds 63 chars (vmName label truncated)",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePodWithLongName, duringMigrationKvTargetPodWithLongName},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePodWithLongName,
+					TargetPod: &duringMigrationKvTargetPodWithLongName,
+					State:     LiveMigrationInProgress,
+				},
+			},
+		),
+		Entry("discovers migration when another VM has colliding truncated vmName label",
+			testParams{
+				pods: []corev1.Pod{runningKvSourcePodWithLongName, duringMigrationKvTargetPodWithLongName, collidingVMPod},
+				expectedMigrationStatus: &LiveMigrationStatus{
+					SourcePod: &runningKvSourcePodWithLongName,
+					TargetPod: &duringMigrationKvTargetPodWithLongName,
+					State:     LiveMigrationInProgress,
+				},
+			},
+		),
 	)
+
+	Describe("NewVMDescriptionFromPod", func() {
+		It("returns nil for non-kubevirt pod", func() {
+			pod := nonKubevirtPod()
+			desc, err := NewVMDescriptionFromPod(&pod)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(desc).To(BeNil())
+		})
+
+		It("returns correct key and finds owned pods for standard pod (vmName label == domain)", func() {
+			sourcePod := runningKvSourcePod
+			targetPod := duringMigrationKvTargetPod
+
+			wf, shutdown := initWatchFactory([]corev1.Pod{sourcePod, targetPod, nonKubevirtPod()})
+			defer shutdown()
+
+			desc, err := NewVMDescriptionFromPod(&sourcePod)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(desc).ToNot(BeNil())
+			Expect(desc.Key().Name).To(Equal(vmName))
+
+			pods, err := desc.OwnedPods(wf.PodCoreInformer().Lister())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods).To(HaveLen(2))
+			for _, p := range pods {
+				Expect(p.Annotations[kubevirtv1.DomainAnnotation]).To(Equal(vmName))
+			}
+		})
+
+		type vmDescriptionParams struct {
+			pods           []corev1.Pod
+			expectedVMName string
+			expectedPods   int
+		}
+		DescribeTable("returns correct key and finds only owned pods",
+			func(params vmDescriptionParams) {
+				allPods := append(params.pods, nonKubevirtPod())
+				wf, shutdown := initWatchFactory(allPods)
+				defer shutdown()
+
+				sourcePod := params.pods[0]
+				desc, err := NewVMDescriptionFromPod(&sourcePod)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(desc).ToNot(BeNil())
+				Expect(desc.Key().Name).To(Equal(params.expectedVMName))
+
+				pods, err := desc.OwnedPods(wf.PodCoreInformer().Lister())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pods).To(HaveLen(params.expectedPods))
+				for _, p := range pods {
+					Expect(p.Annotations[kubevirtv1.DomainAnnotation]).To(Equal(params.expectedVMName))
+				}
+			},
+			Entry("when VM has hostname (vmName label != domain annotation)",
+				vmDescriptionParams{
+					pods: []corev1.Pod{
+						newKubevirtPodWithHostname(corev1.PodRunning, t0, hostnameVMName, hostname),
+						newKubevirtPodWithHostname(corev1.PodRunning, t4, hostnameVMName, hostname),
+						newKubevirtPodWithHostname(corev1.PodRunning, t2, "other-vm", hostname),
+					},
+					expectedVMName: hostnameVMName,
+					expectedPods:   2,
+				},
+			),
+			Entry("when VM name exceeds 63 chars (truncated vmName label)",
+				vmDescriptionParams{
+					pods: []corev1.Pod{
+						newKubevirtPodWithLongName(corev1.PodRunning, t0, longVMName),
+						newKubevirtPodWithLongName(corev1.PodRunning, t4, longVMName),
+					},
+					expectedVMName: longVMName,
+					expectedPods:   2,
+				},
+			),
+			Entry("when multiple VMs share the same truncated vmName label",
+				vmDescriptionParams{
+					pods: func() []corev1.Pod {
+						longVMName1 := "this-is-a-very-long-virtual-machine-name-that-exceeds-sixty-three-characters-vm1"
+						longVMName2 := "this-is-a-very-long-virtual-machine-name-that-exceeds-sixty-three-characters-vm2"
+						longVMName3 := "this-is-a-very-long-virtual-machine-name-that-exceeds-sixty-three-characters-vm3"
+						return []corev1.Pod{
+							newKubevirtPodWithLongName(corev1.PodRunning, t0, longVMName1),
+							newKubevirtPodWithLongName(corev1.PodRunning, t4, longVMName1),
+							newKubevirtPodWithLongName(corev1.PodRunning, t2, longVMName2),
+							newKubevirtPodWithLongName(corev1.PodRunning, t3, longVMName3),
+						}
+					}(),
+					expectedVMName: "this-is-a-very-long-virtual-machine-name-that-exceeds-sixty-three-characters-vm1",
+					expectedPods:   2,
+				},
+			),
+		)
+
+		It("returns error when domain annotation is missing", func() {
+			pod := corev1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "virt-launcher-broken",
+					Namespace: corev1.NamespaceDefault,
+					Labels:    map[string]string{kubevirtv1.AppLabel: "virt-launcher"},
+				},
+			}
+			desc, err := NewVMDescriptionFromPod(&pod)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing the mandatory kubevirt annotation"))
+			Expect(desc).To(BeNil())
+		})
+	})
 })
 
 func completedKubevirtPod(creationOffset time.Duration) corev1.Pod {
-	return newKubevirtPod(corev1.PodSucceeded, nil, creationOffset)
+	return newKubevirtPod(corev1.PodSucceeded, creationOffset)
 }
 
 func failedKubevirtPod(creationOffset time.Duration) corev1.Pod {
-	return newKubevirtPod(corev1.PodFailed, nil, creationOffset)
+	return newKubevirtPod(corev1.PodFailed, creationOffset)
 }
 
 func runningKubevirtPod(creationOffset time.Duration) corev1.Pod {
-	return newKubevirtPod(corev1.PodRunning, nil, creationOffset)
+	return newKubevirtPod(corev1.PodRunning, creationOffset)
 }
 
 func domainReadyKubevirtPod(creationOffset time.Duration) corev1.Pod {
-	return newKubevirtPod(corev1.PodRunning, map[string]string{kubevirtv1.MigrationTargetReadyTimestamp: "some-timestamp"}, creationOffset)
+	virtLauncherPod := newKubevirtPod(corev1.PodRunning, creationOffset)
+	virtLauncherPod.Annotations[kubevirtv1.MigrationTargetReadyTimestamp] = "some-timestamp"
+	return virtLauncherPod
 }
 
 func nonKubevirtPod() corev1.Pod {
@@ -220,7 +380,8 @@ func nonKubevirtPod() corev1.Pod {
 		Spec: corev1.PodSpec{},
 	}
 }
-func newKubevirtPod(phase corev1.PodPhase, annotations map[string]string, creationOffset time.Duration) corev1.Pod {
+
+func newKubevirtPod(phase corev1.PodPhase, creationOffset time.Duration) corev1.Pod {
 	return corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -229,8 +390,48 @@ func newKubevirtPod(phase corev1.PodPhase, annotations map[string]string, creati
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "virt-launcher-" + vmName + rand.String(5),
 			Namespace:         corev1.NamespaceDefault,
-			Annotations:       annotations,
-			Labels:            map[string]string{kubevirtv1.VirtualMachineNameLabel: vmName},
+			Annotations:       map[string]string{kubevirtv1.DomainAnnotation: vmName},
+			Labels:            map[string]string{kubevirtv1.AppLabel: "virt-launcher", kubevirtv1.VirtualMachineNameLabel: vmName},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(creationOffset)},
+		},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func newKubevirtPodWithHostname(phase corev1.PodPhase, creationOffset time.Duration, vmName, hostname string) corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "virt-launcher-" + vmName + "-" + rand.String(5),
+			Namespace:         corev1.NamespaceDefault,
+			Annotations:       map[string]string{kubevirtv1.DomainAnnotation: vmName},
+			Labels:            map[string]string{kubevirtv1.AppLabel: "virt-launcher", kubevirtv1.VirtualMachineNameLabel: hostname},
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(creationOffset)},
+		},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func newKubevirtPodWithLongName(phase corev1.PodPhase, creationOffset time.Duration, longVMName string) corev1.Pod {
+	return corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "virt-launcher-" + longVMName[:40] + "-" + rand.String(5),
+			Namespace:         corev1.NamespaceDefault,
+			Annotations:       map[string]string{kubevirtv1.DomainAnnotation: longVMName},
+			Labels:            map[string]string{kubevirtv1.AppLabel: "virt-launcher", kubevirtv1.VirtualMachineNameLabel: longVMName[:63]},
 			CreationTimestamp: metav1.Time{Time: time.Now().Add(creationOffset)},
 		},
 		Spec: corev1.PodSpec{},

--- a/go-controller/pkg/kubevirt/router.go
+++ b/go-controller/pkg/kubevirt/router.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
@@ -25,13 +26,19 @@ import (
 )
 
 func DeleteRoutingForMigratedPodWithZone(nbClient libovsdbclient.Client, pod *corev1.Pod, zone string) error {
-	vm := ExtractVMNameFromPod(pod)
+	vmDescription, err := NewVMDescriptionFromPod(pod)
+	if err != nil {
+		return err
+	}
+	if vmDescription == nil {
+		return nil
+	}
 	predicate := func(itemExternalIDs map[string]string) bool {
 		containsZone := true
 		if zone != "" {
 			containsZone = itemExternalIDs[OvnZoneExternalIDKey] == zone
 		}
-		return containsZone && externalIDsContainsVM(itemExternalIDs, vm)
+		return containsZone && externalIDsContainsVM(itemExternalIDs, ptr.To(vmDescription.Key()))
 	}
 	routePredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
 		return predicate(item.ExternalIDs)
@@ -104,6 +111,13 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 
 	for _, podIP := range podAnnotation.IPs {
 		podAddress := podIP.IP.String()
+		vmDescription, err := NewVMDescriptionFromPod(pod)
+		if err != nil {
+			return err
+		}
+		if vmDescription == nil {
+			return nil
+		}
 
 		// Add a route for reroute ingress traffic to the VM port since
 		// the subnet is alien to ovn_cluster_router
@@ -115,7 +129,7 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 			OutputPort: &outputPort,
 			ExternalIDs: map[string]string{
 				OvnZoneExternalIDKey:         OvnLocalZone,
-				VirtualMachineExternalIDsKey: pod.Labels[kubevirtv1.VirtualMachineNameLabel],
+				VirtualMachineExternalIDsKey: vmDescription.Key().Name,
 				NamespaceExternalIDsKey:      pod.Namespace,
 			},
 		}
@@ -180,6 +194,13 @@ func EnsureRemoteZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory,
 	if err != nil {
 		return err
 	}
+	vmDescription, err := NewVMDescriptionFromPod(pod)
+	if err != nil {
+		return err
+	}
+	if vmDescription == nil {
+		return nil
+	}
 	for _, podIP := range podAnnotation.IPs {
 		ipFamily := utilnet.IPFamilyOfCIDR(podIP)
 		transitSwitchPortAddr, err := util.MatchFirstIPNetFamily(ipFamily == utilnet.IPv6, transitSwitchPortAddrs)
@@ -192,7 +213,7 @@ func EnsureRemoteZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory,
 			Policy:   &nbdb.LogicalRouterStaticRoutePolicyDstIP,
 			ExternalIDs: map[string]string{
 				OvnZoneExternalIDKey:         OvnRemoteZone,
-				VirtualMachineExternalIDsKey: pod.Labels[kubevirtv1.VirtualMachineNameLabel],
+				VirtualMachineExternalIDsKey: vmDescription.Key().Name,
 				NamespaceExternalIDsKey:      pod.Namespace,
 			},
 		}

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -94,7 +94,11 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 				Namespace: "foo",
 				Name:      "dummy",
 				Labels: map[string]string{
+					kubevirtv1.AppLabel:                "virt-launcher",
 					kubevirtv1.VirtualMachineNameLabel: t.vmName,
+				},
+				Annotations: map[string]string{
+					kubevirtv1.DomainAnnotation: t.vmName,
 				},
 			},
 		}
@@ -222,11 +226,18 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 		)
 
 		newVirtLauncherPod := func(name, nodeName string, phase corev1.PodPhase, annotations map[string]string) *corev1.Pod {
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
+			annotations[kubevirtv1.DomainAnnotation] = vmName
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              name,
-					Namespace:         "awips",
-					Labels:            map[string]string{kubevirtv1.VirtualMachineNameLabel: vmName},
+					Name:      name,
+					Namespace: "awips",
+					Labels: map[string]string{
+						kubevirtv1.AppLabel:                "virt-launcher",
+						kubevirtv1.VirtualMachineNameLabel: vmName,
+					},
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Annotations:       annotations,
 					OwnerReferences: []metav1.OwnerReference{{

--- a/go-controller/pkg/ovn/kubevirt_test.go
+++ b/go-controller/pkg/ovn/kubevirt_test.go
@@ -488,12 +488,14 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 			labels := map[string]string{
 				kubevirtv1.VirtualMachineNameLabel: t.vmName,
 				kubevirtv1.NodeNameLabel:           t.nodeName,
+				kubevirtv1.AppLabel:                "virt-launcher",
 			}
 			for k, v := range t.extraLabels {
 				labels[k] = v
 			}
 			annotations := map[string]string{
 				kubevirtv1.AllowPodBridgeNetworkLiveMigrationAnnotation: "",
+				kubevirtv1.DomainAnnotation:                             t.vmName,
 			}
 			for k, v := range t.extraAnnotations {
 				annotations[k] = v

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -453,6 +453,8 @@ func icClusterTestConfiguration(opts ...testConfigOpt) testConfiguration {
 func newMultiHomedKubevirtPod(vmName string, liveMigrationInfo liveMigrationPodInfo, testPod testPod, multiHomingConfigs ...userDefinedNetInfo) *corev1.Pod {
 	pod := newMultiHomedPod(testPod, multiHomingConfigs...)
 	pod.Labels[kubevirtv1.VirtualMachineNameLabel] = vmName
+	pod.Labels[kubevirtv1.AppLabel] = "virt-launcher"
+	pod.Annotations[kubevirtv1.DomainAnnotation] = vmName
 	pod.Status.Phase = liveMigrationInfo.podPhase
 	for key, val := range liveMigrationInfo.annotation {
 		pod.Annotations[key] = val

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -53,7 +53,6 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
-	testutils "k8s.io/kubernetes/test/utils"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -2355,40 +2354,30 @@ ip route add %[3]s via %[4]s
 	})
 	Context("with kubevirt VM using layer2 UDPN", Ordered, func() {
 		var (
-			podName                 = "virt-launcher-vm1"
-			cidrIPv4                = "172.31.0.0/24"
-			cidrIPv6                = "2010:100:200::/60"
-			primaryUDNNetworkStatus nadapi.NetworkStatus
-			virtLauncherCommand     = func(command string) (string, error) {
-				stdout, stderr, err := ExecShellInPodWithFullOutput(fr, namespace, podName, command)
-				if err != nil {
-					return "", fmt.Errorf("%s: %s: %w", stdout, stderr, err)
-				}
-				return stdout, nil
+			cidrIPv4   = "172.31.0.0/24"
+			cidrIPv6   = "2010:100:200::/60"
+			vmi        *kubevirtv1.VirtualMachineInstance
+			vmiCommand = func(command string) (string, error) {
+				return virtClient.RunCommand(vmi, command, 5*time.Second)
 			}
-			primaryUDNValueFor = func(ty, field string) ([]string, error) {
-				output, err := virtLauncherCommand(fmt.Sprintf(`nmcli -e no -g %s %s show ovn-udn1`, field, ty))
+			primaryUDNDeviceValue = func(field string) ([]string, error) {
+				output, err := vmiCommand(fmt.Sprintf(`nmcli -e no -g %s device show eth0`, field))
 				if err != nil {
 					return nil, err
 				}
+				output = strings.ReplaceAll(output, "\r", "")
 				return strings.Split(output, " | "), nil
-			}
-			primaryUDNValueForConnection = func(field string) ([]string, error) {
-				return primaryUDNValueFor("connection", field)
-			}
-			primaryUDNValueForDevice = func(field string) ([]string, error) {
-				return primaryUDNValueFor("device", field)
 			}
 		)
 		AfterAll(func() {
-			Expect(removeImagesInNodes(kubevirt.FakeLauncherImage)).To(Succeed())
+			Expect(removeImagesInNodes(kubevirt.FedoraWithTestToolingContainerDiskImage)).To(Succeed())
 		})
 		BeforeEach(func() {
 			ns, err := fr.CreateNamespace(context.TODO(), fr.BaseName, map[string]string{
 				"e2e-framework":           fr.BaseName,
 				RequiredUDNNamespaceLabel: "",
 			})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			fr.Namespace = ns
 			namespace = fr.Namespace.Name
 			dualCIDRs := filterDualStackCIDRs(fr.ClientSet, []udnv1.CIDR{udnv1.CIDR(cidrIPv4), udnv1.CIDR(cidrIPv6)})
@@ -2396,44 +2385,38 @@ ip route add %[3]s via %[4]s
 			cudn.Spec.Network.Layer2.MTU = 1300
 			createCUDN(cudn)
 
-			By("Create virt-launcher pod")
-			kubevirtPod := kubevirt.GenerateFakeVirtLauncherPod(namespace, "vm1")
-			Expect(crClient.Create(context.Background(), kubevirtPod)).To(Succeed())
+			By("Create VMI with primary UDN")
+			networkData := `version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+    dhcp6: true
+    ipv6-address-generation: eui64`
+			vmi = fedoraWithTestToolingVMI(nil /*labels*/, nil /*annotations*/, nil, /*nodeSelector*/
+				kubevirtv1.NetworkSource{
+					Pod: &kubevirtv1.PodNetwork{},
+				}, "#", networkData)
+			vmi.Spec.Domain.Devices.Interfaces[0].Bridge = nil
+			vmi.Spec.Domain.Devices.Interfaces[0].Binding = &kubevirtv1.PluginBinding{Name: "l2bridge"}
+			createVirtualMachineInstance(vmi)
 
-			By("Wait for virt-launcher pod to be ready and primary UDN network status to pop up")
-			waitForPodsCondition([]*corev1.Pod{kubevirtPod}, func(g Gomega, pod *corev1.Pod) {
-				ok, err := testutils.PodRunningReady(pod)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(ok).To(BeTrue())
+			By("Wait for VMI to be ready")
+			waitVirtualMachineInstanceReadiness(vmi)
+			Expect(crClient.Get(context.Background(), crclient.ObjectKeyFromObject(vmi), vmi)).To(Succeed())
 
-				primaryUDNNetworkStatuses, err := podNetworkStatus(pod, func(networkStatus nadapi.NetworkStatus) bool {
-					return networkStatus.Default
-				})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(primaryUDNNetworkStatuses).To(HaveLen(1))
-				primaryUDNNetworkStatus = primaryUDNNetworkStatuses[0]
-			})
-
-			By("Wait NetworkManager readiness")
-			Eventually(func() error {
-				_, err := virtLauncherCommand("systemctl is-active NetworkManager")
-				return err
-			}).
-				WithTimeout(5 * time.Second).
-				WithPolling(time.Second).
-				Should(Succeed())
-
-			By("Reconfigure primary UDN interface to use dhcp/nd for ipv4 and ipv6")
-			_, err = virtLauncherCommand(kubevirt.GenerateAddressDiscoveryConfigurationCommand("ovn-udn1"))
-			Expect(err).NotTo(HaveOccurred())
+			By("Login to the VM console")
+			Expect(virtClient.LoginToFedora(vmi, "fedora", "fedora")).To(Succeed())
 		})
 		It("should configure IPv4 and IPv6 using DHCP and NDP", func() {
 			dnsService, err := fr.ClientSet.CoreV1().Services(config.Kubernetes.DNSServiceNamespace).
 				Get(context.Background(), config.Kubernetes.DNSServiceName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
+			expectedNumberOfAddresses := len(filterDualStackCIDRs(fr.ClientSet, []udnv1.CIDR{udnv1.CIDR(cidrIPv4), udnv1.CIDR(cidrIPv6)}))
+			vmiAddresses := virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
+
 			if isIPv4Supported(fr.ClientSet) {
-				expectedIP, err := matchIPv4StringFamily(primaryUDNNetworkStatus.IPs)
+				expectedIP, err := matchIPv4StringFamily(vmiAddresses)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedDNS, err := matchIPv4StringFamily(dnsService.Spec.ClusterIPs)
@@ -2443,40 +2426,40 @@ ip route add %[3]s via %[4]s
 				Expect(err).NotTo(HaveOccurred())
 				expectedGateway := util.GetNodeGatewayIfAddr(cidr).IP.String()
 
-				Eventually(primaryUDNValueForConnection).
+				Eventually(primaryUDNDeviceValue).
 					WithArguments("DHCP4.OPTION").
 					WithTimeout(10 * time.Second).
 					WithPolling(time.Second).
 					Should(ContainElements(
-						"host_name = vm1",
+						fmt.Sprintf("host_name = %s", vmi.Name),
 						fmt.Sprintf("ip_address = %s", expectedIP),
 						fmt.Sprintf("domain_name_servers = %s", expectedDNS),
 						fmt.Sprintf("routers = %s", expectedGateway),
 						"interface_mtu = 1300",
 					))
-				Expect(primaryUDNValueForConnection("IP4.ADDRESS")).To(ConsistOf(expectedIP + "/24"))
-				Expect(primaryUDNValueForConnection("IP4.GATEWAY")).To(ConsistOf(expectedGateway))
-				Expect(primaryUDNValueForConnection("IP4.DNS")).To(ConsistOf(expectedDNS))
-				Expect(primaryUDNValueForDevice("GENERAL.MTU")).To(ConsistOf("1300"))
+				Expect(primaryUDNDeviceValue("IP4.ADDRESS")).To(ConsistOf(expectedIP + "/24"))
+				Expect(primaryUDNDeviceValue("IP4.GATEWAY")).To(ConsistOf(expectedGateway))
+				Expect(primaryUDNDeviceValue("IP4.DNS")).To(ConsistOf(expectedDNS))
+				Expect(primaryUDNDeviceValue("GENERAL.MTU")).To(ConsistOf("1300"))
 			}
 
 			if isIPv6Supported(fr.ClientSet) {
-				expectedIP, err := matchIPv6StringFamily(primaryUDNNetworkStatus.IPs)
+				expectedIP, err := matchIPv6StringFamily(vmiAddresses)
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(primaryUDNValueFor).
-					WithArguments("connection", "DHCP6.OPTION").
+				Eventually(primaryUDNDeviceValue).
+					WithArguments("DHCP6.OPTION").
 					WithTimeout(10 * time.Second).
 					WithPolling(time.Second).
 					Should(ContainElements(
-						"fqdn_fqdn = vm1",
+						fmt.Sprintf("fqdn_fqdn = %s", vmi.Name),
 						fmt.Sprintf("ip6_address = %s", expectedIP),
 					))
-				Expect(primaryUDNValueForConnection("IP6.ADDRESS")).To(SatisfyAll(HaveLen(2), ContainElements(expectedIP+"/128")))
-				Expect(primaryUDNValueForConnection("IP6.GATEWAY")).To(ConsistOf(WithTransform(func(ipv6 string) bool {
+				Expect(primaryUDNDeviceValue("IP6.ADDRESS")).To(SatisfyAll(HaveLen(2), ContainElements(expectedIP+"/128")))
+				Expect(primaryUDNDeviceValue("IP6.GATEWAY")).To(ConsistOf(WithTransform(func(ipv6 string) bool {
 					return netip.MustParseAddr(ipv6).IsLinkLocalUnicast()
 				}, BeTrue())))
-				Expect(primaryUDNValueForConnection("IP6.ROUTE")).To(ContainElement(ContainSubstring(fmt.Sprintf("dst = %s", cidrIPv6))))
-				Expect(primaryUDNValueForDevice("GENERAL.MTU")).To(ConsistOf("1300"))
+				Expect(primaryUDNDeviceValue("IP6.ROUTE")).To(ContainElement(ContainSubstring(fmt.Sprintf("dst = %s", cidrIPv6))))
+				Expect(primaryUDNDeviceValue("GENERAL.MTU")).To(ConsistOf("1300"))
 			}
 		})
 	})

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -2528,6 +2528,52 @@ password: fedora
 chpasswd: { expire: False }
 `
 		)
+		It("should start multiple VMs with same hostname", func() {
+			By("setting up the localnet underlay")
+			cudn, networkName := kubevirt.GenerateCUDN(namespace, "net1", udnv1.NetworkTopologyLocalnet, udnv1.NetworkRoleSecondary, udnv1.DualStackCIDRs{})
+			createCUDN(cudn)
+
+			Expect(providerCtx.SetupUnderlay(fr, infraapi.Underlay{LogicalNetworkName: networkName})).To(Succeed())
+
+			type vmConfig struct {
+				ipv4 string
+				ipv6 string
+				mac  string
+			}
+			configs := []vmConfig{
+				{ipv4: "172.31.0.101/24", ipv6: "2010:100:200::101/60", mac: "0A:58:0A:80:00:65"},
+				{ipv4: "172.31.0.102/24", ipv6: "2010:100:200::102/60", mac: "0A:58:0A:80:00:66"},
+				{ipv4: "172.31.0.103/24", ipv6: "2010:100:200::103/60", mac: "0A:58:0A:80:00:67"},
+			}
+
+			vmis := make([]*kubevirtv1.VirtualMachineInstance, len(configs))
+			for i, cfg := range configs {
+				filteredCIDRs := filterCIDRs(fr.ClientSet, cfg.ipv4, cfg.ipv6)
+				networkData, err := staticIPsNetworkData(filteredCIDRs)
+				Expect(err).NotTo(HaveOccurred())
+
+				vm := fedoraWithTestToolingVM(nil, nil, nil, kubevirtv1.NetworkSource{
+					Multus: &kubevirtv1.MultusNetwork{
+						NetworkName: cudn.Name,
+					},
+				}, userData, networkData)
+				vm.Spec.Template.Spec.Hostname = "shared-hostname"
+				vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress = cfg.mac
+				createVirtualMachine(vm)
+
+				vmis[i] = &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      vm.Name,
+					},
+				}
+			}
+
+			By("Waiting for all 3 VMIs to become ready")
+			for _, vmi := range vmis {
+				waitVirtualMachineInstanceReadiness(vmi)
+			}
+		})
 		DescribeTable("should maintain tcp connection with minimal downtime", func(td func(vmi *kubevirtv1.VirtualMachineInstance)) {
 			By("setting up the localnet underlay")
 			cudn, networkName := kubevirt.GenerateCUDN(namespace, "net1", udnv1.NetworkTopologyLocalnet, udnv1.NetworkRoleSecondary, udnv1.DualStackCIDRs{})

--- a/test/e2e/kubevirt/net.go
+++ b/test/e2e/kubevirt/net.go
@@ -19,17 +19,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
-func GenerateAddressDiscoveryConfigurationCommand(iface string) string {
-	// since kindest/node v1.32+, which was upgraded with containerd v2, /sys is
-	// mounted into kind pods as read/write which activates udev in them
-	// including a rule that sets as unmanaged any veth device with a name not
-	// starting with 'eth*'. To workaround, we force the device as managed here.
-	return fmt.Sprintf(`
-nmcli d set %[1]s managed true
-nmcli c mod %[1]s ipv4.addresses "" ipv6.addresses "" ipv4.gateway "" ipv6.gateway "" ipv6.method auto ipv4.method auto ipv6.addr-gen-mode eui64
-nmcli d reapply %[1]s`, iface)
-}
-
 func RetrieveCachedGatewayMAC(cli *Client, vmi *kubevirtv1.VirtualMachineInstance, dev, cidr string) (string, error) {
 	_, ipNet, err := net.ParseCIDR(cidr)
 	if err != nil {

--- a/test/e2e/kubevirt/pod.go
+++ b/test/e2e/kubevirt/pod.go
@@ -24,7 +24,11 @@ func GenerateFakeVirtLauncherPod(namespace, vmName string) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "virt-launcher-" + vmName,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				kubevirtv1.DomainAnnotation: vmName,
+			},
 			Labels: map[string]string{
+				kubevirtv1.AppLabel:                "virt-launcher",
 				kubevirtv1.VirtualMachineNameLabel: vmName,
 			},
 		},

--- a/test/e2e/kubevirt/pod.go
+++ b/test/e2e/kubevirt/pod.go
@@ -8,44 +8,11 @@ import (
 	"fmt"
 
 	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
-
-	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 const (
 	AddressesAnnotation = "network.kubevirt.io/addresses"
 )
-
-func GenerateFakeVirtLauncherPod(namespace, vmName string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "virt-launcher-" + vmName,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				kubevirtv1.DomainAnnotation: vmName,
-			},
-			Labels: map[string]string{
-				kubevirtv1.AppLabel:                "virt-launcher",
-				kubevirtv1.VirtualMachineNameLabel: vmName,
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "compute",
-				Image: FakeLauncherImage,
-				SecurityContext: &corev1.SecurityContext{
-					Privileged: ptr.To(true),
-					Capabilities: &corev1.Capabilities{
-						Add: []corev1.Capability{"NET_ADMIN"},
-					},
-				},
-			}},
-		},
-	}
-}
 
 func ForceKillVirtLauncherAtNode(p infraapi.Provider, nodeName, vmNamespace, vmName string) error {
 	// /usr/bin/virt-launcher --qemu-timeout 312s --name worker-dcf9j --uid bcf975f4-7bdd-4264-948b-b6080320e38a --namespace kv-live-migration-2575 --kubevirt-share-dir /var/run/kubevirt --ephemeral-disk-dir /var/run/kubevirt-ephemeral-disks --container-disk-dir /var/run/kubevirt/container-disks --grace-period-seconds 20 --hook-sidecars 0 --ovmf-path /usr/share/OVMF --run-as-nonroot

--- a/test/e2e/kubevirt/types.go
+++ b/test/e2e/kubevirt/types.go
@@ -7,5 +7,4 @@ const (
 	FedoraCoreOSContainerDiskImage          = "quay.io/kubevirtci/fedora-coreos-kubevirt:v20230905-be4fa50"
 	FedoraWithTestToolingContainerDiskImage = "quay.io/kubevirtci/fedora-with-test-tooling:v20250416-e37573e"
 	FedoraContainerDiskImage                = "quay.io/containerdisks/fedora:39"
-	FakeLauncherImage                       = "quay.io/nmstate/c10s-nmstate-dev:latest"
 )


### PR DESCRIPTION
## 📑 Description
  When a VM's spec.template.spec.hostname is set, KubeVirt copies it into the vm.kubevirt.io/name label on virt-launcher pods instead of the actual VM name. OVN-K used this label to find pods belonging to a VM
  (e.g. during live migration, or to tag OVN topology elements for cleanup). Since multiple VMs can share the same hostname, the label can no longer uniquely identify a VM's pods — with 3+ VMs sharing a         
  hostname, the 3rd VM fails with "unexpected live migration state at pods".
                                                                                                                                                                                                                   
  This change switches to the kubevirt.io/domain annotation, which always reflects the real VM name. Since annotations can't be used in label selectors, we optimize: if the domain name matches the               
  vm.kubevirt.io/name label (the common case), we use the label for lookup; otherwise we fall back to iterating virt-launcher pods in the namespace and matching by annotation.
                                                                                                                                                                                                                   
  Note: KubeVirt >= 1.7 introduces a vm.kubevirt.io/id label that reliably identifies the VM, but it is not added retroactively to pods created with older versions. If KubeVirt adds a mutating webhook for that  
  in the future, we can use it as a further optimization.


### KubeVirt pod identifiers

| Identifier | Type | Source | Truncation | Uniqueness |
|---|---|---|---|---|
| `kubevirt.io/domain` | Annotation | VMI object name | None (annotations have no length limit) | Unique per VMI |
| `vm.kubevirt.io/name` (**deprecated**) | Label | VM hostname (can be overridden via `spec.template.spec.hostname`) | Truncates to 63 chars, no hash | **Not unique** — different VMs with the same hostname or names sharing the first 63 chars get the same value |
| `vmi.kubevirt.io/id` | Label | VMI name | Truncates + appends sha1 hash for names > 63 chars | Unique (hash preserves uniqueness) |

Fixes https://redhat.atlassian.net/browse/CNV-79752

### References

- KubeVirt PR introducing `vmi.kubevirt.io/id` and deprecating `vm.kubevirt.io/name`: https://github.com/kubevirt/kubevirt/pull/15783

## Additional Information for reviewers

Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5520

Kubevirt issue https://github.com/kubevirt/kubevirt/issues/17869

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it
The PR includes unit tests and e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple virtual machines sharing the same hostname with distinct network configurations and MAC addresses.

* **Tests**
  * Added end-to-end test validating multiple virtual machines with identical hostnames and distinct static IP address assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->