### PR TITLE
EVPN E2E: Use framework.CreateTestingNS for test namespace setup

### DIFF
--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -3028,22 +3028,13 @@ func createNamespaceWithPrimaryNetworkOfType(
 		frrConfigurationLabels = map[string]string{"network": networkName}
 	}
 
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: networkName,
-			Labels: map[string]string{
-				"e2e-framework": testName,
-			},
-		},
+	nsLabels := map[string]string{
+		"e2e-framework": testName,
 	}
 	if networkType != defaultNetwork {
-		namespace.Labels[RequiredUDNNamespaceLabel] = ""
+		nsLabels[RequiredUDNNamespaceLabel] = ""
 	}
-	namespace, err := f.ClientSet.CoreV1().Namespaces().Create(
-		context.Background(),
-		namespace,
-		metav1.CreateOptions{},
-	)
+	namespace, err := framework.CreateTestingNS(context.Background(), networkName, f.ClientSet, nsLabels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create namespace: %w", err)
 	}


### PR DESCRIPTION
This PR replaces direct API call with `framework.CreateTestingNS()` to ensure that the required labels are correctly propagated to the test namespace, as configured in `newPrivilegedTestFramework`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated end-to-end tests to use a centralized framework helper for namespace creation, improving consistency and maintainability of test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->