### PR TITLE
config: move EnableMulticast into OVNKubernetesFeatureConfig struct

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -225,9 +225,6 @@ var (
 	// UnprivilegedMode allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
 	UnprivilegedMode bool
 
-	// EnableMulticast enables multicast support between the pods within the same namespace
-	EnableMulticast bool
-
 	// IPv4Mode captures whether we are using IPv4 for OVN logical topology. (ie, single-stack IPv4 or dual-stack)
 	IPv4Mode bool
 
@@ -505,6 +502,8 @@ type OVNKubernetesFeatureConfig struct {
 	EnableObservability             bool `gcfg:"enable-observability"`
 	EnableNetworkQoS                bool `gcfg:"enable-network-qos"`
 	AllowICMPNetworkPolicy          bool `gcfg:"allow-icmp-network-policy"`
+	// EnableMulticast enables multicast support between the pods within the same namespace
+	EnableMulticast bool `gcfg:"enable-multicast"`
 	// This feature requires a kernel fix https://github.com/torvalds/linux/commit/7f3287db654395f9c5ddd246325ff7889f550286
 	// to work on a kind cluster. Flag allows to disable it for current CI, will be turned on when github runners have this fix.
 	AdvertisedUDNIsolationMode string `gcfg:"advertised-udn-isolation-mode"`
@@ -799,7 +798,6 @@ func PrepareTestConfig() error {
 	NoOverlay = savedNoOverlay
 	ManagedBGP = savedManagedBGP
 	Kubernetes.DisableRequestedChassis = false
-	EnableMulticast = false
 	UnprivilegedMode = false
 	Default.OVSDBTxnTimeout = 5 * time.Second
 	if Gateway.Mode != GatewayModeDisabled {
@@ -1046,7 +1044,7 @@ var CommonFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:        "enable-multicast",
 		Usage:       "Adds multicast support. Valid only with --init-master option.",
-		Destination: &EnableMulticast,
+		Destination: &cliConfig.OVNKubernetesFeature.EnableMulticast,
 	},
 	// Logging options
 	&cli.IntFlag{

--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -275,7 +275,7 @@ func NewControllerManager(ovnClient *util.OVNClientset, wf *factory.WatchFactory
 		podRecorder:      &podRecorder,
 		portCache:        ovn.NewPortCache(stopCh),
 		wg:               wg,
-		multicastSupport: config.EnableMulticast,
+		multicastSupport: config.OVNKubernetesFeature.EnableMulticast,
 	}
 	var err error
 

--- a/go-controller/pkg/ovn/kubevirt_test.go
+++ b/go-controller/pkg/ovn/kubevirt_test.go
@@ -561,7 +561,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 		app.Flags = config.Flags
 
 		// To skip port group not found error
-		config.EnableMulticast = false
+		config.OVNKubernetesFeature.EnableMulticast = false
 		config.Gateway.DisableSNATMultipleGWs = true
 
 		fakeOvn = NewFakeOVN(true)

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -452,7 +452,7 @@ func NewLayer2UserDefinedNetworkController(
 
 	// enable multicast support for UDN only for primaries + multicast enabled
 	// TBD: changes needs to be made to support multicast beyond primary UDN
-	oc.multicastSupport = oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() && config.EnableMulticast
+	oc.multicastSupport = oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() && config.OVNKubernetesFeature.EnableMulticast
 
 	oc.initRetryFramework()
 	return oc, nil

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -425,7 +425,7 @@ func NewLayer3UserDefinedNetworkController(
 
 	// enable multicast support for UDN only for primaries + multicast enabled
 	// TBD: changes needs to be made to support multicast beyond primary UDN
-	oc.multicastSupport = oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() && config.EnableMulticast
+	oc.multicastSupport = oc.IsPrimaryNetwork() && util.IsNetworkSegmentationSupportEnabled() && config.OVNKubernetesFeature.EnableMulticast
 
 	oc.initRetryFramework()
 	return oc, nil

--- a/go-controller/pkg/ovn/multicast_test.go
+++ b/go-controller/pkg/ovn/multicast_test.go
@@ -364,7 +364,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 	BeforeEach(func() {
 		// Restore global default values before each testcase
 		Expect(config.PrepareTestConfig()).To(Succeed())
-		config.EnableMulticast = true
+		config.OVNKubernetesFeature.EnableMulticast = true
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.OVNKubernetesFeature.EnableMultiNetworkPolicy = true
@@ -373,7 +373,7 @@ var _ = Describe("OVN Multicast with IP Address Family", func() {
 
 		app = cli.NewApp()
 		app.Name = "test"
-		// flags are written to config.EnableMulticast
+		// flags are written to config.OVNKubernetesFeature.EnableMulticast
 		// if there is no --enable-multicast flag, it will set to false.
 		// alternative approach is to give this flag to app.Run, but that require more changes.
 		//app.Flags = config.Flags

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -586,7 +586,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 
 					namespace1 := *ovntest.NewNamespace(namespaceName1)
 
-					config.EnableMulticast = false
+					config.OVNKubernetesFeature.EnableMulticast = false
 					startOvn(initialDB, watchNodes, []corev1.Node{node}, []corev1.Namespace{namespace1}, nil, nil,
 						[]nettypes.NetworkAttachmentDefinition{*nad}, []testPod{}, map[string]string{labelName: labelVal})
 

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -304,7 +304,7 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 		o.addressSetManager,
 	)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	o.controller.multicastSupport = config.EnableMulticast
+	o.controller.multicastSupport = config.OVNKubernetesFeature.EnableMulticast
 	o.eIPController.zone = o.controller.zone
 
 	setupCOPP := false


### PR DESCRIPTION
## Problem

`EnableMulticast` was declared as a **global variable** in `config.go`, but CNO writes `enable-multicast=true` under the `[ovnkubernetesfeature]` section in `ovnkube.conf`. The gcfg parser looks for `enable-multicast` inside the `OVNKubernetesFeatureConfig` struct when parsing that section — since the field was not there, gcfg silently discards the value and emits:

```
W config.go: can't store data at section "ovnkubernetesfeature", variable "enable-multicast"
```

This leaves `config.EnableMulticast = false` at runtime even when multicast is configured, resulting in:
- No multicast ACLs created in the OVN NB database (`clusterRtrPortGroup acls: []`)
- No `mcast_snoop` set on node logical switches
- 100% cross-node multicast packet loss

Verified broken on OCP 4.21 (AWS) and 4.22.0 nightly (GCP).

## Fix

- Remove the orphaned global `EnableMulticast bool` declaration
- Add `EnableMulticast bool \`gcfg:"enable-multicast"\`` into `OVNKubernetesFeatureConfig` struct so the `[ovnkubernetesfeature]` config section is parsed correctly
- Update the CLI flag `Destination` to `&cliConfig.OVNKubernetesFeature.EnableMulticast`
- Update all call sites (`controller_manager.go`, `layer2_user_defined_network_controller.go`, `layer3_user_defined_network_controller.go`) and test files

## Testing

- `go build ./pkg/config/... ./pkg/controllermanager/... ./pkg/ovn/...` — passes
- Existing multicast unit tests updated to reference `config.OVNKubernetesFeature.EnableMulticast`

Fixes: https://issues.redhat.com/browse/OCPBUGS-78731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized multicast configuration structure to support per-namespace feature settings instead of global settings, enabling more granular control over multicast support across different namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->