### PR TITLE
Avoid netlink dump when checking VRF membership

### DIFF
--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -217,11 +217,11 @@ func (vrfm *Controller) sync(vrf vrf) error {
 		}
 	}
 	if len(vrf.managedSlave) > 0 {
-		existingSlaves, err := getSlaveInterfaceNamesForVRF(vrfLink)
+		alreadyEnslaved, err := isInterfaceSlaveOfVRF(vrf.managedSlave, vrfLink.Attrs().Index)
 		if err != nil {
-			return fmt.Errorf("failed to get existing slaves for VRF device %s, err: %v", vrfLink.Attrs().Name, err)
+			return fmt.Errorf("failed to check if %s is slave of VRF device %s, err: %v", vrf.managedSlave, vrfLink.Attrs().Name, err)
 		}
-		if !existingSlaves.Has(vrf.managedSlave) {
+		if !alreadyEnslaved {
 			if err = enslaveInterfaceToVRF(vrf.name, vrf.managedSlave); err != nil {
 				return fmt.Errorf("failed to enslave interface %s into VRF device: %s, err: %v", vrf.managedSlave, vrf.name, err)
 			}
@@ -425,18 +425,16 @@ func (vrfm *Controller) deleteVRF(link netlink.Link) error {
 	return util.GetNetLinkOps().LinkDelete(link)
 }
 
-func getSlaveInterfaceNamesForVRF(vrfLink netlink.Link) (sets.Set[string], error) {
-	links, err := util.GetNetLinkOps().LinkList()
+// isInterfaceSlaveOfVRF checks if a specific interface is enslaved to a VRF
+func isInterfaceSlaveOfVRF(ifName string, vrfIndex int) (bool, error) {
+	link, err := util.GetNetLinkOps().LinkByName(ifName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list links on the node, err: %v", err)
-	}
-	enslavedInterfaces := make(sets.Set[string])
-	for _, link := range links {
-		if link.Attrs().MasterIndex == vrfLink.Attrs().Index {
-			enslavedInterfaces.Insert(link.Attrs().Name)
+		if util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			return false, nil
 		}
+		return false, fmt.Errorf("failed to get link %s, err: %v", ifName, err)
 	}
-	return enslavedInterfaces, nil
+	return link.Attrs().MasterIndex == vrfIndex, nil
 }
 
 func enslaveInterfaceToVRF(vrfName, ifName string) error {


### PR DESCRIPTION
Replace LinkList() + filter with a targeted LinkByName() lookup in getSlaveInterfaceNamesForVRF. The caller only checks whether a single known interface is enslaved to a VRF, so dumping all links on the node is unnecessary.

In scale tests we observed a lot of NLM_F_DUMP_INTR because the links are being modified by concurrent mp port and VRF creation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced overhead during VRF synchronization by replacing broad interface enumeration with a targeted existence check, improving performance.
  * Improved handling of missing or unavailable interfaces during VRF updates to avoid unnecessary errors and make interface state changes more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->