### PR TITLE
tests: Wait for subnet annotation to update

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -548,17 +548,28 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		Expect(err).NotTo(HaveOccurred())
 
 		// check that masquerade subnet annotation got updated
-		node, err := wf.GetNode(nodeName)
-		Expect(err).NotTo(HaveOccurred())
-		subnets, err := util.ParseNodeMasqueradeSubnet(node)
-		Expect(err).NotTo(HaveOccurred())
-		for _, subnet := range subnets {
-			if utilnet.IsIPv4CIDR(subnet) {
-				Expect(subnet.String()).To(Equal(config.Gateway.V4MasqueradeSubnet))
-			} else if utilnet.IsIPv6CIDR(subnet) {
-				Expect(subnet.String()).To(Equal(config.Gateway.V6MasqueradeSubnet))
+		Eventually(func() error {
+			node, err := kubeFakeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			if err != nil {
+				return err
 			}
-		}
+			subnets, err := util.ParseNodeMasqueradeSubnet(node)
+			if err != nil {
+				return err
+			}
+			for _, subnet := range subnets {
+				if utilnet.IsIPv4CIDR(subnet) {
+					if subnet.String() != config.Gateway.V4MasqueradeSubnet {
+						return fmt.Errorf("unexpected IPv4 masquerade subnet: got %s, want %s", subnet, config.Gateway.V4MasqueradeSubnet)
+					}
+				} else if utilnet.IsIPv6CIDR(subnet) {
+					if subnet.String() != config.Gateway.V6MasqueradeSubnet {
+						return fmt.Errorf("unexpected IPv6 masquerade subnet: got %s, want %s", subnet, config.Gateway.V6MasqueradeSubnet)
+					}
+				}
+			}
+			return nil
+		}, 5).ShouldNot(HaveOccurred())
 
 		return nil
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Wait for cache to update after annotation is set.

Fixes #5570

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced reliability of masquerade subnet annotation verification tests by implementing retry logic with eventual assertions, reducing test flakiness and improving consistency of node configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->