### PR TITLE
Fix LSP deletion race when multiple NADs map to the same network during upgrade

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -656,12 +656,17 @@ func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods
 			bsnc.networkManager.GetNetworkNameForNADKey,
 			bsnc.networkManager.GetPrimaryNADForNamespace,
 		)
-		if err != nil || !on {
-			if err != nil {
-				bsnc.recordPodErrorEvent(pod, err)
-				klog.Errorf("Failed to determine if pod %s/%s needs to be plumb interface on network %s: %v",
-					pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
-			}
+		if err != nil {
+			bsnc.recordPodErrorEvent(pod, err)
+			klog.Errorf("Failed to determine if pod %s/%s needs to be plumb interface on network %s: %v",
+				pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
+			continue
+		}
+		if !on {
+			// Pod's NADs may not be registered with this controller yet (race during startup
+			// when multiple NADs map to the same network). Check the NAD informer cache directly
+			// to avoid deleting LSPs for pods whose NADs haven't been synced yet.
+			bsnc.trackPodsWithUnregisteredNADs(pod, expectedLogicalPorts)
 			continue
 		}
 
@@ -704,6 +709,55 @@ func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods
 	bsnc.trackPodsReleasedBeforeStartup(annotatedLocalPods)
 
 	return bsnc.deleteStaleLogicalSwitchPorts(expectedLogicalPorts)
+}
+
+// trackPodsWithUnregisteredNADs checks if a pod references a NAD that belongs to this
+// network but hasn't been registered with the controller yet. This happens during startup
+// when multiple NADs map to the same network and they arrive at different times.
+// If the pod's NAD is found in the informer cache and maps to this network, the pod's
+// expected LSP name is added to expectedLogicalPorts to prevent deletion.
+func (bsnc *BaseUserDefinedNetworkController) trackPodsWithUnregisteredNADs(pod *corev1.Pod, expectedLogicalPorts map[string]bool) {
+	if !util.PodScheduled(pod) || util.PodWantsHostNetwork(pod) {
+		return
+	}
+	networks, err := util.GetK8sPodAllNetworkSelections(pod)
+	if err != nil {
+		return
+	}
+	for _, network := range networks {
+		nadNamespace := network.Namespace
+		if nadNamespace == "" {
+			nadNamespace = pod.Namespace
+		}
+		nadName := util.GetNADName(nadNamespace, network.Name)
+		if bsnc.networkManager.GetNetworkNameForNADKey(nadName) != "" {
+			// Already registered, would have been handled by the normal path
+			continue
+		}
+		nad, err := bsnc.watchFactory.GetNAD(nadNamespace, network.Name)
+		if err != nil {
+			continue
+		}
+		// Check if the NAD belongs to this network. First try the annotation
+		// (set by cluster manager), then fall back to parsing the NAD config
+		// (needed during upgrades when the annotation hasn't been set yet).
+		nadNetworkName := util.GetAnnotatedNetworkName(nad)
+		if nadNetworkName == "" {
+			nadInfo, err := util.ParseNADInfo(nad)
+			if err == nil {
+				nadNetworkName = nadInfo.GetNetworkName()
+			}
+		}
+		if nadNetworkName != bsnc.GetNetworkName() {
+			continue
+		}
+		// This pod references a NAD that belongs to our network but isn't registered yet.
+		// Track its LSP to prevent deletion during sync.
+		portName := bsnc.GetLogicalPortName(pod, nadName)
+		expectedLogicalPorts[portName] = true
+		klog.Infof("Preserving LSP %s for pod %s/%s: NAD %s belongs to network %s but is not yet registered",
+			portName, pod.Namespace, pod.Name, nadName, bsnc.GetNetworkName())
+	}
 }
 
 // addPodToNamespaceForUserDefinedNetwork returns the ops needed to add pod's IP to the namespace's address set.

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -3,10 +3,13 @@ package ovn
 import (
 	"context"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	fakenadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -207,6 +210,178 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 			},
 		}),
 	)
+	It("should not delete localnet LSPs for pods whose NADs are not yet registered", func() {
+		// This test reproduces a race condition where multiple NADs map to the same
+		// localnet network. When the network controller starts (triggered by the first
+		// NAD), syncPodsForUserDefinedNetwork only sees pods whose NADs are registered.
+		// Pods using later-arriving NADs are skipped, and their existing LSPs get
+		// deleted as stale.
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+
+		const (
+			networkName = "localnet1"
+			namespace   = "myvms"
+			nodeName    = "worker1"
+		)
+
+		// Create 4 ipamless localnet NADs all for the same network.
+		makeNAD := func(name string) *nadapi.NetworkAttachmentDefinition {
+			nad := ovntest.GenerateNAD(networkName, name, namespace,
+				types.LocalnetTopology, "", types.NetworkRoleSecondary)
+			ovntest.AnnotateNADWithNetworkID("1", nad)
+			if nad.Annotations == nil {
+				nad.Annotations = map[string]string{}
+			}
+			nad.Annotations[types.OvnNetworkNameAnnotation] = networkName
+			return nad
+		}
+		nad0 := makeNAD("vm0")
+		nad1 := makeNAD("vm1")
+		nad2 := makeNAD("vm2")
+		nad3 := makeNAD("vm3")
+
+		// Compute localnet switch name and LSP names using the real helpers
+		nInfo, err := util.ParseNADInfo(nad0)
+		Expect(err).NotTo(HaveOccurred())
+		localnetSwitchName := nInfo.GetNetworkScopedName(types.OVNLocalnetSwitch)
+
+		// LSP names
+		lspName := func(nadNS, nadName, podNS, podName string) string {
+			return util.GetUserDefinedNetworkLogicalPortName(podNS, podName, nadNS+"/"+nadName)
+		}
+		lsp0Name := lspName(namespace, "vm0", namespace, "pod-0")
+		lsp1Name := lspName(namespace, "vm1", namespace, "pod-1")
+		lsp2Name := lspName(namespace, "vm2", namespace, "pod-2")
+		lsp3Name := lspName(namespace, "vm3", namespace, "pod-3")
+
+		// Pre-populate OVN DB with all 4 LSPs on the localnet switch
+		lsp0 := &nbdb.LogicalSwitchPort{UUID: "lsp0-UUID", Name: lsp0Name, ExternalIDs: map[string]string{"pod": "true", "namespace": namespace}}
+		lsp1 := &nbdb.LogicalSwitchPort{UUID: "lsp1-UUID", Name: lsp1Name, ExternalIDs: map[string]string{"pod": "true", "namespace": namespace}}
+		lsp2 := &nbdb.LogicalSwitchPort{UUID: "lsp2-UUID", Name: lsp2Name, ExternalIDs: map[string]string{"pod": "true", "namespace": namespace}}
+		lsp3 := &nbdb.LogicalSwitchPort{UUID: "lsp3-UUID", Name: lsp3Name, ExternalIDs: map[string]string{"pod": "true", "namespace": namespace}}
+
+		localnetSwitch := &nbdb.LogicalSwitch{
+			UUID:  localnetSwitchName + "-UUID",
+			Name:  localnetSwitchName,
+			Ports: []string{lsp0.UUID, lsp1.UUID, lsp2.UUID, lsp3.UUID},
+		}
+
+		initialDB := libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{localnetSwitch, lsp0, lsp1, lsp2, lsp3},
+		}
+
+		fakeOVN := NewFakeOVN(false)
+		fakeOVN.startWithDBSetup(
+			initialDB,
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Labels: map[string]string{
+						"kubernetes.io/hostname": nodeName,
+					},
+					Annotations: map[string]string{
+						"k8s.ovn.org/zone":        nodeName,
+						"k8s.ovn.org/network-ids": `{"localnet1": "1"}`,
+					},
+				},
+			},
+			// Add only nad0 via the standard mechanism
+			&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad0}},
+		)
+		defer fakeOVN.shutdown()
+
+		// Add nad1-3 directly to the watch factory's NAD informer cache.
+		// They exist in the API server but the NAD controller hasn't registered
+		// them with the network controller yet (simulating the race).
+		for _, nad := range []*nadapi.NetworkAttachmentDefinition{nad1, nad2, nad3} {
+			_, err = fakeOVN.watcher.GetNAD(nad.Namespace, nad.Name)
+			if err != nil {
+				nadCopy := nad.DeepCopy()
+				tracker := fakeOVN.fakeClient.NetworkAttchDefClient.(*fakenadclient.Clientset).Tracker()
+				Expect(tracker.Create(schema.GroupVersionResource{
+					Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions",
+				}, nadCopy, nadCopy.Namespace)).To(Succeed())
+			}
+		}
+		// Wait for the informer to pick up the NADs
+		Eventually(func() error {
+			for _, nad := range []*nadapi.NetworkAttachmentDefinition{nad1, nad2, nad3} {
+				_, err := fakeOVN.watcher.GetNAD(nad.Namespace, nad.Name)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}).Should(Succeed())
+
+		// Register ONLY the first NAD (vm0) with the controller.
+		Expect(fakeOVN.NewUserDefinedNetworkController(nad0)).To(Succeed())
+		controller, ok := fakeOVN.userDefinedNetworkControllers[networkName]
+		Expect(ok).To(BeTrue())
+
+		// Replace the networkManager with a fake that only knows about vm0.
+		// This simulates the race: the NAD controller has only processed the
+		// first NAD when syncPodsForUserDefinedNetwork runs.
+		controller.bnc.networkManager = &networkmanager.FakeNetworkManager{
+			NADNetworks: map[string]util.NetInfo{
+				namespace + "/vm0": nInfo,
+			},
+		}
+
+		By("verifying only vm0 NAD is registered")
+		Expect(controller.bnc.networkManager.GetNetworkNameForNADKey(namespace + "/vm0")).To(Equal(networkName))
+		Expect(controller.bnc.networkManager.GetNetworkNameForNADKey(namespace + "/vm1")).To(BeEmpty())
+		Expect(controller.bnc.networkManager.GetNetworkNameForNADKey(namespace + "/vm2")).To(BeEmpty())
+		Expect(controller.bnc.networkManager.GetNetworkNameForNADKey(namespace + "/vm3")).To(BeEmpty())
+
+		By("building pod list with all 4 pods referencing their respective NADs")
+		makePod := func(name, nadName string) *corev1.Pod {
+			nadKey := namespace + "/" + nadName
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": `[{"name":"` + nadName + `"}]`,
+						"k8s.ovn.org/pod-networks":    `{"` + nadKey + `":{"mac_address":"0a:58:01:02:03:04","role":"secondary"}}`,
+					},
+				},
+				Spec:   corev1.PodSpec{NodeName: nodeName},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+		}
+		podList := []interface{}{
+			makePod("pod-0", "vm0"),
+			makePod("pod-1", "vm1"),
+			makePod("pod-2", "vm2"),
+			makePod("pod-3", "vm3"),
+		}
+
+		By("calling syncPodsForUserDefinedNetwork (this is where the race manifests)")
+		err = controller.bnc.syncPodsForUserDefinedNetwork(podList)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking how many LSPs remain on the localnet switch")
+		obtainedSwitches := []*nbdb.LogicalSwitch{}
+		Expect(fakeOVN.nbClient.List(context.Background(), &obtainedSwitches)).To(Succeed())
+
+		var localnetSW *nbdb.LogicalSwitch
+		for _, sw := range obtainedSwitches {
+			if sw.Name == localnetSwitchName {
+				localnetSW = sw
+				break
+			}
+		}
+		Expect(localnetSW).NotTo(BeNil(), "localnet switch should exist")
+
+		// With the fix, all 4 LSPs should be preserved because the sync function
+		// falls back to checking the NAD informer cache for unregistered NADs.
+		Expect(localnetSW.Ports).To(HaveLen(4), "all 4 localnet LSPs should be preserved when multiple NADs map to the same network")
+	})
+
 	It("should not fail to sync pods if namespace is gone", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true

--- a/test/e2e/network_segmentation_localnet.go
+++ b/test/e2e/network_segmentation_localnet.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -283,6 +284,198 @@ var _ = Describe("Network Segmentation: Localnet", feature.NetworkSegmentation, 
 		Expect(err).NotTo(HaveOccurred())
 		_, hasAnnotation := pod.Annotations["k8s.ovn.org/pod-networks"]
 		Expect(hasAnnotation).To(BeTrue(), "pod should still have network annotation")
+	})
+
+	It("should preserve LSPs for IPAM-less localnet pods with multiple NADs after simulated upgrade", func() {
+		const (
+			vlan    = 203
+			numNADs = 4
+		)
+		var (
+			ovsBrName           = "ovsbr-upgrade"
+			networkName         = uniqueMetaName("localnet-upgrade")
+			physicalNetworkName = uniqueMetaName("physnet-upgrade")
+		)
+
+		nadClient, err := nadclient.NewForConfig(f.ClientConfig())
+		Expect(err).NotTo(HaveOccurred())
+
+		By("setup the localnet underlay")
+		Expect(providerCtx.SetupUnderlay(f, infraapi.Underlay{
+			BridgeName:         ovsBrName,
+			LogicalNetworkName: physicalNetworkName,
+			VlanID:             vlan,
+		})).To(Succeed())
+
+		By("create test namespace")
+		namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+			"e2e-framework": f.BaseName,
+		})
+		f.Namespace = namespace
+		Expect(err).NotTo(HaveOccurred())
+		nsName := namespace.Name
+
+		By(fmt.Sprintf("create %d IPAM-less localnet NADs sharing network %s", numNADs, networkName))
+		type podInfo struct {
+			nadName string
+			podName string
+		}
+		var pods []podInfo
+		for i := 0; i < numNADs; i++ {
+			nadName := fmt.Sprintf("vm%d", i)
+			nad := generateNetAttachDef(nsName, nadName, fmt.Sprintf(`
+{
+	"cniVersion": "0.3.1",
+	"name": %q,
+	"type": "ovn-k8s-cni-overlay",
+	"topology": "localnet",
+	"physicalNetworkName": %q,
+	"netAttachDefName": "%s/%s",
+	"vlanID": %d,
+	"role": "secondary"
+}`, networkName, physicalNetworkName, nsName, nadName, vlan))
+			_, err := nadClient.NetworkAttachmentDefinitions(nsName).Create(context.Background(), nad, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			pods = append(pods, podInfo{nadName: nadName, podName: fmt.Sprintf("pod-%d", i)})
+		}
+		DeferCleanup(func() {
+			for _, p := range pods {
+				_ = nadClient.NetworkAttachmentDefinitions(nsName).Delete(context.Background(), p.nadName, metav1.DeleteOptions{})
+			}
+		})
+
+		By("pick a target worker node")
+		workerNodes, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		var nodeName string
+		for _, node := range workerNodes.Items {
+			if _, isCP := node.Labels["node-role.kubernetes.io/control-plane"]; !isCP {
+				nodeName = node.Name
+				break
+			}
+		}
+		if nodeName == "" {
+			// schedulable control plane (e.g. 3-node cluster)
+			nodeName = workerNodes.Items[0].Name
+		}
+		framework.Logf("Target node: %s", nodeName)
+
+		By("create pods pinned to the target node")
+		for _, p := range pods {
+			podCfg := podConfiguration{
+				name:         p.podName,
+				namespace:    nsName,
+				attachments:  []nadapi.NetworkSelectionElement{{Name: p.nadName}},
+				nodeSelector: map[string]string{"kubernetes.io/hostname": nodeName},
+			}
+			_, err := f.ClientSet.CoreV1().Pods(nsName).Create(context.Background(), generatePodSpec(podCfg), metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("wait for all pods to be running")
+		for _, p := range pods {
+			Expect(e2epod.WaitForPodNameRunningInNamespace(context.Background(), f.ClientSet, p.podName, nsName)).To(Succeed())
+		}
+
+		ovnNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+
+		By("verify all localnet LSPs exist before simulated upgrade")
+		ovnkubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ovnkubeNodePods.Items).NotTo(BeEmpty())
+		ovnkubeNodePod := ovnkubeNodePods.Items[0]
+
+		for _, p := range pods {
+			nadFullName := fmt.Sprintf("%s/%s", nsName, p.nadName)
+			nadNameWithDots := strings.ReplaceAll(strings.ReplaceAll(nadFullName, "-", "."), "/", ".")
+			lspName := fmt.Sprintf("%s_%s_%s", nadNameWithDots, nsName, p.podName)
+			stdout, stderr, err := ExecCommandInContainerWithFullOutput(f, ovnNamespace, ovnkubeNodePod.Name, "nb-ovsdb",
+				"ovn-nbctl", "get", "logical-switch-port", lspName, "_uuid")
+			Expect(err).ToNot(HaveOccurred(), "LSP %s should exist before upgrade simulation, stderr: %s", lspName, stderr)
+			Expect(stdout).ToNot(BeEmpty())
+			framework.Logf("Found LSP %s for pod %s", lspName, p.podName)
+		}
+
+		By("simulate upgrade: scale down ovnkube-control-plane")
+		cpDeploy, err := f.ClientSet.AppsV1().Deployments(ovnNamespace).Get(context.Background(), "ovnkube-control-plane", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		originalReplicas := *cpDeploy.Spec.Replicas
+		zero := int32(0)
+		cpDeploy.Spec.Replicas = &zero
+		_, err = f.ClientSet.AppsV1().Deployments(ovnNamespace).Update(context.Background(), cpDeploy, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			By("restore ovnkube-control-plane replicas")
+			cpDeploy, err := f.ClientSet.AppsV1().Deployments(ovnNamespace).Get(context.Background(), "ovnkube-control-plane", metav1.GetOptions{})
+			if err == nil {
+				cpDeploy.Spec.Replicas = &originalReplicas
+				_, _ = f.ClientSet.AppsV1().Deployments(ovnNamespace).Update(context.Background(), cpDeploy, metav1.UpdateOptions{})
+			}
+		})
+
+		By("wait for control plane pods to terminate")
+		Eventually(func() int {
+			cpPods, err := f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: "app=ovnkube-control-plane",
+			})
+			if err != nil {
+				return -1
+			}
+			return len(cpPods.Items)
+		}).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(Equal(0), "control plane pods should be gone")
+
+		By("remove network-id and network-name annotations from NADs (simulates pre-upgrade state)")
+		for _, p := range pods {
+			nad, err := nadClient.NetworkAttachmentDefinitions(nsName).Get(context.Background(), p.nadName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(nad.Annotations, "k8s.ovn.org/network-id")
+			delete(nad.Annotations, "k8s.ovn.org/network-name")
+			_, err = nadClient.NetworkAttachmentDefinitions(nsName).Update(context.Background(), nad, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("restart ovnkube-node on target node (without control plane)")
+		err = restartOVNKubeNodePod(f.ClientSet, ovnNamespace, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("wait for ovnkube-node to start and hit the deferral path")
+		time.Sleep(30 * time.Second)
+
+		By("scale control plane back up (triggers network ID allocation and controller start)")
+		cpDeploy, err = f.ClientSet.AppsV1().Deployments(ovnNamespace).Get(context.Background(), "ovnkube-control-plane", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		cpDeploy.Spec.Replicas = &originalReplicas
+		_, err = f.ClientSet.AppsV1().Deployments(ovnNamespace).Update(context.Background(), cpDeploy, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("wait for control plane and localnet controller to settle")
+		time.Sleep(60 * time.Second)
+
+		By("find new ovnkube-node pod")
+		ovnkubeNodePods, err = f.ClientSet.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=ovnkube-node",
+			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ovnkubeNodePods.Items).NotTo(BeEmpty())
+		ovnkubeNodePod = ovnkubeNodePods.Items[0]
+
+		By("verify ALL localnet LSPs still exist after simulated upgrade")
+		for _, p := range pods {
+			nadFullName := fmt.Sprintf("%s/%s", nsName, p.nadName)
+			nadNameWithDots := strings.ReplaceAll(strings.ReplaceAll(nadFullName, "-", "."), "/", ".")
+			lspName := fmt.Sprintf("%s_%s_%s", nadNameWithDots, nsName, p.podName)
+			framework.Logf("Checking LSP %s for pod %s (NAD %s)", lspName, p.podName, p.nadName)
+			stdout, stderr, err := ExecCommandInContainerWithFullOutput(f, ovnNamespace, ovnkubeNodePod.Name, "nb-ovsdb",
+				"ovn-nbctl", "get", "logical-switch-port", lspName, "_uuid")
+			Expect(err).ToNot(HaveOccurred(),
+				"LSP %s for pod %s (NAD %s) should be preserved after simulated upgrade, stderr: %s",
+				lspName, p.podName, p.nadName, stderr)
+			Expect(stdout).ToNot(BeEmpty())
+		}
 	})
 })
 


### PR DESCRIPTION
## 📑 Description

During upgrades, NADs temporarily lack the `k8s.ovn.org/network-id` annotation until the cluster manager allocates it. When ovnkube-node restarts in this window and multiple NADs reference the same network, only the first NAD triggers the controller start. Pods using the remaining NADs fail the network matching check and their LSPs are deleted as stale.

This adds a fallback in `syncPodsForUserDefinedNetwork`: when a pod is not matched to the network, check the NAD informer cache directly and parse the CNI config to resolve the network name. If it matches, preserve the pod's LSP.

Fixes https://redhat.atlassian.net/browse/OCPBUGS-78777

## Additional Information for reviewers

**Root cause:** In older versions, `k8s.ovn.org/network-id` was stored on node annotations. After upgrade, the new NAD controller defers processing until the cluster manager annotates each NAD with a network ID. The first annotated NAD triggers the controller start, but `syncPodsForUserDefinedNetwork` only tracks pods whose NADs are already registered. The remaining pods' LSPs are deleted as stale before their NADs get registered.

**Changes:**
- `base_network_controller_user_defined.go`: Added `trackPodsWithUnregisteredNADs()` — when a pod's NAD isn't registered yet, looks it up from the informer cache and checks the network name via annotation or CNI config parsing (`ParseNADInfo` fallback for the upgrade case where annotations don't exist yet).
- `base_network_controller_user_defined_test.go`: Unit test that registers only 1 of 4 NADs, verifies all 4 LSPs are preserved.
- `network_segmentation_localnet.go`: E2E test that simulates the upgrade race by removing NAD annotations, restarting ovnkube-node without the control plane, then bringing it back.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

**Unit test:**
```bash
cd go-controller && go test ./pkg/ovn/ -v -ginkgo.focus="should not delete localnet LSPs"
```

**E2E test:**
```bash
ginkgo run -v --focus="simulated upgrade" -- --provider=local --kubeconfig=$KUBECONFIG
```

**Manual reproduction on any OCP 4.18 cluster with multiple NADs on the same localnet network:**
1. Scale down control plane: `oc scale deploy -n openshift-ovn-kubernetes ovnkube-control-plane --replicas=0`
2. Remove annotations: `oc annotate net-attach-def <nad> -n <ns> k8s.ovn.org/network-id- k8s.ovn.org/network-name-`
3. Delete ovnkube-node pod on the target node
4. Wait 30s, scale control plane back up
5. Without fix: LSPs deleted. With fix: LSPs preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod synchronization for user-defined networks to preserve expected logical ports when network attachments are present but not yet registered, preventing unintended port deletions.

* **Tests**
  * New unit test covering pod sync behavior with unregistered network attachments.
  * New end-to-end test ensuring logical ports persist across simulated upgrade and annotation mutation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->