### PR TITLE
e2e: fix invalid address cleanup due to invalid variable closure

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1698,16 +1698,17 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 				} else {
 					newIP = "172.18.1." + strconv.Itoa(i+1)
 				}
+				newCIDR := newIP + util.GetIPFullMaskString(newIP)
 				// manually add the a secondary IP to each node
-				_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "add", newIP, "dev", deploymentconfig.Get().ExternalBridgeName()})
+				_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "add", newCIDR, "dev", deploymentconfig.Get().ExternalBridgeName()})
 				if err != nil {
 					framework.Failf("failed to add new Addresses to node %s: %v", nodeName, err)
 				}
-				ipToCleanup := newIP
+				cidrToCleanup := newCIDR
 				providerCtx.AddCleanUpFn(func() error {
-					_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "del", ipToCleanup, "dev", deploymentconfig.Get().ExternalBridgeName()})
+					_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "del", cidrToCleanup, "dev", deploymentconfig.Get().ExternalBridgeName()})
 					if err != nil {
-						framework.Logf("failed to delete address %s from node %s: %v", ipToCleanup, nodeName, err)
+						framework.Logf("failed to delete address %s from node %s: %v", cidrToCleanup, nodeName, err)
 					}
 					return nil
 				})

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1689,23 +1689,25 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 			}
 			ginkgo.By("Adding ip addresses to each node")
 			// add new secondary IP from node subnet to all nodes, if the cluster is v6 add an ipv6 address
-			var newIP string
-			newNodeAddresses = make([]string, 0)
+			newNodeAddresses = make([]string, 0, len(nodes.Items))
 			for i, node := range nodes.Items {
+				nodeName := node.Name
+				var newIP string
 				if utilnet.IsIPv6String(e2enode.GetAddresses(&node, v1.NodeInternalIP)[0]) {
 					newIP = "fc00:f853:ccd:e794::" + strconv.Itoa(i)
 				} else {
 					newIP = "172.18.1." + strconv.Itoa(i+1)
 				}
 				// manually add the a secondary IP to each node
-				_, err := infraprovider.Get().ExecK8NodeCommand(node.Name, []string{"ip", "addr", "add", newIP, "dev", deploymentconfig.Get().ExternalBridgeName()})
+				_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "add", newIP, "dev", deploymentconfig.Get().ExternalBridgeName()})
 				if err != nil {
-					framework.Failf("failed to add new Addresses to node %s: %v", node.Name, err)
+					framework.Failf("failed to add new Addresses to node %s: %v", nodeName, err)
 				}
+				ipToCleanup := newIP
 				providerCtx.AddCleanUpFn(func() error {
-					_, err := infraprovider.Get().ExecK8NodeCommand(node.Name, []string{"ip", "addr", "del", newIP, "dev", deploymentconfig.Get().ExternalBridgeName()})
+					_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "del", ipToCleanup, "dev", deploymentconfig.Get().ExternalBridgeName()})
 					if err != nil {
-						framework.Logf("failed to add new Addresses to node %s: %v", node.Name, err)
+						framework.Logf("failed to delete address %s from node %s: %v", ipToCleanup, nodeName, err)
 					}
 					return nil
 				})

--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
 
 	v1 "k8s.io/api/core/v1"
@@ -668,16 +669,17 @@ spec:
 				ginkgo.By("Adding additional IP addresses to node on which source pod lives")
 				for nodeName, ipFamilies := range node2ndaryIPs {
 					for _, ip := range ipFamilies {
+						cidr := ip + util.GetIPFullMaskString(ip)
 						// manually add the a secondary IP to each node
 						framework.Logf("Adding IP %s to node %s", ip, nodeName)
 						_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{
-							"ip", "addr", "add", ip, "dev", deploymentconfig.Get().PrimaryInterfaceName(),
+							"ip", "addr", "add", cidr, "dev", deploymentconfig.Get().PrimaryInterfaceName(),
 						})
 						if err != nil && !strings.Contains(err.Error(), "Address already assigned") {
 							framework.Failf("failed to add new IP address %s to node %s: %v", ip, nodeName, err)
 						}
 						ginkgo.DeferCleanup(func() error {
-							_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "delete", ip, "dev", deploymentconfig.Get().PrimaryInterfaceName()})
+							_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "delete", cidr, "dev", deploymentconfig.Get().PrimaryInterfaceName()})
 							return err
 						})
 						toCurlSecondaryNodeIPAddresses.Insert(ip)

--- a/test/e2e/egress_services.go
+++ b/test/e2e/egress_services.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
@@ -426,14 +427,15 @@ spec:
 			}
 			framework.ExpectNoError(err, "failed to allocate secondary node IP")
 			otherDst := otherDstIP.String()
+			otherDstCIDR := otherDst + util.GetIPFullMaskString(otherDst)
 			ginkgo.By(fmt.Sprintf("adding secondary IP %q to node %s", otherDst, dstNode.Name))
 			extBridgeName := deploymentconfig.Get().ExternalBridgeName()
-			_, err = infraprovider.Get().ExecK8NodeCommand(dstNode.Name, []string{"ip", "addr", "add", otherDst, "dev", extBridgeName})
+			_, err = infraprovider.Get().ExecK8NodeCommand(dstNode.Name, []string{"ip", "addr", "add", otherDstCIDR, "dev", extBridgeName})
 			if err != nil {
 				framework.Failf("failed to add address to node %s: %v", dstNode.Name, err)
 			}
 			providerCtx.AddCleanUpFn(func() error {
-				_, err = infraprovider.Get().ExecK8NodeCommand(dstNode.Name, []string{"ip", "addr", "delete", otherDst, "dev", extBridgeName})
+				_, err = infraprovider.Get().ExecK8NodeCommand(dstNode.Name, []string{"ip", "addr", "delete", otherDstCIDR, "dev", extBridgeName})
 				return err
 			})
 			ginkgo.By(fmt.Sprintf("Creating host-networked pod on non-egress node %s acting as \"another node\"", dstNode.Name))

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -1124,13 +1124,14 @@ spec:
 				otherDstIP, err = ipalloc.NewPrimaryIPv4()
 			}
 			otherDst := otherDstIP.String()
+			otherDstCIDR := otherDst + util.GetIPFullMaskString(otherDst)
 			framework.Logf("Adding secondary IP %s to external bridge %s on Node %s", otherDst, deploymentconfig.Get().ExternalBridgeName(), egress2Node.name)
-			_, err = infraprovider.Get().ExecK8NodeCommand(egress2Node.name, []string{"ip", "addr", "add", otherDst, "dev", deploymentconfig.Get().ExternalBridgeName()})
+			_, err = infraprovider.Get().ExecK8NodeCommand(egress2Node.name, []string{"ip", "addr", "add", otherDstCIDR, "dev", deploymentconfig.Get().ExternalBridgeName()})
 			if err != nil {
 				framework.Failf("failed to add address to node %s: %v", egress2Node.name, err)
 			}
 			providerCtx.AddCleanUpFn(func() error {
-				_, err := infraprovider.Get().ExecK8NodeCommand(egress2Node.name, []string{"ip", "addr", "del", otherDst, "dev", deploymentconfig.Get().ExternalBridgeName()})
+				_, err := infraprovider.Get().ExecK8NodeCommand(egress2Node.name, []string{"ip", "addr", "del", otherDstCIDR, "dev", deploymentconfig.Get().ExternalBridgeName()})
 				return err
 			})
 

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -817,8 +817,9 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 					if utilnet.IsIPv6String(ip) {
 						subnetMask = "/128"
 					}
+					cidr := ip + subnetMask
 					_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "delete",
-						fmt.Sprintf("%s/%s", ip, subnetMask), "dev", deploymentconfig.Get().ExternalBridgeName()})
+						cidr, "dev", deploymentconfig.Get().ExternalBridgeName()})
 					if err != nil && !(strings.Contains(err.Error(),
 						"RTNETLINK answers: Cannot assign requested address") || !strings.Contains(err.Error(), "Address not found")) {
 						framework.Failf("failed to remove ip address %s from node %s, err: %q", ip, nodeName, err)
@@ -1078,15 +1079,16 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 			ginkgo.By("Adding additional IP addresses to each node")
 			for nodeName, ipFamilies := range nodeIPs {
 				for _, ip := range ipFamilies {
+					cidr := ip + util.GetIPFullMaskString(ip)
 					// manually add the a secondary IP to each node
 					framework.Logf("adding IP %q to Node %s", ip, nodeName)
-					_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", iproute2Proto, "addr", "add", ip, "dev", deploymentconfig.Get().ExternalBridgeName()})
+					_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", iproute2Proto, "addr", "add", cidr, "dev", deploymentconfig.Get().ExternalBridgeName()})
 					if err != nil {
 						framework.Failf("failed to add new IP address %s to node %s: %v", ip, nodeName, err)
 					}
 					providerCtx.AddCleanUpFn(func() error {
 						// manually add the a secondary IP to each node
-						_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", iproute2Proto, "addr", "del", ip, "dev", deploymentconfig.Get().ExternalBridgeName()})
+						_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", iproute2Proto, "addr", "del", cidr, "dev", deploymentconfig.Get().ExternalBridgeName()})
 						if err != nil {
 							return fmt.Errorf("failed to add new IP address %s to node %s: %v", ip, nodeName, err)
 						}
@@ -1345,13 +1347,14 @@ spec:
 				framework.ExpectNoError(err, "must get Node %s network interface %s", nodeName, secondaryProviderNetwork)
 				gomega.Expect(secondaryNetworkInterface.InfName).NotTo(gomega.BeEmpty(), "failed to fetch interface name from a k8 node attached to a secondary network")
 				for _, ip := range ipFamilies {
+					cidr := ip + util.GetIPFullMaskString(ip)
 					// manually add the a secondary IP to each node
-					_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "add", ip, "dev", secondaryNetworkInterface.InfName})
+					_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "add", cidr, "dev", secondaryNetworkInterface.InfName})
 					if err != nil {
 						framework.Failf("failed to add new IP address %s to node %s: %v", ip, nodeName, err)
 					}
 					providerCtx.AddCleanUpFn(func() error {
-						_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "del", ip, "dev", secondaryNetworkInterface.InfName})
+						_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "del", cidr, "dev", secondaryNetworkInterface.InfName})
 						if err != nil {
 							return fmt.Errorf("failed to del newly assigned node IP address %s to node %s: %v", ip, nodeName, err)
 						}

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1086,14 +1086,6 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 					if err != nil {
 						framework.Failf("failed to add new IP address %s to node %s: %v", ip, nodeName, err)
 					}
-					providerCtx.AddCleanUpFn(func() error {
-						// manually add the a secondary IP to each node
-						_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", iproute2Proto, "addr", "del", cidr, "dev", deploymentconfig.Get().ExternalBridgeName()})
-						if err != nil {
-							return fmt.Errorf("failed to add new IP address %s to node %s: %v", ip, nodeName, err)
-						}
-						return nil
-					})
 					toCurlAddresses.Insert(ip)
 				}
 			}

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -821,7 +821,7 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 					_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "addr", "delete",
 						cidr, "dev", deploymentconfig.Get().ExternalBridgeName()})
 					if err != nil && !(strings.Contains(err.Error(),
-						"RTNETLINK answers: Cannot assign requested address") || !strings.Contains(err.Error(), "Address not found")) {
+						"RTNETLINK answers: Cannot assign requested address") || strings.Contains(err.Error(), "Address not found")) {
 						framework.Failf("failed to remove ip address %s from node %s, err: %q", ip, nodeName, err)
 					}
 				}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
providerCtx.AddCleanUpFn defined a cleanup function that was referring
to a variable that was defined outside of a loop, meaning that it was
always calling each registered cleanup handler on the same (last) value
of the newIP variable, leaving some IP addresses not deleted.

Related #6140

Marking as Related, not Fixed because it will only fix cleanup but the
underlying connection refused error is still there.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->