### PR TITLE
Add NodeReady check to zone controller

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -212,6 +212,15 @@ type EgressIPController struct {
 	controllerName string
 }
 
+func isNodeReady(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
 func NewEIPController(
 	nbClient libovsdbclient.Client,
 	kube *kube.KubeOVN,
@@ -351,6 +360,7 @@ func (e *EgressIPController) reconcileEgressIP(old, new *egressipv1.EgressIP) (e
 					return err
 				}
 			}
+
 		}
 
 		oldNamespaceSelector, err := metav1.LabelSelectorAsSelector(&oldEIP.Spec.NamespaceSelector)
@@ -2687,6 +2697,12 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 	if err != nil {
 		return fmt.Errorf("failed to add pod %s/%s because failed to lookup node %s: %v", pod.Namespace, pod.Name,
 			pod.Spec.NodeName, err)
+	}
+	if !isNodeReady(eNode) {
+		klog.V(5).Infof("Skipping egress IP assignment: egress node %s is NotReady (pod: %s/%s, egressIP: %s)",
+			status.Node, pod.Namespace, pod.Name, status.EgressIP)
+		return types.NewSuppressedError(fmt.Errorf("egress node %s is not ready, skipping egress IP assignment for pod %s/%s",
+			status.Node, pod.Namespace, pod.Name))
 	}
 	parsedNodeEIPConfig, err := util.GetNodeEIPConfig(eNode)
 	if err != nil {

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -360,11 +360,15 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 				klog.Errorf("%s: %v retry: cannot update object that is not scheduled: %s", r.name, r.ResourceHandler.ObjType, objKey)
 			} else if err := r.ResourceHandler.UpdateResource(entry.config, entry.newObj, true); err != nil {
 				entry.timeStamp = time.Now()
-				r.increaseFailedAttemptsCounter(entry)
-				if entry.failedAttempts >= MaxFailedAttempts && !entry.infiniteRetry {
-					klog.Errorf("%s: retry update failed final attempt for %s %s: error: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
+				if !ovntypes.IsSuppressedError(err) {
+					r.increaseFailedAttemptsCounter(entry)
+					if entry.failedAttempts >= MaxFailedAttempts && !entry.infiniteRetry {
+						klog.Errorf("%s: retry update failed final attempt for %s %s: error: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
+					} else {
+						klog.Infof("%s: %v retry update failed for %s, will try again later: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
+					}
 				} else {
-					klog.Infof("%s: %v retry update failed for %s, will try again later: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
+					klog.V(5).Infof("%s: %v retry update suppressed for %s: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
 				}
 				return
 			}
@@ -404,11 +408,15 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 					klog.Errorf("%s: %v retry: cannot create object that is not scheduled %s", r.name, r.ResourceHandler.ObjType, objKey)
 				} else if err := r.ResourceHandler.AddResource(entry.newObj, true); err != nil {
 					entry.timeStamp = time.Now()
-					r.increaseFailedAttemptsCounter(entry)
-					if entry.failedAttempts >= MaxFailedAttempts && !entry.infiniteRetry {
-						klog.Errorf("%s: retry add failed final attempt for %s %s: error: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
+					if !ovntypes.IsSuppressedError(err) {
+						r.increaseFailedAttemptsCounter(entry)
+						if entry.failedAttempts >= MaxFailedAttempts && !entry.infiniteRetry {
+							klog.Errorf("%s: retry add failed final attempt for %s %s: error: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
+						} else {
+							klog.Infof("%s: retry add failed for %s %s, will try again later: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
+						}
 					} else {
-						klog.Infof("%s: retry add failed for %s %s, will try again later: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
+						klog.V(5).Infof("%s: %v retry add suppressed for %s: %v", r.name, r.ResourceHandler.ObjType, objKey, err)
 					}
 					return
 				}
@@ -578,10 +586,10 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 						if !ovntypes.IsSuppressedError(err) {
 							klog.Errorf("%s: failed to create %s %s, error: %v", r.name, r.ResourceHandler.ObjType, key, err)
 							r.ResourceHandler.RecordErrorEvent(obj, "ErrorAddingResource", err)
+							r.increaseFailedAttemptsCounter(retryObj)
 						} else {
 							klog.Infof("%s: failed to create %s %s, error: %v", r.name, r.ResourceHandler.ObjType, key, err)
 						}
-						r.increaseFailedAttemptsCounter(retryObj)
 						return
 					}
 					klog.V(5).Infof("%s: creating %s %s took: %v", r.name, r.ResourceHandler.ObjType, key, time.Since(start))
@@ -727,14 +735,16 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 							} else {
 								retryEntry = r.initRetryObjWithAdd(latest, key)
 							}
-							r.increaseFailedAttemptsCounter(retryEntry)
+							if !ovntypes.IsSuppressedError(err) {
+								r.increaseFailedAttemptsCounter(retryEntry)
+							}
 							return
 						}
 					} else { // we previously deleted old object, now let's add the new one
 						if err := r.ResourceHandler.AddResource(latest, false); err != nil {
 							retryEntry := r.initRetryObjWithAdd(latest, key)
-							r.increaseFailedAttemptsCounter(retryEntry)
 							if !ovntypes.IsSuppressedError(err) {
+								r.increaseFailedAttemptsCounter(retryEntry)
 								klog.Errorf("%s: failed to add %s %s, during update: %v",
 									r.name, r.ResourceHandler.ObjType, newKey, err)
 								r.ResourceHandler.RecordErrorEvent(latest, "ErrorAddingResource", err)


### PR DESCRIPTION
Before cluster manager assigns an EIP to a node, it will check that the node is Egress assignable, meaning that it is ready, reachable, and has the egress-assignable label

Zone controller will receive this event, but then the node can enter an unready state. The cm will detect this and assign the EIP to a different node, but the event can already be in the retry queue on the node. The zone controller will blindly attempt the EIP assignment on the unready node, which will lead retry exhaustion and
OVNKubernetesResourceRetryFailure alert firing

Adding a nodeReadiness check in the zone controller will allow us to fail fast if the node isnt ready instead of retrying to exhaustion

- update: had to rework this due to a loop between OVSBD and adding the LSP. Now this adds a return of a suppressed error (just a wrapper on an error; we still want to signal to the retry framework that there was a failure, but its marked as transient / expected. So now the error flow looks like this
1. EIP is assigned to node1 by cluster manager
2. zone controller sees this and queues EIP pod in retry queue
3. node-1 goes NotReady for whatever reason
4. cm sees this and re-assigns EIP to node-foo
5. every 30 seconds the retry loop runs
6. we will return a suppressed error to the retry that the node is not ready (its still trying to assign to node1 which is down)
7. reconcileEgressIP will eventually process the status change and on the next retry it will succeed and the entry will be cleared from the retry

Issue investigation was assisted by claude sonnet 4.6




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Egress IP assignment now checks target node readiness and skips programming for nodes that are not Ready; skipped assignments are logged at reduced verbosity.
  * Retry handling no longer counts suppressed/transient errors toward failure limits and reduces their log verbosity, avoiding noisy final-attempt logs for suppressed conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->