### PR TITLE
ci: run a control-plane lane with ubuntu images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,34 +165,42 @@ jobs:
   build-pr:
     name: Build-PR
     runs-on: ubuntu-24.04
+    env:
+      PR_IMAGE_FAMILY: fedora
+      PR_IMAGE: ovn-daemonset-fedora:pr
+      PR_IMAGE_TARGET: fedora-image
+      PR_IMAGE_ARTIFACT: test-image-pr
     steps:
-    # Create a cache for the build PR image
-    - name: Restore PR image cache
-      id: image_cache_pr
+    # These anchored steps are shared with build-pr-ubuntu below.
+    - &restore_pr_image_cache
+      name: Restore PR image cache
       uses: actions/cache@v4
       with:
         path: |
           ${{ env.CI_IMAGE_CACHE }}
-        key: ${{ github.run_id }}-image-cache-pr
+        key: ${{ github.run_id }}-image-cache-pr-${{ env.PR_IMAGE_FAMILY }}
 
-    - name: Check if PR image build is needed
+    - &check_pr_image_build
+      name: Check if PR image build is needed
       id: is_pr_image_build_needed
       continue-on-error: true
       run: |
         set -x
-        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz ]; then
-            mkdir -p ${CI_DIST_IMAGES_OUTPUT}
-            cp ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}.gz
-            gunzip ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}.gz
+        mkdir -p "${CI_DIST_IMAGES_OUTPUT}"
+        if [ -f "${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz" ]; then
+            cp "${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz" "${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}.gz"
+            gunzip "${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}.gz"
             echo "PR_IMAGE_RESTORED=true" >> "$GITHUB_OUTPUT"
         fi
 
     # only run the following steps if the PR image was not found in the cache
-    - name: Check out code into the Go module directory - from current pr branch
+    - &checkout_pr_image_source
+      name: Check out code into the Go module directory - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       uses: actions/checkout@v6
 
-    - name: Set up Go
+    - &setup_pr_image_go
+      name: Set up Go
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       uses: actions/setup-go@v6
       with:
@@ -217,39 +225,55 @@ jobs:
            make windows
         popd
 
-    - name: Build docker image - from current pr branch
+    - &build_pr_image
+      name: Build PR image - from current pr branch
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       run: |
         pushd dist/images
-          IMAGE=ovn-daemonset-fedora:pr
-          make IMAGE=${IMAGE} \
-            OVN_REPO=${{ env.OVN_REPO }} \
-            OVN_GITREF=${{ env.OVN_GITREF }} \
-            fedora-image
-          mkdir _output
-          docker save ${IMAGE} > _output/${CI_IMAGE_PR_TAR}
+          make IMAGE="${PR_IMAGE}" \
+            OVN_REPO="${OVN_REPO}" \
+            OVN_GITREF="${OVN_GITREF}" \
+            "${PR_IMAGE_TARGET}"
+          mkdir -p _output
+          docker save "${PR_IMAGE}" -o "_output/${CI_IMAGE_PR_TAR}"
         popd
 
-    - name: Cache PR image
+    - &cache_pr_image
+      name: Cache PR image
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       continue-on-error: true
       run: |
         set -x
-        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR} ]; then
-            rm -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
-        fi
-        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz ]; then
-           rm -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz
-        fi
-        mkdir -p ${CI_IMAGE_CACHE}/
-        cp ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR} ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
-        gzip ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
+        mkdir -p "${CI_IMAGE_CACHE}"
+        rm -f "${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}" "${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz"
+        cp "${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}" "${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}"
+        gzip -f "${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}"
 
     # run the following if none of the previous steps failed
-    - uses: actions/upload-artifact@v7
+    - &upload_pr_image
+      name: Upload PR image
+      uses: actions/upload-artifact@v7
       with:
-        name: test-image-pr
+        name: ${{ env.PR_IMAGE_ARTIFACT }}
         path: ${{ env.CI_DIST_IMAGES_OUTPUT }}/${{ env.CI_IMAGE_PR_TAR }}
+
+  build-pr-ubuntu:
+    name: Build-PR (Ubuntu)
+    runs-on: ubuntu-24.04
+    env:
+      PR_IMAGE_FAMILY: ubuntu
+      PR_IMAGE: ovn-daemonset-ubuntu:pr
+      PR_IMAGE_TARGET: ubuntu-image
+      PR_IMAGE_ARTIFACT: test-image-pr-ubuntu
+      CI_IMAGE_PR_TAR: image-pr-ubuntu.tar
+    steps:
+    - *restore_pr_image_cache
+    - *check_pr_image_build
+    - *checkout_pr_image_source
+    - *setup_pr_image_go
+    - *build_pr_image
+    - *cache_pr_image
+    - *upload_pr_image
 
   test-pr:
     name: Test-PR
@@ -470,7 +494,7 @@ jobs:
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
-          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
+          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver", "image_family": "ubuntu"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones", "cni-mode": "unprivileged"}
@@ -502,12 +526,17 @@ jobs:
           - {"target": "traffic-flow-test-only", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "traffic-flow-tests": "1-24", "network-segmentation": "enable-network-segmentation"}
           - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "network-segmentation": "enable-network-segmentation"}
           - {"target": "serial", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
-    needs: [ build-pr ]
+    needs: [ build-pr, build-pr-ubuntu ]
+    if: ${{ !cancelled() }}
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
       OVN_HYBRID_OVERLAY_ENABLE: ${{ matrix.target == 'control-plane' && (matrix.ipfamily == 'ipv4' || matrix.ipfamily == 'dualstack' ) }}
       OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || startsWith(matrix.target, 'network-segmentation') || startsWith(matrix.target, 'bgp') }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' || startsWith(matrix.target, 'bgp') }}"
+      OVN_IMAGE_FAMILY: "${{ matrix.image_family || 'fedora' }}"
+      OVN_IMAGE: "${{ matrix.image_family == 'ubuntu' && 'ovn-daemonset-ubuntu:pr' || 'ovn-daemonset-fedora:pr' }}"
+      CI_E2E_IMAGE_ARTIFACT: "${{ matrix.image_family == 'ubuntu' && 'test-image-pr-ubuntu' || 'test-image-pr' }}"
+      CI_E2E_IMAGE_TAR: "${{ matrix.image_family == 'ubuntu' && 'image-pr-ubuntu.tar' || 'image-pr.tar' }}"
       OVN_HA: "${{ matrix.ha == 'HA' }}"
       OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws == 'noSnatGW' }}"
       KIND_INSTALL_METALLB: "${{ matrix.target == 'control-plane' || startsWith(matrix.target, 'network-segmentation') }}"
@@ -539,6 +568,17 @@ jobs:
       ENABLE_NO_OVERLAY_OUTBOUND_SNAT: "${{ matrix.no-overlay == 'snat-enabled' || matrix.no-overlay == 'managed' }}"
       ENABLE_NO_OVERLAY_MANAGED_ROUTING: "${{ matrix.no-overlay == 'managed' }}"
     steps:
+    - name: Verify selected image build
+      env:
+        FEDORA_BUILD_RESULT: ${{ needs.build-pr.result }}
+        UBUNTU_BUILD_RESULT: ${{ needs.build-pr-ubuntu.result }}
+      run: |
+        if [ "${OVN_IMAGE_FAMILY}" = "ubuntu" ]; then
+          test "${UBUNTU_BUILD_RESULT}" = "success"
+        else
+          test "${FEDORA_BUILD_RESULT}" = "success"
+        fi
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6
 
@@ -632,10 +672,10 @@ jobs:
       run: |
         sudo ufw disable
 
-    - name: Download test-image-pr
+    - name: Download selected PR image
       uses: actions/download-artifact@v8
       with:
-        name: test-image-pr
+        name: ${{ env.CI_E2E_IMAGE_ARTIFACT }}
 
     - name: Disable containerd image store
       # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
@@ -653,13 +693,12 @@ jobs:
 
     - name: Load docker image
       run: |
-        docker load --input ${CI_IMAGE_PR_TAR} && rm -rf ${CI_IMAGE_PR_TAR}
+        docker load --input ${CI_E2E_IMAGE_TAR} && rm -rf ${CI_E2E_IMAGE_TAR}
         docker images || true
 
     - name: kind setup
       timeout-minutes: 30
       run: |
-        export OVN_IMAGE="ovn-daemonset-fedora:pr"
         make -C test install-kind
 
     - name: traffic-flow-tests setup
@@ -674,9 +713,6 @@ jobs:
       # get its output
       timeout-minutes: ${{ startsWith(matrix.target, 'bgp') && 190 || matrix.target == 'evpn' && 190 || matrix.target == 'control-plane' && 190 || matrix.target == 'external-gateway' && 190 || startsWith(matrix.target, 'network-segmentation') && 190 || 130 }}
       run: |
-        # used by e2e diagnostics package
-        export OVN_IMAGE="ovn-daemonset-fedora:pr"
-
         if [ "${{ matrix.target }}" == "multi-homing" ]; then
           make -C test control-plane WHAT="Multi Homing"
         elif [ "${{ matrix.target }}" == "node-ip-mac-migration" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -529,7 +529,7 @@ jobs:
     needs: [ build-pr, build-pr-ubuntu ]
     if: ${{ !cancelled() }}
     env:
-      JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
+      JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}-${{ matrix.image_family || 'fedora' }}"
       OVN_HYBRID_OVERLAY_ENABLE: ${{ matrix.target == 'control-plane' && (matrix.ipfamily == 'ipv4' || matrix.ipfamily == 'dualstack' ) }}
       OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || startsWith(matrix.target, 'network-segmentation') || startsWith(matrix.target, 'bgp') }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' || startsWith(matrix.target, 'bgp') }}"

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -91,11 +91,20 @@ set_common_default_params() {
 
   # Image/source code params
   OVN_IMAGE=${OVN_IMAGE:-local}
+  OVN_IMAGE_FAMILY=${OVN_IMAGE_FAMILY:-fedora}
   OVN_REPO=${OVN_REPO:-""}
   OVN_GITREF=${OVN_GITREF:-""}
   # Pods to force-delete on --deploy so they respawn with the kind-loaded image.
   # ovs-node excluded: restarting it under live ovnkube-node pods breaks the cluster.
   OVN_DEPLOY_PODS=${OVN_DEPLOY_PODS:-"ovnkube-identity ovnkube-control-plane ovnkube-node"}
+  case "${OVN_IMAGE_FAMILY}" in
+    fedora|ubuntu)
+      ;;
+    *)
+      echo "Unsupported OVN image family: ${OVN_IMAGE_FAMILY}"
+      exit 1
+      ;;
+  esac
 
   # Subnet params
   # Input not currently validated. Modify outside script at your own risk.
@@ -262,10 +271,11 @@ set_common_default_params() {
 }
 
 set_ovn_image() {
+  local ovn_image_repo="ovn-daemonset-${OVN_IMAGE_FAMILY}"
   if [ "${KIND_LOCAL_REGISTRY:-false}" == true ]; then
-    OVN_IMAGE="localhost:5000/ovn-daemonset-fedora:latest"
+    OVN_IMAGE="localhost:5000/${ovn_image_repo}:latest"
   else
-    OVN_IMAGE="localhost/ovn-daemonset-fedora:dev"
+    OVN_IMAGE="localhost/${ovn_image_repo}:dev"
   fi
 }
 
@@ -309,6 +319,7 @@ EOF
 }
 
 build_ovn_image() {
+  local build_target="${OVN_IMAGE_FAMILY}-image"
   local push_args=""
   if [ "$OCI_BIN" == "podman" ]; then
     # docker doesn't perform tls check by default only podman does, hence we need to disable it for podman.
@@ -319,7 +330,7 @@ build_ovn_image() {
     set_ovn_image
 
     # Build image
-    make -C ${DIR}/../dist/images IMAGE="${OVN_IMAGE}" OVN_REPO="${OVN_REPO}" OVN_GITREF="${OVN_GITREF}" OCI_BIN="${OCI_BIN}" fedora-image
+    make -C ${DIR}/../dist/images IMAGE="${OVN_IMAGE}" OVN_REPO="${OVN_REPO}" OVN_GITREF="${OVN_GITREF}" OCI_BIN="${OCI_BIN}" "${build_target}"
 
     # store in local registry
     if [ "$KIND_LOCAL_REGISTRY" == true ];then

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -15,7 +15,8 @@ FROM ubuntu:26.04
 
 USER root
 
-RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables
+# Keep socat until ovn-kubernetes#6122 removes the e2e/runtime dependency on it.
+RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables socat
 
 # Install OVS and OVN packages.
 RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host

--- a/dist/images/Dockerfile.ubuntu.arm64
+++ b/dist/images/Dockerfile.ubuntu.arm64
@@ -15,7 +15,8 @@ FROM ubuntu:26.04
 
 USER root
 
-RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables
+# Keep socat until ovn-kubernetes#6122 removes the e2e/runtime dependency on it.
+RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables socat
 
 # Install OVS and OVN packages.
 RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -21,6 +21,8 @@ ifeq ($(ARCH),arm64)
         DOCKERFILE_ARCH=.arm64
 endif
 IMAGE ?= ovn-daemonset-fedora
+UBUNTU_IMAGE ?= $(if $(filter ovn-daemonset-fedora,$(IMAGE)),ovn-kube-ubuntu$(IMAGE_ARCH),$(IMAGE))
+UBUNTU_IMAGE_LATEST ?= $(if $(filter ovn-daemonset-fedora,$(IMAGE)),ovn-kube-ubuntu,$(IMAGE))
 
 OVN_REPO ?= https://github.com/ovn-org/ovn
 OVN_GITREF ?=
@@ -37,10 +39,12 @@ OCI_BIN ?= docker
 
 # The image of ovnkube/ovn-daemonset-ubuntu should be multi-arched before using it on arm64
 ubuntu-image: bld
-	${OCI_BIN} build -t ovn-kube-ubuntu$(IMAGE_ARCH) -f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
+	${OCI_BIN} build -t ${UBUNTU_IMAGE} -f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
 ifeq ($(ARCH),amd64)
-	${OCI_BIN} tag "ovn-kube-ubuntu$(IMAGE_ARCH):latest" \
-              "ovn-kube-ubuntu:latest"
+ifneq ($(UBUNTU_IMAGE),$(UBUNTU_IMAGE_LATEST))
+	${OCI_BIN} tag "${UBUNTU_IMAGE}" \
+              "${UBUNTU_IMAGE_LATEST}"
+endif
 endif
 
 FEDORA_BASE_IMAGE ?= quay.io/fedora/fedora:43

--- a/test/e2e/diagnostics/daemonset.go
+++ b/test/e2e/diagnostics/daemonset.go
@@ -23,7 +23,11 @@ func composePeriodicCmd(cmd string, interval uint32) string {
 func (d *Diagnostics) composeDiagnosticsDaemonSet(name, cmd, tool string) appsv1.DaemonSet {
 	ovnImage := os.Getenv("OVN_IMAGE")
 	if ovnImage == "" {
-		ovnImage = "localhost/ovn-daemonset-fedora:dev"
+		ovnImageFamily := os.Getenv("OVN_IMAGE_FAMILY")
+		if ovnImageFamily == "" {
+			ovnImageFamily = "fedora"
+		}
+		ovnImage = fmt.Sprintf("localhost/ovn-daemonset-%s:dev", ovnImageFamily)
 	}
 	return appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/scripts/test-ovnkube-trace.sh
+++ b/test/scripts/test-ovnkube-trace.sh
@@ -15,7 +15,8 @@ set -e
 if [ "${KUBECONFIG}" == "" ]; then
   export KUBECONFIG=${HOME}/ovn.conf
 fi
-export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-fedora:pr}
+export OVN_IMAGE_FAMILY=${OVN_IMAGE_FAMILY:-fedora}
+export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-${OVN_IMAGE_FAMILY}:pr}
 
 DIR=$(dirname "${BASH_SOURCE[0]}")
 

--- a/test/scripts/upgrade-ovn.sh
+++ b/test/scripts/upgrade-ovn.sh
@@ -5,7 +5,8 @@
 set -ex
 
 export KUBECONFIG=${KUBECONFIG:-${HOME}/ovn.conf}
-export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-fedora:pr}
+export OVN_IMAGE_FAMILY=${OVN_IMAGE_FAMILY:-fedora}
+export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-${OVN_IMAGE_FAMILY}:pr}
 export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This should give some more confidence in changes to ubuntu dockerfiles,
and in general in that ovn-kubernetes services work if built on top of
ubuntu base images.

Fixes #6146

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

The job that switched to ubuntu image should pass. I also confirmed locally as follows:

```
export OVN_IMAGE_FAMILY=ubuntu
export OVN_IMAGE=local

./contrib/kind.sh \
  -cn ovn-ubuntu-test \
  -gm local \
  -ds \
  -ic \
  -ho \
  -me \
  -el \
  -nqe \
  -mlb \
  -ii \
  -mps

kubectl -n ovn-kubernetes get pods \
  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}' \
  | grep 'ovn-daemonset-ubuntu'
```
