### PR TITLE
no-overlay: add CUDN support for no-overlay managed routing 

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -203,7 +203,7 @@ func NewClusterManager(
 	if util.IsRouteAdvertisementsEnabled() {
 		cm.raController = routeadvertisements.NewController(cm.networkManager.Interface(), wf, ovnClient)
 		if config.ManagedBGP.FRRNamespace != "" {
-			cm.managedBGPController = managedbgp.NewController(wf, ovnClient.FRRClient, ovnClient.RouteAdvertisementsClient, recorder)
+			cm.managedBGPController = managedbgp.NewController(wf, ovnClient.FRRClient, ovnClient.RouteAdvertisementsClient, ovnClient.UserDefinedNetworkClient)
 		}
 		if config.Default.Transport == types.NetworkTransportNoOverlay {
 			cm.noOverlayController = nooverlay.NewController(wf, recorder)

--- a/go-controller/pkg/clustermanager/managedbgp/controller.go
+++ b/go-controller/pkg/clustermanager/managedbgp/controller.go
@@ -15,8 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/tools/record"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
@@ -26,24 +25,32 @@ import (
 	raclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned"
 	ralisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/listers/routeadvertisements/v1"
 	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
+	userdefinednetworkv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	cudnclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned"
+	cudnlisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/listers/userdefinednetwork/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 const (
-	// ControllerName is the name of the managed BGP controller
-	ControllerName = "managed-bgp-controller"
-	// fieldManager identifies writes performed by this controller.
-	fieldManager = "clustermanager-managedbgp-controller"
-	// FRRConfigManagedLabel is the label used to identify FRRConfigurations managed by this controller
-	FRRConfigManagedLabel = "k8s.ovn.org/managed-internal-fabric"
-	// FRRConfigManagedValue is the value used for the FRRConfigManagedLabel
-	FRRConfigManagedValue = "bgp"
-	// ManagedRANetworkLabel is the label set on managed RouteAdvertisements to identify the network they advertise
-	ManagedRANetworkLabel = "k8s.ovn.org/managed-network"
+	// controllerName is the name of the managed BGP controller
+	controllerName = "managed-bgp-controller"
+	// fieldManager identifies this controller as the server-side author of owned resources.
+	// Used with FieldManager in Create/Update options so that isOwnUpdate can
+	// filter out informer events that result from our own writes.
+	fieldManager = "clustermanager-managed-bgp-controller"
+	// frrConfigManagedLabel is the label used to identify FRRConfigurations managed by this controller
+	frrConfigManagedLabel = "k8s.ovn.org/managed-internal-fabric"
+	// frrConfigManagedValue is the value used for the frrConfigManagedLabel
+	frrConfigManagedValue = "bgp"
+	// managedRANetworkLabel is the label used to identify managed resources by network name.
+	// It is set on managed RouteAdvertisements and on CUDNs (to enable RA network selection).
+	managedRANetworkLabel = "k8s.ovn.org/managed-network"
 	// managedNamePrefix is the prefix for managed resource names
-	managedNamePrefix = "ovnk-managed-"
+	managedNamePrefix = "ovnk-managedbgp-"
+	// managedFRRConfigurationName is the static name for the managed base FRRConfiguration.
+	managedFRRConfigurationName = "ovnk-managedbgp-nooverlay"
 )
 
 func managedHashedName(s string) string {
@@ -52,32 +59,26 @@ func managedHashedName(s string) string {
 	return fmt.Sprintf("%s%x", managedNamePrefix, h.Sum64())
 }
 
-// ManagedRouteAdvertisementName returns the name of the managed RouteAdvertisement
-// for the given network name. The name follows the pattern "ovnk-managed-<hash>"
+// managedRouteAdvertisementName returns the name of the managed RouteAdvertisement
+// for the given network name. The name follows the pattern "ovnk-managedbgp-<hash>"
 // where <hash> is derived from the network name.
-func ManagedRouteAdvertisementName(networkName string) string {
+func managedRouteAdvertisementName(networkName string) string {
 	return managedHashedName(networkName)
-}
-
-// BaseFRRConfigName returns the name of the base FRRConfiguration that
-// configures the cluster internal BGP fabric. This FRRConfiguration is shared
-// by all networks in managed routing mode. The name follows the pattern
-// "ovnk-managed-<hash>" where <hash> is derived from the configured AS number.
-func BaseFRRConfigName() string {
-	return managedHashedName(fmt.Sprintf("%d", config.ManagedBGP.ASNumber))
 }
 
 // Controller manages the BGP topology for no-overlay networks with managed routing
 type Controller struct {
-	frrClient            frrclientset.Interface
-	frrLister            frrlisters.FRRConfigurationLister
-	raClient             raclientset.Interface
-	raLister             ralisters.RouteAdvertisementsLister
-	nodeController       controllerutil.Controller
-	managedRAController  controllerutil.Controller
-	managedFRRController controllerutil.Controller
-	wf                   *factory.WatchFactory
-	recorder             record.EventRecorder
+	frrClient      frrclientset.Interface
+	frrLister      frrlisters.FRRConfigurationLister
+	raClient       raclientset.Interface
+	raLister       ralisters.RouteAdvertisementsLister
+	cudnClient     cudnclientset.Interface
+	cudnLister     cudnlisters.ClusterUserDefinedNetworkLister
+	nodeController controllerutil.Controller
+	raController   controllerutil.Controller
+	frrController  controllerutil.Controller
+	cudnController controllerutil.Controller
+	wf             *factory.WatchFactory
 }
 
 // NewController creates a new managed BGP controller
@@ -85,15 +86,15 @@ func NewController(
 	wf *factory.WatchFactory,
 	frrClient frrclientset.Interface,
 	raClient raclientset.Interface,
-	recorder record.EventRecorder,
+	cudnClient cudnclientset.Interface,
 ) *Controller {
 	c := &Controller{
-		frrClient: frrClient,
-		frrLister: wf.FRRConfigurationsInformer().Lister(),
-		raClient:  raClient,
-		raLister:  wf.RouteAdvertisementsInformer().Lister(),
-		wf:        wf,
-		recorder:  recorder,
+		frrClient:  frrClient,
+		frrLister:  wf.FRRConfigurationsInformer().Lister(),
+		raClient:   raClient,
+		raLister:   wf.RouteAdvertisementsInformer().Lister(),
+		cudnClient: cudnClient,
+		wf:         wf,
 	}
 
 	nodeConfig := &controllerutil.ControllerConfig[corev1.Node]{
@@ -104,49 +105,110 @@ func NewController(
 		Lister:         wf.NodeCoreInformer().Lister().List,
 		ObjNeedsUpdate: c.nodeNeedsUpdate,
 	}
-	c.nodeController = controllerutil.NewController(ControllerName, nodeConfig)
+	c.nodeController = controllerutil.NewController(controllerName, nodeConfig)
 
-	managedRAConfig := &controllerutil.ControllerConfig[ratypes.RouteAdvertisements]{
+	raConfig := &controllerutil.ControllerConfig[ratypes.RouteAdvertisements]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
-		Reconcile:      c.reconcileManagedRouteAdvertisement,
+		Reconcile:      c.reconcileRA,
 		Threadiness:    1,
 		Informer:       wf.RouteAdvertisementsInformer().Informer(),
 		Lister:         wf.RouteAdvertisementsInformer().Lister().List,
-		ObjNeedsUpdate: c.managedRANeedsUpdate,
+		ObjNeedsUpdate: c.raNeedsUpdate,
 	}
-	c.managedRAController = controllerutil.NewController(ControllerName+"-routeadvertisement", managedRAConfig)
+	c.raController = controllerutil.NewController(controllerName+"-ra", raConfig)
 
-	managedFRRConfig := &controllerutil.ControllerConfig[frrtypes.FRRConfiguration]{
+	frrConfig := &controllerutil.ControllerConfig[frrtypes.FRRConfiguration]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
-		Reconcile:      c.reconcileManagedFRRConfiguration,
+		Reconcile:      c.reconcileFRRConfiguration,
 		Threadiness:    1,
 		Informer:       wf.FRRConfigurationsInformer().Informer(),
 		Lister:         wf.FRRConfigurationsInformer().Lister().List,
-		ObjNeedsUpdate: c.managedFRRConfigNeedsUpdate,
+		ObjNeedsUpdate: c.frrNeedsUpdate,
 	}
-	c.managedFRRController = controllerutil.NewController(ControllerName+"-frrconfiguration", managedFRRConfig)
+	c.frrController = controllerutil.NewController(controllerName+"-frr", frrConfig)
+
+	if util.IsNetworkSegmentationSupportEnabled() {
+		c.cudnLister = wf.ClusterUserDefinedNetworkInformer().Lister()
+		cudnConfig := &controllerutil.ControllerConfig[userdefinednetworkv1.ClusterUserDefinedNetwork]{
+			RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
+			Reconcile:      c.reconcileNetwork,
+			Threadiness:    1,
+			Informer:       wf.ClusterUserDefinedNetworkInformer().Informer(),
+			Lister:         wf.ClusterUserDefinedNetworkInformer().Lister().List,
+			ObjNeedsUpdate: c.cudnNeedsUpdate,
+		}
+		c.cudnController = controllerutil.NewController(controllerName+"-cudn", cudnConfig)
+	}
 
 	return c
 }
 
+// isCDNManaged returns true if the cluster default network is configured for
+// no-overlay mode with managed routing.
+func isCDNManaged() bool {
+	return config.Default.Transport == types.NetworkTransportNoOverlay &&
+		config.NoOverlay.Routing == config.NoOverlayRoutingManaged
+}
+
+// isCUDNManaged returns true if the given CUDN is configured for
+// no-overlay transport with managed routing.
+func isCUDNManaged(cudn *userdefinednetworkv1.ClusterUserDefinedNetwork) bool {
+	if cudn == nil {
+		return false
+	}
+	return cudn.Spec.Network.Transport == userdefinednetworkv1.TransportOptionNoOverlay &&
+		cudn.Spec.Network.NoOverlay != nil &&
+		cudn.Spec.Network.NoOverlay.Routing == userdefinednetworkv1.RoutingManaged
+}
+
+// getManagedCUDNs returns all CUDNs that are configured for no-overlay with managed routing.
+func (c *Controller) getManagedCUDNs() ([]*userdefinednetworkv1.ClusterUserDefinedNetwork, error) {
+	if c.cudnLister == nil {
+		return nil, nil
+	}
+	allCUDNs, err := c.cudnLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list CUDNs: %w", err)
+	}
+	var managed []*userdefinednetworkv1.ClusterUserDefinedNetwork
+	for _, cudn := range allCUDNs {
+		if isCUDNManaged(cudn) {
+			managed = append(managed, cudn)
+		}
+	}
+	return managed, nil
+}
+
 // Start starts the managed BGP controller.
-// If managed routing mode is not active, it cleans up any previously created
-// managed resources and returns without starting the controllers.
 func (c *Controller) Start() error {
 	klog.Infof("Starting managed BGP controller")
 
-	if config.Default.Transport != types.NetworkTransportNoOverlay || config.NoOverlay.Routing != config.NoOverlayRoutingManaged {
-		klog.Infof("Managed routing mode is not active, cleaning up any stale managed resources")
-		return c.cleanupManagedResources()
+	controllers := []controllerutil.Reconciler{c.nodeController, c.raController, c.frrController}
+	if c.cudnController != nil {
+		controllers = append(controllers, c.cudnController)
 	}
 
-	return controllerutil.StartWithInitialSync(c.ensureManagedResources, c.nodeController, c.managedRAController, c.managedFRRController)
+	if err := controllerutil.Start(controllers...); err != nil {
+		return err
+	}
+
+	if isCDNManaged() {
+		// Trigger initial reconciliation for the CDN managed RouteAdvertisement so
+		// it is created on startup even before any RA informer events arrive.
+		c.raController.Reconcile(managedRouteAdvertisementName(types.DefaultNetworkName))
+	}
+
+	return nil
 }
 
 // Stop stops the managed BGP controller
 func (c *Controller) Stop() {
 	klog.Infof("Stopping managed BGP controller")
-	controllerutil.Stop(c.nodeController, c.managedRAController, c.managedFRRController)
+	controllers := []controllerutil.Reconciler{c.nodeController, c.raController, c.frrController}
+	if c.cudnController != nil {
+		controllers = append(controllers, c.cudnController)
+	}
+	controllerutil.Stop(controllers...)
 }
 
 func (c *Controller) nodeNeedsUpdate(oldNode, newNode *corev1.Node) bool {
@@ -159,97 +221,214 @@ func (c *Controller) nodeNeedsUpdate(oldNode, newNode *corev1.Node) bool {
 	return !reflect.DeepEqual(oldV4, newV4) || !reflect.DeepEqual(oldV6, newV6)
 }
 
-func (c *Controller) managedRANeedsUpdate(oldRA, newRA *ratypes.RouteAdvertisements) bool {
-	if newRA == nil || newRA.Name != c.defaultManagedRAName() {
-		return false
-	}
-	if isOwnUpdate(newRA.ManagedFields) {
-		return false
-	}
-	if oldRA == nil {
-		return true
-	}
-	return !reflect.DeepEqual(oldRA.Spec, newRA.Spec) || !reflect.DeepEqual(oldRA.Labels, newRA.Labels)
-}
-
-func (c *Controller) managedFRRConfigNeedsUpdate(oldConfig, newConfig *frrtypes.FRRConfiguration) bool {
-	if newConfig == nil || newConfig.Namespace != config.ManagedBGP.FRRNamespace || newConfig.Name != BaseFRRConfigName() {
-		return false
-	}
-	if isOwnUpdate(newConfig.ManagedFields) {
-		return false
-	}
-	if oldConfig == nil {
-		return true
-	}
-	return !reflect.DeepEqual(oldConfig.Spec, newConfig.Spec) || !reflect.DeepEqual(oldConfig.Labels, newConfig.Labels)
-}
-
+// isOwnUpdate checks if an object was last updated by this controller,
+// as indicated by its managed fields. Used to avoid reconciling events
+// that result from our own writes.
 func isOwnUpdate(managedFields []metav1.ManagedFieldsEntry) bool {
 	return util.IsLastUpdatedByManager(fieldManager, managedFields)
 }
 
-func (c *Controller) reconcileManagedRouteAdvertisement(key string) error {
-	if key != c.defaultManagedRAName() {
-		return nil
+func isManagedRA(ra *ratypes.RouteAdvertisements) bool {
+	if ra == nil {
+		return false
 	}
-	if err := c.ensureManagedRouteAdvertisement(types.DefaultNetworkName); err != nil {
-		return fmt.Errorf("failed to ensure managed RouteAdvertisement: %w", err)
+	_, ok := ra.Labels[managedRANetworkLabel]
+	return ok
+}
+
+func isManagedBaseFRRConfiguration(cfg *frrtypes.FRRConfiguration) bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.Name == managedFRRConfigurationName
+}
+
+func (c *Controller) cudnNeedsUpdate(oldCUDN, newCUDN *userdefinednetworkv1.ClusterUserDefinedNetwork) bool {
+	if newCUDN == nil {
+		// Delete events bypass ObjNeedsUpdate and are always reconciled.
+		return false
+	}
+	if oldCUDN == nil {
+		return isCUDNManaged(newCUDN)
+	}
+
+	if !isCUDNManaged(oldCUDN) && !isCUDNManaged(newCUDN) {
+		return false
+	}
+	// Ignore events from our own writes (e.g. ensureManagedNetworkLabel)
+	if isOwnUpdate(newCUDN.ManagedFields) {
+		return false
+	}
+
+	// CUDN spec is immutable, only managedRANetworkLabel changes matter.
+	return oldCUDN.Labels[managedRANetworkLabel] != newCUDN.Labels[managedRANetworkLabel]
+}
+
+func (c *Controller) raNeedsUpdate(oldRA, newRA *ratypes.RouteAdvertisements) bool {
+	if !isManagedRA(oldRA) && !isManagedRA(newRA) {
+		return false
+	}
+	// Ignore events from our own writes.
+	// The nil check is a safety guard; newRA should never be nil here as delete events bypass ObjNeedsUpdate.
+	if newRA == nil || isOwnUpdate(newRA.ManagedFields) {
+		return false
+	}
+	return oldRA == nil ||
+		!reflect.DeepEqual(oldRA.Spec, newRA.Spec) ||
+		oldRA.Labels[managedRANetworkLabel] != newRA.Labels[managedRANetworkLabel]
+}
+
+func (c *Controller) frrNeedsUpdate(oldFRR, newFRR *frrtypes.FRRConfiguration) bool {
+	if !isManagedBaseFRRConfiguration(oldFRR) && !isManagedBaseFRRConfiguration(newFRR) {
+		return false
+	}
+	// Ignore events from our own writes.
+	// The nil check is a safety guard; newFRR should never be nil here as delete events bypass ObjNeedsUpdate.
+	if newFRR == nil || isOwnUpdate(newFRR.ManagedFields) {
+		return false
+	}
+	return oldFRR == nil ||
+		!reflect.DeepEqual(oldFRR.Spec, newFRR.Spec) ||
+		oldFRR.Labels[frrConfigManagedLabel] != newFRR.Labels[frrConfigManagedLabel]
+}
+
+// reconcileNetwork reconciles managed resources for a network (CDN or CUDN).
+// For CUDNs, the key is the CUDN name from the informer. For the CDN, the key
+// is types.DefaultNetworkName, enqueued on startup.
+func (c *Controller) reconcileNetwork(key string) error {
+	var cudn *userdefinednetworkv1.ClusterUserDefinedNetwork
+	var managed bool
+
+	if key == types.DefaultNetworkName {
+		managed = isCDNManaged()
+	} else if c.cudnLister != nil {
+		var err error
+		cudn, err = c.cudnLister.Get(key)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get CUDN %s: %w", key, err)
+		}
+		if cudn == nil {
+			klog.Infof("CUDN %s was deleted, cleaning up managed RouteAdvertisement", key)
+		}
+		managed = isCUDNManaged(cudn)
+	}
+
+	if managed {
+		return c.ensureManagedNetworkResources(key, cudn)
+	}
+	return c.cleanupManagedNetworkResources(key)
+}
+
+func (c *Controller) ensureManagedNetworkResources(networkName string, cudn *userdefinednetworkv1.ClusterUserDefinedNetwork) error {
+	networkType := "CDN"
+	if cudn != nil {
+		networkType = "CUDN"
+	}
+	if err := c.ensureBaseFRRConfiguration(); err != nil {
+		return fmt.Errorf("failed to ensure base FRRConfiguration for %s %s: %w", networkType, networkName, err)
+	}
+	if cudn != nil {
+		if err := c.ensureManagedNetworkLabel(cudn); err != nil {
+			return err
+		}
+	}
+	return c.ensureManagedRouteAdvertisement(networkName)
+}
+
+func (c *Controller) cleanupManagedNetworkResources(networkName string) error {
+	if err := c.deleteManagedRA(networkName); err != nil {
+		return err
+	}
+	return c.cleanupBaseFRRConfigurationsIfUnused()
+}
+
+func (c *Controller) cleanupBaseFRRConfigurationsIfUnused() error {
+	managedCUDNs, err := c.getManagedCUDNs()
+	if err != nil {
+		return err
+	}
+	if !isCDNManaged() && len(managedCUDNs) == 0 {
+		return c.cleanupBaseFRRConfigurations()
 	}
 	return nil
 }
 
-func (c *Controller) reconcileManagedFRRConfiguration(key string) error {
-	if key != c.managedBaseFRRConfigKey() {
+func (c *Controller) reconcileRA(key string) error {
+	networkName, err := c.resolveNetworkForRA(key)
+	if err != nil {
+		return err
+	}
+	if networkName == "" {
 		return nil
 	}
-	return c.ensureManagedBaseFRRConfiguration()
+	return c.reconcileNetwork(networkName)
 }
 
-func (c *Controller) defaultManagedRAName() string {
-	return ManagedRouteAdvertisementName(types.DefaultNetworkName)
+func (c *Controller) reconcileFRRConfiguration(_ string) error {
+	managedCUDNs, err := c.getManagedCUDNs()
+	if err != nil {
+		return err
+	}
+	if isCDNManaged() || len(managedCUDNs) > 0 {
+		return c.ensureBaseFRRConfiguration()
+	}
+	return c.cleanupBaseFRRConfigurations()
 }
 
-func (c *Controller) managedBaseFRRConfigKey() string {
-	return fmt.Sprintf("%s/%s", config.ManagedBGP.FRRNamespace, BaseFRRConfigName())
-}
-
-func (c *Controller) ensureManagedResources() error {
-	if err := c.ensureManagedRouteAdvertisement(types.DefaultNetworkName); err != nil {
-		return fmt.Errorf("failed to ensure managed RouteAdvertisement: %w", err)
+// resolveNetworkForRA resolves the network name for the given RA key.
+func (c *Controller) resolveNetworkForRA(key string) (string, error) {
+	// Get the network name from the RA label if it exists.
+	ra, err := c.raLister.Get(key)
+	if err == nil {
+		if networkName, ok := ra.Labels[managedRANetworkLabel]; ok {
+			return networkName, nil
+		}
 	}
 
-	return c.ensureManagedBaseFRRConfiguration()
+	// If the label is missing, determine the network name by matching the RA hash name.
+	if key == managedRouteAdvertisementName(types.DefaultNetworkName) {
+		return types.DefaultNetworkName, nil
+	}
+	if c.cudnLister != nil {
+		allCUDNs, err := c.cudnLister.List(labels.Everything())
+		if err != nil {
+			return "", fmt.Errorf("failed to list CUDNs: %w", err)
+		}
+		for _, cudn := range allCUDNs {
+			if key == managedRouteAdvertisementName(cudn.Name) {
+				return cudn.Name, nil
+			}
+		}
+	}
+	return "", nil
 }
 
 func (c *Controller) reconcileNode(_ string) error {
-	return c.ensureManagedResources()
-}
-
-func (c *Controller) ensureManagedBaseFRRConfiguration() error {
-	if config.ManagedBGP.Topology != config.ManagedBGPTopologyFullMesh {
-		return fmt.Errorf("unsupported managed BGP topology: %s", config.ManagedBGP.Topology)
-	}
-
-	nodes, err := c.wf.GetNodes()
+	// Node IPs only affect the FRRConfiguration peer list.
+	managedCUDNs, err := c.getManagedCUDNs()
 	if err != nil {
-		return fmt.Errorf("failed to list nodes: %w", err)
+		return err
+	}
+	if !isCDNManaged() && len(managedCUDNs) == 0 {
+		return nil
 	}
 
-	// For full-mesh, we ensure there is a single base FRRConfiguration peering with all nodes.
-	// The RouteAdvertisements controller will then generate per-node configs based on this,
-	// excluding self-peering.
-	if err := c.ensureBaseFRRConfiguration(nodes); err != nil {
-		klog.Errorf("Failed to ensure base FRRConfiguration: %v", err)
-		return err
+	if err := c.ensureBaseFRRConfiguration(); err != nil {
+		return fmt.Errorf("failed to ensure base FRRConfiguration: %w", err)
 	}
 
 	return nil
 }
 
-// ensureBaseFRRConfiguration creates or updates the base FRRConfiguration
-// for iBGP full-mesh peering between all cluster nodes.
-func (c *Controller) ensureBaseFRRConfiguration(allNodes []*corev1.Node) error {
+func (c *Controller) ensureBaseFRRConfiguration() error {
+	if config.ManagedBGP.Topology != config.ManagedBGPTopologyFullMesh {
+		return fmt.Errorf("unsupported managed BGP topology %q, only %q is supported", config.ManagedBGP.Topology, config.ManagedBGPTopologyFullMesh)
+	}
+
+	allNodes, err := c.wf.GetNodes()
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
 	neighbors := []frrtypes.Neighbor{}
 	for _, node := range allNodes {
 		v4, v6 := util.GetNodeInternalAddrs(node)
@@ -273,86 +452,76 @@ func (c *Controller) ensureBaseFRRConfiguration(allNodes []*corev1.Node) error {
 		return neighbors[i].Address < neighbors[j].Address
 	})
 
-	baseName := BaseFRRConfigName()
-	if err := c.cleanupStaleFRRConfigurations(baseName); err != nil {
-		return err
-	}
-
-	frrConfig := &frrtypes.FRRConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      baseName,
-			Namespace: config.ManagedBGP.FRRNamespace,
-			Labels: map[string]string{
-				FRRConfigManagedLabel: FRRConfigManagedValue,
-			},
-		},
-		Spec: frrtypes.FRRConfigurationSpec{
-			// Empty NodeSelector means it applies as a base for all nodes by RouteAdvertisements controller
-			NodeSelector: metav1.LabelSelector{},
-			BGP: frrtypes.BGPConfig{
-				Routers: []frrtypes.Router{
-					{
-						ASN:       config.ManagedBGP.ASNumber,
-						Neighbors: neighbors,
-					},
+	desiredSpec := frrtypes.FRRConfigurationSpec{
+		// Empty NodeSelector means it applies as a base for all nodes by RouteAdvertisements controller
+		NodeSelector: metav1.LabelSelector{},
+		BGP: frrtypes.BGPConfig{
+			Routers: []frrtypes.Router{
+				{
+					ASN:       config.ManagedBGP.ASNumber,
+					Neighbors: neighbors,
 				},
 			},
 		},
 	}
 
-	existing, err := c.frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), baseName, metav1.GetOptions{})
+	frrConfigName := managedFRRConfigurationName
+	existing, err := c.frrLister.FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(frrConfigName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			klog.Infof("Creating base FRRConfiguration %s", baseName)
-			_, err = c.frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Create(context.TODO(), frrConfig, metav1.CreateOptions{
-				FieldManager: fieldManager,
-			})
-			if err != nil && !apierrors.IsAlreadyExists(err) {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		frrConfig := &frrtypes.FRRConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      frrConfigName,
+				Namespace: config.ManagedBGP.FRRNamespace,
+				Labels: map[string]string{
+					frrConfigManagedLabel: frrConfigManagedValue,
+				},
+			},
+			Spec: desiredSpec,
+		}
+		klog.Infof("Creating base FRRConfiguration")
+		_, err = c.frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Create(context.TODO(), frrConfig, metav1.CreateOptions{FieldManager: fieldManager})
+		if err != nil {
+			return fmt.Errorf("failed to create base FRRConfiguration: %w", err)
+		}
+	} else {
+		needsUpdate := !reflect.DeepEqual(existing.Spec, desiredSpec) ||
+			existing.Labels[frrConfigManagedLabel] != frrConfigManagedValue
+		if needsUpdate {
+			klog.Infof("Updating base FRRConfiguration %s", existing.Name)
+			updated := existing.DeepCopy()
+			if updated.Labels == nil {
+				updated.Labels = map[string]string{}
+			}
+			updated.Labels[frrConfigManagedLabel] = frrConfigManagedValue
+			updated.Spec = desiredSpec
+			_, err = c.frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Update(context.TODO(), updated, metav1.UpdateOptions{FieldManager: fieldManager})
+			if err != nil {
 				return err
 			}
-			return nil
 		}
-		return err
-	}
-
-	needsUpdate := !reflect.DeepEqual(existing.Spec, frrConfig.Spec) ||
-		existing.Labels[FRRConfigManagedLabel] != FRRConfigManagedValue
-	if needsUpdate {
-		klog.Infof("Updating base FRRConfiguration %s", baseName)
-		updated := existing.DeepCopy()
-		if updated.Labels == nil {
-			updated.Labels = map[string]string{}
-		}
-		updated.Labels[FRRConfigManagedLabel] = FRRConfigManagedValue
-		updated.Spec = frrConfig.Spec
-		_, err = c.frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Update(context.TODO(), updated, metav1.UpdateOptions{
-			FieldManager: fieldManager,
-		})
-		return err
 	}
 
 	return nil
 }
 
-// cleanupStaleFRRConfigurations removes any FRRConfigurations with the managed label
-// whose name doesn't match the current base name (e.g. after an AS number change).
-func (c *Controller) cleanupStaleFRRConfigurations(currentBaseName string) error {
-	managedConfigs, err := c.frrLister.FRRConfigurations(config.ManagedBGP.FRRNamespace).List(
-		labels.SelectorFromSet(labels.Set{FRRConfigManagedLabel: FRRConfigManagedValue}),
-	)
+// ensureManagedNetworkLabel sets managedRANetworkLabel=cudn.Name on the CUDN so that
+// the managed RA's ClusterUserDefinedNetworkSelector can match the CUDN's NADs by label.
+// The RA cannot select by CUDN name directly, so we stamp this label onto the CUDN and
+// reference it from the RA's NetworkSelector.
+func (c *Controller) ensureManagedNetworkLabel(cudn *userdefinednetworkv1.ClusterUserDefinedNetwork) error {
+	if cudn.Labels != nil && cudn.Labels[managedRANetworkLabel] == cudn.Name {
+		return nil
+	}
+	patch := fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, managedRANetworkLabel, cudn.Name)
+	_, err := c.cudnClient.K8sV1().ClusterUserDefinedNetworks().Patch(
+		context.TODO(), cudn.Name, k8stypes.MergePatchType, []byte(patch), metav1.PatchOptions{FieldManager: fieldManager})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to set %s label on CUDN %s: %w", managedRANetworkLabel, cudn.Name, err)
 	}
-	for _, cfg := range managedConfigs {
-		if cfg.Name == currentBaseName {
-			continue
-		}
-		if err := c.frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Delete(
-			context.TODO(), cfg.Name, metav1.DeleteOptions{},
-		); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete stale FRRConfiguration %s: %w", cfg.Name, err)
-		}
-	}
+	klog.Infof("Set %s=%s label on CUDN %s", managedRANetworkLabel, cudn.Name, cudn.Name)
 	return nil
 }
 
@@ -362,30 +531,29 @@ func (c *Controller) cleanupStaleFRRConfigurations(currentBaseName string) error
 func (c *Controller) ensureManagedRouteAdvertisement(networkName string) error {
 	var netSelector apitypes.NetworkSelectors
 	if networkName == types.DefaultNetworkName {
-		if config.Default.Transport != types.NetworkTransportNoOverlay || config.NoOverlay.Routing != config.NoOverlayRoutingManaged {
+		if !isCDNManaged() {
 			return nil
 		}
 		netSelector = apitypes.NetworkSelectors{{NetworkSelectionType: apitypes.DefaultNetwork}}
 	} else {
-		// CUDN: build a selector that matches the CUDN by the managed network label
 		netSelector = apitypes.NetworkSelectors{{
 			NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
 			ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
 				NetworkSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						ManagedRANetworkLabel: networkName,
+						managedRANetworkLabel: networkName,
 					},
 				},
 			},
 		}}
 	}
 
-	raName := ManagedRouteAdvertisementName(networkName)
+	raName := managedRouteAdvertisementName(networkName)
 	ra := &ratypes.RouteAdvertisements{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: raName,
 			Labels: map[string]string{
-				ManagedRANetworkLabel: networkName,
+				managedRANetworkLabel: networkName,
 			},
 		},
 		Spec: ratypes.RouteAdvertisementsSpec{
@@ -395,10 +563,9 @@ func (c *Controller) ensureManagedRouteAdvertisement(networkName string) error {
 			},
 			FRRConfigurationSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					FRRConfigManagedLabel: FRRConfigManagedValue,
+					frrConfigManagedLabel: frrConfigManagedValue,
 				},
 			},
-			// nodeSelector must select all nodes for PodNetwork
 			NodeSelector: metav1.LabelSelector{},
 		},
 	}
@@ -406,10 +573,8 @@ func (c *Controller) ensureManagedRouteAdvertisement(networkName string) error {
 	existing, err := c.raLister.Get(raName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.Infof("Creating managed RouteAdvertisement %s for network %s", raName, networkName)
-			_, err = c.raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{
-				FieldManager: fieldManager,
-			})
+			klog.Infof("Creating managed RouteAdvertisement %s", raName)
+			_, err = c.raClient.K8sV1().RouteAdvertisements().Create(context.TODO(), ra, metav1.CreateOptions{FieldManager: fieldManager})
 			if err != nil && !apierrors.IsAlreadyExists(err) {
 				return err
 			}
@@ -419,66 +584,39 @@ func (c *Controller) ensureManagedRouteAdvertisement(networkName string) error {
 	}
 
 	needsUpdate := !reflect.DeepEqual(existing.Spec, ra.Spec) ||
-		existing.Labels[ManagedRANetworkLabel] != networkName
+		existing.Labels[managedRANetworkLabel] != networkName
 	if needsUpdate {
-		klog.Infof("Updating managed RouteAdvertisement %s for network %s", raName, networkName)
+		klog.Infof("Updating managed RouteAdvertisement %s", raName)
 		updated := existing.DeepCopy()
 		if updated.Labels == nil {
 			updated.Labels = map[string]string{}
 		}
-		updated.Labels[ManagedRANetworkLabel] = networkName
+		updated.Labels[managedRANetworkLabel] = networkName
 		updated.Spec = ra.Spec
-		_, err = c.raClient.K8sV1().RouteAdvertisements().Update(context.TODO(), updated, metav1.UpdateOptions{
-			FieldManager: fieldManager,
-		})
+		_, err = c.raClient.K8sV1().RouteAdvertisements().Update(context.TODO(), updated, metav1.UpdateOptions{FieldManager: fieldManager})
 		return err
 	}
 
 	return nil
 }
 
-// cleanupManagedResources removes the default network's managed RouteAdvertisement
-// and the base FRRConfiguration (if no other RA still selects it).
-func (c *Controller) cleanupManagedResources() error {
-	// Delete the default network's managed RouteAdvertisement
-	raName := ManagedRouteAdvertisementName(types.DefaultNetworkName)
+// deleteManagedRA deletes the managed RouteAdvertisement for the given network name.
+func (c *Controller) deleteManagedRA(networkName string) error {
+	raName := managedRouteAdvertisementName(networkName)
 	err := c.raClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), raName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete managed RouteAdvertisement %s: %w", raName, err)
 	}
+	return nil
+}
 
-	// Delete the base FRRConfiguration if no remaining RA selects it.
-	// Other CUDNs in managed mode may still reference it.
-	managedConfigs, err := c.frrLister.FRRConfigurations(config.ManagedBGP.FRRNamespace).List(
-		labels.SelectorFromSet(labels.Set{FRRConfigManagedLabel: FRRConfigManagedValue}),
-	)
-	if err != nil {
-		return err
+// cleanupBaseFRRConfigurations deletes the managed base FRRConfiguration.
+func (c *Controller) cleanupBaseFRRConfigurations() error {
+	klog.Infof("Deleting managed base FRRConfiguration %s", managedFRRConfigurationName)
+	if err := c.frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Delete(
+		context.TODO(), managedFRRConfigurationName, metav1.DeleteOptions{},
+	); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete base FRRConfiguration %s: %w", managedFRRConfigurationName, err)
 	}
-	if len(managedConfigs) == 0 {
-		return nil
-	}
-
-	// If any other managed RA exists (e.g. CUDN), keep the base FRRConfiguration.
-	managedRAReq, _ := labels.NewRequirement(ManagedRANetworkLabel, selection.Exists, nil)
-	nonDefaultReq, _ := labels.NewRequirement(ManagedRANetworkLabel, selection.NotEquals, []string{types.DefaultNetworkName})
-	remainingManagedRAs, err := c.raLister.List(labels.NewSelector().Add(*managedRAReq, *nonDefaultReq))
-	if err != nil {
-		return fmt.Errorf("failed to list RouteAdvertisements: %w", err)
-	}
-	if len(remainingManagedRAs) > 0 {
-		klog.Infof("Base FRRConfiguration still in use by %d managed RouteAdvertisement(s), skipping deletion", len(remainingManagedRAs))
-		return nil
-	}
-
-	for _, cfg := range managedConfigs {
-		klog.Infof("Deleting managed base FRRConfiguration %s", cfg.Name)
-		if err := c.frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Delete(
-			context.TODO(), cfg.Name, metav1.DeleteOptions{},
-		); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete base FRRConfiguration %s: %w", cfg.Name, err)
-		}
-	}
-
 	return nil
 }

--- a/go-controller/pkg/clustermanager/managedbgp/controller_test.go
+++ b/go-controller/pkg/clustermanager/managedbgp/controller_test.go
@@ -3,6 +3,7 @@ package managedbgp
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,17 +16,40 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
+	ctesting "k8s.io/client-go/testing"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ratypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
 	rafake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned/fake"
 	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
+	userdefinednetworkv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	udnfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
+
+var generateNameCount uint32
+
+// addGenerateNameReactor adds a reactor to a fake client that simulates
+// the server-side GenerateName behavior.
+func addGenerateNameReactor(fake interface {
+	PrependReactor(verb, resource string, reaction ctesting.ReactionFunc)
+}) {
+	fake.PrependReactor("create", "*", func(action ctesting.Action) (handled bool, ret runtime.Object, err error) {
+		ret = action.(ctesting.CreateAction).GetObject()
+		meta, ok := ret.(metav1.Object)
+		if !ok {
+			return
+		}
+		if meta.GetName() == "" && meta.GetGenerateName() != "" {
+			meta.SetName(meta.GetGenerateName() + fmt.Sprintf("%d", atomic.AddUint32(&generateNameCount, 1)))
+		}
+		return
+	})
+}
 
 func TestManagedBGPController(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
@@ -34,17 +58,16 @@ func TestManagedBGPController(t *testing.T) {
 
 var _ = ginkgo.Describe("Managed BGP Controller", func() {
 	var (
-		recorder *record.FakeRecorder
-
 		// Save original config
-		oldTopology             string
-		oldASNumber             uint32
-		oldFRRNamespace         string
-		oldOVNConfigNamespace   string
-		oldEnableMultiNetwork   bool
-		oldEnableRouteAdvertise bool
-		oldTransport            string
-		oldNoOverlayRouting     string
+		oldTopology              string
+		oldASNumber              uint32
+		oldFRRNamespace          string
+		oldOVNConfigNamespace    string
+		oldEnableMultiNetwork    bool
+		oldEnableRouteAdvertise  bool
+		oldEnableNetSegmentation bool
+		oldTransport             string
+		oldNoOverlayRouting      string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -55,6 +78,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 		oldOVNConfigNamespace = config.Kubernetes.OVNConfigNamespace
 		oldEnableMultiNetwork = config.OVNKubernetesFeature.EnableMultiNetwork
 		oldEnableRouteAdvertise = config.OVNKubernetesFeature.EnableRouteAdvertisements
+		oldEnableNetSegmentation = config.OVNKubernetesFeature.EnableNetworkSegmentation
 		oldTransport = config.Default.Transport
 		oldNoOverlayRouting = config.NoOverlay.Routing
 
@@ -67,8 +91,8 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 		config.Kubernetes.OVNConfigNamespace = "ovn-kubernetes"
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 
-		recorder = record.NewFakeRecorder(100)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -79,6 +103,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 		config.Kubernetes.OVNConfigNamespace = oldOVNConfigNamespace
 		config.OVNKubernetesFeature.EnableMultiNetwork = oldEnableMultiNetwork
 		config.OVNKubernetesFeature.EnableRouteAdvertisements = oldEnableRouteAdvertise
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = oldEnableNetSegmentation
 		config.Default.Transport = oldTransport
 		config.NoOverlay.Routing = oldNoOverlayRouting
 	})
@@ -88,24 +113,25 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset()
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			gomega.Expect(controller).NotTo(gomega.BeNil())
 			gomega.Expect(controller.frrClient).To(gomega.Equal(frrFakeClient))
 			gomega.Expect(controller.wf).To(gomega.Equal(wf))
-			gomega.Expect(controller.recorder).To(gomega.Equal(recorder))
 			gomega.Expect(controller.nodeController).NotTo(gomega.BeNil())
-			gomega.Expect(controller.managedRAController).NotTo(gomega.BeNil())
-			gomega.Expect(controller.managedFRRController).NotTo(gomega.BeNil())
+			gomega.Expect(controller.raController).NotTo(gomega.BeNil())
+			gomega.Expect(controller.frrController).NotTo(gomega.BeNil())
 		})
 	})
 
@@ -121,12 +147,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset(node1, node2)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -134,7 +162,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
@@ -146,9 +174,9 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			}, 2*time.Second).Should(gomega.Equal(1))
 
 			// Verify base configuration
-			baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+			baseConfig, err := getBaseFRRConfig(frrFakeClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(baseConfig.Labels).To(gomega.HaveKeyWithValue(FRRConfigManagedLabel, FRRConfigManagedValue))
+			gomega.Expect(baseConfig.Labels).To(gomega.HaveKeyWithValue(frrConfigManagedLabel, frrConfigManagedValue))
 			gomega.Expect(baseConfig.Spec.BGP.Routers).To(gomega.HaveLen(1))
 			gomega.Expect(baseConfig.Spec.BGP.Routers[0].ASN).To(gomega.Equal(uint32(64512)))
 			gomega.Expect(baseConfig.Spec.BGP.Routers[0].Neighbors).To(gomega.HaveLen(2))
@@ -170,12 +198,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset(node1, node2)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -183,7 +213,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
@@ -193,7 +223,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 				return len(list.Items)
 			}, 2*time.Second).Should(gomega.Equal(1))
 
-			baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+			baseConfig, err := getBaseFRRConfig(frrFakeClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(baseConfig.Spec.BGP.Routers[0].Neighbors).To(gomega.HaveLen(2))
 
@@ -208,12 +238,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset(node1, node2)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -221,7 +253,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
@@ -231,7 +263,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 				return len(list.Items)
 			}, 2*time.Second).Should(gomega.Equal(1))
 
-			baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+			baseConfig, err := getBaseFRRConfig(frrFakeClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// 2 nodes × 2 addresses each = 4 neighbors
 			gomega.Expect(baseConfig.Spec.BGP.Routers[0].Neighbors).To(gomega.HaveLen(4))
@@ -243,56 +275,6 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			gomega.Expect(addresses).To(gomega.ConsistOf("10.0.0.1", "fd00::1", "10.0.0.2", "fd00::2"))
 		})
 
-		ginkgo.It("should remove stale managed base FRRConfigurations", func() {
-			node1 := createNode("node1", "10.0.0.1", "")
-			staleBaseConfig := &frrtypes.FRRConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ovnk-managed-stale",
-					Namespace: config.ManagedBGP.FRRNamespace,
-					Labels: map[string]string{
-						FRRConfigManagedLabel: FRRConfigManagedValue,
-					},
-				},
-				Spec: frrtypes.FRRConfigurationSpec{},
-			}
-
-			fakeClient := fake.NewSimpleClientset(node1)
-			frrFakeClient := frrfake.NewSimpleClientset(staleBaseConfig)
-			raFakeClient := rafake.NewSimpleClientset()
-
-			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
-				KubeClient:                fakeClient,
-				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
-				RouteAdvertisementsClient: raFakeClient,
-				FRRClient:                 frrFakeClient,
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer wf.Shutdown()
-
-			err = wf.Start()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
-			err = controller.Start()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer controller.Stop()
-
-			gomega.Eventually(func() int {
-				list, _ := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).List(context.TODO(), metav1.ListOptions{})
-				return len(list.Items)
-			}, 2*time.Second).Should(gomega.Equal(1))
-
-			gomega.Eventually(func() bool {
-				_, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), "ovnk-managed-stale", metav1.GetOptions{})
-				return apierrors.IsNotFound(err)
-			}, 2*time.Second).Should(gomega.BeTrue())
-
-			baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(baseConfig.Labels).To(gomega.HaveKeyWithValue(FRRConfigManagedLabel, FRRConfigManagedValue))
-			gomega.Expect(baseConfig.Spec.BGP.Routers[0].Neighbors).To(gomega.HaveLen(1))
-		})
-
 		ginkgo.It("should update base FRRConfiguration when a node is added", func() {
 			node1 := createNode("node1", "10.0.0.1", "")
 			node2 := createNode("node2", "10.0.0.2", "")
@@ -300,12 +282,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset(node1, node2)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -313,14 +297,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
 
 			// Wait for initial configuration
 			gomega.Eventually(func() int {
-				bc, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+				bc, err := getBaseFRRConfig(frrFakeClient)
 				if err != nil {
 					return 0
 				}
@@ -334,7 +318,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 
 			// Should update to include node3
 			gomega.Eventually(func() []string {
-				bc, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+				bc, err := getBaseFRRConfig(frrFakeClient)
 				if err != nil {
 					return nil
 				}
@@ -353,12 +337,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset(node1, node2)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -366,13 +352,13 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
 
 			gomega.Eventually(func() int {
-				bc, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+				bc, err := getBaseFRRConfig(frrFakeClient)
 				if err != nil {
 					return 0
 				}
@@ -385,14 +371,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 
 			// Should update to exclude node2
 			gomega.Eventually(func() int {
-				bc, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+				bc, err := getBaseFRRConfig(frrFakeClient)
 				if err != nil {
 					return -1
 				}
 				return len(bc.Spec.BGP.Routers[0].Neighbors)
 			}, 2*time.Second).Should(gomega.Equal(1))
 
-			baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+			baseConfig, err := getBaseFRRConfig(frrFakeClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(baseConfig.Spec.BGP.Routers[0].Neighbors[0].Address).To(gomega.Equal("10.0.0.1"))
 		})
@@ -403,12 +389,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset(node1)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -416,13 +404,13 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
 
 			gomega.Eventually(func() string {
-				bc, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+				bc, err := getBaseFRRConfig(frrFakeClient)
 				if err != nil || len(bc.Spec.BGP.Routers) == 0 || len(bc.Spec.BGP.Routers[0].Neighbors) == 0 {
 					return ""
 				}
@@ -436,7 +424,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 
 			// Should update to new IP
 			gomega.Eventually(func() string {
-				bc, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+				bc, err := getBaseFRRConfig(frrFakeClient)
 				if err != nil || len(bc.Spec.BGP.Routers) == 0 || len(bc.Spec.BGP.Routers[0].Neighbors) == 0 {
 					return ""
 				}
@@ -444,23 +432,80 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			}, 2*time.Second).Should(gomega.Equal("10.0.0.99"))
 		})
 
-		ginkgo.It("should clean up managed resources when managed mode is disabled", func() {
+		ginkgo.It("should repair base FRRConfiguration drift", func() {
+			node := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node)
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			err = wf.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
+			err = controller.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer controller.Stop()
+
+			gomega.Eventually(func() error {
+				_, err := getBaseFRRConfig(frrFakeClient)
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+
+			// Drift the FRR config externally (both spec and label)
+			baseConfig, err := getBaseFRRConfig(frrFakeClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			drifted := baseConfig.DeepCopy()
+			drifted.Labels = map[string]string{"drifted": "true"}
+			drifted.Spec.BGP.Routers[0].Neighbors = []frrtypes.Neighbor{{
+				Address:   "10.0.0.99",
+				ASN:       config.ManagedBGP.ASNumber,
+				DisableMP: false,
+			}}
+			_, err = frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Update(context.TODO(), drifted, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// FRR config should be repaired
+			gomega.Eventually(func() bool {
+				cfg, err := getBaseFRRConfig(frrFakeClient)
+				if err != nil {
+					return false
+				}
+				return cfg.Labels[frrConfigManagedLabel] == frrConfigManagedValue &&
+					len(cfg.Spec.BGP.Routers) == 1 &&
+					len(cfg.Spec.BGP.Routers[0].Neighbors) == 1 &&
+					cfg.Spec.BGP.Routers[0].Neighbors[0].Address == "10.0.0.1" &&
+					cfg.Spec.BGP.Routers[0].Neighbors[0].DisableMP
+			}, 2*time.Second).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("should clean up CDN RouteAdvertisement and FRR config when CDN managed mode is disabled", func() {
 			// Pre-create the resources that would have been created by a previous managed-mode run
 			baseFRRConfig := &frrtypes.FRRConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      BaseFRRConfigName(),
+					Name:      managedFRRConfigurationName,
 					Namespace: config.ManagedBGP.FRRNamespace,
 					Labels: map[string]string{
-						FRRConfigManagedLabel: FRRConfigManagedValue,
+						frrConfigManagedLabel: frrConfigManagedValue,
 					},
 				},
 				Spec: frrtypes.FRRConfigurationSpec{},
 			}
 			managedRA := &ratypes.RouteAdvertisements{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: ManagedRouteAdvertisementName(types.DefaultNetworkName),
+					Name: managedRouteAdvertisementName(types.DefaultNetworkName),
 					Labels: map[string]string{
-						ManagedRANetworkLabel: types.DefaultNetworkName,
+						managedRANetworkLabel: types.DefaultNetworkName,
 					},
 				},
 			}
@@ -468,12 +513,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset()
 			frrFakeClient := frrfake.NewSimpleClientset(baseFRRConfig)
 			raFakeClient := rafake.NewSimpleClientset(managedRA)
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -481,24 +528,24 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// Switch to unmanaged mode
+			// Switch CDN to unmanaged mode
 			config.NoOverlay.Routing = config.NoOverlayRoutingUnmanaged
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
 
-			// Base FRRConfiguration should be deleted
+			// CDN managed RouteAdvertisement should be deleted
 			gomega.Eventually(func() bool {
-				_, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName(types.DefaultNetworkName), metav1.GetOptions{})
 				return apierrors.IsNotFound(err)
 			}, 2*time.Second).Should(gomega.BeTrue())
 
-			// Managed RouteAdvertisement should be deleted
+			// Base FRRConfiguration should be deleted (no managed networks remain)
 			gomega.Eventually(func() bool {
-				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ManagedRouteAdvertisementName(types.DefaultNetworkName), metav1.GetOptions{})
-				return apierrors.IsNotFound(err)
+				_, err := getBaseFRRConfig(frrFakeClient)
+				return err != nil
 			}, 2*time.Second).Should(gomega.BeTrue())
 		})
 
@@ -506,12 +553,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset()
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -519,7 +568,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
@@ -531,21 +580,20 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), "temp", metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+			var baseConfig *frrtypes.FRRConfiguration
 			// Should still create base config, just with no neighbors
 			gomega.Eventually(func() bool {
-				bc, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
-				return err == nil && bc != nil
+				baseConfig, err = getBaseFRRConfig(frrFakeClient)
+				return err == nil && baseConfig != nil
 			}, 2*time.Second).Should(gomega.BeTrue())
 
-			baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(baseConfig.Spec.BGP.Routers).To(gomega.HaveLen(1))
 			gomega.Expect(baseConfig.Spec.BGP.Routers[0].Neighbors).To(gomega.BeEmpty())
 		})
 	})
 
 	ginkgo.Context("Non-full-mesh topology", func() {
-		ginkgo.It("should fail to start when topology is not full-mesh", func() {
+		ginkgo.It("should return error from ensureBaseFRRConfiguration when topology is not full-mesh", func() {
 			config.ManagedBGP.Topology = ""
 
 			node1 := createNode("node1", "10.0.0.1", "")
@@ -553,12 +601,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset(node1)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -566,15 +616,10 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
-			err = controller.Start()
-			gomega.Expect(err).To(gomega.MatchError("initial sync failed: unsupported managed BGP topology: "))
-
-			// Start should fail before creating the base FRRConfiguration
-			gomega.Consistently(func() int {
-				list, _ := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).List(context.TODO(), metav1.ListOptions{})
-				return len(list.Items)
-			}, 1*time.Second, 100*time.Millisecond).Should(gomega.Equal(0))
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
+			err = controller.ensureBaseFRRConfiguration()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("unsupported managed BGP topology"))
 		})
 	})
 
@@ -585,16 +630,18 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset()
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller = NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller = NewController(wf, frrFakeClient, raFakeClient, nil)
 		})
 
 		ginkgo.It("should return true when old node is nil", func() {
@@ -644,12 +691,14 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			fakeClient := fake.NewSimpleClientset()
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -657,37 +706,39 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
 
 			// Verify managed RouteAdvertisement was created
 			gomega.Eventually(func() error {
-				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ManagedRouteAdvertisementName(types.DefaultNetworkName), metav1.GetOptions{})
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName(types.DefaultNetworkName), metav1.GetOptions{})
 				return err
 			}, 2*time.Second).Should(gomega.Succeed())
 
-			ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ManagedRouteAdvertisementName(types.DefaultNetworkName), metav1.GetOptions{})
+			ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName(types.DefaultNetworkName), metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(ra.Labels).To(gomega.HaveKeyWithValue(ManagedRANetworkLabel, types.DefaultNetworkName))
-			gomega.Expect(ra.Spec.FRRConfigurationSelector.MatchLabels).To(gomega.HaveKeyWithValue(FRRConfigManagedLabel, FRRConfigManagedValue))
+			gomega.Expect(ra.Labels).To(gomega.HaveKeyWithValue(managedRANetworkLabel, types.DefaultNetworkName))
+			gomega.Expect(ra.Spec.FRRConfigurationSelector.MatchLabels).To(gomega.HaveKeyWithValue(frrConfigManagedLabel, frrConfigManagedValue))
 			gomega.Expect(ra.Spec.Advertisements).To(gomega.ConsistOf(ratypes.PodNetwork))
 			gomega.Expect(ra.Spec.NetworkSelectors).To(gomega.HaveLen(1))
 			gomega.Expect(ra.Spec.NetworkSelectors[0].NetworkSelectionType).To(gomega.Equal(apitypes.DefaultNetwork))
 		})
 
-		ginkgo.It("should recreate managed RouteAdvertisement when deleted", func() {
+		ginkgo.It("should repair managed RouteAdvertisement drift", func() {
 			node := createNode("node1", "10.0.0.1", "")
 			fakeClient := fake.NewSimpleClientset(node)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -695,12 +746,399 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
+			controller := NewController(wf, frrFakeClient, raFakeClient, nil)
 			err = controller.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
 
-			raName := ManagedRouteAdvertisementName(types.DefaultNetworkName)
+			raName := managedRouteAdvertisementName(types.DefaultNetworkName)
+			gomega.Eventually(func() error {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+
+			// Drift the RA externally
+			ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			drifted := ra.DeepCopy()
+			drifted.Labels = map[string]string{"drifted": "true"}
+			drifted.Spec.FRRConfigurationSelector.MatchLabels = map[string]string{"drifted": "true"}
+			_, err = raFakeClient.K8sV1().RouteAdvertisements().Update(context.TODO(), drifted, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// RA should be repaired
+			gomega.Eventually(func() bool {
+				ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				return ra.Labels[managedRANetworkLabel] == types.DefaultNetworkName &&
+					ra.Spec.FRRConfigurationSelector.MatchLabels[frrConfigManagedLabel] == frrConfigManagedValue
+			}, 2*time.Second).Should(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.Context("cudnNeedsUpdate", func() {
+		var controller *Controller
+
+		ginkgo.BeforeEach(func() {
+			fakeClient := fake.NewSimpleClientset()
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			controller = NewController(wf, frrFakeClient, raFakeClient, nil)
+		})
+
+		ginkgo.It("should return true when a managed CUDN is added", func() {
+			newCUDN := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			gomega.Expect(controller.cudnNeedsUpdate(nil, newCUDN)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should return false when an unmanaged CUDN is added", func() {
+			newCUDN := createUnmanagedCUDN("green", map[string]string{"network": "green"})
+			gomega.Expect(controller.cudnNeedsUpdate(nil, newCUDN)).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should return true when a managed CUDN managed-network label changes", func() {
+			oldCUDN := createManagedCUDN("blue", map[string]string{managedRANetworkLabel: "blue"})
+			newCUDN := oldCUDN.DeepCopy()
+			newCUDN.Labels[managedRANetworkLabel] = "changed"
+			gomega.Expect(controller.cudnNeedsUpdate(oldCUDN, newCUDN)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should return false when a managed CUDN unrelated labels change", func() {
+			oldCUDN := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			newCUDN := oldCUDN.DeepCopy()
+			newCUDN.Labels["extra"] = "value"
+			gomega.Expect(controller.cudnNeedsUpdate(oldCUDN, newCUDN)).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should return false when an unmanaged CUDN labels change", func() {
+			oldCUDN := createUnmanagedCUDN("green", map[string]string{"network": "green"})
+			newCUDN := oldCUDN.DeepCopy()
+			newCUDN.Labels["extra"] = "value"
+			gomega.Expect(controller.cudnNeedsUpdate(oldCUDN, newCUDN)).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should return false when new CUDN is nil", func() {
+			oldCUDN := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			gomega.Expect(controller.cudnNeedsUpdate(oldCUDN, nil)).To(gomega.BeFalse())
+		})
+	})
+
+	ginkgo.Context("owned resource update filters", func() {
+		var controller *Controller
+
+		ginkgo.BeforeEach(func() {
+			fakeClient := fake.NewSimpleClientset()
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			controller = NewController(wf, frrFakeClient, raFakeClient, nil)
+		})
+
+		ginkgo.It("should reconcile external managed RouteAdvertisement add events", func() {
+			ra := &ratypes.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: managedRouteAdvertisementName("blue"),
+					Labels: map[string]string{
+						managedRANetworkLabel: "blue",
+					},
+				},
+			}
+			gomega.Expect(controller.raNeedsUpdate(nil, ra)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should ignore own managed RouteAdvertisement add events", func() {
+			now := metav1.Now()
+			ra := &ratypes.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: managedRouteAdvertisementName("blue"),
+					Labels: map[string]string{
+						managedRANetworkLabel: "blue",
+					},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: fieldManager, Time: &now},
+					},
+				},
+			}
+			gomega.Expect(controller.raNeedsUpdate(nil, ra)).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should reconcile managed RouteAdvertisement updates", func() {
+			oldRA := &ratypes.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: managedRouteAdvertisementName("blue"),
+					Labels: map[string]string{
+						managedRANetworkLabel: "blue",
+					},
+				},
+			}
+			newRA := oldRA.DeepCopy()
+			newRA.Spec.Advertisements = []ratypes.AdvertisementType{ratypes.EgressIP}
+			gomega.Expect(controller.raNeedsUpdate(oldRA, newRA)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should reconcile external managed FRRConfiguration add events", func() {
+			frr := &frrtypes.FRRConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedFRRConfigurationName,
+					Namespace: config.ManagedBGP.FRRNamespace,
+					Labels: map[string]string{
+						frrConfigManagedLabel: frrConfigManagedValue,
+					},
+				},
+			}
+			gomega.Expect(controller.frrNeedsUpdate(nil, frr)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should ignore own managed FRRConfiguration add events", func() {
+			now := metav1.Now()
+			frr := &frrtypes.FRRConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedFRRConfigurationName,
+					Namespace: config.ManagedBGP.FRRNamespace,
+					Labels: map[string]string{
+						frrConfigManagedLabel: frrConfigManagedValue,
+					},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: fieldManager, Time: &now},
+					},
+				},
+			}
+			gomega.Expect(controller.frrNeedsUpdate(nil, frr)).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should reconcile managed FRRConfiguration updates", func() {
+			oldFRR := &frrtypes.FRRConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedFRRConfigurationName,
+					Namespace: config.ManagedBGP.FRRNamespace,
+					Labels: map[string]string{
+						frrConfigManagedLabel: frrConfigManagedValue,
+					},
+				},
+			}
+			newFRR := oldFRR.DeepCopy()
+			newFRR.Spec.NodeSelector.MatchLabels = map[string]string{"role": "worker"}
+			gomega.Expect(controller.frrNeedsUpdate(oldFRR, newFRR)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should reconcile managed FRRConfiguration label drift", func() {
+			oldFRR := &frrtypes.FRRConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managedFRRConfigurationName,
+					Namespace: config.ManagedBGP.FRRNamespace,
+					Labels: map[string]string{
+						frrConfigManagedLabel: frrConfigManagedValue,
+					},
+				},
+			}
+			newFRR := oldFRR.DeepCopy()
+			newFRR.Labels = map[string]string{"drifted": "true"}
+			gomega.Expect(controller.frrNeedsUpdate(oldFRR, newFRR)).To(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.Context("CUDN managed routing", func() {
+		ginkgo.BeforeEach(func() {
+			config.ManagedBGP.Topology = config.ManagedBGPTopologyFullMesh
+			// CDN is NOT no-overlay — CUDN-only managed mode
+			config.Default.Transport = ""
+			config.NoOverlay.Routing = ""
+		})
+
+		ginkgo.It("should create RouteAdvertisement for managed CUDN", func() {
+			cudn := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			udnFakeClient := udnfake.NewSimpleClientset(cudn)
+
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnFakeClient,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			err = wf.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			c := NewController(wf, frrFakeClient, raFakeClient, udnFakeClient)
+			err = c.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer c.Stop()
+
+			// Verify CUDN RouteAdvertisement was created
+			gomega.Eventually(func() error {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName("blue"), metav1.GetOptions{})
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+
+			ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName("blue"), metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(ra.Labels).To(gomega.HaveKeyWithValue(managedRANetworkLabel, "blue"))
+			gomega.Expect(ra.Spec.Advertisements).To(gomega.ConsistOf(ratypes.PodNetwork))
+			gomega.Expect(ra.Spec.FRRConfigurationSelector.MatchLabels).To(gomega.HaveKeyWithValue(frrConfigManagedLabel, frrConfigManagedValue))
+			gomega.Expect(ra.Spec.NetworkSelectors).To(gomega.HaveLen(1))
+			gomega.Expect(ra.Spec.NetworkSelectors[0].NetworkSelectionType).To(gomega.Equal(apitypes.ClusterUserDefinedNetworks))
+			gomega.Expect(ra.Spec.NetworkSelectors[0].ClusterUserDefinedNetworkSelector).NotTo(gomega.BeNil())
+			gomega.Expect(ra.Spec.NetworkSelectors[0].ClusterUserDefinedNetworkSelector.NetworkSelector.MatchLabels).To(
+				gomega.HaveKeyWithValue(managedRANetworkLabel, "blue"))
+
+			// Verify base FRRConfiguration was also created
+			gomega.Eventually(func() error {
+				_, err := getBaseFRRConfig(frrFakeClient)
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+
+			// Verify NO CDN RouteAdvertisement was created (CDN is not no-overlay)
+			_, err = raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName(types.DefaultNetworkName), metav1.GetOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should delete RouteAdvertisement when managed CUDN is deleted", func() {
+			cudn := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			udnFakeClient := udnfake.NewSimpleClientset(cudn)
+
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnFakeClient,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			err = wf.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			c := NewController(wf, frrFakeClient, raFakeClient, udnFakeClient)
+			err = c.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer c.Stop()
+
+			// Wait for RA to be created
+			gomega.Eventually(func() error {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName("blue"), metav1.GetOptions{})
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+
+			// Delete the CUDN
+			err = udnFakeClient.K8sV1().ClusterUserDefinedNetworks().Delete(context.TODO(), "blue", metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// RA should be deleted
+			gomega.Eventually(func() bool {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName("blue"), metav1.GetOptions{})
+				return apierrors.IsNotFound(err)
+			}, 2*time.Second).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("should create base FRRConfiguration when a managed CUDN is added after startup", func() {
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			udnFakeClient := udnfake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnFakeClient,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			err = wf.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			c := NewController(wf, frrFakeClient, raFakeClient, udnFakeClient)
+			err = c.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer c.Stop()
+
+			cudn := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			_, err = udnFakeClient.K8sV1().ClusterUserDefinedNetworks().Create(context.TODO(), cudn, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() error {
+				_, err := getBaseFRRConfig(frrFakeClient)
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+
+			gomega.Eventually(func() error {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName("blue"), metav1.GetOptions{})
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should restore RouteAdvertisement if externally deleted while running", func() {
+			cudn := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			udnFakeClient := udnfake.NewSimpleClientset(cudn)
+
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnFakeClient,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			err = wf.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			c := NewController(wf, frrFakeClient, raFakeClient, udnFakeClient)
+			err = c.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer c.Stop()
+
+			raName := managedRouteAdvertisementName("blue")
 			gomega.Eventually(func() error {
 				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
 				return err
@@ -710,31 +1148,27 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				if ra.Labels[ManagedRANetworkLabel] != types.DefaultNetworkName {
-					return fmt.Errorf("managed label not restored")
-				}
-				if ra.Spec.NetworkSelectors[0].NetworkSelectionType != apitypes.DefaultNetwork {
-					return fmt.Errorf("default network selector not restored")
-				}
-				return nil
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+				return err
 			}, 2*time.Second).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should repair managed RouteAdvertisement drift", func() {
-			node := createNode("node1", "10.0.0.1", "")
-			fakeClient := fake.NewSimpleClientset(node)
+		ginkgo.It("should restore base FRRConfiguration if externally deleted while running", func() {
+			cudn := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			udnFakeClient := udnfake.NewSimpleClientset(cudn)
+
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnFakeClient,
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -742,96 +1176,43 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
-			err = controller.Start()
+			c := NewController(wf, frrFakeClient, raFakeClient, udnFakeClient)
+			err = c.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer controller.Stop()
+			defer c.Stop()
 
-			raName := ManagedRouteAdvertisementName(types.DefaultNetworkName)
-			ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			drifted := ra.DeepCopy()
-			drifted.Labels = map[string]string{"drifted": "true"}
-			drifted.Spec.FRRConfigurationSelector.MatchLabels = map[string]string{"drifted": "true"}
-			_, err = raFakeClient.K8sV1().RouteAdvertisements().Update(context.TODO(), drifted, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
+			var baseFRR *frrtypes.FRRConfiguration
 			gomega.Eventually(func() error {
-				ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				if ra.Labels[ManagedRANetworkLabel] != types.DefaultNetworkName {
-					return fmt.Errorf("managed label not restored")
-				}
-				if ra.Spec.FRRConfigurationSelector.MatchLabels[FRRConfigManagedLabel] != FRRConfigManagedValue {
-					return fmt.Errorf("frr selector not restored")
-				}
-				return nil
-			}, 2*time.Second).Should(gomega.Succeed())
-		})
-	})
-
-	ginkgo.Context("Base FRRConfiguration self-healing", func() {
-		ginkgo.It("should recreate base FRRConfiguration when deleted", func() {
-			node := createNode("node1", "10.0.0.1", "")
-			fakeClient := fake.NewSimpleClientset(node)
-			frrFakeClient := frrfake.NewSimpleClientset()
-			raFakeClient := rafake.NewSimpleClientset()
-
-			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
-				KubeClient:                fakeClient,
-				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
-				RouteAdvertisementsClient: raFakeClient,
-				FRRClient:                 frrFakeClient,
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer wf.Shutdown()
-
-			err = wf.Start()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
-			err = controller.Start()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer controller.Stop()
-
-			baseName := BaseFRRConfigName()
-			gomega.Eventually(func() error {
-				_, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), baseName, metav1.GetOptions{})
+				baseFRR, err = getBaseFRRConfig(frrFakeClient)
 				return err
 			}, 2*time.Second).Should(gomega.Succeed())
 
-			err = frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Delete(context.TODO(), baseName, metav1.DeleteOptions{})
+			err = frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Delete(context.TODO(), baseFRR.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+			// Controller recreates the base FRRConfiguration
 			gomega.Eventually(func() error {
-				cfg, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), baseName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				if cfg.Labels[FRRConfigManagedLabel] != FRRConfigManagedValue {
-					return fmt.Errorf("managed label not restored")
-				}
-				if len(cfg.Spec.BGP.Routers) != 1 || len(cfg.Spec.BGP.Routers[0].Neighbors) != 1 {
-					return fmt.Errorf("expected single-node full-mesh config to be restored")
-				}
-				return nil
+				_, err := getBaseFRRConfig(frrFakeClient)
+				return err
 			}, 2*time.Second).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should repair base FRRConfiguration drift", func() {
-			node := createNode("node1", "10.0.0.1", "")
-			fakeClient := fake.NewSimpleClientset(node)
+		ginkgo.It("should not create RouteAdvertisement for unmanaged CUDN", func() {
+			cudn := createUnmanagedCUDN("green", map[string]string{"network": "green"})
+			udnFakeClient := udnfake.NewSimpleClientset(cudn)
+
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnFakeClient,
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -839,58 +1220,48 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
-			err = controller.Start()
+			c := NewController(wf, frrFakeClient, raFakeClient, udnFakeClient)
+			err = c.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer controller.Stop()
+			defer c.Stop()
 
-			baseName := BaseFRRConfigName()
-			baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), baseName, metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			drifted := baseConfig.DeepCopy()
-			drifted.Labels = map[string]string{"drifted": "true"}
-			drifted.Spec.BGP.Routers[0].Neighbors = []frrtypes.Neighbor{{
-				Address:   "10.0.0.99",
-				ASN:       config.ManagedBGP.ASNumber,
-				DisableMP: false,
-			}}
-			_, err = frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Update(context.TODO(), drifted, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			gomega.Eventually(func() error {
-				cfg, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), baseName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				if cfg.Labels[FRRConfigManagedLabel] != FRRConfigManagedValue {
-					return fmt.Errorf("managed label not restored")
-				}
-				if len(cfg.Spec.BGP.Routers) != 1 || len(cfg.Spec.BGP.Routers[0].Neighbors) != 1 {
-					return fmt.Errorf("expected single-node full-mesh config to be restored")
-				}
-				neighbor := cfg.Spec.BGP.Routers[0].Neighbors[0]
-				if neighbor.Address != "10.0.0.1" || !neighbor.DisableMP {
-					return fmt.Errorf("base FRRConfiguration not restored")
-				}
-				return nil
-			}, 2*time.Second).Should(gomega.Succeed())
+			// Should not create a CUDN RA
+			gomega.Consistently(func() bool {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName("green"), metav1.GetOptions{})
+				return apierrors.IsNotFound(err)
+			}, 1*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
 		})
-	})
 
-	ginkgo.Context("ensureManagedRouteAdvertisement for CUDN", func() {
-		ginkgo.It("should build correct CUDN network selector", func() {
-			config.ManagedBGP.Topology = config.ManagedBGPTopologyFullMesh
+		ginkgo.It("should not create RouteAdvertisement for non-no-overlay CUDN", func() {
+			// CUDN without transport set (default Geneve)
+			cudn := &userdefinednetworkv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "default-transport",
+					Labels: map[string]string{"network": "default-transport"},
+				},
+				Spec: userdefinednetworkv1.ClusterUserDefinedNetworkSpec{
+					Network: userdefinednetworkv1.NetworkSpec{
+						Topology: userdefinednetworkv1.NetworkTopologyLayer3,
+						Layer3: &userdefinednetworkv1.Layer3Config{
+							Role: userdefinednetworkv1.NetworkRolePrimary,
+						},
+					},
+				},
+			}
+			udnFakeClient := udnfake.NewSimpleClientset(cudn)
 
-			fakeClient := fake.NewSimpleClientset()
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
 			frrFakeClient := frrfake.NewSimpleClientset()
 			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
 
 			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
 				KubeClient:                fakeClient,
 				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
 				RouteAdvertisementsClient: raFakeClient,
 				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnFakeClient,
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer wf.Shutdown()
@@ -898,24 +1269,122 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			controller := NewController(wf, frrFakeClient, raFakeClient, recorder)
-			err = controller.ensureManagedRouteAdvertisement("blue")
+			c := NewController(wf, frrFakeClient, raFakeClient, udnFakeClient)
+			err = c.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer c.Stop()
+
+			gomega.Consistently(func() bool {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), managedRouteAdvertisementName("default-transport"), metav1.GetOptions{})
+				return apierrors.IsNotFound(err)
+			}, 1*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("should restore RouteAdvertisement if externally deleted on restart", func() {
+			cudn := createManagedCUDN("blue", map[string]string{"network": "blue"})
+			udnFakeClient := udnfake.NewSimpleClientset(cudn)
+
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnFakeClient,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			err = wf.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ra, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), ManagedRouteAdvertisementName("blue"), metav1.GetOptions{})
+			c := NewController(wf, frrFakeClient, raFakeClient, udnFakeClient)
+			err = c.Start()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(ra.Labels).To(gomega.HaveKeyWithValue(ManagedRANetworkLabel, "blue"))
-			gomega.Expect(ra.Spec.NetworkSelectors).To(gomega.HaveLen(1))
-			gomega.Expect(ra.Spec.NetworkSelectors[0].NetworkSelectionType).To(gomega.Equal(apitypes.ClusterUserDefinedNetworks))
-			gomega.Expect(ra.Spec.NetworkSelectors[0].ClusterUserDefinedNetworkSelector).NotTo(gomega.BeNil())
-			gomega.Expect(ra.Spec.NetworkSelectors[0].ClusterUserDefinedNetworkSelector.NetworkSelector.MatchLabels).To(
-				gomega.HaveKeyWithValue(ManagedRANetworkLabel, "blue"),
-			)
-			gomega.Expect(ra.Spec.Advertisements).To(gomega.ConsistOf(ratypes.PodNetwork))
-			gomega.Expect(ra.Spec.FRRConfigurationSelector.MatchLabels).To(gomega.HaveKeyWithValue(FRRConfigManagedLabel, FRRConfigManagedValue))
+			defer c.Stop()
+
+			// Wait for RA to be created
+			raName := managedRouteAdvertisementName("blue")
+			gomega.Eventually(func() error {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+
+			c.Stop()
+
+			// Delete the RA externally
+			err = raFakeClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), raName, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() bool {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+				return apierrors.IsNotFound(err)
+			}, 2*time.Second).Should(gomega.BeTrue())
+
+			// Wait for the informer cache to process the deletion
+			gomega.Eventually(func() error {
+				_, err := c.raLister.Get(raName)
+				return err
+			}, 2*time.Second).ShouldNot(gomega.Succeed())
+
+			// reconcileNetwork (triggered on restart) should restore the RA
+			err = c.reconcileNetwork("blue")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() error {
+				_, err := raFakeClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+				return err
+			}, 2*time.Second).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should not create RA when no managed CUDNs exist", func() {
+			node1 := createNode("node1", "10.0.0.1", "")
+			fakeClient := fake.NewSimpleClientset(node1)
+			frrFakeClient := frrfake.NewSimpleClientset()
+			raFakeClient := rafake.NewSimpleClientset()
+			addGenerateNameReactor(frrFakeClient)
+
+			wf, err := factory.NewClusterManagerWatchFactory(&util.OVNClusterManagerClientset{
+				KubeClient:                fakeClient,
+				NetworkAttchDefClient:     nadfake.NewSimpleClientset(),
+				RouteAdvertisementsClient: raFakeClient,
+				FRRClient:                 frrFakeClient,
+				UserDefinedNetworkClient:  udnfake.NewSimpleClientset(),
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer wf.Shutdown()
+
+			err = wf.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			c := NewController(wf, frrFakeClient, raFakeClient, nil)
+			err = c.Start()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer c.Stop()
+
+			// No CUDN RAs should be created (no CDN RA either since CDN is not no-overlay)
+			gomega.Consistently(func() int {
+				list, _ := raFakeClient.K8sV1().RouteAdvertisements().List(context.TODO(), metav1.ListOptions{})
+				return len(list.Items)
+			}, 1*time.Second, 100*time.Millisecond).Should(gomega.Equal(0))
 		})
 	})
 })
+
+// getBaseFRRConfig returns the managed base FRRConfiguration found by name.
+func getBaseFRRConfig(frrClient *frrfake.Clientset) (*frrtypes.FRRConfiguration, error) {
+	cfg, err := frrClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(
+		context.TODO(), managedFRRConfigurationName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
 
 // Helper function to create test nodes
 func createNode(name, ipv4, ipv6 string) *corev1.Node {
@@ -959,4 +1428,48 @@ func createNode(name, ipv4, ipv6 string) *corev1.Node {
 	return node
 }
 
-// Helper function to create test RouteAdvertisement
+// Helper function to create a managed CUDN (NoOverlay + Managed routing)
+func createManagedCUDN(name string, labels map[string]string) *userdefinednetworkv1.ClusterUserDefinedNetwork {
+	return &userdefinednetworkv1.ClusterUserDefinedNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Spec: userdefinednetworkv1.ClusterUserDefinedNetworkSpec{
+			Network: userdefinednetworkv1.NetworkSpec{
+				Topology: userdefinednetworkv1.NetworkTopologyLayer3,
+				Layer3: &userdefinednetworkv1.Layer3Config{
+					Role: userdefinednetworkv1.NetworkRolePrimary,
+				},
+				Transport: userdefinednetworkv1.TransportOptionNoOverlay,
+				NoOverlay: &userdefinednetworkv1.NoOverlayConfig{
+					OutboundSNAT: userdefinednetworkv1.SNATEnabled,
+					Routing:      userdefinednetworkv1.RoutingManaged,
+				},
+			},
+		},
+	}
+}
+
+// Helper function to create an unmanaged CUDN (NoOverlay + Unmanaged routing)
+func createUnmanagedCUDN(name string, labels map[string]string) *userdefinednetworkv1.ClusterUserDefinedNetwork {
+	return &userdefinednetworkv1.ClusterUserDefinedNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Spec: userdefinednetworkv1.ClusterUserDefinedNetworkSpec{
+			Network: userdefinednetworkv1.NetworkSpec{
+				Topology: userdefinednetworkv1.NetworkTopologyLayer3,
+				Layer3: &userdefinednetworkv1.Layer3Config{
+					Role: userdefinednetworkv1.NetworkRolePrimary,
+				},
+				Transport: userdefinednetworkv1.TransportOptionNoOverlay,
+				NoOverlay: &userdefinednetworkv1.NoOverlayConfig{
+					OutboundSNAT: userdefinednetworkv1.SNATDisabled,
+					Routing:      userdefinednetworkv1.RoutingUnmanaged,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added management of cluster user-defined networks in BGP routing with guaranteed initial full convergence on startup.

* **Improvements**
  * Ensured network label propagation so routing selections align with user-defined networks.
  * Made managed routing and base configuration cleanup/deletion and reconciliation flows more deterministic and robust.

* **Tests**
  * Expanded coverage for user-defined network scenarios, drift recovery, ownership/event filtering, and controller repair behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->