### PR TITLE
add e2e test cases for no-overlay manage routing mode

### DIFF
--- a/test/e2e/no_overlay.go
+++ b/test/e2e/no_overlay.go
@@ -3,18 +3,25 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	raclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned"
+	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -24,7 +31,6 @@ import (
 
 var _ = ginkgo.Describe("No-Overlay: Default network is enabled with no-overlay", feature.NoOverlay, func() {
 	f := wrappedTestFramework("no-overlay-default-network")
-
 	const (
 		tcpdumpPodName = "tcpdump-pod-no-overlay"
 		serverPodName  = "server-pod-no-overlay"
@@ -185,6 +191,105 @@ var _ = ginkgo.Describe("No-Overlay: Default network is enabled with no-overlay"
 		})
 	})
 
+	ginkgo.When("managed mode routing is enabled", func() {
+		ginkgo.BeforeEach(func() {
+			if !isManagedRoutingEnabled() {
+				ginkgo.Skip("Test requires managed routing mode to be enabled")
+			}
+		})
+
+		ginkgo.It("should reconcile RA CR if manually deleted in managed mode", func() {
+			raClient, err := raclientset.NewForConfig(f.ClientConfig())
+			framework.ExpectNoError(err, "Failed to create RouteAdvertisements client")
+
+			ginkgo.By("Verifying auto-created RA exists before deletion")
+			raName := managedRouteAdvertisementName(types.DefaultNetworkName)
+			ra, err := raClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "Failed to get RouteAdvertisement")
+			gomega.Expect(ra).NotTo(gomega.BeNil(), "RouteAdvertisement should exist")
+			originalUID := ra.UID
+			framework.Logf("RouteAdvertisement %s exists before deletion (UID=%s)", raName, originalUID)
+
+			ginkgo.By("Deleting RouteAdvertisement manually")
+			err = raClient.K8sV1().RouteAdvertisements().Delete(context.TODO(), raName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "Failed to delete RouteAdvertisement")
+
+			ginkgo.By("Verifying RA is auto-recreated by the managed BGP controller")
+			gomega.Eventually(func() bool {
+				current, err := raClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+				return err == nil &&
+					current.DeletionTimestamp == nil &&
+					current.UID != originalUID
+			}, 30*time.Second, 1*time.Second).Should(gomega.BeTrue(), "Auto-created RA should be recreated within 30 seconds")
+
+			ginkgo.By("Verifying RA is Accepted")
+			gomega.Eventually(func() bool {
+				ra, err = raClient.K8sV1().RouteAdvertisements().Get(context.TODO(), raName, metav1.GetOptions{})
+				if err != nil {
+					framework.Logf("Failed to get RouteAdvertisement: %v", err)
+					return false
+				}
+				acceptedCond := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
+				return acceptedCond != nil && acceptedCond.Status == metav1.ConditionTrue
+			}, 30*time.Second, 1*time.Second).Should(gomega.BeTrue(), "RouteAdvertisement should be Accepted within 30 seconds")
+
+			ginkgo.By("Verifying RA has the expected label")
+			expectedLabel := "k8s.ovn.org/managed-network"
+			gomega.Expect(ra.Labels[expectedLabel]).To(gomega.Equal(types.DefaultNetworkName))
+
+			ginkgo.By("Verifying RA selects managed FRRConfigurations")
+			expectedFRRLabel := "k8s.ovn.org/managed-internal-fabric"
+			gomega.Expect(ra.Spec.FRRConfigurationSelector.MatchLabels[expectedFRRLabel]).To(gomega.Equal("bgp"))
+			ginkgo.By("Verifying it selects the default network")
+			gomega.Expect(ra.Spec.NetworkSelectors).To(gomega.ContainElement(apitypes.NetworkSelector{NetworkSelectionType: apitypes.DefaultNetwork}))
+
+			ginkgo.By("Verifying pod2pod connectivity works after RA recreation")
+			checkConnectivityWithoutOverlay(serverPod.Status.PodIPs, nil, clientPod, tcpdumpPod)
+		})
+
+		ginkgo.It("should reconcile FRRConfiguration if manually deleted in managed mode", func() {
+			frrNamespace := deploymentconfig.Get().FRRK8sNamespace()
+
+			ginkgo.By("Getting FRRConfigurations managed by the system")
+			labelSelector := "k8s.ovn.org/managed-internal-fabric=bgp"
+			getFRRCmd := []string{"get", "frrconfigurations", "-n", frrNamespace, "-l", labelSelector, "-o", "jsonpath={.items[0].metadata.name}"}
+			frrName := e2ekubectl.RunKubectlOrDie(frrNamespace, getFRRCmd...)
+			gomega.Expect(frrName).NotTo(gomega.BeEmpty(), "Should find at least one managed FRRConfiguration")
+			framework.Logf("Found FRRConfiguration %s in namespace %s", frrName, frrNamespace)
+
+			originalUID := strings.TrimSpace(e2ekubectl.RunKubectlOrDie(frrNamespace,
+				"get", "frrconfigurations", frrName, "-n", frrNamespace, "-o", "jsonpath={.metadata.uid}"))
+			gomega.Expect(originalUID).NotTo(gomega.BeEmpty(), "FRRConfiguration should have a UID")
+
+			ginkgo.By("Deleting FRRConfiguration manually")
+			deleteCmd := []string{"delete", "frrconfigurations", frrName, "-n", frrNamespace}
+			e2ekubectl.RunKubectlOrDie(frrNamespace, deleteCmd...)
+			framework.Logf("Deleted FRRConfiguration %s (UID was %s)", frrName, originalUID)
+
+			ginkgo.By("Verifying the new FRRConfiguration is recreated (new UID, not terminating)")
+			gomega.Eventually(func() bool {
+				currentUID, err := e2ekubectl.RunKubectl(frrNamespace,
+					"get", "frrconfigurations", frrName, "-n", frrNamespace, "-o", "jsonpath={.metadata.uid}")
+				if err != nil {
+					return false
+				}
+				currentUID = strings.TrimSpace(currentUID)
+				if currentUID == "" || currentUID == originalUID {
+					return false
+				}
+				dt, err := e2ekubectl.RunKubectl(frrNamespace,
+					"get", "frrconfigurations", frrName, "-n", frrNamespace, "-o", "jsonpath={.metadata.deletionTimestamp}")
+				if err != nil {
+					return false
+				}
+				return strings.TrimSpace(dt) == ""
+			}, 30*time.Second, 1*time.Second).Should(gomega.BeTrue(),
+				"FRRConfiguration %s should be recreated with a new UID and no deletion timestamp", frrName)
+
+			ginkgo.By("Verifying pod2pod connectivity works after FRRConfiguration recreation")
+			checkConnectivityWithoutOverlay(serverPod.Status.PodIPs, nil, clientPod, tcpdumpPod)
+		})
+	})
 })
 
 // getTcpdumpOnPhysicalIface starts tcpdump on the physical NIC (from deploymentconfig) filtered
@@ -264,4 +369,25 @@ func checkConnectivityWithoutOverlay(serverPodIPs []corev1.PodIP, serviceCluster
 		gomega.Expect(tcpdumpOut).To(gomega.MatchRegexp(`(?m)^[1-9][0-9]* packets captured`),
 			"Should capture unencapsulated pod traffic on the physical interface")
 	}
+}
+
+func isManagedRoutingEnabled() bool {
+	ovnKubeNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+	args := []string{"get", "configmap", "ovnkube-config", "-o=jsonpath={.data.ovnkube\\.conf}"}
+	conf := e2ekubectl.RunKubectlOrDie(ovnKubeNamespace, args...)
+	// Simplistic check for routing = managed
+	if strings.Contains(conf, "routing = managed") || strings.Contains(conf, "routing=managed") {
+		framework.Logf("Managed routing is enabled in ovnkube-config")
+		return true
+	}
+	return false
+}
+
+// managedRouteAdvertisementName matches clustermanager/managedbgp.ManagedRouteAdvertisementName
+// ("ovnk-managed-" + hex(fnv64a(networkName)))
+func managedRouteAdvertisementName(networkName string) string {
+	const prefix = "ovnk-managed-"
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(networkName))
+	return fmt.Sprintf("%s%x", prefix, h.Sum64())
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2080,4 +2080,3 @@ func waitForNodeReadyState(f *framework.Framework, nodeName string, timeout time
 		return false
 	}, timeout, 10*time.Second).Should(gomega.BeTrue(), expectationMessage)
 }
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Add e2e tests to verify that RouteAdvertisement and FRRConfiguration
resources are automatically reconciled when manually deleted in managed
routing mode. Tests verify resources are recreated with correct labels
and connectivity is maintained.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated environment setup into a shared before-each so pods, service, and packet-capture are prepared once for all connectivity checks.
  * Added ordered pod readiness and IP verification before starting tests.
  * Added gated managed-routing scenarios that delete and validate auto-recreated routing resources and re-run pod-to-pod connectivity.
  * Added detection of managed routing from configuration to conditionally run those scenarios.

* **Chores**
  * Minor test formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->