### PR TITLE
e2e: fix a few image preload issues

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -105,7 +105,7 @@ func newControllerRuntimeClient() (crclient.Client, error) {
 
 func init() {
 	if os.Getenv("KIND_INSTALL_KUBEVIRT") == "true" {
-		images.Add(images.IPerf3())
+		images.Add(images.Netshoot())
 	}
 }
 

--- a/test/e2e/no_overlay.go
+++ b/test/e2e/no_overlay.go
@@ -9,6 +9,7 @@ import (
 	"hash/fnv"
 	"net"
 	"strings"
+	"os"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -31,6 +32,12 @@ import (
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	utilnet "k8s.io/utils/net"
 )
+
+func init() {
+	if os.Getenv("ENABLE_NO_OVERLAY") == "true" {
+		images.Add(images.Netshoot())
+	}
+}
 
 var _ = ginkgo.Describe("No-Overlay: Default network is enabled with no-overlay", feature.NoOverlay, func() {
 	f := wrappedTestFramework("no-overlay-default-network")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Kubevirt suite was preloading incorrect image. And no-overlay suite was not
preloading at all.

- **e2e: preload netshoot image for kubevirt tests instead of iperf**
- **e2e: preload netshoot image for no_overlay suite**

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated container image configuration for KubeVirt test initialization scenarios.
  * Added conditional image registration for test environments with overlay disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->