### PR TITLE
e2e: avoid EVPN CUDN subnet collisions with container engine networks

### DIFF
--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -878,7 +878,8 @@ func randomVNI() int32 {
 
 // randomCUDNSubnets generates random non-overlapping CUDN subnets for parallel test isolation.
 // Uses /20 (4096 addresses) instead of /16 to allow randomizing both second and third octets,
-// giving ~4032 possible subnets within 10.0.0.0/8 while avoiding collisions with:
+// giving ~4016 possible subnets within 10.0.0.0/8 while avoiding collisions with:
+//   - 10.88.0.0/16  (podman default network)
 //   - 10.96.0.0/16  (Kubernetes services)
 //   - 10.132.0.0/16 (UDN perf tests)
 //   - 10.243.0.0/16, 10.244.0.0/16 (pod CIDRs)
@@ -890,13 +891,13 @@ func randomVNI() int32 {
 func randomCUDNSubnets() (ipv4, ipv6 string) {
 	// 4096 possible /20 subnets in 10.0.0.0/8 (256 second octets * 16 /20-aligned third octets)
 	// Exclude blocks overlapping known /16 reservations (16 /20 blocks each):
-	//   10.96, 10.132, 10.243, 10.244 = 64 excluded → ~4032 usable
+	//   10.88, 10.96, 10.132, 10.243, 10.244 = 80 excluded → ~4016 usable
 	for {
 		second := randomN(256)
 		// 16 /20-aligned slots per second octet (256/16)
 		third := randomN(16) * 16 // 0, 16, 32, ..., 240
 		switch second {
-		case 96, 132, 243, 244:
+		case 88, 96, 132, 243, 244:
 			continue
 		}
 		n := second*16 + third/16


### PR DESCRIPTION

## 📑 Description
randomCUDNSubnets() excluded four second octets (96, 132, 243, 244)
but not 88, so it could generate /20 subnets within podman's default
10.88.0.0/16 network, causing EVPN e2e test failures on hosts with
the default podman bridge.

Add 88 to the hardcoded exclusion list.

Fixes #

## Additional Information for reviewers


## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by excluding an additional reserved IPv4 address block to prevent collision issues in parallel testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->