### PR TITLE
Add service CIDR to cluster router external-ids

### DIFF
--- a/go-controller/pkg/ovn/topology/topologyfactory.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory.go
@@ -3,9 +3,11 @@ package topology
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -68,6 +70,14 @@ func (gtf *GatewayTopologyFactory) newClusterRouter(
 	if netInfo.IsUserDefinedNetwork() {
 		logicalRouter.ExternalIDs[types.NetworkExternalID] = netInfo.GetNetworkName()
 		logicalRouter.ExternalIDs[types.TopologyExternalID] = netInfo.TopologyType()
+	}
+
+	if !netInfo.IsUserDefinedNetwork() && len(config.Kubernetes.ServiceCIDRs) > 0 {
+		serviceCIDRs := make([]string, 0, len(config.Kubernetes.ServiceCIDRs))
+		for _, cidr := range config.Kubernetes.ServiceCIDRs {
+			serviceCIDRs = append(serviceCIDRs, cidr.String())
+		}
+		logicalRouter.ExternalIDs[types.ClusterRouterServiceCIDR] = strings.Join(serviceCIDRs, ",")
 	}
 
 	if err := libovsdbops.CreateOrUpdateLogicalRouter(

--- a/go-controller/pkg/ovn/topology/topologyfactory_test.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory_test.go
@@ -116,6 +116,104 @@ var _ = Describe("Topology factory", func() {
 		})
 	})
 
+	When("creating a cluster router for the default network", func() {
+		var defaultNetInfo util.NetInfo
+
+		BeforeEach(func() {
+			config.IPv4Mode = true
+			config.IPv6Mode = false
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{
+				{IP: net.ParseIP("10.96.0.0"), Mask: net.CIDRMask(12, 32)},
+			}
+
+			initialNBDB := []libovsdbtest.TestData{}
+			initialSBDB := []libovsdbtest.TestData{}
+			dbSetup := libovsdbtest.TestSetup{
+				NBData: initialNBDB,
+				SBData: initialSBDB,
+			}
+			libovsdbNBClient, _, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
+			ovnDB = libovsdbCleanup
+			nbClient = libovsdbNBClient
+
+			defaultNetInfo = &util.DefaultNetInfo{}
+			factory = NewGatewayTopologyFactory(libovsdbNBClient)
+		})
+
+		AfterEach(func() {
+			if ovnDB != nil {
+				ovnDB.Cleanup()
+			}
+		})
+
+		It("sets the service CIDR in external-ids for single-stack", func() {
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{
+				{IP: net.ParseIP("10.96.0.0"), Mask: net.CIDRMask(12, 32)},
+			}
+			clusterRouter, err := factory.NewClusterRouter(routerName, defaultNetInfo, coopUUID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterRouter.ExternalIDs).To(HaveKeyWithValue(
+				ovntypes.ClusterRouterServiceCIDR, "10.96.0.0/12",
+			))
+			Expect(clusterRouter.ExternalIDs).To(HaveKeyWithValue(
+				"k8s-cluster-router", "yes",
+			))
+			Expect(clusterRouter.ExternalIDs).NotTo(HaveKey(ovntypes.NetworkExternalID))
+		})
+
+		It("sets the service CIDR in external-ids for dual-stack", func() {
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{
+				{IP: net.ParseIP("10.96.0.0"), Mask: net.CIDRMask(12, 32)},
+				{IP: net.ParseIP("fd00:10:96::"), Mask: net.CIDRMask(112, 128)},
+			}
+			clusterRouter, err := factory.NewClusterRouter(routerName, defaultNetInfo, coopUUID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterRouter.ExternalIDs).To(HaveKeyWithValue(
+				ovntypes.ClusterRouterServiceCIDR, "10.96.0.0/12,fd00:10:96::/112",
+			))
+		})
+	})
+
+	When("creating a cluster router for a UDN", func() {
+		BeforeEach(func() {
+			config.IPv4Mode = true
+			config.IPv6Mode = true
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{
+				{IP: net.ParseIP("10.96.0.0"), Mask: net.CIDRMask(12, 32)},
+			}
+
+			initialNBDB := []libovsdbtest.TestData{}
+			initialSBDB := []libovsdbtest.TestData{}
+			dbSetup := libovsdbtest.TestSetup{
+				NBData: initialNBDB,
+				SBData: initialSBDB,
+			}
+			libovsdbNBClient, _, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
+			ovnDB = libovsdbCleanup
+			nbClient = libovsdbNBClient
+
+			netInfo, err = util.NewNetInfo(newLayer3PrimaryNetworkConf(networkName, networkSubnets))
+			Expect(err).NotTo(HaveOccurred())
+
+			factory = NewGatewayTopologyFactory(libovsdbNBClient)
+		})
+
+		AfterEach(func() {
+			if ovnDB != nil {
+				ovnDB.Cleanup()
+			}
+		})
+
+		It("does not set the service CIDR in external-ids", func() {
+			clusterRouter, err := factory.NewClusterRouter(routerName, netInfo, coopUUID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterRouter.ExternalIDs).NotTo(HaveKey(ovntypes.ClusterRouterServiceCIDR))
+			Expect(clusterRouter.ExternalIDs).To(HaveKey(ovntypes.NetworkExternalID))
+		})
+	})
+
 	When("a cluster router object is present on the OVN northbound DB", func() {
 		var initialClusterRouter *nbdb.LogicalRouter
 

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -242,6 +242,8 @@ const (
 	LoadBalancerKindExternalID = OvnK8sPrefix + "/" + "kind"
 	// key for load_balancer service external-id
 	LoadBalancerOwnerExternalID = OvnK8sPrefix + "/" + "owner"
+	// Cluster router external-id key for service CIDR
+	ClusterRouterServiceCIDR = OvnK8sPrefix + "/" + "service-cidr"
 	// key for UDN enabled services routes
 	UDNEnabledServiceExternalID = OvnK8sPrefix + "/" + "udn-enabled-default-service"
 	// key for management port name, indicating the netdev link name associated with the given management port representor OVS interface


### PR DESCRIPTION
It is useful to derive the Kubernetes service CIDR purely by looking at OVN NB artifacts for easier debugging. Today, an operator inspecting the NB database cannot determine the configured service CIDR without cross-referencing the Kubernetes API or ovnkube config.

Set k8s.ovn.org/service-cidr on the default network's cluster router (ovn_cluster_router) external-ids at creation time. The value is the comma-separated service CIDR(s) from config, e.g. "10.96.0.0/12" or "10.96.0.0/12,fd00:10:96::/112" for dual-stack.

Only the default network cluster router gets this annotation; UDN routers are skipped.

This feature also helps if a user decides to program the breth0 bridge by only looking at the OVN NB database and not k8s API server.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service CIDR configuration in cluster routers for default networks, supporting both single-stack and dual-stack deployments.

* **Tests**
  * Added comprehensive test coverage for cluster router service CIDR configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->