### PR TITLE
Annotate OVN load balancers with ExternalTrafficPolicy for debugging

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -1469,6 +1469,83 @@ func TestSyncServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "upgrade: pre-existing LBs without etp annotation get updated for ETP=Local service",
+			nodeAInfo: nodeAInfo,
+			nodeBInfo: nodeBInfo,
+			slices: []discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      serviceName + "ab23",
+						Namespace: ns,
+						Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+					},
+					Ports:       []discovery.EndpointPort{},
+					AddressType: discovery.AddressTypeIPv4,
+					Endpoints:   []discovery.Endpoint{},
+				},
+			},
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+				Spec: corev1.ServiceSpec{
+					Type:                  corev1.ServiceTypeClusterIP,
+					ClusterIP:             serviceClusterIP,
+					ClusterIPs:            []string{serviceClusterIP},
+					Selector:              map[string]string{"foo": "bar"},
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					Ports: []corev1.ServicePort{{
+						Port:       servicePort,
+						Protocol:   corev1.ProtocolTCP,
+						TargetPort: intstr.FromInt32(outPort),
+					}},
+				},
+			},
+			networks: []networkData{
+				{
+					netInfo: &util.DefaultNetInfo{},
+					initialDb: []libovsdbtest.TestData{
+						&nbdb.LoadBalancer{
+							UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+							Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+							Options:  servicesOptions(),
+							Protocol: &nbdb.LoadBalancerProtocolTCP,
+							Vips: map[string]string{
+								IPAndPort(serviceClusterIP, servicePort): "",
+							},
+							ExternalIDs: loadBalancerExternalIDs(namespacedServiceName(ns, serviceName)),
+						},
+						nodeLogicalSwitch(nodeA, initialLsGroups),
+						nodeLogicalSwitch(nodeB, initialLsGroups),
+						nodeLogicalRouter(nodeA, initialLrGroups),
+						nodeLogicalRouter(nodeB, initialLrGroups),
+						lbGroup(types.ClusterLBGroupName, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+						lbGroup(types.ClusterSwitchLBGroupName),
+						lbGroup(types.ClusterRouterLBGroupName),
+					},
+					expectedDb: []libovsdbtest.TestData{
+						&nbdb.LoadBalancer{
+							UUID:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+							Name:     loadBalancerClusterWideTCPServiceName(ns, serviceName),
+							Options:  servicesOptions(),
+							Protocol: &nbdb.LoadBalancerProtocolTCP,
+							Vips: map[string]string{
+								IPAndPort(serviceClusterIP, servicePort): "",
+							},
+							ExternalIDs: loadBalancerExternalIDsWithETP(namespacedServiceName(ns, serviceName)),
+						},
+						nodeLogicalSwitch(nodeA, initialLsGroups),
+						nodeLogicalSwitch(nodeB, initialLsGroups),
+						nodeLogicalRouter(nodeA, initialLrGroups),
+						nodeLogicalRouter(nodeB, initialLrGroups),
+						lbGroup(types.ClusterLBGroupName, loadBalancerClusterWideTCPServiceName(ns, serviceName)),
+						lbGroup(types.ClusterSwitchLBGroupName),
+						lbGroup(types.ClusterRouterLBGroupName),
+						nodeIPTemplate(nodeAInfo),
+						nodeIPTemplate(nodeBInfo),
+					},
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {
@@ -1575,6 +1652,178 @@ func TestSyncServices(t *testing.T) {
 		}
 
 	}
+}
+
+func TestSyncServiceETPFlip(t *testing.T) {
+	initialMaxLength := format.MaxLength
+	temporarilyEnableGomegaMaxLengthFormat()
+	t.Cleanup(func() {
+		restoreGomegaMaxLengthFormat(initialMaxLength)
+	})
+
+	const (
+		ns          = "testns"
+		serviceName = "foo"
+	)
+	var (
+		serviceClusterIP = "192.168.1.1"
+		servicePort      = int32(80)
+		outPort          = int32(3456)
+		initialLsGroups  = []string{types.ClusterLBGroupName, types.ClusterSwitchLBGroupName}
+		initialLrGroups  = []string{types.ClusterLBGroupName, types.ClusterRouterLBGroupName}
+	)
+
+	oldGateway := config.Gateway.Mode
+	oldClusterSubnet := config.Default.ClusterSubnets
+	config.Kubernetes.OVNEmptyLbEvents = true
+	config.IPv4Mode = true
+	config.Gateway.Mode = config.GatewayModeShared
+	defer func() {
+		config.Kubernetes.OVNEmptyLbEvents = false
+		config.IPv4Mode = false
+		config.Gateway.Mode = oldGateway
+		config.Default.ClusterSubnets = oldClusterSubnet
+	}()
+	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
+	config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 26}}
+
+	nodeAInfo := getNodeInfo(nodeA, []string{"10.0.0.1"}, nil)
+	nodeBInfo := getNodeInfo(nodeB, []string{"10.0.0.2"}, nil)
+
+	g := gomega.NewGomegaWithT(t)
+
+	initialDb := []libovsdbtest.TestData{
+		nodeLogicalSwitch(nodeA, initialLsGroups),
+		nodeLogicalSwitch(nodeB, initialLsGroups),
+		nodeLogicalRouter(nodeA, initialLrGroups),
+		nodeLogicalRouter(nodeB, initialLrGroups),
+		lbGroup(types.ClusterLBGroupName),
+		lbGroup(types.ClusterSwitchLBGroupName),
+		lbGroup(types.ClusterRouterLBGroupName),
+	}
+
+	controller, err := newControllerWithDBSetupForNetwork(libovsdbtest.TestSetup{NBData: initialDb}, &util.DefaultNetInfo{}, ns)
+	if err != nil {
+		t.Fatalf("Error creating controller: %v", err)
+	}
+	defer controller.close()
+
+	controller.nodeTracker.nodes = map[string]nodeInfo{
+		nodeA: *nodeAInfo,
+		nodeB: *nodeBInfo,
+	}
+
+	svcKey := namespacedServiceName(ns, serviceName)
+	lbName := loadBalancerClusterWideTCPServiceName(ns, serviceName)
+
+	slice := discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName + "ab23",
+			Namespace: ns,
+			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+		},
+		Ports:       []discovery.EndpointPort{},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints:   []discovery.Endpoint{},
+	}
+	g.Expect(controller.endpointSliceStore.Add(&slice)).To(gomega.Succeed())
+
+	baseSvc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+		Spec: corev1.ServiceSpec{
+			Type:       corev1.ServiceTypeClusterIP,
+			ClusterIP:  serviceClusterIP,
+			ClusterIPs: []string{serviceClusterIP},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports: []corev1.ServicePort{{
+				Port:       servicePort,
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt32(outPort),
+			}},
+		},
+	}
+
+	// Step 1: sync with ETP=Local, expect etp=local in external IDs.
+	svcLocal := baseSvc.DeepCopy()
+	svcLocal.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+	g.Expect(controller.serviceStore.Add(svcLocal)).To(gomega.Succeed())
+
+	controller.RequestFullSync(controller.nodeTracker.getZoneNodes())
+	g.Expect(controller.syncService(svcKey)).To(gomega.Succeed())
+
+	g.Expect(controller.nbClient).To(libovsdbtest.HaveData([]libovsdbtest.TestData{
+		&nbdb.LoadBalancer{
+			UUID:        lbName,
+			Name:        lbName,
+			Options:     servicesOptions(),
+			Protocol:    &nbdb.LoadBalancerProtocolTCP,
+			Vips:        map[string]string{IPAndPort(serviceClusterIP, servicePort): ""},
+			ExternalIDs: loadBalancerExternalIDsWithETP(svcKey),
+		},
+		nodeLogicalSwitch(nodeA, initialLsGroups),
+		nodeLogicalSwitch(nodeB, initialLsGroups),
+		nodeLogicalRouter(nodeA, initialLrGroups),
+		nodeLogicalRouter(nodeB, initialLrGroups),
+		lbGroup(types.ClusterLBGroupName, lbName),
+		lbGroup(types.ClusterSwitchLBGroupName),
+		lbGroup(types.ClusterRouterLBGroupName),
+		nodeIPTemplate(nodeAInfo),
+		nodeIPTemplate(nodeBInfo),
+	}))
+
+	// Step 2: flip to ETP=Cluster, expect etp key removed.
+	svcCluster := baseSvc.DeepCopy()
+	svcCluster.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+	g.Expect(controller.serviceStore.Add(svcCluster)).To(gomega.Succeed())
+
+	g.Expect(controller.syncService(svcKey)).To(gomega.Succeed())
+
+	g.Expect(controller.nbClient).To(libovsdbtest.HaveData([]libovsdbtest.TestData{
+		&nbdb.LoadBalancer{
+			UUID:        lbName,
+			Name:        lbName,
+			Options:     servicesOptions(),
+			Protocol:    &nbdb.LoadBalancerProtocolTCP,
+			Vips:        map[string]string{IPAndPort(serviceClusterIP, servicePort): ""},
+			ExternalIDs: loadBalancerExternalIDs(svcKey),
+		},
+		nodeLogicalSwitch(nodeA, initialLsGroups),
+		nodeLogicalSwitch(nodeB, initialLsGroups),
+		nodeLogicalRouter(nodeA, initialLrGroups),
+		nodeLogicalRouter(nodeB, initialLrGroups),
+		lbGroup(types.ClusterLBGroupName, lbName),
+		lbGroup(types.ClusterSwitchLBGroupName),
+		lbGroup(types.ClusterRouterLBGroupName),
+		nodeIPTemplate(nodeAInfo),
+		nodeIPTemplate(nodeBInfo),
+	}))
+
+	// Step 3: flip back to ETP=Local, expect etp=local restored.
+	svcLocalAgain := baseSvc.DeepCopy()
+	svcLocalAgain.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+	g.Expect(controller.serviceStore.Add(svcLocalAgain)).To(gomega.Succeed())
+
+	g.Expect(controller.syncService(svcKey)).To(gomega.Succeed())
+
+	g.Expect(controller.nbClient).To(libovsdbtest.HaveData([]libovsdbtest.TestData{
+		&nbdb.LoadBalancer{
+			UUID:        lbName,
+			Name:        lbName,
+			Options:     servicesOptions(),
+			Protocol:    &nbdb.LoadBalancerProtocolTCP,
+			Vips:        map[string]string{IPAndPort(serviceClusterIP, servicePort): ""},
+			ExternalIDs: loadBalancerExternalIDsWithETP(svcKey),
+		},
+		nodeLogicalSwitch(nodeA, initialLsGroups),
+		nodeLogicalSwitch(nodeB, initialLsGroups),
+		nodeLogicalRouter(nodeA, initialLrGroups),
+		nodeLogicalRouter(nodeB, initialLrGroups),
+		lbGroup(types.ClusterLBGroupName, lbName),
+		lbGroup(types.ClusterSwitchLBGroupName),
+		lbGroup(types.ClusterRouterLBGroupName),
+		nodeIPTemplate(nodeAInfo),
+		nodeIPTemplate(nodeBInfo),
+	}))
 }
 
 func nodeLogicalSwitch(nodeName string, lbGroups []string, namespacedServiceNames ...string) *nbdb.LogicalSwitch {
@@ -1753,7 +2002,16 @@ func loadBalancerExternalIDsForNetwork(namespacedServiceName string, network str
 	}
 	maps.Copy(externalIDs, getExternalIDsForNetwork(network))
 	return externalIDs
+}
 
+func loadBalancerExternalIDsWithETP(namespacedServiceName string) map[string]string {
+	return loadBalancerExternalIDsWithETPForNetwork(namespacedServiceName, types.DefaultNetworkName)
+}
+
+func loadBalancerExternalIDsWithETPForNetwork(namespacedServiceName string, network string) map[string]string {
+	externalIDs := loadBalancerExternalIDsForNetwork(namespacedServiceName, network)
+	externalIDs[types.LoadBalancerETPExternalID] = "local"
+	return externalIDs
 }
 
 func nodeIPTemplate(node *nodeInfo) *nbdb.ChassisTemplateVar {

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -41,6 +41,10 @@ func getExternalIDsForLoadBalancer(service *corev1.Service, netInfo util.NetInfo
 		types.LoadBalancerKindExternalID:  "Service",
 	}
 
+	if util.ServiceExternalTrafficPolicyLocal(service) {
+		externalIDs[types.LoadBalancerETPExternalID] = "local"
+	}
+
 	if netInfo.IsDefault() {
 		return externalIDs
 	}

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -78,4 +78,59 @@ func TestExternalIDsForLoadBalancer(t *testing.T) {
 		}, UDNNetInfo),
 	)
 
+	// ETP=Local on default network should set the etp external-id
+	assert.Equal(t,
+		map[string]string{
+			types.LoadBalancerKindExternalID:  "Service",
+			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
+			types.LoadBalancerETPExternalID:   "local",
+		},
+		getExternalIDsForLoadBalancer(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+			},
+		}, &defaultNetInfo),
+	)
+
+	// ETP=Cluster on default network should NOT set the etp external-id
+	assert.Equal(t,
+		map[string]string{
+			types.LoadBalancerKindExternalID:  "Service",
+			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
+		},
+		getExternalIDsForLoadBalancer(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
+			},
+		}, &defaultNetInfo),
+	)
+
+	// ETP=Local on UDN should set both etp and network external-ids
+	assert.Equal(t,
+		map[string]string{
+			types.LoadBalancerKindExternalID:  "Service",
+			types.LoadBalancerOwnerExternalID: "ns/svc-ab23",
+			types.LoadBalancerETPExternalID:   "local",
+			types.NetworkExternalID:           UDNNetInfo.GetNetworkName(),
+			types.NetworkRoleExternalID:       types.NetworkRolePrimary,
+		},
+		getExternalIDsForLoadBalancer(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+			},
+		}, UDNNetInfo),
+	)
+
 }

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -242,6 +242,8 @@ const (
 	LoadBalancerKindExternalID = OvnK8sPrefix + "/" + "kind"
 	// key for load_balancer service external-id
 	LoadBalancerOwnerExternalID = OvnK8sPrefix + "/" + "owner"
+	// key for load_balancer ExternalTrafficPolicy (set only when "local")
+	LoadBalancerETPExternalID = OvnK8sPrefix + "/" + "etp"
 	// key for UDN enabled services routes
 	UDNEnabledServiceExternalID = OvnK8sPrefix + "/" + "udn-enabled-default-service"
 	// key for management port name, indicating the netdev link name associated with the given management port representor OVS interface


### PR DESCRIPTION
It is useful to derive a service's ExternalTrafficPolicy purely by inspecting OVN NB load balancer external-ids, without needing access to the Kubernetes API. This makes debugging traffic-policy related issues easier when only the OVN northbound database is available.

Set k8s.ovn.org/etp=local on load balancer external-ids when the backing service has externalTrafficPolicy: Local. When the policy is Cluster (the default), the key is omitted.

This annotation will also be useful, if a user decides to program breth0 bridge for traffic muxing by only looking at OVN NB database.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load balancers now record ExternalTrafficPolicy=Local so the policy is honored across default and user-defined networks; syncing adds or removes this marker when the service policy changes.

* **Tests**
  * Added coverage validating ExternalTrafficPolicy behavior and sync behavior (including policy flips) across network configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->