### PR TITLE
Fix duplicate deleteEgressIPStatusSetup call in deleteEgressIPAssignments

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1083,11 +1083,6 @@ func (e *EgressIPController) deleteEgressIPAssignments(name string, statusesToRe
 						if err := e.deleteEgressIPStatusSetup(cachedNetwork, name, statusToRemove); err != nil {
 							return fmt.Errorf("failed to delete EgressIP %s status setup for network %s: %v", name, cachedNetwork.GetNetworkName(), err)
 						}
-						if cachedNetwork != nil {
-							if err := e.deleteEgressIPStatusSetup(cachedNetwork, name, statusToRemove); err != nil {
-								klog.Errorf("Failed to delete EgressIP %s status setup for network %s: %v", name, cachedNetwork.GetNetworkName(), err)
-							}
-						}
 					}
 					processedNetworks[cachedNetwork.GetNetworkName()] = struct{}{}
 					// this pod was managed by statusToRemove.EgressIP; we need to try and add its SNAT back towards nodeIP


### PR DESCRIPTION
The `deleteEgressIPStatusSetup` function was called twice with the exact same arguments. The second call was guarded by a nil check on `cachedNetwork`, but `cachedNetwork` was already dereferenced earlier in the same scope (`.GetNetworkName()`), so it was guaranteed non-nil. The guard was dead code and the second call was always executed, causing redundant OVN queries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate deletion operations during Egress IP cleanup to improve efficiency and reduce unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->