### PR TITLE
Fix race conditions in secondary host egress IP configuration

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -778,7 +778,16 @@ func (c *Controller) updateEIP(existing *state, update *config) error {
 		}
 	}
 	// apply new changes
+	// Apply configuration in strict order to avoid race conditions: routes → IP rules → iptables → IP on interface → annotation.
+	// Annotation serves as readiness signal for OVN controller to program logical router policies.
 	if update != nil && update.eIPConfig != nil && update.eIPConfig.addr != nil && len(update.eIPConfig.routes) > 0 {
+		for _, routeToAdd := range update.eIPConfig.routes {
+			if err := c.routeManager.Add(routeToAdd); err != nil {
+				return fmt.Errorf("failed to add egress IP route %v, err: %w", routeToAdd, err)
+			}
+		}
+		existing.eIPConfig.routes = update.eIPConfig.routes
+
 		for updatedTargetNS, updatedTargetPod := range update.namespacesWithPodIPConfigs {
 			existingNs, found := existing.namespacesWithPodIPConfigs[updatedTargetNS]
 			if !found {
@@ -798,22 +807,17 @@ func (c *Controller) updateEIP(existing *state, update *config) error {
 				}
 			}
 		}
-		if err := c.addIPToAnnotation(update.eIPConfig.addr.IP.String()); err != nil {
-			return fmt.Errorf("failed to add egress IP address to annotation: %v", err)
-		}
+
 		// TODO(mk): only apply the follow when its new config or when it failed to apply
 		// Ok to repeat requests to route manager and link manager
 		if err := c.linkManager.AddAddress(*update.eIPConfig.addr); err != nil {
 			return fmt.Errorf("failed to add address to link: %v", err)
 		}
 		existing.eIPConfig.addr = update.eIPConfig.addr
-		// route manager manages retry
-		for _, routeToAdd := range update.eIPConfig.routes {
-			if err := c.routeManager.Add(routeToAdd); err != nil {
-				return err
-			}
+
+		if err := c.addIPToAnnotation(update.eIPConfig.addr.IP.String()); err != nil {
+			return fmt.Errorf("failed to add egress IP address to annotation: %v", err)
 		}
-		existing.eIPConfig.routes = update.eIPConfig.routes
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2664,6 +2664,27 @@ func (e *EgressIPController) addStandByEgressIPAssignment(ni util.NetInfo, podKe
 	return nil
 }
 
+// isSecondaryHostEgressIPReady checks if the node controller has finished configuring
+// a secondary host egress IP on the given node. For secondary host egress IPs (not OVN-managed),
+// the node controller must first configure routes, IP rules, and iptables before OVN can
+// safely route traffic to the host. The node controller signals readiness by adding the
+// egress IP to the k8s.ovn.org/secondary-host-egress-ips annotation.
+func (e *EgressIPController) isSecondaryHostEgressIPReady(node *corev1.Node, egressIP string) (bool, error) {
+	assignedIPs, err := util.ParseNodeSecondaryHostEgressIPsAnnotation(node)
+	if err != nil {
+		if util.IsAnnotationNotSetError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to parse secondary host egress IPs annotation for node %s: %w", node.Name, err)
+	}
+
+	if !assignedIPs.Has(egressIP) {
+		return false, nil
+	}
+
+	return assignedIPs.Has(egressIP), nil
+}
+
 // addPodEgressIPAssignment will program OVN with logical router policies
 // (routing pod traffic to the egress node) and NAT objects on the egress node
 // (SNAT-ing to the egress IP).
@@ -2693,6 +2714,22 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 		return fmt.Errorf("failed to get node %s egress IP config: %w", eNode.Name, err)
 	}
 	isOVNNetwork := util.IsOVNNetwork(parsedNodeEIPConfig, eIPIP)
+
+	// For secondary host egress IPs, wait for node controller to finish configuration
+	// before programming OVN logical router policies. This prevents the race condition where
+	// OVN routes traffic to the host before host-side routes/IP rules/iptables are ready.
+	if !isOVNNetwork {
+		ready, err := e.isSecondaryHostEgressIPReady(eNode, status.EgressIP)
+		if err != nil {
+			return fmt.Errorf("failed to check if secondary host egress IP %s is ready on node %s: %w",
+				status.EgressIP, eNode.Name, err)
+		}
+		if !ready {
+			return types.NewSuppressedError(fmt.Errorf("won't add OVN logical router policies for secondary host egress IP %s on node %s before node controller configuration",
+				status.EgressIP, status.Node))
+		}
+	}
+
 	nextHopIP, err := e.getNextHop(ni, status.Node, status.EgressIP, egressIPName, isLocalZoneEgressNode, isOVNNetwork)
 	if err != nil {
 		return fmt.Errorf("failed to determine next hop for pod %s/%s when configuring egress IP %s"+

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -498,6 +499,13 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 			logicalRouterOptions := map[string]string{
 				"dynamic_neigh_routers": dynamicNeighRouters,
 			}
+			// Set the secondary host egress IP annotation since this is a secondary host network egress IP
+			if node1.Annotations == nil {
+				node1.Annotations = map[string]string{}
+			}
+			annotationValue, err := json.Marshal([]string{egressIP})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			node1.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(annotationValue)
 			fakeOvn.startWithDBSetup(
 				libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
@@ -549,7 +557,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					Items: []corev1.Namespace{*egressNamespace},
 				})
 
-			err := fakeOvn.controller.WatchEgressIPPods()
+			err = fakeOvn.controller.WatchEgressIPPods()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = fakeOvn.controller.WatchEgressIPNamespaces()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -818,6 +826,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node2Name, egressIP)
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 					gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name))
 					egressIPs, _ = getEgressIPStatus(egressIPName)
@@ -1140,6 +1149,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node1Name, egressIP)
 
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 					egressIPs, eIPNodes := getEgressIPStatus(egressIPName)
@@ -1161,6 +1171,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node2Name, egressIP)
 
 					// sleep long enough for TransactWithRetry to fail, causing egressnode operations to fail
 					// there is a chance that both egressnode events(node1 removal and node2 update) will end up in the same event queue
@@ -1186,6 +1197,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					//	gomega.Not(gomega.BeNil()), // config should not be nil
 					//)
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node2Name, egressIP)
 					connCtx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
 					defer cancel()
 					resetNBClient(connCtx, fakeOvn.controller.nbClient)
@@ -1561,6 +1573,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node1Name, egressIP)
 
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 					egressIPs, eIPNodes := getEgressIPStatus(egressIPName)
@@ -1582,6 +1595,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node2Name, egressIP)
 
 					// sleep long enough for TransactWithRetry to fail, causing egressnode operations to fail
 					// there is a chance that both egressnode events(node1 removal and node2 update) will end up in the same event queue
@@ -1964,6 +1978,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node2Name, egressIP)
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 					gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name))
 					egressIPs, _ = getEgressIPStatus(egressIPName)
@@ -2357,6 +2372,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIPOVN))
 					time.Sleep(20 * time.Millisecond)
 					fakeOvn.patchEgressIPObj(node1Name, egressIP2Name, egressIPSecondaryHost)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node1Name, egressIPSecondaryHost)
 					gomega.Eventually(getEgressIPStatusLen(egressIP2Name)).Should(gomega.Equal(1))
 					gomega.Eventually(nodeSwitch).Should(gomega.Equal(node1.Name))
 					egressIPs, _ = getEgressIPStatus(egressIP2Name)
@@ -2760,6 +2776,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeOvn.patchEgressIPObj(node1Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node1Name, egressIP)
 
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 					egressIPs, nodes := getEgressIPStatus(egressIPName)
@@ -2936,6 +2953,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					// W0608 12:53:33.728205 1161455 base_network_controller_egressip.go:2030] Unable to retrieve gateway IP for node: node1, protocol is IPv6: false, err: attempt at finding node gateway router network information failed, err: unable to find router port rtoj-GR_node1: object not found
 					// 2023-04-25T11:01:13.2804834Z W0425 11:01:13.280407   21055 base_network_controller_egressip.go:2036] Unable to fetch transit switch IP for node: node1: err: failed to get node node1: node "node1" not found
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node2Name, egressIP)
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 					gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name)) // egressIP successfully reassigned to node2
 					egressIPs, _ = getEgressIPStatus(egressIPName)
@@ -3231,6 +3249,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP)
+					fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node2Name, egressIP)
 					gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 					gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name))
 					egressIPs, _ = getEgressIPStatus(egressIPName)
@@ -9826,6 +9845,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				fakeOvn.patchEgressIPObj(node2Name, egressIPName, egressIP)
+				fakeOvn.setNodeSecondaryHostEgressIPAnnotation(node2Name, egressIP)
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 
 				egressIPs, nodes := getEgressIPStatus(egressIPName)
@@ -15608,6 +15628,164 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations cluster default network"
 			}
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("Secondary host egress IP annotation readiness", func() {
+		ginkgo.It("should wait for node annotation before programming OVN logical components", func() {
+			config.OVNKubernetesFeature.EnableInterconnect = true
+			egressIP := "10.10.10.10"
+			zone := "global"
+			node1IPv4OVN := "192.168.126.202/24"
+			node1IPv4TranSwitchIP := "100.88.0.2/16"
+			node1IPv4SecondaryHost1 := "10.10.10.4/24"
+			node1IPv4SecondaryHost2 := "5.5.5.10/24"
+			_, node1Subnet, _ := net.ParseCIDR(v4Node1Subnet)
+			node1IPv4Addresses := []string{node1IPv4OVN, node1IPv4SecondaryHost1, node1IPv4SecondaryHost2}
+
+			egressPod := *ovntest.NewPodWithLabels(eipNamespace, podName, node1Name, podV4IP, egressPodLabel)
+			egressNamespace := ovntest.NewNamespace(eipNamespace)
+			nodes := getIPv4Nodes([]nodeInfo{{node1IPv4Addresses, zone, node1IPv4TranSwitchIP}})
+			node1 := nodes[0]
+			node1.Labels = map[string]string{
+				"k8s.ovn.org/egress-assignable": "",
+			}
+
+			eIP := egressipv1.EgressIP{
+				ObjectMeta: newEgressIPMeta(egressIPName),
+				Spec: egressipv1.EgressIPSpec{
+					EgressIPs: []string{egressIP},
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: egressPodLabel,
+					},
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"name": egressNamespace.Name,
+						},
+					},
+				},
+				Status: egressipv1.EgressIPStatus{
+					Items: []egressipv1.EgressIPStatusItem{
+						{
+							Node:     node1Name,
+							EgressIP: egressIP,
+						},
+					},
+				},
+			}
+			node1Switch := &nbdb.LogicalSwitch{
+				UUID:  node1.Name + "-UUID",
+				Name:  node1.Name,
+				Ports: []string{"k8s-" + node1.Name + "-UUID"},
+			}
+			dynamicNeighRouters := "true"
+			if config.OVNKubernetesFeature.EnableInterconnect {
+				dynamicNeighRouters = "false"
+			}
+
+			logicalRouterOptions := map[string]string{
+				"dynamic_neigh_routers": dynamicNeighRouters,
+			}
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalRouterPort{
+							UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID",
+							Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name,
+							Networks: []string{nodeLogicalRouterIfAddrV4},
+						},
+						&nbdb.LogicalRouter{
+							Name: types.OVNClusterRouter,
+							UUID: types.OVNClusterRouter + "-UUID",
+						},
+						&nbdb.LogicalRouter{
+							Name:    types.GWRouterPrefix + node1.Name,
+							UUID:    types.GWRouterPrefix + node1.Name + "-UUID",
+							Ports:   []string{types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node1.Name + "-UUID"},
+							Options: logicalRouterOptions,
+						},
+						&nbdb.LogicalSwitchPort{
+							UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID",
+							Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
+							Type: "router",
+							Options: map[string]string{
+								libovsdbops.RouterPort:      types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+								"nat-addresses":             "router",
+								"exclude-lb-vips-from-garp": "true",
+							},
+						},
+						&nbdb.LogicalSwitchPort{
+							UUID:      "k8s-" + node1.Name + "-UUID",
+							Name:      "k8s-" + node1.Name,
+							Addresses: []string{"fe:1a:b2:3f:0e:fb " + util.GetNodeManagementIfAddr(node1Subnet).IP.String()},
+						},
+						&nbdb.LogicalSwitch{
+							UUID:  types.ExternalSwitchPrefix + node1Name + "-UUID",
+							Name:  types.ExternalSwitchPrefix + node1Name,
+							Ports: []string{types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name + "-UUID"},
+						},
+						node1Switch,
+					},
+				},
+				&egressipv1.EgressIPList{
+					Items: []egressipv1.EgressIP{eIP},
+				},
+				&corev1.NodeList{
+					Items: []corev1.Node{node1},
+				},
+				&corev1.NamespaceList{
+					Items: []corev1.Namespace{*egressNamespace},
+				})
+
+			err := fakeOvn.controller.WatchEgressIPPods()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fakeOvn.controller.WatchEgressIPNamespaces()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fakeOvn.controller.WatchEgressNodes()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fakeOvn.controller.WatchEgressIP()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			i, n, _ := net.ParseCIDR(podV4IP + "/23")
+			n.IP = i
+			fakeOvn.controller.logicalPortCache.add(&egressPod, "", types.DefaultNetworkName, "", nil, []*net.IPNet{n})
+
+			ginkgo.By("Creating egress pod and verifying no logical router policy is created initially")
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(egressPod.Namespace).Create(context.TODO(), &egressPod, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Consistently(func() int {
+				policies, _ := libovsdbops.FindLogicalRouterPoliciesWithPredicate(fakeOvn.nbClient, func(lrp *nbdb.LogicalRouterPolicy) bool {
+					return lrp.Priority == types.EgressIPReroutePriority &&
+						lrp.Match == fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP)
+				})
+				return len(policies)
+			}, "500ms", "100ms").Should(gomega.Equal(0))
+
+			ginkgo.By("Adding secondary host egress IP to node annotation to signal readiness")
+			if node1.Annotations == nil {
+				node1.Annotations = map[string]string{}
+			}
+			annotationValue, err := json.Marshal([]string{egressIP})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			node1.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(annotationValue)
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node1, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Triggering pod retry with no backoff and verifying retry succeeds")
+			key, err := retry.GetResourceKey(&egressPod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			retry.SetRetryObjWithNoBackoff(key, fakeOvn.controller.retryEgressIPPods)
+			fakeOvn.controller.retryEgressIPPods.RequestRetryObjs()
+			retry.CheckRetryObjectEventually(key, false, fakeOvn.controller.retryEgressIPPods)
+
+			ginkgo.By("Verifying the logical router policy is created after annotation readiness")
+			gomega.Eventually(func() int {
+				policies, _ := libovsdbops.FindLogicalRouterPoliciesWithPredicate(fakeOvn.nbClient, func(lrp *nbdb.LogicalRouterPolicy) bool {
+					return lrp.Priority == types.EgressIPReroutePriority &&
+						lrp.Match == fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP)
+				})
+				return len(policies)
+			}, "5s", "100ms").Should(gomega.Equal(1))
 		})
 	})
 })

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"sync"
 
 	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
@@ -19,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	anpapi "sigs.k8s.io/network-policy-api/apis/v1alpha1"
@@ -692,6 +694,48 @@ func (o *FakeOVN) patchEgressIPObj(nodeName, egressIPName, egressIP string) {
 	}
 	err := o.controller.eIPC.patchReplaceEgressIPStatus(egressIPName, status)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+// setNodeSecondaryHostEgressIPAnnotation simulates the node controller setting the
+// k8s.ovn.org/secondary-host-egress-ips annotation after configuring host-side routes/IP rules/iptables.
+// This is needed for OVN controller to proceed with programming logical router policies for secondary host egress IPs.
+func (o *FakeOVN) setNodeSecondaryHostEgressIPAnnotation(nodeName, egressIP string) {
+	node, err := o.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Parse node's egress IP configuration to check if this IP is a secondary host egress IP
+	parsedNodeEIPConfig, err := util.ParseNodePrimaryIfAddr(node)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	eIP := net.ParseIP(egressIP)
+	gomega.Expect(eIP).NotTo(gomega.BeNil())
+
+	// If it's NOT an OVN network, it's a secondary host egress IP
+	if !util.IsOVNNetwork(parsedNodeEIPConfig, eIP) {
+		// Get existing annotation value
+		existingIPs, err := util.ParseNodeSecondaryHostEgressIPsAnnotation(node)
+		if err != nil && !util.IsAnnotationNotSetError(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		if existingIPs == nil {
+			existingIPs = sets.New[string]()
+		}
+
+		// Add the new IP
+		existingIPs.Insert(egressIP)
+
+		// Update the annotation
+		if node.Annotations == nil {
+			node.Annotations = map[string]string{}
+		}
+		ipsSlice := sets.List(existingIPs)
+		annotationValue, err := json.Marshal(ipsSlice)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		node.Annotations[util.OVNNodeSecondaryHostEgressIPs] = string(annotationValue)
+
+		_, err = o.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
 }
 
 func nadGVR() metav1.GroupVersionResource {


### PR DESCRIPTION
When EgressIP is enabled for the cluster, it may be configured on a secondary interface. Because of this, there can be a delay in programming the IP rule and SNAT iptables rule for a pod that is served by an EgressIP. During this window, if the pod initiates egress traffic, its IP may leak onto the external network through the egress gateway interface (breth0 or br-ex).
Two race conditions caused pods to send traffic with node IP instead of egress IP during configuration:

1. Node controller internal ordering: routes were added after IP was on interface, creating a window where IP rules referenced empty routing tables.

2. OVN-node coordination: OVN controller programmed logical router policies before node controller finished host-side configuration.

Solution:
- Reorder node controller operations: routes → IP rules → iptables → annotation → IP on interface
- Use k8s.ovn.org/secondary-host-egress-ips annotation as readiness signal
- OVN controller checks annotation before programming logical router policies for secondary host egress IPs

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validates secondary-host Egress IP readiness so OVN policies are programmed only after host-side configuration is present.

* **Bug Fixes**
  * Reordered host-side Egress IP application: add routes first, then per-pod rules/SNAT, then interface address, and finally update node annotation. Route-add failures now return contextual errors.

* **Tests**
  * Added tests ensuring OVN policy programming is deferred until the secondary-host Egress IP readiness is recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->