### PR TITLE
Report NetworkAllocationSucceeded status condition for CUDNs

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -574,10 +575,10 @@ func (c *Controller) ReconcileNamespace(key string) error {
 	return nil
 }
 
-// UpdateSubsystemCondition may be used by other controllers handling UDN/NAD/network setup to report conditions that
-// may affect UDN functionality.
+// UpdateSubsystemCondition may be used by other controllers handling UDN/CUDN/NAD/network setup to report conditions that
+// may affect UDN/CUDN functionality.
 // FieldManager should be unique for every subsystem.
-// If given network is not managed by a UDN, no condition will be reported and no error will be returned.
+// If given network is not managed by a UDN/CUDN, no condition will be reported and no error will be returned.
 // Events may be used to report additional information about the condition to avoid overloading the condition message.
 // When condition should not change, but new events should be reported, pass condition = nil.
 func (c *Controller) UpdateSubsystemCondition(
@@ -586,28 +587,32 @@ func (c *Controller) UpdateSubsystemCondition(
 	condition *metav1.Condition,
 	events ...*util.EventDetails,
 ) error {
-	// try to find udn using network name
+	// try to find udn/cudn using network name
 	udnNamespace, udnName := util.ParseNetworkName(networkName)
 	if udnName == "" {
 		return nil
 	}
 
-	// Handle CUDN (cluster-scoped): namespace is empty for CUDNs
+	var obj runtime.Object
+	var err error
 	if udnNamespace == "" {
-		return c.updateCUDNSubsystemCondition(udnName, fieldManager, condition, events...)
+		obj, err = c.cudnLister.Get(udnName)
+	} else {
+		obj, err = c.udnLister.UserDefinedNetworks(udnNamespace).Get(udnName)
+	}
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get (Cluster)UserDefinedNetwork %s/%s from cache: %w", udnNamespace, udnName, err)
 	}
 
-	udn, err := c.udnLister.UserDefinedNetworks(udnNamespace).Get(udnName)
+	objRef, err := reference.GetReference(userdefinednetworkscheme.Scheme, obj)
 	if err != nil {
-		return nil
-	}
-
-	udnRef, err := reference.GetReference(userdefinednetworkscheme.Scheme, udn)
-	if err != nil {
-		return fmt.Errorf("failed to get object reference for UserDefinedNetwork %s/%s: %w", udnNamespace, udnName, err)
+		return fmt.Errorf("failed to get object reference for (Cluster)UserDefinedNetwork %s/%s: %w", udnNamespace, udnName, err)
 	}
 	for _, event := range events {
-		c.eventRecorder.Event(udnRef, event.EventType, event.Reason, event.Note)
+		c.eventRecorder.Event(objRef, event.EventType, event.Reason, event.Note)
 	}
 
 	if condition == nil {
@@ -622,69 +627,25 @@ func (c *Controller) UpdateSubsystemCondition(
 		Message:            &condition.Message,
 	}
 
-	udnStatus := udnapplyconfkv1.UserDefinedNetworkStatus().WithConditions(applyCondition)
-
-	applyUDN := udnapplyconfkv1.UserDefinedNetwork(udnName, udnNamespace).WithStatus(udnStatus)
 	opts := metav1.ApplyOptions{
 		FieldManager: fieldManager,
 		Force:        true,
 	}
-	_, err = c.udnClient.K8sV1().UserDefinedNetworks(udnNamespace).ApplyStatus(context.Background(), applyUDN, opts)
+
+	if udnNamespace == "" {
+		applyConf := udnapplyconfkv1.ClusterUserDefinedNetwork(udnName).
+			WithStatus(udnapplyconfkv1.ClusterUserDefinedNetworkStatus().WithConditions(applyCondition))
+		_, err = c.udnClient.K8sV1().ClusterUserDefinedNetworks().ApplyStatus(context.Background(), applyConf, opts)
+	} else {
+		udnStatus := udnapplyconfkv1.UserDefinedNetworkStatus().WithConditions(applyCondition)
+		applyUDN := udnapplyconfkv1.UserDefinedNetwork(udnName, udnNamespace).WithStatus(udnStatus)
+		_, err = c.udnClient.K8sV1().UserDefinedNetworks(udnNamespace).ApplyStatus(context.Background(), applyUDN, opts)
+	}
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to update UserDefinedNetwork %s/%s status: %w", udnNamespace, udnName, err)
-	}
-	return nil
-}
-
-func (c *Controller) updateCUDNSubsystemCondition(
-	cudnName string,
-	fieldManager string,
-	condition *metav1.Condition,
-	events ...*util.EventDetails,
-) error {
-	cudn, err := c.cudnLister.Get(cudnName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to get ClusterUserDefinedNetwork %s from cache: %w", cudnName, err)
-	}
-
-	cudnRef, err := reference.GetReference(userdefinednetworkscheme.Scheme, cudn)
-	if err != nil {
-		return fmt.Errorf("failed to get object reference for ClusterUserDefinedNetwork %s: %w", cudnName, err)
-	}
-	for _, event := range events {
-		c.eventRecorder.Event(cudnRef, event.EventType, event.Reason, event.Note)
-	}
-
-	if condition == nil {
-		return nil
-	}
-
-	applyCondition := &metaapplyv1.ConditionApplyConfiguration{
-		Type:               &condition.Type,
-		Status:             &condition.Status,
-		LastTransitionTime: &condition.LastTransitionTime,
-		Reason:             &condition.Reason,
-		Message:            &condition.Message,
-	}
-
-	applyConf := udnapplyconfkv1.ClusterUserDefinedNetwork(cudnName).
-		WithStatus(udnapplyconfkv1.ClusterUserDefinedNetworkStatus().WithConditions(applyCondition))
-	opts := metav1.ApplyOptions{
-		FieldManager: fieldManager,
-		Force:        true,
-	}
-	_, err = c.udnClient.K8sV1().ClusterUserDefinedNetworks().ApplyStatus(context.Background(), applyConf, opts)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to update ClusterUserDefinedNetwork %s status: %w", cudnName, err)
+		return fmt.Errorf("failed to update (Cluster)UserDefinedNetwork %s/%s status: %w", udnNamespace, udnName, err)
 	}
 	return nil
 }

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -588,9 +588,15 @@ func (c *Controller) UpdateSubsystemCondition(
 ) error {
 	// try to find udn using network name
 	udnNamespace, udnName := util.ParseNetworkName(networkName)
-	if udnName == "" || udnNamespace == "" {
+	if udnName == "" {
 		return nil
 	}
+
+	// Handle CUDN (cluster-scoped): namespace is empty for CUDNs
+	if udnNamespace == "" {
+		return c.updateCUDNSubsystemCondition(udnName, fieldManager, condition, events...)
+	}
+
 	udn, err := c.udnLister.UserDefinedNetworks(udnNamespace).Get(udnName)
 	if err != nil {
 		return nil
@@ -629,6 +635,56 @@ func (c *Controller) UpdateSubsystemCondition(
 			return nil
 		}
 		return fmt.Errorf("failed to update UserDefinedNetwork %s/%s status: %w", udnNamespace, udnName, err)
+	}
+	return nil
+}
+
+func (c *Controller) updateCUDNSubsystemCondition(
+	cudnName string,
+	fieldManager string,
+	condition *metav1.Condition,
+	events ...*util.EventDetails,
+) error {
+	cudn, err := c.cudnLister.Get(cudnName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get ClusterUserDefinedNetwork %s from cache: %w", cudnName, err)
+	}
+
+	cudnRef, err := reference.GetReference(userdefinednetworkscheme.Scheme, cudn)
+	if err != nil {
+		return fmt.Errorf("failed to get object reference for ClusterUserDefinedNetwork %s: %w", cudnName, err)
+	}
+	for _, event := range events {
+		c.eventRecorder.Event(cudnRef, event.EventType, event.Reason, event.Note)
+	}
+
+	if condition == nil {
+		return nil
+	}
+
+	applyCondition := &metaapplyv1.ConditionApplyConfiguration{
+		Type:               &condition.Type,
+		Status:             &condition.Status,
+		LastTransitionTime: &condition.LastTransitionTime,
+		Reason:             &condition.Reason,
+		Message:            &condition.Message,
+	}
+
+	applyConf := udnapplyconfkv1.ClusterUserDefinedNetwork(cudnName).
+		WithStatus(udnapplyconfkv1.ClusterUserDefinedNetworkStatus().WithConditions(applyCondition))
+	opts := metav1.ApplyOptions{
+		FieldManager: fieldManager,
+		Force:        true,
+	}
+	_, err = c.udnClient.K8sV1().ClusterUserDefinedNetworks().ApplyStatus(context.Background(), applyConf, opts)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to update ClusterUserDefinedNetwork %s status: %w", cudnName, err)
 	}
 	return nil
 }

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -1513,6 +1513,79 @@ spec:
 				}
 			})
 		})
+
+		It("should correctly report subsystem error on node subnet allocation", func() {
+			nodes, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+			framework.ExpectNoError(err)
+
+			By("create test ClusterUserDefinedNetwork")
+			// create network that only has 2 node subnets (/24 cluster subnet has only 2 /25 node subnets)
+			cudnName := randomNetworkMetaName()
+			cudnManifest := `
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: ` + cudnName + `
+spec:
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values: [` + strings.Join(testTenantNamespaces, ",") + `]
+  network:
+    topology: "Layer3"
+    layer3:
+      role: Secondary
+      subnets:
+        - cidr: "10.10.100.0/24"
+          hostSubnet: 25
+`
+			cleanup, err := createManifest("", cudnManifest)
+			DeferCleanup(func() {
+				cleanup()
+				_, _ = e2ekubectl.RunKubectl("", "delete", clusterUserDefinedNetworkResource, cudnName)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 5*time.Second, time.Second).Should(Succeed())
+
+			conditionsJSON, err := e2ekubectl.RunKubectl("", "get", clusterUserDefinedNetworkResource, cudnName, "-o", "jsonpath={.status.conditions}")
+			Expect(err).NotTo(HaveOccurred())
+			var actualConditions []metav1.Condition
+			Expect(json.Unmarshal([]byte(conditionsJSON), &actualConditions)).To(Succeed())
+
+			netAllocationCondition := "NetworkAllocationSucceeded"
+
+			if len(nodes.Items) <= 2 {
+				By("when cluster has <= 2 nodes, no error is expected")
+				found := false
+				for _, condition := range actualConditions {
+					if condition.Type == netAllocationCondition && condition.Status == metav1.ConditionTrue {
+						found = true
+					}
+				}
+				Expect(found).To(BeTrue(), "NetworkAllocationSucceeded condition should be True when cluster has <= 2 nodes")
+			} else {
+				By("when cluster has > 2 nodes, error is expected")
+				found := false
+				for _, condition := range actualConditions {
+					if condition.Type == netAllocationCondition && condition.Status == metav1.ConditionFalse {
+						found = true
+					}
+				}
+				Expect(found).To(BeTrue(), "NetworkAllocationSucceeded condition should be False when cluster has > 2 nodes")
+				events, err := cs.CoreV1().Events("").List(context.Background(), metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				found = false
+				for _, event := range events.Items {
+					if event.Reason == "NetworkAllocationFailed" && event.LastTimestamp.After(time.Now().Add(-30*time.Second)) &&
+						strings.Contains(event.Message, "error allocating network") {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "should have found an event for failed node allocation")
+			}
+		})
 	})
 
 	It("when primary network exist, ClusterUserDefinedNetwork status should report not-ready", func() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
UpdateSubsystemCondition previously skipped cluster-scoped networks (CUDNs) because it returned early when namespace was empty. Route CUDN network names to a new updateCUDNSubsystemCondition method so NetworkAllocationSucceeded status is reported for CUDNs the same way it already is for UDNs.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of user-defined network updates so cluster-scoped networks are routed correctly and status updates are applied more reliably.
  * Status changes now consistently record events and treat initially-missing resources as non-fatal.

* **Bug Fixes**
  * Fixed suppression of valid update paths so relevant updates are no longer skipped; remaining errors are surfaced appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->