### PR TITLE
Fix DPU healthcheck by propagating namespace configuration to ovnkube

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1245,8 +1245,8 @@ ovnkube-identity() {
     --webhook-cert-dir="/etc/webhook-cert" \
     ${ovnkube_enable_interconnect_flag} \
     ${ovnkube_enable_hybrid_overlay_flag} \
-    --extra-allowed-user="system:serviceaccount:ovn-kubernetes:ovnkube-cluster-manager" \
-    --extra-allowed-user="system:serviceaccount:ovn-kubernetes:ovnkube-master" \
+    --extra-allowed-user="system:serviceaccount:${ovn_kubernetes_namespace}:ovnkube-cluster-manager" \
+    --extra-allowed-user="system:serviceaccount:${ovn_kubernetes_namespace}:ovnkube-master" \
     --loglevel="${ovnkube_loglevel}"
 
     exit 9
@@ -1563,6 +1563,7 @@ ovn-master() {
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} \
     --metrics-enable-pprof \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
+    --ovn-config-namespace ${ovn_kubernetes_namespace} \
     --pidfile ${OVN_RUNDIR}/ovnkube-master.pid &
 
   echo "=============== ovn-master ========== running"
@@ -1925,6 +1926,7 @@ ovnkube-controller() {
     --loglevel=${ovnkube_loglevel} \
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} \
     --metrics-enable-pprof \
+    --ovn-config-namespace ${ovn_kubernetes_namespace} \
     --pidfile ${OVN_RUNDIR}/ovnkube-controller.pid \
     --zone ${ovn_zone} &
 
@@ -2472,6 +2474,7 @@ ovnkube-controller-with-node() {
     --metrics-enable-pprof \
     --mtu=${mtu} \
     --nodeport \
+    --ovn-config-namespace ${ovn_kubernetes_namespace} \
     --ovn-metrics-bind-address ${ovn_metrics_bind_address} \
     --pidfile ${OVN_RUNDIR}/ovnkube-controller-with-node.pid \
     --zone ${ovn_zone} &
@@ -2739,6 +2742,7 @@ ovn-cluster-manager() {
     --loglevel=${ovnkube_loglevel} \
     --metrics-bind-address ${ovnkube_cluster_manager_metrics_bind_address} \
     --metrics-enable-pprof \
+    --ovn-config-namespace ${ovn_kubernetes_namespace} \
     --pidfile ${OVN_RUNDIR}/ovnkube-cluster-manager.pid &
 
   echo "=============== ovn-cluster-manager ========== running"
@@ -3175,6 +3179,7 @@ ovn-node() {
         --metrics-enable-pprof \
         --mtu=${mtu} \
         --nodeport \
+        --ovn-config-namespace ${ovn_kubernetes_namespace} \
         --ovn-metrics-bind-address ${ovn_metrics_bind_address} \
         --pidfile ${OVN_RUNDIR}/ovnkube.pid \
         --zone ${ovn_zone} &
@@ -3211,7 +3216,8 @@ cleanup-ovn-node() {
   /usr/bin/ovnkube --cleanup-node ${K8S_NODE} --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
     --k8s-token=${k8s_token} --k8s-apiserver=${K8S_APISERVER} --k8s-cacert=${k8s_cacert} \
     --loglevel=${ovnkube_loglevel} \
-    --logfile /var/log/ovn-kubernetes/ovnkube.log
+    --logfile /var/log/ovn-kubernetes/ovnkube.log \
+    --ovn-config-namespace ${ovn_kubernetes_namespace}
 
 }
 


### PR DESCRIPTION
Fix DPU healthcheck by propagating namespace configuration to ovnkube
In DPU (Data Processing Unit) deployments, the OVN-Kubernetes namespace
may differ from the default "ovn-kubernetes" (e.g. when deployed via
operators that use a custom namespace). The ovnkube.sh entrypoint script
already reads OVN_KUBERNETES_NAMESPACE from the environment, but never
actually passed it through to the ovnkube binary via --ovn-config-namespace.
This caused DPU healthcheck failures because the ovnkube processes were
always looking for resources in the hardcoded "ovn-kubernetes" namespace,
while the actual resources (leases, services) lived in the
operator-configured namespace.

This change:
- Adds --ovn-config-namespace ${ovn_kubernetes_namespace} to all six
  ovnkube binary invocations: ovn-master, ovnkube-controller,
  ovnkube-controller-with-node, ovn-cluster-manager, ovn-node, and
  cleanup-ovn-node.
- Replaces the hardcoded "ovn-kubernetes" namespace in ovnkube-identity
  --extra-allowed-user service account references with the configurable
  ${ovn_kubernetes_namespace} variable.

Without this fix, DPU nodes fail healthchecks when deployed in a
non-default namespace because leader election leases target the wrong
namespace.

Signed-off-by: Igal Tsoiref <itsoiref@redhat.com>
Made-with: Cursor
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
