### PR TITLE
e2e: fix no-overlay tcpdump race losing captured packets

### DIFF
--- a/test/e2e/no_overlay.go
+++ b/test/e2e/no_overlay.go
@@ -218,7 +218,7 @@ func getTcpdumpOnPhysicalIface(tcpdumpPod *corev1.Pod, clientPod *corev1.Pod, cu
 
 	// Always stop tcpdump and collect output before returning, so the background
 	// process is not left running even when curl failed.
-	collectCmd := "sh -c 'kill -INT $(cat /tmp/tcpdump.pid) >/dev/null 2>&1 || true; sleep 1; cat /tmp/tcpdump.log'"
+	collectCmd := "sh -c 'sleep 0.5; kill -INT $(cat /tmp/tcpdump.pid) >/dev/null 2>&1 || true; sleep 1; cat /tmp/tcpdump.log'"
 	tcpdumpOut, err := e2epodoutput.RunHostCmdWithRetries(tcpdumpPod.Namespace, tcpdumpPod.Name, collectCmd, framework.Poll, 10*time.Second)
 	framework.ExpectNoError(err, "Failed to collect tcpdump output")
 	framework.Logf("tcpdump output:\n%s", tcpdumpOut)


### PR DESCRIPTION
## Description

Fixes a race condition in test/e2e/no_overlay.go that causes intermittent failures in the bgp-no-overlay CI lane.

The collectCmd sent SIGINT to tcpdump immediately after curl finished, before pcap_loop had time to drain the kernel ring buffer. This caused tcpdump to report "0 packets captured" intermittently, failing the no-overlay connectivity assertion.

The fix adds sleep 0.5 before the SIGINT in the collect command, giving pcap_loop time to drain the ring buffer before tcpdump is interrupted.

Fixes #6178

How to verify it
The race condition was observed in CI: https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/23621736791/job/68803104206?pr=6115

In that run, tcpdump reported "0 packets captured" even though curl succeeded and traffic was flowing. The root cause is that SIGINT arrived before pcap_loop drained the ring buffer. The sleep 0.5 gives enough time for packets to be processed.



## Checks

- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test stability for network diagnostics by adding a brief 0.5s delay before stopping packet capture to reduce flakiness.
  * Collection and logging of captured data remain unchanged; this change only smooths timing in teardown to make end-to-end tests more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->