### PR TITLE
EVPN pod ctrl: clean up stale FDB/neighbor entries on pod UID change

### DIFF
--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
@@ -110,14 +110,22 @@ func (c *Controller) reconcilePod(key string) error {
 	}
 
 	// If we already have cached entries for this exact pod (same UID), ensure the
-	// neighbors are present without re-parsing the annotation. On rapid pod
-	// delete/recreate with the same name, the UID changes and we fall through to
-	// re-parse the annotation and replace the stale cache entry.
+	// neighbors are present without re-parsing the annotation.
 	c.podNeighLock.Lock()
 	existing, hasExisting := c.podNeighbors[key]
 	c.podNeighLock.Unlock()
 	if hasExisting && existing.uid == pod.UID {
 		return c.ensurePodNeighbors(existing)
+	}
+	// On rapid pod delete/recreate with the same name (e.g. force-deleted
+	// StatefulSet pod), the workqueue may coalesce the delete and create events
+	// into a single reconcile for the new pod. Clean up the old kernel
+	// FDB/neighbor entries before programming new ones, otherwise stale entries
+	// for the previous pod's MAC/IPs would persist until the next periodic sync.
+	if hasExisting {
+		if err := c.deletePodNeighbors(key); err != nil {
+			return fmt.Errorf("failed to delete stale neighbors for recreated pod %s: %v", key, err)
+		}
 	}
 
 	nadKey, err := c.networkMgr.GetPrimaryNADForNamespace(pod.Namespace)

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
@@ -112,6 +112,86 @@ var _ = Describe("EVPN pod controller", func() {
 			Expect(entry.uid).To(Equal(k8stypes.UID("pod-uid-1")))
 		})
 
+		It("cleans up stale entries when pod is recreated with a different UID", func() {
+			oldMAC, _ := net.ParseMAC("0a:58:0a:00:00:05")
+			key := "test-ns/test-pod"
+
+			ctrl.podNeighbors[key] = &neighEntries{
+				uid:         "pod-uid-old",
+				sviName:     "svl2-test",
+				ovsPortName: "evovs-test",
+				macvrfVID:   100,
+				ips:         []net.IP{net.ParseIP("10.0.0.5")},
+				mac:         oldMAC,
+			}
+
+			netInfo := &multinetworkmocks.NetInfo{}
+			netInfo.On("EVPNVTEPName").Return("vtep1")
+			netInfo.On("EVPNMACVRFVID").Return(100)
+			netInfo.On("EVPNMACVRFVNI").Return(int32(10100))
+			netInfo.On("GetNetworkName").Return("mynet")
+			netInfo.On("GetNetworkID").Return(5)
+			netInfo.On("IsPrimaryNetwork").Return(true)
+			const nadKey = "test-ns/test-nad"
+			fakeNM.NADNetworks = map[string]util.NetInfo{nadKey: netInfo}
+			fakeNM.PrimaryNetworks = map[string]util.NetInfo{"test-ns": netInfo}
+
+			sviName := GetEVPNL2SVIName(netInfo)
+			ovsPortName := GetEVPNOVSPortName(netInfo)
+			sviLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: sviName, Index: 10}}
+			ovsPortLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ovsPortName, Index: 20}}
+
+			oldSVILink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "svl2-test", Index: 10}}
+			oldOVSLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "evovs-test", Index: 20}}
+			nlMock.On("LinkByName", "svl2-test").Return(oldSVILink, nil)
+			nlMock.On("LinkByName", "evovs-test").Return(oldOVSLink, nil)
+			nlMock.On("LinkByName", sviName).Return(sviLink, nil)
+			nlMock.On("LinkByName", ovsPortName).Return(ovsPortLink, nil)
+			nlMock.On("NeighDel", mock.Anything).Return(nil)
+			nlMock.On("NeighAdd", mock.Anything).Return(nil)
+
+			newMAC, _ := net.ParseMAC("0a:58:0a:00:00:06")
+			podAnnotation := `{"test-ns/test-nad":{"ip_addresses":["10.0.0.6/24"],"mac_address":"0a:58:0a:00:00:06","ip_address":"10.0.0.6/24"}}`
+			newPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod", Namespace: "test-ns",
+					UID:         "pod-uid-new",
+					Annotations: map[string]string{util.OvnPodAnnotationName: podAnnotation},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			}
+			ctrl.podLister = newFakePodLister(newPod)
+
+			Expect(ctrl.reconcilePod(key)).To(Succeed())
+
+			By("verifying old FDB entry was deleted")
+			nlMock.AssertCalled(GinkgoT(), "NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+				return n.LinkIndex == 20 && n.HardwareAddr.String() == oldMAC.String()
+			}))
+
+			By("verifying old neighbor entry was deleted")
+			nlMock.AssertCalled(GinkgoT(), "NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+				return n.LinkIndex == 10 && n.IP.Equal(net.ParseIP("10.0.0.5"))
+			}))
+
+			By("verifying new FDB entry was added")
+			nlMock.AssertCalled(GinkgoT(), "NeighAdd", mock.MatchedBy(func(n *netlink.Neigh) bool {
+				return n.LinkIndex == 20 && n.HardwareAddr.String() == newMAC.String()
+			}))
+
+			By("verifying new neighbor entry was added")
+			nlMock.AssertCalled(GinkgoT(), "NeighAdd", mock.MatchedBy(func(n *netlink.Neigh) bool {
+				return n.LinkIndex == 10 && n.IP.Equal(net.ParseIP("10.0.0.6"))
+			}))
+
+			By("verifying cache has the new UID")
+			ctrl.podNeighLock.Lock()
+			entry, exists := ctrl.podNeighbors[key]
+			ctrl.podNeighLock.Unlock()
+			Expect(exists).To(BeTrue())
+			Expect(entry.uid).To(Equal(k8stypes.UID("pod-uid-new")))
+		})
+
 		It("cleans up entries when pod is deleted", func() {
 			mac, _ := net.ParseMAC("0a:58:0a:00:00:05")
 			key := "test-ns/test-pod"
@@ -215,7 +295,7 @@ var _ = Describe("EVPN pod controller", func() {
 			Expect(exists).To(BeFalse())
 		})
 
-		It("skips pods whose EVPN network annotation is not yet set", func() {
+		It("skips pods whose CUDN network annotation is not yet set", func() {
 			netInfo := &multinetworkmocks.NetInfo{}
 			netInfo.On("EVPNMACVRFVNI").Return(int32(10100))
 			netInfo.On("IsPrimaryNetwork").Return(true)


### PR DESCRIPTION
When a pod is rapidly recreated, there is technically a chance for the workqueue to coalesce both events into a single reconcile. Delete the old pod's kernel FDB/neighbor entries before programming new ones.

Additionally clarify one test name.

@maiqueb ptal

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Now proactively removes stale dataplane neighbor/FDB entries when a pod is recreated with the same name but a different UID, preventing stale kernel networking state.

* **Tests**
  * Added test coverage for pod recreation scenarios that verifies stale entries are deleted and new network state is programmed, and that the in-memory cache is updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->