### PR TITLE
CNC: Add Validation Admission Policy

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -1327,6 +1327,7 @@ ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \
   jinjanate ../templates/rbac-ovnkube-node.yaml.j2 -o ${output_dir}/rbac-ovnkube-node.yaml
 
 ovn_network_segmentation_enable=${ovn_network_segmentation_enable} \
+ovn_network_connect_enable=${ovn_network_connect_enable} \
 ovn_pre_conf_udn_addr_enable=${ovn_pre_conf_udn_addr_enable} \
 ovn_enable_dnsnameresolver=${ovn_enable_dnsnameresolver} \
 ovn_allow_icmp_netpol=${ovn_allow_icmp_netpol} \

--- a/dist/templates/rbac-ovnkube-cluster-manager.yaml.j2
+++ b/dist/templates/rbac-ovnkube-cluster-manager.yaml.j2
@@ -76,7 +76,6 @@ rules:
           - userdefinednetworks
           - clusteruserdefinednetworks
           - networkqoses
-          - clusternetworkconnects
           - vteps
       verbs: [ "get", "list", "watch" ]
     - apiGroups: ["k8s.ovn.org"]
@@ -93,8 +92,6 @@ rules:
           - clusteruserdefinednetworks/status
           - clusteruserdefinednetworks/finalizers
           - routeadvertisements/status
-          - clusternetworkconnects # Unlike core kubernetes objects, for CRDs there is strict enforcement of status subresource permissions. Since CM has to annotate CNC we need to provide full object patch permissions.
-          - clusternetworkconnects/status
           - vteps
           - vteps/status
       verbs: [ "patch", "update" ]
@@ -144,3 +141,102 @@ rules:
           - frrconfigurations
       verbs: [ "create", "delete", "get", "list", "patch", "update", "watch" ]
     {%- endif %}
+    {% if ovn_network_connect_enable == "true" -%}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - clusternetworkconnects
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - clusternetworkconnects # Unlike core kubernetes objects, for CRDs there is strict enforcement of status subresource permissions. Since CM has to annotate CNC we need to provide full object patch permissions.
+          - clusternetworkconnects/status
+      verbs: [ "patch", "update" ]
+    {%- endif %}
+
+{% if ovn_network_connect_enable == "true" -%}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: cnc-annotation-validation
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["k8s.ovn.org"]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["clusternetworkconnects"]
+  validations:
+  # Prevent creating ClusterNetworkConnect with either annotation
+  - expression: >-
+      request.operation != "CREATE" ||
+      !has(object.metadata.annotations) ||
+      (!("k8s.ovn.org/network-connect-subnet" in object.metadata.annotations) &&
+      !("k8s.ovn.org/connect-router-tunnel-key" in object.metadata.annotations))
+    message: >-
+      ClusterNetworkConnect resources cannot be created with the
+      "k8s.ovn.org/network-connect-subnet" or "k8s.ovn.org/connect-router-tunnel-key"
+      annotations. These annotations are managed by the system.
+    reason: Invalid
+  # Immutable once set; only cluster-manager can add connect-router-tunnel-key.
+  # Passes when:
+  #   Branch 1 - neither old nor new has the annotation (no change)
+  #   Branch 2 - both have it with the same value (no modification)
+  #   Branch 3 - annotation is being added and user is cluster-manager
+  - expression: >-
+      request.operation != "UPDATE" ||
+      ((!has(oldObject.metadata.annotations) ||
+      !("k8s.ovn.org/connect-router-tunnel-key" in oldObject.metadata.annotations)) &&
+      (!has(object.metadata.annotations) ||
+      !("k8s.ovn.org/connect-router-tunnel-key" in object.metadata.annotations))) ||
+      (has(oldObject.metadata.annotations) &&
+      "k8s.ovn.org/connect-router-tunnel-key" in oldObject.metadata.annotations &&
+      has(object.metadata.annotations) &&
+      "k8s.ovn.org/connect-router-tunnel-key" in object.metadata.annotations &&
+      oldObject.metadata.annotations["k8s.ovn.org/connect-router-tunnel-key"] ==
+      object.metadata.annotations["k8s.ovn.org/connect-router-tunnel-key"]) ||
+      ((!has(oldObject.metadata.annotations) ||
+      !("k8s.ovn.org/connect-router-tunnel-key" in oldObject.metadata.annotations)) &&
+      has(object.metadata.annotations) &&
+      "k8s.ovn.org/connect-router-tunnel-key" in object.metadata.annotations &&
+      request.userInfo.username ==
+      "system:serviceaccount:ovn-kubernetes:ovnkube-cluster-manager")
+    message: >-
+      The "k8s.ovn.org/connect-router-tunnel-key" annotation is immutable once set
+      and can only be added by the cluster-manager service account.
+    reason: Invalid
+  # Only cluster-manager can add, modify, or remove network-connect-subnet.
+  # Passes when:
+  #   Branch 1 - user is cluster-manager (any mutation allowed)
+  #   Branch 2 - neither old nor new has the annotation (no change)
+  #   Branch 3 - both have it with the same value (no modification)
+  - expression: >-
+      request.operation != "UPDATE" ||
+      request.userInfo.username ==
+      "system:serviceaccount:ovn-kubernetes:ovnkube-cluster-manager" ||
+      ((!has(oldObject.metadata.annotations) ||
+      !("k8s.ovn.org/network-connect-subnet" in oldObject.metadata.annotations)) &&
+      (!has(object.metadata.annotations) ||
+      !("k8s.ovn.org/network-connect-subnet" in object.metadata.annotations))) ||
+      (has(oldObject.metadata.annotations) &&
+      "k8s.ovn.org/network-connect-subnet" in oldObject.metadata.annotations &&
+      has(object.metadata.annotations) &&
+      "k8s.ovn.org/network-connect-subnet" in object.metadata.annotations &&
+      oldObject.metadata.annotations["k8s.ovn.org/network-connect-subnet"] ==
+      object.metadata.annotations["k8s.ovn.org/network-connect-subnet"])
+    message: >-
+      A regular user must not add, modify, or remove the
+      "k8s.ovn.org/network-connect-subnet" annotation on a
+      ClusterNetworkConnect custom resource.
+    reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: cnc-annotation-validation-binding
+spec:
+  policyName: cnc-annotation-validation
+  validationActions: [Deny]
+{%- endif %}

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/rbac-ovnkube-cluster-manager.yaml
@@ -77,7 +77,6 @@ rules:
           - userdefinednetworks
           - clusteruserdefinednetworks
           - vteps
-          - clusternetworkconnects
       verbs: [ "get", "list", "watch" ]
     - apiGroups: ["k8s.ovn.org"]
       resources:
@@ -89,8 +88,6 @@ rules:
           - clusteruserdefinednetworks
           - clusteruserdefinednetworks/status
           - clusteruserdefinednetworks/finalizers
-          - clusternetworkconnects
-          - clusternetworkconnects/status
           - vteps
           - vteps/status
       verbs: [ "patch", "update" ]
@@ -146,6 +143,17 @@ rules:
       resources:
           - frrconfigurations
       verbs: [ "create", "delete", "get", "list", "patch", "update", "watch" ]
+    {{- end }}
+    {{- if eq (hasKey .Values.global "enableNetworkConnect" | ternary .Values.global.enableNetworkConnect false) true }}
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - clusternetworkconnects
+      verbs: [ "get", "list", "watch" ]
+    - apiGroups: ["k8s.ovn.org"]
+      resources:
+          - clusternetworkconnects
+          - clusternetworkconnects/status
+      verbs: [ "patch", "update" ]
     {{- end }}
 
 ---
@@ -260,3 +268,91 @@ metadata:
 spec:
   policyName: egressip-mark-annotation-validation
   validationActions: [Deny]
+
+{{- if eq (hasKey .Values.global "enableNetworkConnect" | ternary .Values.global.enableNetworkConnect false) true }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: cnc-annotation-validation
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["k8s.ovn.org"]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["clusternetworkconnects"]
+  validations:
+  # Prevent creating ClusterNetworkConnect with either annotation
+  - expression: >-
+      request.operation != "CREATE" ||
+      !has(object.metadata.annotations) ||
+      (!("k8s.ovn.org/network-connect-subnet" in object.metadata.annotations) &&
+      !("k8s.ovn.org/connect-router-tunnel-key" in object.metadata.annotations))
+    message: >-
+      ClusterNetworkConnect resources cannot be created with the
+      "k8s.ovn.org/network-connect-subnet" or "k8s.ovn.org/connect-router-tunnel-key"
+      annotations. These annotations are managed by the system.
+    reason: Invalid
+  # Immutable once set; only cluster-manager can add connect-router-tunnel-key.
+  # Passes when:
+  #   Branch 1 - neither old nor new has the annotation (no change)
+  #   Branch 2 - both have it with the same value (no modification)
+  #   Branch 3 - annotation is being added and user is cluster-manager
+  - expression: >-
+      request.operation != "UPDATE" ||
+      ((!has(oldObject.metadata.annotations) ||
+      !("k8s.ovn.org/connect-router-tunnel-key" in oldObject.metadata.annotations)) &&
+      (!has(object.metadata.annotations) ||
+      !("k8s.ovn.org/connect-router-tunnel-key" in object.metadata.annotations))) ||
+      (has(oldObject.metadata.annotations) &&
+      "k8s.ovn.org/connect-router-tunnel-key" in oldObject.metadata.annotations &&
+      has(object.metadata.annotations) &&
+      "k8s.ovn.org/connect-router-tunnel-key" in object.metadata.annotations &&
+      oldObject.metadata.annotations["k8s.ovn.org/connect-router-tunnel-key"] ==
+      object.metadata.annotations["k8s.ovn.org/connect-router-tunnel-key"]) ||
+      ((!has(oldObject.metadata.annotations) ||
+      !("k8s.ovn.org/connect-router-tunnel-key" in oldObject.metadata.annotations)) &&
+      has(object.metadata.annotations) &&
+      "k8s.ovn.org/connect-router-tunnel-key" in object.metadata.annotations &&
+      request.userInfo.username ==
+      "system:serviceaccount:ovn-kubernetes:ovnkube-cluster-manager")
+    message: >-
+      The "k8s.ovn.org/connect-router-tunnel-key" annotation is immutable once set
+      and can only be added by the cluster-manager service account.
+    reason: Invalid
+  # Only cluster-manager can add, modify, or remove network-connect-subnet.
+  # Passes when:
+  #   Branch 1 - user is cluster-manager (any mutation allowed)
+  #   Branch 2 - neither old nor new has the annotation (no change)
+  #   Branch 3 - both have it with the same value (no modification)
+  - expression: >-
+      request.operation != "UPDATE" ||
+      request.userInfo.username ==
+      "system:serviceaccount:ovn-kubernetes:ovnkube-cluster-manager" ||
+      ((!has(oldObject.metadata.annotations) ||
+      !("k8s.ovn.org/network-connect-subnet" in oldObject.metadata.annotations)) &&
+      (!has(object.metadata.annotations) ||
+      !("k8s.ovn.org/network-connect-subnet" in object.metadata.annotations))) ||
+      (has(oldObject.metadata.annotations) &&
+      "k8s.ovn.org/network-connect-subnet" in oldObject.metadata.annotations &&
+      has(object.metadata.annotations) &&
+      "k8s.ovn.org/network-connect-subnet" in object.metadata.annotations &&
+      oldObject.metadata.annotations["k8s.ovn.org/network-connect-subnet"] ==
+      object.metadata.annotations["k8s.ovn.org/network-connect-subnet"])
+    message: >-
+      A regular user must not add, modify, or remove the
+      "k8s.ovn.org/network-connect-subnet" annotation on a
+      ClusterNetworkConnect custom resource.
+    reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: cnc-annotation-validation-binding
+spec:
+  policyName: cnc-annotation-validation
+  validationActions: [Deny]
+{{- end }}

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -75,6 +75,8 @@ global:
   enableMultiNetwork: false
   # -- Configure to use user defined networks (UDN) feature with ovn-kubernetes
   enableNetworkSegmentation: false
+  # -- Configure to enable cluster network connect feature with ovn-kubernetes
+  enableNetworkConnect: false
   # -- Configure to use route advertisements feature with ovn-kubernetes
   enableRouteAdvertisements: false
   # -- Configure to use EVPN feature with ovn-kubernetes

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -192,10 +192,17 @@ func createOrUpdateCNCWithConnectivity(cs clientset.Interface, cncName string, c
 		generateConnectSubnets(cs), connectivity)
 }
 
-// createOrUpdateCNCWithSubnetsAndConnectivity creates or updates a CNC with custom connect subnets and connectivity
-func createOrUpdateCNCWithSubnetsAndConnectivity(cncName string, cudnLabelSelector, udnLabelSelector map[string]string, connectSubnets string, connectivity []string) {
+// generateCNCManifest builds a CNC YAML manifest string.
+// annotations is optional; pass nil for no annotations.
+func generateCNCManifest(
+	cncName string,
+	cudnLabelSelector, udnLabelSelector map[string]string,
+	connectSubnets string,
+	connectivity []string,
+	annotations map[string]string,
+) string {
 	Expect(cudnLabelSelector != nil || udnLabelSelector != nil).To(BeTrue(),
-		"createOrUpdateCNCWithSubnetsAndConnectivity requires at least one selector (cudnLabelSelector or udnLabelSelector)")
+		"generateCNCManifest requires at least one selector (cudnLabelSelector or udnLabelSelector)")
 
 	var networkSelectors []string
 
@@ -229,7 +236,6 @@ func createOrUpdateCNCWithSubnetsAndConnectivity(cncName string, cudnLabelSelect
             %s`, udnLabelSelectorStr))
 	}
 
-	// Format connectivity array as YAML
 	connectivityYAML := "["
 	for i, c := range connectivity {
 		if i > 0 {
@@ -239,18 +245,40 @@ func createOrUpdateCNCWithSubnetsAndConnectivity(cncName string, cudnLabelSelect
 	}
 	connectivityYAML += "]"
 
-	manifest := fmt.Sprintf(`
+	annotationsBlock := ""
+	if len(annotations) > 0 {
+		lines := "  annotations:\n"
+		for k, v := range annotations {
+			lines += fmt.Sprintf("    %s: '%s'\n", k, v)
+		}
+		annotationsBlock = lines
+	}
+
+	return fmt.Sprintf(`
 apiVersion: k8s.ovn.org/v1
 kind: ClusterNetworkConnect
 metadata:
   name: %s
-spec:
+%sspec:
   networkSelectors:
 %s
   connectSubnets:
 %s
   connectivity: %s
-`, cncName, strings.Join(networkSelectors, "\n"), connectSubnets, connectivityYAML)
+`, cncName, annotationsBlock, strings.Join(networkSelectors, "\n"), connectSubnets, connectivityYAML)
+}
+
+// createOrUpdateCNCWithSubnetsAndConnectivity creates or updates a CNC with custom connect subnets and connectivity
+func createOrUpdateCNCWithSubnetsAndConnectivity(
+	cncName string,
+	cudnLabelSelector, udnLabelSelector map[string]string,
+	connectSubnets string,
+	connectivity []string,
+) {
+	manifest := generateCNCManifest(
+		cncName, cudnLabelSelector, udnLabelSelector,
+		connectSubnets, connectivity, nil,
+	)
 	_, err := e2ekubectl.RunKubectlInput("", manifest, "apply", "-f", "-")
 	Expect(err).NotTo(HaveOccurred())
 }
@@ -2167,6 +2195,199 @@ var _ = Describe("ClusterNetworkConnect ClusterManagerController", feature.Netwo
 
 		By("verifying CNC status reports selected networks subnet overlap")
 		verifyCNCAcceptedConditionFailed(cncName, "selected networks have overlapping subnets")
+	})
+
+})
+
+// ============================================================================
+// CNC Annotation ValidatingAdmissionPolicy Testing
+// ============================================================================
+var _ = Describe("ClusterNetworkConnect ValidatingAdmissionPolicy", feature.NetworkConnect, func() {
+	f := wrappedTestFramework("cnc-vap")
+	f.SkipNamespaceCreation = true
+
+	var (
+		cs clientset.Interface
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+	})
+
+	It("should reject CREATE with managed annotations pre-set", func() {
+		cncName := generateCNCName()
+		noMatchSelector := map[string]string{"nonexistent": "label"}
+		connectSubnets := generateConnectSubnets(cs)
+
+		By("attempting to create CNC with network-connect-subnet annotation")
+		manifest := generateCNCManifest(
+			cncName, noMatchSelector, nil, connectSubnets, []string{"PodNetwork"},
+			map[string]string{ovnNetworkConnectSubnetAnnotation: `{"test": {"ipv4": "1.2.3.4/24"}}`},
+		)
+		_, err := e2ekubectl.RunKubectlInput("", manifest, "create", "-f", "-")
+		Expect(err).To(HaveOccurred(), "CREATE should be rejected when network-connect-subnet annotation is present")
+		Expect(err).To(MatchError(ContainSubstring(
+			`ClusterNetworkConnect resources cannot be created with the` +
+				` "k8s.ovn.org/network-connect-subnet" or "k8s.ovn.org/connect-router-tunnel-key"` +
+				` annotations. These annotations are managed by the system.`)))
+
+		By("attempting to create CNC with connect-router-tunnel-key annotation")
+		manifest = generateCNCManifest(
+			cncName, noMatchSelector, nil, connectSubnets, []string{"PodNetwork"},
+			map[string]string{ovnConnectRouterTunnelKeyAnnotation: "42"},
+		)
+		_, err = e2ekubectl.RunKubectlInput("", manifest, "create", "-f", "-")
+		Expect(err).To(HaveOccurred(), "CREATE should be rejected when connect-router-tunnel-key annotation is present")
+		Expect(err).To(MatchError(ContainSubstring(
+			`ClusterNetworkConnect resources cannot be created with the` +
+				` "k8s.ovn.org/network-connect-subnet" or "k8s.ovn.org/connect-router-tunnel-key"` +
+				` annotations. These annotations are managed by the system.`)))
+
+		By("attempting to create CNC with both annotations")
+		manifest = generateCNCManifest(
+			cncName, noMatchSelector, nil, connectSubnets, []string{"PodNetwork"},
+			map[string]string{
+				ovnNetworkConnectSubnetAnnotation:   `{"test": {"ipv4": "1.2.3.4/24"}}`,
+				ovnConnectRouterTunnelKeyAnnotation: "42",
+			},
+		)
+		_, err = e2ekubectl.RunKubectlInput("", manifest, "create", "-f", "-")
+		Expect(err).To(HaveOccurred(), "CREATE should be rejected when both managed annotations are present")
+		Expect(err).To(MatchError(ContainSubstring(
+			`ClusterNetworkConnect resources cannot be created with the` +
+				` "k8s.ovn.org/network-connect-subnet" or "k8s.ovn.org/connect-router-tunnel-key"` +
+				` annotations. These annotations are managed by the system.`)))
+	})
+
+	It("should allow CREATE with unmanaged annotations", func() {
+		cncName := generateCNCName()
+		DeferCleanup(func() {
+			deleteCNC(cncName)
+		})
+
+		By("creating CNC with an unmanaged annotation")
+		manifest := generateCNCManifest(
+			cncName, map[string]string{"nonexistent": "label"}, nil,
+			generateConnectSubnets(cs), []string{"PodNetwork"},
+			map[string]string{"custom-annotation": "some-value"},
+		)
+		_, err := e2ekubectl.RunKubectlInput("", manifest, "create", "-f", "-")
+		Expect(err).NotTo(HaveOccurred(), "CREATE should succeed with unmanaged annotations")
+	})
+
+	It("should reject regular admin adding network-connect-subnet annotation", func() {
+		cncName := generateCNCName()
+		DeferCleanup(func() {
+			deleteCNC(cncName)
+		})
+
+		By("creating a CNC with no matching networks")
+		createOrUpdateCNC(cs, cncName, map[string]string{"nonexistent": "label"}, nil)
+
+		By("waiting for cluster-manager to set tunnel-key annotation")
+		verifyCNCHasOnlyTunnelIDAnnotation(cncName)
+
+		By("attempting to add network-connect-subnet annotation as regular admin")
+		_, err := e2ekubectl.RunKubectl("", "annotate", "--overwrite", "clusternetworkconnect", cncName,
+			fmt.Sprintf("%s={\"test\":{\"ipv4\":\"1.2.3.4/24\"}}", ovnNetworkConnectSubnetAnnotation))
+		Expect(err).To(HaveOccurred(), "regular admin should not be able to add network-connect-subnet annotation")
+		Expect(err).To(MatchError(ContainSubstring(
+			`A regular user must not add, modify, or remove the` +
+				` "k8s.ovn.org/network-connect-subnet" annotation on a` +
+				` ClusterNetworkConnect custom resource.`)))
+	})
+
+	// Note: Rule 2 also prohibits non-CM users from *adding* connect-router-tunnel-key,
+	// but the cluster-manager sets it immediately after CNC creation so there is no
+	// reliable e2e window to test that branch. Rule 1 (CREATE rejection) and the
+	// modify/remove tests below provide sufficient coverage.
+	It("should reject modifying or removing connect-router-tunnel-key once set", func() {
+		cncName := generateCNCName()
+		cncLabel := map[string]string{"test-vap-tunnel-key": "true"}
+		nextSubnets := newTestNetworkSubnetsAllocator()
+
+		ns := createUDNNamespace(cs, "test-vap-tunnel-ns", nil)
+		cudnName := fmt.Sprintf("vap-tunnel-cudn-%s", rand.String(5))
+
+		DeferCleanup(func() {
+			deleteCNC(cncName)
+			deleteCUDN(cudnName)
+			cs.CoreV1().Namespaces().Delete(context.Background(), ns.Name, metav1.DeleteOptions{})
+		})
+
+		By("creating a CUDN and CNC so cluster-manager sets both annotations")
+		v4, v6 := nextSubnets()
+		createLayer3PrimaryCUDNWithSubnets(cs, cudnName, cncLabel, v4, v6, ns.Name)
+		Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 30*time.Second, time.Second).Should(Succeed())
+
+		createOrUpdateCNC(cs, cncName, cncLabel, nil)
+		verifyCNCHasBothAnnotations(cncName)
+
+		By("reading current tunnel-key value")
+		tunnelID := getCNCTunnelID(cncName)
+		Expect(tunnelID).NotTo(BeEmpty())
+
+		newValue := "99999"
+		if tunnelID == newValue {
+			newValue = "99998"
+		}
+
+		By("attempting to modify connect-router-tunnel-key annotation")
+		_, err := e2ekubectl.RunKubectl("", "annotate", "--overwrite", "clusternetworkconnect", cncName,
+			fmt.Sprintf("%s=%s", ovnConnectRouterTunnelKeyAnnotation, newValue))
+		Expect(err).To(HaveOccurred(), "connect-router-tunnel-key should be immutable once set")
+		Expect(err).To(MatchError(ContainSubstring(
+			`The "k8s.ovn.org/connect-router-tunnel-key" annotation is immutable` +
+				` once set and can only be added by the cluster-manager service account.`)))
+
+		By("attempting to remove connect-router-tunnel-key annotation")
+		_, err = e2ekubectl.RunKubectl("", "annotate", "--overwrite", "clusternetworkconnect", cncName,
+			fmt.Sprintf("%s-", ovnConnectRouterTunnelKeyAnnotation))
+		Expect(err).To(HaveOccurred(), "connect-router-tunnel-key should not be removable once set")
+		Expect(err).To(MatchError(ContainSubstring(
+			`The "k8s.ovn.org/connect-router-tunnel-key" annotation is immutable` +
+				` once set and can only be added by the cluster-manager service account.`)))
+	})
+
+	It("should reject regular user modifying or removing network-connect-subnet annotation", func() {
+		cncName := generateCNCName()
+		cncLabel := map[string]string{"test-vap-subnet": "true"}
+		nextSubnets := newTestNetworkSubnetsAllocator()
+
+		ns := createUDNNamespace(cs, "test-vap-subnet-ns", nil)
+		cudnName := fmt.Sprintf("vap-subnet-cudn-%s", rand.String(5))
+
+		DeferCleanup(func() {
+			deleteCNC(cncName)
+			deleteCUDN(cudnName)
+			cs.CoreV1().Namespaces().Delete(context.Background(), ns.Name, metav1.DeleteOptions{})
+		})
+
+		By("creating a CUDN and CNC so cluster-manager sets both annotations")
+		v4, v6 := nextSubnets()
+		createLayer3PrimaryCUDNWithSubnets(cs, cudnName, cncLabel, v4, v6, ns.Name)
+		Eventually(clusterUserDefinedNetworkReadyFunc(f.DynamicClient, cudnName), 30*time.Second, time.Second).Should(Succeed())
+
+		createOrUpdateCNC(cs, cncName, cncLabel, nil)
+		verifyCNCHasBothAnnotations(cncName)
+
+		By("attempting to modify network-connect-subnet annotation")
+		_, err := e2ekubectl.RunKubectl("", "annotate", "--overwrite", "clusternetworkconnect", cncName,
+			fmt.Sprintf(`%s={"bogus":{"ipv4":"9.9.9.0/24"}}`, ovnNetworkConnectSubnetAnnotation))
+		Expect(err).To(HaveOccurred(), "regular user should not be able to modify network-connect-subnet")
+		Expect(err).To(MatchError(ContainSubstring(
+			`A regular user must not add, modify, or remove the` +
+				` "k8s.ovn.org/network-connect-subnet" annotation on a` +
+				` ClusterNetworkConnect custom resource.`)))
+
+		By("attempting to remove network-connect-subnet annotation")
+		_, err = e2ekubectl.RunKubectl("", "annotate", "--overwrite", "clusternetworkconnect", cncName,
+			fmt.Sprintf("%s-", ovnNetworkConnectSubnetAnnotation))
+		Expect(err).To(HaveOccurred(), "regular user should not be able to remove network-connect-subnet")
+		Expect(err).To(MatchError(ContainSubstring(
+			`A regular user must not add, modify, or remove the` +
+				` "k8s.ovn.org/network-connect-subnet" annotation on a` +
+				` ClusterNetworkConnect custom resource.`)))
 	})
 })
 


### PR DESCRIPTION

## 📑 Description
<!-- Add a brief description of the pr -->

Adds VAPs for CNC annotations to prevent users from
changing managed annotations

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional validation blocks creation/updates that modify system-managed CNC annotations when network-connect is enabled.

* **Chores**
  * Cluster permissions for ClusterNetworkConnect are only granted when network-connect is enabled (default: disabled).
  * Added a new helm configuration flag to toggle the network-connect feature (defaults to false).

* **Tests**
  * Added e2e tests covering create acceptance/rejection and annotation modification protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->