### PR TITLE
kubevirt: skip source LSP re-enable when source pod is not local

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -387,12 +387,9 @@ func (bsnc *BaseUserDefinedNetworkController) addLogicalPortToNetworkForNAD(pod 
 		// We have a source pod LSP at this zone if the source pod and:
 		// - layer2 IC There is one at all the zones since we have the remote LSP to implement east/west
 		// - localnet only if this is the zone where the source pod is running
-		hasSourcePodLogicalPort := kubevirtLiveMigrationStatus.SourcePod != nil && (bsnc.isPodScheduledinLocalZone(kubevirtLiveMigrationStatus.SourcePod) || bsnc.isLayer2WithInterconnectTransport())
-		if hasSourcePodLogicalPort {
-			ops, err = bsnc.disableLiveMigrationSourceLSPOps(kubevirtLiveMigrationStatus, nadKey, ops)
-			if err != nil {
-				return fmt.Errorf("failed to create LSP ops for source pod during Live-migration status: %w", err)
-			}
+		ops, err = bsnc.disableLiveMigrationSourceLSPOps(kubevirtLiveMigrationStatus, nadKey, ops)
+		if err != nil {
+			return fmt.Errorf("failed to create LSP ops for source pod during Live-migration status: %w", err)
 		}
 	}
 
@@ -462,11 +459,6 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 
 	podDesc := pod.Namespace + "/" + pod.Name
 
-	// there is only a logical port for local pods or remote pods of layer2
-	// networks on interconnect, so only delete in these cases
-	isLocalPod := bsnc.isPodScheduledinLocalZone(pod)
-	hasLogicalPort := isLocalPod || bsnc.isLayer2WithInterconnectTransport()
-
 	// for a specific NAD belongs to this network, Pod's logical port might already be created half-way
 	// without its lpInfo cache being created; need to deleted resources created for that NAD as well.
 	// So, first get all nadKeys from pod annotation, but handle NADs belong to this network only.
@@ -490,7 +482,7 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 		klog.Infof("Deleting pod: %s for network %s, NAD key: %s", podDesc, bsnc.GetNetworkName(), nadKey)
 
 		// handle remote pod clean up but only do this one time
-		if !hasLogicalPort && !alreadyProcessed {
+		if !bsnc.hasPodLogicalPort(pod) && !alreadyProcessed {
 			// except for localnet networks, continue the delete flow in case a node just
 			// became remote where we might still need to cleanup. On L3 networks
 			// the node switch is removed so there is no need to do this.
@@ -1079,7 +1071,12 @@ func (bsnc *BaseUserDefinedNetworkController) disableLiveMigrationSourceLSPOps(
 	kubevirtLiveMigrationStatus *kubevirt.LiveMigrationStatus,
 	nadKey string, ops []ovsdb.Operation,
 ) ([]ovsdb.Operation, error) {
-	// closing the sourcePod lsp to ensure traffic goes to the now ready targetPod.
+
+	// Only disable the source LSP if it exists at this zone
+	if !bsnc.hasPodLogicalPort(kubevirtLiveMigrationStatus.SourcePod) {
+		return ops, nil
+	}
+
 	ops, _, err := bsnc.setPodLogicalSwitchPortAddressesAndEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadKey, "", nil, false, ops)
 	return ops, err
 }
@@ -1094,6 +1091,12 @@ func (bsnc *BaseUserDefinedNetworkController) enableSourceLSPFailedLiveMigration
 		kubevirtLiveMigrationStatus.State != kubevirt.LiveMigrationFailed {
 		return nil
 	}
+
+	// Only re-enable the source LSP if it exists at this zone
+	if !bsnc.hasPodLogicalPort(kubevirtLiveMigrationStatus.SourcePod) {
+		return nil
+	}
+
 	// make sure sourcePod lsp is enabled if migration failed after DomainReady was set.
 	ops, sourcePodLsp, err := bsnc.setPodLogicalSwitchPortAddressesAndEnabledField(kubevirtLiveMigrationStatus.SourcePod, nadKey, mac, ips, true, nil)
 	if err != nil {
@@ -1105,6 +1108,12 @@ func (bsnc *BaseUserDefinedNetworkController) enableSourceLSPFailedLiveMigration
 	}
 
 	return nil
+}
+
+// hasPodLogicalPort On localnet topologies with interconnect the pod's LSP lives only on the
+// node where the pod was scheduled
+func (bsnc *BaseUserDefinedNetworkController) hasPodLogicalPort(pod *corev1.Pod) bool {
+	return pod != nil && (bsnc.isPodScheduledinLocalZone(pod) || bsnc.isLayer2WithInterconnectTransport())
 }
 
 func shouldAddPort(oldPod, newPod *corev1.Pod, inRetryCache bool) bool {

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -5,11 +5,15 @@ package ovn
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -210,6 +214,154 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 			},
 		}),
 	)
+	Context("enableSourceLSPFailedLiveMigration", func() {
+		const (
+			vmName        = "test-vm"
+			nadKey        = "awips/mgmt"
+			localNodeName = "node-local"
+		)
+
+		newVirtLauncherPod := func(name, nodeName string, phase corev1.PodPhase, annotations map[string]string) *corev1.Pod {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              name,
+					Namespace:         "awips",
+					Labels:            map[string]string{kubevirtv1.VirtualMachineNameLabel: vmName},
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					Annotations:       annotations,
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "kubevirt.io/v1",
+						Kind:       "VirtualMachineInstance",
+						Name:       vmName,
+					}},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: nodeName,
+				},
+				Status: corev1.PodStatus{
+					Phase: phase,
+				},
+			}
+			return pod
+		}
+
+		setupControllerWithDBSetup := func(dbSetup *libovsdbtest.TestSetup, pods ...*corev1.Pod) (*BaseUserDefinedNetworkController, *FakeOVN) {
+			localnetNAD := ovntest.GenerateNAD("mgmt", "mgmt", "awips",
+				types.LocalnetTopology, "", types.NetworkRoleSecondary)
+
+			fakeOVN := NewFakeOVN(false)
+			objs := []runtime.Object{}
+			for _, p := range pods {
+				objs = append(objs, p)
+			}
+			if dbSetup != nil {
+				fakeOVN.startWithDBSetup(*dbSetup, objs...)
+			} else {
+				fakeOVN.start(objs...)
+			}
+			DeferCleanup(fakeOVN.shutdown)
+
+			Expect(fakeOVN.NewUserDefinedNetworkController(localnetNAD)).To(Succeed())
+			controller, ok := fakeOVN.userDefinedNetworkControllers["mgmt"]
+			Expect(ok).To(BeTrue())
+
+			// Set local zone to only include localNodeName
+			controller.bnc.localZoneNodes = &sync.Map{}
+			controller.bnc.localZoneNodes.Store(localNodeName, true)
+
+			return controller.bnc, fakeOVN
+		}
+
+		setupController := func(pods ...*corev1.Pod) *BaseUserDefinedNetworkController {
+			bnc, _ := setupControllerWithDBSetup(nil, pods...)
+			return bnc
+		}
+
+		It("should skip source LSP re-enable when source pod is on a remote node", func() {
+			config.OVNKubernetesFeature.EnableInterconnect = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+			sourcePod := newVirtLauncherPod("virt-launcher-"+vmName+"-source", "node-remote", corev1.PodRunning, nil)
+			// Target pod is local, failed (completed) — triggers LiveMigrationFailed detection
+			targetPod := newVirtLauncherPod("virt-launcher-"+vmName+"-target", localNodeName, corev1.PodFailed, nil)
+			// Make target created after source so DiscoverLiveMigrationStatus picks it as target
+			targetPod.CreationTimestamp = metav1.Time{Time: sourcePod.CreationTimestamp.Add(time.Second)}
+
+			bnc := setupController(sourcePod, targetPod)
+
+			// Call with empty IPs (IPAM-less localnet) — this would fail without the locality guard
+			err := bnc.enableSourceLSPFailedLiveMigration(targetPod, nadKey, "", nil)
+			Expect(err).NotTo(HaveOccurred(), "should not error when source pod is on a remote node")
+		})
+
+		It("should skip source LSP re-enable when source pod LSP is not local", func() {
+			config.OVNKubernetesFeature.EnableInterconnect = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+			sourcePod := newVirtLauncherPod("virt-launcher-"+vmName+"-source", "node-remote", corev1.PodRunning, nil)
+			targetPod := newVirtLauncherPod("virt-launcher-"+vmName+"-target", localNodeName, corev1.PodSucceeded, nil)
+			targetPod.CreationTimestamp = metav1.Time{Time: sourcePod.CreationTimestamp.Add(time.Second)}
+
+			bnc := setupController(sourcePod, targetPod)
+
+			err := bnc.enableSourceLSPFailedLiveMigration(targetPod, nadKey, "", nil)
+			Expect(err).NotTo(HaveOccurred(), "should not error when source pod LSP is not local")
+		})
+
+		It("should re-enable source LSP when source pod is local and migration failed", func() {
+			config.OVNKubernetesFeature.EnableInterconnect = true
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+			sourcePodName := "virt-launcher-" + vmName + "-source"
+			sourcePod := newVirtLauncherPod(sourcePodName, localNodeName, corev1.PodRunning, nil)
+			targetPod := newVirtLauncherPod("virt-launcher-"+vmName+"-target", localNodeName, corev1.PodFailed, nil)
+			targetPod.CreationTimestamp = metav1.Time{Time: sourcePod.CreationTimestamp.Add(time.Second)}
+
+			// Build LSP and switch names matching what the controller will compute:
+			//   LSP name: GetUserDefinedNetworkLogicalPortName(namespace, podName, nadKey)
+			//   Switch name: GetNetworkScopedSwitchName(OVNLocalnetSwitch)
+			sourceLSPName := util.GetUserDefinedNetworkLogicalPortName(sourcePod.Namespace, sourcePodName, nadKey)
+			sourceLSP := &nbdb.LogicalSwitchPort{
+				UUID:    sourceLSPName + "-UUID",
+				Name:    sourceLSPName,
+				Enabled: ptr.To(false),
+			}
+			switchName := util.GetUserDefinedNetworkPrefix("mgmt") + types.OVNLocalnetSwitch
+			logicalSwitch := &nbdb.LogicalSwitch{
+				UUID:  switchName + "-UUID",
+				Name:  switchName,
+				Ports: []string{sourceLSP.UUID},
+			}
+
+			dbSetup := &libovsdbtest.TestSetup{
+				NBData: []libovsdbtest.TestData{
+					logicalSwitch,
+					sourceLSP,
+				},
+			}
+
+			bnc, fakeOVN := setupControllerWithDBSetup(dbSetup, sourcePod, targetPod)
+
+			mac := "0a:58:0a:80:00:05"
+			ips := []string{"10.128.0.5/24"}
+			err := bnc.enableSourceLSPFailedLiveMigration(targetPod, nadKey, mac, ips)
+			Expect(err).NotTo(HaveOccurred(), "should re-enable source LSP without error")
+
+			// Verify the LSP was updated: Enabled=true and addresses set
+			expectedLSP := &nbdb.LogicalSwitchPort{
+				UUID:      sourceLSP.UUID,
+				Name:      sourceLSPName,
+				Enabled:   ptr.To(true),
+				Addresses: []string{mac + " 10.128.0.5"},
+			}
+			expectedSwitch := logicalSwitch.DeepCopy()
+			Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedSwitch, expectedLSP))
+		})
+	})
+
 	It("should not fail to sync pods if namespace is gone", func() {
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true


### PR DESCRIPTION
## 📑 Description

During pod deletion on localnet topologies with interconnect,
`enableSourceLSPFailedLiveMigration` attempts to re-enable the source pod's LSP
when a migration is detected as failed. However, on localnet with IC the source
pod's LSP only exists on the node where the source pod was scheduled. When the
target pod is deleted on a different node, the function fails with "missing mac
and ips" because the source pod has no local LSP. This error blocks the target
pod cleanup entirely, leaving a stale retry entry that causes the retry framework
to recreate the target pod's LSP as a zombie via the "stale object during add"
path. The subsequent DELETE event is then ignored because the pod was already
marked as terminal.

Fixes https://issues.redhat.com/browse/OCPBUGS-81326

## Additional Information for reviewers

The fix adds the same locality guard already used in `addLogicalPortToNetworkForNAD`
to the `enableSourceLSPFailedLiveMigration` delete path: only attempt to re-enable
the source LSP when the source pod is scheduled in the local zone or the network
uses layer2 interconnect transport. When the source pod is remote, skip the
re-enable and let the deletion proceed normally.

**Root cause from user:**

1. Kubevirt evacuation moves VM from node1 (source `cpv1-sgtrj`) to node3 (target `cpv1-gdpbp`)
2. Target pod reaches terminal state on node3's controller
3. `enableSourceLSPFailedLiveMigration` tries to re-enable source LSP on node3 — but source LSP only exists on node1 (localnet + IC)
4. Fails with `missing mac and ips for pod virt-launcher-cpv1-sgtrj`
5. Error blocks `deletePodLogicalPort` → stale retry entry created
6. DELETE event triggers retry framework's "stale object during add" → DELETE + ADD → zombie LSP recreated
7. Subsequent DELETE events ignored as terminal state already processed

**Files changed:**
- `go-controller/pkg/ovn/base_network_controller_user_defined.go` — locality guard in `enableSourceLSPFailedLiveMigration`
- `go-controller/pkg/ovn/base_network_controller_user_defined_test.go` — unit tests for remote source pod cases

## ✅ Checks
- [ ] My code requires changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Unit tests added:
```
go test ./pkg/ovn/ -v -count=1 -ginkgo.focus="enableSourceLSPFailedLiveMigration"
```

Tests verify that `enableSourceLSPFailedLiveMigration` returns nil (no error) when the source pod is on a remote node (the customer's exact scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live-migration cleanup to avoid re-enabling a source pod's network port when that port isn't present in the local zone or when topology conditions don't warrant it, preventing cross-zone network updates during failed migrations.

* **Tests**
  * Added unit tests validating failed live-migration behavior for local vs. remote pod placements, ensuring cleanup proceeds without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->