### PR TITLE
Fix node tracker missing node-subnets annotation transitions

### DIFF
--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -142,13 +142,22 @@ func NodeSubnetAnnotationChanged(oldNode, newNode *corev1.Node) bool {
 }
 
 func NodeSubnetAnnotationChangedForNetwork(oldNode, newNode *corev1.Node, netName string) bool {
-	var oldSubnets, newSubnets map[string]json.RawMessage
+	oldRaw := oldNode.Annotations[types.NodeSubnetsAnnotation]
+	newRaw := newNode.Annotations[types.NodeSubnetsAnnotation]
 
-	if err := json.Unmarshal([]byte(oldNode.Annotations[types.NodeSubnetsAnnotation]), &oldSubnets); err != nil {
+	if oldRaw == newRaw {
+		return false
+	}
+	if oldRaw == "" || newRaw == "" {
+		return true
+	}
+
+	var oldSubnets, newSubnets map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(oldRaw), &oldSubnets); err != nil {
 		klog.Errorf("Failed to unmarshal old node %s annotation: %v", oldNode.Name, err)
 		return false
 	}
-	if err := json.Unmarshal([]byte(newNode.Annotations[types.NodeSubnetsAnnotation]), &newSubnets); err != nil {
+	if err := json.Unmarshal([]byte(newRaw), &newSubnets); err != nil {
 		klog.Errorf("Failed to unmarshal new node %s annotation: %v", newNode.Name, err)
 		return false
 	}

--- a/go-controller/pkg/util/subnet_annotations_unit_test.go
+++ b/go-controller/pkg/util/subnet_annotations_unit_test.go
@@ -251,6 +251,141 @@ func TestNodeSubnetAnnotationChanged(t *testing.T) {
 	}
 }
 
+func TestNodeSubnetAnnotationChangedForNetwork(t *testing.T) {
+	tests := []struct {
+		desc    string
+		oldNode *corev1.Node
+		newNode *corev1.Node
+		netName string
+		result  bool
+	}{
+		{
+			desc: "true: annotation added (old missing)",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testNode",
+					Annotations: map[string]string{},
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default":["10.244.0.0/24"]}`,
+					},
+				},
+			},
+			netName: "default",
+			result:  true,
+		},
+		{
+			desc: "true: annotation removed (new missing)",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default":["10.244.0.0/24"]}`,
+					},
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testNode",
+					Annotations: map[string]string{},
+				},
+			},
+			netName: "default",
+			result:  true,
+		},
+		{
+			desc: "false: both missing",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testNode",
+					Annotations: map[string]string{},
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testNode",
+					Annotations: map[string]string{},
+				},
+			},
+			netName: "default",
+			result:  false,
+		},
+		{
+			desc: "true: default network subnet changed",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default":["10.244.0.0/24"]}`,
+					},
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default":["10.244.2.0/24"]}`,
+					},
+				},
+			},
+			netName: "default",
+			result:  true,
+		},
+		{
+			desc: "false: default network subnet unchanged, other network changed",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default":["10.244.0.0/24"],"other":["10.245.0.0/24"]}`,
+					},
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default":["10.244.0.0/24"],"other":["10.245.2.0/24"]}`,
+					},
+				},
+			},
+			netName: "default",
+			result:  false,
+		},
+		{
+			desc: "false: identical annotations",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default":["10.244.0.0/24"]}`,
+					},
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default":["10.244.0.0/24"]}`,
+					},
+				},
+			},
+			netName: "default",
+			result:  false,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			result := NodeSubnetAnnotationChangedForNetwork(tc.oldNode, tc.newNode, tc.netName)
+			assert.Equal(t, tc.result, result)
+		})
+	}
+}
+
 func TestCreateNodeHostSubnetAnnotation(t *testing.T) {
 	tests := []struct {
 		desc            string


### PR DESCRIPTION
When the node-subnets annotation transitions from absent to present (or vice versa), json.Unmarshal on the empty string fails and the function incorrectly returns false. This causes the node tracker to miss the update, leaving the node out of the service load balancer configuration.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for network annotation change detection across multiple scenarios.

* **Chores**
  * Internal improvements to annotation comparison logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->