### PR TITLE
Fix subnet IP allocator to reject out-of-range IPs

### DIFF
--- a/go-controller/pkg/allocator/ip/subnet/allocator.go
+++ b/go-controller/pkg/allocator/ip/subnet/allocator.go
@@ -289,6 +289,11 @@ func (allocator *allocator) AllocateIPPerSubnet(name string, ips []*net.IPNet) e
 				}
 			}
 		}
+
+		if !allocated {
+			err = fmt.Errorf("failed to allocate IP %s for %s: not contained in any known subnet", ipnet.IP, name)
+			return err
+		}
 	}
 	return nil
 }

--- a/go-controller/pkg/allocator/ip/subnet/allocator_test.go
+++ b/go-controller/pkg/allocator/ip/subnet/allocator_test.go
@@ -242,6 +242,19 @@ var _ = ginkgo.Describe("Subnet IP allocator operations", func() {
 			gomega.Expect(err).To(gomega.MatchError(ipam.ErrAllocated))
 		})
 
+		ginkgo.It("fails to allocate IP not contained in any known subnet", func() {
+			err := allocator.AddOrUpdateSubnet(SubnetConfig{
+				Name:    subnetName,
+				Subnets: ovntest.MustParseIPNets("10.1.1.0/24"),
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Try to allocate an IP from a completely different subnet
+			outOfRangeIPs := ovntest.MustParseIPNets("10.2.0.50/24")
+			err = allocator.AllocateIPPerSubnet(subnetName, outOfRangeIPs)
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("not contained in any known subnet")))
+		})
+
 	})
 
 	// Reserved subnets test cases

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -873,8 +873,18 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 
 		if bnc.doesNetworkRequireIPAM() {
 			if zoneContainsPodSubnet {
-				// ensure we have reserved the IPs in the annotation
-				if err = bnc.lsManager.AllocateIPs(switchName, podIfAddrs); err != nil && err != ipallocator.ErrAllocated {
+				// ensure we have reserved the IPs in the annotation.
+				// For live migratable pods, the IPs may belong to a different
+				// node's subnet (the source node) during migration. In that case
+				// skip allocation here.
+				if kubevirt.IsPodLiveMigratable(pod) {
+					if sn, ok := bnc.lsManager.GetSubnetName(podIfAddrs); !ok || sn != switchName {
+						klog.V(5).Infof("Skipping IP allocation for live migratable pod %s: IPs %s belong to switch %s, not %s",
+							podDesc, util.JoinIPNetIPs(podIfAddrs, " "), sn, switchName)
+						return podAnnotation, false, nil
+					}
+				}
+				if err = bnc.lsManager.AllocateIPs(switchName, podIfAddrs); err != nil && !ipallocator.IsErrAllocated(err) {
 					return nil, false, fmt.Errorf("unable to ensure IPs allocated for already annotated pod: %s, IPs: %s, error: %v",
 						podDesc, util.JoinIPNetIPs(podIfAddrs, " "), err)
 				}
@@ -905,7 +915,7 @@ func (bnc *BaseNetworkController) allocatePodAnnotation(pod *corev1.Pod, existin
 	if len(podIfAddrs) == 0 {
 		needsNewMacOrIPAllocation = true
 	} else if bnc.doesNetworkRequireIPAM() {
-		if err = bnc.lsManager.AllocateIPs(switchName, podIfAddrs); err != nil && err != ipallocator.ErrAllocated {
+		if err = bnc.lsManager.AllocateIPs(switchName, podIfAddrs); err != nil && !ipallocator.IsErrAllocated(err) {
 			klog.Warningf("Unable to allocate IPs %s found on existing OVN port: %s, for pod %s on switch: %s"+
 				" error: %v", util.JoinIPNetIPs(podIfAddrs, " "), bnc.GetLogicalPortName(pod, nadKey), podDesc, switchName, err)
 

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -464,7 +464,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 
 					namespace1 := *ovntest.NewNamespace(namespaceName1)
 					nPodTest := getTestPod(namespace1.Name, nodeName)
-					nPodTest.addNetwork(userDefinedNetworkName, nadNamespacedName, "", "", "", "10.1.1.1", "0a:58:0a:01:01:01", "secondary", 1, nil)
+					nPodTest.addNetwork(userDefinedNetworkName, nadNamespacedName, "", "", "", "10.1.0.1", "0a:58:0a:01:00:01", "secondary", 1, nil)
 					networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
 
 					watchNodes := false
@@ -653,7 +653,7 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 				namespace2 := *ovntest.NewNamespace(namespaceName2)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
-				nPodTest.addNetwork(userDefinedNetworkName, nadNamespacedName, "", "", "", "10.1.1.1", "0a:58:0a:01:01:01", "secondary", 1, nil)
+				nPodTest.addNetwork(userDefinedNetworkName, nadNamespacedName, "", "", "", "10.1.0.1", "0a:58:0a:01:00:01", "secondary", 1, nil)
 				networkPolicy := getPortNetworkPolicy(netPolicyName1, namespace1.Name, labelName, labelVal, portNum)
 
 				watchNodes := false

--- a/go-controller/pkg/ovnwebhook/podadmission.go
+++ b/go-controller/pkg/ovnwebhook/podadmission.go
@@ -36,6 +36,9 @@ var interconnectPodAnnotations = map[string]checkPodAnnot{
 
 		podAnnot, err := util.UnmarshalPodAnnotation(map[string]string{util.OvnPodAnnotationName: v.value}, types.DefaultNetworkName)
 		if err != nil {
+			if util.IsAnnotationNotSetError(err) {
+				return nil
+			}
 			return err
 		}
 		node, err := nodeLister.Get(nodeName)


### PR DESCRIPTION
The IP subnet allocator silently accepted IPs not contained in any known subnet.
Additionally, fix the admission webhook to tolerate missing default network annotations in case a UDN annotation comes first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IP allocation now returns a clear error when requested addresses are outside any known subnet.
  * Pod admission treats missing/unset pod annotations as non-fatal instead of aborting validation.
  * Allocation logic skips reassigning IPs for live-migrating pods when annotated IPs map to a different subnet, avoiding unnecessary updates.
* **Tests**
  * Added a test to verify allocation fails for IPs not in known subnets; updated secondary attachment test parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->