### PR TITLE
Fix IPv6 and dual-stack support for kind-helm.sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -465,14 +465,14 @@ jobs:
         # network-segmentation : ["", "enable-network-segmentation"]
         # traffic-flow-tests : "<tests range. i.e. 1-24>"
         include:
-          - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
-          - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default"}
-          - {"target": "shard-conformance", "ha": "HA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default"}
-          - {"target": "shard-conformance", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "no-overlay": "true"}
-          - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "managed", "no-overlay": "managed"}
-          - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
-          - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "shard-conformance-helm", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
+          - {"target": "shard-conformance-helm", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "shard-conformance-helm", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default"}
+          - {"target": "shard-conformance-helm", "ha": "HA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default"}
+          - {"target": "shard-conformance-helm", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "no-overlay": "true"}
+          - {"target": "shard-conformance-helm", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "managed", "no-overlay": "managed"}
+          - {"target": "shard-conformance-helm", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "shard-conformance-helm", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "control-plane",     "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "traffic-flow-tests": "1,2,3"}
           - {"target": "control-plane-helm","ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "dns-name-resolver": "enable-dns-name-resolver"}
@@ -483,15 +483,15 @@ jobs:
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones", "cni-mode": "unprivileged"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "shared",  "ipfamily": "dualstack",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "multi-homing-helm", "ha": "HA",   "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled", "network-segmentation": "enable-network-segmentation"}
-          - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
-          - {"target": "node-ip-mac-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "node-ip-mac-migration-helm", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
+          - {"target": "node-ip-mac-migration-helm", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "compact-mode",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "network-segmentation": "enable-network-segmentation"}
-          - {"target": "multi-node-zones",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-multi-node-zones", "num-workers": "3", "num-nodes-per-zone": "2"}
+          - {"target": "multi-node-zones-helm",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-multi-node-zones", "num-workers": "3", "num-nodes-per-zone": "2"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
-          - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "external-gateway-helm",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
-          - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "external-gateway-helm",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled", "num-workers": "3", "network-segmentation": "enable-network-segmentation", "local-kind-registry": "true"}
           - {"target": "kv-live-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "num-workers": "3", "network-segmentation": "enable-network-segmentation", "routeadvertisements": "true"}
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
@@ -500,7 +500,7 @@ jobs:
           - {"target": "network-segmentation-dynamic", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "cni-mode": "unprivileged"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "bgp", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "dns-name-resolver": "enable-dns-name-resolver"}
-          - {"target": "bgp", "ha": "noHA", "gateway-mode": "shared",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "dns-name-resolver": "enable-dns-name-resolver"}
+          - {"target": "bgp-helm", "ha": "noHA", "gateway-mode": "shared",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "bgp", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation"}
           # no-overlay mode cannot be enabled alongside other tests: activating it on the default network requires
           # restarting ovn-k pods (day-2 reconfiguration), which would disrupt any concurrently running test jobs.
@@ -508,11 +508,11 @@ jobs:
           # no-overlay (e.g. BGP route advertisements, network-segmentation) where implementations are not strictly orthogonal.
           - {"target": "bgp-no-overlay-helm", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "no-overlay": "snat-enabled"}
           - {"target": "bgp-no-overlay",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "no-overlay": "true"}          
-          - {"target": "bgp-loose-isolation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "advertised-udn-isolation-mode": "loose"}
-          - {"target": "evpn", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "evpn": "enable-evpn"}
-          - {"target": "traffic-flow-test-only","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "traffic-flow-tests": "1-24", "network-segmentation": "enable-network-segmentation"}
-          - {"target": "tools", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "network-segmentation": "enable-network-segmentation"}
-          - {"target": "serial", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "bgp-loose-isolation-helm", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "advertised-udn-isolation-mode": "loose"}
+          - {"target": "evpn-helm", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "evpn": "enable-evpn"}
+          - {"target": "traffic-flow-test-only-helm","ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "traffic-flow-tests": "1-24", "network-segmentation": "enable-network-segmentation"}
+          - {"target": "tools-helm", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "network-segmentation": "enable-network-segmentation"}
+          - {"target": "serial-helm", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
@@ -524,7 +524,7 @@ jobs:
       KIND_INSTALL_METALLB: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' || startsWith(matrix.target, 'network-segmentation') }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
-      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || startsWith(matrix.target, 'network-segmentation') || matrix.target == 'tools' || matrix.target == 'multi-homing-helm' || matrix.target == 'traffic-flow-test-only' || matrix.routeadvertisements != '' }}"
+      ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' || matrix.target == 'kv-live-migration' || startsWith(matrix.target, 'network-segmentation') || matrix.target == 'tools-helm' || matrix.target == 'multi-homing-helm' || matrix.target == 'traffic-flow-test-only-helm' || matrix.routeadvertisements != '' }}"
       ENABLE_NETWORK_SEGMENTATION: "${{ startsWith(matrix.target, 'network-segmentation') || matrix.network-segmentation == 'enable-network-segmentation' }}"
       PLATFORM_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       PLATFORM_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
@@ -536,18 +536,18 @@ jobs:
       KIND_NUM_WORKER: "${{ matrix.num-workers }}"
       KIND_NUM_NODES_PER_ZONE: "${{ matrix.num-nodes-per-zone }}"
       OVN_DISABLE_FORWARDING: "${{ matrix.forwarding == 'disable-forwarding' }}"
-      USE_HELM: "${{ matrix.target == 'control-plane-helm' || matrix.target == 'multi-homing-helm' || matrix.target == 'bgp-no-overlay-helm' }}"
+      USE_HELM: "${{ endsWith(matrix.target, '-helm') }}"
       OVN_ENABLE_DNSNAMERESOLVER: "${{ matrix.dns-name-resolver == 'enable-dns-name-resolver' }}"
       OVN_NETWORK_QOS_ENABLE: "${{ matrix.target == 'control-plane' || matrix.target == 'control-plane-helm' }}"
       TRAFFIC_FLOW_TESTS: "${{ matrix.traffic-flow-tests }}"
       ENABLE_ROUTE_ADVERTISEMENTS: "${{ matrix.routeadvertisements != '' }}"
-      ENABLE_EVPN: "${{ matrix.target == 'evpn' }}"
+      ENABLE_EVPN: "${{ matrix.target == 'evpn-helm' }}"
       ADVERTISE_DEFAULT_NETWORK:  "${{ matrix.routeadvertisements == 'advertise-default' }}"
       ENABLE_NETWORK_CONNECT: "${{ startsWith(matrix.target, 'network-segmentation') }}"
       ENABLE_PRE_CONF_UDN_ADDR: "${{ matrix.ic == 'ic-single-node-zones' && (startsWith(matrix.target, 'network-segmentation') || matrix.network-segmentation == 'enable-network-segmentation') }}"
       ADVERTISED_UDN_ISOLATION_MODE: "${{ matrix.advertised-udn-isolation-mode }}"
       # Override PARALLEL=true for Serial tests target to run Serial tests
-      PARALLEL: "${{ matrix.target != 'serial' }}"
+      PARALLEL: "${{ matrix.target != 'serial' && matrix.target != 'serial-helm' }}"
       OVN_UNPRIVILEGED_MODE: "${{ matrix.cni-mode == 'unprivileged' }}"
       MULTI_POD_SUBNET: true
       DYNAMIC_UDN_ALLOCATION: "${{ matrix.target == 'network-segmentation-dynamic' }}"
@@ -696,20 +696,20 @@ jobs:
       # set 3 hours for control-plane tests as these might take a while
       # give 10m extra to give ginkgo chance to timeout before github so that we
       # get its output
-      timeout-minutes: ${{ startsWith(matrix.target, 'bgp') && 190 || matrix.target == 'evpn' && 190 || matrix.target == 'control-plane' && 190 || matrix.target == 'control-plane-helm' && 190 || matrix.target == 'external-gateway' && 190 || startsWith(matrix.target, 'network-segmentation') && 190 || 130 }}
+      timeout-minutes: ${{ startsWith(matrix.target, 'bgp') && 190 || matrix.target == 'evpn' && 190 || matrix.target == 'evpn-helm' && 190 || matrix.target == 'control-plane' && 190 || matrix.target == 'control-plane-helm' && 190 || matrix.target == 'external-gateway' && 190 || matrix.target == 'external-gateway-helm' && 190 || startsWith(matrix.target, 'network-segmentation') && 190 || 130 }}
       run: |
         # used by e2e diagnostics package
         export OVN_IMAGE="ovn-daemonset-fedora:pr"
 
         if [ "${{ matrix.target }}" == "multi-homing" ] || [ "${{ matrix.target }}" == "multi-homing-helm" ]; then
           make -C test control-plane WHAT="Multi Homing"
-        elif [ "${{ matrix.target }}" == "node-ip-mac-migration" ]; then
+        elif [ "${{ matrix.target }}" == "node-ip-mac-migration" ] || [ "${{ matrix.target }}" == "node-ip-mac-migration-helm" ]; then
           make -C test control-plane WHAT="Node IP and MAC address migration"
         elif [ "${{ matrix.target }}" == "compact-mode" ]; then
           SINGLE_NODE_CLUSTER="true" make -C test shard-network
-        elif [ "${{ matrix.target }}" == "multi-node-zones" ]; then
+        elif [ "${{ matrix.target }}" == "multi-node-zones" ] || [ "${{ matrix.target }}" == "multi-node-zones-helm" ]; then
           make -C test control-plane WHAT="Multi node zones interconnect"
-        elif [ "${{ matrix.target }}" == "external-gateway" ]; then
+        elif [ "${{ matrix.target }}" == "external-gateway" ] || [ "${{ matrix.target }}" == "external-gateway-helm" ]; then
           make -C test control-plane WHAT="External Gateway"
         elif [ "${{ matrix.target }}" == "kv-live-migration" ]; then
           make -C test control-plane WHAT="Kubevirt Virtual Machines"
@@ -718,20 +718,25 @@ jobs:
           if [ "${{ matrix.ipfamily }}" != "ipv6" ]; then
             make -C test conformance
           fi
+        elif [ "${{ matrix.target }}" == "shard-conformance-helm" ]; then
+          make -C test shard-conformance
+          if [ "${{ matrix.ipfamily }}" != "ipv6" ]; then
+            make -C test conformance
+          fi
         elif [[ "${{ matrix.target }}" == network-segmentation* ]]; then
           make -C test control-plane WHAT="Network Segmentation"
           make -C test control-plane WHAT="ClusterNetworkConnect"
-        elif [ "${{ matrix.target }}" == "evpn" ]; then
+        elif [ "${{ matrix.target }}" == "evpn" ] || [ "${{ matrix.target }}" == "evpn-helm" ]; then
           make -C test control-plane WHAT="EVPN"
         elif [[ "${{ matrix.target }}" == bgp* ]]; then
           make -C test control-plane
-        elif [ "${{ matrix.target }}" == "serial" ]; then
+        elif [ "${{ matrix.target }}" == "serial" ] || [ "${{ matrix.target }}" == "serial-helm" ]; then
           # Run only Serial tests with ginkgo focus
           make -C test control-plane WHAT=Serial
-        elif [ "${{ matrix.target }}" == "tools" ]; then
+        elif [ "${{ matrix.target }}" == "tools" ] || [ "${{ matrix.target }}" == "tools-helm" ]; then
           make -C go-controller build
           make -C test tools
-        elif [ "${{ matrix.target }}" == "traffic-flow-test-only" ]; then
+        elif [ "${{ matrix.target }}" == "traffic-flow-test-only" ] || [ "${{ matrix.target }}" == "traffic-flow-test-only-helm" ]; then
           # Traffic Flow Tests can be ran as part of a target, as an additional
           # set of test, set via TRAFFIC_FLOW_TESTS. See below.
           :

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -93,6 +93,11 @@ set_common_default_params() {
   OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
   OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
   OVN_HA=${OVN_HA:-false}
+  OVN_GATEWAY_MODE=${OVN_GATEWAY_MODE:-shared}
+  OVN_SECOND_BRIDGE=${OVN_SECOND_BRIDGE:-false}
+  OVN_DISABLE_SNAT_MULTIPLE_GWS=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-false}
+  OVN_DISABLE_FORWARDING=${OVN_DISABLE_FORWARDING:-false}
+  OVN_UNPRIVILEGED_MODE=${OVN_UNPRIVILEGED_MODE:-false}
   ADVERTISE_DEFAULT_NETWORK=${ADVERTISE_DEFAULT_NETWORK:-false}
   ADVERTISED_UDN_ISOLATION_MODE=${ADVERTISED_UDN_ISOLATION_MODE:-strict}
   BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4:-172.26.0.0/16}
@@ -339,6 +344,84 @@ docker_disable_ipv6() {
     $OCI_BIN exec "$n" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
     $OCI_BIN exec "$n" sysctl --ignore net.ipv6.conf.all.forwarding=1
   done
+}
+
+docker_create_second_interface() {
+  echo "adding second interfaces to nodes"
+
+  # Create the network as dual stack, regardless of the type of the deployment. Ignore if already exists.
+  "$OCI_BIN" network create --ipv6 --driver=bridge xgw --subnet=172.19.0.0/16 --subnet=fc00:f853:ccd:e798::/64 || true
+
+  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
+  for n in $KIND_NODES; do
+    "$OCI_BIN" network connect xgw "$n"
+  done
+}
+
+check_ipv6() {
+  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    # Collect additional IPv6 data on test environment
+    ERROR_FOUND=false
+    TMPVAR=$(sysctl net.ipv6.conf.all.forwarding | awk '{print $3}')
+    echo "net.ipv6.conf.all.forwarding is equal to $TMPVAR"
+    if [ "$TMPVAR" != 1 ]; then
+      if [ "$KIND_ALLOW_SYSTEM_WRITES" == true ]; then
+	sudo sysctl -w net.ipv6.conf.all.forwarding=1
+      else
+	echo "RUN: 'sudo sysctl -w net.ipv6.conf.all.forwarding=1' to use IPv6."
+	ERROR_FOUND=true
+      fi
+    fi
+    TMPVAR=$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')
+    echo "net.ipv6.conf.all.disable_ipv6 is equal to $TMPVAR"
+    if [ "$TMPVAR" != 0 ]; then
+      if [ "$KIND_ALLOW_SYSTEM_WRITES" == true ]; then
+	sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
+      else
+	echo "RUN: 'sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0' to use IPv6."
+	ERROR_FOUND=true
+      fi
+    fi
+    if [ -f /proc/net/if_inet6 ]; then
+      echo "/proc/net/if_inet6 exists so IPv6 supported in kernel."
+    else
+      echo "/proc/net/if_inet6 does not exists so no IPv6 support found! Compile the kernel!!"
+      ERROR_FOUND=true
+    fi
+    if "$ERROR_FOUND"; then
+      exit 2
+    fi
+  fi
+}
+
+set_cluster_cidr_ip_families() {
+# kind only allows single subnet for pod network, while ovn-kubernetes supports multiple subnets.
+# So we pick the first subnet from the provided list for kind configuration and store it in KIND_CIDR.
+# remove host subnet mask info for kind configuration (when the subnet is set as 10.0.0.0/16/14)
+  KIND_CIDR_IPV4=$(echo "${NET_CIDR_IPV4}"| cut -d',' -f1 | cut -d'/' -f1,2 )
+  KIND_CIDR_IPV6=$(echo "${NET_CIDR_IPV6}"| cut -d',' -f1 | cut -d'/' -f1,2 )
+  if [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == false ]; then
+    IP_FAMILY=""
+    KIND_CIDR=$KIND_CIDR_IPV4
+    NET_CIDR=$NET_CIDR_IPV4
+    SVC_CIDR=$SVC_CIDR_IPV4
+    echo "IPv4 Only Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+  elif [ "$PLATFORM_IPV4_SUPPORT" == false ] && [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    IP_FAMILY="ipv6"
+    KIND_CIDR=$KIND_CIDR_IPV6
+    NET_CIDR=$NET_CIDR_IPV6
+    SVC_CIDR=$SVC_CIDR_IPV6
+    echo "IPv6 Only Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+  elif [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+    IP_FAMILY="dual"
+    KIND_CIDR=$KIND_CIDR_IPV4,$KIND_CIDR_IPV6
+    NET_CIDR=$NET_CIDR_IPV4,$NET_CIDR_IPV6
+    SVC_CIDR=$SVC_CIDR_IPV4,$SVC_CIDR_IPV6
+    echo "Dual Stack Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+  else
+    echo "Invalid setup. PLATFORM_IPV4_SUPPORT and/or PLATFORM_IPV6_SUPPORT must be true."
+    exit 1
+  fi
 }
 
 coredns_patch() {

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -10,16 +10,8 @@ source "${DIR}/kind-common.sh"
 
 set_default_params() {
   set_common_default_params
-
-  # Hard code ipv4 support until IPv6 is implemented
-  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    echo "kind-helm.sh does not support IPv6 yet"
-    exit 1
-  fi
-  if [ "$PLATFORM_IPV4_SUPPORT" != true ]; then
-    echo "kind-helm.sh only supports IPv4, must set PLATFORM_IPV4_SUPPORT to true "
-    exit 1
-  fi
+  check_ipv6
+  set_cluster_cidr_ip_families
 }
 
 usage() {
@@ -46,6 +38,8 @@ usage() {
     echo "       [-rud | --routed-udn-isolation-disable]"
     echo "       [ -nqe | --network-qos-enable ]"
     echo "       [ -noe | --no-overlay-enable [snat-enabled|managed] ]"
+    echo "       [ -n4  | --no-ipv4 ]"
+    echo "       [ -i6  | --ipv6 ]"
     echo "       [ -wk  | --num-workers <num> ]"
     echo "       [ -ic  | --enable-interconnect]"
     echo "       [ -npz | --node-per-zone ]"
@@ -84,6 +78,8 @@ usage() {
     echo "-nqe | --network-qos-enable                   Enable network QoS. DEFAULT: Disabled"
     echo "-noe | --no-overlay-enable [snat-enabled|managed] Enable no overlay for the default network. Optional value: 'snat-enabled' to enable SNAT, 'managed' to enable SNAT and managed routing. DEFAULT: disabled."
     echo "-ha  | --ha-enabled                           Enable high availability. DEFAULT: HA Disabled"
+    echo "-n4  | --no-ipv4                              Disable IPv4. DEFAULT: IPv4 Enabled."
+    echo "-i6  | --ipv6                                 Enable IPv6. DEFAULT: IPv6 Disabled."
     echo "-wk  | --num-workers                          Number of worker nodes. DEFAULT: 2 workers"
     echo "-ov  | --ovn-image                            Use the specified docker image instead of building locally. DEFAULT: local build."
     echo "-ovr | --ovn-repo                             Specify the repository to build OVN from"
@@ -184,6 +180,10 @@ parse_args() {
                                                     ENABLE_NO_OVERLAY_MANAGED_ROUTING=false
                                                   fi
                                                   ;;
+            -n4 | --no-ipv4 )                     PLATFORM_IPV4_SUPPORT=false
+                                                  ;;
+            -i6 | --ipv6 )                        PLATFORM_IPV6_SUPPORT=true
+                                                  ;;
             -ha | --ha-enabled )                  OVN_HA=true
                                                   KIND_NUM_MASTER=3
                                                   ;;
@@ -279,6 +279,11 @@ print_params() {
      echo "ENABLE_NO_OVERLAY = $ENABLE_NO_OVERLAY"
      echo "ENABLE_NO_OVERLAY_OUTBOUND_SNAT = $ENABLE_NO_OVERLAY_OUTBOUND_SNAT"
      echo "ENABLE_NO_OVERLAY_MANAGED_ROUTING = $ENABLE_NO_OVERLAY_MANAGED_ROUTING"
+     echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
+     echo "OVN_SECOND_BRIDGE = $OVN_SECOND_BRIDGE"
+     echo "OVN_DISABLE_SNAT_MULTIPLE_GWS = $OVN_DISABLE_SNAT_MULTIPLE_GWS"
+     echo "OVN_DISABLE_FORWARDING = $OVN_DISABLE_FORWARDING"
+     echo "OVN_UNPRIVILEGED_MODE = $OVN_UNPRIVILEGED_MODE"
      echo "OVN_MTU = $OVN_MTU"
      echo "OVN_IMAGE = $OVN_IMAGE"
      echo "OVN_REPO = $OVN_REPO"
@@ -366,12 +371,13 @@ create_ovn_kubernetes() {
     # When Helm encounters a comma within a string value in a --set argument, it attempts to parse the comma as a separator
     # for multiple values (like a list or a map), not as part of a single string value.
     set -x
-    ESCAPED_NET_CIDR_IPV4="${NET_CIDR_IPV4//,/\\,}"
+    ESCAPED_NET_CIDR="${NET_CIDR//,/\\,}"
+    ESCAPED_SVC_CIDR="${SVC_CIDR//,/\\,}"
     cmd=$(cat <<EOF
 helm install ovn-kubernetes . -f "${value_file}" \
           --set k8sAPIServer=${API_URL} \
-          --set podNetwork="${ESCAPED_NET_CIDR_IPV4}" \
-          --set serviceNetwork=${SVC_CIDR_IPV4} \
+          --set podNetwork="${ESCAPED_NET_CIDR}" \
+          --set serviceNetwork="${ESCAPED_SVC_CIDR}" \
           --set mtu=${OVN_MTU} \
           --set ovnkube-master.replicas=${MASTER_REPLICAS} \
           --set global.image.repository=${OVN_IMAGE%%:*} \
@@ -398,6 +404,10 @@ helm install ovn-kubernetes . -f "${value_file}" \
           --set global.enableNoOverlayManagedRouting=$(if [ "${ENABLE_NO_OVERLAY_MANAGED_ROUTING}" == "true" ]; then echo "true"; else echo "false"; fi) \
           --set global.enableCoredumps=$(if [ "${ENABLE_COREDUMPS}" == "true" ]; then echo "true"; else echo "false"; fi) \
           --set global.allowICMPNetworkPolicy=$(if [ "${OVN_ALLOW_ICMP_NETPOL}" == "true" ]; then echo "true"; else echo "false"; fi) \
+          --set global.gatewayMode="${OVN_GATEWAY_MODE}" \
+          --set global.disableSnatMultipleGws=$(if [ "${OVN_DISABLE_SNAT_MULTIPLE_GWS}" == "true" ]; then echo "true"; else echo "false"; fi) \
+          --set global.disableForwarding=$(if [ "${OVN_DISABLE_FORWARDING}" == "true" ]; then echo "true"; else echo "false"; fi) \
+          --set global.unprivilegedMode=false \
           ${ovnkube_db_options}
 EOF
        )
@@ -423,6 +433,9 @@ if [ "$ENABLE_COREDUMPS" == true ]; then
 fi
 detect_apiserver_url
 install_ovn_image
+if [ "$OVN_SECOND_BRIDGE" == true ]; then
+  docker_create_second_interface
+fi
 docker_disable_ipv6
 coredns_patch
 if [ "$OVN_ENABLE_DNSNAMERESOLVER" == true ]; then

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -584,72 +584,6 @@ set_default_params() {
   fi
 }
 
-check_ipv6() {
-  if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    # Collect additional IPv6 data on test environment
-    ERROR_FOUND=false
-    TMPVAR=$(sysctl net.ipv6.conf.all.forwarding | awk '{print $3}')
-    echo "net.ipv6.conf.all.forwarding is equal to $TMPVAR"
-    if [ "$TMPVAR" != 1 ]; then
-      if [ "$KIND_ALLOW_SYSTEM_WRITES" == true ]; then
-	sudo sysctl -w net.ipv6.conf.all.forwarding=1
-      else
-	echo "RUN: 'sudo sysctl -w net.ipv6.conf.all.forwarding=1' to use IPv6."
-	ERROR_FOUND=true
-      fi
-    fi
-    TMPVAR=$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')
-    echo "net.ipv6.conf.all.disable_ipv6 is equal to $TMPVAR"
-    if [ "$TMPVAR" != 0 ]; then
-      if [ "$KIND_ALLOW_SYSTEM_WRITES" == true ]; then
-	sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
-      else
-	echo "RUN: 'sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0' to use IPv6."
-	ERROR_FOUND=true
-      fi
-    fi
-    if [ -f /proc/net/if_inet6 ]; then
-      echo "/proc/net/if_inet6 exists so IPv6 supported in kernel."
-    else
-      echo "/proc/net/if_inet6 does not exists so no IPv6 support found! Compile the kernel!!"
-      ERROR_FOUND=true
-    fi
-    if "$ERROR_FOUND"; then
-      exit 2
-    fi
-  fi
-}
-
-set_cluster_cidr_ip_families() {
-# kind only allows single subnet for pod network, while ovn-kubernetes supports multiple subnets.
-# So we pick the first subnet from the provided list for kind configuration and store it in KIND_CIDR.
-# remove host subnet mask info for kind configuration (when the subnet is set as 10.0.0.0/16/14)
-  KIND_CIDR_IPV4=$(echo "${NET_CIDR_IPV4}"| cut -d',' -f1 | cut -d'/' -f1,2 )
-  KIND_CIDR_IPV6=$(echo "${NET_CIDR_IPV6}"| cut -d',' -f1 | cut -d'/' -f1,2 )
-  if [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == false ]; then
-    IP_FAMILY=""
-    KIND_CIDR=$KIND_CIDR_IPV4
-    NET_CIDR=$NET_CIDR_IPV4
-    SVC_CIDR=$SVC_CIDR_IPV4
-    echo "IPv4 Only Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
-  elif [ "$PLATFORM_IPV4_SUPPORT" == false ] && [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    IP_FAMILY="ipv6"
-    KIND_CIDR=$KIND_CIDR_IPV6
-    NET_CIDR=$NET_CIDR_IPV6
-    SVC_CIDR=$SVC_CIDR_IPV6
-    echo "IPv6 Only Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
-  elif [ "$PLATFORM_IPV4_SUPPORT" == true ] && [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    IP_FAMILY="dual"
-    KIND_CIDR=$KIND_CIDR_IPV4,$KIND_CIDR_IPV6
-    NET_CIDR=$NET_CIDR_IPV4,$NET_CIDR_IPV6
-    SVC_CIDR=$SVC_CIDR_IPV4,$SVC_CIDR_IPV6
-    echo "Dual Stack Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
-  else
-    echo "Invalid setup. PLATFORM_IPV4_SUPPORT and/or PLATFORM_IPV6_SUPPORT must be true."
-    exit 1
-  fi
-}
-
 create_local_registry() {
     # create registry container unless it already exists
     if [ "$($OCI_BIN inspect -f '{{.State.Running}}' "${KIND_LOCAL_REGISTRY_NAME}" 2>/dev/null || true)" != 'true' ]; then
@@ -968,17 +902,6 @@ install_ipsec() {
   fi
 }
 
-docker_create_second_interface() {
-  echo "adding second interfaces to nodes"
-
-  # Create the network as dual stack, regardless of the type of the deployment. Ignore if already exists.
-  "$OCI_BIN" network create --ipv6 --driver=bridge xgw --subnet=172.19.0.0/16 --subnet=fc00:f853:ccd:e798::/64 || true
-
-  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
-  for n in $KIND_NODES; do
-    "$OCI_BIN" network connect xgw "$n"
-  done
-}
 
 # run_script_in_container should be used when kind.sh is run nested in a container
 # and makes sure the control-plane node is reachable by substituting 127.0.0.1

--- a/helm/ovn-kubernetes/values-multi-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-multi-node-zone.yaml
@@ -10,6 +10,7 @@ tags:
   ovnkube-master: false
   ovnkube-node-dpu: false
   ovnkube-node-dpu-host: false
+  ovnkube-single-node-zone-dpu: false
   ovnkube-single-node-zone: false
 
 # -- Endpoint of Kubernetes api server


### PR DESCRIPTION
**Continuing the feature migration to kind-helm.sh script. Will have more PRs following this one with end goal being deprecating the kind.sh script and moving everything to kind-helm.sh**

Move check_ipv6(), set_cluster_cidr_ip_families(), and
docker_create_second_interface() from kind.sh to kind-common.sh so
they can be called from kind-helm.sh.

Add -i6/--ipv6 and -n4/--no-ipv4 flags to kind-helm.sh and pass
gateway mode, snat, forwarding through helm --set.

Hardcode unprivileged-mode=false to match kind.sh behavior.

Escape dual-stack CIDRs to prevent helm from splitting on commas.

Fix values-multi-node-zone.yaml missing value

Update some CI targets to use kind-helm script, other targets
are not yet supported, will be migrated later.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IPv4/IPv6 platform support configuration options for cluster deployment
  * Introduced OVN gateway behavior parameters (gateway mode, SNAT configuration, forwarding control)

* **Tests**
  * Expanded e2e test matrix with Helm-specific test variants for improved coverage

* **Chores**
  * Reorganized deployment scripts to consolidate network and IPv6 validation logic
  * Updated Helm chart values for gateway-related configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->