### PR TITLE
e2e, kubevirt: Fix ipamless localnet iperf flake

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -329,7 +329,22 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 			polling := 15 * time.Second
 			for podName, serverPodIPs := range serverPodIPsByName {
 				for _, serverPodIP := range serverPodIPs {
-					output, err := virtClient.RunCommand(vmi, fmt.Sprintf("iperf3 -t 0 -c %[2]s --logfile /tmp/%[1]s_%[2]s_iperf3.log &", podName, serverPodIP), polling)
+					iperfLogFile := fmt.Sprintf("/tmp/%s_%s_iperf3.log", podName, serverPodIP)
+
+					By(fmt.Sprintf("remove iperf3 log for %s: %s", serverPodIP, stage))
+					output, err := virtClient.RunCommand(vmi, fmt.Sprintf("rm -f %s", iperfLogFile), polling)
+					if err != nil {
+						return fmt.Errorf("failed removing iperf3 log file %s: %w", output, err)
+					}
+
+					By(fmt.Sprintf("check iperf3 connectivity for %s: %s", serverPodIP, stage))
+					output, err = virtClient.RunCommand(vmi, fmt.Sprintf("iperf3 -t 1 -c %s", serverPodIP), polling)
+					if err != nil {
+						return fmt.Errorf("failed checking iperf3 connectivity %s: %w", output, err)
+					}
+
+					By(fmt.Sprintf("start iperf3 to %s: %s", serverPodIP, stage))
+					output, err = virtClient.RunCommand(vmi, fmt.Sprintf("nohup iperf3 -t 0 -c %[2]s --logfile %[1]s &", iperfLogFile, serverPodIP), polling)
 					if err != nil {
 						return fmt.Errorf("%s: %w", output, err)
 					}


### PR DESCRIPTION
## 📑 Description

Fix flaky test `should maintain tcp connection with minimal downtime [It] after failed live migration`
in the ipamless localnet kubevirt e2e tests.

`startEastWestIperfTraffic` was firing iperf3 in the background without verifying network readiness.
After a VM force-kill and restart, the network may not be immediately available (OVN port re-binding,
ARP resolution), causing the 2-second `checkIperfTraffic` timeout to expire with an empty log file.

Align `startEastWestIperfTraffic` with `startNorthSouthIperfTraffic` by adding old log file removal
and a foreground `iperf3 -t 1` connectivity check before starting the background iperf, ensuring the
network path and server are ready.

Closes #5456

## Additional Information for reviewers

The root cause is a race between starting iperf3 in background and checking
its log file. After VM restart, the iperf3 client may still be establishing
the TCP connection when the 2-second check window expires, resulting in an
empty log file.

`startNorthSouthIperfTraffic` already uses this pattern (log cleanup +
foreground connectivity check), this change brings `startEastWestIperfTraffic`
in line.

Verified locally with `ginkgo --until-it-fails`: 12+ consecutive passes with
zero failures.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Run the flaky test with `--until-it-fails`:

```
cd test/e2e
go run github.com/onsi/ginkgo/v2/ginkgo --until-it-fails \
  --focus "should maintain tcp connection with minimal downtime.*after failed live migration" \
  -v -timeout=10h .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end network traffic tests with clearer, step-scoped progress messages.
  * Each test target now uses a dedicated log file and explicitly removes stale logs before starting; failures are surfaced promptly.
  * Added a short connectivity probe before launching background throughput measurements to fail fast on connection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->