### PR TITLE
Improve EndpointSlice mirror controller scale bottlenecks

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -258,7 +258,9 @@ func (cm *ClusterManager) Start(ctx context.Context) error {
 	}
 
 	if util.IsNetworkSegmentationSupportEnabled() {
-		if err := cm.endpointSliceMirrorController.Start(ctx, 1); err != nil {
+		// Use 5 workers to match the upstream kube-controller-manager default for EndpointSlice reconciliation:
+		// https://github.com/kubernetes/kubernetes/blob/462e759d1995c143fda094cd7f591b10fd8cdee6/pkg/controller/endpointslice/config/v1alpha1/defaults.go#L35
+		if err := cm.endpointSliceMirrorController.Start(ctx, 5); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go
@@ -94,7 +94,7 @@ func (c *Controller) enqueueEndpointSlice(obj interface{}) {
 		}
 	}
 	if key := c.getDefaultEndpointSliceKey(eps); key != "" {
-		c.queue.AddRateLimited(key)
+		c.queue.Add(key)
 	}
 }
 
@@ -256,19 +256,8 @@ func (c *Controller) syncDefaultEndpointSlice(ctx context.Context, key string) e
 		return nil
 	}
 
-	klog.Infof("Processing %s/%s EndpointSlice in %q primary network", namespace, name, namespacePrimaryNetwork.GetNetworkName())
-
-	nadKey, err := c.networkManager.GetPrimaryNADForNamespace(namespace)
-	if err != nil {
-		return err
-	}
-	if nadKey == types.DefaultNetworkName {
-		return fmt.Errorf("no primary NAD found for namespace %s", namespace)
-	}
-	if networkName := c.networkManager.GetNetworkNameForNADKey(nadKey); networkName == "" || networkName != namespacePrimaryNetwork.GetNetworkName() {
-		return fmt.Errorf("primary NAD %s does not match network %s", nadKey, namespacePrimaryNetwork.GetNetworkName())
-	}
-
+	// Fetch the default and mirrored EndpointSlices first so we can do a cheap
+	// resource-version check before the more expensive NAD lookups.
 	defaultEndpointSlice, err := c.endpointSliceLister.EndpointSlices(namespace).Get(name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
@@ -327,6 +316,20 @@ func (c *Controller) syncDefaultEndpointSlice(ctx context.Context, key string) e
 		}
 	}
 
+	// We have actual work to do — resolve the NAD for the primary network.
+	klog.Infof("Processing %s/%s EndpointSlice in %q primary network", namespace, name, namespacePrimaryNetwork.GetNetworkName())
+
+	nadKey, err := c.networkManager.GetPrimaryNADForNamespace(namespace)
+	if err != nil {
+		return err
+	}
+	if nadKey == types.DefaultNetworkName {
+		return fmt.Errorf("no primary NAD found for namespace %s", namespace)
+	}
+	if networkName := c.networkManager.GetNetworkNameForNADKey(nadKey); networkName == "" || networkName != namespacePrimaryNetwork.GetNetworkName() {
+		return fmt.Errorf("primary NAD %s does not match network %s", nadKey, namespacePrimaryNetwork.GetNetworkName())
+	}
+
 	currentMirror, err := c.mirrorEndpointSlice(mirroredEndpointSlice, defaultEndpointSlice, namespacePrimaryNetwork, nadKey)
 	if err != nil {
 		return err
@@ -334,6 +337,10 @@ func (c *Controller) syncDefaultEndpointSlice(ctx context.Context, key string) e
 
 	if !reflect.DeepEqual(currentMirror, mirroredEndpointSlice) {
 		if currentMirror.Name == "" {
+			if len(currentMirror.Endpoints) == 0 {
+				klog.V(5).Infof("Skipping creation of empty mirrored EndpointSlice for: %s", cache.MetaObjectToName(defaultEndpointSlice))
+				return nil
+			}
 			klog.Infof("Creating the mirrored EndpointSlice for: %s", cache.MetaObjectToName(defaultEndpointSlice))
 			_, err := c.kubeClient.DiscoveryV1().EndpointSlices(namespace).Create(ctx, currentMirror, metav1.CreateOptions{})
 			return err


### PR DESCRIPTION
The EndpointSlice mirror controller had several performance issues that became apparent at scale:

- Use queue.Add instead of queue.AddRateLimited on the enqueue path.
- Reorder syncDefaultEndpointSlice to perform the cheap resource-version check before the expensive NAD lookups. Most syncs short-circuit without ever calling GetPrimaryNADForNamespace.
- Skip creation of empty mirrored EndpointSlices to avoid unnecessary API server writes.
- Increase worker count from 1 to 5, matching the upstream kube-controller-manager default for EndpointSlice reconciliation.


Kudos to @liqcui for finding out that there are significant gains in increasing the worker count of the mirror controller.
In the future we can consider making the worker count configurable but I think this is a good first step. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance of endpoint slice mirroring by enabling concurrent reconciliation.
  * Optimized reconciliation logic to skip unnecessary lookups when not required.
  * Enhanced empty endpoint slice handling to prevent creation of unnecessary mirror resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->