### PR TITLE
services: fix UDN service route race during controller startup

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -815,6 +815,11 @@ func (c *Controller) cleanupUDNEnabledServiceRoute(key string) error {
 func (c *Controller) configureUDNEnabledServiceRoute(service *corev1.Service) error {
 	klog.Infof("Configuring UDN enabled service route for service %s/%s in network: %s", service.Namespace, service.Name, c.netInfo.GetNetworkName())
 
+	if len(c.nodeInfos) == 0 {
+		return fmt.Errorf("no nodes tracked yet for network %s, cannot configure UDN enabled service route for %s/%s",
+			c.netInfo.GetNetworkName(), service.Namespace, service.Name)
+	}
+
 	extIDs := map[string]string{
 		types.NetworkExternalID:           c.netInfo.GetNetworkName(),
 		types.TopologyExternalID:          c.netInfo.TopologyType(),

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -1876,3 +1876,45 @@ func deleteTestNBGlobal(nbClient libovsdbclient.Client) error {
 
 	return nil
 }
+
+// TestConfigureUDNEnabledServiceRouteWithoutNodes - verifies retry when no nodes tracked
+func TestConfigureUDNEnabledServiceRouteWithoutNodes(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ns := "default"
+
+	oldIPv4Mode := config.IPv4Mode
+	config.IPv4Mode = true
+	defer func() { config.IPv4Mode = oldIPv4Mode }()
+
+	l3UDN, err := getSampleUDNNetInfo(ns, types.Layer3Topology)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	dbSetup := libovsdbtest.TestSetup{}
+	controller, err := newControllerWithDBSetupForNetwork(dbSetup, l3UDN, ns)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	defer controller.close()
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubernetes",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.96.0.1",
+			Type:      corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	serviceKey := "default/kubernetes"
+
+	err = controller.configureUDNEnabledServiceRoute(service)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("no nodes tracked yet"))
+
+	initialRequeues := controller.queue.NumRequeues(serviceKey)
+	controller.handleErr(err, serviceKey)
+	g.Expect(controller.queue.NumRequeues(serviceKey)).To(gomega.Equal(initialRequeues + 1))
+
+	controller.handleErr(nil, serviceKey)
+	g.Expect(controller.queue.NumRequeues(serviceKey)).To(gomega.Equal(0))
+}


### PR DESCRIPTION
UDN pods intermittently fail to reach cluster services (kubernetes.default, kube-dns) shortly after network creation. The services controller processes UDN-enabled services before nodes are tracked, iterating zero times and creating zero routes, but TransactAndCheck() with empty ops succeeds and the service is marked complete.

Return an error when nodeInfos is empty so the service gets requeued and retried until nodes are available.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for User-Defined Network (UDN) enabled services to gracefully handle scenarios when cluster nodes are not yet available, preventing invalid route configuration attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->