### PR TITLE
Fix kubevirt live migration test flake

### DIFF
--- a/go-controller/pkg/ovn/kubevirt_test.go
+++ b/go-controller/pkg/ovn/kubevirt_test.go
@@ -816,8 +816,28 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 
 					// Change the phase by updating to emulate the logic of transition
 					if virtLauncherPodToCreate.updatePhase != nil {
-						podToCreate.Status.Phase = *virtLauncherPodToCreate.updatePhase
-						_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(), podToCreate, metav1.UpdateOptions{})
+						// Wait for the controller to finish processing the pod
+						// (i.e., OVN annotations are set by EnsurePodAnnotationForVM).
+						// The fake client's UpdateStatus replaces the entire object,
+						// so we must read the latest pod to avoid overwriting the
+						// controller's annotation patch, which would race with this
+						// status update.
+						Eventually(func() error {
+							p, err := fakeOvn.controller.watchFactory.GetPod(podToCreate.Namespace, podToCreate.Name)
+							if err != nil {
+								return err
+							}
+							_, err = util.UnmarshalPodAnnotation(p.Annotations, ovntypes.DefaultNetworkName)
+							return err
+						}).
+							WithTimeout(time.Minute).
+							WithPolling(time.Second).
+							Should(Succeed(), "should have OVN pod annotation set by the controller")
+
+						latestPod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), podToCreate.Name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						latestPod.Status.Phase = *virtLauncherPodToCreate.updatePhase
+						_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).UpdateStatus(context.TODO(), latestPod, metav1.UpdateOptions{})
 						Expect(err).NotTo(HaveOccurred())
 						Eventually(func() (corev1.PodPhase, error) {
 							updatedPod, err := fakeOvn.controller.watchFactory.GetPod(podToCreate.Namespace, podToCreate.Name)
@@ -825,7 +845,7 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 						}).
 							WithTimeout(time.Minute).
 							WithPolling(time.Second).
-							Should(Equal(podToCreate.Status.Phase), "should be in the updated phase")
+							Should(Equal(*virtLauncherPodToCreate.updatePhase), "should be in the updated phase")
 
 					}
 				}


### PR DESCRIPTION
## 📑 Description

Fix the intermittent unit test failure in `"OVN Kubevirt Operations during execution reconcile migratable vm pods [It] for failing live migration"` (and its sibling `"for failing target virt-launcher after live migration"`).

Related: #5112

## Additional Information for reviewers

**Root cause:** The fake client's `UpdateStatus` replaces the **entire** pod object, not just the Status subresource (this is a known limitation of `client-go`'s fake client). When the test called `UpdateStatus(podToCreate)`, the `podToCreate` object had stale metadata — it lacked the OVN annotations that the controller had just patched via `EnsurePodAnnotationForVM`. This overwrote the controller's annotations, causing retries and additional watch events that raced with the informer cache updates, occasionally leaving the pod phase stuck at "Running" in the cache.

**Fix:**
1. Wait for the OVN pod annotation to appear on the migration target pod (ensuring the controller's `EnsurePodAnnotationForVM` has completed its annotation patch)
2. Read the **latest** pod from the fake client via `Pods().Get()` (preserving the controller's annotations)
3. Set the phase on the latest pod and call `UpdateStatus` with it

This eliminates the race between the controller's annotation patch and the test's status update.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Run the affected tests with `--until-it-fails`:

```bash
ginkgo run --focus "for failing live migration" --until-it-fails -v --timeout=15m ./pkg/ovn/
ginkgo run --focus "for failing target virt-launcher after live migration" --until-it-fails -v --timeout=15m ./pkg/ovn/
```

**Before fix:** fails around attempt #136 (~10 minutes) with `"should be in the updated phase"` timeout.
**After fix:** 200+ consecutive passes until the suite timeout is hit — no actual test failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for KubeVirt pod phase transitions by waiting for the controller to apply pod annotations before proceeding.
  * Fetches the current pod state before applying status updates to avoid races with the controller.
  * Tightened assertions to verify the controller-observed pod phase matches the expected transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->