### PR TITLE
Replace fast-slow rate limiters with exponential backoff 

### DIFF
--- a/go-controller/pkg/clustermanager/dnsnameresolver/controller.go
+++ b/go-controller/pkg/clustermanager/dnsnameresolver/controller.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"time"
 
 	ocpnetworkapiv1alpha1 "github.com/openshift/api/network/v1alpha1"
 	ocpnetworkclientset "github.com/openshift/client-go/network/clientset/versioned"
@@ -18,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -65,7 +63,6 @@ func (c *Controller) initControllers(watchFactory *factory.WatchFactory) {
 	efSharedIndexInformer := watchFactory.EgressFirewallInformer().Informer()
 	c.efLister = watchFactory.EgressFirewallInformer().Lister()
 	efConfig := &controller.ControllerConfig[egressfirewall.EgressFirewall]{
-		RateLimiter:    workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		Informer:       efSharedIndexInformer,
 		Lister:         c.efLister.List,
 		ObjNeedsUpdate: efNeedsUpdate,
@@ -77,7 +74,6 @@ func (c *Controller) initControllers(watchFactory *factory.WatchFactory) {
 	dnsSharedIndexInformer := watchFactory.DNSNameResolverInformer().Informer()
 	c.dnsLister = ocpnetworklisterv1alpha1.NewDNSNameResolverLister(dnsSharedIndexInformer.GetIndexer())
 	dnsConfig := &controller.ControllerConfig[ocpnetworkapiv1alpha1.DNSNameResolver]{
-		RateLimiter:    workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		Informer:       dnsSharedIndexInformer,
 		Lister:         c.dnsLister.List,
 		ObjNeedsUpdate: dnsNeedsUpdate,

--- a/go-controller/pkg/clustermanager/egressservice/egressservice_cluster.go
+++ b/go-controller/pkg/clustermanager/egressservice/egressservice_cluster.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	egressserviceapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1"
 	egressservicelisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/listers/egressservice/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
@@ -119,7 +120,7 @@ func NewController(
 	c.egressServiceLister = esInformer.Lister()
 	c.egressServiceSynced = esInformer.Informer().HasSynced
 	c.egressServiceQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "egressservices"},
 	)
 	_, err := esInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -156,7 +157,7 @@ func NewController(
 
 	c.nodesSynced = wf.NodeInformer().HasSynced
 	c.nodesQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "egressservicenodes"},
 	)
 	_, err = wf.NodeInformer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{

--- a/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go
+++ b/go-controller/pkg/clustermanager/endpointslicemirror/endpointslice_mirror_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -128,7 +129,7 @@ func NewController(
 	}
 
 	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: c.name},
 	)
 

--- a/go-controller/pkg/clustermanager/status_manager/status_manager.go
+++ b/go-controller/pkg/clustermanager/status_manager/status_manager.go
@@ -8,14 +8,12 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/status_manager/zone_tracker"
@@ -79,7 +77,6 @@ func newStatusManager[T any](name string, informer cache.SharedIndexInformer,
 	controllerConfig := &controller.ControllerConfig[T]{
 		Informer:       informer,
 		Lister:         lister,
-		RateLimiter:    workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		ObjNeedsUpdate: m.needsUpdate,
 		Reconcile:      m.updateStatus,
 		Threadiness:    1,

--- a/go-controller/pkg/clustermanager/status_manager/zone_tracker/zone_tracker.go
+++ b/go-controller/pkg/clustermanager/status_manager/zone_tracker/zone_tracker.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
@@ -71,7 +70,6 @@ func NewZoneTracker(nodeInformer coreinformers.NodeInformer, onZonesUpdate func(
 	}
 
 	controllerConfig := &controller.ControllerConfig[corev1.Node]{
-		RateLimiter:    workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		Informer:       nodeInformer.Informer(),
 		Lister:         nodeInformer.Lister().List,
 		ObjNeedsUpdate: zt.needsUpdate,

--- a/go-controller/pkg/controller/controller.go
+++ b/go-controller/pkg/controller/controller.go
@@ -26,6 +26,19 @@ const (
 	InfiniteAttempts   = math.MaxInt
 )
 
+// DefaultRateLimiter returns the default rate limiter for controller work
+// queues. It uses per-item exponential backoff starting at 5ms and capped at 1
+// minute. The delay doubles on each retry (5ms, 10ms, 20ms, 40ms, ...) until
+// reaching the cap.
+//
+// This is similar to the upstream DefaultTypedControllerRateLimiter but with a
+// lower max delay (1m vs ~17m) which is more appropriate for networking
+// controllers, and without the global token-bucket limiter since we already
+// rely on per-item backoff.
+func DefaultRateLimiter[T comparable]() workqueue.TypedRateLimiter[T] {
+	return workqueue.NewTypedItemExponentialFailureRateLimiter[T](5*time.Millisecond, 1*time.Minute)
+}
+
 // Reconciler is a basic level-driven controller that is fed externally of items
 // to reconcile through its Reconcile method
 type Reconciler interface {
@@ -104,11 +117,15 @@ func NewReconciler(name string, config *ReconcilerConfig) Reconciler {
 // NewController creates a new level-driven controller. It should be started and
 // stopped using Start/StartWithInitialSync/Stop functions.
 func NewController[T any](name string, config *ControllerConfig[T]) Controller {
+	rateLimiter := config.RateLimiter
+	if rateLimiter == nil {
+		rateLimiter = DefaultRateLimiter[string]()
+	}
 	c := &controller[T]{
 		name:   name,
 		config: config,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			config.RateLimiter,
+			rateLimiter,
 			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: name,
 			},

--- a/go-controller/pkg/controller/controller_test.go
+++ b/go-controller/pkg/controller/controller_test.go
@@ -59,9 +59,6 @@ var _ = Describe("Level-driven controller", func() {
 
 		config.Informer = coreFactory.Core().V1().Pods().Informer()
 		config.Lister = coreFactory.Core().V1().Pods().Lister().List
-		if config.RateLimiter == nil {
-			config.RateLimiter = workqueue.NewTypedItemFastSlowRateLimiter[string](100*time.Millisecond, 1*time.Second, 5)
-		}
 		controller = NewController("controller-name", config)
 
 		coreFactory.Start(stopChan)
@@ -140,11 +137,11 @@ var _ = Describe("Level-driven controller", func() {
 			failureCounter.Add(1)
 			return fmt.Errorf("failure")
 		}
-		config.RateLimiter = workqueue.NewTypedItemFastSlowRateLimiter[string](100*time.Millisecond, 1*time.Second, DefaultMaxAttempts)
+		config.RateLimiter = workqueue.NewTypedItemExponentialFailureRateLimiter[string](1*time.Millisecond, 50*time.Millisecond)
 		startController(config, nil, namespace, pod)
 
-		Eventually(failureCounter.Load, (DefaultMaxAttempts+1)*100*time.Millisecond).Should(BeEquivalentTo(DefaultMaxAttempts))
-		time.Sleep(1 * time.Second)
+		Eventually(failureCounter.Load, 5*time.Second).Should(BeEquivalentTo(DefaultMaxAttempts))
+		time.Sleep(200 * time.Millisecond)
 		Expect(failureCounter.Load()).To(BeEquivalentTo(DefaultMaxAttempts + 1))
 
 		// trigger update, check it is handled
@@ -253,14 +250,14 @@ var _ = Describe("Level-driven controllers with shared initialSync", func() {
 		podConfig.Informer = coreFactory.Core().V1().Pods().Informer()
 		podConfig.Lister = coreFactory.Core().V1().Pods().Lister().List
 		if podConfig.RateLimiter == nil {
-			podConfig.RateLimiter = workqueue.NewTypedItemFastSlowRateLimiter[string](100*time.Millisecond, 1*time.Second, 5)
+			podConfig.RateLimiter = workqueue.NewTypedItemExponentialFailureRateLimiter[string](100*time.Millisecond, 1*time.Second)
 		}
 		podController = NewController("podController", podConfig)
 
 		nsConfig.Informer = coreFactory.Core().V1().Namespaces().Informer()
 		nsConfig.Lister = coreFactory.Core().V1().Namespaces().Lister().List
 		if nsConfig.RateLimiter == nil {
-			nsConfig.RateLimiter = workqueue.NewTypedItemFastSlowRateLimiter[string](100*time.Millisecond, 1*time.Second, 5)
+			nsConfig.RateLimiter = workqueue.NewTypedItemExponentialFailureRateLimiter[string](100*time.Millisecond, 1*time.Second)
 		}
 		namespaceController = NewController("namespaceController", nsConfig)
 

--- a/go-controller/pkg/controllers/node/node_controller.go
+++ b/go-controller/pkg/controllers/node/node_controller.go
@@ -7,14 +7,12 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
@@ -105,7 +103,6 @@ func NewController(wf *factory.WatchFactory, name string, networkManager network
 	}
 
 	nodeControllerConfig := &controller.ControllerConfig[corev1.Node]{
-		RateLimiter:    workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		Informer:       nodeInformer.Informer(),
 		Lister:         nodeInformer.Lister().List,
 		MaxAttempts:    controller.InfiniteAttempts,

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -36,6 +36,7 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	ovnconfig "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	eipv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions/egressip/v1"
 	egressiplisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/listers/egressip/v1"
@@ -158,20 +159,20 @@ func NewController(k kube.Interface, eIPInformer egressipinformer.EgressIPInform
 		eIPLister:   eIPInformer.Lister(),
 		eIPInformer: eIPInformer.Informer(),
 		eIPQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
+			controller.DefaultRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "eipeip"},
 		),
 		nodeLister:        corelisters.NewNodeLister(nodeInformer.GetIndexer()),
 		namespaceLister:   namespaceInformer.Lister(),
 		namespaceInformer: namespaceInformer.Informer(),
 		namespaceQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.NewTypedItemFastSlowRateLimiter[*corev1.Namespace](time.Second, 5*time.Second, 5),
+			controller.DefaultRateLimiter[*corev1.Namespace](),
 			workqueue.TypedRateLimitingQueueConfig[*corev1.Namespace]{Name: "eipnamespace"},
 		),
 		podLister:   podInformer.Lister(),
 		podInformer: podInformer.Informer(),
 		podQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.NewTypedItemFastSlowRateLimiter[*corev1.Pod](time.Second, 5*time.Second, 5),
+			controller.DefaultRateLimiter[*corev1.Pod](),
 			workqueue.TypedRateLimitingQueueConfig[*corev1.Pod]{Name: "eippods"},
 		),
 		getActiveNetworkForNamespace: getActiveNetworkForNamespaceFn,

--- a/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
+++ b/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	egressserviceapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1"
 	egressserviceinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/informers/externalversions/egressservice/v1"
 	egressservicelisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/listers/egressservice/v1"
@@ -105,7 +106,7 @@ func NewController(stopCh <-chan struct{}, returnMark, thisNode string,
 	c.egressServiceLister = esInformer.Lister()
 	c.egressServiceSynced = esInformer.Informer().HasSynced
 	c.egressServiceQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controller.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "egressservices"},
 	)
 	_, err := esInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{

--- a/go-controller/pkg/node/udn_isolation.go
+++ b/go-controller/pkg/node/udn_isolation.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/moby/sys/userns"
@@ -28,7 +27,6 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"sigs.k8s.io/knftables"
@@ -88,7 +86,6 @@ func NewUDNHostIsolationManager(ipv4, ipv6 bool, podInformer coreinformers.PodIn
 		udnOpenPortsICMPv6: newNFTPodElementsSet(nftablesUDNOpenPortsICMPv6, false),
 	}
 	controllerConfig := &controller.ControllerConfig[corev1.Pod]{
-		RateLimiter:    workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		Informer:       podInformer.Informer(),
 		Lister:         podInformer.Lister().List,
 		ObjNeedsUpdate: podNeedsUpdate,

--- a/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
+++ b/go-controller/pkg/ovn/controller/admin_network_policy/admin_network_policy_controller.go
@@ -26,6 +26,7 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/observability"
@@ -139,7 +140,7 @@ func NewController(
 	c.anpLister = anpInformer.Lister()
 	c.anpCacheSynced = anpInformer.Informer().HasSynced
 	c.anpQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "adminNetworkPolicy"},
 	)
 	_, err := anpInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -157,7 +158,7 @@ func NewController(
 	c.banpLister = banpInformer.Lister()
 	c.banpCacheSynced = banpInformer.Informer().HasSynced
 	c.banpQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "baselineAdminNetworkPolicy"},
 	)
 	_, err = banpInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -173,7 +174,7 @@ func NewController(
 	c.anpNamespaceLister = namespaceInformer.Lister()
 	c.anpNamespaceSynced = namespaceInformer.Informer().HasSynced
 	c.anpNamespaceQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "anpNamespaces"},
 	)
 	_, err = namespaceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -189,7 +190,7 @@ func NewController(
 	c.anpPodLister = podInformer.Lister()
 	c.anpPodSynced = podInformer.Informer().HasSynced
 	c.anpPodQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "anpPods"},
 	)
 	_, err = podInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -205,7 +206,7 @@ func NewController(
 	c.anpNodeLister = nodeInformer.Lister()
 	c.anpNodeSynced = podInformer.Informer().HasSynced
 	c.anpNodeQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "anpNodes"},
 	)
 	_, err = nodeInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 	v1pod "k8s.io/kubernetes/pkg/api/v1/pod"
 
+	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	adminpolicybasedrouteapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1"
 	adminpolicybasedrouteinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/informers/externalversions/adminpolicybasedroute/v1"
 	adminpolicybasedroutelisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/listers/adminpolicybasedroute/v1"
@@ -255,19 +256,19 @@ func newExternalPolicyManager(
 		routeLister:   apbRouteInformer.Lister(),
 		routeInformer: apbRouteInformer.Informer(),
 		routeQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
+			controllerutil.DefaultRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "adminpolicybasedexternalroutes"},
 		),
 		podLister:   podInformer.Lister(),
 		podInformer: podInformer.Informer(),
 		podQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.NewTypedItemFastSlowRateLimiter[*corev1.Pod](time.Second, 5*time.Second, 5),
+			controllerutil.DefaultRateLimiter[*corev1.Pod](),
 			workqueue.TypedRateLimitingQueueConfig[*corev1.Pod]{Name: "apbexternalroutepods"},
 		),
 		namespaceLister:   namespaceInformer.Lister(),
 		namespaceInformer: namespaceInformer.Informer(),
 		namespaceQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.NewTypedItemFastSlowRateLimiter[*corev1.Namespace](time.Second, 5*time.Second, 5),
+			controllerutil.DefaultRateLimiter[*corev1.Namespace](),
 			workqueue.TypedRateLimitingQueueConfig[*corev1.Namespace]{Name: "apbexternalroutenamespaces"},
 		),
 		updatePolicyStatusFunc: updatePolicyStatusFunc,

--- a/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go
+++ b/go-controller/pkg/ovn/controller/egressfirewall/egressfirewall.go
@@ -188,7 +188,6 @@ func NewEFController(
 	)
 
 	nodeControllerConfig := &controller.ControllerConfig[corev1.Node]{
-		RateLimiter:    workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		Informer:       nodeInformer.Informer(),
 		Lister:         nodeInformer.Lister().List,
 		MaxAttempts:    controller.InfiniteAttempts,

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	egressserviceapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1"
 	egressserviceinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/informers/externalversions/egressservice/v1"
 	egressservicelisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/listers/egressservice/v1"
@@ -153,7 +154,7 @@ func NewController(
 	c.egressServiceLister = esInformer.Lister()
 	c.egressServiceSynced = esInformer.Informer().HasSynced
 	c.egressServiceQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "egressservices"},
 	)
 	_, err := esInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -192,7 +193,7 @@ func NewController(
 	c.nodeLister = nodeInformer.Lister()
 	c.nodesSynced = nodeInformer.Informer().HasSynced
 	c.nodesQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "egressservicenodes"},
 	)
 	_, err = nodeInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{

--- a/go-controller/pkg/ovn/controller/network_qos/network_qos_controller.go
+++ b/go-controller/pkg/ovn/controller/network_qos/network_qos_controller.go
@@ -26,6 +26,7 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	networkqosapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1"
 	networkqosclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1/apis/clientset/versioned"
 	networkqosinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1/apis/informers/externalversions/networkqos/v1alpha1"
@@ -166,7 +167,7 @@ func NewController(
 	c.nqosLister = nqosInformer.Lister()
 	c.nqosCacheSynced = nqosInformer.Informer().HasSynced
 	c.nqosQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "networkQoS"},
 	)
 	_, err := nqosInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -182,7 +183,7 @@ func NewController(
 	c.nqosNamespaceLister = namespaceInformer.Lister()
 	c.nqosNamespaceSynced = namespaceInformer.Informer().HasSynced
 	c.nqosNamespaceQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[*eventData[*corev1.Namespace]](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[*eventData[*corev1.Namespace]](),
 		workqueue.TypedRateLimitingQueueConfig[*eventData[*corev1.Namespace]]{Name: "nqosNamespaces"},
 	)
 	_, err = namespaceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -198,7 +199,7 @@ func NewController(
 	c.nqosPodLister = podInformer.Lister()
 	c.nqosPodSynced = podInformer.Informer().HasSynced
 	c.nqosPodQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[*eventData[*corev1.Pod]](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[*eventData[*corev1.Pod]](),
 		workqueue.TypedRateLimitingQueueConfig[*eventData[*corev1.Pod]]{Name: "nqosPods"},
 	)
 	_, err = podInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -214,7 +215,7 @@ func NewController(
 	c.nqosNodeLister = nodeInformer.Lister()
 	c.nqosNodeSynced = nodeInformer.Informer().HasSynced
 	c.nqosNodeQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controllerutil.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "nqosNodes"},
 	)
 	_, err = nodeInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{

--- a/go-controller/pkg/ovn/controller/udnenabledsvc/udn_enabled_svc.go
+++ b/go-controller/pkg/ovn/controller/udnenabledsvc/udn_enabled_svc.go
@@ -22,6 +22,7 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -67,7 +68,7 @@ func NewController(nbClient libovsdbclient.Client, addressSetFactory addressset.
 		addressSetMu:      &sync.Mutex{},
 		serviceInformer:   serviceInformer,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
+			controllerutil.DefaultRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "udnenabledservice"},
 		),
 		cache:    make(map[string][]string),

--- a/go-controller/pkg/ovn/dns_name_resolver/external_dns.go
+++ b/go-controller/pkg/ovn/dns_name_resolver/external_dns.go
@@ -7,14 +7,12 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"time"
 
 	ocpnetworkapiv1alpha1 "github.com/openshift/api/network/v1alpha1"
 	ocpnetworklisterv1alpha1 "github.com/openshift/client-go/network/listers/network/v1alpha1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
@@ -67,7 +65,6 @@ func NewExternalEgressDNS(
 
 	extEgDNS.dnsLister = ocpnetworklisterv1alpha1.NewDNSNameResolverLister(dnsSharedIndexInformer.GetIndexer())
 	dnsConfig := &controller.ControllerConfig[ocpnetworkapiv1alpha1.DNSNameResolver]{
-		RateLimiter:    workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		Informer:       dnsSharedIndexInformer,
 		Lister:         extEgDNS.dnsLister.List,
 		ObjNeedsUpdate: dnsNeedsUpdate,

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	egressqosapi "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1"
 	egressqosapply "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1/apis/applyconfiguration/egressqos/v1"
 	egressqosinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1/apis/informers/externalversions/egressqos/v1"
@@ -188,7 +189,7 @@ func (oc *DefaultNetworkController) initEgressQoSController(
 	oc.egressQoSLister = eqInformer.Lister()
 	oc.egressQoSSynced = eqInformer.Informer().HasSynced
 	oc.egressQoSQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controller.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "egressqos"},
 	)
 	_, err := eqInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -204,7 +205,7 @@ func (oc *DefaultNetworkController) initEgressQoSController(
 	oc.egressQoSPodLister = podInformer.Lister()
 	oc.egressQoSPodSynced = podInformer.Informer().HasSynced
 	oc.egressQoSPodQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controller.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "egressqospods"},
 	)
 	_, err = podInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
@@ -219,7 +220,7 @@ func (oc *DefaultNetworkController) initEgressQoSController(
 	oc.egressQoSNodeLister = nodeInformer.Lister()
 	oc.egressQoSNodeSynced = nodeInformer.Informer().HasSynced
 	oc.egressQoSNodeQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.NewTypedItemFastSlowRateLimiter[string](1*time.Second, 5*time.Second, 5),
+		controller.DefaultRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "egressqosnodes"},
 	)
 	_, err = nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/go-controller/pkg/ovn/routeimport/route_import.go
+++ b/go-controller/pkg/ovn/routeimport/route_import.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-kubernetes/libovsdb/client"
@@ -81,7 +80,6 @@ func New(node string, nbClient client.Client) Controller {
 		&controllerutil.ReconcilerConfig{
 			Threadiness: 1,
 			Reconcile:   c.syncNetwork,
-			RateLimiter: workqueue.NewTypedItemFastSlowRateLimiter[string](time.Second, 5*time.Second, 5),
 		},
 	)
 

--- a/go-controller/pkg/ovn/routeimport/route_import_test.go
+++ b/go-controller/pkg/ovn/routeimport/route_import_test.go
@@ -441,7 +441,7 @@ func Test_controller_syncRouteUpdate(t *testing.T) {
 			}
 			r := controllerutil.NewReconciler(
 				"test",
-				&controllerutil.ReconcilerConfig{Reconcile: reconcile, Threadiness: 1, RateLimiter: workqueue.NewTypedItemFastSlowRateLimiter[string](0, 0, 0)})
+				&controllerutil.ReconcilerConfig{Reconcile: reconcile, Threadiness: 1, RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[string](0, 0)})
 			c := &controller{
 				log:        testr.New(t),
 				networkIDs: tt.fields.networkIDs,
@@ -575,7 +575,7 @@ func Test_controller_syncLinkUpdate(t *testing.T) {
 			}
 			r := controllerutil.NewReconciler(
 				"test",
-				&controllerutil.ReconcilerConfig{Reconcile: reconcile, Threadiness: 1, RateLimiter: workqueue.NewTypedItemFastSlowRateLimiter[string](0, 0, 0)},
+				&controllerutil.ReconcilerConfig{Reconcile: reconcile, Threadiness: 1, RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[string](0, 0)},
 			)
 			for id, network := range tt.fields.networkIDs {
 				netInfo := &multinetworkmocks.NetInfo{}


### PR DESCRIPTION
Replace all usages of fast-slow rate limiter with exponential backoff (5ms base, 1min cap). Add a centralized DefaultRateLimiter[T]() in the controller package so all controllers share the same default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized retry/backoff across controllers by consolidating per-controller rate limiters to a single default exponential backoff (starting ~5ms, capped ~1min), removing many custom fast/slow configurations.
  * Controllers and node components now use the unified default rate limiter for more consistent retry behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->