### PR TITLE
E2E: Fix flaky NodePort ingress tests error

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1285,6 +1285,9 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 						ginkgo.By("Hitting the nodeport on " + node.Name + " and reaching all the endpoints " + protocol)
 						for i := 0; i < maxTries; i++ {
 							epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "hostname")
+							if epHostname == "" {
+								continue
+							}
 							responses.Insert(epHostname)
 
 							// each endpoint returns its hostname. By doing this, we validate that each ep was reached at least once.
@@ -1424,6 +1427,9 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 								valid := false
 								for i := 0; i < maxTries; i++ {
 									epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, address, port, "hostname")
+									if epHostname == "" {
+										continue
+									}
 									responses.Insert(epHostname)
 
 									// each endpoint returns its hostname. By doing this, we validate that each ep was reached at least once.
@@ -1496,8 +1502,13 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 						for i := 0; i < maxTries; i++ {
 							epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "hostname")
 							epClientIP := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "clientip")
+							if epHostname == "" || epClientIP == "" {
+								continue
+							}
 							epClientIP, _, err = net.SplitHostPort(epClientIP)
-							framework.ExpectNoError(err, "failed to parse client ip:port")
+							if err != nil {
+								continue
+							}
 							responses.Insert(epHostname, epClientIP)
 
 							if responses.Equal(expectedResponses) {
@@ -1505,7 +1516,6 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 								valid = true
 								break
 							}
-
 						}
 						gomega.Expect(valid).To(gomega.Equal(true), fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Actual Responses=%v", node.Name, expectedResponses, responses))
 					}
@@ -1718,6 +1728,9 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 					ginkgo.By("Hitting the external service on " + externalAddress + " and reaching all the endpoints " + protocol)
 					for i := 0; i < maxTries; i++ {
 						epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, externalAddress, externalPort, "hostname")
+						if epHostname == "" {
+							continue
+						}
 						responses.Insert(epHostname)
 
 						// each endpoint returns its hostname. By doing this, we validate that each ep was reached at least once.
@@ -1871,8 +1884,13 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 						for i := 0; i < maxTries; i++ {
 							epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "hostname")
 							epClientIP := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "clientip")
+							if epHostname == "" || epClientIP == "" {
+								continue
+							}
 							epClientIP, _, err = net.SplitHostPort(epClientIP)
-							framework.ExpectNoError(err, "failed to parse client ip:port")
+							if err != nil {
+								continue
+							}
 							responses.Insert(epHostname, epClientIP)
 
 							if responses.Equal(expectedResponses) {
@@ -1880,7 +1898,6 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 								valid = true
 								break
 							}
-
 						}
 						gomega.Expect(valid).To(gomega.Equal(true),
 							fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Actual Responses=%v", node.Name, expectedResponses, responses))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test error validation to support matching multiple error substrings with AND logic instead of single substring matching.
  * Improved test robustness by skipping invalid probe results and handling edge cases in endpoint validation.

* **Refactor**
  * Consolidated error assertion logic into reusable helper for consistent error validation across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->