### PR TITLE
Replace the last namespace address set usage in netpol with addressset manager

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_test.go
@@ -101,7 +101,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -167,7 +166,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -259,7 +257,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -331,7 +328,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -442,7 +438,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -515,7 +510,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -627,7 +621,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -754,7 +747,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1110,7 +1102,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 				config.OVNKubernetesFeature.EnableMultiNetwork = true
 				config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 				config.OVNKubernetesFeature.EnableNetworkConnect = true
@@ -1248,7 +1239,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1324,7 +1314,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1421,7 +1410,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1535,7 +1523,6 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
@@ -904,7 +904,6 @@ func initConfig(ctx *cli.Context, ovkConfig config.OVNKubernetesFeatureConfig) e
 	if err != nil {
 		return err
 	}
-	config.Kubernetes.HostNetworkNamespace = ""
 	config.OVNKubernetesFeature = ovkConfig
 	return nil
 }

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -215,7 +215,6 @@ func SetEventQueueSize(newEventQueueSize uint32) {
 }
 
 // types for dynamic handlers created when adding a network policy
-type peerNamespaceSelector struct{}
 type localPodSelector struct{}
 
 // types for handlers related to egress IP
@@ -248,7 +247,6 @@ var (
 	EgressServiceType               reflect.Type = reflect.TypeOf(&egressserviceapi.EgressService{})
 	AdminNetworkPolicyType          reflect.Type = reflect.TypeOf(&anpapi.AdminNetworkPolicy{})
 	BaselineAdminNetworkPolicyType  reflect.Type = reflect.TypeOf(&anpapi.BaselineAdminNetworkPolicy{})
-	PeerNamespaceSelectorType       reflect.Type = reflect.TypeOf(&peerNamespaceSelector{})
 	LocalPodSelectorType            reflect.Type = reflect.TypeOf(&localPodSelector{})
 	NetworkAttachmentDefinitionType reflect.Type = reflect.TypeOf(&nadapi.NetworkAttachmentDefinition{})
 	MultiNetworkPolicyType          reflect.Type = reflect.TypeOf(&mnpapi.MultiNetworkPolicy{})
@@ -1294,7 +1292,7 @@ type AddHandlerFuncType func(namespace string, sel labels.Selector, funcs cache.
 // Priority of the handler is what determine which handler would get an event first
 // This is relevant only for handlers that are sharing the same resources:
 // Pods: shared by PodType (0), EgressIPPodType (1), LocalPodSelectorType (3)
-// Namespaces: shared by NamespaceType (0), EgressIPNamespaceType (1), PeerNamespaceSelectorType (2)
+// Namespaces: shared by NamespaceType (0), EgressIPNamespaceType (1)
 // Nodes: shared by NodeType (0), EgressNodeType (1)
 // By default handlers get the defaultHandlerPriority which is 0 (highest priority). Higher the number, lower the priority to get an event.
 // Example: EgressIPPodType will always get the pod event after PodType
@@ -1307,8 +1305,6 @@ func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority int) 
 		return 3
 	case EgressIPNamespaceType:
 		return 1
-	case PeerNamespaceSelectorType:
-		return 2
 	case EgressNodeType:
 		return 1
 	default:
@@ -1349,7 +1345,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting, priority)
 		}, nil
 
-	case PeerNamespaceSelectorType, EgressIPNamespaceType:
+	case EgressIPNamespaceType:
 		return func(namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
 			return wf.AddFilteredNamespaceHandler(namespace, sel, funcs, processExisting, priority)
 		}, nil

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -666,12 +666,6 @@ var _ = Describe("Watch Factory Operations", func() {
 			testExistingFilteredHandler(PodType, LocalPodSelectorType, "default", nil, 3)
 		})
 
-		It("is called for each existing policy: PeerNamespaceSelectorType", func() {
-			policies = append(policies, newPolicy("denyall", "default"))
-			pods = append(pods, newPod("pod1", "default"))
-			testExistingFilteredHandler(NamespaceType, PeerNamespaceSelectorType, "default", nil, 2)
-		})
-
 		It("is called for each existing endpointSlice", func() {
 			endpointSlices = append(endpointSlices, newEndpointSlice("myEndpointSlice", "default", "myService"))
 			testExisting(EndpointSliceType, "", nil, defaultHandlerPriority)
@@ -1529,7 +1523,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				// Expect updates to be processed after Add
 				ot.mu.Lock()
 				defer ot.mu.Unlock()
-				Expect(ot.added).To(Equal(8), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.added).To(Equal(10), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(0))
 				ot.updated++
 				Expect(newNamespace.Status.Phase).To(Equal(corev1.NamespaceActive))
@@ -1542,10 +1536,10 @@ var _ = Describe("Watch Factory Operations", func() {
 				// Verify that deletes were processed after the updates and adds
 				ot.mu.Lock()
 				defer ot.mu.Unlock()
-				Expect(ot.added).To(Equal(8), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
-				Expect(ot.updated).To(Equal(8), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
-				Expect(ot.deleted).To(Equal(10))
-				ot.deleted = ot.deleted - 2
+				Expect(ot.added).To(Equal(10), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(10), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(1))
+				ot.deleted = ot.deleted * 10
 				Expect(newNamespace.Status.Phase).To(Equal(corev1.NamespaceTerminating))
 			},
 		})
@@ -1570,7 +1564,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				// Expect updates to be processed after Add
 				ot.mu.Lock()
 				defer ot.mu.Unlock()
-				Expect(ot.added).To(Equal(8), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.added).To(Equal(10), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(1), "update for EIP namespace %s processed before initial namespace update!", newNamespace.Name)
 				ot.updated = ot.updated * 10
 				Expect(newNamespace.Status.Phase).To(Equal(corev1.NamespaceActive))
@@ -1583,48 +1577,8 @@ var _ = Describe("Watch Factory Operations", func() {
 				// Verify that deletes were processed after the updates and adds
 				ot.mu.Lock()
 				defer ot.mu.Unlock()
-				Expect(ot.added).To(Equal(8), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
-				Expect(ot.updated).To(Equal(8), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
-				Expect(ot.deleted).To(Equal(1))
-				ot.deleted = ot.deleted * 10
-				Expect(newNamespace.Status.Phase).To(Equal(corev1.NamespaceTerminating))
-			},
-		})
-		peernsh, c3 := addPriorityHandler(wf, NamespaceType, PeerNamespaceSelectorType, cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				defer GinkgoRecover()
-				namespace := obj.(*corev1.Namespace)
-				ot, ok := testNamespaces[namespace.Name]
-				Expect(ok).To(BeTrue())
-				ot.mu.Lock()
-				defer ot.mu.Unlock()
-				Expect(ot.added).To(Equal(10), "add for peer namespace %s processed before EIP namespace add!", namespace.Name)
-				ot.added = ot.added - 2
-				Expect(namespace.Status.Phase).To(BeEmpty())
-			},
-			UpdateFunc: func(_, new interface{}) {
-				defer GinkgoRecover()
-				newNamespace := new.(*corev1.Namespace)
-				ot, ok := testNamespaces[newNamespace.Name]
-				Expect(ok).To(BeTrue())
-				// Expect updates to be processed after Add
-				ot.mu.Lock()
-				defer ot.mu.Unlock()
-				Expect(ot.added).To(Equal(8), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
-				Expect(ot.updated).To(Equal(10), "update for peer namespace %s processed before EIP namespace update!", newNamespace.Name)
-				ot.updated = ot.updated - 2
-				Expect(newNamespace.Status.Phase).To(Equal(corev1.NamespaceActive))
-			},
-			DeleteFunc: func(obj interface{}) {
-				defer GinkgoRecover()
-				newNamespace := obj.(*corev1.Namespace)
-				ot, ok := testNamespaces[newNamespace.Name]
-				Expect(ok).To(BeTrue())
-				// Verify that deletes were processed after the updates and adds
-				ot.mu.Lock()
-				defer ot.mu.Unlock()
-				Expect(ot.added).To(Equal(8), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
-				Expect(ot.updated).To(Equal(8), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.added).To(Equal(10), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(10), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
 				Expect(ot.deleted).To(Equal(0))
 				ot.deleted++
 				Expect(newNamespace.Status.Phase).To(Equal(corev1.NamespaceTerminating))
@@ -1643,23 +1597,21 @@ var _ = Describe("Watch Factory Operations", func() {
 		// Adds are done synchronously at handler addition time
 		for _, ot := range testNamespaces {
 			ot.mu.Lock()
-			// (((0 + 1) * 10) - 2) = 8
-			Expect(ot.added).To(Equal(8), "missing add for namespace %s", ot.namespace.Name)
+			// ((0 + 1) * 10) = 10
+			Expect(ot.added).To(Equal(10), "missing add for namespace %s", ot.namespace.Name)
 			ot.mu.Unlock()
 		}
 		Expect(c1.getAdded()).To(Equal(len(testNamespaces)))
 		Expect(c2.getAdded()).To(Equal(len(testNamespaces)))
-		Expect(c3.getAdded()).To(Equal(len(testNamespaces)))
 		<-done
 		// Updates are async and may take a bit longer to finish
 		Eventually(c1.getUpdated, 10).Should(Equal(len(testNamespaces)))
 		Eventually(c2.getUpdated, 10).Should(Equal(len(testNamespaces)))
-		Eventually(c3.getUpdated, 10).Should(Equal(len(testNamespaces)))
 
 		for _, ot := range testNamespaces {
 			ot.mu.Lock()
-			// (((0 + 1) * 10) - 2) = 8
-			Expect(ot.updated).To(Equal(8), "missing update for namespace %s", ot.namespace.Name)
+			// ((0 + 1) * 10) = 10
+			Expect(ot.updated).To(Equal(10), "missing update for namespace %s", ot.namespace.Name)
 			ot.mu.Unlock()
 		}
 
@@ -1675,18 +1627,16 @@ var _ = Describe("Watch Factory Operations", func() {
 		// Deletes are async and may take a bit longer to finish
 		Eventually(c1.getDeleted, 10).Should(Equal(len(testNamespaces)))
 		Eventually(c2.getDeleted, 10).Should(Equal(len(testNamespaces)))
-		Eventually(c3.getDeleted, 10).Should(Equal(len(testNamespaces)))
 
 		for _, ot := range testNamespaces {
 			ot.mu.Lock()
-			// (((0 + 1) * 10) - 2) = 8
-			Expect(ot.deleted).To(Equal(8), "missing delete for namespace %s", ot.namespace.Name)
+			// ((0 + 1) * 10) = 10
+			Expect(ot.deleted).To(Equal(10), "missing delete for namespace %s", ot.namespace.Name)
 			ot.mu.Unlock()
 		}
 
 		wf.RemoveNamespaceHandler(nsh)
 		wf.RemoveNamespaceHandler(eipnsh)
-		wf.RemoveNamespaceHandler(peernsh)
 	})
 
 	It("responds to policy add/update/delete events", func() {

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -175,6 +175,13 @@ func (m *AddressSetManager) Stop() {
 	controller.Stop(m.podController, m.nsController, m.nodeController, m.addressSetReconciler)
 }
 
+// initialSync will clean up all address sets that don't have ACL reference
+// Since addressset manager is started before its users, the cleanup for not-anymore-existing objects will be done
+// after this function returns, so we technically clean up address sets that are not used anymore on the next restart only.
+// There is no good way to know at this point which address sets will become unused after all the users finish their cleanup.
+// Address sets don't have an informer, so we won't run reconcile for every address set, only when someone requests
+// it through EnsureAddressSet, so if you look in the db directly some address sets may have stale IPs, but that only means
+// that they are not used anymore.
 func (m *AddressSetManager) initialSync() error {
 	return libovsdbutil.DeleteAddrSetsWithoutACLRefAnyController(libovsdbops.AddressSetPodSelector, m.nbClient)
 }
@@ -238,11 +245,11 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 			var addrSet addressset.AddressSet
 			switch {
 			case ipv4Mode && !ipv6Mode:
-				addrSet, err = m.addressSetFactoryV4.NewAddressSet(addrSetDbIDs, nil)
+				addrSet, err = m.addressSetFactoryV4.EnsureAddressSet(addrSetDbIDs)
 			case !ipv4Mode && ipv6Mode:
-				addrSet, err = m.addressSetFactoryV6.NewAddressSet(addrSetDbIDs, nil)
+				addrSet, err = m.addressSetFactoryV6.EnsureAddressSet(addrSetDbIDs)
 			case ipv4Mode && ipv6Mode:
-				addrSet, err = m.addressSetFactoryDualstack.NewAddressSet(addrSetDbIDs, nil)
+				addrSet, err = m.addressSetFactoryDualstack.EnsureAddressSet(addrSetDbIDs)
 			}
 			// if the first step of creating address set fails, return error since there is nothing to cleanup
 			if err != nil {

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -53,7 +53,7 @@ type podSelectorAddressSet struct {
 
 	// selectedNamespaces is a cache for namespaces that were selected by this address set during the last reconciliation
 	// used to optimize events processing.
-	selectedNamespaces sets.Set[string]
+	selectedNamespaces *selectedNamespaces
 	// selectedNodes is a cache for nodes that were selected by this address set during the last reconciliation
 	// used to optimize node event processing. Only set when nodeSelector is non-nil.
 	selectedNodes sets.Set[string]
@@ -274,6 +274,11 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 				controllerName:    controllerName,
 				netInfo:           netInfo,
 				legacyNetpolMode:  legacyNetpolMode,
+				selectedNamespaces: &selectedNamespaces{
+					set: sets.New[string](),
+					// until the first reconcile, we assume all namespaces are selected to avoid missing any updates
+					all: true,
+				},
 			}
 			m.addressSets.LoadOrStore(key, psAddrSet)
 			// this only puts key to the queue, no lock
@@ -477,14 +482,14 @@ func (m *AddressSetManager) reconcileNamespace(nsKey string) error {
 			if err != nil {
 				return err
 			}
-			if currentlyMatchedNamespaces == nil || currentlyMatchedNamespaces.Has(nsKey) {
+			if currentlyMatchedNamespaces.Has(nsKey) {
 				// this namespace is relevant for this address set, reconcile
 				m.addressSetReconciler.Reconcile(addrSetKey)
 				return nil
 			}
 			// now check if this address set was matching this namespace before, if yes, reconcile since it might not match anymore
 			previouslyMatchedNamespaces := addrSet.selectedNamespaces
-			if previouslyMatchedNamespaces == nil || previouslyMatchedNamespaces.Has(nsKey) {
+			if previouslyMatchedNamespaces.Has(nsKey) {
 				m.addressSetReconciler.Reconcile(addrSetKey)
 				return nil
 			}
@@ -694,7 +699,7 @@ func (m *AddressSetManager) reconcileAddressSet(key string) error {
 			return fmt.Errorf("failed to get selected namespaces for address set %s: %v", key, err)
 		}
 		var pods []*corev1.Pod
-		if matchedNamespaces == nil {
+		if matchedNamespaces.all {
 			// no namespace selector, use pod selector only
 			if psAddrSet.podSelector.Empty() {
 				// all cluster pods
@@ -711,7 +716,7 @@ func (m *AddressSetManager) reconcileAddressSet(key string) error {
 			}
 		} else {
 			// namespace selector is set, apply pod selector in every namespace
-			for ns := range matchedNamespaces {
+			for ns := range matchedNamespaces.set {
 				if psAddrSet.podSelector.Empty() {
 					// empty selector means no filtering, select all pods in a given namespace
 					nsPods, err := m.podLister.Pods(ns).List(labels.Everything())
@@ -755,7 +760,7 @@ func (m *AddressSetManager) reconcileAddressSet(key string) error {
 			// update m.hostNetworkSelectingAddrSets
 			m.hostNetworkNamespaceLock.Lock()
 			if m.hostNetworkNamespaceExists {
-				if matchedNamespaces == nil || matchedNamespaces.Has(config.Kubernetes.HostNetworkNamespace) {
+				if matchedNamespaces.Has(config.Kubernetes.HostNetworkNamespace) {
 					for _, hostnetIPs := range m.hostNetworkNamespaceIPsPerNode {
 						ips = append(ips, hostnetIPs...)
 					}
@@ -778,16 +783,28 @@ func (m *AddressSetManager) reconcileAddressSet(key string) error {
 	})
 }
 
+type selectedNamespaces struct {
+	set sets.Set[string]
+	// if true, it means all namespaces are selected, so set won't be populated
+	all bool
+}
+
+func (s *selectedNamespaces) Has(namespace string) bool {
+	return s.all || s.set.Has(namespace)
+}
+
 // getSelectedNamespaces returns a set of namespaces that should be selected for a given podSelectorAddressSet.
 // nil set means no namespace selector is set and all namespaces match.
-func (m *AddressSetManager) getSelectedNamespaces(s *podSelectorAddressSet) (sets.Set[string], error) {
-	matchedNamespaces := sets.New[string]()
+func (m *AddressSetManager) getSelectedNamespaces(s *podSelectorAddressSet) (*selectedNamespaces, error) {
+	matchedNamespaces := &selectedNamespaces{
+		set: sets.New[string](),
+	}
 	if s.namespace != "" {
 		// static namespace case
-		matchedNamespaces.Insert(s.namespace)
+		matchedNamespaces.set.Insert(s.namespace)
 	} else if s.namespaceSelector.Empty() {
 		// any namespace
-		matchedNamespaces = nil
+		matchedNamespaces.all = true
 	} else {
 		// selected namespaces
 		namespaces, err := m.namespaceLister.List(s.namespaceSelector)
@@ -795,7 +812,7 @@ func (m *AddressSetManager) getSelectedNamespaces(s *podSelectorAddressSet) (set
 			return nil, fmt.Errorf("failed to list namespaces: %v", err)
 		}
 		for _, ns := range namespaces {
-			matchedNamespaces.Insert(ns.Name)
+			matchedNamespaces.set.Insert(ns.Name)
 		}
 	}
 	return matchedNamespaces, nil

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -5,6 +5,7 @@ package addresssetmanager
 
 import (
 	"fmt"
+	"net"
 	"slices"
 	"sort"
 	"strings"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -95,11 +97,12 @@ type AddressSetManager struct {
 	// All network controllers are getting this function from the same networkmanager, so we can share it
 	getNetworkNameForNADKey func(nadKey string) string
 
-	// both hostNetworkNamespaceIps and hostNetworkSelectingAddrSets are protected by the same lock.
+	// hostNetworkNamespaceExists, hostNetworkNamespaceIPsPerNode and hostNetworkSelectingAddrSets are protected by the same lock.
 	// can only be taken after the addressSets key lock and never vice versa to avoid deadlocks.
-	hostNetworkNamespaceLock sync.RWMutex
+	hostNetworkNamespaceLock   sync.RWMutex
+	hostNetworkNamespaceExists bool
 	// local cache of HostNetworkNamespace address set IPs
-	hostNetworkNamespaceIps []string
+	hostNetworkNamespaceIPsPerNode map[string][]string
 	// local cache of address sets that select HostNetworkNamespace
 	hostNetworkSelectingAddrSets sets.Set[string]
 }
@@ -107,17 +110,18 @@ type AddressSetManager struct {
 func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInformer coreinformers.NamespaceInformer,
 	nodeInformer coreinformers.NodeInformer, nbClient libovsdbclient.Client, getNetworkNameForNADKey func(nadKey string) string) *AddressSetManager {
 	m := &AddressSetManager{
-		name:                         "pod-selector-address-set-manager",
-		nbClient:                     nbClient,
-		addressSetFactoryV4:          addressset.NewOvnAddressSetFactory(nbClient, true, false),
-		addressSetFactoryV6:          addressset.NewOvnAddressSetFactory(nbClient, false, true),
-		addressSetFactoryDualstack:   addressset.NewOvnAddressSetFactory(nbClient, true, true),
-		addressSets:                  syncmap.NewSyncMap[*podSelectorAddressSet](),
-		podLister:                    podInformer.Lister(),
-		namespaceLister:              namespaceInformer.Lister(),
-		nodeLister:                 nodeInformer.Lister(),
-		getNetworkNameForNADKey:      getNetworkNameForNADKey,
-		hostNetworkSelectingAddrSets: sets.New[string](),
+		name:                           "pod-selector-address-set-manager",
+		nbClient:                       nbClient,
+		addressSetFactoryV4:            addressset.NewOvnAddressSetFactory(nbClient, true, false),
+		addressSetFactoryV6:            addressset.NewOvnAddressSetFactory(nbClient, false, true),
+		addressSetFactoryDualstack:     addressset.NewOvnAddressSetFactory(nbClient, true, true),
+		addressSets:                    syncmap.NewSyncMap[*podSelectorAddressSet](),
+		podLister:                      podInformer.Lister(),
+		namespaceLister:                namespaceInformer.Lister(),
+		nodeLister:                     nodeInformer.Lister(),
+		getNetworkNameForNADKey:        getNetworkNameForNADKey,
+		hostNetworkSelectingAddrSets:   sets.New[string](),
+		hostNetworkNamespaceIPsPerNode: make(map[string][]string),
 	}
 	podCfg := &controller.ControllerConfig[corev1.Pod]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -183,6 +187,11 @@ func (m *AddressSetManager) Stop() {
 // it through EnsureAddressSet, so if you look in the db directly some address sets may have stale IPs, but that only means
 // that they are not used anymore.
 func (m *AddressSetManager) initialSync() error {
+	if config.Kubernetes.HostNetworkNamespace != "" {
+		if err := m.updateHostNetworkNamespaceExists(); err != nil {
+			return fmt.Errorf("failed to check if host network namespace %s exists: %v", config.Kubernetes.HostNetworkNamespace, err)
+		}
+	}
 	return libovsdbutil.DeleteAddrSetsWithoutACLRefAnyController(libovsdbops.AddressSetPodSelector, m.nbClient)
 }
 
@@ -414,7 +423,43 @@ func (m *AddressSetManager) nsNeedUpdate(old, new *corev1.Namespace) bool {
 	return false
 }
 
+func (m *AddressSetManager) updateHostNetworkNamespaceExists() error {
+	_, err := m.namespaceLister.Get(config.Kubernetes.HostNetworkNamespace)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get host network namespace %s: %v", config.Kubernetes.HostNetworkNamespace, err)
+		}
+	}
+	m.hostNetworkNamespaceLock.Lock()
+	defer m.hostNetworkNamespaceLock.Unlock()
+	if err != nil {
+		// namespace was deleted/never existed
+		clear(m.hostNetworkNamespaceIPsPerNode)
+		m.hostNetworkNamespaceExists = false
+		return nil
+	}
+	if !m.hostNetworkNamespaceExists {
+		// namespace was just created, get all existing host network IPs
+		ips, err := m.getAllHostNamespaceAddresses()
+		if err != nil {
+			return fmt.Errorf("error getting host network namespace %s IPs: %v", config.Kubernetes.HostNetworkNamespace, err)
+		}
+
+		m.hostNetworkNamespaceIPsPerNode = ips
+		for addrSetKey := range m.hostNetworkSelectingAddrSets {
+			m.addressSetReconciler.Reconcile(addrSetKey)
+		}
+	}
+	m.hostNetworkNamespaceExists = true
+	return nil
+}
+
 func (m *AddressSetManager) reconcileNamespace(nsKey string) error {
+	if config.Kubernetes.HostNetworkNamespace != "" && nsKey == config.Kubernetes.HostNetworkNamespace {
+		if err := m.updateHostNetworkNamespaceExists(); err != nil {
+			return fmt.Errorf("failed to check if host network namespace %s exists: %v", config.Kubernetes.HostNetworkNamespace, err)
+		}
+	}
 	// find address sets that could be affected by this namespace event
 	// Get all existing keys, then lock address sets per key and check if they are affected.
 	// If the new keys are added, it will always call reconcile for that new key, so there is no race.
@@ -461,10 +506,23 @@ func (m *AddressSetManager) nodeNeedUpdate(old, new *corev1.Node) bool {
 		// if node labels change, we need to reconcile address sets that use a node selector
 		return true
 	}
+	// only check annotations that are used in getHostNamespaceAddressesForNode
+	if util.NodeSubnetAnnotationChangedForNetwork(old, new, ovntypes.DefaultNetworkName) || util.NodeIDAnnotationChanged(old, new) ||
+		old.Annotations[util.OvnNodeIfAddr] != new.Annotations[util.OvnNodeIfAddr] {
+		// hostnetwork namespace may need to be updated
+		m.hostNetworkNamespaceLock.Lock()
+		defer m.hostNetworkNamespaceLock.Unlock()
+		return m.hostNetworkNamespaceExists
+	}
+
 	return false
 }
 
 func (m *AddressSetManager) reconcileNode(nodeKey string) error {
+	// update host network IPs first to have fresh info for addr set reconcile
+	// don't return error immediately to let other changes like node selector be propagated
+	hostNetworkErr := m.updateHostNetworkIPs(nodeKey)
+
 	// find address sets that could be affected by this node event
 	// Get all existing keys, then lock address sets per key and check if they are affected.
 	// If the new keys are added, it will always call reconcile for that new key, so there is no race.
@@ -500,54 +558,129 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 			return fmt.Errorf("failed to reconcile address set %s for node %s: %v", addrSetKey, nodeKey, err)
 		}
 	}
+	return hostNetworkErr
+}
+
+func (m *AddressSetManager) updateHostNetworkIPs(nodeName string) error {
+	m.hostNetworkNamespaceLock.Lock()
+	defer m.hostNetworkNamespaceLock.Unlock()
+	if !m.hostNetworkNamespaceExists {
+		return nil
+	}
+	node, err := m.nodeLister.Get(nodeName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get node %s: %v", nodeName, err)
+	}
+	if err != nil || config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
+		// delete event OR node started matching hybrid overlay and should be ignored for host network namespace
+		// delete host network IPs for this node from host network namespace's address set
+		updated := len(m.hostNetworkNamespaceIPsPerNode[nodeName]) != 0
+		delete(m.hostNetworkNamespaceIPsPerNode, nodeName)
+
+		if !updated {
+			return nil
+		}
+		for addrSetKey := range m.hostNetworkSelectingAddrSets {
+			m.addressSetReconciler.Reconcile(addrSetKey)
+		}
+		return nil
+	}
+	// add/update node event
+	hostNetworkPolicyIPs, err := m.getHostNamespaceAddressesForNode(node)
+	if err != nil {
+		return fmt.Errorf("error parsing annotation for node %s: %w", node.Name, err)
+	}
+	// add the host network IPs for this node to host network namespace's address set
+	// hostNetworkPolicyIPs is built from the annotations and always preserves ips order
+	if slices.Equal(m.hostNetworkNamespaceIPsPerNode[node.Name], hostNetworkPolicyIPs) {
+		return nil
+	}
+	m.hostNetworkNamespaceIPsPerNode[node.Name] = hostNetworkPolicyIPs
+	for addrSetKey := range m.hostNetworkSelectingAddrSets {
+		m.addressSetReconciler.Reconcile(addrSetKey)
+	}
 	return nil
 }
 
-func (m *AddressSetManager) SetHostNetworkNamespaceIPs(ips []string) {
-	m.hostNetworkNamespaceLock.Lock()
-	defer m.hostNetworkNamespaceLock.Unlock()
-	m.hostNetworkNamespaceIps = ips
-	for addrSetKey := range m.hostNetworkSelectingAddrSets {
-		m.addressSetReconciler.Reconcile(addrSetKey)
-	}
-}
-
-func (m *AddressSetManager) AddHostNetworkNamespaceIPs(ips []string) {
-	m.hostNetworkNamespaceLock.Lock()
-	defer m.hostNetworkNamespaceLock.Unlock()
-	updated := false
-	for _, ip := range ips {
-		if !slices.Contains(m.hostNetworkNamespaceIps, ip) {
-			updated = true
-			m.hostNetworkNamespaceIps = append(m.hostNetworkNamespaceIps, ip)
+// getAllHostNamespaceAddresses retrieves management port and gateway router LRP
+// IP for all nodes in the cluster
+func (m *AddressSetManager) getAllHostNamespaceAddresses() (map[string][]string, error) {
+	ips := make(map[string][]string)
+	// add the mp0 interface addresses to this namespace.
+	existingNodes, err := m.nodeLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get all nodes (%v)", err)
+	} else {
+		for _, node := range existingNodes {
+			if config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
+				// skip hybrid overlay nodes
+				continue
+			}
+			hostNetworkIPs, err := m.getHostNamespaceAddressesForNode(node)
+			if err != nil {
+				klog.Errorf("Error parsing annotation for node %s: %v", node.Name, err)
+			}
+			ips[node.Name] = hostNetworkIPs
 		}
 	}
-	if !updated {
-		return
-	}
-	for addrSetKey := range m.hostNetworkSelectingAddrSets {
-		m.addressSetReconciler.Reconcile(addrSetKey)
-	}
+	return ips, nil
 }
 
-func (m *AddressSetManager) DeleteHostNetworkNamespaceIPs(ips []string) {
-	m.hostNetworkNamespaceLock.Lock()
-	defer m.hostNetworkNamespaceLock.Unlock()
-	updated := false
-	for _, ip := range ips {
-		ipIdx := slices.Index(m.hostNetworkNamespaceIps, ip)
-		if ipIdx == -1 {
-			continue
+// getHostNamespaceAddressesForNode retrieves management port and gateway router LRP
+// IP of a specific node
+func (m *AddressSetManager) getHostNamespaceAddressesForNode(node *corev1.Node) ([]string, error) {
+	var ips []string
+	defaultNetInfo := &util.DefaultNetInfo{}
+	hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, ovntypes.DefaultNetworkName)
+	if err != nil {
+		if !util.IsAnnotationNotSetError(err) {
+			return nil, fmt.Errorf("failed to get node host subnets: %w", err)
 		}
-		m.hostNetworkNamespaceIps = slices.Delete(m.hostNetworkNamespaceIps, ipIdx, ipIdx+1)
-		updated = true
 	}
-	if !updated {
-		return
+	for _, hostSubnet := range hostSubnets {
+		mgmtIfAddr := defaultNetInfo.GetNodeManagementIP(hostSubnet)
+		if mgmtIfAddr == nil {
+			return nil, fmt.Errorf("node %s has no management IP in subnet %s", node.Name, hostSubnet.String())
+		}
+		ips = append(ips, mgmtIfAddr.IP.String())
 	}
-	for addrSetKey := range m.hostNetworkSelectingAddrSets {
-		m.addressSetReconciler.Reconcile(addrSetKey)
+	// for shared gateway mode we will use LRP IPs to SNAT host network traffic
+	// so add these to the address set.
+	lrpIPs, gwIPsErr := udn.GetGWRouterIPs(node, defaultNetInfo)
+	if gwIPsErr != nil {
+		if !util.IsAnnotationNotSetError(gwIPsErr) {
+			return nil, gwIPsErr
+		}
 	}
+
+	for _, lrpIP := range lrpIPs {
+		ips = append(ips, lrpIP.IP.String())
+	}
+	// When NoOverlay mode is enabled, also include the node's primary physical interface IP
+	if defaultNetInfo.Transport() == ovntypes.NetworkTransportNoOverlay {
+		nodeIfAddr, err := util.GetNodeIfAddrAnnotation(node)
+		if err != nil {
+			if !util.IsAnnotationNotSetError(err) {
+				return nil, fmt.Errorf("failed to get node primary interface address: %w", err)
+			}
+		} else {
+			if nodeIfAddr.IPv4 != "" {
+				ipv4, _, err := net.ParseCIDR(nodeIfAddr.IPv4)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse node primary IPv4 address %s: %w", nodeIfAddr.IPv4, err)
+				}
+				ips = append(ips, ipv4.String())
+			}
+			if nodeIfAddr.IPv6 != "" {
+				ipv6, _, err := net.ParseCIDR(nodeIfAddr.IPv6)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse node primary IPv6 address %s: %w", nodeIfAddr.IPv6, err)
+				}
+				ips = append(ips, ipv6.String())
+			}
+		}
+	}
+	return ips, nil
 }
 
 func (m *AddressSetManager) reconcileAddressSet(key string) error {
@@ -621,11 +754,15 @@ func (m *AddressSetManager) reconcileAddressSet(key string) error {
 			psAddrSet.podSelector.Empty() {
 			// update m.hostNetworkSelectingAddrSets
 			m.hostNetworkNamespaceLock.Lock()
-			if matchedNamespaces == nil || matchedNamespaces.Has(config.Kubernetes.HostNetworkNamespace) {
-				ips = append(ips, m.hostNetworkNamespaceIps...)
-				m.hostNetworkSelectingAddrSets.Insert(key)
-			} else {
-				m.hostNetworkSelectingAddrSets.Delete(key)
+			if m.hostNetworkNamespaceExists {
+				if matchedNamespaces == nil || matchedNamespaces.Has(config.Kubernetes.HostNetworkNamespace) {
+					for _, hostnetIPs := range m.hostNetworkNamespaceIPsPerNode {
+						ips = append(ips, hostnetIPs...)
+					}
+					m.hostNetworkSelectingAddrSets.Insert(key)
+				} else {
+					m.hostNetworkSelectingAddrSets.Delete(key)
+				}
 			}
 			m.hostNetworkNamespaceLock.Unlock()
 		}

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +23,7 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
@@ -57,6 +59,13 @@ type podSelectorAddressSet struct {
 	// network-specific fields
 	controllerName string
 	netInfo        util.NetInfo
+
+	// legacyNetpolMode makes nil and empty PodSelectors behave differently (it shouldn't be the case,
+	// but this is a legacy behaviour that customers rely on).
+	// when set to true hostNetwork pods aren't selected,
+	// and config.Kubernetes.HostNetworkNamespace address set IPs will be included when that namespace is matched and
+	// podSelector is empty.
+	legacyNetpolMode bool
 }
 
 // AddressSetManager manages shared address sets with pod IPs based on provided pod and namespace selectors.
@@ -85,21 +94,30 @@ type AddressSetManager struct {
 
 	// All network controllers are getting this function from the same networkmanager, so we can share it
 	getNetworkNameForNADKey func(nadKey string) string
+
+	// both hostNetworkNamespaceIps and hostNetworkSelectingAddrSets are protected by the same lock.
+	// can only be taken after the addressSets key lock and never vice versa to avoid deadlocks.
+	hostNetworkNamespaceLock sync.RWMutex
+	// local cache of HostNetworkNamespace address set IPs
+	hostNetworkNamespaceIps []string
+	// local cache of address sets that select HostNetworkNamespace
+	hostNetworkSelectingAddrSets sets.Set[string]
 }
 
 func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInformer coreinformers.NamespaceInformer,
 	nodeInformer coreinformers.NodeInformer, nbClient libovsdbclient.Client, getNetworkNameForNADKey func(nadKey string) string) *AddressSetManager {
 	m := &AddressSetManager{
-		name:                       "pod-selector-address-set-manager",
-		nbClient:                   nbClient,
-		addressSetFactoryV4:        addressset.NewOvnAddressSetFactory(nbClient, true, false),
-		addressSetFactoryV6:        addressset.NewOvnAddressSetFactory(nbClient, false, true),
-		addressSetFactoryDualstack: addressset.NewOvnAddressSetFactory(nbClient, true, true),
-		addressSets:                syncmap.NewSyncMap[*podSelectorAddressSet](),
-		podLister:                  podInformer.Lister(),
-		namespaceLister:            namespaceInformer.Lister(),
+		name:                         "pod-selector-address-set-manager",
+		nbClient:                     nbClient,
+		addressSetFactoryV4:          addressset.NewOvnAddressSetFactory(nbClient, true, false),
+		addressSetFactoryV6:          addressset.NewOvnAddressSetFactory(nbClient, false, true),
+		addressSetFactoryDualstack:   addressset.NewOvnAddressSetFactory(nbClient, true, true),
+		addressSets:                  syncmap.NewSyncMap[*podSelectorAddressSet](),
+		podLister:                    podInformer.Lister(),
+		namespaceLister:              namespaceInformer.Lister(),
 		nodeLister:                 nodeInformer.Lister(),
-		getNetworkNameForNADKey:    getNetworkNameForNADKey,
+		getNetworkNameForNADKey:      getNetworkNameForNADKey,
+		hostNetworkSelectingAddrSets: sets.New[string](),
 	}
 	podCfg := &controller.ControllerConfig[corev1.Pod]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -169,11 +187,13 @@ func (m *AddressSetManager) initialSync() error {
 // podSelector = metav1.LabelSelector{} + static namespace may be replaced with namespace address set,
 // podSelector = metav1.LabelSelector{} + namespaceSelector may be replaced with a set of namespace address sets,
 // but both cases will work here too.
+// legacyNetpolMode will not select hostnetwork pod IPs and will include config.Kubernetes.HostNetworkNamespace address set IPs
+// when that namespace is matched with an empty pod selector.
 //
 // backRef is the key that should be used for cleanup.
 // psAddrSetHashV4, psAddrSetHashV6 may be set to empty string if address set for that ipFamily wasn't created.
 func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector,
-	namespace, backRef, controllerName string, netInfo util.NetInfo) (addrSetKey, psAddrSetHashV4, psAddrSetHashV6 string, err error) {
+	namespace, backRef, controllerName string, netInfo util.NetInfo, legacyNetpolMode bool) (addrSetKey, psAddrSetHashV4, psAddrSetHashV6 string, err error) {
 	nodeSelector = normalizeNodeSelector(nodeSelector)
 	if podSelector == nil {
 		err = fmt.Errorf("pod selector is nil")
@@ -208,12 +228,12 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 			return
 		}
 	}
-	addrSetKey = getInternalKey(podSelector, namespaceSelector, nodeSelector, namespace, controllerName)
+	addrSetKey = getInternalKey(podSelector, namespaceSelector, nodeSelector, namespace, controllerName, legacyNetpolMode)
 
 	err = m.addressSets.DoWithLock(addrSetKey, func(key string) error {
 		psAddrSet, found := m.addressSets.Load(key)
 		if !found {
-			addrSetDbIDs := GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector, nodeSelector, namespace, controllerName)
+			addrSetDbIDs := GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector, nodeSelector, namespace, controllerName, legacyNetpolMode)
 			ipv4Mode, ipv6Mode := netInfo.IPMode()
 			var addrSet addressset.AddressSet
 			switch {
@@ -237,6 +257,7 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 				addressSet:        addrSet,
 				controllerName:    controllerName,
 				netInfo:           netInfo,
+				legacyNetpolMode:  legacyNetpolMode,
 			}
 			m.addressSets.LoadOrStore(key, psAddrSet)
 			// this only puts key to the queue, no lock
@@ -284,6 +305,9 @@ func (m *AddressSetManager) DeleteAddressSet(addrSetKey, backRef string) error {
 				return err
 			}
 			m.addressSets.Delete(key)
+			m.hostNetworkNamespaceLock.Lock()
+			m.hostNetworkSelectingAddrSets.Delete(key)
+			m.hostNetworkNamespaceLock.Unlock()
 		}
 		return nil
 	})
@@ -472,6 +496,53 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 	return nil
 }
 
+func (m *AddressSetManager) SetHostNetworkNamespaceIPs(ips []string) {
+	m.hostNetworkNamespaceLock.Lock()
+	defer m.hostNetworkNamespaceLock.Unlock()
+	m.hostNetworkNamespaceIps = ips
+	for addrSetKey := range m.hostNetworkSelectingAddrSets {
+		m.addressSetReconciler.Reconcile(addrSetKey)
+	}
+}
+
+func (m *AddressSetManager) AddHostNetworkNamespaceIPs(ips []string) {
+	m.hostNetworkNamespaceLock.Lock()
+	defer m.hostNetworkNamespaceLock.Unlock()
+	updated := false
+	for _, ip := range ips {
+		if !slices.Contains(m.hostNetworkNamespaceIps, ip) {
+			updated = true
+			m.hostNetworkNamespaceIps = append(m.hostNetworkNamespaceIps, ip)
+		}
+	}
+	if !updated {
+		return
+	}
+	for addrSetKey := range m.hostNetworkSelectingAddrSets {
+		m.addressSetReconciler.Reconcile(addrSetKey)
+	}
+}
+
+func (m *AddressSetManager) DeleteHostNetworkNamespaceIPs(ips []string) {
+	m.hostNetworkNamespaceLock.Lock()
+	defer m.hostNetworkNamespaceLock.Unlock()
+	updated := false
+	for _, ip := range ips {
+		ipIdx := slices.Index(m.hostNetworkNamespaceIps, ip)
+		if ipIdx == -1 {
+			continue
+		}
+		m.hostNetworkNamespaceIps = slices.Delete(m.hostNetworkNamespaceIps, ipIdx, ipIdx+1)
+		updated = true
+	}
+	if !updated {
+		return
+	}
+	for addrSetKey := range m.hostNetworkSelectingAddrSets {
+		m.addressSetReconciler.Reconcile(addrSetKey)
+	}
+}
+
 func (m *AddressSetManager) reconcileAddressSet(key string) error {
 	return m.addressSets.DoWithLock(key, func(key string) error {
 		psAddrSet, found := m.addressSets.Load(key)
@@ -533,10 +604,25 @@ func (m *AddressSetManager) reconcileAddressSet(key string) error {
 			pods = filtered
 			psAddrSet.selectedNodes = selectedNodes
 		}
-		ips, err := m.getPodIPs(pods, psAddrSet.netInfo)
+		ips, err := m.getPodIPs(pods, psAddrSet.netInfo, psAddrSet.legacyNetpolMode)
 		if err != nil {
 			return fmt.Errorf("failed to get pod IPs: %v", err)
 		}
+		// now check if this address set should add hostNetworkNamespace IPs
+		// it only makes sense for the default network
+		if psAddrSet.legacyNetpolMode && psAddrSet.netInfo.IsDefault() && config.Kubernetes.HostNetworkNamespace != "" &&
+			psAddrSet.podSelector.Empty() {
+			// update m.hostNetworkSelectingAddrSets
+			m.hostNetworkNamespaceLock.Lock()
+			if matchedNamespaces == nil || matchedNamespaces.Has(config.Kubernetes.HostNetworkNamespace) {
+				ips = append(ips, m.hostNetworkNamespaceIps...)
+				m.hostNetworkSelectingAddrSets.Insert(key)
+			} else {
+				m.hostNetworkSelectingAddrSets.Delete(key)
+			}
+			m.hostNetworkNamespaceLock.Unlock()
+		}
+
 		// this operation doesn't check the contents on the address set and will run a db transaction
 		// every time, may be improved.
 		err = psAddrSet.addressSet.SetAddresses(ips)
@@ -584,9 +670,13 @@ func (m *AddressSetManager) getSelectedNodes(nodeSelector labels.Selector) (sets
 	return names, nil
 }
 
-func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, netInfo util.NetInfo) ([]string, error) {
+func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, netInfo util.NetInfo, noHostNetwork bool) ([]string, error) {
 	ips := []string{}
 	for _, pod := range pods {
+		if noHostNetwork && pod.Spec.HostNetwork {
+			// skip hostNetwork pods if requested, since they are not selected in legacyNetpolMode
+			continue
+		}
 		if pod.Annotations[util.OvnPodAnnotationName] == "" && len(pod.Status.PodIPs) == 0 {
 			// pod doesn't have IPs yet, skip it
 			continue
@@ -606,9 +696,9 @@ func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, netInfo util.NetInfo) 
 	return ips, nil
 }
 
-func GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace, controller string) *libovsdbops.DbObjectIDs {
+func GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace, controller string, legacyNetpolMode bool) *libovsdbops.DbObjectIDs {
 	nodeSelector = normalizeNodeSelector(nodeSelector)
-	addrsetKey := getPodSelectorKey(podSelector, namespaceSelector, nodeSelector, namespace)
+	addrsetKey := getPodSelectorKey(podSelector, namespaceSelector, nodeSelector, namespace, legacyNetpolMode)
 	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetPodSelector, controller, map[libovsdbops.ExternalIDKey]string{
 		// pod selector address sets are cluster-scoped, only need name
 		libovsdbops.ObjectNameKey: addrsetKey,
@@ -681,11 +771,11 @@ func shortLabelSelectorString(sel *metav1.LabelSelector) string {
 
 // Since we have joined this manager for multiple controllers, we need to make keys unique across controllers.
 // In the db it is already achieved by using controller name in ExternalIDs, but for internal map we also need to add controller name
-func getInternalKey(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace, controllerName string) string {
-	return controllerName + "_" + getPodSelectorKey(podSelector, namespaceSelector, nodeSelector, namespace)
+func getInternalKey(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace, controllerName string, legacyNetpolMode bool) string {
+	return controllerName + "_" + getPodSelectorKey(podSelector, namespaceSelector, nodeSelector, namespace, legacyNetpolMode)
 }
 
-func getPodSelectorKey(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace string) string {
+func getPodSelectorKey(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector, namespace string, legacyNetpolMode bool) string {
 	var namespaceKey string
 	if namespaceSelector == nil {
 		// namespace is static
@@ -697,7 +787,11 @@ func getPodSelectorKey(podSelector, namespaceSelector, nodeSelector *metav1.Labe
 	if nodeSelector != nil {
 		key += "_" + shortLabelSelectorString(nodeSelector)
 	}
-	return key
+	if legacyNetpolMode {
+		return key + "_LNM"
+	} else {
+		return key
+	}
 }
 
 func normalizeNodeSelector(sel *metav1.LabelSelector) *metav1.LabelSelector {

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -34,17 +34,19 @@ func getPolicyKeyWithKind(policy *knet.NetworkPolicy) string {
 	return fmt.Sprintf("%v/%v/%v", "NetworkPolicy", policy.Namespace, policy.Name)
 }
 
-func eventuallyExpectAddressSetsWithIP(asf *addressset.FakeAddressSetFactory, peer knet.NetworkPolicyPeer, namespace, ip string) {
+func eventuallyExpectAddressSetsWithIP(nbClient libovsdbclient.Client, peer knet.NetworkPolicyPeer, namespace, ip string) {
 	if peer.PodSelector != nil {
 		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace, controllerName, false)
-		asf.EventuallyExpectAddressSetWithAddresses(dbIDs, []string{ip})
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{ip})
+		gomega.Eventually(nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 	}
 }
 
-func eventuallyExpectEmptyAddressSetsExist(asf *addressset.FakeAddressSetFactory, peer knet.NetworkPolicyPeer, namespace string) {
+func eventuallyExpectEmptyAddressSetsExist(nbClient libovsdbclient.Client, peer knet.NetworkPolicyPeer, namespace string) {
 	if peer.PodSelector != nil {
 		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace, controllerName, false)
-		asf.EventuallyExpectEmptyAddressSetExist(dbIDs)
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{})
+		gomega.Eventually(nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 	}
 }
 
@@ -64,7 +66,6 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		node1MgmtIP    = "10.244.0.2"
 	)
 	var (
-		asf               *addressset.FakeAddressSetFactory
 		addressSetManager *AddressSetManager
 		wf                *factory.WatchFactory
 		clientSet         *util.OVNKubeControllerClientset
@@ -76,7 +77,6 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
-		asf = addressset.NewFakeAddressSetFactory(controllerName)
 		initialDB = libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{},
 		}
@@ -109,7 +109,6 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
 			func(_ string) string { return "" })
-		addressSetManager.addressSetFactoryV4 = asf
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
@@ -140,8 +139,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("is not a valid label selector operator"))
 		// address set will not be created
-		peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, networkPolicy.Namespace, controllerName, false)
-		asf.EventuallyExpectNoAddressSet(peerASIDs)
+		gomega.Consistently(addressSetManager.nbClient, 100*time.Millisecond, 20*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{}))
 
 		// add nil pod selector
 		_, _, _, err = addressSetManager.EnsureAddressSet(
@@ -149,8 +147,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("pod selector is nil"))
 		// address set will not be created
-		peerASIDs = GetPodSelectorAddrSetDbIDs(nil, peer.NamespaceSelector, nil, networkPolicy.Namespace, controllerName, false)
-		asf.EventuallyExpectNoAddressSet(peerASIDs)
+		gomega.Consistently(addressSetManager.nbClient, 100*time.Millisecond, 20*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{}))
 
 		// namespace selector is nil and namespace is empty
 		_, _, _, err = addressSetManager.EnsureAddressSet(
@@ -158,8 +155,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("namespace selector is nil and namespace is empty"))
 		// address set will not be created
-		peerASIDs = GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, nil, "", controllerName, false)
-		asf.EventuallyExpectNoAddressSet(peerASIDs)
+		gomega.Consistently(addressSetManager.nbClient, 100*time.Millisecond, 20*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{}))
 	})
 	ginkgo.It("creates one address set for multiple users with the same selector", func() {
 		namespace1 := *testing.NewNamespace(namespaceName1)
@@ -179,9 +175,9 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name, controllerName, false)
-		asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+		peerAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{})
 		// expect peer address set only
-		asf.ExpectNumberOfAddressSets(1)
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{peerAS}))
 	})
 	ginkgo.It("creates different address set for multiple users with the same selector depending on legacyNetpolMode", func() {
 		namespace1 := *testing.NewNamespace(namespaceName1)
@@ -205,12 +201,12 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 
 		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name,
 			controllerName, false)
-		asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
-		peerASIDs = GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name,
+		peerAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{})
+		peerASLegacyIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name,
 			controllerName, true)
-		asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+		peerASLegacy, _ := addressset.GetTestDbAddrSets(peerASLegacyIDs, []string{})
 		// expect 2 peer address sets only
-		asf.ExpectNumberOfAddressSets(2)
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{peerAS, peerASLegacy}))
 	})
 	ginkgo.DescribeTable("adds selected pod ips to the address set",
 		func(peer knet.NetworkPolicyPeer, staticNamespace string, addrSetIPs []string, legacyMode bool) {
@@ -245,7 +241,8 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// address set should be created and pod ips added
 			peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, controllerName, legacyMode)
-			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, addrSetIPs)
+			peerAS, _ := addressset.GetTestDbAddrSets(peerASIDs, addrSetIPs)
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{peerAS}))
 		},
 		ginkgo.Entry("all pods from a static namespace", knet.NetworkPolicyPeer{
 			PodSelector:       &metav1.LabelSelector{},
@@ -336,7 +333,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			},
 		}, namespaceName1, []string{ip3}, true),
 	)
-	ginkgo.It("on initial sync deletes unreferenced and leaves referenced address sets", func() {
+	ginkgo.It("on initial sync deletes unreferenced and updates referenced address sets", func() {
 		unusedPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", controllerName, false)
 		unusedPodSelAS, _ := addressset.GetTestDbAddrSets(unusedPodSelIDs, []string{"1.1.1.2"})
 		refNetpolIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName2", controllerName, false)
@@ -401,6 +398,24 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			},
 		}
 		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(finalDB))
+		// now request address sets for the referenced netpol and pod selector, addresses should be updated to empty
+		// because no pods exist in that namespace
+		_, _, _, err := addressSetManager.EnsureAddressSet(
+			&metav1.LabelSelector{}, nil, nil, "nsName2", "backref", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		updatedNetpolAS, _ := addressset.GetTestDbAddrSets(refNetpolIDs, []string{})
+		updatedDB := []libovsdbtest.TestData{
+			updatedNetpolAS,
+			netpolACL,
+			refPodSelAS,
+			podSelACL,
+			&nbdb.LogicalSwitch{
+				UUID: "node",
+				ACLs: []string{podSelACL.UUID, netpolACL.UUID},
+			},
+		}
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(updatedDB))
+
 	})
 	ginkgo.It("reconciles a completed and deleted pod whose IP has been assigned to a running pod", func() {
 		namespace1 := *testing.NewNamespace(namespaceName1)
@@ -424,7 +439,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 				metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		// pod should be added to the address set
-		eventuallyExpectAddressSetsWithIP(asf, peer, namespace1.Name, podIP)
+		eventuallyExpectAddressSetsWithIP(addressSetManager.nbClient, peer, namespace1.Name, podIP)
 
 		// Spawn a pod with an IP address that collides with a completed pod (we don't watch pods in this test,
 		// therefore the same ip is allowed)
@@ -443,7 +458,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// make sure the delete event is handled and address set is not changed
 		time.Sleep(100 * time.Millisecond)
 		// Running pod policy should not be affected by pod deletions
-		eventuallyExpectAddressSetsWithIP(asf, peer, namespace1.Name, podIP)
+		eventuallyExpectAddressSetsWithIP(addressSetManager.nbClient, peer, namespace1.Name, podIP)
 	})
 	ginkgo.It("reconciles a completed pod whose IP has been assigned to a running pod with non-matching namespace selector", func() {
 		namespace1 := *testing.NewNamespace(namespaceName1)
@@ -473,7 +488,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 				metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		// pod should be added to the address set
-		eventuallyExpectAddressSetsWithIP(asf, peer, namespace1.Name, podIP)
+		eventuallyExpectAddressSetsWithIP(addressSetManager.nbClient, peer, namespace1.Name, podIP)
 
 		// Spawn a pod with an IP address that collides with a completed pod (we don't watch pods in this test,
 		// therefore the same ip is allowed). This pod has another namespace that is not matched by the address set
@@ -491,7 +506,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 
 		// IP should be deleted from the address set on delete event, since the new pod with the same ip
 		// should not be present in given address set
-		eventuallyExpectEmptyAddressSetsExist(asf, peer, namespace1.Name)
+		eventuallyExpectEmptyAddressSetsExist(addressSetManager.nbClient, peer, namespace1.Name)
 	})
 
 	ginkgo.It("CleanupForController removes controller entries", func() {
@@ -508,10 +523,11 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, backRef, controllerName, &util.DefaultNetInfo{}, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, controllerName, false)
-		asf.EventuallyExpectAddressSetWithAddresses(dbIDs, []string{ip1})
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{ip1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 
 		gomega.Expect(addressSetManager.CleanupForController(controllerName)).To(gomega.Succeed())
-		asf.EventuallyExpectNoAddressSet(dbIDs)
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveEmptyData())
 	})
 
 	ginkgo.When("node selector is set", func() {
@@ -567,17 +583,16 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			dbIDsWorker := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelWorker, namespace1.Name, controllerName, false)
 			dbIDsControlPlane := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelControlPlane, namespace1.Name, controllerName, false)
 			// expect 2 address sets with IPs populated
-			asf.EventuallyExpectAddressSetWithAddresses(dbIDsWorker, []string{ip1})
-			asf.EventuallyExpectAddressSetWithAddresses(dbIDsControlPlane, []string{ip2})
-			asf.ExpectNumberOfAddressSets(2)
+			workerAS, _ := addressset.GetTestDbAddrSets(dbIDsWorker, []string{ip1})
+			controlPlaneAS, _ := addressset.GetTestDbAddrSets(dbIDsControlPlane, []string{ip2})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{workerAS, controlPlaneAS}))
 		})
 
 		ginkgo.It("doesn't add pod IP to address set if its labels don't match pod label selector", func() {
 			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Consistently(func(_ gomega.Gomega) {
-				asf.ExpectEmptyAddressSet(peerASIDs)
-			}).WithTimeout(500 * time.Millisecond).Should(gomega.Succeed())
+			emptyAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{})
+			gomega.Consistently(addressSetManager.nbClient, 500*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 		})
 
 		ginkgo.It("adds pod IP to address set if its labels match pod label selector", func() {
@@ -587,7 +602,8 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			pod1Copy.Labels = map[string]string{podLabelKey: podAppVideo}
 			_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), pod1Copy, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, []string{ip1})
+			expectedAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{ip1})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 		})
 
 		ginkgo.It("adds pod IP to address set if its node labels match node label selector", func() {
@@ -601,14 +617,16 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, specialNodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// expect the address set to be empty initially since nodeType "special-node" doesn't match "worker"
-			asf.EventuallyExpectEmptyAddressSetExist(asID)
+			emptyAS, _ := addressset.GetTestDbAddrSets(asID, []string{})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 			// label the node as "special-node"
 			node1Copy := node1.DeepCopy()
 			node1Copy.Labels = map[string]string{nodeLabelKey: "special-node"}
 			_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), node1Copy, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// expect the address set to be populated
-			asf.EventuallyExpectAddressSetWithAddresses(asID, []string{ip1})
+			expectedAS, _ := addressset.GetTestDbAddrSets(asID, []string{ip1})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 		})
 
 		ginkgo.It("deletes pod IP from address set when pod is deleted", func() {
@@ -619,11 +637,13 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, []string{ip1})
+			expectedAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{ip1})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 			// delete the pod
 			err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Delete(context.TODO(), pod1.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+			emptyAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 		})
 
 		ginkgo.It("deletes pod IP from address set when node label changes", func() {
@@ -634,13 +654,15 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			pod1Copy.Labels = map[string]string{podLabelKey: podAppVideo}
 			_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), pod1Copy, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, []string{ip1})
+			expectedAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{ip1})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 			// change the node label to not match the node selector
 			node1Copy := node1.DeepCopy()
 			node1Copy.Labels = map[string]string{nodeLabelKey: "control-plane"}
 			_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), node1Copy, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+			emptyAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 		})
 	})
 
@@ -654,7 +676,8 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
 			"", controllerName, true)
-		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+		emptyAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 		// this is calculated based on node-id
 		gwIP1 := "100.64.0.1"
 
@@ -669,14 +692,16 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		}
 		_, err = clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP1})
+		expectedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{node1MgmtIP, gwIP1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 
 		// imitate node update, even though that should never happen
 		gwIP2 := "100.64.0.2"
 		testNode.Annotations["k8s.ovn.org/node-id"] = "2"
 		_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP2})
+		expectedAS, _ = addressset.GetTestDbAddrSets(hostNSASIDs, []string{node1MgmtIP, gwIP2})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 		node2MgmtIP := "10.244.1.2"
 		testNode2 := corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -688,12 +713,14 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		}
 		_, err = clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode2, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP2, node2MgmtIP})
+		expectedAS, _ = addressset.GetTestDbAddrSets(hostNSASIDs, []string{node1MgmtIP, gwIP2, node2MgmtIP})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 
 		// delete second node and check if IPs are removed from address set
 		err = clientSet.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode2.Name, metav1.DeleteOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP2})
+		expectedAS, _ = addressset.GetTestDbAddrSets(hostNSASIDs, []string{node1MgmtIP, gwIP2})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 
 		// Imitate restart replacing node1 with node2 to make sure HostNetworkNamespace IPs are fully updated on initialSync
 		ginkgo.By("restarting addressSetManager with different node in the cluster")
@@ -704,14 +731,14 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
 			func(_ string) string { return "" })
-		addressSetManager.addressSetFactoryV4 = asf
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		// run EnsureAddressSet again, otherwise address set won't be reconciled with no users
 		_, _, _, err = addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
 			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node2MgmtIP})
+		restartedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{node2MgmtIP})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{restartedAS}))
 	})
 	ginkgo.It("updates IPs for existing nodes when the host network traffic namespace is created", func() {
 		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
@@ -732,12 +759,14 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
 			"", controllerName, true)
-		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+		emptyAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 
 		hostNetNamespace := testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
 		_, err = clientSet.KubeClient.CoreV1().Namespaces().Create(context.TODO(), hostNetNamespace, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP1})
+		expectedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{node1MgmtIP, gwIP1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 
 	})
 	ginkgo.It("includes node primary IP in HostNetworkNamespace address_set when NoOverlay mode is enabled", func() {
@@ -754,7 +783,8 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
 			"", controllerName, true)
 		// Wait for empty address set to be created
-		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+		emptyAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 
 		// Create the node with only 1 annotation, it shouldn't fail and will parse what we have
 		testNode := corev1.Node{
@@ -770,13 +800,15 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 
 		// Build expected IPs following the same pattern as the remote zone test
 		// When NoOverlay is enabled, primary interface IPv4 should also be included
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{"192.168.1.10"})
+		expectedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{"192.168.1.10"})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 
 		// Now update primary IP. Even though it should never happen, make sure we handle it correctly
 		testNode.Annotations[util.OvnNodeIfAddr] = "{\"ipv4\":\"192.168.1.11/24\"}"
 		_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{"192.168.1.11"})
+		expectedAS, _ = addressset.GetTestDbAddrSets(hostNSASIDs, []string{"192.168.1.11"})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 	})
 	ginkgo.It("correctly updates HostNetworkNamespace for hybrid overlay nodes", func() {
 		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
@@ -793,7 +825,8 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
 			"", controllerName, true)
 		// Wait for empty address set to be created
-		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+		emptyAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 
 		// this is calculated based on node-id
 		gwIP := "100.64.0.1"
@@ -809,13 +842,15 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		}
 		_, err = clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP})
+		expectedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{node1MgmtIP, gwIP})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 
 		// Now label node as hybrid overlay, should be removed
 		testNode.Labels = map[string]string{"a": "b"}
 		_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+		emptyAS, _ = addressset.GetTestDbAddrSets(hostNSASIDs, []string{})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 	})
 })
 

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -60,7 +60,8 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		ip3            = "10.128.1.3"
 		ip4            = "10.128.1.4"
 		hostNetPodIP   = "10.0.1.1"
-		hostNetNsIP    = "10.244.0.2"
+		node1Subnet    = "10.244.0.0/24"
+		node1MgmtIP    = "10.244.0.2"
 	)
 	var (
 		asf               *addressset.FakeAddressSetFactory
@@ -69,6 +70,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		clientSet         *util.OVNKubeControllerClientset
 		initialDB         libovsdbtest.TestSetup
 		libovsdbCleanup   *libovsdbtest.Context
+		libovsdbNBClient  libovsdbclient.Client
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -103,7 +105,6 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		wf, err = factory.NewOVNKubeControllerWatchFactory(clientSet)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(wf.Start()).To(gomega.Succeed())
-		var libovsdbNBClient libovsdbclient.Client
 		libovsdbNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
@@ -228,9 +229,16 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 				pod.Labels = map[string]string{podLabelKey: pod.Name}
 				podsList = append(podsList, *pod)
 			}
-			startAddrSetManager(initialDB, []corev1.Namespace{namespace1, namespace2, hostNetNamespace}, podsList)
-			// imitate HostNetworkNamespace address set update
-			addressSetManager.SetHostNetworkNamespaceIPs([]string{hostNetNsIP})
+			testNode := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet),
+					},
+				},
+			}
+			startAddrSetManagerWithNodes(initialDB, []corev1.Namespace{namespace1, namespace2, hostNetNamespace}, podsList,
+				[]corev1.Node{testNode})
 
 			_, _, _, err := addressSetManager.EnsureAddressSet(
 				peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, "backRef", controllerName, &util.DefaultNetInfo{}, legacyMode)
@@ -296,7 +304,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		ginkgo.Entry("all pods from all namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
 			PodSelector:       &metav1.LabelSelector{},
 			NamespaceSelector: &metav1.LabelSelector{},
-		}, namespaceName1, []string{ip1, ip2, ip3, ip4, hostNetNsIP}, true),
+		}, namespaceName1, []string{ip1, ip2, ip3, ip4, node1MgmtIP}, true),
 		ginkgo.Entry("selected pods from all namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
 			PodSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -634,6 +642,180 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
 		})
+	})
+
+	ginkgo.It("reconciles HostNetworkNamespace IPs", func() {
+		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+		hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+		startAddrSetManager(initialDB, []corev1.Namespace{hostNetNamespace}, nil)
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", controllerName, true)
+		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+		// this is calculated based on node-id
+		gwIP1 := "100.64.0.1"
+
+		testNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet),
+					"k8s.ovn.org/node-id":      "1",
+				},
+			},
+		}
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP1})
+
+		// imitate node update, even though that should never happen
+		gwIP2 := "100.64.0.2"
+		testNode.Annotations["k8s.ovn.org/node-id"] = "2"
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP2})
+		node2MgmtIP := "10.244.1.2"
+		testNode2 := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", "10.244.1.0/24"),
+				},
+			},
+		}
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode2, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP2, node2MgmtIP})
+
+		// delete second node and check if IPs are removed from address set
+		err = clientSet.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode2.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP2})
+
+		// Imitate restart replacing node1 with node2 to make sure HostNetworkNamespace IPs are fully updated on initialSync
+		ginkgo.By("restarting addressSetManager with different node in the cluster")
+		addressSetManager.Stop()
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode2, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = clientSet.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
+			func(_ string) string { return "" })
+		addressSetManager.addressSetFactoryV4 = asf
+		err = addressSetManager.Start()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// run EnsureAddressSet again, otherwise address set won't be reconciled with no users
+		_, _, _, err = addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node2MgmtIP})
+	})
+	ginkgo.It("updates IPs for existing nodes when the host network traffic namespace is created", func() {
+		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+		// this is calculated based on node-id
+		gwIP1 := "100.64.0.1"
+		testNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet),
+					"k8s.ovn.org/node-id":      "1",
+				},
+			},
+		}
+		startAddrSetManagerWithNodes(initialDB, nil, nil, []corev1.Node{testNode})
+		_, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", controllerName, true)
+		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+
+		hostNetNamespace := testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+		_, err = clientSet.KubeClient.CoreV1().Namespaces().Create(context.TODO(), hostNetNamespace, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP1})
+
+	})
+	ginkgo.It("includes node primary IP in HostNetworkNamespace address_set when NoOverlay mode is enabled", func() {
+		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+		// Enable NoOverlay transport mode
+		config.Default.Transport = "no-overlay"
+		hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+		// Start with empty NodeList, then add node after namespace is created
+		startAddrSetManager(initialDB, []corev1.Namespace{hostNetNamespace}, nil)
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", controllerName, true)
+		// Wait for empty address set to be created
+		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+
+		// Create the node with only 1 annotation, it shouldn't fail and will parse what we have
+		testNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					util.OvnNodeIfAddr: "{\"ipv4\":\"192.168.1.10/24\"}",
+				},
+			},
+		}
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Build expected IPs following the same pattern as the remote zone test
+		// When NoOverlay is enabled, primary interface IPv4 should also be included
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{"192.168.1.10"})
+
+		// Now update primary IP. Even though it should never happen, make sure we handle it correctly
+		testNode.Annotations[util.OvnNodeIfAddr] = "{\"ipv4\":\"192.168.1.11/24\"}"
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{"192.168.1.11"})
+	})
+	ginkgo.It("correctly updates HostNetworkNamespace for hybrid overlay nodes", func() {
+		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+		hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+		// set hybrid overlay selector
+		config.HybridOverlay.Enabled = true
+		config.Kubernetes.NoHostSubnetNodes, _ = metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}})
+		// Start with empty NodeList, then add node after namespace is created
+		startAddrSetManager(initialDB, []corev1.Namespace{hostNetNamespace}, nil)
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", controllerName, true)
+		// Wait for empty address set to be created
+		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
+
+		// this is calculated based on node-id
+		gwIP := "100.64.0.1"
+		// Create node that doesn't match hybrid overlay selector, it should be added to HostNetworkNamespace address set
+		testNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet),
+					"k8s.ovn.org/node-id":      "1",
+				},
+			},
+		}
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectAddressSetWithAddresses(hostNSASIDs, []string{node1MgmtIP, gwIP})
+
+		// Now label node as hybrid overlay, should be removed
+		testNode.Labels = map[string]string{"a": "b"}
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		asf.EventuallyExpectEmptyAddressSetExist(hostNSASIDs)
 	})
 })
 

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -36,14 +36,14 @@ func getPolicyKeyWithKind(policy *knet.NetworkPolicy) string {
 
 func eventuallyExpectAddressSetsWithIP(asf *addressset.FakeAddressSetFactory, peer knet.NetworkPolicyPeer, namespace, ip string) {
 	if peer.PodSelector != nil {
-		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace, controllerName)
+		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace, controllerName, false)
 		asf.EventuallyExpectAddressSetWithAddresses(dbIDs, []string{ip})
 	}
 }
 
 func eventuallyExpectEmptyAddressSetsExist(asf *addressset.FakeAddressSetFactory, peer knet.NetworkPolicyPeer, namespace string) {
 	if peer.PodSelector != nil {
-		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace, controllerName)
+		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace, controllerName, false)
 		asf.EventuallyExpectEmptyAddressSetExist(dbIDs)
 	}
 }
@@ -53,13 +53,14 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		namespaceName1 = "namespace1"
 		namespaceName2 = "namespace2"
 		netPolicyName1 = "networkpolicy1"
-		netPolicyName2 = "networkpolicy2"
 		nodeName       = "node1"
 		podLabelKey    = "podLabel"
 		ip1            = "10.128.1.1"
 		ip2            = "10.128.1.2"
 		ip3            = "10.128.1.3"
 		ip4            = "10.128.1.4"
+		hostNetPodIP   = "10.0.1.1"
+		hostNetNsIP    = "10.244.0.2"
 	)
 	var (
 		asf               *addressset.FakeAddressSetFactory
@@ -134,29 +135,29 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		}
 		// try to add invalid peer
 		_, _, _, err := addressSetManager.EnsureAddressSet(
-			peer.PodSelector, peer.NamespaceSelector, nil, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, peer.NamespaceSelector, nil, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{}, false)
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("is not a valid label selector operator"))
 		// address set will not be created
-		peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, networkPolicy.Namespace, controllerName)
+		peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, networkPolicy.Namespace, controllerName, false)
 		asf.EventuallyExpectNoAddressSet(peerASIDs)
 
 		// add nil pod selector
 		_, _, _, err = addressSetManager.EnsureAddressSet(
-			nil, peer.NamespaceSelector, nil, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
+			nil, peer.NamespaceSelector, nil, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{}, false)
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("pod selector is nil"))
 		// address set will not be created
-		peerASIDs = GetPodSelectorAddrSetDbIDs(nil, peer.NamespaceSelector, nil, networkPolicy.Namespace, controllerName)
+		peerASIDs = GetPodSelectorAddrSetDbIDs(nil, peer.NamespaceSelector, nil, networkPolicy.Namespace, controllerName, false)
 		asf.EventuallyExpectNoAddressSet(peerASIDs)
 
 		// namespace selector is nil and namespace is empty
 		_, _, _, err = addressSetManager.EnsureAddressSet(
-			peer.PodSelector, nil, nil, "", getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, nil, nil, "", getPolicyKeyWithKind(networkPolicy), controllerName, &util.DefaultNetInfo{}, false)
 		// error should happen on handler add
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring("namespace selector is nil and namespace is empty"))
 		// address set will not be created
-		peerASIDs = GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, nil, "", controllerName)
+		peerASIDs = GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, nil, "", controllerName, false)
 		asf.EventuallyExpectNoAddressSet(peerASIDs)
 	})
 	ginkgo.It("creates one address set for multiple users with the same selector", func() {
@@ -170,53 +171,88 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, nil)
 
 		_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nil, namespace1.Name,
-			"backref1", controllerName, &util.DefaultNetInfo{})
+			"backref1", controllerName, &util.DefaultNetInfo{}, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nil, namespace1.Name,
-			"backref2", controllerName, &util.DefaultNetInfo{})
+			"backref2", controllerName, &util.DefaultNetInfo{}, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name, controllerName)
+		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name, controllerName, false)
 		asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
 		// expect peer address set only
 		asf.ExpectNumberOfAddressSets(1)
 	})
+	ginkgo.It("creates different address set for multiple users with the same selector depending on legacyNetpolMode", func() {
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		podSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"name": "label1",
+			},
+		}
+
+		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, nil)
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nil, namespace1.Name,
+			"backref1", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nil, namespace1.Name,
+			"backref2", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nil, namespace1.Name,
+			"backref3", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name,
+			controllerName, false)
+		asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+		peerASIDs = GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name,
+			controllerName, true)
+		asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+		// expect 2 peer address sets only
+		asf.ExpectNumberOfAddressSets(2)
+	})
 	ginkgo.DescribeTable("adds selected pod ips to the address set",
-		func(peer knet.NetworkPolicyPeer, staticNamespace string, addrSetIPs []string) {
+		func(peer knet.NetworkPolicyPeer, staticNamespace string, addrSetIPs []string, legacyMode bool) {
 			namespace1 := *testing.NewNamespace(namespaceName1)
 			namespace2 := *testing.NewNamespace(namespaceName2)
+			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+			hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
 			ns1pod1 := testing.NewPod(namespace1.Name, "ns1pod1", nodeName, ip1)
 			ns1pod2 := testing.NewPod(namespace1.Name, "ns1pod2", nodeName, ip2)
+			ns1pod3 := testing.NewPod(namespace1.Name, "ns1pod3", nodeName, hostNetPodIP)
+			ns1pod3.Spec.HostNetwork = true
 			ns2pod1 := testing.NewPod(namespace2.Name, "ns2pod1", nodeName, ip3)
 			ns2pod2 := testing.NewPod(namespace2.Name, "ns2pod2", nodeName, ip4)
 			podsList := []corev1.Pod{}
-			for _, pod := range []*corev1.Pod{ns1pod1, ns1pod2, ns2pod1, ns2pod2} {
+			for _, pod := range []*corev1.Pod{ns1pod1, ns1pod2, ns1pod3, ns2pod1, ns2pod2} {
 				pod.Labels = map[string]string{podLabelKey: pod.Name}
 				podsList = append(podsList, *pod)
 			}
-			startAddrSetManager(initialDB, []corev1.Namespace{namespace1, namespace2}, podsList)
+			startAddrSetManager(initialDB, []corev1.Namespace{namespace1, namespace2, hostNetNamespace}, podsList)
+			// imitate HostNetworkNamespace address set update
+			addressSetManager.SetHostNetworkNamespaceIPs([]string{hostNetNsIP})
 
 			_, _, _, err := addressSetManager.EnsureAddressSet(
-				peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, "backRef", controllerName, &util.DefaultNetInfo{})
+				peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, "backRef", controllerName, &util.DefaultNetInfo{}, legacyMode)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// address set should be created and pod ips added
-			peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, controllerName)
+			peerASIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, staticNamespace, controllerName, legacyMode)
 			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, addrSetIPs)
 		},
 		ginkgo.Entry("all pods from a static namespace", knet.NetworkPolicyPeer{
 			PodSelector:       &metav1.LabelSelector{},
 			NamespaceSelector: nil,
-		}, namespaceName1, []string{ip1, ip2}),
+		}, namespaceName1, []string{ip1, ip2, hostNetPodIP}, false),
 		ginkgo.Entry("selected pods from a static namespace", knet.NetworkPolicyPeer{
 			PodSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{podLabelKey: "ns1pod1"},
 			},
 			NamespaceSelector: nil,
-		}, namespaceName1, []string{ip1}),
+		}, namespaceName1, []string{ip1}, false),
 		ginkgo.Entry("all pods from all namespaces", knet.NetworkPolicyPeer{
 			PodSelector:       &metav1.LabelSelector{},
 			NamespaceSelector: &metav1.LabelSelector{},
-		}, namespaceName1, []string{ip1, ip2, ip3, ip4}),
+		}, namespaceName1, []string{ip1, ip2, hostNetPodIP, ip3, ip4}, false),
 		ginkgo.Entry("selected pods from all namespaces", knet.NetworkPolicyPeer{
 			PodSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -228,7 +264,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 				},
 			},
 			NamespaceSelector: &metav1.LabelSelector{},
-		}, namespaceName1, []string{ip1, ip3}),
+		}, namespaceName1, []string{ip1, ip3}, false),
 		ginkgo.Entry("all pods from selected namespaces", knet.NetworkPolicyPeer{
 			PodSelector: &metav1.LabelSelector{},
 			NamespaceSelector: &metav1.LabelSelector{
@@ -236,7 +272,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 					"name": namespaceName2,
 				},
 			},
-		}, namespaceName1, []string{ip3, ip4}),
+		}, namespaceName1, []string{ip3, ip4}, false),
 		ginkgo.Entry("selected pods from selected namespaces", knet.NetworkPolicyPeer{
 			PodSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{podLabelKey: "ns2pod1"},
@@ -246,12 +282,56 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 					"name": namespaceName2,
 				},
 			},
-		}, namespaceName1, []string{ip3}),
+		}, namespaceName1, []string{ip3}, false),
+		ginkgo.Entry("all pods from a static namespace, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector:       &metav1.LabelSelector{},
+			NamespaceSelector: nil,
+		}, namespaceName1, []string{ip1, ip2}, true),
+		ginkgo.Entry("selected pods from a static namespace, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{podLabelKey: "ns1pod1"},
+			},
+			NamespaceSelector: nil,
+		}, namespaceName1, []string{ip1}, true),
+		ginkgo.Entry("all pods from all namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector:       &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{},
+		}, namespaceName1, []string{ip1, ip2, ip3, ip4, hostNetNsIP}, true),
+		ginkgo.Entry("selected pods from all namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      podLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"ns1pod1", "ns2pod1"},
+					},
+				},
+			},
+			NamespaceSelector: &metav1.LabelSelector{},
+		}, namespaceName1, []string{ip1, ip3}, true),
+		ginkgo.Entry("all pods from selected namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName2,
+				},
+			},
+		}, namespaceName1, []string{ip3, ip4}, true),
+		ginkgo.Entry("selected pods from selected namespaces, legacyNetpolMode", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{podLabelKey: "ns2pod1"},
+			},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName2,
+				},
+			},
+		}, namespaceName1, []string{ip3}, true),
 	)
 	ginkgo.It("on initial sync deletes unreferenced and leaves referenced address sets", func() {
-		unusedPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", controllerName)
+		unusedPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", controllerName, false)
 		unusedPodSelAS, _ := addressset.GetTestDbAddrSets(unusedPodSelIDs, []string{"1.1.1.2"})
-		refNetpolIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName2", controllerName)
+		refNetpolIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName2", controllerName, false)
 		refNetpolAS, _ := addressset.GetTestDbAddrSets(refNetpolIDs, []string{"1.1.1.3"})
 		netpolACL := libovsdbops.BuildACL(
 			"netpolACL",
@@ -269,7 +349,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			types.DefaultACLTier,
 		)
 		netpolACL.UUID = "netpolACL-UUID"
-		refPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName3", controllerName)
+		refPodSelIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName3", controllerName, false)
 		refPodSelAS, _ := addressset.GetTestDbAddrSets(refPodSelIDs, []string{"1.1.1.4"})
 		podSelACL := libovsdbops.BuildACL(
 			"podSelACL",
@@ -325,7 +405,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, nil)
 
 		_, _, _, err := addressSetManager.EnsureAddressSet(
-			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Start a pod
@@ -374,7 +454,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		startAddrSetManager(initialDB, []corev1.Namespace{namespace1, namespace2}, nil)
 
 		_, _, _, err := addressSetManager.EnsureAddressSet(
-			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Start a pod
@@ -417,9 +497,9 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		backRef := "NetworkPolicy/namespace1/testpolicy"
 
 		_, _, _, err := addressSetManager.EnsureAddressSet(
-			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, backRef, controllerName, &util.DefaultNetInfo{})
+			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, backRef, controllerName, &util.DefaultNetInfo{}, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, controllerName)
+		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, controllerName, false)
 		asf.EventuallyExpectAddressSetWithAddresses(dbIDs, []string{ip1})
 
 		gomega.Expect(addressSetManager.CleanupForController(controllerName)).To(gomega.Succeed())
@@ -456,7 +536,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		nodeSelector := &metav1.LabelSelector{
 			MatchLabels: map[string]string{nodeLabelKey: nodeTypeWorker},
 		}
-		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelector, namespace1.Name, controllerName)
+		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelector, namespace1.Name, controllerName, false)
 
 		ginkgo.BeforeEach(func() {
 			startAddrSetManagerWithNodes(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*pod1}, []corev1.Node{node1})
@@ -472,12 +552,12 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			podSelector := &metav1.LabelSelector{}
 			nodeSelWorker := &metav1.LabelSelector{MatchLabels: map[string]string{nodeLabelKey: nodeTypeWorker}}
 			nodeSelControlPlane := &metav1.LabelSelector{MatchLabels: map[string]string{nodeLabelKey: nodeTypeControlPlane}}
-			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelWorker, namespace1.Name, "backRef1", controllerName, &util.DefaultNetInfo{})
+			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelWorker, namespace1.Name, "backRef1", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelControlPlane, namespace1.Name, "backRef2", controllerName, &util.DefaultNetInfo{})
+			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelControlPlane, namespace1.Name, "backRef2", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			dbIDsWorker := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelWorker, namespace1.Name, controllerName)
-			dbIDsControlPlane := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelControlPlane, namespace1.Name, controllerName)
+			dbIDsWorker := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelWorker, namespace1.Name, controllerName, false)
+			dbIDsControlPlane := GetPodSelectorAddrSetDbIDs(podSelector, nil, nodeSelControlPlane, namespace1.Name, controllerName, false)
 			// expect 2 address sets with IPs populated
 			asf.EventuallyExpectAddressSetWithAddresses(dbIDsWorker, []string{ip1})
 			asf.EventuallyExpectAddressSetWithAddresses(dbIDsControlPlane, []string{ip2})
@@ -485,7 +565,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		})
 
 		ginkgo.It("doesn't add pod IP to address set if its labels don't match pod label selector", func() {
-			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Consistently(func(_ gomega.Gomega) {
 				asf.ExpectEmptyAddressSet(peerASIDs)
@@ -493,7 +573,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		})
 
 		ginkgo.It("adds pod IP to address set if its labels match pod label selector", func() {
-			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			pod1Copy := pod1.DeepCopy()
 			pod1Copy.Labels = map[string]string{podLabelKey: podAppVideo}
@@ -509,8 +589,8 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 				},
 			}
 			podSelector := &metav1.LabelSelector{}
-			asID := GetPodSelectorAddrSetDbIDs(podSelector, nil, specialNodeSelector, namespace1.Name, controllerName)
-			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, specialNodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			asID := GetPodSelectorAddrSetDbIDs(podSelector, nil, specialNodeSelector, namespace1.Name, controllerName, false)
+			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, specialNodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// expect the address set to be empty initially since nodeType "special-node" doesn't match "worker"
 			asf.EventuallyExpectEmptyAddressSetExist(asID)
@@ -529,7 +609,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			pod1Copy.Labels = map[string]string{podLabelKey: podAppVideo}
 			_, err := clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), pod1Copy, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			_, _, _, err = addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			asf.EventuallyExpectAddressSetWithAddresses(peerASIDs, []string{ip1})
 			// delete the pod
@@ -539,7 +619,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		})
 
 		ginkgo.It("deletes pod IP from address set when node label changes", func() {
-			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{})
+			_, _, _, err := addressSetManager.EnsureAddressSet(podSelector, nil, nodeSelector, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// add the pod to the address set
 			pod1Copy := pod1.DeepCopy()

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -253,7 +253,7 @@ func (bnc *BaseNetworkController) multicastDeleteNamespace(ns *corev1.Namespace,
 // ns is the name of the namespace, while namespace is the optional k8s namespace object
 // if no k8s namespace object is provided, this function will attempt to find it via informer cache
 func (bnc *BaseNetworkController) ensureNamespaceLockedCommon(ns string, readOnly bool, namespace *corev1.Namespace,
-	ipsGetter func(ns string) []net.IP, configureNamespace func(nsInfo *namespaceInfo, ns *corev1.Namespace) error) (*namespaceInfo, func(), error) {
+	configureNamespace func(nsInfo *namespaceInfo, ns *corev1.Namespace) error) (*namespaceInfo, func(), error) {
 	bnc.namespacesMutex.Lock()
 	nsInfo := bnc.namespaces[ns]
 	nsInfoExisted := false
@@ -269,7 +269,7 @@ func (bnc *BaseNetworkController) ensureNamespaceLockedCommon(ns string, readOnl
 		defer bnc.namespacesMutex.Unlock()
 		// create the adddress set for the new namespace
 		var err error
-		ips := ipsGetter(ns)
+		ips := bnc.getAllNamespacePodAddresses(ns)
 		nsInfo.addressSet, err = bnc.createNamespaceAddrSetAllPods(ns, ips)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create address set for namespace: %s, error: %v", ns, err)

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -171,8 +171,6 @@ type networkPolicy struct {
 	localPodSelector labels.Selector
 	// retry framework for this policy's local pod selector watcher
 	localPodRetry *retry.RetryFramework
-	// peer namespace reconcilers
-	reconcilePeerNamespaces []*peerNamespacesRetry
 	// peerAddressSets stores PodSelectorAddressSet keys for peers that this network policy was successfully added to.
 	// Required for cleanup.
 	peerAddressSets []string
@@ -197,22 +195,16 @@ type networkPolicy struct {
 	cancelableContext *util.CancelableContext
 }
 
-type peerNamespacesRetry struct {
-	retryFramework *retry.RetryFramework
-	handler        *factory.Handler
-}
-
 func NewNetworkPolicy(policy *knet.NetworkPolicy) *networkPolicy {
 	policyTypeIngress, policyTypeEgress := getPolicyType(policy)
 	np := &networkPolicy{
-		name:                    policy.Name,
-		namespace:               policy.Namespace,
-		ingressPolicies:         make([]*gressPolicy, 0),
-		egressPolicies:          make([]*gressPolicy, 0),
-		isIngress:               policyTypeIngress,
-		isEgress:                policyTypeEgress,
-		reconcilePeerNamespaces: make([]*peerNamespacesRetry, 0),
-		localPods:               sync.Map{},
+		name:            policy.Name,
+		namespace:       policy.Namespace,
+		ingressPolicies: make([]*gressPolicy, 0),
+		egressPolicies:  make([]*gressPolicy, 0),
+		isIngress:       policyTypeIngress,
+		isEgress:        policyTypeEgress,
+		localPods:       sync.Map{},
 	}
 	return np
 }
@@ -969,11 +961,6 @@ func (bnc *BaseNetworkController) getNetworkPolicyPGName(namespace, name string)
 	return libovsdbutil.GetPortGroupName(bnc.getNetworkPolicyPortGroupDbIDs(namespace, name))
 }
 
-type policyHandler struct {
-	gress             *gressPolicy
-	namespaceSelector *metav1.LabelSelector
-}
-
 // createNetworkPolicy creates a network policy, should be retriable.
 // If network policy with given key exists, it will try to clean it up first, and return an error if it fails.
 // No need to log network policy key here, because caller of createNetworkPolicy should prepend error message with
@@ -994,7 +981,6 @@ func (bnc *BaseNetworkController) createNetworkPolicy(policy *knet.NetworkPolicy
 
 	npKey := getPolicyKey(policy)
 	var np *networkPolicy
-	var policyHandlers []*policyHandler
 
 	// network policy will be annotated with this
 	// annotation -- [ "k8s.ovn.org/acl-stateless": "true"] for the ingress/egress
@@ -1067,12 +1053,9 @@ func (bnc *BaseNetworkController) createNetworkPolicy(policy *knet.NetworkPolicy
 			}
 
 			for _, fromJSON := range ingressJSON.From {
-				handler, err := bnc.setupGressPolicy(np, ingress, fromJSON)
+				err := bnc.setupGressPolicy(np, ingress, fromJSON)
 				if err != nil {
 					return err
-				}
-				if handler != nil {
-					policyHandlers = append(policyHandlers, handler)
 				}
 			}
 		}
@@ -1093,12 +1076,9 @@ func (bnc *BaseNetworkController) createNetworkPolicy(policy *knet.NetworkPolicy
 			}
 
 			for _, toJSON := range egressJSON.To {
-				handler, err := bnc.setupGressPolicy(np, egress, toJSON)
+				err := bnc.setupGressPolicy(np, egress, toJSON)
 				if err != nil {
 					return err
-				}
-				if handler != nil {
-					policyHandlers = append(policyHandlers, handler)
 				}
 			}
 		}
@@ -1154,16 +1134,6 @@ func (bnc *BaseNetworkController) createNetworkPolicy(policy *knet.NetworkPolicy
 			np.cancelableContext = &cancelableContext
 		}
 
-		// 6. Start peer handlers to update all allow rules first
-		for _, handler := range policyHandlers {
-			// For each peer namespace selector, we create a watcher that
-			// populates ingress.peerAddressSets
-			err = bnc.addPeerNamespaceHandler(handler.namespaceSelector, handler.gress, np)
-			if err != nil {
-				return fmt.Errorf("failed to start peer handler: %v", err)
-			}
-		}
-
 		// 7. Start local pod handlers, that will update networkPolicy and default deny port groups with selected pods.
 		err = bnc.addLocalPodHandler(policy, np)
 		if err != nil {
@@ -1183,26 +1153,16 @@ func useNamespaceAddrSet(peer knet.NetworkPolicyPeer) bool {
 }
 
 func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressPolicy,
-	peer knet.NetworkPolicyPeer) (*policyHandler, error) {
+	peer knet.NetworkPolicyPeer) error {
 	// Add IPBlock to ingress network policy
 	if peer.IPBlock != nil {
 		gp.addIPBlock(peer.IPBlock)
-		return nil, nil
+		return nil
 	}
 	if peer.PodSelector == nil && peer.NamespaceSelector == nil {
 		// undefined behaviour
 		klog.Errorf("setupGressPolicy failed: all fields unset")
-		return nil, nil
-	}
-	gp.hasPeerSelector = true
-
-	if useNamespaceAddrSet(peer) {
-		// namespace selector, use namespace address sets
-		handler := &policyHandler{
-			gress:             gp,
-			namespaceSelector: peer.NamespaceSelector,
-		}
-		return handler, nil
+		return nil
 	}
 	// use podSelector address set
 	podSelector := peer.PodSelector
@@ -1212,15 +1172,15 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 	}
 	// np.namespace will be used when fromJSON.NamespaceSelector = nil
 	asKey, ipv4as, ipv6as, err := bnc.addressSetManager.EnsureAddressSet(
-		podSelector, peer.NamespaceSelector, nil, np.namespace, np.getKeyWithKind(), bnc.controllerName, bnc.GetNetInfo())
+		podSelector, peer.NamespaceSelector, nil, np.namespace, np.getKeyWithKind(), bnc.controllerName, bnc.GetNetInfo(), useNamespaceAddrSet(peer))
 	// even if GetPodSelectorAddressSet failed, add key for future cleanup or retry.
 	np.peerAddressSets = append(np.peerAddressSets, asKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to ensure pod selector address set %s: %v", asKey, err)
+		return fmt.Errorf("failed to ensure pod selector address set %s: %v", asKey, err)
 	}
 	gp.addPeerAddressSets(ipv4as, ipv6as)
 
-	return nil, nil
+	return nil
 }
 
 // addNetworkPolicy creates and applies OVN ACLs to pod logical switch
@@ -1430,209 +1390,6 @@ func (bnc *BaseNetworkController) cleanupNetworkPolicy(np *networkPolicy) error 
 
 type NetworkPolicyExtraParameters struct {
 	np *networkPolicy
-	gp *gressPolicy
-}
-
-func (bnc *BaseNetworkController) handlePeerNamespaceSelectorAdd(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
-	if !bnc.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
-		start := time.Now()
-		defer func() {
-			duration := time.Since(start)
-			metrics.RecordNetpolPeerNamespaceEvent("add", duration)
-		}()
-	}
-	np.RLock()
-	if np.deleted {
-		np.RUnlock()
-		return nil
-	}
-	updated := false
-	var errors []error
-	for _, obj := range objs {
-		namespace := obj.(*corev1.Namespace)
-		// addNamespaceAddressSet is safe for concurrent use, doesn't require additional synchronization
-		nsUpdated, err := gp.addNamespaceAddressSet(namespace.Name, bnc.addressSetFactory)
-		if err != nil {
-			errors = append(errors, err)
-		} else if nsUpdated {
-			updated = true
-		}
-	}
-	np.RUnlock()
-	// unlock networkPolicy, before calling peerNamespaceUpdate
-	if updated {
-		err := bnc.peerNamespaceUpdate(np, gp)
-		if err != nil {
-			errors = append(errors, err)
-		}
-	}
-	return utilerrors.Join(errors...)
-
-}
-
-func (bnc *BaseNetworkController) handlePeerNamespaceSelectorDel(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
-	if !bnc.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
-		start := time.Now()
-		defer func() {
-			duration := time.Since(start)
-			metrics.RecordNetpolPeerNamespaceEvent("delete", duration)
-		}()
-	}
-	np.RLock()
-	if np.deleted {
-		np.RUnlock()
-		return nil
-	}
-	updated := false
-	for _, obj := range objs {
-		namespace := obj.(*corev1.Namespace)
-		// delNamespaceAddressSet is safe for concurrent use, doesn't require additional synchronization
-		if gp.delNamespaceAddressSet(namespace.Name) {
-			updated = true
-		}
-	}
-	np.RUnlock()
-	// unlock networkPolicy, before calling peerNamespaceUpdate
-	if updated {
-		return bnc.peerNamespaceUpdate(np, gp)
-	}
-	return nil
-}
-
-// peerNamespaceUpdate updates gress ACLs, for this purpose it need to take nsInfo lock and np.RLock
-// make sure to pass unlocked networkPolicy
-func (bnc *BaseNetworkController) peerNamespaceUpdate(np *networkPolicy, gp *gressPolicy) error {
-	// Lock namespace before locking np
-	// this is to make sure we don't miss update acl loglevel event for namespace.
-	// The order of locking is strict: namespace first, then network policy, otherwise deadlock may happen
-	nsInfo, nsUnlock := bnc.getNamespaceLocked(np.namespace, true)
-	var aclLogging *libovsdbutil.ACLLoggingLevels
-	if nsInfo == nil {
-		aclLogging = &libovsdbutil.ACLLoggingLevels{
-			Allow: "",
-			Deny:  "",
-		}
-	} else {
-		defer nsUnlock()
-		aclLogging = &nsInfo.aclLogging
-	}
-	np.RLock()
-	defer np.RUnlock()
-	if np.deleted {
-		return nil
-	}
-	// buildLocalPodACLs is safe for concurrent use, see function comment for details
-	acls, deletedACLs := gp.buildLocalPodACLs(np.portGroupName, aclLogging)
-	ops, err := libovsdbops.CreateOrUpdateACLsOps(bnc.nbClient, nil, bnc.GetSamplingConfig(), acls...)
-	if err != nil {
-		return err
-	}
-	ops, err = libovsdbops.AddACLsToPortGroupOps(bnc.nbClient, ops, np.portGroupName, acls...)
-	if err != nil {
-		return err
-	}
-	if len(deletedACLs) > 0 {
-		deletedACLsWithUUID, err := libovsdbops.FindACLs(bnc.nbClient, deletedACLs)
-		if err != nil {
-			return fmt.Errorf("failed to find deleted acls: %w", err)
-		}
-
-		ops, err = libovsdbops.DeleteACLsFromPortGroupOps(bnc.nbClient, ops, np.portGroupName, deletedACLsWithUUID...)
-		if err != nil {
-			return err
-		}
-	}
-	_, err = libovsdbops.TransactAndCheck(bnc.nbClient, ops)
-	return err
-}
-
-// requeuePeerNamespace enqueues the namespace into network policy peer namespace
-// retry framework object(s) which need to be retried immediately with add event.
-func (bnc *BaseNetworkController) requeuePeerNamespace(namespace *corev1.Namespace) error {
-	var errors []error
-	npKeys := bnc.networkPolicies.GetKeys()
-	for _, npKey := range npKeys {
-		err := bnc.networkPolicies.DoWithLock(npKey, func(npKey string) error {
-			np, ok := bnc.networkPolicies.Load(npKey)
-			if !ok {
-				return nil
-			}
-			np.RLock()
-			defer np.RUnlock()
-			if np.deleted {
-				return nil
-			}
-			var errors []error
-			for _, reconcilePeerNamespace := range np.reconcilePeerNamespaces {
-				// Filter out namespace when it's labels not matching with network policy peer namespace
-				// selector.
-				if !reconcilePeerNamespace.handler.FilterFunc(namespace) {
-					continue
-				}
-				err := reconcilePeerNamespace.retryFramework.AddRetryObjWithAddNoBackoff(namespace)
-				if err != nil {
-					errors = append(errors, fmt.Errorf("failed to retry peer namespace %s for network policy %s on network %s: %w",
-						namespace.Name, npKey, bnc.GetNetworkName(), err))
-					continue
-				}
-				reconcilePeerNamespace.retryFramework.RequestRetryObjs()
-			}
-			return utilerrors.Join(errors...)
-		})
-		if err != nil {
-			errors = append(errors, fmt.Errorf("failed to retry peer namespaces for network policy %s on network %s: %w",
-				npKey, bnc.GetNetworkName(), err))
-		}
-	}
-	return utilerrors.Join(errors...)
-}
-
-// addPeerNamespaceHandler starts a watcher for PeerNamespaceSelectorType.
-// Sync function and Add event for every existing namespace will be executed sequentially first, and an error will be
-// returned if something fails.
-// PeerNamespaceSelectorType uses handlePeerNamespaceSelectorAdd on Add,
-// and handlePeerNamespaceSelectorDel on Delete.
-func (bnc *BaseNetworkController) addPeerNamespaceHandler(
-	namespaceSelector *metav1.LabelSelector,
-	gress *gressPolicy, np *networkPolicy) error {
-
-	// NetworkPolicy is validated by the apiserver; this can't fail.
-	sel, err := metav1.LabelSelectorAsSelector(namespaceSelector)
-	if err != nil {
-		return err
-	}
-	// start watching namespaces selected by the namespace selector
-	syncFunc := func(objs []interface{}) error {
-		// ignore returned error, since any namespace that wasn't properly handled will be retried individually.
-		_ = bnc.handlePeerNamespaceSelectorAdd(np, gress, objs...)
-		return nil
-	}
-	retryPeerNamespaces := bnc.newNetpolRetryFramework(
-		factory.PeerNamespaceSelectorType,
-		syncFunc,
-		&NetworkPolicyExtraParameters{gp: gress, np: np},
-		np.cancelableContext.Done(),
-	)
-
-	namespaceHandler, err := retryPeerNamespaces.WatchResourceFiltered("", sel)
-	if err != nil {
-		klog.Errorf("WatchResource failed for addPeerNamespaceHandler: %v", err)
-		return err
-	}
-
-	// Add peer namespace retry framework object into np.reconcilePeerNamespaces so that when
-	// a new peer namespace is newly created later under UDN network, it gets reconciled and
-	// address set is created for the namespace. so we must reconcile it for network policy
-	// as well to update gress policy ACL with matching peer namespace address set.
-	if bnc.IsPrimaryNetwork() {
-		np.Lock()
-		np.reconcilePeerNamespaces = append(np.reconcilePeerNamespaces,
-			&peerNamespacesRetry{retryFramework: retryPeerNamespaces,
-				handler: namespaceHandler})
-		np.Unlock()
-	}
-
-	return nil
 }
 
 func (bnc *BaseNetworkController) shutdownHandlers(np *networkPolicy) {
@@ -1647,10 +1404,6 @@ func (bnc *BaseNetworkController) shutdownHandlers(np *networkPolicy) {
 		np.localPodSelector = nil
 		np.localPodRetry = nil
 	}
-	for _, retry := range np.reconcilePeerNamespaces {
-		bnc.watchFactory.RemoveNamespaceHandler(retry.handler)
-	}
-	np.reconcilePeerNamespaces = make([]*peerNamespacesRetry, 0)
 }
 
 // The following 2 functions should return the same key for network policy based on k8s on internal networkPolicy object

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -743,7 +743,7 @@ func (bsnc *BaseUserDefinedNetworkController) AddNamespaceForUserDefinedNetwork(
 // and returns it with its mutex locked.
 // ns is the name of the namespace, while namespace is the optional k8s namespace object
 func (bsnc *BaseUserDefinedNetworkController) ensureNamespaceLockedForUserDefinedNetwork(ns string, readOnly bool, namespace *corev1.Namespace) (*namespaceInfo, func(), error) {
-	return bsnc.ensureNamespaceLockedCommon(ns, readOnly, namespace, bsnc.getAllNamespacePodAddresses, bsnc.configureNamespaceCommon)
+	return bsnc.ensureNamespaceLockedCommon(ns, readOnly, namespace, bsnc.configureNamespaceCommon)
 }
 
 func (bsnc *BaseUserDefinedNetworkController) updateNamespaceForUserDefinedNetwork(old, newer *corev1.Namespace) error {

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -736,14 +736,6 @@ func (bsnc *BaseUserDefinedNetworkController) AddNamespaceForUserDefinedNetwork(
 		return fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
 	nsUnlock()
-	// Enqueue the UDN namespace into network policy controller if it needs to be
-	// processed by network policy peer namespace handlers.
-	if bsnc.IsPrimaryNetwork() {
-		err = bsnc.requeuePeerNamespace(ns)
-		if err != nil {
-			return fmt.Errorf("failed to requeue peer namespace %s: %v", ns.Name, err)
-		}
-	}
 	return nil
 }
 

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -129,7 +129,6 @@ type DefaultNetworkController struct {
 	nodeClusterRouterPortFailed sync.Map
 	hybridOverlayFailed         sync.Map
 	syncZoneICFailed            sync.Map
-	syncHostNetAddrSetFailed    sync.Map
 	syncEIPNodeRerouteFailed    sync.Map
 	syncEIPNodeFailed           sync.Map
 
@@ -486,12 +485,11 @@ func (oc *DefaultNetworkController) ReconcileNode(oldNode, newNode *corev1.Node,
 			_, gwSync := oc.gatewaysFailed.Load(newNode.Name)
 			_, hoSync := oc.hybridOverlayFailed.Load(newNode.Name)
 			_, zoneICSync := oc.syncZoneICFailed.Load(newNode.Name)
-			_, hostNetAddrSetSync := oc.syncHostNetAddrSetFailed.Load(newNode.Name)
 			// When a bootstrap retry first failed while the node was remote, only syncZoneICFailed may be set.
 			// If the node later becomes local before any local switch state was populated in lsManager, we must
 			// do the full local node add instead of replaying only the previous remote-zone retry state.
 			localSwitchReady := oc.hasLocalNodeSwitchState(newNode)
-			if localSwitchReady && (nodeSync || clusterRtrSync || mgmtSync || gwSync || hoSync || zoneICSync || hostNetAddrSetSync) {
+			if localSwitchReady && (nodeSync || clusterRtrSync || mgmtSync || gwSync || hoSync || zoneICSync) {
 				nodeSyncsParam = &nodeSyncs{
 					syncNode:              nodeSync,
 					syncClusterRouterPort: clusterRtrSync,
@@ -576,29 +574,6 @@ func (oc *DefaultNetworkController) ReconcileNode(oldNode, newNode *corev1.Node,
 		}
 		if err := oc.addUpdateRemoteNodeEvent(newNode, syncZoneIC); err != nil {
 			aggregatedErrors = append(aggregatedErrors, err)
-		}
-	}
-
-	_, syncHostNetAddrSet := oc.syncHostNetAddrSetFailed.Load(newNode.Name)
-	hostNamespaceAddressesChanged := oldNode != nil &&
-		(defaultNodeSubnetChangedWithState(oldNode, newNode, oldState, newState) ||
-			gatewayChanged(oldNode, newNode, oldState, newState, oc.GetNetworkName()))
-	if oldNode == nil || syncHostNetAddrSet || hostNamespaceAddressesChanged {
-		hostNamespaceAddrSetErr := false
-		if hostNamespaceAddressesChanged {
-			if err := oc.delIPFromHostNetworkNamespaceAddrSet(oldNode); err != nil {
-				klog.Errorf("Failed to delete old node IPs from %s address_set: %v", config.Kubernetes.HostNetworkNamespace, err)
-				hostNamespaceAddrSetErr = true
-				oc.syncHostNetAddrSetFailed.Store(newNode.Name, true)
-				aggregatedErrors = append(aggregatedErrors, err)
-			}
-		}
-		if err := oc.addIPToHostNetworkNamespaceAddrSet(newNode); err != nil {
-			klog.Errorf("Failed to add node IPs to %s address_set: %v", config.Kubernetes.HostNetworkNamespace, err)
-			oc.syncHostNetAddrSetFailed.Store(newNode.Name, true)
-			aggregatedErrors = append(aggregatedErrors, err)
-		} else if !hostNamespaceAddrSetErr {
-			oc.syncHostNetAddrSetFailed.Delete(newNode.Name)
 		}
 	}
 

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -17,7 +17,6 @@ import (
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
-	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -46,9 +45,7 @@ type gressPolicy struct {
 	// peerV6AddressSets has Address sets for all namespaces and pod selectors for IPv6
 	peerV6AddressSets *sync.Map
 	// if gressPolicy has at least 1 rule with selector, set this field to true.
-	// This is required to distinguish gress that doesn't have any peerAddressSets added yet
-	// (e.g. because there are no namespaces matching label selector) and should allow nothing,
-	// from empty gress, which should allow all.
+	// This field is a quick check on whether at least 1 peerAddressSets has been added (and they are never deleted)
 	hasPeerSelector bool
 
 	// portPolicies represents all the ports to which traffic is allowed for
@@ -102,9 +99,11 @@ func syncMapToSortedList(m *sync.Map) []string {
 func (gp *gressPolicy) addPeerAddressSets(asHashNameV4, asHashNameV6 string) {
 	if gp.ipv4Mode && asHashNameV4 != "" {
 		gp.peerV4AddressSets.Store("$"+asHashNameV4, true)
+		gp.hasPeerSelector = true
 	}
 	if gp.ipv6Mode && asHashNameV6 != "" {
 		gp.peerV6AddressSets.Store("$"+asHashNameV6, true)
+		gp.hasPeerSelector = true
 	}
 }
 
@@ -209,68 +208,6 @@ func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) string {
 		return fmt.Sprintf("%s && %s", l3Match, lportMatch)
 	}
 	return fmt.Sprintf("%s && %s && %s", l3Match, l4Match, lportMatch)
-}
-
-// addNamespaceAddressSet adds a namespace address set to the gress policy.
-// If the address set is not found in the db, return error.
-// If the address set is already added for this policy, return false, otherwise returns true.
-// This function is safe for concurrent use, doesn't require additional synchronization
-func (gp *gressPolicy) addNamespaceAddressSet(name string, asf addressset.AddressSetFactory) (bool, error) {
-	dbIDs := getNamespaceAddrSetDbIDs(name, gp.controllerName)
-	as, err := asf.GetAddressSet(dbIDs)
-	if err != nil {
-		return false, fmt.Errorf("cannot add peer namespace %s: failed to get address set: %v", name, err)
-	}
-	v4HashName, v6HashName := as.GetASHashNames()
-	if v4HashName == "" && v6HashName == "" {
-		// This would happen when a namespace is not yet reconciled with UDN network.
-		return false, fmt.Errorf("cannot add peer namespace %s: address set has empty hashed name", name)
-	}
-	v4HashName = "$" + v4HashName
-	v6HashName = "$" + v6HashName
-
-	v4NoUpdate := true
-	v6NoUpdate := true
-	// only update vXNoUpdate if value was stored and not loaded
-	if gp.ipv4Mode {
-		_, v4NoUpdate = gp.peerV4AddressSets.LoadOrStore(v4HashName, true)
-	}
-	if gp.ipv6Mode {
-		_, v6NoUpdate = gp.peerV6AddressSets.LoadOrStore(v6HashName, true)
-	}
-	if v4NoUpdate && v6NoUpdate {
-		// no changes were applied, return false
-		return false, nil
-	}
-	return true, nil
-}
-
-// delNamespaceAddressSet removes a namespace address set from the gress policy.
-// If the address set is already deleted for this policy, return false, otherwise returns true.
-// This function is safe for concurrent use, doesn't require additional synchronization
-func (gp *gressPolicy) delNamespaceAddressSet(name string) bool {
-	dbIDs := getNamespaceAddrSetDbIDs(name, gp.controllerName)
-	v4HashName, v6HashName := addressset.GetHashNamesForAS(dbIDs)
-	if v4HashName == "" && v6HashName == "" {
-		return false
-	}
-	v4HashName = "$" + v4HashName
-	v6HashName = "$" + v6HashName
-
-	v4Update := false
-	v6Update := false
-	// only update vXUpdate if value was loaded
-	if gp.ipv4Mode {
-		_, v4Update = gp.peerV4AddressSets.LoadAndDelete(v4HashName)
-	}
-	if gp.ipv6Mode {
-		_, v6Update = gp.peerV6AddressSets.LoadAndDelete(v6HashName)
-	}
-	if v4Update || v6Update {
-		// at least 1 address set was updated, return true
-		return true
-	}
-	return false
 }
 
 func (gp *gressPolicy) isEmpty() bool {

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -322,7 +322,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			vlanID := 1024
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{KClient: kubeFakeClient}, testNode.Name)
 			l3Config := node1.gatewayConfig(config.GatewayModeShared, uint(vlanID))
 			err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)
@@ -600,7 +599,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			vlanID := 1024
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{KClient: kubeFakeClient}, testNode.Name)
 			l3Config := node1.gatewayConfig(config.GatewayModeShared, uint(vlanID))
 			err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)
@@ -807,7 +805,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			vlanID := 1024
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{KClient: kubeFakeClient}, testNode.Name)
 			l3Config := node1.gatewayConfig(config.GatewayModeShared, uint(vlanID))
 			err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)
@@ -1102,7 +1099,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			vlanID := 1024
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{KClient: kubeFakeClient}, testNode1.Name)
 			l3Config := node1.gatewayConfig(config.GatewayModeShared, uint(vlanID))
 			err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)
@@ -1311,7 +1307,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			vlanID := 1024
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{KClient: kubeFakeClient}, testNode.Name)
 			l3Config := node1.gatewayConfig(config.GatewayModeShared, uint(vlanID))
 			err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)
@@ -1512,7 +1507,6 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			vlanID := 1024
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{KClient: kubeFakeClient}, testNode.Name)
 			l3Config := node1.gatewayConfig(config.GatewayModeShared, uint(vlanID))
 			err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -679,7 +679,7 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 			// Wait for netpols to appear
 			controllerName := l2Controller.controllerName
 			peer := netpol.Spec.Ingress[0].From[0]
-			dbIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, nil, ns, controllerName)
+			dbIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(peer.PodSelector, nil, nil, ns, controllerName, false)
 			v4Hash, _ := addressset.GetHashNamesForAS(dbIDs)
 			Eventually(func(g Gomega) {
 				acls, err := libovsdbops.FindACLsWithPredicate(fakeOvn.nbClient, func(acl *nbdb.ACL) bool {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -905,6 +905,7 @@ func (oc *DefaultNetworkController) addIPToHostNetworkNamespaceAddrSet(node *cor
 				return fmt.Errorf("failed to ensure namespace locked: %v", err)
 			}
 			defer nsUnlock()
+			oc.addressSetManager.AddHostNetworkNamespaceIPs(util.StringSlice(hostNetworkPolicyIPs))
 			if err = nsInfo.addressSet.AddAddresses(util.StringSlice(hostNetworkPolicyIPs)); err != nil {
 				return err
 			}
@@ -942,6 +943,7 @@ func (oc *DefaultNetworkController) delIPFromHostNetworkNamespaceAddrSet(node *c
 				return fmt.Errorf("failed to ensure namespace locked: %v", err)
 			}
 			defer nsUnlock()
+			oc.addressSetManager.DeleteHostNetworkNamespaceIPs(util.StringSlice(hostNetworkPolicyIPs))
 			if err = nsInfo.addressSet.DeleteAddresses(util.StringSlice(hostNetworkPolicyIPs)); err != nil {
 				return err
 			}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -802,20 +802,12 @@ func (oc *DefaultNetworkController) deleteOVNNodeEvent(node *corev1.Node) error 
 		oc.syncZoneICFailed.Delete(node.Name)
 	}
 
-	// Remove management port IP and node's gateway-router-lrp-ifaddr
-	// from address_set specific to HostNetworkNamespace
-	if err := oc.delIPFromHostNetworkNamespaceAddrSet(node); err != nil {
-		return fmt.Errorf("failed to delete IPs from %s address_set: %v",
-			config.Kubernetes.HostNetworkNamespace, err)
-	}
-
 	oc.lsManager.DeleteSwitch(node.Name)
 	oc.addNodeFailed.Delete(node.Name)
 	oc.mgmtPortFailed.Delete(node.Name)
 	oc.gatewaysFailed.Delete(node.Name)
 	oc.nodeClusterRouterPortFailed.Delete(node.Name)
 	oc.localZoneNodes.Delete(node.Name)
-	oc.syncHostNetAddrSetFailed.Delete(node.Name)
 
 	return nil
 }
@@ -873,84 +865,6 @@ func (oc *DefaultNetworkController) deleteHoNodeEvent(node *corev1.Node) error {
 		if err != nil {
 			return fmt.Errorf("failed to remove hybrid overlay static routes and route policy: %w", err)
 		}
-	}
-	return nil
-}
-
-// addIPToHostNetworkNamespaceAddrSet adds management port IP and node's
-// gateway-router-lrp-ifaddr to address_set created for HostNetworkNamespace.
-// This function gets called from both AddResource & UpdateResource to add IPs
-// to address_set for both local and remote zone nodes.
-func (oc *DefaultNetworkController) addIPToHostNetworkNamespaceAddrSet(node *corev1.Node) error {
-	var hostNetworkPolicyIPs []net.IP
-
-	if util.NoHostSubnet(node) {
-		return nil
-	}
-	hostNetworkPolicyIPs, err := oc.getHostNamespaceAddressesForNode(node)
-	if err != nil {
-		parsedErr := err
-		if !oc.isLocalZoneNode(node) {
-			parsedErr = types.NewSuppressedError(err)
-		}
-		return fmt.Errorf("error parsing annotation for node %s: %w", node.Name, parsedErr)
-	}
-
-	// add the host network IPs for this node to host network namespace's address set
-	if err = func() error {
-		hostNetworkNamespace := config.Kubernetes.HostNetworkNamespace
-		if hostNetworkNamespace != "" {
-			nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(hostNetworkNamespace, true, nil)
-			if err != nil {
-				return fmt.Errorf("failed to ensure namespace locked: %v", err)
-			}
-			defer nsUnlock()
-			oc.addressSetManager.AddHostNetworkNamespaceIPs(util.StringSlice(hostNetworkPolicyIPs))
-			if err = nsInfo.addressSet.AddAddresses(util.StringSlice(hostNetworkPolicyIPs)); err != nil {
-				return err
-			}
-		}
-		return nil
-	}(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// delIPFromHostNetworkNamespaceAddrSet removes management port IP and node's
-// gateway-router-lrp-ifaddr from address_set created for HostNetworkNamespace.
-// This function gets called from deleteOVNNodeEvent to remove IPs from address_set
-// for both local and remote zone nodes
-func (oc *DefaultNetworkController) delIPFromHostNetworkNamespaceAddrSet(node *corev1.Node) error {
-	var hostNetworkPolicyIPs []net.IP
-
-	hostNetworkPolicyIPs, err := oc.getHostNamespaceAddressesForNode(node)
-	if err != nil {
-		if util.IsAnnotationNotSetError(err) {
-			// if annotation is not set for node subnet or node GW router LRP IP address, we can assume nothing was added to the
-			// host network namespace address set. We depend on both annotations to be set before configuring the address set.
-			return nil
-		}
-		return fmt.Errorf("error parsing annotation for node %s: %v", node.Name, err)
-	}
-
-	// delete host network IPs for this node from host network namespace's address set
-	if err = func() error {
-		hostNetworkNamespace := config.Kubernetes.HostNetworkNamespace
-		if hostNetworkNamespace != "" {
-			nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(hostNetworkNamespace, true, nil)
-			if err != nil {
-				return fmt.Errorf("failed to ensure namespace locked: %v", err)
-			}
-			defer nsUnlock()
-			oc.addressSetManager.DeleteHostNetworkNamespaceIPs(util.StringSlice(hostNetworkPolicyIPs))
-			if err = nsInfo.addressSet.DeleteAddresses(util.StringSlice(hostNetworkPolicyIPs)); err != nil {
-				return err
-			}
-		}
-		return nil
-	}(); err != nil {
-		return err
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -35,7 +35,6 @@ import (
 	egressqosfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1/apis/clientset/versioned/fake"
 	egressservicefake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kubevirt"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
@@ -852,7 +851,6 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		expectedNBDatabaseState        []libovsdbtest.TestData
 		l3GatewayConfig                *util.L3GatewayConfig
 		nodeHostCIDRs                  sets.Set[string]
-		fakeOvn                        *FakeOVN
 	)
 
 	const (
@@ -866,7 +864,6 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
-		fakeOvn = NewFakeOVN(true)
 		config.OVNKubernetesFeature.EnableEgressIP = true
 
 		app = cli.NewApp()
@@ -1477,12 +1474,6 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				ginkgo.By("delete node and check that there are no retries for the deleted node")
 				err = kubeFakeClient.CoreV1().Nodes().Delete(context.TODO(), node.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				ginkgo.By("ensure failures for sync host network address or adding nodes are cleared")
-				gomega.Eventually(func() bool {
-					_, foundSyncHostNetAddrSetFailed := oc.syncHostNetAddrSetFailed.Load(node.Name)
-					_, foundAddNodeFailed := oc.addNodeFailed.Load(node.Name)
-					return foundSyncHostNetAddrSetFailed || foundAddNodeFailed
-				}).Should(gomega.BeFalse())
 				return nil
 			}
 			err := app.Run([]string{
@@ -1772,217 +1763,6 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				})
 				return err
 			}).Should(gomega.Succeed())
-
-			return nil
-		}
-
-		err := app.Run([]string{
-			app.Name,
-			"-cluster-subnets=" + clusterCIDR,
-			"--init-gateways",
-			"--nodeport",
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	})
-
-	ginkgo.It("verify IPs in host-network-namespace address_set after remote zone node add or delete", func() {
-		app.Action = func(ctx *cli.Context) error {
-			_, err := config.InitConfig(ctx, nil, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.OVNKubernetesFeature.EnableInterconnect = true
-			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
-
-			// add the transit switch port bindings on behalf of ovn-northd so that
-			// the node gets added successfully. This is required for test simulation
-			// and not required in real world scenario.
-			pb := &sbdb.PortBinding{
-				LogicalPort: "tstor-node1",
-				Datapath:    "tstor-node1",
-				TunnelKey:   5,
-			}
-			dp := &sbdb.DatapathBinding{
-				UUID:      "tstor-node1",
-				TunnelKey: 6,
-			}
-			dbSetup.SBData = append(
-				dbSetup.SBData,
-				pb,
-				dp,
-			)
-
-			// transit_switch is required to be able to start OVN with an empty
-			// NodeList and to avoid calling ensureTransitSwitch which expects
-			// a list of nodes. This is required for test simulation and not
-			// required in real world scenario.
-			ts := &nbdb.LogicalSwitch{
-				Name: "transit_switch",
-			}
-			dbSetup.NBData = append(
-				dbSetup.NBData,
-				ts,
-			)
-
-			// https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/go-controller/pkg/ovn/namespace.go#L312
-			// adds management port and gateway router LRP IP to HostNetworkNamespace address set whenever
-			// the namespace gets created. Hence starting OVN with an empty NodeList and adding the node
-			// after the namespace is created successfully
-			fakeOvn.startWithDBSetup(dbSetup,
-				&corev1.NamespaceList{
-					Items: []corev1.Namespace{*ovntest.NewNamespace(config.Kubernetes.HostNetworkNamespace)},
-				},
-				&corev1.NodeList{
-					Items: []corev1.Node{},
-				},
-			)
-
-			// Required to make sure a remote zone node is being added
-			fakeOvn.controller.zone = "node1"
-
-			gomega.Expect(fakeOvn.controller.WatchNamespaces()).To(gomega.Succeed(), "Namespace should be created fine")
-			startDefaultNodeController(fakeOvn.controller)
-
-			// Check whether the address_set is empty after HostNetworkNamespace addition
-			fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(config.Kubernetes.HostNetworkNamespace)
-
-			// Set annotations required to create remote zone node
-			newNodeSubnet := "10.1.2.0/24"
-			transitSwitchSubnet := "100.88.0.3/16"
-			testNode.Annotations["k8s.ovn.org/node-subnets"] = fmt.Sprintf("{\"default\":[\"%s\"]}", newNodeSubnet)
-			testNode.Annotations["k8s.ovn.org/node-chassis-id"] = chassisIDForNode(testNode.Name)
-			testNode.Annotations["k8s.ovn.org/node-encap-ips"] = "[\"1.2.3.4\"]"
-			testNode.Annotations["k8s.ovn.org/node-transit-switch-port-ifaddr"] = fmt.Sprintf("{\"ipv4\":\"%s\"}", transitSwitchSubnet)
-			testNode.Annotations["k8s.ovn.org/zone-name"] = "foo"
-			updatedNode, err := fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// Check whether node IPs have been added to HostNetworkNamespace
-			// address_set or not
-			var ips []string
-			hostSubnets, err := util.ParseNodeHostSubnetAnnotation(updatedNode, types.DefaultNetworkName)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			mgmt_ips := util.GetNodeManagementIfAddr(hostSubnets[0])
-			ips = append(ips, mgmt_ips.IP.String())
-			lrpips, err := udn.GetGWRouterIPs(updatedNode, oc.GetNetInfo())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			lrpip, _, _ := net.ParseCIDR(lrpips[0].String())
-			ips = append(ips, lrpip.String())
-
-			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(config.Kubernetes.HostNetworkNamespace, ips)
-
-			// Delete the node and check whether the address_set is empty or not
-			err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			var emptyAddress []string
-			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(config.Kubernetes.HostNetworkNamespace, emptyAddress)
-
-			return nil
-		}
-
-		err := app.Run([]string{
-			app.Name,
-			"-cluster-subnets=" + clusterCIDR,
-			"--init-gateways",
-			"--nodeport",
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	})
-
-	ginkgo.It("refreshes IPs in host-network-namespace address_set after local node update", func() {
-		app.Action = func(ctx *cli.Context) error {
-			_, err := config.InitConfig(ctx, nil, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
-			annotatedNode, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), testNode.Name, metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			fakeOvn.startWithDBSetup(dbSetup,
-				&corev1.NamespaceList{
-					Items: []corev1.Namespace{*ovntest.NewNamespace(config.Kubernetes.HostNetworkNamespace)},
-				},
-				&corev1.NodeList{
-					Items: []corev1.Node{*annotatedNode},
-				},
-			)
-
-			gomega.Expect(fakeOvn.controller.WatchNamespaces()).To(gomega.Succeed(), "Namespace should be created fine")
-			startDefaultNodeController(fakeOvn.controller)
-
-			updatedNode, err := fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), testNode.Name, metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			initialIPs, err := fakeOvn.controller.getHostNamespaceAddressesForNode(updatedNode)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(config.Kubernetes.HostNetworkNamespace, util.StringSlice(initialIPs))
-
-			updatedNode = updatedNode.DeepCopy()
-			updatedNode.Annotations["k8s.ovn.org/node-subnets"] = "{\"default\":[\"10.1.3.0/24\"]}"
-			updatedNode, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), updatedNode, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			refreshedIPs, err := fakeOvn.controller.getHostNamespaceAddressesForNode(updatedNode)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(config.Kubernetes.HostNetworkNamespace, util.StringSlice(refreshedIPs))
-
-			return nil
-		}
-
-		err := app.Run([]string{
-			app.Name,
-			"-cluster-subnets=" + clusterCIDR,
-			"--init-gateways",
-			"--nodeport",
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	})
-
-	ginkgo.It("includes node primary IP in host-network-namespace address_set when NoOverlay mode is enabled", func() {
-		app.Action = func(ctx *cli.Context) error {
-			_, err := config.InitConfig(ctx, nil, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
-			// Enable NoOverlay transport mode
-			config.Default.Transport = "no-overlay"
-
-			// Start with empty NodeList, then add node after namespace is created
-			fakeOvn.startWithDBSetup(dbSetup,
-				&corev1.NamespaceList{
-					Items: []corev1.Namespace{*ovntest.NewNamespace(config.Kubernetes.HostNetworkNamespace)},
-				},
-				&corev1.NodeList{
-					Items: []corev1.Node{},
-				},
-			)
-
-			gomega.Expect(fakeOvn.controller.WatchNamespaces()).To(gomega.Succeed(), "Namespace should be created fine")
-			startDefaultNodeController(fakeOvn.controller)
-
-			// Wait for empty address set to be created
-			fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(config.Kubernetes.HostNetworkNamespace)
-
-			// Now create the node with all required annotations
-			newNodeSubnet := "10.1.1.0/24"
-			testNode.Annotations["k8s.ovn.org/node-subnets"] = fmt.Sprintf("{\"default\":[\"%s\"]}", newNodeSubnet)
-			testNode.Annotations["k8s.ovn.org/node-chassis-id"] = chassisIDForNode(testNode.Name)
-			testNode.Annotations["k8s.ovn.org/node-primary-ifaddr"] = "{\"ipv4\":\"192.168.1.10/24\"}"
-			createdNode, err := fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// Build expected IPs following the same pattern as the remote zone test
-			var ips []string
-			hostSubnets, err := util.ParseNodeHostSubnetAnnotation(createdNode, types.DefaultNetworkName)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			mgmt_ips := util.GetNodeManagementIfAddr(hostSubnets[0])
-			ips = append(ips, mgmt_ips.IP.String())
-			lrpips, err := udn.GetGWRouterIPs(createdNode, fakeOvn.controller.GetNetInfo())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			lrpip, _, _ := net.ParseCIDR(lrpips[0].String())
-			ips = append(ips, lrpip.String())
-
-			// When NoOverlay is enabled, primary interface IPv4 should also be included
-			ips = append(ips, "192.168.1.10") // IPv4 primary interface IP
-
-			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(config.Kubernetes.HostNetworkNamespace, ips)
 
 			return nil
 		}

--- a/go-controller/pkg/ovn/multipolicy_test.go
+++ b/go-controller/pkg/ovn/multipolicy_test.go
@@ -443,7 +443,6 @@ var _ = ginkgo.Describe("OVN MultiNetworkPolicy Operations", func() {
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(policy).
-						withPeerNamespaces(namespace2.Name).
 						withNetInfo(netInfo),
 					initialDB.NBData)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData))

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -330,6 +330,10 @@ func (oc *DefaultNetworkController) ensureNamespaceLocked(ns string, readOnly bo
 		}
 		return oc.getAllNamespacePodAddresses(ns)
 	}
+	// special handling of host network namespace. issues/3381
+	if config.Kubernetes.HostNetworkNamespace != "" && ns == config.Kubernetes.HostNetworkNamespace {
+		oc.addressSetManager.SetHostNetworkNamespaceIPs(util.StringSlice(oc.getAllHostNamespaceAddresses()))
+	}
 	return oc.ensureNamespaceLockedCommon(ns, readOnly, namespace, ipsGetter, oc.configureNamespace)
 }
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -323,101 +322,5 @@ func (oc *DefaultNetworkController) deleteNamespace(ns *corev1.Namespace) error 
 // with its mutex locked.
 // ns is the name of the namespace, while namespace is the optional k8s namespace object
 func (oc *DefaultNetworkController) ensureNamespaceLocked(ns string, readOnly bool, namespace *corev1.Namespace) (*namespaceInfo, func(), error) {
-	ipsGetter := func(ns string) []net.IP {
-		// special handling of host network namespace. issues/3381
-		if config.Kubernetes.HostNetworkNamespace != "" && ns == config.Kubernetes.HostNetworkNamespace {
-			return oc.getAllHostNamespaceAddresses()
-		}
-		return oc.getAllNamespacePodAddresses(ns)
-	}
-	// special handling of host network namespace. issues/3381
-	if config.Kubernetes.HostNetworkNamespace != "" && ns == config.Kubernetes.HostNetworkNamespace {
-		oc.addressSetManager.SetHostNetworkNamespaceIPs(util.StringSlice(oc.getAllHostNamespaceAddresses()))
-	}
-	return oc.ensureNamespaceLockedCommon(ns, readOnly, namespace, ipsGetter, oc.configureNamespace)
-}
-
-// getAllHostNamespaceAddresses retrives management port and gateway router LRP
-// IP for all nodes in the cluster
-func (oc *DefaultNetworkController) getAllHostNamespaceAddresses() []net.IP {
-	var ips []net.IP
-	// add the mp0 interface addresses to this namespace.
-	existingNodes, err := oc.watchFactory.GetNodes()
-	if err != nil {
-		klog.Errorf("Failed to get all nodes (%v)", err)
-	} else {
-		ips = make([]net.IP, 0, len(existingNodes))
-		for _, node := range existingNodes {
-			if config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
-				// skip hybrid overlay nodes
-				continue
-			}
-			hostNetworkIPs, err := oc.getHostNamespaceAddressesForNode(node)
-			if err != nil {
-				klog.Errorf("Error parsing annotation for node %s: %v", node.Name, err)
-			}
-			ips = append(ips, hostNetworkIPs...)
-		}
-	}
-	return ips
-}
-
-// getHostNamespaceAddressesForNode retrives management port and gateway router LRP
-// IP of a specific node
-func (oc *DefaultNetworkController) getHostNamespaceAddressesForNode(node *corev1.Node) ([]net.IP, error) {
-	var ips []net.IP
-	hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName)
-	if err != nil {
-		return nil, err
-	}
-	for _, hostSubnet := range hostSubnets {
-		mgmtIfAddr := oc.GetNodeManagementIP(hostSubnet)
-		ips = append(ips, mgmtIfAddr.IP)
-	}
-	// for shared gateway mode we will use LRP IPs to SNAT host network traffic
-	// so add these to the address set.
-	lrpIPs, gwIPsErr := udn.GetGWRouterIPs(node, oc.GetNetInfo())
-	if gwIPsErr != nil {
-		if !util.IsAnnotationNotSetError(gwIPsErr) {
-			return nil, gwIPsErr
-		}
-		// FIXME(tssurya): This is present for backwards compatibility
-		// Remove me a few months from now
-		var lrpAddrsErr error
-		lrpIPs, lrpAddrsErr = util.ParseNodeGatewayRouterLRPAddrs(node)
-		if lrpAddrsErr != nil {
-			return nil, fmt.Errorf("failed to fallback to annotations after error %q: %w", gwIPsErr, lrpAddrsErr)
-		}
-	}
-
-	for _, lrpIP := range lrpIPs {
-		ips = append(ips, lrpIP.IP)
-	}
-
-	// When NoOverlay mode is enabled, also include the node's primary physical interface IP
-	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay {
-		nodeIfAddr, err := util.GetNodeIfAddrAnnotation(node)
-		if err != nil {
-			if !util.IsAnnotationNotSetError(err) {
-				return nil, fmt.Errorf("failed to get node primary interface address: %w", err)
-			}
-		} else {
-			if nodeIfAddr.IPv4 != "" {
-				ipv4, _, err := net.ParseCIDR(nodeIfAddr.IPv4)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse node primary IPv4 address %s: %w", nodeIfAddr.IPv4, err)
-				}
-				ips = append(ips, ipv4)
-			}
-			if nodeIfAddr.IPv6 != "" {
-				ipv6, _, err := net.ParseCIDR(nodeIfAddr.IPv6)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse node primary IPv6 address %s: %w", nodeIfAddr.IPv6, err)
-				}
-				ips = append(ips, ipv6)
-			}
-		}
-	}
-
-	return ips, nil
+	return oc.ensureNamespaceLockedCommon(ns, readOnly, namespace, oc.configureNamespace)
 }

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -5,7 +5,6 @@ package ovn
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -15,12 +14,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -30,7 +26,6 @@ import (
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func getNamespaceAnnotations(fakeClient kubernetes.Interface, name string) map[string]string {
@@ -103,7 +98,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			_, err = fakeOvn.asf.NewAddressSet(ns2, []string{"1.1.1.2"})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// netpol peer address set for existing netpol, should stay
-			netpol := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", ovntypes.DefaultNetworkControllerName)
+			netpol := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", ovntypes.DefaultNetworkControllerName, false)
 			_, err = fakeOvn.asf.NewAddressSet(netpol, []string{"1.1.1.3"})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// egressQoS-owned address set, should stay
@@ -202,139 +197,6 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			pg := libovsdbutil.BuildPortGroup(pgIDs, nil, nil)
 			pg.UUID = pg.Name + "-UUID"
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData([]libovsdb.TestData{pg}))
-		})
-
-		ginkgo.It("creates an address set for existing nodes when the host network traffic namespace is created", func() {
-			config.Gateway.Mode = config.GatewayModeShared
-			config.Gateway.NodeportEnable = true
-			config.Gateway.EphemeralPortRange = config.DefaultEphemeralPortRange
-			var err error
-			config.Default.ClusterSubnets, err = config.ParseClusterSubnetEntries(clusterCIDR)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			node1 := tNode{
-				Name:                 "node1",
-				NodeIP:               "1.2.3.4",
-				NodeLRPMAC:           "0a:58:0a:01:01:01",
-				LrpIP:                "100.64.0.2",
-				LrpIPv6:              "fd98::2",
-				DrLrpIP:              "100.64.0.1",
-				PhysicalBridgeMAC:    "11:22:33:44:55:66",
-				SystemID:             "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6",
-				NodeSubnet:           "10.1.1.0/24",
-				GWRouter:             ovntypes.GWRouterPrefix + "node1",
-				GatewayRouterIPMask:  "172.16.16.2/24",
-				GatewayRouterIP:      "172.16.16.2",
-				GatewayRouterNextHop: "172.16.16.1",
-				PhysicalBridgeName:   "br-eth0",
-				NodeGWIP:             "10.1.1.1/24",
-				NodeMgmtPortIP:       "10.1.1.2",
-				NodeMgmtPortMAC:      "0a:58:0a:01:01:02",
-				DnatSnatIP:           "169.254.0.1",
-			}
-			// create a test node and annotate it with host subnet
-			testNode := node1.k8sNode("2")
-
-			hostNetworkNamespace := "test-host-network-ns"
-			config.Kubernetes.HostNetworkNamespace = hostNetworkNamespace
-
-			expectedClusterLBGroup := newLoadBalancerGroup(ovntypes.ClusterLBGroupName)
-			expectedSwitchLBGroup := newLoadBalancerGroup(ovntypes.ClusterSwitchLBGroupName)
-			expectedRouterLBGroup := newLoadBalancerGroup(ovntypes.ClusterRouterLBGroupName)
-			expectedOVNClusterRouter := newOVNClusterRouter()
-			expectedNodeSwitch := node1.logicalSwitch([]string{expectedClusterLBGroup.UUID, expectedSwitchLBGroup.UUID})
-			expectedClusterRouterPortGroup := newRouterPortGroup()
-			expectedClusterPortGroup := newClusterPortGroup()
-
-			fakeOvn.startWithDBSetup(
-				libovsdb.TestSetup{
-					NBData: []libovsdb.TestData{
-						newClusterJoinSwitch(),
-						expectedOVNClusterRouter,
-						expectedNodeSwitch,
-						expectedClusterRouterPortGroup,
-						expectedClusterPortGroup,
-						expectedClusterLBGroup,
-						expectedSwitchLBGroup,
-						expectedRouterLBGroup,
-					},
-				},
-				&corev1.NamespaceList{
-					Items: []corev1.Namespace{
-						*ovntest.NewNamespace(hostNetworkNamespace),
-					},
-				},
-				&corev1.NodeList{
-					Items: []corev1.Node{
-						testNode,
-					},
-				},
-			)
-			fakeOvn.controller.multicastSupport = false
-
-			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{KClient: fakeOvn.fakeClient.KubeClient}, testNode.Name)
-
-			vlanID := uint(1024)
-			l3Config := node1.gatewayConfig(config.GatewayModeShared, vlanID)
-			err = util.SetL3GatewayConfig(nodeAnnotator, l3Config)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.UpdateNodeManagementPortMACAddresses(&testNode, nodeAnnotator, ovntest.MustParseMAC(node1.NodeMgmtPortMAC), ovntypes.DefaultNetworkName)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.SetNodeHostCIDRs(nodeAnnotator, sets.New[string](fmt.Sprintf("%s/24", node1.NodeIP)))
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = nodeAnnotator.Run()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			updatedNode, err := fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1.Name, metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			nodeHostSubnetAnnotations, err := util.ParseNodeHostSubnetAnnotation(updatedNode, ovntypes.DefaultNetworkName)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(nodeHostSubnetAnnotations[0].String()).To(gomega.Equal(node1.NodeSubnet))
-
-			expectedDatabaseState := []libovsdb.TestData{}
-			expectedDatabaseState = addNodeLogicalFlowsWithServiceController(expectedDatabaseState, expectedOVNClusterRouter,
-				expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, fakeOvn.controller.svcTemplateSupport)
-
-			// Addressset of the host-network namespace was initialized but the node logical switch management port address may or may not
-			// be in the addressset yet, depending on if the host subnets annotation of the node exists in the informer cache. The addressset
-			// can only be deterministic when WatchNamespaces() handles this host network namespace.
-
-			gwLRPIPs, err := udn.GetGWRouterIPs(&testNode, &util.DefaultNetInfo{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(gwLRPIPs).ToNot(gomega.BeEmpty())
-
-			err = fakeOvn.controller.WatchNamespaces()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			startDefaultNodeController(fakeOvn.controller)
-
-			err = fakeOvn.controller.StartServiceController(wg, false)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			nodeSubnet := ovntest.MustParseIPNet(node1.NodeSubnet)
-			var clusterSubnets []*net.IPNet
-			for _, clusterSubnet := range config.Default.ClusterSubnets {
-				clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR)
-			}
-			skipSnat := false
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
-				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{nodeSubnet}, l3Config,
-				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
-				node1.NodeMgmtPortIP, "1400")
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDatabaseState))
-
-			// check the namespace again and ensure the address set
-			// being created with the right set of IPs in it.
-			allowIPs := []string{node1.NodeMgmtPortIP}
-			for _, lrpIP := range gwLRPIPs {
-				allowIPs = append(allowIPs, lrpIP.IP.String())
-			}
-			fakeOvn.asf.EventuallyExpectAddressSetWithAddresses(hostNetworkNamespace, allowIPs)
 		})
 
 		ginkgo.It("reconciles an existing namespace port group, without updating it", func() {

--- a/go-controller/pkg/ovn/network_controller_policy_event_handler.go
+++ b/go-controller/pkg/ovn/network_controller_policy_event_handler.go
@@ -25,7 +25,7 @@ import (
 // and resource-specific extra parameters (used now for network-policy-dependant types).
 // newNetpolRetryFramework is also called directly by the watchers that are
 // dynamically created when a network policy is added:
-// PeerNamespaceSelectorType, LocalPodSelectorType
+// LocalPodSelectorType
 func (bnc *BaseNetworkController) newNetpolRetryFramework(
 	objectType reflect.Type,
 	syncFunc func([]interface{}) error,
@@ -78,11 +78,6 @@ func (h *networkControllerPolicyEventHandler) AreResourcesEqual(_, _ interface{}
 		// For these types, there was no old vs new obj comparison in the original update code,
 		// so pretend they're always different so that the update code gets executed
 		return false, nil
-
-	case factory.PeerNamespaceSelectorType: //
-		// For these types there is no update code, so pretend old and new
-		// objs are always equivalent and stop processing the update event.
-		return true, nil
 	}
 
 	return false, fmt.Errorf("no object comparison for type %s", h.objType)
@@ -110,9 +105,6 @@ func (h *networkControllerPolicyEventHandler) GetResourceFromInformerCache(key s
 	case factory.LocalPodSelectorType:
 		obj, err = h.watchFactory.GetPod(namespace, name)
 
-	case factory.PeerNamespaceSelectorType:
-		obj, err = h.watchFactory.GetNamespace(name)
-
 	default:
 		err = fmt.Errorf("object type %s not supported, cannot retrieve it from informers cache",
 			h.objType)
@@ -125,10 +117,6 @@ func (h *networkControllerPolicyEventHandler) GetResourceFromInformerCache(key s
 // Given an object to add and a boolean specifying if the function was executed from iterateRetryResources
 func (h *networkControllerPolicyEventHandler) AddResource(obj interface{}, _ bool) error {
 	switch h.objType {
-	case factory.PeerNamespaceSelectorType:
-		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)
-		return h.bnc.handlePeerNamespaceSelectorAdd(extraParameters.np, extraParameters.gp, obj)
-
 	case factory.LocalPodSelectorType:
 		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)
 		return h.bnc.handleLocalPodSelectorAddFunc(
@@ -168,10 +156,6 @@ func (h *networkControllerPolicyEventHandler) UpdateResource(_, newObj interface
 // used for now for pods and network policies.
 func (h *networkControllerPolicyEventHandler) DeleteResource(obj, _ interface{}) error {
 	switch h.objType {
-	case factory.PeerNamespaceSelectorType:
-		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)
-		return h.bnc.handlePeerNamespaceSelectorDel(extraParameters.np, extraParameters.gp, obj)
-
 	case factory.LocalPodSelectorType:
 		extraParameters := h.extraParameters.(*NetworkPolicyExtraParameters)
 		return h.bnc.handleLocalPodSelectorDelFunc(
@@ -191,8 +175,7 @@ func (h *networkControllerPolicyEventHandler) SyncFunc(objs []interface{}) error
 		syncFunc = h.syncFunc
 	} else {
 		switch h.objType {
-		case factory.LocalPodSelectorType,
-			factory.PeerNamespaceSelectorType:
+		case factory.LocalPodSelectorType:
 			syncFunc = nil
 
 		default:

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -129,6 +129,7 @@ type testPod struct {
 	nodeGWIP      string
 	podName       string
 	podIP         string
+	hostNetwork   bool
 	podMAC        string
 	namespace     string
 	portName      string

--- a/go-controller/pkg/ovn/policy_stale_test.go
+++ b/go-controller/pkg/ovn/policy_stale_test.go
@@ -155,7 +155,7 @@ func getStalePolicyACLs(gressIdx int, namespace, policyName string, peerNamespac
 				// nil pod selector is equivalent to empty pod selector, which selects all
 				podSelector = &metav1.LabelSelector{}
 			}
-			peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, nil, namespace, controllerName)
+			peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, nil, namespace, controllerName, false)
 			asv4, _ := addressset.GetHashNamesForAS(peerIndex)
 			hashedASNames = append(hashedASNames, asv4)
 		}
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
-		fakeOvn = NewFakeOVN(true)
+		fakeOvn = NewFakeOVN(false)
 
 		initialData := getHairpinningACLsV4AndPortGroup()
 		initialDB = libovsdbtest.TestSetup{
@@ -289,16 +289,17 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 				startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1, namespace2},
 					[]knet.NetworkPolicy{*networkPolicy})
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
-				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
-
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// make sure stale ACLs were updated
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
+					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
+
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 			},
 			ginkgo.Entry("with allow ICMP network policy disabled", false),
@@ -320,16 +321,17 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1, namespace2},
 				[]knet.NetworkPolicy{*networkPolicy})
 
-			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
-			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
-
 			_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 				Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// make sure stale ICMP ACLs were removed to match disabled allow-icmp config
 			expectedData := getNamespaceWithSinglePolicyExpectedData(
-				newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
+				newNetpolDataParams(networkPolicy),
 				initialDB.NBData)
+			namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
+			namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
+			expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
+
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 		})
 
@@ -348,16 +350,16 @@ var _ = ginkgo.Describe("OVN Stale NetworkPolicy Operations", func() {
 			startOvn(libovsdbtest.TestSetup{NBData: initialData}, []corev1.Namespace{namespace1, namespace2},
 				[]knet.NetworkPolicy{*networkPolicy})
 
-			fakeOvn.asf.ExpectEmptyAddressSet(longNamespaceName63)
-			fakeOvn.asf.ExpectEmptyAddressSet(namespaceName2)
-
 			_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 				Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// make sure stale ACLs were updated
 			expectedData := getNamespaceWithSinglePolicyExpectedData(
-				newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
+				newNetpolDataParams(networkPolicy),
 				initialDB.NBData)
+			namespace1AddressSetv4, _ := buildNamespaceAddressSets(longNamespaceName63, nil)
+			namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
+			expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 		})
 	})

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -629,6 +629,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		netPolicyName1        = "networkpolicy1"
 		netPolicyName2        = "networkpolicy2"
 		nodeName              = "node1"
+		node1Subnet           = "10.244.0.0/24"
+		node1MgmtIP           = "10.244.0.2"
 		labelName      string = "pod-name"
 		labelVal       string = "server"
 		portNum        int32  = 81
@@ -686,13 +688,15 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			}
 			podsList = append(podsList, *knetPod)
 		}
+		testNode := newNode(nodeName, "192.168.126.202/24")
+		testNode.Annotations["k8s.ovn.org/node-subnets"] = fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet)
 		fakeOvn.startWithDBSetup(dbSetup,
 			&corev1.NamespaceList{
 				Items: namespaces,
 			},
 			&corev1.NodeList{
 				Items: []corev1.Node{
-					*newNode(nodeName, "192.168.126.202/24"),
+					*testNode,
 				},
 			},
 			&corev1.PodList{
@@ -1119,7 +1123,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 	})
 
 	ginkgo.Context("during execution", func() {
-		const hostNetIP = "10.244.0.2"
 		const ns1PodIP = "10.128.1.3"
 		const ns1HostnetPodIP = "10.0.1.1"
 		const ns2PodIP = "10.128.1.4"
@@ -1140,18 +1143,15 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				}, nil)
 				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2, hostNetNamespace}, []knet.NetworkPolicy{*netpol},
 					[]testPod{ns1Pod, ns1HosnetPod, ns2Pod}, nil)
-				// imitate HostNetworkNamespace address set update
-				fakeOvn.controller.addressSetManager.SetHostNetworkNamespaceIPs([]string{hostNetIP})
 
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{ns1Pod.podIP})
 				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{ns2Pod.podIP})
-				// this namespace doesn't have ips, because we don't create nodes
-				hostNamespaceAddressSetv4, _ := buildNamespaceAddressSets(hostNetNamespace.Name, nil)
+				hostNamespaceAddressSetV4, _ := buildNamespaceAddressSets(config.Kubernetes.HostNetworkNamespace, []string{})
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(netpol).withPeerIPs(peerIPs...).withLocalPortUUIDs(ns1Pod.portUUID),
 					getUpdatedInitialDB([]testPod{ns1Pod, ns2Pod}))
-				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4, hostNamespaceAddressSetv4)
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4, hostNamespaceAddressSetV4)
 
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 			},
@@ -1201,7 +1201,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			ginkgo.Entry("empty namespace selector matches on HostNetworkNamespace IPs + legacyNetpolMode=true",
 				knet.NetworkPolicyPeer{
 					NamespaceSelector: &metav1.LabelSelector{},
-				}, []string{ns1PodIP, ns2PodIP, hostNetIP}),
+				}, []string{ns1PodIP, ns2PodIP, node1MgmtIP}),
 		)
 
 		ginkgo.It("correctly creates and deletes a networkpolicy allowing a port to a local pod", func() {
@@ -1906,7 +1906,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
 		})
 
-		ginkgo.It("references all namespace address sets for empty namespace selector, even if they don't have pods (HostNetworkNamespace)", func() {
+		ginkgo.It("references all namespaces pod IP for empty namespace selector, (including HostNetworkNamespace)", func() {
 			app.Action = func(*cli.Context) error {
 				config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
 				hostNamespace := *ovntest.NewNamespace(config.Kubernetes.HostNetworkNamespace)
@@ -1923,9 +1923,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				startOvn(initialDB, []corev1.Namespace{namespace1, hostNamespace}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
-				// emulate namespace handler adding management IPs for this address set
-				fakeOvn.controller.addressSetManager.SetHostNetworkNamespaceIPs([]string{hostNetIP})
-
 				// create networkPolicy, check db
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
@@ -1934,12 +1931,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy).
 						withLocalPortUUIDs(nPodTest.portUUID).
-						withPeerIPs(nPodTest.podIP, "10.244.0.2"),
+						// this is added via HostNetworkNamespace
+						withPeerIPs(nPodTest.podIP, node1MgmtIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
-				// this namespace doesn't have ips, because we don't create nodes
-				hostNamespaceAddressSetv4, _ := buildNamespaceAddressSets(hostNamespace.Name, nil)
-				expectedData = append(expectedData, namespace1AddressSetv4, hostNamespaceAddressSetv4)
+				hostNamespaceAddressSetV4, _ := buildNamespaceAddressSets(config.Kubernetes.HostNetworkNamespace, []string{})
+
+				expectedData = append(expectedData, namespace1AddressSetv4, hostNamespaceAddressSetV4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -240,10 +240,10 @@ func getMultinetNsAddrSetHashNames(ns, controllerName string) (string, string) {
 	return addressset.GetHashNamesForAS(getNamespaceAddrSetDbIDs(ns, controllerName))
 }
 
-// getGressACLs can only handle tcpPeerPorts for policies built with getPortNetworkPolicy, i.e. peer should only
+// getGressACLsAndAddrSets can only handle tcpPeerPorts for policies built with getPortNetworkPolicy, i.e. peer should only
 // have `Ports` filled, but no `To`/`From`.
-func getGressACLs(gressIdx int, peers []knet.NetworkPolicyPeer, policyType knet.PolicyType,
-	params *netpolDataParams) []*nbdb.ACL {
+func getGressACLsAndAddrSets(gressIdx int, peers []knet.NetworkPolicyPeer, policyType knet.PolicyType,
+	params *netpolDataParams) ([]*nbdb.ACL, []*nbdb.AddressSet) {
 	namespace := params.networkPolicy.Namespace
 	fakeController := getFakeBaseController(params.netInfo)
 	pgName := fakeController.getNetworkPolicyPGName(namespace, params.networkPolicy.Name)
@@ -254,6 +254,7 @@ func getGressACLs(gressIdx int, peers []knet.NetworkPolicyPeer, policyType knet.
 	var portDir string
 	var ipDir string
 	acls := []*nbdb.ACL{}
+	addressSets := []*nbdb.AddressSet{}
 	if policyType == knet.PolicyTypeEgress {
 		options = map[string]string{
 			"apply-after-lb": "true",
@@ -267,20 +268,19 @@ func getGressACLs(gressIdx int, peers []knet.NetworkPolicyPeer, policyType knet.
 		ipDir = "src"
 	}
 	hashedASNames := []string{}
-	for _, nsName := range params.peerNamespaces {
-		hashedASName, _ := getMultinetNsAddrSetHashNames(nsName, controllerName)
-		hashedASNames = append(hashedASNames, hashedASName)
-	}
 	ipBlocks := []string{}
 	for _, peer := range peers {
 		// follow the algorithm from setupGressPolicy
-		if (peer.NamespaceSelector != nil || peer.PodSelector != nil) && !useNamespaceAddrSet(peer) {
+		if peer.NamespaceSelector != nil || peer.PodSelector != nil {
 			podSelector := peer.PodSelector
 			if podSelector == nil {
 				// nil pod selector is equivalent to empty pod selector, which selects all
 				podSelector = &metav1.LabelSelector{}
 			}
-			peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, nil, namespace, controllerName)
+			legacyNetpolMode := useNamespaceAddrSet(peer)
+			peerIndex := addresssetmanager.GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, nil, namespace, controllerName, legacyNetpolMode)
+			netpolASv4, _ := addressset.GetTestDbAddrSets(peerIndex, params.peerIPs)
+			addressSets = append(addressSets, netpolASv4)
 			asv4, _ := addressset.GetHashNamesForAS(peerIndex)
 			hashedASNames = append(hashedASNames, asv4)
 		}
@@ -369,7 +369,7 @@ func getGressACLs(gressIdx int, peers []knet.NetworkPolicyPeer, policyType knet.
 		acl.UUID = dbIDs.String() + "-UUID"
 		acls = append(acls, acl)
 	}
-	return acls
+	return acls, addressSets
 }
 
 func allowAction(statelessNetPol bool) nbdb.ACLAction {
@@ -382,7 +382,7 @@ func allowAction(statelessNetPol bool) nbdb.ACLAction {
 type netpolDataParams struct {
 	networkPolicy    *knet.NetworkPolicy
 	localPortUUIDs   []string
-	peerNamespaces   []string
+	peerIPs          []string
 	tcpPeerPorts     []int32
 	allowLogSeverity nbdb.ACLSeverity
 	denyLogSeverity  nbdb.ACLSeverity
@@ -392,17 +392,48 @@ type netpolDataParams struct {
 
 func getPolicyData(params *netpolDataParams) []libovsdbtest.TestData {
 	acls := []*nbdb.ACL{}
-
+	addrSets := []*nbdb.AddressSet{}
 	for i, ingress := range params.networkPolicy.Spec.Ingress {
-		acls = append(acls, getGressACLs(i, ingress.From, knet.PolicyTypeIngress, params)...)
+		newACLs, newAddrSets := getGressACLsAndAddrSets(i, ingress.From, knet.PolicyTypeIngress, params)
+		acls = append(acls, newACLs...)
+		// use shared address sets, dedup
+		for _, newAddrSet := range newAddrSets {
+			found := false
+			for _, addrSet := range addrSets {
+				if newAddrSet.UUID == addrSet.UUID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				addrSets = append(addrSets, newAddrSet)
+			}
+		}
 	}
 	for i, egress := range params.networkPolicy.Spec.Egress {
-		acls = append(acls, getGressACLs(i, egress.To, knet.PolicyTypeEgress, params)...)
+		newACLs, newAddrSets := getGressACLsAndAddrSets(i, egress.To, knet.PolicyTypeEgress, params)
+		acls = append(acls, newACLs...)
+		// use shared address sets, dedup
+		for _, newAddrSet := range newAddrSets {
+			found := false
+			for _, addrSet := range addrSets {
+				if newAddrSet.UUID == addrSet.UUID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				addrSets = append(addrSets, newAddrSet)
+			}
+		}
 	}
 
 	pg := getPolicyPortGroup(params, acls)
 
 	data := []libovsdbtest.TestData{}
+	for _, addrSet := range addrSets {
+		data = append(data, addrSet)
+	}
 	for _, acl := range acls {
 		data = append(data, acl)
 	}
@@ -432,7 +463,7 @@ func newNetpolDataParams(networkPolicy *knet.NetworkPolicy) *netpolDataParams {
 	return &netpolDataParams{
 		networkPolicy:    networkPolicy,
 		localPortUUIDs:   nil,
-		peerNamespaces:   nil,
+		peerIPs:          nil,
 		tcpPeerPorts:     nil,
 		allowLogSeverity: "",
 		denyLogSeverity:  "",
@@ -441,8 +472,8 @@ func newNetpolDataParams(networkPolicy *knet.NetworkPolicy) *netpolDataParams {
 	}
 }
 
-func (p *netpolDataParams) withPeerNamespaces(peerNamespaces ...string) *netpolDataParams {
-	p.peerNamespaces = peerNamespaces
+func (p *netpolDataParams) withPeerIPs(peerIPs ...string) *netpolDataParams {
+	p.peerIPs = peerIPs
 	return p
 }
 
@@ -567,56 +598,28 @@ func getPortNetworkPolicy(policyName, namespace, labelName, labelVal string, tcp
 	)
 }
 
-// buildNetworkPolicyPeerAddressSet builds the addresssets for the networkpolicy peer provided
-func buildNetworkPolicyPeerAddressSets(namespaceName string, peer knet.NetworkPolicyPeer, ips ...string) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	dbIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespaceName, types.DefaultNetworkControllerName)
-	return addressset.GetTestDbAddrSets(dbIDs, ips)
-}
-
-// buildNetworkPolicyAddressSets builds all the addresssets for all the network policy peers of a network policy
-// the limitation is that all the addressSets must be empty
-func buildNetworkPolicyAddressSets(networkPolicy *knet.NetworkPolicy) []libovsdbtest.TestData {
-	addressSets := []libovsdbtest.TestData{}
-	for _, egress := range networkPolicy.Spec.Egress {
-		for _, peer := range egress.To {
-			if peer.PodSelector != nil {
-				peerASv4, peerASv6 := buildNetworkPolicyPeerAddressSets(networkPolicy.Namespace, peer)
-				if config.IPv4Mode {
-					addressSets = append(addressSets, peerASv4)
-				}
-				if config.IPv6Mode {
-					addressSets = append(addressSets, peerASv6)
-				}
-			}
-		}
-	}
-	for _, ingress := range networkPolicy.Spec.Ingress {
-		for _, peer := range ingress.From {
-			if peer.PodSelector != nil {
-				peerASv4, peerASv6 := buildNetworkPolicyPeerAddressSets(networkPolicy.Namespace, peer)
-				if config.IPv4Mode {
-					addressSets = append(addressSets, peerASv4)
-				}
-				if config.IPv6Mode {
-					addressSets = append(addressSets, peerASv6)
-				}
-			}
-		}
-	}
-	return addressSets
-}
-
 func getTestPod(namespace, nodeName string) testPod {
-	return newTPod(
+	return getTestPodAdvanced(namespace, nodeName, "10.128.1.3", false)
+}
+
+func getTestPodAdvanced(namespace, nodeName, podIP string, hostNetwork bool) testPod {
+	ip := net.ParseIP(podIP).To4()
+	mac := net.HardwareAddr{
+		0x02, 0x00,
+		ip[0], ip[1], ip[2], ip[3],
+	}
+	tPod := newTPod(
 		nodeName,
 		"10.128.1.0/24",
 		"10.128.1.2",
 		"10.128.1.1",
-		"myPod",
-		"10.128.1.3",
-		"0a:58:0a:80:01:03",
+		"myPod"+strings.ReplaceAll(podIP, ".", "-"),
+		podIP,
+		mac.String(),
 		namespace,
 	)
+	tPod.hostNetwork = hostNetwork
+	return tPod
 }
 
 var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
@@ -669,15 +672,16 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		format.MaxLength = gomegaFormatMaxLength
 	})
 
-	startOvnWithHostNetPods := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, networkPolicies []knet.NetworkPolicy,
-		pods []testPod, podLabels map[string]string, hostNetPods bool) {
+	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, networkPolicies []knet.NetworkPolicy,
+		pods []testPod, podLabels map[string]string) {
 		var podsList []corev1.Pod
 		for _, testPod := range pods {
 			knetPod := ovntest.NewPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
 			if len(podLabels) > 0 {
 				knetPod.Labels = podLabels
 			}
-			if hostNetPods {
+			knetPod.Annotations = map[string]string{util.OvnPodAnnotationName: fmt.Sprintf(`{"default":{"mac_address":"%s","ip_address":"%s/24","role":"infrastructure-locked"}}`, testPod.podMAC, testPod.podIP)}
+			if testPod.hostNetwork {
 				knetPod.Spec.HostNetwork = true
 			}
 			podsList = append(podsList, *knetPod)
@@ -715,11 +719,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
-	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, networkPolicies []knet.NetworkPolicy,
-		pods []testPod, podLabels map[string]string) {
-		startOvnWithHostNetPods(dbSetup, namespaces, networkPolicies, pods, podLabels, false)
-	}
-
 	getUpdatedInitialDB := func(tPods []testPod) []libovsdbtest.TestData {
 		updatedSwitchAndPods := getDefaultNetExpectedPodsAndSwitches(tPods, []string{nodeName})
 		return append(getHairpinningACLsV4AndPortGroup(), updatedSwitchAndPods...)
@@ -751,7 +750,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		ginkgo.It("deletes stale port groups", func() {
 			app.Action = func(*cli.Context) error {
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
-				// network policy with peer selector
+				// network policy with peer selector, has an address set
 				networkPolicy1 := ovntest.NewMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
 					"", "podName", true, true)
 				// network policy with ipBlock (won't have any address sets)
@@ -767,6 +766,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				initialData := initialDB.NBData
 				afterCleanup := initialDB.NBData
 				policy1Db := getPolicyData(newNetpolDataParams(networkPolicy1))
+				policy1PeerAddrSet := policy1Db[0]
 				initialData = append(initialData, policy1Db...)
 
 				policy2Db := getPolicyData(newNetpolDataParams(networkPolicy2))
@@ -776,10 +776,15 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				initialData = append(initialData, defaultDenyDb...)
 
 				// start ovn with no objects, expect stale port db entries to be cleaned up
+				// peer selector address set will stay until the next restart
 				startOvn(libovsdbtest.TestSetup{NBData: initialData}, nil, nil, nil, nil)
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(afterCleanup))
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(append(afterCleanup, policy1PeerAddrSet)))
 
+				// now restart address set manager
+				fakeOvn.controller.addressSetManager.Stop()
+				gomega.Expect(fakeOvn.controller.addressSetManager.Start()).To(gomega.Succeed())
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(afterCleanup))
 				return nil
 			}
 
@@ -807,7 +812,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 					expectedData := getNamespaceWithSinglePolicyExpectedData(
-						newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
+						newNetpolDataParams(networkPolicy),
 						initialDB.NBData)
 					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 					return nil
@@ -845,7 +850,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// check peer namespace was added
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(networkPolicy).withPeerNamespaces(namespace2.Name),
+					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
@@ -864,7 +869,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
 					[]testPod{nPodTest}, nil)
 
-				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace1.Name, networkPolicy.Spec.Ingress[0].From[0], nPodTest.podIP)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -872,9 +876,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(networkPolicy).withLocalPortUUIDs(nPodTest.portUUID),
+					newNetpolDataParams(networkPolicy).withLocalPortUUIDs(nPodTest.portUUID).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
-				expectedData = append(expectedData, netpolASv4, namespace1AddressSetv4)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -884,7 +888,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 		ginkgo.It("reconciles an existing networkPolicy with a pod and namespace selector in another namespace from empty db", func() {
 			app.Action = func(*cli.Context) error {
-
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 				namespace2 := *ovntest.NewNamespace(namespaceName2)
 
@@ -897,16 +900,15 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
 				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{nPodTest.podIP})
-				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(networkPolicy.Namespace, networkPolicy.Spec.Ingress[0].From[0], nPodTest.podIP)
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(networkPolicy),
+					newNetpolDataParams(networkPolicy).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
-				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4, netpolASv4)
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData))
 
 				return nil
@@ -1117,48 +1119,59 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 	})
 
 	ginkgo.Context("during execution", func() {
-		ginkgo.DescribeTable("correctly uses namespace and shared peer selector address sets",
-			func(peer knet.NetworkPolicyPeer, peerNamespaces []string) {
+		const hostNetIP = "10.244.0.2"
+		const ns1PodIP = "10.128.1.3"
+		const ns1HostnetPodIP = "10.0.1.1"
+		const ns2PodIP = "10.128.1.4"
+		ginkgo.DescribeTable("correctly uses shared peer selector address sets",
+			func(peer knet.NetworkPolicyPeer, peerIPs []string) {
+				config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+				hostNetNamespace := *ovntest.NewNamespace(config.Kubernetes.HostNetworkNamespace)
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
+				ns1Pod := getTestPodAdvanced(namespace1.Name, nodeName, ns1PodIP, false)
+				ns1HosnetPod := getTestPodAdvanced(namespace1.Name, nodeName, ns1HostnetPodIP, true)
 				namespace2 := *ovntest.NewNamespace(namespaceName2)
-				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
-				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, nil)
+				ns2Pod := getTestPodAdvanced(namespace2.Name, nodeName, ns2PodIP, false)
 
 				netpol := ovntest.NewTestNetworkPolicy("netpolName", namespace1.Name, metav1.LabelSelector{}, []knet.NetworkPolicyIngressRule{
 					{
 						From: []knet.NetworkPolicyPeer{peer},
 					},
 				}, nil)
-				initialDB.NBData = append(initialDB.NBData, namespace1AddressSetv4, namespace2AddressSetv4)
-				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2}, []knet.NetworkPolicy{*netpol}, nil, nil)
+				startOvn(initialDB, []corev1.Namespace{namespace1, namespace2, hostNetNamespace}, []knet.NetworkPolicy{*netpol},
+					[]testPod{ns1Pod, ns1HosnetPod, ns2Pod}, nil)
+				// imitate HostNetworkNamespace address set update
+				fakeOvn.controller.addressSetManager.SetHostNetworkNamespaceIPs([]string{hostNetIP})
+
+				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{ns1Pod.podIP})
+				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{ns2Pod.podIP})
+				// this namespace doesn't have ips, because we don't create nodes
+				hostNamespaceAddressSetv4, _ := buildNamespaceAddressSets(hostNetNamespace.Name, nil)
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(netpol).withPeerNamespaces(peerNamespaces...),
-					initialDB.NBData)
-				// if peer.PodSelector == nil then the network policy ACL will use the AddressSet of the namespace selected
-				if peer.PodSelector != nil {
-					netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace1.Name, peer)
-					expectedData = append(expectedData, netpolASv4)
-				}
+					newNetpolDataParams(netpol).withPeerIPs(peerIPs...).withLocalPortUUIDs(ns1Pod.portUUID),
+					getUpdatedInitialDB([]testPod{ns1Pod, ns2Pod}))
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4, hostNamespaceAddressSetv4)
+
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 			},
 			ginkgo.Entry("empty pod selector => use pod selector",
 				knet.NetworkPolicyPeer{
 					PodSelector: &metav1.LabelSelector{},
-				}, nil),
-			ginkgo.Entry("namespace selector with nil pod selector => use a set of selected namespace address sets",
+				}, []string{ns1PodIP, ns1HostnetPodIP}),
+			ginkgo.Entry("namespace selector with nil pod selector => use pod selector + legacyNetpolMode=true",
 				knet.NetworkPolicyPeer{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"name": namespaceName2,
+							"name": namespaceName1,
 						},
 					},
-				}, []string{namespaceName2}),
+				}, []string{ns1PodIP}),
 			ginkgo.Entry("empty namespace and pod selector => use all pods shared address set",
 				knet.NetworkPolicyPeer{
 					PodSelector:       &metav1.LabelSelector{},
 					NamespaceSelector: &metav1.LabelSelector{},
-				}, nil),
+				}, []string{ns1PodIP, ns1HostnetPodIP, ns2PodIP}),
 			ginkgo.Entry("pod selector with nil namespace => use static namespace+pod selector",
 				knet.NetworkPolicyPeer{
 					PodSelector: &metav1.LabelSelector{
@@ -1166,20 +1179,16 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 							"name": "podName",
 						},
 					},
-				}, nil),
+				}, []string{}),
 			ginkgo.Entry("pod selector with namespace selector => use namespace selector+pod selector",
 				knet.NetworkPolicyPeer{
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"name": "podName",
-						},
-					},
+					PodSelector: &metav1.LabelSelector{},
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"name": namespaceName2,
 						},
 					},
-				}, nil),
+				}, []string{ns2PodIP}),
 			ginkgo.Entry("pod selector with empty namespace selector => use global pod selector",
 				knet.NetworkPolicyPeer{
 					PodSelector: &metav1.LabelSelector{
@@ -1188,7 +1197,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 					NamespaceSelector: &metav1.LabelSelector{},
-				}, nil),
+				}, []string{}),
+			ginkgo.Entry("empty namespace selector matches on HostNetworkNamespace IPs + legacyNetpolMode=true",
+				knet.NetworkPolicyPeer{
+					NamespaceSelector: &metav1.LabelSelector{},
+				}, []string{ns1PodIP, ns2PodIP, hostNetIP}),
 		)
 
 		ginkgo.It("correctly creates and deletes a networkpolicy allowing a port to a local pod", func() {
@@ -1402,8 +1415,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				dataParams := newNetpolDataParams(networkPolicy).
-					withLocalPortUUIDs(nPodTest.portUUID).
-					withPeerNamespaces(namespace2.Name)
+					withLocalPortUUIDs(nPodTest.portUUID)
 				gressPolicyExpectedData := getPolicyData(dataParams)
 				defaultDenyExpectedData := getDefaultDenyData(dataParams)
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
@@ -1445,8 +1457,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				dataParams := newNetpolDataParams(networkPolicy).
-					withPeerNamespaces(namespace2.Name)
+				dataParams := newNetpolDataParams(networkPolicy)
 				gressPolicyExpectedData := getPolicyData(dataParams)
 				defaultDenyExpectedData := getDefaultDenyData(dataParams)
 				expectedData := initialDB.NBData
@@ -1491,13 +1502,11 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy).
-						withLocalPortUUIDs(nPodTest.portUUID),
+						withLocalPortUUIDs(nPodTest.portUUID).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
 
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
 				expectedData = append(expectedData, namespace1AddressSetv4)
-				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace1.Name, networkPolicy.Spec.Ingress[0].From[0], nPodTest.podIP)
-				expectedData = append(expectedData, netpolASv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				// Delete pod
@@ -1508,9 +1517,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData = getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
-				netpolASv4.Addresses = nil
 				namespace1AddressSetv4.Addresses = nil
-				expectedData = append(expectedData, netpolASv4, namespace1AddressSetv4)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -1534,10 +1542,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(networkPolicy),
+					newNetpolDataParams(networkPolicy).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
-				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace1.Name, networkPolicy.Spec.Ingress[0].From[0], nPodTest.podIP)
-				expectedData = append(expectedData, netpolASv4)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
 				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{nPodTest.podIP})
 				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
@@ -1551,9 +1557,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					newNetpolDataParams(networkPolicy),
 					getUpdatedInitialDB([]testPod{}))
 				// After deleting the pod all address sets should be empty
-				netpolASv4.Addresses = nil
 				namespace2AddressSetv4.Addresses = nil
-				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4, netpolASv4)
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -1575,10 +1580,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(networkPolicy),
+					newNetpolDataParams(networkPolicy).withPeerIPs(nPodTest.podIP),
 					getUpdatedInitialDB([]testPod{nPodTest}))
-				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace2.Name, networkPolicy.Spec.Ingress[0].From[0], nPodTest.podIP)
-				expectedData = append(expectedData, netpolASv4)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
 				namespace2AddressSetv4, _ := buildNamespaceAddressSets(namespace2.Name, []string{nPodTest.podIP})
 				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
@@ -1591,9 +1594,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// After updating the namespace all address sets should be empty
-				netpolASv4.Addresses = nil
-				namespace1AddressSetv4.Addresses = nil
-
+				expectedData = getNamespaceWithSinglePolicyExpectedData(
+					newNetpolDataParams(networkPolicy),
+					getUpdatedInitialDB([]testPod{nPodTest}))
+				expectedData = append(expectedData, namespace1AddressSetv4, namespace2AddressSetv4)
 				// db data should reflect the empty addressets
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
@@ -1616,12 +1620,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				dataParams := newNetpolDataParams(networkPolicy).
-					withLocalPortUUIDs(nPodTest.portUUID)
+					withLocalPortUUIDs(nPodTest.portUUID).withPeerIPs(nPodTest.podIP)
 				gressPolicyExpectedData := getPolicyData(dataParams)
 				defaultDenyExpectedData := getDefaultDenyData(dataParams)
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
-				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace1.Name, networkPolicy.Spec.Ingress[0].From[0], nPodTest.podIP)
-				expectedData = append(expectedData, netpolASv4)
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
@@ -1659,12 +1661,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				dataParams := newNetpolDataParams(networkPolicy).
-					withLocalPortUUIDs(nPodTest.portUUID)
+					withLocalPortUUIDs(nPodTest.portUUID).withPeerIPs(nPodTest.podIP)
 				gressPolicyExpectedData := getPolicyData(dataParams)
 				defaultDenyExpectedData := getDefaultDenyData(dataParams)
 				expectedData := getUpdatedInitialDB([]testPod{nPodTest})
-				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace1.Name, networkPolicy.Spec.Ingress[0].From[0], nPodTest.podIP)
-				expectedData = append(expectedData, netpolASv4)
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
@@ -1908,8 +1908,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 		ginkgo.It("references all namespace address sets for empty namespace selector, even if they don't have pods (HostNetworkNamespace)", func() {
 			app.Action = func(*cli.Context) error {
-				hostNamespaceName := "host-network"
-				hostNamespace := *ovntest.NewNamespace(hostNamespaceName)
+				config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+				hostNamespace := *ovntest.NewNamespace(config.Kubernetes.HostNetworkNamespace)
 
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 				nPodTest := getTestPod(namespace1.Name, nodeName)
@@ -1924,30 +1924,21 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					[]testPod{nPodTest}, nil)
 
 				// emulate namespace handler adding management IPs for this address set
-				// we could let controller do that, but that would require adding nodes with their annotations
-				dbIDs := libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNamespace, fakeOvn.controller.controllerName,
-					map[libovsdbops.ExternalIDKey]string{
-						libovsdbops.ObjectNameKey: hostNamespaceName,
-					})
-				// random set of IPs
-				as, err := fakeOvn.controller.addressSetFactory.GetAddressSet(dbIDs)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				// emulate management IP being added to the hostNetwork address set, but no pods in that namespace
-				err = as.AddAddresses([]string{"10.244.0.2"})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.controller.addressSetManager.SetHostNetworkNamespaceIPs([]string{hostNetIP})
 
 				// create networkPolicy, check db
-				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 					Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
 					newNetpolDataParams(networkPolicy).
 						withLocalPortUUIDs(nPodTest.portUUID).
-						withPeerNamespaces(hostNamespace.Name, namespaceName1),
+						withPeerIPs(nPodTest.podIP, "10.244.0.2"),
 					getUpdatedInitialDB([]testPod{nPodTest}))
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, []string{nPodTest.podIP})
-				hostNamespaceAddressSetv4, _ := buildNamespaceAddressSets(hostNamespaceName, []string{"10.244.0.2"})
+				// this namespace doesn't have ips, because we don't create nodes
+				hostNamespaceAddressSetv4, _ := buildNamespaceAddressSets(hostNamespace.Name, nil)
 				expectedData = append(expectedData, namespace1AddressSetv4, hostNamespaceAddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
@@ -1974,14 +1965,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				time.Sleep(100 * time.Millisecond)
 				goroutinesNumInit := runtime.NumGoroutine()
 				fmt.Printf("goroutinesNumInit %v", goroutinesNumInit)
-				// network policy will create 1 watchFactory for local pods selector, and 1 peer namespace selector
-				// that gives us 2 retryFrameworks, so 2 periodicallyRetryResources goroutines.
+				// network policy will create 1 watchFactory for local pods selector
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
 					Create(context.TODO(), networkPolicy, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() int {
 					return runtime.NumGoroutine()
-				}).Should(gomega.Equal(goroutinesNumInit + 2))
+				}).Should(gomega.Equal(goroutinesNumInit + 1))
 
 				// Delete network policy
 				err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -2072,7 +2062,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			app.Action = func(*cli.Context) error {
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 				namespace1.Labels = map[string]string{labelName: labelVal}
-				nPodTest := getTestPod(namespace1.Name, nodeName)
+				nPodTest := getTestPodAdvanced(namespace1.Name, nodeName, "10.128.1.3", true)
 
 				networkPolicy := ovntest.NewTestNetworkPolicy(netPolicyName1, namespace1.Name,
 					metav1.LabelSelector{},
@@ -2088,8 +2078,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					knet.PolicyTypeEgress,
 				)
 
-				startOvnWithHostNetPods(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
-					[]testPod{nPodTest}, nil, true)
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+					[]testPod{nPodTest}, nil)
 
 				ginkgo.By("Check networkPolicy includes hostNetwork")
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -2099,11 +2089,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// netpol peer address set will
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(networkPolicy),
+					newNetpolDataParams(networkPolicy).withPeerIPs(nPodTest.podIP),
 					initialDB.NBData)
-				netpolASv4, _ := buildNetworkPolicyPeerAddressSets(namespace1.Name, networkPolicy.Spec.Egress[0].To[0], nPodTest.podIP)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
-				expectedData = append(expectedData, netpolASv4, namespace1AddressSetv4)
+				expectedData = append(expectedData, namespace1AddressSetv4)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedData...))
 
 				return nil
@@ -2117,7 +2106,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			app.Action = func(*cli.Context) error {
 				namespace1 := *ovntest.NewNamespace(namespaceName1)
 				namespace1.Labels = map[string]string{labelName: labelVal}
-				nPodTest := getTestPod(namespace1.Name, nodeName)
+				nPodTest := getTestPodAdvanced(namespace1.Name, nodeName, "10.128.1.3", true)
 
 				networkPolicy := ovntest.NewTestNetworkPolicy(netPolicyName1, namespace1.Name,
 					metav1.LabelSelector{},
@@ -2132,8 +2121,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					knet.PolicyTypeEgress,
 				)
 
-				startOvnWithHostNetPods(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
-					[]testPod{nPodTest}, nil, true)
+				startOvn(initialDB, []corev1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy},
+					[]testPod{nPodTest}, nil)
 
 				ginkgo.By("Check networkPolicy doesn't select hostNetwork pods")
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).
@@ -2141,8 +2130,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				expectedData := getNamespaceWithSinglePolicyExpectedData(
-					newNetpolDataParams(networkPolicy).
-						withPeerNamespaces(namespace1.Name),
+					newNetpolDataParams(networkPolicy),
 					initialDB.NBData)
 				namespace1AddressSetv4, _ := buildNamespaceAddressSets(namespace1.Name, nil)
 				expectedData = append(expectedData, namespace1AddressSetv4)
@@ -2324,8 +2312,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicies[i].GetNamespace()).
 						Create(context.TODO(), networkPolicies[i], metav1.CreateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					netpolAS := buildNetworkPolicyAddressSets(networkPolicies[i])
-					createsPoliciesData = append(createsPoliciesData, netpolAS...)
 
 					createsPoliciesData = append(createsPoliciesData,
 						// originalACLLogSeverity.Allow == nbdb.ACLSeverityNotice
@@ -2348,8 +2334,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					getPolicyData(newNetpolDataParams(initialDenyAllPolicy).
 						withAllowLogSeverity(updatedLogSeverity))...)
 				for i := range networkPolicies {
-					netpolAS := buildNetworkPolicyAddressSets(networkPolicies[i])
-					expectedData = append(expectedData, netpolAS...)
 					expectedData = append(expectedData,
 						getPolicyData(newNetpolDataParams(networkPolicies[i]).
 							withAllowLogSeverity(updatedLogSeverity))...)
@@ -2366,7 +2350,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				ovntest.NewMatchLabelsNetworkPolicy(netPolicyName1, namespaceName1, namespaceName2, "", true, false)),
 			ginkgo.Entry("when the namespace features *multiple* network policies with a single rule",
 				ovntest.NewMatchLabelsNetworkPolicy(netPolicyName1, namespaceName1, namespaceName2, "", true, false),
-				ovntest.NewMatchLabelsNetworkPolicy(netPolicyName2, namespaceName1, namespaceName2, "", false, true)),
+				ovntest.NewMatchLabelsNetworkPolicy(netPolicyName2, namespaceName1, namespaceName1, "", false, true)),
 			ginkgo.Entry("when the namespace features a network policy with *multiple* rules",
 				ovntest.NewMatchLabelsNetworkPolicy(netPolicyName1, namespaceName1, namespaceName2, "tiny-winy-pod", true, false)))
 
@@ -2626,6 +2610,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		return acl
 	}
 
+	getNsPeerDBIDs := func(nsName, controllerName string) *libovsdbops.DbObjectIDs {
+		return addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, nsName, controllerName, false)
+	}
+
 	ginkgo.It("computes match strings from address sets correctly", func() {
 		const (
 			pgName         string = "pg-name"
@@ -2636,18 +2624,18 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		asFactory = addressset.NewFakeAddressSetFactory(controllerName)
 		config.IPv4Mode = true
 		config.IPv6Mode = false
-		asIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", types.DefaultNetworkControllerName)
+		asIDs := addresssetmanager.GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, "nsName", types.DefaultNetworkControllerName, false)
 		gp := newGressPolicy(knet.PolicyTypeIngress, 0, "testing", "policy", controllerName,
 			false, &util.DefaultNetInfo{})
 		gp.hasPeerSelector = true
 		gp.addPeerAddressSets(addressset.GetHashNamesForAS(asIDs))
 
-		one := getNamespaceAddrSetDbIDs("ns1", controllerName)
-		two := getNamespaceAddrSetDbIDs("ns2", controllerName)
-		three := getNamespaceAddrSetDbIDs("ns3", controllerName)
-		four := getNamespaceAddrSetDbIDs("ns4", controllerName)
-		five := getNamespaceAddrSetDbIDs("ns5", controllerName)
-		six := getNamespaceAddrSetDbIDs("ns6", controllerName)
+		one := getNsPeerDBIDs("ns1", controllerName)
+		two := getNsPeerDBIDs("ns2", controllerName)
+		three := getNsPeerDBIDs("ns3", controllerName)
+		four := getNsPeerDBIDs("ns4", controllerName)
+		five := getNsPeerDBIDs("ns5", controllerName)
+		six := getNsPeerDBIDs("ns6", controllerName)
 		for _, addrSetID := range []*libovsdbops.DbObjectIDs{one, two, three, four, five, six} {
 			_, err := asFactory.EnsureAddressSet(addrSetID)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2657,91 +2645,34 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 			Deny:  nbdb.ACLSeverityInfo,
 		}
 
-		gomega.Expect(gp.addNamespaceAddressSet(one.GetObjectID(libovsdbops.ObjectNameKey), asFactory)).To(gomega.BeTrue())
+		gp.addPeerAddressSets(addressset.GetHashNamesForAS(one))
 		expected := buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
 			asIDs, one}, &defaultAclLogging)
 		actual, _ := gp.buildLocalPodACLs(pgName, &defaultAclLogging)
 		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
 
-		gomega.Expect(gp.addNamespaceAddressSet(two.GetObjectID(libovsdbops.ObjectNameKey), asFactory)).To(gomega.BeTrue())
+		gp.addPeerAddressSets(addressset.GetHashNamesForAS(two))
 		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
 			asIDs, one, two}, &defaultAclLogging)
 		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
 		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
 
 		// address sets should be alphabetized
-		gomega.Expect(gp.addNamespaceAddressSet(three.GetObjectID(libovsdbops.ObjectNameKey), asFactory)).To(gomega.BeTrue())
+		gp.addPeerAddressSets(addressset.GetHashNamesForAS(three))
 		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
 			asIDs, one, two, three}, &defaultAclLogging)
 		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
 		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
 
 		// re-adding an existing set is a no-op
-		gomega.Expect(gp.addNamespaceAddressSet(three.GetObjectID(libovsdbops.ObjectNameKey), asFactory)).To(gomega.BeFalse())
+		gp.addPeerAddressSets(addressset.GetHashNamesForAS(three))
+		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
+		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
 
-		gomega.Expect(gp.addNamespaceAddressSet(four.GetObjectID(libovsdbops.ObjectNameKey), asFactory)).To(gomega.BeTrue())
+		gp.addPeerAddressSets(addressset.GetHashNamesForAS(four))
 		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
 			asIDs, one, two, three, four}, &defaultAclLogging)
 		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
 		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		// now delete a set
-		gomega.Expect(gp.delNamespaceAddressSet(one.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeTrue())
-		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
-			asIDs, two, three, four}, &defaultAclLogging)
-		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
-		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		// deleting again is a no-op
-		gomega.Expect(gp.delNamespaceAddressSet(one.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeFalse())
-
-		// add and delete some more...
-		gomega.Expect(gp.addNamespaceAddressSet(five.GetObjectID(libovsdbops.ObjectNameKey), asFactory)).To(gomega.BeTrue())
-		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
-			asIDs, two, three, four, five}, &defaultAclLogging)
-		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
-		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		gomega.Expect(gp.delNamespaceAddressSet(three.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeTrue())
-		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
-			asIDs, two, four, five}, &defaultAclLogging)
-		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
-		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		// deleting again is no-op
-		gomega.Expect(gp.delNamespaceAddressSet(one.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeFalse())
-
-		gomega.Expect(gp.addNamespaceAddressSet(six.GetObjectID(libovsdbops.ObjectNameKey), asFactory)).To(gomega.BeTrue())
-		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
-			asIDs, two, four, five, six}, &defaultAclLogging)
-		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
-		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		gomega.Expect(gp.delNamespaceAddressSet(two.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeTrue())
-		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
-			asIDs, four, five, six}, &defaultAclLogging)
-		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
-		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		gomega.Expect(gp.delNamespaceAddressSet(five.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeTrue())
-		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
-			asIDs, four, six}, &defaultAclLogging)
-		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
-		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		gomega.Expect(gp.delNamespaceAddressSet(six.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeTrue())
-		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
-			asIDs, four}, &defaultAclLogging)
-		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
-		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		gomega.Expect(gp.delNamespaceAddressSet(four.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeTrue())
-		expected = buildExpectedIngressPeerNSv4ACL(gp, pgName, []*libovsdbops.DbObjectIDs{
-			asIDs}, &defaultAclLogging)
-		actual, _ = gp.buildLocalPodACLs(pgName, &defaultAclLogging)
-		gomega.Expect(actual).To(libovsdbtest.ConsistOfIgnoringUUIDs(expected))
-
-		// deleting again is no-op
-		gomega.Expect(gp.delNamespaceAddressSet(four.GetObjectID(libovsdbops.ObjectNameKey))).To(gomega.BeFalse())
 	})
 })

--- a/go-controller/pkg/ovn/zone_interconnect/chassis_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/chassis_handler_test.go
@@ -128,7 +128,6 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			var libovsdbOvnSBClient libovsdbclient.Client
 			_, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -175,7 +174,6 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 			config.Default.EncapPort = 9880
 
 			var libovsdbOvnSBClient libovsdbclient.Client
@@ -217,7 +215,6 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			var libovsdbOvnSBClient libovsdbclient.Client
 			_, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -270,7 +267,6 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			var libovsdbOvnSBClient libovsdbclient.Client
 			_, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -319,7 +315,6 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			var libovsdbOvnSBClient libovsdbclient.Client
 			_, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -373,7 +368,6 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			var libovsdbOvnSBClient libovsdbclient.Client
 			_, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -435,7 +429,6 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			var libovsdbOvnSBClient libovsdbclient.Client
 			_, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -483,7 +476,6 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 			_, err := config.InitConfig(ctx, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			config.Kubernetes.HostNetworkNamespace = ""
 
 			var libovsdbOvnSBClient libovsdbclient.Client
 			_, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
@@ -371,7 +371,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -412,7 +411,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(config.IPv4Mode).To(gomega.BeTrue())
 				gomega.Expect(config.IPv6Mode).To(gomega.BeTrue())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -496,7 +494,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -548,7 +545,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -596,7 +592,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -706,7 +701,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -895,7 +889,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -935,7 +928,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -1059,7 +1051,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -1119,7 +1110,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -1197,7 +1187,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 
 				_, err := config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				config.Kubernetes.HostNetworkNamespace = ""
 
 				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Add `legacyNetpol` mode to the addressset manager to support previous behaviour: it ignores hostNetwork pods, but matches on the fake hostNetwork namespace (same behaviour as namespace address sets provide).
Move hostNamespace-related handling to the addressset manager, fortunately it already has a node watcher

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed peer-namespace selector handling and related watchers from policy processing.
  * Centralized namespace/address-set initialization and introduced a legacy network-policy mode that changes address-set identity and host-network IP inclusion.

* **Tests**
  * Updated many tests to align with new address-set behavior, removed redundant host-network config mutations, and added coverage for legacy-netpol and host-network reconciliation scenarios.

* **Chores**
  * Removed obsolete host-network address-set bookkeeping and related retry/state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->