### PR TITLE
E2E: Replace GetNetwork("kind") with PrimaryNetwork()

### DIFF
--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -1125,7 +1125,7 @@ func randomVTEPSubnets() (ipv4, ipv6 string) {
 // =============================================================================
 
 func getExternalFRRIP(ipFamilySet sets.Set[utilnet.IPFamily]) (string, error) {
-	kindNetwork, err := infraprovider.Get().GetNetwork("kind")
+	kindNetwork, err := infraprovider.Get().PrimaryNetwork()
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1950,7 +1950,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			} else {
 				// KIND network subnet: node InternalIPs fall within this range,
 				// so the node-side controller can discover them via host-cidrs.
-				kindNetwork, err := infraprovider.Get().GetNetwork("kind")
+				kindNetwork, err := infraprovider.Get().PrimaryNetwork()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				kindV4Subnet, _, err := kindNetwork.IPv4IPv6Subnets()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
Use the provider-agnostic `PrimaryNetwork()` method instead of hardcoding the "kind" network name in EVPN and RA tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use the provider's primary network for FRR configuration instead of a hardcoded network reference, improving test flexibility and reducing coupling to specific network names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->