### PR TITLE
e2e: add EgressIP upgrade test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -416,7 +416,13 @@ jobs:
       run: |
         export OVN_IMAGE="ovn-daemonset-fedora:pr"
         make -C test upgrade-ovn
-
+    
+    - name: Run EgressIP upgrade verification
+      run: |
+       export OVN_IMAGE="ovn-daemonset-fedora:pr"
+       make -C test control-plane \
+        WHAT="EgressIP survives ovnkube-node rolling upgrade"
+    
     - name: Runner Diagnostics
       if: always()
       uses: ./.github/actions/diagnostics

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -419,9 +419,8 @@ jobs:
     
     - name: Run EgressIP upgrade verification
       run: |
-       export OVN_IMAGE="ovn-daemonset-fedora:pr"
-       make -C test control-plane \
-        WHAT="EgressIP survives ovnkube-node rolling upgrade"
+        export OVN_IMAGE="ovn-daemonset-fedora:pr"
+        make -C test control-plane WHAT="EgressIP survives ovnkube-node rolling upgrade"
     
     - name: Runner Diagnostics
       if: always()

--- a/test/e2e/upgrade_egressip.go
+++ b/test/e2e/upgrade_egressip.go
@@ -1,0 +1,411 @@
+package e2e
+
+// upgrade_egressip.go
+//
+// CORENET-6408 — Baseline EgressIP upgrade test
+//
+// Verifies that EgressIP works correctly through a rolling upgrade of
+// ovnkube-node pods. The upgrade is triggered by patching the DaemonSet
+// image via the Kubernetes API.
+//
+// Two modes depending on OVN_IMAGE env var:
+//
+//   Real upgrade (CI):
+//     OVN_IMAGE is set to the PR image by the CI job.
+//     DaemonSet is patched to that image → real version change → rollout.
+//
+//   Simulated upgrade (local KIND testing):
+//     OVN_IMAGE is not set.
+//     Current image is read from the DaemonSet and reused.
+//     Rollout mechanics are still exercised even if image does not change.
+//
+// Test flow:
+//   PRE-UPGRADE
+//     0. Label node as egress-assignable
+//     1. Create EgressIP object
+//     2. Create test pod
+//     3. Verify pod traffic uses EgressIP as source IP
+//
+//   UPGRADE (via Kubernetes API)
+//     4. Read OVN_IMAGE from env (or use current image if not set)
+//     5. Set maxUnavailable=1 to ensure standard rolling update behaviour
+//     6. Patch ovnkube-node DaemonSet with new image
+//     7. Wait for DaemonSet rollout to complete
+//
+//   POST-UPGRADE
+//     8. Verify EgressIP is still assigned
+//     9. Verify pod traffic still uses EgressIP as source IP
+//
+// How to run locally:
+//   cd test && make control-plane WHAT="EgressIP survives ovnkube-node rolling upgrade"
+//
+// CI wiring (add to test.yml after the "ovn upgrade" step):
+//   make -C test control-plane WHAT="EgressIP survives ovnkube-node rolling upgrade"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
+	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
+)
+
+const (
+	// ovnKubeNodeDSName is the name of the ovnkube-node DaemonSet.
+	ovnKubeNodeDSName = "ovnkube-node"
+
+	// ovnUpgradeImageEnvVar is the env var CI sets to the new image.
+	// If not set, the current image is used (simulated upgrade for local testing).
+	ovnUpgradeImageEnvVar = "OVN_IMAGE"
+
+	// ovnUpgradeRolloutTimeout is how long to wait for DaemonSet rollout.
+	ovnUpgradeRolloutTimeout = 3 * time.Minute
+)
+
+var _ = ginkgo.Describe("e2e EgressIP upgrade validation", feature.EgressIP, func() {
+
+	const (
+		upgradeEIPName = "egressip-upgrade-test"
+		upgradeEIPYaml = "egressip-upgrade-test.yaml"
+		upgradePodName = "egressip-upgrade-pod"
+		upgradePodPort = 8080
+	)
+
+	podEgressLabel := map[string]string{"wants": "egress"}
+
+	f := wrappedTestFramework("egressip-upgrade")
+	f.SkipNamespaceCreation = true
+
+	var (
+		providerCtx       infraapi.Context
+		externalContainer infraapi.ExternalContainer
+		egressNodeName    string
+		podNodeName       string
+		egressIPStr       string
+		ovnKubeNS         string
+	)
+
+	ginkgo.BeforeEach(func() {
+		providerCtx = infraprovider.Get().NewTestContext()
+
+		// Need at least 2 nodes: one for egress assignment, one for the test pod
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 2)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			framework.Failf("EgressIP upgrade test requires >= 2 Ready nodes, got %d", len(nodes.Items))
+		}
+
+		// Create test namespace
+		ns, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+			"e2e-framework": f.BaseName,
+		})
+		framework.ExpectNoError(err)
+		f.Namespace = ns
+
+		// First node is the egress node, second runs the test pod
+		egressNodeName = nodes.Items[0].Name
+		podNodeName = nodes.Items[1].Name
+
+		// Derive EgressIP from the egress node's actual IP by setting
+		// the last octet to 200 — stays in the same subnet and is routable
+		nodeIP := upgradeEIPGetNodeIP(nodes.Items[0])
+		var deriveErr error
+		egressIPStr, deriveErr = upgradeEIPDeriveEgressIP(nodeIP)
+		gomega.Expect(deriveErr).ShouldNot(gomega.HaveOccurred(), "must derive EgressIP")
+
+		// Create external container (outside the cluster) for traffic verification
+		primaryNetwork, err := infraprovider.Get().PrimaryNetwork()
+		framework.ExpectNoError(err, "failed to get primary provider network")
+		port := infraprovider.Get().GetExternalContainerPort()
+		externalContainer, err = providerCtx.CreateExternalContainer(infraapi.ExternalContainer{
+			Name:    "upgrade-eip-target",
+			Image:   images.AgnHost(),
+			Network: primaryNetwork,
+			CmdArgs: getAgnHostHTTPPortBindCMDArgs(port),
+			ExtPort: port,
+		})
+		framework.ExpectNoError(err, "failed to create external target container")
+
+		ovnKubeNS = deploymentconfig.Get().OVNKubernetesNamespace()
+	})
+
+	ginkgo.AfterEach(func() {
+		unlabelNodeForEgress(f, egressNodeName)
+		e2ekubectl.RunKubectlOrDie("default", "delete", "eip", upgradeEIPName, "--ignore-not-found=true")
+		os.Remove(upgradeEIPYaml)
+	})
+
+	ginkgo.It("EgressIP survives ovnkube-node rolling upgrade", func() {
+
+		// ----------------------------------------------------------------
+		// PRE-UPGRADE SETUP
+		// ----------------------------------------------------------------
+
+		ginkgo.By(fmt.Sprintf("0. Labeling node %s as egress-assignable", egressNodeName))
+		labelNodeForEgress(f, egressNodeName)
+
+		ginkgo.By("1. Setting namespace label for EgressIP namespace selector")
+		updateNamespaceLabels(f, f.Namespace, map[string]string{"name": f.Namespace.Name})
+
+		ginkgo.By(fmt.Sprintf("2. Creating EgressIP object %s with IP %s", upgradeEIPName, egressIPStr))
+		eipConfig := fmt.Sprintf(`apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: %s
+spec:
+    egressIPs:
+    - %s
+    podSelector:
+        matchLabels:
+            wants: egress
+    namespaceSelector:
+        matchLabels:
+            name: %s
+`, upgradeEIPName, egressIPStr, f.Namespace.Name)
+
+		if err := os.WriteFile(upgradeEIPYaml, []byte(eipConfig), 0644); err != nil {
+			framework.Failf("failed to write EgressIP yaml: %v", err)
+		}
+		defer os.Remove(upgradeEIPYaml)
+		e2ekubectl.RunKubectlOrDie("default", "create", "-f", upgradeEIPYaml)
+
+		ginkgo.By("3. Waiting for EgressIP to be assigned to a node")
+		upgradeEIPWaitForAssignment(upgradeEIPName, 1)
+
+		ginkgo.By(fmt.Sprintf("4. Creating test pod on node %s", podNodeName))
+		_, err := createGenericPodWithLabel(f, upgradePodName, podNodeName,
+			f.Namespace.Name, getAgnHostHTTPPortBindFullCMD(upgradePodPort), podEgressLabel)
+		framework.ExpectNoError(err, "failed to create test pod")
+
+		ginkgo.By("5. [PRE-UPGRADE] Verifying EgressIP traffic — source IP must be " + egressIPStr)
+		err = wait.PollImmediate(retryInterval, retryTimeout,
+			targetExternalContainerAndTest(externalContainer,
+				f.Namespace.Name, upgradePodName, true, []string{egressIPStr}))
+		framework.ExpectNoError(err, "pre-upgrade traffic check failed: %v", err)
+		framework.Logf("PRE-UPGRADE PASS: source IP confirmed as %s", egressIPStr)
+
+		// ----------------------------------------------------------------
+		// UPGRADE — patch DaemonSet image via Kubernetes API
+		// ----------------------------------------------------------------
+
+		// Determine which image to roll to.
+		// In CI: OVN_IMAGE env var is set to the new PR image.
+		// Locally: OVN_IMAGE not set — read current image from DaemonSet
+		// and reuse it. Rollout still happens so mechanics are tested.
+		newImage := os.Getenv(ovnUpgradeImageEnvVar)
+		if newImage == "" {
+			ds, err := f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Get(
+				context.Background(), ovnKubeNodeDSName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get ovnkube-node DaemonSet")
+			newImage = upgradeEIPGetContainerImage(ds)
+			framework.Logf("OVN_IMAGE not set — using current image: %s (simulated upgrade)", newImage)
+		} else {
+			framework.Logf("OVN_IMAGE set — upgrading to: %s", newImage)
+		}
+
+		ginkgo.By("6. Setting maxUnavailable=1 to ensure standard rolling update behaviour")
+		// This ensures one pod is restarted at a time — matching real CI upgrade
+		// behaviour and allowing the rollout check to detect the start correctly.
+		// KIND clusters set maxUnavailable=100% by default for fast setup,
+		// which would cause all pods to restart simultaneously.
+		rollingPatch := `{"spec":{"updateStrategy":{"rollingUpdate":{"maxUnavailable":1}}}}`
+		_, err = f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Patch(
+			context.Background(),
+			ovnKubeNodeDSName,
+			types.StrategicMergePatchType,
+			[]byte(rollingPatch),
+			metav1.PatchOptions{},
+		)
+		framework.ExpectNoError(err, "failed to patch ovnkube-node DaemonSet maxUnavailable")
+
+		ginkgo.By(fmt.Sprintf("7. Patching ovnkube-node DaemonSet to image: %s", newImage))
+		patch := fmt.Sprintf(
+			`{"spec":{"template":{"spec":{"containers":[{"name":"%s","image":"%s"}]}}}}`,
+			getNodeContainerName(), newImage,
+		)
+		_, err = f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Patch(
+			context.Background(),
+			ovnKubeNodeDSName,
+			types.StrategicMergePatchType,
+			[]byte(patch),
+			metav1.PatchOptions{},
+		)
+		framework.ExpectNoError(err, "failed to patch ovnkube-node DaemonSet")
+
+		ginkgo.By("8. Waiting for ovnkube-node DaemonSet rollout to complete")
+		upgradeEIPWaitForDSRollout(f, ovnKubeNS, ovnKubeNodeDSName, ovnUpgradeRolloutTimeout)
+		framework.Logf("UPGRADE COMPLETE: DaemonSet rollout finished")
+
+		// ----------------------------------------------------------------
+		// POST-UPGRADE VERIFICATION
+		// ----------------------------------------------------------------
+
+		ginkgo.By("9. [POST-UPGRADE] Verifying EgressIP is still assigned")
+		upgradeEIPWaitForAssignment(upgradeEIPName, 1)
+		framework.Logf("POST-UPGRADE: EgressIP assignment verified")
+
+		ginkgo.By("10. [POST-UPGRADE] Verifying EgressIP traffic — source IP must still be " + egressIPStr)
+		err = wait.PollImmediate(retryInterval, retryTimeout,
+			targetExternalContainerAndTest(externalContainer,
+				f.Namespace.Name, upgradePodName, true, []string{egressIPStr}))
+		framework.ExpectNoError(err, "post-upgrade traffic check failed: %v", err)
+		framework.Logf("POST-UPGRADE PASS: source IP confirmed as %s after upgrade", egressIPStr)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Helpers — scoped to upgrade tests only.
+// Functions from egressip.go (same package) are used directly without copying.
+// ---------------------------------------------------------------------------
+
+// upgradeEIPWaitForAssignment polls until the named EgressIP has the expected
+// number of node assignments, failing the test if timeout is reached.
+func upgradeEIPWaitForAssignment(eipName string, expectedCount int) {
+	err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+		stdout, err := e2ekubectl.RunKubectl("default", "get", "eip", eipName, "-o", "json")
+		if err != nil {
+			return false, nil
+		}
+		eip := struct {
+			Status struct {
+				Items []egressIPStatus `json:"items"`
+			} `json:"status"`
+		}{}
+		if err := json.Unmarshal([]byte(stdout), &eip); err != nil {
+			return false, nil
+		}
+		return len(eip.Status.Items) == expectedCount, nil
+	})
+	if err != nil {
+		framework.Failf("EgressIP %q: expected %d assignments, timed out: %v",
+			eipName, expectedCount, err)
+	}
+}
+
+// upgradeEIPWaitForDSRollout waits until the DaemonSet rolling update is
+// complete — all pods updated, available, and ready.
+// Phase 1 waits for rollout to START, Phase 2 waits for it to COMPLETE.
+func upgradeEIPWaitForDSRollout(f *framework.Framework, namespace, dsName string, timeout time.Duration) {
+	// Phase 1: Wait for rollout to START — at least one pod not yet updated/available
+	framework.Logf("Waiting for DaemonSet %s rollout to start...", dsName)
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		2*time.Second,
+		30*time.Second,
+		true,
+		func(ctx context.Context) (bool, error) {
+			ds, err := f.ClientSet.AppsV1().DaemonSets(namespace).Get(
+				ctx, dsName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			desired := ds.Status.DesiredNumberScheduled
+			updated := ds.Status.UpdatedNumberScheduled
+			available := ds.Status.NumberAvailable
+			started := updated < desired || available < desired
+			framework.Logf("DaemonSet %s waiting for rollout start: desired=%d updated=%d available=%d started=%v",
+				dsName, desired, updated, available, started)
+			return started, nil
+		},
+	)
+	if err != nil {
+		framework.Logf("Warning: could not confirm rollout started (may have been instant): %v", err)
+	}
+
+	// Phase 2: Wait for rollout to COMPLETE
+	framework.Logf("Waiting for DaemonSet %s rollout to complete...", dsName)
+	err = wait.PollUntilContextTimeout(
+		context.Background(),
+		5*time.Second,
+		timeout,
+		true,
+		func(ctx context.Context) (bool, error) {
+			ds, err := f.ClientSet.AppsV1().DaemonSets(namespace).Get(
+				ctx, dsName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			desired := ds.Status.DesiredNumberScheduled
+			if desired == 0 {
+				return false, nil
+			}
+			updated := ds.Status.UpdatedNumberScheduled
+			available := ds.Status.NumberAvailable
+			ready := ds.Status.NumberReady
+			framework.Logf("DaemonSet %s rollout: desired=%d updated=%d available=%d ready=%d",
+				dsName, desired, updated, available, ready)
+			return updated == desired && available == desired && ready == desired, nil
+		},
+	)
+	if err != nil {
+		framework.Failf("DaemonSet %q rollout did not complete within %v: %v",
+			dsName, timeout, err)
+	}
+}
+
+// upgradeEIPGetContainerImage returns the image of the ovnkube-node container
+// from the DaemonSet spec. Falls back to first container if named one not found.
+func upgradeEIPGetContainerImage(ds *appsv1.DaemonSet) string {
+	containerName := getNodeContainerName()
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name == containerName {
+			return c.Image
+		}
+	}
+	if len(ds.Spec.Template.Spec.Containers) > 0 {
+		return ds.Spec.Template.Spec.Containers[0].Image
+	}
+	framework.Failf("no containers found in DaemonSet %s", ds.Name)
+	return ""
+}
+
+// upgradeEIPGetNodeIP returns the first InternalIP of the given node.
+func upgradeEIPGetNodeIP(node corev1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address
+		}
+	}
+	return ""
+}
+
+// upgradeEIPDeriveEgressIP takes a node IP like 172.18.0.2 and returns
+// an EgressIP in the same subnet with last octet set to 200.
+// This ensures the IP is on the node's actual interface subnet and
+// will be accepted by the EgressIP controller.
+func upgradeEIPDeriveEgressIP(nodeIP string) (string, error) {
+	ip := net.ParseIP(nodeIP)
+	if ip == nil {
+		return "", fmt.Errorf("failed to parse node IP: %s", nodeIP)
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		// IPv6 — set second to last byte to 0xc8 (200)
+		ip6 := ip.To16()
+		ip6[14] = 0xc8
+		ip6[15] = 0x00
+		return ip6.String(), nil
+	}
+	// IPv4 — set last octet to 200, keep first three octets
+	ip4[3] = 200
+	return ip4.String(), nil
+}

--- a/test/e2e/upgrade_egressip.go
+++ b/test/e2e/upgrade_egressip.go
@@ -1,8 +1,7 @@
 package e2e
 
-// upgrade_egressip.go
 //
-// CORENET-6408 — Baseline EgressIP upgrade test
+// Baseline EgressIP upgrade test
 //
 // Verifies that EgressIP works correctly through a rolling upgrade of
 // ovnkube-node pods. The upgrade is triggered by patching the DaemonSet
@@ -14,10 +13,6 @@ package e2e
 //     OVN_IMAGE is set to the PR image by the CI job.
 //     DaemonSet is patched to that image → real version change → rollout.
 //
-//   Simulated upgrade (local KIND testing):
-//     OVN_IMAGE is not set.
-//     Current image is read from the DaemonSet and reused.
-//     Rollout mechanics are still exercised even if image does not change.
 //
 // Test flow:
 //   PRE-UPGRADE
@@ -29,17 +24,22 @@ package e2e
 //   UPGRADE (via Kubernetes API)
 //     4. Read OVN_IMAGE from env (or use current image if not set)
 //     5. Set maxUnavailable=1 to ensure standard rolling update behaviour
-//     6. Patch ovnkube-node DaemonSet with new image
-//     7. Wait for DaemonSet rollout to complete
+//     6. Start traffic polling goroutine to monitor EgressIP during rollout
+//     7. Patch ovnkube-node DaemonSet with new image
+//     8. Wait for DaemonSet rollout to complete
+//     9. Stop traffic polling — log failure summary
 //
 //   POST-UPGRADE
-//     8. Verify EgressIP is still assigned
-//     9. Verify pod traffic still uses EgressIP as source IP
+//     10. Verify EgressIP is still assigned
+//     11. Verify pod traffic still uses EgressIP as source IP
+//
+// Key assertion: EgressIP traffic must be intact (zero failures) during upgrade. 
+// currently logging the failures, assertions will be added later.
 //
 // How to run locally:
 //   cd test && make control-plane WHAT="EgressIP survives ovnkube-node rolling upgrade"
 //
-// CI wiring (add to test.yml after the "ovn upgrade" step):
+// CI wiring (added to test.yml after the "ovn upgrade" step):
 //   make -C test control-plane WHAT="EgressIP survives ovnkube-node rolling upgrade"
 
 import (
@@ -79,6 +79,12 @@ const (
 
 	// ovnUpgradeRolloutTimeout is how long to wait for DaemonSet rollout.
 	ovnUpgradeRolloutTimeout = 3 * time.Minute
+
+	// ovnUpgradeTrafficPollInterval is how often to check EgressIP traffic during rollout.
+	ovnUpgradeTrafficPollInterval = 5 * time.Second
+
+	// ovnUpgradeTrafficCheckTimeout is how long a single traffic check is allowed to take.
+	ovnUpgradeTrafficCheckTimeout = 3 * time.Second
 )
 
 var _ = ginkgo.Describe("e2e EgressIP upgrade validation", feature.EgressIP, func() {
@@ -210,7 +216,7 @@ spec:
 		// Determine which image to roll to.
 		// In CI: OVN_IMAGE env var is set to the new PR image.
 		// Locally: OVN_IMAGE not set — read current image from DaemonSet
-		// and reuse it. Rollout still happens so mechanics are tested.
+		// and reuse it.
 		newImage := os.Getenv(ovnUpgradeImageEnvVar)
 		if newImage == "" {
 			ds, err := f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Get(
@@ -237,6 +243,38 @@ spec:
 		)
 		framework.ExpectNoError(err, "failed to patch ovnkube-node DaemonSet maxUnavailable")
 
+		// Start traffic polling goroutine BEFORE patching the image.
+		// EgressIP traffic must be intact (zero failures) during the rolling upgrade.
+		// The OVN dataplane maintains SNAT rules even while ovnkube-node pods are
+		// restarting one by one
+		trafficFailures := 0
+		trafficTotal := 0
+		stopPolling := make(chan struct{})
+		pollingDone := make(chan struct{})
+
+		go func() {
+			defer close(pollingDone)
+			for {
+				select {
+				case <-stopPolling:
+					return
+				case <-time.After(ovnUpgradeTrafficPollInterval):
+					trafficTotal++
+					checkErr := wait.PollImmediate(1*time.Second, ovnUpgradeTrafficCheckTimeout,
+						targetExternalContainerAndTest(externalContainer,
+							f.Namespace.Name, upgradePodName, true, []string{egressIPStr}))
+					if checkErr != nil {
+						trafficFailures++
+						framework.Logf("[DURING-UPGRADE] Traffic check FAILED (%d/%d): %v",
+							trafficFailures, trafficTotal, checkErr)
+					} else {
+						framework.Logf("[DURING-UPGRADE] Traffic check PASSED (%d/%d): source IP = %s",
+							trafficTotal-trafficFailures, trafficTotal, egressIPStr)
+					}
+				}
+			}
+		}()
+
 		ginkgo.By(fmt.Sprintf("7. Patching ovnkube-node DaemonSet to image: %s", newImage))
 		patch := fmt.Sprintf(
 			`{"spec":{"template":{"spec":{"containers":[{"name":"%s","image":"%s"}]}}}}`,
@@ -253,8 +291,19 @@ spec:
 
 		ginkgo.By("8. Waiting for ovnkube-node DaemonSet rollout to complete")
 		upgradeEIPWaitForDSRollout(f, ovnKubeNS, ovnKubeNodeDSName, ovnUpgradeRolloutTimeout)
-		framework.Logf("UPGRADE COMPLETE: DaemonSet rollout finished")
 
+		// Stop traffic polling goroutine and wait for it to finish
+		close(stopPolling)
+		<-pollingDone
+
+		framework.Logf("UPGRADE COMPLETE: rollout finished. EgressIP traffic checks during rollout: %d passed, %d failed out of %d total",
+			trafficTotal-trafficFailures, trafficFailures, trafficTotal)
+
+		// NOTE: traffic failures during rollout are logged above.
+		// Zero failures are expected — the OVN dataplane must maintain SNAT rules
+		// while ovnkube-node pods restart. 
+		// TODO : Add assertion for zero traffic failures.
+		
 		// ----------------------------------------------------------------
 		// POST-UPGRADE VERIFICATION
 		// ----------------------------------------------------------------
@@ -269,12 +318,13 @@ spec:
 				f.Namespace.Name, upgradePodName, true, []string{egressIPStr}))
 		framework.ExpectNoError(err, "post-upgrade traffic check failed: %v", err)
 		framework.Logf("POST-UPGRADE PASS: source IP confirmed as %s after upgrade", egressIPStr)
+		framework.Logf("SUMMARY: EgressIP traffic fully intact during rolling upgrade — %d/%d checks passed",
+			trafficTotal-trafficFailures, trafficTotal)
 	})
 })
 
 // ---------------------------------------------------------------------------
 // Helpers — scoped to upgrade tests only.
-// Functions from egressip.go (same package) are used directly without copying.
 // ---------------------------------------------------------------------------
 
 // upgradeEIPWaitForAssignment polls until the named EgressIP has the expected
@@ -389,9 +439,7 @@ func upgradeEIPGetNodeIP(node corev1.Node) string {
 }
 
 // upgradeEIPDeriveEgressIP takes a node IP like 172.18.0.2 and returns
-// an EgressIP in the same subnet with last octet set to 200.
-// This ensures the IP is on the node's actual interface subnet and
-// will be accepted by the EgressIP controller.
+// an EgressIP in the same subnet
 func upgradeEIPDeriveEgressIP(nodeIP string) (string, error) {
 	ip := net.ParseIP(nodeIP)
 	if ip == nil {

--- a/test/e2e/upgrade_egressip.go
+++ b/test/e2e/upgrade_egressip.go
@@ -13,28 +13,34 @@ package e2e
 //     OVN_IMAGE is set to the PR image by the CI job.
 //     DaemonSet is patched to that image → real version change → rollout.
 //
+//   Simulated upgrade (local KIND):
+//     OVN_IMAGE is not set — the current DaemonSet image is read and reused.
+//     Exercises rollout mechanics without a real version change.
 //
 // Test flow:
 //   PRE-UPGRADE
 //     0. Label node as egress-assignable
 //     1. Create EgressIP object
-//     2. Create test pod
-//     3. Verify pod traffic uses EgressIP as source IP
+//     2. Create two test pods — one on egress node, one on a different node
+//     3. Verify both pods traffic uses EgressIP as source IP
 //
 //   UPGRADE (via Kubernetes API)
 //     4. Read OVN_IMAGE from env (or use current image if not set)
-//     5. Set maxUnavailable=1 to ensure standard rolling update behaviour
-//     6. Start traffic polling goroutine to monitor EgressIP during rollout
-//     7. Patch ovnkube-node DaemonSet with new image
-//     8. Wait for DaemonSet rollout to complete
-//     9. Stop traffic polling — log failure summary
+//     5. Record original image and maxUnavailable for revert after upgrade
+//     6. Set maxUnavailable=1 to ensure standard rolling update behaviour
+//     7. Start traffic polling goroutine to monitor EgressIP during rollout
+//     8. Patch ovnkube-node DaemonSet with new image
+//     9. Wait for DaemonSet rollout to complete
+//     10. Stop traffic polling — log failure summary
 //
 //   POST-UPGRADE
-//     10. Verify EgressIP is still assigned
-//     11. Verify pod traffic still uses EgressIP as source IP
+//     11. Verify EgressIP is still assigned
+//     12. Verify both pods traffic still uses EgressIP as source IP
 //
-// Key assertion: EgressIP traffic must be intact (zero failures) during upgrade. 
-// currently logging the failures, assertions will be added later.
+//   REVERT
+//     13. Restore original DaemonSet image and maxUnavailable
+//     14. Wait for revert rollout to complete
+//
 //
 // How to run locally:
 //   cd test && make control-plane WHAT="EgressIP survives ovnkube-node rolling upgrade"
@@ -70,30 +76,21 @@ import (
 )
 
 const (
-	// ovnKubeNodeDSName is the name of the ovnkube-node DaemonSet.
-	ovnKubeNodeDSName = "ovnkube-node"
-
-	// ovnUpgradeImageEnvVar is the env var CI sets to the new image.
-	// If not set, the current image is used (simulated upgrade for local testing).
-	ovnUpgradeImageEnvVar = "OVN_IMAGE"
-
-	// ovnUpgradeRolloutTimeout is how long to wait for DaemonSet rollout.
-	ovnUpgradeRolloutTimeout = 3 * time.Minute
-
-	// ovnUpgradeTrafficPollInterval is how often to check EgressIP traffic during rollout.
+	ovnKubeNodeDSName             = "ovnkube-node"
+	ovnUpgradeImageEnvVar         = "OVN_IMAGE"
+	ovnUpgradeRolloutTimeout      = 5 * time.Minute
 	ovnUpgradeTrafficPollInterval = 5 * time.Second
-
-	// ovnUpgradeTrafficCheckTimeout is how long a single traffic check is allowed to take.
 	ovnUpgradeTrafficCheckTimeout = 3 * time.Second
 )
 
 var _ = ginkgo.Describe("e2e EgressIP upgrade validation", feature.EgressIP, func() {
 
 	const (
-		upgradeEIPName = "egressip-upgrade-test"
-		upgradeEIPYaml = "egressip-upgrade-test.yaml"
-		upgradePodName = "egressip-upgrade-pod"
-		upgradePodPort = 8080
+		upgradeEIPName     = "egressip-upgrade-test"
+		upgradeEIPYaml     = "egressip-upgrade-test.yaml"
+		upgradePodSameName = "egressip-upgrade-pod-same-node"
+		upgradePodDiffName = "egressip-upgrade-pod-diff-node"
+		upgradePodPort     = 8080
 	)
 
 	podEgressLabel := map[string]string{"wants": "egress"}
@@ -113,32 +110,26 @@ var _ = ginkgo.Describe("e2e EgressIP upgrade validation", feature.EgressIP, fun
 	ginkgo.BeforeEach(func() {
 		providerCtx = infraprovider.Get().NewTestContext()
 
-		// Need at least 2 nodes: one for egress assignment, one for the test pod
 		nodes, err := e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 2)
 		framework.ExpectNoError(err)
 		if len(nodes.Items) < 2 {
 			framework.Failf("EgressIP upgrade test requires >= 2 Ready nodes, got %d", len(nodes.Items))
 		}
 
-		// Create test namespace
 		ns, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
 			"e2e-framework": f.BaseName,
 		})
 		framework.ExpectNoError(err)
 		f.Namespace = ns
 
-		// First node is the egress node, second runs the test pod
 		egressNodeName = nodes.Items[0].Name
 		podNodeName = nodes.Items[1].Name
 
-		// Derive EgressIP from the egress node's actual IP by setting
-		// the last octet to 200 — stays in the same subnet and is routable
 		nodeIP := upgradeEIPGetNodeIP(nodes.Items[0])
 		var deriveErr error
 		egressIPStr, deriveErr = upgradeEIPDeriveEgressIP(nodeIP)
 		gomega.Expect(deriveErr).ShouldNot(gomega.HaveOccurred(), "must derive EgressIP")
 
-		// Create external container (outside the cluster) for traffic verification
 		primaryNetwork, err := infraprovider.Get().PrimaryNetwork()
 		framework.ExpectNoError(err, "failed to get primary provider network")
 		port := infraprovider.Get().GetExternalContainerPort()
@@ -155,9 +146,10 @@ var _ = ginkgo.Describe("e2e EgressIP upgrade validation", feature.EgressIP, fun
 	})
 
 	ginkgo.AfterEach(func() {
-		unlabelNodeForEgress(f, egressNodeName)
+		if egressNodeName != "" {
+			unlabelNodeForEgress(f, egressNodeName)
+		}
 		e2ekubectl.RunKubectlOrDie("default", "delete", "eip", upgradeEIPName, "--ignore-not-found=true")
-		os.Remove(upgradeEIPYaml)
 	})
 
 	ginkgo.It("EgressIP survives ovnkube-node rolling upgrade", func() {
@@ -197,42 +189,49 @@ spec:
 		ginkgo.By("3. Waiting for EgressIP to be assigned to a node")
 		upgradeEIPWaitForAssignment(upgradeEIPName, 1)
 
-		ginkgo.By(fmt.Sprintf("4. Creating test pod on node %s", podNodeName))
-		_, err := createGenericPodWithLabel(f, upgradePodName, podNodeName,
+		// Create two pods:
+		// - same node as egress node (tests local traffic path)
+		// - different node (tests remote traffic path)
+		ginkgo.By(fmt.Sprintf("4a. Creating test pod on egress node %s (same node)", egressNodeName))
+		_, err := createGenericPodWithLabel(f, upgradePodSameName, egressNodeName,
 			f.Namespace.Name, getAgnHostHTTPPortBindFullCMD(upgradePodPort), podEgressLabel)
-		framework.ExpectNoError(err, "failed to create test pod")
+		framework.ExpectNoError(err, "failed to create same-node test pod")
 
-		ginkgo.By("5. [PRE-UPGRADE] Verifying EgressIP traffic — source IP must be " + egressIPStr)
-		err = wait.PollImmediate(retryInterval, retryTimeout,
-			targetExternalContainerAndTest(externalContainer,
-				f.Namespace.Name, upgradePodName, true, []string{egressIPStr}))
-		framework.ExpectNoError(err, "pre-upgrade traffic check failed: %v", err)
-		framework.Logf("PRE-UPGRADE PASS: source IP confirmed as %s", egressIPStr)
+		ginkgo.By(fmt.Sprintf("4b. Creating test pod on non-egress node %s (different node)", podNodeName))
+		_, err = createGenericPodWithLabel(f, upgradePodDiffName, podNodeName,
+			f.Namespace.Name, getAgnHostHTTPPortBindFullCMD(upgradePodPort), podEgressLabel)
+		framework.ExpectNoError(err, "failed to create diff-node test pod")
+
+		ginkgo.By("5. [PRE-UPGRADE] Verifying EgressIP traffic for both pods — source IP must be " + egressIPStr)
+		for _, podName := range []string{upgradePodSameName, upgradePodDiffName} {
+			err = wait.PollImmediate(retryInterval, retryTimeout,
+				targetExternalContainerAndTest(externalContainer,
+					f.Namespace.Name, podName, true, []string{egressIPStr}))
+			framework.ExpectNoError(err, "pre-upgrade traffic check failed for pod %s: %v", podName, err)
+			framework.Logf("PRE-UPGRADE PASS [%s]: source IP confirmed as %s", podName, egressIPStr)
+		}
 
 		// ----------------------------------------------------------------
-		// UPGRADE — patch DaemonSet image via Kubernetes API
+		// UPGRADE
 		// ----------------------------------------------------------------
 
-		// Determine which image to roll to.
-		// In CI: OVN_IMAGE env var is set to the new PR image.
-		// Locally: OVN_IMAGE not set — read current image from DaemonSet
-		// and reuse it.
 		newImage := os.Getenv(ovnUpgradeImageEnvVar)
+
+		// Read current state before patching so we can revert after upgrade
+		currentDS, err := f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Get(
+			context.Background(), ovnKubeNodeDSName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get current ovnkube-node DaemonSet")
+		originalImage := upgradeEIPGetContainerImage(currentDS)
+		originalMaxUnavailable := currentDS.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable
+
 		if newImage == "" {
-			ds, err := f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Get(
-				context.Background(), ovnKubeNodeDSName, metav1.GetOptions{})
-			framework.ExpectNoError(err, "failed to get ovnkube-node DaemonSet")
-			newImage = upgradeEIPGetContainerImage(ds)
+			newImage = originalImage
 			framework.Logf("OVN_IMAGE not set — using current image: %s (simulated upgrade)", newImage)
 		} else {
-			framework.Logf("OVN_IMAGE set — upgrading to: %s", newImage)
+			framework.Logf("OVN_IMAGE set — upgrading from %s to: %s", originalImage, newImage)
 		}
 
 		ginkgo.By("6. Setting maxUnavailable=1 to ensure standard rolling update behaviour")
-		// This ensures one pod is restarted at a time — matching real CI upgrade
-		// behaviour and allowing the rollout check to detect the start correctly.
-		// KIND clusters set maxUnavailable=100% by default for fast setup,
-		// which would cause all pods to restart simultaneously.
 		rollingPatch := `{"spec":{"updateStrategy":{"rollingUpdate":{"maxUnavailable":1}}}}`
 		_, err = f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Patch(
 			context.Background(),
@@ -243,16 +242,24 @@ spec:
 		)
 		framework.ExpectNoError(err, "failed to patch ovnkube-node DaemonSet maxUnavailable")
 
-		// Start traffic polling goroutine BEFORE patching the image.
-		// EgressIP traffic must be intact (zero failures) during the rolling upgrade.
-		// The OVN dataplane maintains SNAT rules even while ovnkube-node pods are
-		// restarting one by one
+		// Start goroutine to monitor EgressIP traffic during rollout.
+		// Failures are logged — zero failures are expected.
 		trafficFailures := 0
 		trafficTotal := 0
 		stopPolling := make(chan struct{})
 		pollingDone := make(chan struct{})
+		pollStopped := false
+		stopPollOnce := func() {
+			if !pollStopped {
+				close(stopPolling)
+				<-pollingDone
+				pollStopped = true
+			}
+		}
+		defer stopPollOnce()
 
 		go func() {
+			defer ginkgo.GinkgoRecover()
 			defer close(pollingDone)
 			for {
 				select {
@@ -260,16 +267,19 @@ spec:
 					return
 				case <-time.After(ovnUpgradeTrafficPollInterval):
 					trafficTotal++
-					checkErr := wait.PollImmediate(1*time.Second, ovnUpgradeTrafficCheckTimeout,
-						targetExternalContainerAndTest(externalContainer,
-							f.Namespace.Name, upgradePodName, true, []string{egressIPStr}))
-					if checkErr != nil {
-						trafficFailures++
-						framework.Logf("[DURING-UPGRADE] Traffic check FAILED (%d/%d): %v",
-							trafficFailures, trafficTotal, checkErr)
-					} else {
-						framework.Logf("[DURING-UPGRADE] Traffic check PASSED (%d/%d): source IP = %s",
-							trafficTotal-trafficFailures, trafficTotal, egressIPStr)
+					// Check both pods during rollout
+					for _, podName := range []string{upgradePodSameName, upgradePodDiffName} {
+						checkErr := wait.PollImmediate(1*time.Second, ovnUpgradeTrafficCheckTimeout,
+							targetExternalContainerAndTest(externalContainer,
+								f.Namespace.Name, podName, true, []string{egressIPStr}))
+						if checkErr != nil {
+							trafficFailures++
+							framework.Logf("[DURING-UPGRADE] Traffic check FAILED pod=%s (%d/%d): %v",
+								podName, trafficFailures, trafficTotal, checkErr)
+						} else {
+							framework.Logf("[DURING-UPGRADE] Traffic check PASSED pod=%s (%d/%d): source IP = %s",
+								podName, trafficTotal-trafficFailures, trafficTotal, egressIPStr)
+						}
 					}
 				}
 			}
@@ -292,18 +302,11 @@ spec:
 		ginkgo.By("8. Waiting for ovnkube-node DaemonSet rollout to complete")
 		upgradeEIPWaitForDSRollout(f, ovnKubeNS, ovnKubeNodeDSName, ovnUpgradeRolloutTimeout)
 
-		// Stop traffic polling goroutine and wait for it to finish
-		close(stopPolling)
-		<-pollingDone
+		stopPollOnce()
 
-		framework.Logf("UPGRADE COMPLETE: rollout finished. EgressIP traffic checks during rollout: %d passed, %d failed out of %d total",
+		framework.Logf("UPGRADE COMPLETE: rollout finished. Traffic checks during rollout: %d passed, %d failed out of %d total",
 			trafficTotal-trafficFailures, trafficFailures, trafficTotal)
 
-		// NOTE: traffic failures during rollout are logged above.
-		// Zero failures are expected — the OVN dataplane must maintain SNAT rules
-		// while ovnkube-node pods restart. 
-		// TODO : Add assertion for zero traffic failures.
-		
 		// ----------------------------------------------------------------
 		// POST-UPGRADE VERIFICATION
 		// ----------------------------------------------------------------
@@ -312,23 +315,72 @@ spec:
 		upgradeEIPWaitForAssignment(upgradeEIPName, 1)
 		framework.Logf("POST-UPGRADE: EgressIP assignment verified")
 
-		ginkgo.By("10. [POST-UPGRADE] Verifying EgressIP traffic — source IP must still be " + egressIPStr)
-		err = wait.PollImmediate(retryInterval, retryTimeout,
-			targetExternalContainerAndTest(externalContainer,
-				f.Namespace.Name, upgradePodName, true, []string{egressIPStr}))
-		framework.ExpectNoError(err, "post-upgrade traffic check failed: %v", err)
-		framework.Logf("POST-UPGRADE PASS: source IP confirmed as %s after upgrade", egressIPStr)
-		framework.Logf("SUMMARY: EgressIP traffic fully intact during rolling upgrade — %d/%d checks passed",
+		ginkgo.By("10. [POST-UPGRADE] Verifying EgressIP traffic for both pods — source IP must still be " + egressIPStr)
+		for _, podName := range []string{upgradePodSameName, upgradePodDiffName} {
+			err = wait.PollImmediate(retryInterval, retryTimeout,
+				targetExternalContainerAndTest(externalContainer,
+					f.Namespace.Name, podName, true, []string{egressIPStr}))
+			framework.ExpectNoError(err, "post-upgrade traffic check failed for pod %s: %v", podName, err)
+			framework.Logf("POST-UPGRADE PASS [%s]: source IP confirmed as %s after upgrade", podName, egressIPStr)
+		}
+
+		framework.Logf("SUMMARY: EgressIP traffic during rolling upgrade — %d/%d checks passed",
 			trafficTotal-trafficFailures, trafficTotal)
+
+		// ----------------------------------------------------------------
+		// REVERT — restore original DaemonSet state
+		// ----------------------------------------------------------------
+
+		ginkgo.By(fmt.Sprintf("11. Reverting ovnkube-node DaemonSet to original image: %s", originalImage))
+		revertPatch := fmt.Sprintf(
+			`{"spec":{"template":{"spec":{"containers":[{"name":"%s","image":"%s"}]}}}}`,
+			getNodeContainerName(), originalImage,
+		)
+		_, err = f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Patch(
+			context.Background(),
+			ovnKubeNodeDSName,
+			types.StrategicMergePatchType,
+			[]byte(revertPatch),
+			metav1.PatchOptions{},
+		)
+		framework.ExpectNoError(err, "failed to revert ovnkube-node DaemonSet image")
+
+		ginkgo.By("12. Restoring original maxUnavailable setting")
+		var revertRollingPatch string
+		if originalMaxUnavailable == nil || originalMaxUnavailable.Type == 0 {
+			intVal := int32(1)
+			if originalMaxUnavailable != nil {
+				intVal = originalMaxUnavailable.IntVal
+			}
+			revertRollingPatch = fmt.Sprintf(
+				`{"spec":{"updateStrategy":{"rollingUpdate":{"maxUnavailable":%d}}}}`,
+				intVal,
+			)
+		} else {
+			revertRollingPatch = fmt.Sprintf(
+				`{"spec":{"updateStrategy":{"rollingUpdate":{"maxUnavailable":%q}}}}`,
+				originalMaxUnavailable.StrVal,
+			)
+		}
+		_, err = f.ClientSet.AppsV1().DaemonSets(ovnKubeNS).Patch(
+			context.Background(),
+			ovnKubeNodeDSName,
+			types.StrategicMergePatchType,
+			[]byte(revertRollingPatch),
+			metav1.PatchOptions{},
+		)
+		framework.ExpectNoError(err, "failed to revert ovnkube-node DaemonSet maxUnavailable")
+
+		ginkgo.By("13. Waiting for revert rollout to complete")
+		upgradeEIPWaitForDSRollout(f, ovnKubeNS, ovnKubeNodeDSName, ovnUpgradeRolloutTimeout)
+		framework.Logf("REVERT COMPLETE: DaemonSet restored to original image %s", originalImage)
 	})
 })
 
 // ---------------------------------------------------------------------------
-// Helpers — scoped to upgrade tests only.
+// Helpers
 // ---------------------------------------------------------------------------
 
-// upgradeEIPWaitForAssignment polls until the named EgressIP has the expected
-// number of node assignments, failing the test if timeout is reached.
 func upgradeEIPWaitForAssignment(eipName string, expectedCount int) {
 	err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 		stdout, err := e2ekubectl.RunKubectl("default", "get", "eip", eipName, "-o", "json")
@@ -351,11 +403,7 @@ func upgradeEIPWaitForAssignment(eipName string, expectedCount int) {
 	}
 }
 
-// upgradeEIPWaitForDSRollout waits until the DaemonSet rolling update is
-// complete — all pods updated, available, and ready.
-// Phase 1 waits for rollout to START, Phase 2 waits for it to COMPLETE.
 func upgradeEIPWaitForDSRollout(f *framework.Framework, namespace, dsName string, timeout time.Duration) {
-	// Phase 1: Wait for rollout to START — at least one pod not yet updated/available
 	framework.Logf("Waiting for DaemonSet %s rollout to start...", dsName)
 	err := wait.PollUntilContextTimeout(
 		context.Background(),
@@ -372,7 +420,7 @@ func upgradeEIPWaitForDSRollout(f *framework.Framework, namespace, dsName string
 			updated := ds.Status.UpdatedNumberScheduled
 			available := ds.Status.NumberAvailable
 			started := updated < desired || available < desired
-			framework.Logf("DaemonSet %s waiting for rollout start: desired=%d updated=%d available=%d started=%v",
+			framework.Logf("DaemonSet %s rollout start check: desired=%d updated=%d available=%d started=%v",
 				dsName, desired, updated, available, started)
 			return started, nil
 		},
@@ -381,7 +429,6 @@ func upgradeEIPWaitForDSRollout(f *framework.Framework, namespace, dsName string
 		framework.Logf("Warning: could not confirm rollout started (may have been instant): %v", err)
 	}
 
-	// Phase 2: Wait for rollout to COMPLETE
 	framework.Logf("Waiting for DaemonSet %s rollout to complete...", dsName)
 	err = wait.PollUntilContextTimeout(
 		context.Background(),
@@ -396,6 +443,7 @@ func upgradeEIPWaitForDSRollout(f *framework.Framework, namespace, dsName string
 			}
 			desired := ds.Status.DesiredNumberScheduled
 			if desired == 0 {
+				framework.Logf("DaemonSet %s reports DesiredNumberScheduled==0 (possible nodeSelector/stale status)", dsName)
 				return false, nil
 			}
 			updated := ds.Status.UpdatedNumberScheduled
@@ -412,8 +460,6 @@ func upgradeEIPWaitForDSRollout(f *framework.Framework, namespace, dsName string
 	}
 }
 
-// upgradeEIPGetContainerImage returns the image of the ovnkube-node container
-// from the DaemonSet spec. Falls back to first container if named one not found.
 func upgradeEIPGetContainerImage(ds *appsv1.DaemonSet) string {
 	containerName := getNodeContainerName()
 	for _, c := range ds.Spec.Template.Spec.Containers {
@@ -421,14 +467,10 @@ func upgradeEIPGetContainerImage(ds *appsv1.DaemonSet) string {
 			return c.Image
 		}
 	}
-	if len(ds.Spec.Template.Spec.Containers) > 0 {
-		return ds.Spec.Template.Spec.Containers[0].Image
-	}
-	framework.Failf("no containers found in DaemonSet %s", ds.Name)
+	framework.Failf("container %q not found in DaemonSet %s", containerName, ds.Name)
 	return ""
 }
 
-// upgradeEIPGetNodeIP returns the first InternalIP of the given node.
 func upgradeEIPGetNodeIP(node corev1.Node) string {
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == corev1.NodeInternalIP {
@@ -438,8 +480,9 @@ func upgradeEIPGetNodeIP(node corev1.Node) string {
 	return ""
 }
 
-// upgradeEIPDeriveEgressIP takes a node IP like 172.18.0.2 and returns
-// an EgressIP in the same subnet
+// upgradeEIPDeriveEgressIP derives an EgressIP from a node IP by setting
+// the last octet to 200 (or 201 if the node IP already ends in 200).
+// For IPv6, the last byte is set to 0xc8 (200).
 func upgradeEIPDeriveEgressIP(nodeIP string) (string, error) {
 	ip := net.ParseIP(nodeIP)
 	if ip == nil {
@@ -447,13 +490,21 @@ func upgradeEIPDeriveEgressIP(nodeIP string) (string, error) {
 	}
 	ip4 := ip.To4()
 	if ip4 == nil {
-		// IPv6 — set second to last byte to 0xc8 (200)
-		ip6 := ip.To16()
-		ip6[14] = 0xc8
-		ip6[15] = 0x00
-		return ip6.String(), nil
+		ip6 := make([]byte, len(ip.To16()))
+		copy(ip6, ip.To16())
+		if ip6[15] == 0xc8 {
+			ip6[15] = 0xc9
+		} else {
+			ip6[15] = 0xc8
+		}
+		return net.IP(ip6).String(), nil
 	}
-	// IPv4 — set last octet to 200, keep first three octets
-	ip4[3] = 200
-	return ip4.String(), nil
+	ip4copy := make([]byte, len(ip4))
+	copy(ip4copy, ip4)
+	if ip4copy[3] == 200 {
+		ip4copy[3] = 201
+	} else {
+		ip4copy[3] = 200
+	}
+	return net.IP(ip4copy).String(), nil
 }


### PR DESCRIPTION
## Description

Add an e2e test that verifies EgressIP traffic works correctly through
a rolling upgrade of ovnkube-node pods.

The existing `ovn-upgrade-e2e` CI job performs a real base→PR image
upgrade but has no EgressIP verification. CORENET-6408 identified this
gap: "If we had upgrade tests + functional EIP tests during upgrade,
this may have been caught."

Related: CORENET-6409

## What the test does

- Labels a node as egress-assignable and creates an EgressIP object
- Creates two pods: one on the egress node (same node), one on a different node
- Verifies EgressIP traffic works pre-upgrade for both pods
- Records original DaemonSet image and maxUnavailable for revert
- Sets maxUnavailable=1 for standard one-pod-at-a-time rolling update
- Polls EgressIP traffic every 5s during rollout for both pods
- Patches ovnkube-node DaemonSet to new image via Kubernetes API
- Waits for rollout to complete
- Verifies EgressIP assignment and traffic post-upgrade for both pods
- Reverts DaemonSet to original image and maxUnavailable

## Two modes

- CI: `OVN_IMAGE` set → real image upgrade → pods actually restart
- Local KIND: `OVN_IMAGE` not set → rollout mechanics exercised with current image

## Finding during local testing

During rolling upgrade, 2/42 traffic checks failed when the last
ovnkube-node pod on the egress node restarted. Traffic briefly exited
via the node IP instead of the EgressIP (~10 second window).

## How to verify

Run locally:
cd test && make control-plane WHAT="EgressIP survives ovnkube-node rolling upgrade"

With real image upgrade:
OVN_IMAGE=<image> make -C test control-plane WHAT="EgressIP survives ovnkube-node rolling upgrade"

## Checks

- [x] My code requires tests
- [x] I have added and/or updated the tests as required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
...
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests confirming EgressIP connectivity is preserved during rolling upgrades, including continuous traffic-source IP verification, assignment tracking, and pre/post-upgrade validation.

* **Chores**
  * Expanded CI with an extra control-plane verification step to monitor EgressIP behavior during upgrade runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->