### PR TITLE
Add transport label to CUDN count metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -17,6 +17,7 @@ Measurement accuracy can be impacted by other parallel processing that might be 
 ## Change log
 This list is to help notify if there are additions, changes or removals to metrics. Latest changes are at the top of this list.
 
+- Add `transport` label to `ovnkube_clustermanager_cluster_user_defined_networks` to distinguish CUDNs by transport type (Geneve, EVPN, NoOverlay, Localnet)
 - Add metrics to track logfile size for ovnkube processes - ovnkube_node_logfile_size_bytes and ovnkube_controller_logfile_size_bytes
 - Remove ovnkube_controller_ovn_cli_latency_seconds metrics since we have moved most of the OVN DB operations to libovsdb.
 - Effect of OVN IC architecture:

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -17,7 +17,7 @@ Measurement accuracy can be impacted by other parallel processing that might be 
 ## Change log
 This list is to help notify if there are additions, changes or removals to metrics. Latest changes are at the top of this list.
 
-- Add `transport` label to `ovnkube_clustermanager_cluster_user_defined_networks` to distinguish CUDNs by transport type (Geneve, EVPN, NoOverlay, Localnet)
+- Add `transport` label to `ovnkube_clustermanager_cluster_user_defined_networks` to distinguish CUDNs by transport type (Default, EVPN, NoOverlay)
 - Add metrics to track logfile size for ovnkube processes - ovnkube_node_logfile_size_bytes and ovnkube_controller_logfile_size_bytes
 - Remove ovnkube_controller_ovn_cli_latency_seconds metrics since we have moved most of the OVN DB operations to libovsdb.
 - Effect of OVN IC architecture:

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -139,9 +139,10 @@ type Controller struct {
 	namespaceTracker     map[string]sets.Set[string]
 	namespaceTrackerLock sync.RWMutex
 	// cudnMetricTracker tracks which CUDNs are counted in the CUDN gauge metric.
-	// Maps CUDN name to its (role, topology, transport) labels.
+	// Maps (role, topology, transport) labels to the set of CUDN names sharing
+	// that combination.
 	// Only mutated from syncClusterUDN and initializeController (single-threaded).
-	cudnMetricTracker map[string]cudnMetricKey
+	cudnMetricTracker map[cudnMetricKey]sets.Set[string]
 	// renderNadFn render NAD manifest from given object, enable replacing in tests.
 	renderNadFn RenderNetAttachDefManifest
 	// createNetworkLock lock should be held when NAD is created to avoid having two components
@@ -210,7 +211,7 @@ func New(
 		namespaceInformer: namespaceInformer,
 		networkManager:    networkManager,
 		namespaceTracker:  map[string]sets.Set[string]{},
-		cudnMetricTracker: map[string]cudnMetricKey{},
+		cudnMetricTracker: map[cudnMetricKey]sets.Set[string]{},
 		vidAllocator:      vidAllocator,
 		reservedVNIs:      map[vniKey]string{},
 		eventRecorder:     eventRecorder,
@@ -971,7 +972,7 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 			}
 			klog.Infof("Finalizer removed from ClusterUserDefinedNetwork %q", cudn.Name)
 			delete(c.namespaceTracker, cudnName)
-			c.cudnMetricUncounted(cudnName)
+			c.cudnMetricUncounted(cudnName, &cudn.Spec.Network)
 			metrics.DeleteDynamicUDNNodeCount(util.GenerateCUDNNetworkName(cudn.Name))
 			c.releaseEVPNIDsForNetwork(cudnName)
 		}

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -138,6 +138,10 @@ type Controller struct {
 	// Keys are CR name, value is affected namespace names slice.
 	namespaceTracker     map[string]sets.Set[string]
 	namespaceTrackerLock sync.RWMutex
+	// cudnMetricTracker tracks which CUDNs are counted in the CUDN gauge metric.
+	// Maps CUDN name to its (role, topology, transport) labels.
+	// Only mutated from syncClusterUDN and initializeController (single-threaded).
+	cudnMetricTracker map[string]cudnMetricKey
 	// renderNadFn render NAD manifest from given object, enable replacing in tests.
 	renderNadFn RenderNetAttachDefManifest
 	// createNetworkLock lock should be held when NAD is created to avoid having two components
@@ -206,6 +210,7 @@ func New(
 		namespaceInformer: namespaceInformer,
 		networkManager:    networkManager,
 		namespaceTracker:  map[string]sets.Set[string]{},
+		cudnMetricTracker: map[string]cudnMetricKey{},
 		vidAllocator:      vidAllocator,
 		reservedVNIs:      map[vniKey]string{},
 		eventRecorder:     eventRecorder,
@@ -299,6 +304,8 @@ func (c *Controller) initializeController() error {
 	}
 
 	c.initializeNamespaceTracker(cudnNADs)
+	c.seedCUDNCountMetrics(cudnNADs)
+
 	if util.IsEVPNEnabled() {
 		// Recover VID allocations from existing EVPN CUDNs.
 		// Recovery failures are logged and the affected CUDNs are enqueued for reconciliation,
@@ -933,16 +940,6 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 	cudnName := cudn.Name
 	affectedNamespaces := c.namespaceTracker[cudnName]
 
-	var role, topology string
-	if cudn.Spec.Network.Layer2 != nil {
-		role = string(cudn.Spec.Network.Layer2.Role)
-	} else if cudn.Spec.Network.Layer3 != nil {
-		role = string(cudn.Spec.Network.Layer3.Role)
-	} else if cudn.Spec.Network.Localnet != nil {
-		role = string(cudn.Spec.Network.Localnet.Role)
-	}
-	topology = string(cudn.Spec.Network.Topology)
-
 	if !cudn.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(cudn, template.FinalizerUserDefinedNetwork) {
 			var errs []error
@@ -974,7 +971,7 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 			}
 			klog.Infof("Finalizer removed from ClusterUserDefinedNetwork %q", cudn.Name)
 			delete(c.namespaceTracker, cudnName)
-			metrics.DecrementCUDNCount(role, topology)
+			c.cudnMetricUncounted(cudnName)
 			metrics.DeleteDynamicUDNNodeCount(util.GenerateCUDNNetworkName(cudn.Name))
 			c.releaseEVPNIDsForNetwork(cudnName)
 		}
@@ -983,7 +980,6 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 	}
 
 	if _, exist := c.namespaceTracker[cudnName]; !exist {
-		// start tracking CR
 		c.namespaceTracker[cudnName] = sets.Set[string]{}
 	}
 
@@ -994,7 +990,7 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 			return nil, fmt.Errorf("failed to add finalizer to ClusterUserDefinedNetwork %q: %w", cudnName, err)
 		}
 		klog.Infof("Added Finalizer to ClusterUserDefinedNetwork %q", cudnName)
-		metrics.IncrementCUDNCount(role, topology)
+		c.cudnMetricCounted(cudnName, &cudn.Spec.Network)
 	}
 
 	if evpnErr != nil {

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_metrics.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_metrics.go
@@ -4,6 +4,7 @@
 package userdefinednetwork
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/userdefinednetwork/template"
@@ -11,7 +12,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 )
 
-// cudnMetricKey holds the label values for a single CUDN in the count gauge.
+// cudnMetricKey holds the label values for a CUDN metric label combination.
 type cudnMetricKey struct {
 	role, topology, transport string
 }
@@ -30,18 +31,14 @@ type cudnMetricKey struct {
 // short-circuits, and cudnMetricUncounted is never called — leaving a phantom
 // entry in the tracker.
 func (c *Controller) seedCUDNCountMetrics(cudnNADs cudnToNADs) {
-	counts := map[cudnMetricKey]float64{}
 	for _, entry := range cudnNADs {
 		if !controllerutil.ContainsFinalizer(entry.cudn, template.FinalizerUserDefinedNetwork) {
 			continue
 		}
-		role, topology, transport := cudnMetricLabels(&entry.cudn.Spec.Network)
-		key := cudnMetricKey{role, topology, transport}
-		c.cudnMetricTracker[entry.cudn.Name] = key
-		counts[key]++
+		c.trackCUDN(entry.cudn.Name, &entry.cudn.Spec.Network)
 	}
-	for k, count := range counts {
-		metrics.SetCUDNCount(k.role, k.topology, k.transport, count)
+	for key, names := range c.cudnMetricTracker {
+		metrics.SetCUDNCount(key.role, key.topology, key.transport, float64(names.Len()))
 	}
 }
 
@@ -49,44 +46,45 @@ func (c *Controller) seedCUDNCountMetrics(cudnNADs cudnToNADs) {
 // the gauge metric. The caller must have already persisted the finalizer — this
 // is what guarantees a matching cudnMetricUncounted call during deletion.
 func (c *Controller) cudnMetricCounted(name string, spec *userdefinednetworkv1.NetworkSpec) {
+	key, names := c.trackCUDN(name, spec)
+	metrics.SetCUDNCount(key.role, key.topology, key.transport, float64(names.Len()))
+}
+
+// trackCUDN inserts a CUDN name into the metric tracker bucket for its label
+// combination, initializing the set if needed. Returns the bucket key and set.
+func (c *Controller) trackCUDN(name string, spec *userdefinednetworkv1.NetworkSpec) (cudnMetricKey, sets.Set[string]) {
 	role, topology, transport := cudnMetricLabels(spec)
 	key := cudnMetricKey{role, topology, transport}
-	c.cudnMetricTracker[name] = key
-	metrics.SetCUDNCount(key.role, key.topology, key.transport, c.countCUDNMetricKey(key))
+	if c.cudnMetricTracker[key] == nil {
+		c.cudnMetricTracker[key] = sets.New[string]()
+	}
+	c.cudnMetricTracker[key].Insert(name)
+	return key, c.cudnMetricTracker[key]
 }
 
 // cudnMetricUncounted records that a CUDN is no longer counted in the gauge
 // metric. The caller must have already removed the finalizer.
-func (c *Controller) cudnMetricUncounted(name string) {
-	key, existed := c.cudnMetricTracker[name]
-	if !existed {
+func (c *Controller) cudnMetricUncounted(name string, spec *userdefinednetworkv1.NetworkSpec) {
+	role, topology, transport := cudnMetricLabels(spec)
+	key := cudnMetricKey{role, topology, transport}
+	names := c.cudnMetricTracker[key]
+	if names == nil || !names.Has(name) {
 		return
 	}
-	delete(c.cudnMetricTracker, name)
-	remaining := c.countCUDNMetricKey(key)
-	if remaining == 0 {
+	names.Delete(name)
+	if names.Len() == 0 {
+		delete(c.cudnMetricTracker, key)
 		metrics.DeleteCUDNCount(key.role, key.topology, key.transport)
 	} else {
-		metrics.SetCUDNCount(key.role, key.topology, key.transport, remaining)
+		metrics.SetCUDNCount(key.role, key.topology, key.transport, float64(names.Len()))
 	}
-}
-
-// countCUDNMetricKey counts how many CUDNs in the tracker share the given label combination.
-func (c *Controller) countCUDNMetricKey(target cudnMetricKey) float64 {
-	var count float64
-	for _, k := range c.cudnMetricTracker {
-		if k == target {
-			count++
-		}
-	}
-	return count
 }
 
 // cudnMetricLabels extracts the role, topology, and transport label values from
-// a CUDN network spec for use in Prometheus metrics. An empty transport (the
-// default OVN overlay) is mapped to "Geneve" for overlay topologies. Localnet
-// topology uses direct provider-network attachment (no overlay encapsulation),
-// so its transport is labeled "Localnet".
+// a CUDN network spec for use in Prometheus metrics. When spec.Transport is
+// empty (the user did not configure an explicit transport), the label is set to
+// "Default" — meaning the standard OVN overlay (Geneve or VXLAN, depending on
+// ovn-encap-type). This avoids assuming a specific encapsulation protocol.
 func cudnMetricLabels(spec *userdefinednetworkv1.NetworkSpec) (role, topology, transport string) {
 	if spec.Layer2 != nil {
 		role = string(spec.Layer2.Role)
@@ -98,11 +96,7 @@ func cudnMetricLabels(spec *userdefinednetworkv1.NetworkSpec) (role, topology, t
 	topology = string(spec.Topology)
 	transport = string(spec.Transport)
 	if transport == "" {
-		if spec.Topology == userdefinednetworkv1.NetworkTopologyLocalnet {
-			transport = "Localnet"
-		} else {
-			transport = "Geneve"
-		}
+		transport = "Default"
 	}
 	return
 }

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_metrics.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_metrics.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package userdefinednetwork
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/userdefinednetwork/template"
+	userdefinednetworkv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
+)
+
+// cudnMetricKey holds the label values for a single CUDN in the count gauge.
+type cudnMetricKey struct {
+	role, topology, transport string
+}
+
+// seedCUDNCountMetrics populates the metric tracker from existing CUDNs at
+// startup, then sets the gauge once.
+//
+// Only finalized CUDNs are seeded. This preserves the tracker invariant: every
+// entry in cudnMetricTracker has a finalizer that guarantees cudnMetricUncounted
+// will run during deletion. Unfinalized CUDNs are safe to skip — they will be
+// counted by cudnMetricCounted when the reconcile loop adds the finalizer.
+//
+// Without this guard a tracker leak is possible: if an unfinalized CUDN is
+// deleted before the controller reconciles it, Kubernetes garbage-collects it
+// immediately (no finalizer), reconcileCUDN sees NotFound, syncClusterUDN(nil)
+// short-circuits, and cudnMetricUncounted is never called — leaving a phantom
+// entry in the tracker.
+func (c *Controller) seedCUDNCountMetrics(cudnNADs cudnToNADs) {
+	counts := map[cudnMetricKey]float64{}
+	for _, entry := range cudnNADs {
+		if !controllerutil.ContainsFinalizer(entry.cudn, template.FinalizerUserDefinedNetwork) {
+			continue
+		}
+		role, topology, transport := cudnMetricLabels(&entry.cudn.Spec.Network)
+		key := cudnMetricKey{role, topology, transport}
+		c.cudnMetricTracker[entry.cudn.Name] = key
+		counts[key]++
+	}
+	for k, count := range counts {
+		metrics.SetCUDNCount(k.role, k.topology, k.transport, count)
+	}
+}
+
+// cudnMetricCounted records that a CUDN with the given spec is now counted in
+// the gauge metric. The caller must have already persisted the finalizer — this
+// is what guarantees a matching cudnMetricUncounted call during deletion.
+func (c *Controller) cudnMetricCounted(name string, spec *userdefinednetworkv1.NetworkSpec) {
+	role, topology, transport := cudnMetricLabels(spec)
+	key := cudnMetricKey{role, topology, transport}
+	c.cudnMetricTracker[name] = key
+	metrics.SetCUDNCount(key.role, key.topology, key.transport, c.countCUDNMetricKey(key))
+}
+
+// cudnMetricUncounted records that a CUDN is no longer counted in the gauge
+// metric. The caller must have already removed the finalizer.
+func (c *Controller) cudnMetricUncounted(name string) {
+	key, existed := c.cudnMetricTracker[name]
+	if !existed {
+		return
+	}
+	delete(c.cudnMetricTracker, name)
+	remaining := c.countCUDNMetricKey(key)
+	if remaining == 0 {
+		metrics.DeleteCUDNCount(key.role, key.topology, key.transport)
+	} else {
+		metrics.SetCUDNCount(key.role, key.topology, key.transport, remaining)
+	}
+}
+
+// countCUDNMetricKey counts how many CUDNs in the tracker share the given label combination.
+func (c *Controller) countCUDNMetricKey(target cudnMetricKey) float64 {
+	var count float64
+	for _, k := range c.cudnMetricTracker {
+		if k == target {
+			count++
+		}
+	}
+	return count
+}
+
+// cudnMetricLabels extracts the role, topology, and transport label values from
+// a CUDN network spec for use in Prometheus metrics. An empty transport (the
+// default OVN overlay) is mapped to "Geneve" for overlay topologies. Localnet
+// topology uses direct provider-network attachment (no overlay encapsulation),
+// so its transport is labeled "Localnet".
+func cudnMetricLabels(spec *userdefinednetworkv1.NetworkSpec) (role, topology, transport string) {
+	if spec.Layer2 != nil {
+		role = string(spec.Layer2.Role)
+	} else if spec.Layer3 != nil {
+		role = string(spec.Layer3.Role)
+	} else if spec.Localnet != nil {
+		role = string(spec.Localnet.Role)
+	}
+	topology = string(spec.Topology)
+	transport = string(spec.Transport)
+	if transport == "" {
+		if spec.Topology == userdefinednetworkv1.NetworkTopologyLocalnet {
+			transport = "Localnet"
+		} else {
+			transport = "Geneve"
+		}
+	}
+	return
+}

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -14,6 +14,8 @@ import (
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	netv1clientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	netv1fakeclientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +38,7 @@ import (
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
 	vtepinformer "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/informers/externalversions/vtep/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -59,6 +62,7 @@ var _ = Describe("User Defined Network Controller", func() {
 		// Enable EVPN for EVPN-related tests
 		config.OVNKubernetesFeature.EnableRouteAdvertisements = true
 		config.OVNKubernetesFeature.EnableEVPN = true
+		metrics.RegisterClusterManagerFunctional()
 		// satisfy EVPN LGW restriction, otherwise no effect
 		config.Gateway.Mode = config.GatewayModeLocal
 	})
@@ -126,6 +130,17 @@ var _ = Describe("User Defined Network Controller", func() {
 			}
 			return false
 		}, 2*time.Second, 100*time.Millisecond).Should(BeTrue())
+	}
+
+	// markCUDNForDeletion marks a CUDN for deletion by setting its DeletionTimestamp to the current time.
+	markCUDNForDeletion := func(name string) {
+		GinkgoHelper()
+		cudnObj, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		now := metav1.Now()
+		cudnObj.DeletionTimestamp = &now
+		_, err = cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Update(context.Background(), cudnObj, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	Context("manager", func() {
@@ -693,12 +708,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				Expect(c.vidAllocator.GetID("evpn-delete-cudn/macvrf")).To(BeNumerically(">=", 0), "VID should be allocated")
 
 				// Trigger deletion by setting DeletionTimestamp and processing
-				now := metav1.Now()
-				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				cudn.DeletionTimestamp = &now
-				_, err = cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Update(context.Background(), cudn, metav1.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				markCUDNForDeletion(cudn.Name)
 
 				// Wait for finalizer to be removed (indicating deletion was processed)
 				Eventually(func(g Gomega) {
@@ -732,12 +742,7 @@ var _ = Describe("User Defined Network Controller", func() {
 				Expect(c.vidAllocator.GetID("evpn-irb-delete/ipvrf")).To(Equal(3), "IP-VRF VID should be allocated")
 
 				// Trigger deletion
-				now := metav1.Now()
-				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				cudn.DeletionTimestamp = &now
-				_, err = cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Update(context.Background(), cudn, metav1.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				markCUDNForDeletion(cudn.Name)
 
 				// Wait for finalizer to be removed and verify both VIDs are released
 				Eventually(func(g Gomega) {
@@ -2573,6 +2578,104 @@ var _ = Describe("User Defined Network Controller", func() {
 			expectTransportCondition("test-cudn", metav1.ConditionTrue, ReasonEVPNTransportAccepted, "Transport has been configured as 'EVPN'.")
 		})
 	})
+
+	Context("CUDN metrics", func() {
+		var c *Controller
+
+		BeforeEach(func() {
+			metrics.ResetCUDNCount()
+		})
+
+		AfterEach(func() {
+			if c != nil {
+				c.Shutdown()
+			}
+		})
+
+		It("should increment CUDN count on create with Geneve transport", func() {
+			baseVal, _ := getCUDNCountMetricValue("Primary", "Layer3", "Geneve")
+
+			testNs := testNamespace("metrics-ns")
+			cudn := testLayer3PrimaryClusterUDN("metrics-cudn", testNs.Name)
+			cudn.Finalizers = nil
+			c = newTestController(template.RenderNetAttachDefManifest, cudn, testNs)
+			Expect(c.Run()).To(Succeed())
+
+			Eventually(func() []metav1.Condition {
+				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return normalizeConditions(filterTransportConditions(cudn.Status.Conditions))
+			}).Should(Equal([]metav1.Condition{{
+				Type:    "NetworkCreated",
+				Status:  "True",
+				Reason:  "NetworkAttachmentDefinitionCreated",
+				Message: "NetworkAttachmentDefinition has been created in following namespaces: [metrics-ns]",
+			}}))
+
+			val, found := getCUDNCountMetricValue("Primary", "Layer3", "Geneve")
+			Expect(found).To(BeTrue(), "CUDN count metric should exist for default Geneve transport")
+			Expect(val).To(Equal(baseVal + 1))
+		})
+
+		It("should increment CUDN count on create with EVPN transport", func() {
+			baseVal, _ := getCUDNCountMetricValue("Primary", "Layer2", "EVPN")
+
+			testNs := testNamespace("metrics-evpn-ns")
+			vtep := testVTEP("vtep-metrics")
+			cudn := testEVPNClusterUDN("metrics-evpn-cudn", vtep.Name, testNs.Name)
+			cudn.Finalizers = nil
+			cudn.Spec.Network.Layer2.Role = udnv1.NetworkRolePrimary
+
+			c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
+			Expect(c.Run()).To(Succeed())
+
+			Eventually(func() []metav1.Condition {
+				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return normalizeConditions(filterTransportConditions(cudn.Status.Conditions))
+			}).Should(Equal([]metav1.Condition{{
+				Type:    "NetworkCreated",
+				Status:  "True",
+				Reason:  "NetworkAttachmentDefinitionCreated",
+				Message: "NetworkAttachmentDefinition has been created in following namespaces: [metrics-evpn-ns]",
+			}}))
+
+			val, found := getCUDNCountMetricValue("Primary", "Layer2", "EVPN")
+			Expect(found).To(BeTrue(), "CUDN count metric should exist for EVPN transport")
+			Expect(val).To(Equal(baseVal + 1))
+		})
+
+		It("should decrement CUDN count on delete", func() {
+			testNs := testNamespace("metrics-del-ns")
+			cudn := testLayer2SecondaryClusterUDN("metrics-del-cudn", testNs.Name)
+			cudn.Finalizers = nil
+			c = newTestController(template.RenderNetAttachDefManifest, cudn, testNs)
+			Expect(c.Run()).To(Succeed())
+
+			Eventually(func() []metav1.Condition {
+				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return normalizeConditions(filterTransportConditions(cudn.Status.Conditions))
+			}).Should(Equal([]metav1.Condition{{
+				Type:    "NetworkCreated",
+				Status:  "True",
+				Reason:  "NetworkAttachmentDefinitionCreated",
+				Message: "NetworkAttachmentDefinition has been created in following namespaces: [metrics-del-ns]",
+			}}))
+
+			beforeVal, found := getCUDNCountMetricValue("Secondary", "Layer2", "Geneve")
+			Expect(found).To(BeTrue())
+
+			markCUDNForDeletion(cudn.Name)
+
+			expected := beforeVal - 1
+			Eventually(func() float64 {
+				val, _ := getCUDNCountMetricValue("Secondary", "Layer2", "Geneve")
+				return val
+			}).Should(Equal(expected), "CUDN count metric should decrement by exactly one after deletion")
+		})
+
+	})
 })
 
 // assertConditionReportNetworkInUse checks conditions reflect network consumers.
@@ -2786,6 +2889,32 @@ func testClusterUDN(name string, targetNamespaces ...string) *udnv1.ClusterUserD
 	}
 }
 
+// testLayer3PrimaryClusterUDN returns a CUDN with Layer3 Primary topology and default Geneve transport.
+func testLayer3PrimaryClusterUDN(name string, targetNamespaces ...string) *udnv1.ClusterUserDefinedNetwork {
+	cudn := testClusterUDN(name, targetNamespaces...)
+	cudn.Spec.Network = udnv1.NetworkSpec{
+		Topology: udnv1.NetworkTopologyLayer3,
+		Layer3: &udnv1.Layer3Config{
+			Role:    udnv1.NetworkRolePrimary,
+			Subnets: []udnv1.Layer3Subnet{{CIDR: "10.100.0.0/16"}},
+		},
+	}
+	return cudn
+}
+
+// testLayer2SecondaryClusterUDN returns a CUDN with Layer2 Secondary topology and default Geneve transport.
+func testLayer2SecondaryClusterUDN(name string, targetNamespaces ...string) *udnv1.ClusterUserDefinedNetwork {
+	cudn := testClusterUDN(name, targetNamespaces...)
+	cudn.Spec.Network = udnv1.NetworkSpec{
+		Topology: udnv1.NetworkTopologyLayer2,
+		Layer2: &udnv1.Layer2Config{
+			Role:    udnv1.NetworkRoleSecondary,
+			Subnets: udnv1.DualStackCIDRs{"10.20.0.0/16"},
+		},
+	}
+	return cudn
+}
+
 func testClusterUdnNAD(name, namespace string) *netv1.NetworkAttachmentDefinition {
 	return &netv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2974,4 +3103,44 @@ func setNADEVPNVIDs(nad *netv1.NetworkAttachmentDefinition, macVID, ipVID int) e
 	}
 	nad.Spec.Config = string(configBytes)
 	return nil
+}
+
+// getCUDNCountMetricValue returns the current gauge value for the CUDN count metric with the given labels.
+func getCUDNCountMetricValue(role, topology, transport string) (float64, bool) {
+	metricName := prometheus.BuildFQName(ovntypes.MetricOvnkubeNamespace, ovntypes.MetricOvnkubeSubsystemClusterManager, "cluster_user_defined_networks")
+	mf := findMetricFamily(metricName)
+	if mf == nil {
+		return 0, false
+	}
+	for _, metric := range mf.GetMetric() {
+		if metricLabelValue(metric.GetLabel(), "role") == role &&
+			metricLabelValue(metric.GetLabel(), "topology") == topology &&
+			metricLabelValue(metric.GetLabel(), "transport") == transport {
+			return metric.GetGauge().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+// findMetricFamily returns the MetricFamily with the given name from the default Prometheus gatherer.
+func findMetricFamily(name string) *dto.MetricFamily {
+	GinkgoHelper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	Expect(err).NotTo(HaveOccurred(), "failed to gather metrics")
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	return nil
+}
+
+// metricLabelValue returns the value of the label with the given name, or empty string if not found.
+func metricLabelValue(labels []*dto.LabelPair, name string) string {
+	for _, label := range labels {
+		if label.GetName() == name {
+			return label.GetValue()
+		}
+	}
+	return ""
 }

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -2475,7 +2475,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			}
 		})
 
-		It("should not update status for empty transport (defaults to Geneve)", func() {
+		It("should not update status for empty transport (default OVN overlay)", func() {
 			cudn := newCUDNWithTransport("test-cudn", map[string]string{"app": "test"}, "")
 			c = newTestController(template.RenderNetAttachDefManifest, cudn)
 			Expect(c.Run()).To(Succeed())
@@ -2592,8 +2592,8 @@ var _ = Describe("User Defined Network Controller", func() {
 			}
 		})
 
-		It("should increment CUDN count on create with Geneve transport", func() {
-			baseVal, _ := getCUDNCountMetricValue("Primary", "Layer3", "Geneve")
+		It("should increment CUDN count on create with default transport", func() {
+			baseVal, _ := getCUDNCountMetricValue("Primary", "Layer3", "Default")
 
 			testNs := testNamespace("metrics-ns")
 			cudn := testLayer3PrimaryClusterUDN("metrics-cudn", testNs.Name)
@@ -2612,8 +2612,8 @@ var _ = Describe("User Defined Network Controller", func() {
 				Message: "NetworkAttachmentDefinition has been created in following namespaces: [metrics-ns]",
 			}}))
 
-			val, found := getCUDNCountMetricValue("Primary", "Layer3", "Geneve")
-			Expect(found).To(BeTrue(), "CUDN count metric should exist for default Geneve transport")
+			val, found := getCUDNCountMetricValue("Primary", "Layer3", "Default")
+			Expect(found).To(BeTrue(), "CUDN count metric should exist for default transport")
 			Expect(val).To(Equal(baseVal + 1))
 		})
 
@@ -2622,7 +2622,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 			testNs := testNamespace("metrics-evpn-ns")
 			vtep := testVTEP("vtep-metrics")
-			cudn := testEVPNClusterUDN("metrics-evpn-cudn", vtep.Name, testNs.Name)
+			cudn := testEVPNClusterUDN("metrics-evpn-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 			cudn.Finalizers = nil
 			cudn.Spec.Network.Layer2.Role = udnv1.NetworkRolePrimary
 
@@ -2663,14 +2663,14 @@ var _ = Describe("User Defined Network Controller", func() {
 				Message: "NetworkAttachmentDefinition has been created in following namespaces: [metrics-del-ns]",
 			}}))
 
-			beforeVal, found := getCUDNCountMetricValue("Secondary", "Layer2", "Geneve")
+			beforeVal, found := getCUDNCountMetricValue("Secondary", "Layer2", "Default")
 			Expect(found).To(BeTrue())
 
 			markCUDNForDeletion(cudn.Name)
 
 			expected := beforeVal - 1
 			Eventually(func() float64 {
-				val, _ := getCUDNCountMetricValue("Secondary", "Layer2", "Geneve")
+				val, _ := getCUDNCountMetricValue("Secondary", "Layer2", "Default")
 				return val
 			}).Should(Equal(expected), "CUDN count metric should decrement by exactly one after deletion")
 		})
@@ -2889,7 +2889,7 @@ func testClusterUDN(name string, targetNamespaces ...string) *udnv1.ClusterUserD
 	}
 }
 
-// testLayer3PrimaryClusterUDN returns a CUDN with Layer3 Primary topology and default Geneve transport.
+// testLayer3PrimaryClusterUDN returns a CUDN with Layer3 Primary topology and default transport.
 func testLayer3PrimaryClusterUDN(name string, targetNamespaces ...string) *udnv1.ClusterUserDefinedNetwork {
 	cudn := testClusterUDN(name, targetNamespaces...)
 	cudn.Spec.Network = udnv1.NetworkSpec{
@@ -2902,7 +2902,7 @@ func testLayer3PrimaryClusterUDN(name string, targetNamespaces ...string) *udnv1
 	return cudn
 }
 
-// testLayer2SecondaryClusterUDN returns a CUDN with Layer2 Secondary topology and default Geneve transport.
+// testLayer2SecondaryClusterUDN returns a CUDN with Layer2 Secondary topology and default transport.
 func testLayer2SecondaryClusterUDN(name string, targetNamespaces ...string) *udnv1.ClusterUserDefinedNetwork {
 	cudn := testClusterUDN(name, targetNamespaces...)
 	cudn.Spec.Network = udnv1.NetworkSpec{

--- a/go-controller/pkg/metrics/cluster_manager.go
+++ b/go-controller/pkg/metrics/cluster_manager.go
@@ -115,6 +115,7 @@ var metricCUDNCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	[]string{
 		"role",
 		"topology",
+		"transport",
 	},
 )
 
@@ -223,14 +224,20 @@ func DecrementUDNCount(role, topology string) {
 	metricUDNCount.WithLabelValues(role, topology).Dec()
 }
 
-// IncrementCUDNCount increments the number of ClusterUserDefinedNetworks of the given type
-func IncrementCUDNCount(role, topology string) {
-	metricCUDNCount.WithLabelValues(role, topology).Inc()
+// SetCUDNCount sets the CUDN count for a specific label combination.
+func SetCUDNCount(role, topology, transport string, count float64) {
+	metricCUDNCount.WithLabelValues(role, topology, transport).Set(count)
 }
 
-// DecrementCUDNCount decrements the number of ClusterUserDefinedNetworks of the given type
-func DecrementCUDNCount(role, topology string) {
-	metricCUDNCount.WithLabelValues(role, topology).Dec()
+// DeleteCUDNCount removes a label combination from the CUDN count gauge.
+func DeleteCUDNCount(role, topology, transport string) {
+	metricCUDNCount.DeleteLabelValues(role, topology, transport)
+}
+
+// ResetCUDNCount resets the CUDN count gauge, removing all label combinations.
+// Intended for use in tests to ensure metric isolation between test cases.
+func ResetCUDNCount() {
+	metricCUDNCount.Reset()
 }
 
 // SetDynamicUDNNodeCount sets the number of nodes currently active with a CUDN/UDN.


### PR DESCRIPTION
## 📑 Description
Add a `transport` label to the `ovnkube_clustermanager_cluster_user_defined_networks` gauge metric to distinguish CUDNs by transport type (Geneve, EVPN, NoOverlay). This enables operators to monitor CUDN adoption broken down by transport.

## Additional Information for reviewers

Some design decisions:
**Why not Inc/Dec?** The NAD notifier can re-enqueue a CUDN key after the finalizer is removed but before the informer cache updates. With a stale lister, the controller re-enters the deletion path and decrements the metric a second time. In production, resourceVersion rejects the second Update before the decrement fires. In tests, the fake client doesn't enforce resourceVersion, so the gauge goes to -1. More broadly, an idempotent Set-based approach is preferable: it makes double-counting structurally impossible regardless of code ordering, whereas Inc/Dec correctness depends on being called exactly once — a property that is fragile under refactoring (e.g., if the metric call is moved before the API Update).

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI

## How to verify it
Unit tests:
```bash
cd go-controller && go test ./pkg/clustermanager/userdefinednetwork/ -run "CUDN metrics" -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics now include a new "transport" label (Default, EVPN, NoOverlay, Localnet) and startup now seeds counts for existing CUDNs so dashboards reflect current state.

* **Documentation**
  * Observability metrics docs updated to describe the new transport label and its semantics.

* **Tests**
  * Added tests and helpers to validate metric increments, decrements, reset, and inspection of the updated metric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->