### PR TITLE
Create debian version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ env:
   REPOSITORY: ovn-kubernetes
   FEDORA_IMAGE_NAME: ovn-kube-fedora
   UBUNTU_IMAGE_NAME: ovn-kube-ubuntu
+  DEBIAN_IMAGE_NAME: ovn-kube-debian
   BUILDER_IMAGE: quay.io/projectquay/golang:1.25
 jobs:
   # Build Fedora image for each platform
@@ -297,3 +298,142 @@ jobs:
     - name: Inspect image
       run: |
         docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REPOSITORY }}/${{ env.UBUNTU_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+  # Build Debian image for each platform
+  build-debian:
+    name: Build Debian (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+        - platform: linux/amd64
+          runner: ubuntu-latest
+        - platform: linux/arm64
+          runner: ubuntu-24.04-arm
+    steps:
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go-controller/go.mod'
+        # Disabling cache to avoid warnings until these two issues are fixed
+        # https://github.com/actions/setup-go/issues/424
+        # https://github.com/actions/setup-go/issues/403
+        # cache-dependency-path: "**/*.sum"
+        cache: false
+      id: go
+
+    - name: Log in to the GH Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up environment
+      run: |
+        export GOPATH=$(go env GOPATH)
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
+
+    - name: Build ovnkube-binaries copy to context 
+      run: | 
+        pushd go-controller 
+         make 
+        popd 
+
+        pushd dist/images
+          cp -r ../../go-controller/_output/go/bin/* .
+        popd 
+    
+    - name: Generate git-info to write to image
+      run: | 
+        BRANCH=$(git rev-parse --short "$GITHUB_SHA")
+        COMMIT=$(git rev-parse  HEAD)
+        pushd dist/images
+          echo "ref: ${BRANCH}  commit: ${COMMIT}" > git_info
+        popd 
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Extract metadata (tags, labels) for debian ovn-k image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REPOSITORY }}/${{ env.DEBIAN_IMAGE_NAME }}
+
+    - name: Build and push Debian based Docker image
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        context: ./dist/images
+        file: ./dist/images/Dockerfile.debian
+        push: true
+        platforms: ${{ matrix.platform }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=debian-${{ env.PLATFORM_PAIR }}
+        cache-to: type=gha,mode=max,scope=debian-${{ env.PLATFORM_PAIR }}
+        outputs: type=image,name=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REPOSITORY }}/${{ env.DEBIAN_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digest
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v7
+      with:
+        name: digests-debian-${{ env.PLATFORM_PAIR }}
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # Merge Debian multi-platform images
+  merge-debian:
+    name: Merge Debian
+    runs-on: debian-latest
+    needs: build-debian
+    steps:
+    - name: Download digests
+      uses: actions/download-artifact@v8
+      with:
+        path: /tmp/digests
+        pattern: digests-debian-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to the GH Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for debian ovn-k image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REPOSITORY }}/${{ env.DEBIAN_IMAGE_NAME }}
+
+    - name: Create manifest list and push
+      working-directory: /tmp/digests
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REPOSITORY }}/${{ env.DEBIAN_IMAGE_NAME }}@sha256:%s ' *)
+
+    - name: Inspect image
+      run: |
+        docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REPOSITORY }}/${{ env.DEBIAN_IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/dist/images/Dockerfile.debian
+++ b/dist/images/Dockerfile.debian
@@ -1,0 +1,53 @@
+#
+# The standard name for this image is ovn-kube-ubuntu
+
+# Notes:
+# This is for a development build where the ovn-kubernetes utilities
+# are built in this Dockerfile and included in the image (instead of the deb package)
+#
+#
+# So this file will change over time.
+
+FROM debian:13.4
+
+USER root
+
+RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables
+
+# Install OVS and OVN packages.
+RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host
+
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+RUN mkdir -p /var/run/openvswitch
+
+# Built in ../../go_controller, then the binaries are copied here.
+# put things where they are in the pkg
+RUN mkdir -p /usr/libexec/cni/
+COPY ovnkube ovn-kube-util ovndbchecker hybrid-overlay-node ovnkube-identity ovnkube-observ /usr/bin/
+COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+
+# ovnkube.sh is the entry point. This script examines environment
+# variables to direct operation and configure ovn
+COPY ovnkube.sh /root/
+COPY ovndb-raft-functions.sh /root/
+# override the pkg's ovn_k8s.conf with this local copy
+COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
+
+# copy git commit number into image
+COPY git_info /root
+
+# iptables wrappers
+COPY ./iptables-scripts/iptables /usr/sbin/
+COPY ./iptables-scripts/iptables-save /usr/sbin/
+COPY ./iptables-scripts/iptables-restore /usr/sbin/
+COPY ./iptables-scripts/ip6tables /usr/sbin/
+COPY ./iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
+
+LABEL io.k8s.display-name="ovn-kubernetes" \
+      io.k8s.description="ovnkube ubuntu image" 
+
+WORKDIR /root
+ENTRYPOINT /root/ovnkube.sh

--- a/dist/images/Dockerfile.debian.arm64
+++ b/dist/images/Dockerfile.debian.arm64
@@ -1,0 +1,53 @@
+#
+# The standard name for this image is ovn-kube-ubuntu
+
+# Notes:
+# This is for a development build where the ovn-kubernetes utilities
+# are built in this Dockerfile and included in the image (instead of the deb package)
+#
+#
+# So this file will change over time.
+
+FROM debian:13.4
+
+USER root
+
+RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux nftables
+
+# Install OVS and OVN packages.
+RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host
+
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+RUN mkdir -p /var/run/openvswitch
+
+# Built in ../../go_controller, then the binaries are copied here.
+# put things where they are in the pkg
+RUN mkdir -p /usr/libexec/cni/
+COPY ovnkube ovn-kube-util ovndbchecker hybrid-overlay-node ovnkube-identity ovnkube-observ /usr/bin/
+COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+
+# ovnkube.sh is the entry point. This script examines environment
+# variables to direct operation and configure ovn
+COPY ovnkube.sh /root/
+COPY ovndb-raft-functions.sh /root/
+# override the pkg's ovn_k8s.conf with this local copy
+COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
+
+# copy git commit number into image
+COPY git_info /root
+
+# iptables wrappers
+COPY ./iptables-scripts/iptables /usr/sbin/
+COPY ./iptables-scripts/iptables-save /usr/sbin/
+COPY ./iptables-scripts/iptables-restore /usr/sbin/
+COPY ./iptables-scripts/ip6tables /usr/sbin/
+COPY ./iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
+
+LABEL io.k8s.display-name="ovn-kubernetes" \
+      io.k8s.description="ovnkube ubuntu image" 
+
+WORKDIR /root
+ENTRYPOINT /root/ovnkube.sh

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -40,6 +40,13 @@ ifeq ($(ARCH),amd64)
               "ovn-kube-ubuntu:latest"
 endif
 
+debian-image: bld
+	${OCI_BIN} build -t ovn-kube-debian$(IMAGE_ARCH) -f Dockerfile.debian$(DOCKERFILE_ARCH) .
+ifeq ($(ARCH),amd64)
+	${OCI_BIN} tag "ovn-kube-debian$(IMAGE_ARCH):latest" \
+			  "ovn-kube-debian:latest"
+endif
+
 ubuntu-shared-gw-deployment: ubuntu-image
 	# This is the default in the ovnkube*.yaml files
 	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI was enhanced to build and publish Debian-based container images across multiple architectures (amd64, arm64).
  * Per-platform build jobs now produce platform-specific image digests and store them as artifacts for later aggregation.
  * A merge step combines per-platform artifacts into a single multi-architecture Debian image manifest and publishes the final tagged image.
  * Introduced an exported workflow environment variable to configure the Debian image name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->