### PR TITLE
[dpu-sim] Add DPU simulation Support

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -1,0 +1,129 @@
+name: DPU Offload
+
+on:
+  pull_request:
+    branches: [ master, release-* ]
+    paths-ignore:
+      - '**/*.md'
+      - 'mkdocs.yml'
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kind-dpu-offload-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  DPU_SIM_REF: main
+  OVN_KUBERNETES_PATH: ${{ github.workspace }}/ovn-kubernetes
+
+jobs:
+  kind-dpu-offload:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Checkout OVN-Kubernetes (PR/push)
+        uses: actions/checkout@v4
+        with:
+          path: ovn-kubernetes
+
+      - name: Checkout dpu-simulator
+        uses: actions/checkout@v4
+        with:
+          repository: ovn-kubernetes/dpu-simulator
+          ref: ${{ env.DPU_SIM_REF }}
+          path: dpu-simulator
+
+      - name: Set up Go from dpu-simulator
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: dpu-simulator/go.mod
+          cache: true
+
+      - name: Install libvirt development headers
+        run: sudo apt-get update && sudo apt-get install -y libvirt-dev
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up Python for traffic flow tests
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install kind
+        run: |
+          KIND_VERSION=v0.31.0
+          curl -fsSLo /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          curl -fsSLo /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64.sha256sum"
+          (cd /tmp && sha256sum -c kind-linux-amd64.sha256sum)
+          chmod +x /tmp/kind-linux-amd64
+          sudo mv /tmp/kind-linux-amd64 /usr/local/bin/kind
+
+      - name: Build dpu-simulator
+        working-directory: dpu-simulator
+        run: make build
+
+      - name: Disable containerd image store
+        # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
+        run: |
+          sudo mkdir -p /etc/docker
+          [ -s "/etc/docker/daemon.json" ] && {
+            cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+          } || {
+            echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+          }
+          sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
+          sudo systemctl restart docker
+
+      - name: Deploy Kind clusters (OVN-Kubernetes from PR source)
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim --config config-kind-ovnk-offload.yaml --ovn-kubernetes-path "$OVN_KUBERNETES_PATH"
+
+      - name: Verify clusters are ready
+        working-directory: dpu-simulator
+        run: |
+          kubectl wait --for=condition=Ready nodes --all \
+            --kubeconfig kubeconfig/dpu-sim-host.kubeconfig --timeout=25m
+          kubectl wait --for=condition=Ready nodes --all \
+            --kubeconfig kubeconfig/dpu-sim-dpu.kubeconfig --timeout=25m
+
+      - name: TFT Python venv
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim tft venv --config config-kind-ovnk-offload.yaml
+
+      - name: Run traffic flow tests
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim tft run --config config-kind-ovnk-offload.yaml
+
+      - name: Export kind logs on failure
+        if: failure()
+        run: |
+          kind export logs /tmp/kind-offload-logs --name dpu-sim-host-kind 2>/dev/null || true
+          kind export logs /tmp/kind-offload-logs --name dpu-sim-dpu-kind 2>/dev/null || true
+
+      - name: Upload kind logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-dpu-offload-logs
+          path: /tmp/kind-offload-logs
+          if-no-files-found: ignore
+
+      - name: Upload TFT results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tft-results
+          path: dpu-simulator/kubernetes-traffic-flow-tests/ft-logs
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim --config config-kind-ovnk-offload.yaml --ovn-kubernetes-path "$OVN_KUBERNETES_PATH" --cleanup || true

--- a/LICENSES/packages/github.com/ovn-kubernetes/dpu-simulator/lib/dpusim/v0.0.0-20260507161134-3aec48e5cb25/LICENSE
+++ b/LICENSES/packages/github.com/ovn-kubernetes/dpu-simulator/lib/dpusim/v0.0.0-20260507161134-3aec48e5cb25/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -307,6 +307,10 @@ ovn_enable_persistent_ips=${OVN_ENABLE_PERSISTENT_IPS:-false}
 
 # OVNKUBE_NODE_MODE - is the mode which ovnkube node operates
 ovnkube_node_mode=${OVNKUBE_NODE_MODE:-"full"}
+# OVN_SIMULATE_DPU - use simulated DPU operations instead of SR-IOV/switchdev hardware operations
+ovn_simulate_dpu=${OVN_SIMULATE_DPU:-"false"}
+# OVN_DPU_HOST_GATEWAY_REPRESENTOR_INTERFACE - the DPU-side representor interface for the host's uplink (PF)
+ovn_dpu_host_gateway_representor_interface=${OVN_DPU_HOST_GATEWAY_REPRESENTOR_INTERFACE:-""}
 # OVNKUBE_NODE_MGMT_PORT_NETDEV - is the net device to be used for management port
 ovnkube_node_mgmt_port_netdev=${OVNKUBE_NODE_MGMT_PORT_NETDEV:-}
 # OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME - is the device plugin resource name that has
@@ -2251,6 +2255,16 @@ ovnkube-controller-with-node() {
     ovnkube_node_mgmt_port_netdev_flag="--ovnkube-node-mgmt-port-dp-resource-name=${ovnkube_node_mgmt_port_dp_resource_name}"
   fi
 
+  ovn_simulate_dpu_flag=
+  if [[ ${ovn_simulate_dpu} == "true" ]]; then
+    ovn_simulate_dpu_flag="--simulate-dpu"
+  fi
+
+  ovn_dpu_host_gateway_representor_interface_flag=
+  if [[ ${ovn_dpu_host_gateway_representor_interface} != "" ]]; then
+    ovn_dpu_host_gateway_representor_interface_flag="--dpu-host-gateway-representor-interface=${ovn_dpu_host_gateway_representor_interface}"
+  fi
+
   ovn_unprivileged_flag="--unprivileged-mode"
   if test -z "${OVN_UNPRIVILEGED_MODE+x}" -o "x${OVN_UNPRIVILEGED_MODE}" = xno; then
     ovn_unprivileged_flag=""
@@ -2452,6 +2466,8 @@ ovnkube-controller-with-node() {
     ${ovnkube_metrics_tls_opts} \
     ${ovnkube_node_mgmt_port_netdev_flag} \
     ${ovnkube_node_mode_flag} \
+    ${ovn_simulate_dpu_flag} \
+    ${ovn_dpu_host_gateway_representor_interface_flag} \
     ${ovn_unprivileged_flag} \
     ${ovn_v4_join_subnet_opt} \
     ${ovn_v4_masquerade_subnet_opt} \
@@ -3015,6 +3031,16 @@ ovn-node() {
     ovnkube_node_mgmt_port_netdev_flag="--ovnkube-node-mgmt-port-dp-resource-name=${ovnkube_node_mgmt_port_dp_resource_name}"
   fi
 
+  ovn_simulate_dpu_flag=
+  if [[ ${ovn_simulate_dpu} == "true" ]]; then
+    ovn_simulate_dpu_flag="--simulate-dpu"
+  fi
+
+  ovn_dpu_host_gateway_representor_interface_flag=
+  if [[ ${ovn_dpu_host_gateway_representor_interface} != "" ]]; then
+    ovn_dpu_host_gateway_representor_interface_flag="--dpu-host-gateway-representor-interface=${ovn_dpu_host_gateway_representor_interface}"
+  fi
+
   # Get gateway options for DPUs
   if [[ ${ovnkube_node_mode} == "dpu" ]]; then
       get_dpu_gw_options
@@ -3165,6 +3191,8 @@ ovn-node() {
         ${ovnkube_node_certs_flags} \
         ${ovnkube_node_mgmt_port_netdev_flag} \
         ${ovnkube_node_mode_flag} \
+        ${ovn_simulate_dpu_flag} \
+        ${ovn_dpu_host_gateway_representor_interface_flag} \
         ${ovn_node_ssl_opts} \
         ${ovn_unprivileged_flag} \
         ${routable_mtu_flag} \

--- a/docs/features/hardware-offload/dpu-gateway-interface.md
+++ b/docs/features/hardware-offload/dpu-gateway-interface.md
@@ -47,10 +47,45 @@ interface=derive-from-mgmt-port
 ovnkube-node:
   mode: dpu-host
   mgmtPortNetdev: pf0vf0
-  
+
 gateway:
   interface: derive-from-mgmt-port
 ```
+
+## DPU host gateway representor interface
+
+This setting is the `DPUHostGatewayRepresentorInterface` field in code and in the Gateway config section (`dpu-host-gateway-representor-interface`).
+
+On real switchdev DPUs, the DPU-side representor for the host uplink (the PF’s representor toward the embedded CPU) is often discovered automatically from switchdev metadata (for example via `phys_port_name`). Simulation environments do not expose that metadata: dpu-sim Kind clusters, dpu-sim virtio-based VMs, or other “simulated DPU” setups. There, OVN-Kubernetes cannot infer which netdev is the host-gateway representor, and you must set it explicitly.
+
+The optional gateway value (`--dpu-host-gateway-representor-interface`) names that DPU-side representor explicitly. When the node builds an OVS gateway bridge from a plain NIC (not an existing OVS bridge), and this value is non-empty, ovnkube adds that interface as a port on the gateway bridge and marks it `other-config:transient=true` so the host’s uplink path is wired through OVS correctly.
+
+Typical combinations:
+
+- **Production switchdev DPU**: Usually leave this unset; discovery via switchdev metadata handles the representor.
+- **Simulated DPU**: Set `--simulate-dpu` on the node (see [DPU support](dpu-support.md)) and set `--dpu-host-gateway-representor-interface` to the known representor netdev name (for example the veth or virtio peer your topology uses).
+
+### Command line
+
+```bash
+--dpu-host-gateway-representor-interface=<netdev>
+```
+
+### Configuration file
+
+```ini
+[Gateway]
+dpu-host-gateway-representor-interface=<netdev>
+```
+
+### Helm (`global` values)
+
+```yaml
+global:
+  dpuHostGatewayRepresentorInterface: <netdev>
+```
+
+If the representor name is wrong or the interface is missing, gateway bridge setup fails with an error when adding the port to the bridge.
 
 ## Example Scenario
 
@@ -207,4 +242,4 @@ Potential improvements to this feature could include:
 - Integration with device plugin resources
 - Support for multiple gateway interfaces
 - Enhanced error reporting and diagnostics
-- Support for non-SR-IOV hardware configurations 
+- Support for non-SR-IOV hardware configurations

--- a/docs/features/hardware-offload/dpu-support.md
+++ b/docs/features/hardware-offload/dpu-support.md
@@ -1,7 +1,7 @@
 ## DPU support
 
-With the emergence of [Data Processing Units](https://blogs.nvidia.com/blog/2020/05/20/whats-a-dpu-data-processing-unit/) (DPUs), 
-NIC vendors can now offer greater hardware acceleration capability, flexibility and security. 
+With the emergence of [Data Processing Units](https://blogs.nvidia.com/blog/2020/05/20/whats-a-dpu-data-processing-unit/) (DPUs),
+NIC vendors can now offer greater hardware acceleration capability, flexibility and security.
 
 It is desirable to leverage DPU in OVN-kubernetes to accelerate networking and secure the network control plane.
 
@@ -44,10 +44,18 @@ Always check the dependencies on the [Requirements page](../requirements.md)
 
 For detailed configuration of gateway interfaces in DPU host mode, see [DPU Gateway Interface Configuration](dpu-gateway-interface.md).
 
+### Simulated DPU (`simulate-dpu`)
+
+Hardware DPUs rely on SR-IOV and switchdev metadata so OVN-Kubernetes can resolve representors, PCI relationships, and related details. For development and CI, the same code paths can run on **simulated** platforms (for example Kind or VMs using virtio instead of a real switchdev DPU NICs) where that metadata is absent or different.
+
+The ovnkube-node flag **`--simulate-dpu`** (config file `[OvnKubeNode]` key `simulate-dpu`, Helm `global.simulateDpu`) turns on **simulated DPU operations** instead of the default switchdev-based implementation. When the node mode is `dpu` or `dpu-host`, this selects the simulated `DPUOps` backend. Operational parameters such as representor naming, device addressing, and host-representor discovery follow the patterns used in simulated environments (for example `rep<pfId>-<funcId>` style names and netdev-based identifiers) rather than sysfs/sriovnet switchdev discovery.
+
+The flag has no effect in full (non-DPU) node mode. Use it together with the correct simulated topology (veth pairs, virtio links) and, on the DPU host, consider setting an explicit [`dpu-host-gateway-representor-interface`](dpu-gateway-interface.md#dpu-host-gateway-representor-interface) when nicstobridge is used (when there is no pre-provisioned OVS bridges).
+
 ### DPU Cluster
 
 #### OVN-Kubernetes components
-- local-nb-ovsdb 
+- local-nb-ovsdb
 - local-sb-ovsdb
 - run-ovn-northd
 - ovnkube-controller-with-node

--- a/docs/installation/launching-ovn-kubernetes-with-dpu.md
+++ b/docs/installation/launching-ovn-kubernetes-with-dpu.md
@@ -8,6 +8,12 @@ DPUs in the DPU cluster will watch DPU Host cluster for K8s resources such as Po
 
 Refer [DPU support](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/hardware-offload/dpu-support.md) for more details on the setup.
 
+## DPU simulation
+
+The SR-IOV, OVS offload, and bridge examples below assume **hardware** DPUs and DPU hosts with switchdev-capable DPU NICs. For **simulated** DPU topologies (for example Kind/VM cluster used in development and CI), the same two-cluster layout and Helm charts apply, but you should enable **`global.simulateDpu: true`** on the DPU and DPU-host ovnkube workloads so the containers pass **`--simulate-dpu`**. That selects the simulated DPU operations backend (representor naming, device IDs, and discovery) instead of real SR-IOV/switchdev metadata.
+
+For a full description of the flag and when it applies, see the **Simulated DPU (`simulate-dpu`)** subsection in [DPU support](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/hardware-offload/dpu-support.md). On the DPU host, if the host-gateway representor is not auto-discovered, set **`global.dpuHostGatewayRepresentorInterface`** as documented under [DPU host gateway representor interface](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/hardware-offload/dpu-gateway-interface.md#dpu-host-gateway-representor-interface).
+
 ## SR-IOV settings on DPU Host
 
 Follow [OVS Acceleration with Kernel datapath](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/hardware-offload/ovs-kernel.md) or [OVS Acceleration with DOCA datapath](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/features/hardware-offload/ovs-doca.md) to enable Open vSwitch hardware offloading feature on DPU hosts.

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -271,7 +271,7 @@ func combineMetricsEndpoints(runMode *ovnkubeRunMode) bool {
 		runMode.node &&
 		config.Metrics.BindAddress != "" &&
 		config.Metrics.BindAddress == config.Metrics.OVNMetricsBindAddress &&
-		config.OvnKubeNode.Mode != types.NodeModeDPUHost
+		(config.IsModeDPU() || config.IsModeFull())
 }
 
 func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
@@ -303,7 +303,7 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	if config.Kubernetes.BootstrapKubeconfig != "" {
 		// In the case of dpus K8S_NODE will be set to dpu host's name
 		var csrNodeName string
-		if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		if config.IsModeDPU() {
 			csrNodeName = os.Getenv("K8S_NODE_DPU")
 		} else {
 			csrNodeName = os.Getenv("K8S_NODE")
@@ -504,7 +504,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	// Remove when OVN supports native silencing of GARPs on startup: https://issues.redhat.com/browse/FDP-1537
 	// isOVNKubeControllerSyncd is true when ovnkube controller has sync and changes are in OVN Southbound database.
 	var isOVNKubeControllerSyncd *atomic.Bool
-	if runMode.ovnkubeController && runMode.node && config.OVNKubernetesFeature.EnableEgressIP && config.OVNKubernetesFeature.EnableInterconnect && config.OvnKubeNode.Mode == types.NodeModeFull {
+	if runMode.ovnkubeController && runMode.node && config.OVNKubernetesFeature.EnableEgressIP && config.OVNKubernetesFeature.EnableInterconnect && config.IsModeFull() {
 		isOVNKubeControllerSyncd = &atomic.Bool{}
 	}
 
@@ -578,7 +578,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 			metrics.RegisterNodeMetrics(ctx.Done())
 
 			// OVS is not running on dpu-host nodes
-			if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+			if config.IsModeDPU() || config.IsModeFull() {
 				ovsClient, err = libovsdb.NewOVSClient(ctx.Done())
 				if err != nil {
 					nodeErr = fmt.Errorf("failed to initialize libovsdb vswitchd client: %w", err)
@@ -616,7 +616,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 
 	// start the prometheus server to serve OVS and OVN Metrics (default port: 9476)
 	// Note: for ovnkube node mode dpu-host no metrics is required as ovs/ovn is not running on the node.
-	if runMode.node && config.OvnKubeNode.Mode != types.NodeModeDPUHost && config.Metrics.OVNMetricsBindAddress != "" {
+	if runMode.node && (config.IsModeDPU() || config.IsModeFull()) && config.Metrics.OVNMetricsBindAddress != "" {
 
 		if ovsClient == nil {
 			ovsClient, err = libovsdb.NewOVSClient(ctx.Done())

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/openshift/api v0.0.0-20260311143357-f6ee4c095675
 	github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d
+	github.com/ovn-kubernetes/dpu-simulator/lib/dpusim v0.0.0-20260507161134-3aec48e5cb25
 	github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260302130604-c07ce22366ac
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -647,6 +647,8 @@ github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d h1:T+9HFgEEcnu
 github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d/go.mod h1:tIA3XSb/WsC/Fg0YNRfs/JrMrloBKPGF+NKVutd7nMI=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
+github.com/ovn-kubernetes/dpu-simulator/lib/dpusim v0.0.0-20260507161134-3aec48e5cb25 h1:uujE+MtjuaWOz1+nt5uwj193CQEXOKR8qzhsRRV7t9o=
+github.com/ovn-kubernetes/dpu-simulator/lib/dpusim v0.0.0-20260507161134-3aec48e5cb25/go.mod h1:fkgl6NeQ4GO+DImnBM1MQKA5fT3BeALC+pOBaNvlVLs=
 github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260302130604-c07ce22366ac h1:D7Ex9/u5HMz+xvqel1RCCO1AxVG7XRAx9AcP02/nyzk=
 github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260302130604-c07ce22366ac/go.mod h1:x2keWyG0K1WmZeZLRh+z4fWwcqp99Yu9/HAiMucj5D0=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -133,7 +133,7 @@ func (pr *PodRequest) primaryDPUReady(primaryUDN *udn.UserDefinedPrimaryNetwork,
 		// primaryUDNPodRequest would be nil if no primary UDN interface is needed
 		primaryUDNPodRequest := pr.buildPrimaryUDNPodRequest(primaryUDN)
 		// DPU-Host: add DPU connection-details annotation to allow DPU performs the needed primary UDN interface plumbing.
-		if config.OvnKubeNode.Mode == types.NodeModeDPUHost &&
+		if config.IsModeDPUHost() &&
 			primaryUDNPodRequest != nil && primaryUDNPodRequest.CNIConf.DeviceID != "" {
 			netdevName := primaryUDN.NetworkDevice()
 			if err := primaryUDNPodRequest.addDPUConnectionDetailsAnnot(k, podLister, netdevName); err != nil {
@@ -192,7 +192,7 @@ func (pr *PodRequest) cmdAddWithGetCNIResultFunc(
 				return nil, fmt.Errorf("failed in cmdAdd while getting Netdevice name: %w", err)
 			}
 		}
-		if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+		if config.IsModeDPUHost() {
 			// Add DPU connection-details annotation so ovnkube-node running on DPU
 			// performs the needed network plumbing.
 			if err = pr.addDPUConnectionDetailsAnnot(kubecli, clientset.podLister, netdevName); err != nil {
@@ -214,7 +214,7 @@ func (pr *PodRequest) cmdAddWithGetCNIResultFunc(
 	}
 
 	// now checks for default network's DPU connection status
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		if pr.CNIConf.DeviceID != "" {
 			annotCondFn = isDPUReady(annotCondFn, pr.nadKey)
 		}
@@ -258,7 +258,7 @@ func (pr *PodRequest) cmdAddWithGetCNIResultFunc(
 		}
 
 		// Skip checking bridge mapping on DPU hosts as OVS is not present
-		if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+		if config.IsModeDPU() || config.IsModeFull() {
 			if err := checkBridgeMapping(ovsClient, pr.CNIConf.Topology, netName); err != nil {
 				return nil, fmt.Errorf("failed bridge mapping validation: %w", err)
 			}
@@ -338,7 +338,7 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 
 	netdevName := ""
 	if pr.CNIConf.DeviceID != "" {
-		if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+		if config.IsModeDPUHost() {
 			if pod == nil {
 				// no need to update DPU connection-details annotation if pod is already removed
 				klog.Warningf("Failed to get pod %s/%s: %v", pr.PodNamespace, pr.PodName, err)
@@ -415,7 +415,7 @@ func (pr *PodRequest) cmdDel(clientset *ClientSet) (*Response, error) {
 	}
 
 	podInterfaceInfo := &PodInterfaceInfo{
-		IsDPUHostMode: config.OvnKubeNode.Mode == types.NodeModeDPUHost,
+		IsDPUHostMode: config.IsModeDPUHost(),
 		NetdevName:    netdevName,
 	}
 	if !config.UnprivilegedMode {

--- a/go-controller/pkg/cni/cni_dpu.go
+++ b/go-controller/pkg/cni/cni_dpu.go
@@ -37,20 +37,16 @@ func (pr *PodRequest) addDPUConnectionDetailsAnnot(k kube.Interface, podLister c
 	if pr.CNIConf.DeviceID == "" {
 		return fmt.Errorf("DeviceID must be set for Pod request with DPU")
 	}
-	pciAddress := pr.CNIConf.DeviceID
+	deviceID := pr.CNIConf.DeviceID
 
-	vfindex, err := util.GetSriovnetOps().GetVfIndexByPciAddress(pciAddress)
+	details, err := util.GetDPUOps().ResolveDeviceDetails(deviceID)
 	if err != nil {
-		return err
-	}
-	pfindex, err := util.GetSriovnetOps().GetPfIndexByVfPciAddress(pciAddress)
-	if err != nil {
-		return err
+		return fmt.Errorf("failed to resolve device details for %s: %v", deviceID, err)
 	}
 
 	dpuConnDetails := util.DPUConnectionDetails{
-		PfId:         fmt.Sprint(pfindex),
-		VfId:         fmt.Sprint(vfindex),
+		PfId:         fmt.Sprint(details.PfId),
+		VfId:         fmt.Sprint(details.FuncId),
 		SandboxId:    pr.SandboxID,
 		VfNetdevName: vfNetdevName,
 	}

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -231,12 +231,13 @@ func cniRequestToPodRequest(cr *Request) (*PodRequest, error) {
 		} else if util.IsAuxDeviceName(conf.DeviceID) {
 			// DeviceID is an Auxiliary device name - <driver_name>.<kind_of_a_type>.<id>
 			chunks := strings.Split(conf.DeviceID, ".")
-			if chunks[1] != "sf" {
-				return nil, fmt.Errorf("only SF auxiliary devices are supported")
+			if len(chunks) < 2 {
+				return nil, fmt.Errorf("invalid auxiliary device name %q: expected driver.<type>.<id>", conf.DeviceID)
 			}
-		} else {
-			return nil, fmt.Errorf("expected PCI or Auxiliary device name, got - %s", conf.DeviceID)
-		}
+			if chunks[1] != "sf" {
+				return nil, fmt.Errorf("only SF auxiliary devices are supported, device name %q is not supported", conf.DeviceID)
+			}
+		} // else it is a netdev name, which is used for simulated DPU environments.
 	}
 
 	// Match the Kubelet default CRI operation timeout of 2m.

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -69,7 +69,7 @@ func NewCNIServer(
 ) (*Server, error) {
 	var nadLister nadv1Listers.NetworkAttachmentDefinitionLister
 
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		return nil, fmt.Errorf("unsupported ovnkube-node mode for CNI server: %s", config.OvnKubeNode.Mode)
 	}
 
@@ -293,7 +293,7 @@ func (s *Server) handleCNIMetrics(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) checkDPUHealth(req *PodRequest) error {
-	if s.dpuHealth == nil || config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if s.dpuHealth == nil || config.IsModeDPU() || config.IsModeFull() {
 		return nil
 	}
 

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -145,7 +144,7 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, podNADAnnotation *ut
 		RoutableMTU:          config.Default.RoutableMTU, // TBD, configurable for UDNs?
 		Ingress:              ingress,
 		Egress:               egress,
-		IsDPUHostMode:        config.OvnKubeNode.Mode == types.NodeModeDPUHost,
+		IsDPUHostMode:        config.IsModeDPUHost(),
 		PodUID:               podUID,
 		NetdevName:           netdevname,
 		NetName:              netName,

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -547,6 +547,12 @@ type GatewayConfig struct {
 	// on the external bridge. The Host IP would be on this device.
 	// Should be used mutually exclusive to the `--gateway-interface` flag.
 	GatewayAcceleratedInterface string `gcfg:"gateway-accelerated-interface"`
+	// DPUHostGatewayRepresentorInterface is the DPU-side representor of the host's
+	// uplink (PF). For some DPUs this is discovered automatically via
+	// phys_port_name via switchdev metadata. In simulated environments or other
+	// interpretations of DPUs, it must be specified explicitly
+	// because the interface has no switchdev metadata.
+	DPUHostGatewayRepresentorInterface string `gcfg:"dpu-host-gateway-representor-interface"`
 	// Egress gateway interface is the optional network interface to use for external gw pods traffic.
 	EgressGWInterface string `gcfg:"egw-interface"`
 	// NextHop is the gateway IP address of Interface; will be autodetected if not given
@@ -1647,6 +1653,13 @@ var OVNGatewayFlags = []cli.Flag{
 			"This is typically a VF or SF device. When specified it would be used as the in_port for Openflow rules " +
 			"on the external bridge. The Host IP would be on this device.",
 		Destination: &cliConfig.Gateway.GatewayAcceleratedInterface,
+	},
+	&cli.StringFlag{
+		Name: "dpu-host-gateway-representor-interface",
+		Usage: "The DPU-side representor interface for the host's uplink (PF). For some DPUs this is discovered " +
+			"automatically via phys_port_name via switchdev metadata. In simulated environments or other interpretations of " +
+			"DPUs, it must be specified explicitly because the interface has no switchdev metadata.",
+		Destination: &cliConfig.Gateway.DPUHostGatewayRepresentorInterface,
 	},
 	&cli.StringFlag{
 		Name: "exgw-interface",

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -3202,6 +3202,18 @@ func ovnKubeNodeModeSupported(mode string) error {
 	return nil
 }
 
+func IsModeFull() bool {
+	return OvnKubeNode.Mode == types.NodeModeFull
+}
+
+func IsModeDPU() bool {
+	return OvnKubeNode.Mode == types.NodeModeDPU
+}
+
+func IsModeDPUHost() bool {
+	return OvnKubeNode.Mode == types.NodeModeDPUHost
+}
+
 // buildOvnKubeNodeConfig updates OvnKubeNode config from cli and config file
 func buildOvnKubeNodeConfig(cli, file *config) error {
 	// Copy config file values over default values
@@ -3220,7 +3232,7 @@ func buildOvnKubeNodeConfig(cli, file *config) error {
 	}
 
 	// ovnkube-node-mode dpu/dpu-host does not support hybrid overlay
-	if OvnKubeNode.Mode != types.NodeModeFull && HybridOverlay.Enabled {
+	if (IsModeDPU() || IsModeDPUHost()) && HybridOverlay.Enabled {
 		return fmt.Errorf("hybrid overlay is not supported with ovnkube-node mode %s", OvnKubeNode.Mode)
 	}
 
@@ -3247,13 +3259,13 @@ func buildOvnKubeNodeConfig(cli, file *config) error {
 	// when DPU is used, management port is always backed by a representor. On the
 	// host side, it needs to be provided through --ovnkube-node-mgmt-port-netdev.
 	// On the DPU, it is derrived from the annotation exposed on the host side.
-	if OvnKubeNode.Mode == types.NodeModeDPU && !(OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "") {
+	if IsModeDPU() && !(OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "") {
 		return fmt.Errorf("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must not be provided")
 	}
-	if OvnKubeNode.Mode == types.NodeModeDPUHost && OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "" {
+	if IsModeDPUHost() && OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "" {
 		return fmt.Errorf("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must be provided")
 	}
-	if OVNKubernetesFeature.EnableNetworkSegmentation && OvnKubeNode.Mode == types.NodeModeDPUHost && OvnKubeNode.MgmtPortDPResourceName == "" {
+	if OVNKubernetesFeature.EnableNetworkSegmentation && IsModeDPUHost() && OvnKubeNode.MgmtPortDPResourceName == "" {
 		return fmt.Errorf("ovnkube-node-mgmt-port-dp-resource-name must be provided on dpu-host mode if network segmentation is enabled")
 	}
 	return nil

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -651,6 +651,7 @@ type OvnKubeNodeConfig struct {
 	MgmtPortDPResourceName    string `gcfg:"mgmt-port-dp-resource-name"`
 	DPUNodeLeaseRenewInterval int    `gcfg:"dpu-node-lease-renew-interval"`
 	DPUNodeLeaseDuration      int    `gcfg:"dpu-node-lease-duration"`
+	SimulateDPU               bool   `gcfg:"simulate-dpu"`
 }
 
 // ClusterManagerConfig holds configuration for ovnkube-cluster-manager
@@ -1870,6 +1871,12 @@ var OvnKubeNodeFlags = []cli.Flag{
 		Usage:       "Lease duration in seconds before the DPU is considered unhealthy",
 		Value:       OvnKubeNode.DPUNodeLeaseDuration,
 		Destination: &cliConfig.OvnKubeNode.DPUNodeLeaseDuration,
+	},
+	&cli.BoolFlag{
+		Name:        "simulate-dpu",
+		Usage:       "Use simulated DPU operations instead of real SR-IOV/switchdev hardware. Required for Kind and VM-based DPU simulation environments.",
+		Value:       OvnKubeNode.SimulateDPU,
+		Destination: &cliConfig.OvnKubeNode.SimulateDPU,
 	},
 }
 

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -927,7 +927,7 @@ func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (
 	// need to configure OVS interfaces for Pods on secondary networks in the DPU mode
 	// need to know what is the primary network for a namespace on the CNI side, which
 	// needs the NAD factory whenever the UDN feature is used.
-	if config.OVNKubernetesFeature.EnableMultiNetwork && (config.OVNKubernetesFeature.EnableNetworkSegmentation || config.OvnKubeNode.Mode == types.NodeModeDPU) {
+	if config.OVNKubernetesFeature.EnableMultiNetwork && (config.OVNKubernetesFeature.EnableNetworkSegmentation || config.IsModeDPU()) {
 		wf.nadFactory = nadinformerfactory.NewSharedInformerFactory(ovnClientset.NetworkAttchDefClient, resyncInterval)
 		wf.informers[NetworkAttachmentDefinitionType], err = newQueuedInformer(eventQueueSize,
 			NetworkAttachmentDefinitionType, wf.nadFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions().Informer(),

--- a/go-controller/pkg/node/base_node_network_controller_dpu.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu.go
@@ -73,7 +73,7 @@ func (bnnc *BaseNodeNetworkController) delDPUPodForNAD(pod *corev1.Pod, dpuCD *u
 			errs = append(errs, fmt.Errorf("failed to remove the old DPU connection status annotation for %s: %v", podDesc, err))
 		}
 	}
-	vfRepName, err := util.GetSriovnetOps().GetVfRepresentorDPU(dpuCD.PfId, dpuCD.VfId)
+	vfRepName, err := util.GetDPUOps().GetPortRepresentor(dpuCD.PfId, dpuCD.VfId)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to get old VF representor for %s, dpuConnDetail %+v Representor port may have been deleted: %v", podDesc, dpuCD, err))
 	} else {
@@ -261,7 +261,7 @@ func (bnnc *BaseNodeNetworkController) addRepPort(pod *corev1.Pod, dpuCD *util.D
 
 	nadKey := ifInfo.NADKey
 	podDesc := fmt.Sprintf("pod %s/%s for NAD %s", pod.Namespace, pod.Name, nadKey)
-	vfRepName, err := util.GetSriovnetOps().GetVfRepresentorDPU(dpuCD.PfId, dpuCD.VfId)
+	vfRepName, err := util.GetDPUOps().GetPortRepresentor(dpuCD.PfId, dpuCD.VfId)
 	if err != nil {
 		klog.Infof("Failed to get VF representor for %s dpuConnDetail %+v: %v", podDesc, dpuCD, err)
 		return err
@@ -270,14 +270,10 @@ func (bnnc *BaseNodeNetworkController) addRepPort(pod *corev1.Pod, dpuCD *util.D
 	// set netdevName so OVS interface can be added with external_ids:vf-netdev-name, and is able to
 	// be part of healthcheck.
 	ifInfo.NetdevName = vfRepName
-	vfPciAddress, err := util.GetSriovnetOps().GetPCIFromDeviceName(vfRepName)
-	if err != nil {
-		klog.Infof("Failed to get PCI address of VF rep %s: %v", vfRepName, err)
-		return err
-	}
+	deviceID := util.GetDPUOps().GetDeviceAddress(vfRepName)
 
 	klog.Infof("Adding VF representor %s for %s", vfRepName, podDesc)
-	err = cni.ConfigureOVS(context.TODO(), pod.Namespace, pod.Name, "", vfRepName, ifInfo, dpuCD.SandboxId, vfPciAddress, getter)
+	err = cni.ConfigureOVS(context.TODO(), pod.Namespace, pod.Name, "", vfRepName, ifInfo, dpuCD.SandboxId, deviceID, getter)
 	if err != nil {
 		// Note(adrianc): we are lenient with cleanup in this method as pod is going to be retried anyway.
 		_ = bnnc.delRepPort(pod, dpuCD, vfRepName, nadKey)

--- a/go-controller/pkg/node/base_node_network_controller_dpu.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu.go
@@ -270,7 +270,11 @@ func (bnnc *BaseNodeNetworkController) addRepPort(pod *corev1.Pod, dpuCD *util.D
 	// set netdevName so OVS interface can be added with external_ids:vf-netdev-name, and is able to
 	// be part of healthcheck.
 	ifInfo.NetdevName = vfRepName
-	deviceID := util.GetDPUOps().GetDeviceAddress(vfRepName)
+	deviceID, err := util.GetDPUOps().GetDeviceAddress(vfRepName)
+	if err != nil {
+		klog.Infof("Failed to get PCI address of VF rep %s: %v", vfRepName, err)
+		return err
+	}
 
 	klog.Infof("Adding VF representor %s for %s", vfRepName, podDesc)
 	err = cni.ConfigureOVS(context.TODO(), pod.Namespace, pod.Name, "", vfRepName, ifInfo, dpuCD.SandboxId, deviceID, getter)

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -415,7 +415,7 @@ func (b *BridgeConfiguration) ConfigureBridgePorts() error {
 	var hostOVSInterfaceName string
 	if config.IsModeDPU() {
 		var stderr string
-		hostRep, err := util.GetDPUOps().GetDPUHostInterface(b.bridgeName)
+		hostRep, err := util.GetDPUOps().GetDPUHostRepInterface(b.bridgeName)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -239,11 +239,7 @@ func NewBridgeConfiguration(intfName, nodeName,
 
 	// for DPU we use the host MAC address for the Gateway configuration
 	if config.IsModeDPU() {
-		hostRep, err := util.GetDPUHostInterface(res.bridgeName)
-		if err != nil {
-			return nil, err
-		}
-		res.macAddress, err = util.GetSriovnetOps().GetRepresentorPeerMacAddress(hostRep)
+		res.macAddress, err = util.GetDPUOps().GetHostGatewayMACAddress(res.bridgeName, nodeName)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +415,7 @@ func (b *BridgeConfiguration) ConfigureBridgePorts() error {
 	var hostOVSInterfaceName string
 	if config.IsModeDPU() {
 		var stderr string
-		hostRep, err := util.GetDPUHostInterface(b.bridgeName)
+		hostRep, err := util.GetDPUOps().GetDPUHostInterface(b.bridgeName)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -117,7 +117,7 @@ func NewBridgeConfiguration(intfName, nodeName,
 	// temp workaround for https://issues.redhat.com/browse/FDP-1537
 	// we need to ensure we continue dropping GARPs for any new bridge config if the run mode is ovnkube controller + ovnkube node + IC + single zone node
 	// FIXME: only add if run mode is ovnkube controller + node in single process
-	if config.OVNKubernetesFeature.EnableEgressIP && config.OVNKubernetesFeature.EnableInterconnect && config.OvnKubeNode.Mode == types.NodeModeFull {
+	if config.OVNKubernetesFeature.EnableEgressIP && config.OVNKubernetesFeature.EnableInterconnect && config.IsModeFull() {
 		// drop by default - set to false later when ovnkube controller has sync'd and changes propagated to OVN southbound database
 		// we should also match on run mode here to ensure ovnkube controller + ovnkube node are running in the same process
 		res.dropGARP = true
@@ -238,7 +238,7 @@ func NewBridgeConfiguration(intfName, nodeName,
 	defaultNetConfig.PatchPort = (&util.DefaultNetInfo{}).GetNetworkScopedPatchPortName(res.bridgeName, nodeName)
 
 	// for DPU we use the host MAC address for the Gateway configuration
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		hostRep, err := util.GetDPUHostInterface(res.bridgeName)
 		if err != nil {
 			return nil, err
@@ -276,7 +276,7 @@ func (b *BridgeConfiguration) UpdateInterfaceIPAddresses(node *corev1.Node) ([]*
 
 	// For DPU, here we need to use the DPU host's IP address which is the tenant cluster's
 	// host internal IP address instead of the DPU's external bridge IP address.
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		nodeIfAddr, err := util.GetNodePrimaryDPUHostAddrAnnotation(node)
 		if err != nil {
 			return nil, err
@@ -417,7 +417,7 @@ func (b *BridgeConfiguration) ConfigureBridgePorts() error {
 
 	// Get ofport representing the host. That is, host representor port in case of DPUs, ovsLocalPort otherwise.
 	var hostOVSInterfaceName string
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		var stderr string
 		hostRep, err := util.GetDPUHostInterface(b.bridgeName)
 		if err != nil {

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -178,6 +178,17 @@ func NewBridgeConfiguration(intfName, nodeName,
 		if err != nil {
 			return nil, fmt.Errorf("nicToBridge failed for %s: %w", intfName, err)
 		}
+		if config.Gateway.DPUHostGatewayRepresentorInterface != "" {
+			_, stderr, repErr := util.RunOVSVsctl(
+				"--", "--may-exist", "add-port", bridgeName, config.Gateway.DPUHostGatewayRepresentorInterface,
+				"--", "set", "port", config.Gateway.DPUHostGatewayRepresentorInterface, "other-config:transient=true",
+			)
+			if repErr != nil {
+				return nil, fmt.Errorf("failed to add DPU host gateway representor %s to bridge %s: %w, stderr: %s",
+					config.Gateway.DPUHostGatewayRepresentorInterface, bridgeName, repErr, stderr)
+			}
+			klog.Infof("Adding host representor interface %s to bridge %s", config.Gateway.DPUHostGatewayRepresentorInterface, bridgeName)
+		}
 		res.bridgeName = bridgeName
 		res.gwIface = bridgeName
 		res.uplinkName = intfName

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -160,7 +160,7 @@ func newDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, sto
 		routeManager: routeManager,
 		ovsClient:    ovsClient,
 	}
-	if util.IsNetworkSegmentationSupportEnabled() && config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if util.IsNetworkSegmentationSupportEnabled() && (config.IsModeDPUHost() || config.IsModeFull()) {
 		c.udnHostIsolationManager = NewUDNHostIsolationManager(config.IPv4Mode, config.IPv6Mode,
 			cnnci.watchFactory.PodCoreInformer(), cnnci.name, cnnci.recorder)
 	}
@@ -210,7 +210,7 @@ func NewDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, net
 
 	nc.initRetryFrameworkForNode()
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		err = setupRemoteNodeNFTSets()
 		if err != nil {
 			return nil, fmt.Errorf("failed to setup PMTUD nftables sets: %w", err)
@@ -492,7 +492,7 @@ func setupOVNNode(node *corev1.Node) error {
 
 	// In the case of DPU, the hostname should be that of the DPU and not
 	// the K8s Node's. So skip setting the incorrect hostname.
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		setExternalIdsCmd = append(setExternalIdsCmd, fmt.Sprintf("external_ids:hostname=\"%s\"", node.Name))
 	}
 
@@ -707,7 +707,7 @@ func createNodeManagementPortController(
 		return nil, err
 	}
 
-	if config.OvnKubeNode.MgmtPortDPResourceName == "" && config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.OvnKubeNode.MgmtPortDPResourceName == "" && config.IsModeDPUHost() {
 		// this is called only when config.OvnKubeNode.MgmtPortDPResourceName is empty and in dpu-host mode:
 		// 1. If config.OvnKubeNode.MgmtPortDPResourceName is not empty, management port annotation is taken care
 		//    of by node controller manage.
@@ -746,13 +746,13 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	var subnets []*net.IPNet
 	var cniServer *cni.Server
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		if err = configureGlobalForwarding(); err != nil {
 			return err
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// Bootstrap flows in OVS if just normal flow is present
 		if err := bootstrapOVSFlows(nc.name); err != nil {
 			return fmt.Errorf("failed to bootstrap OVS flows: %w", err)
@@ -772,7 +772,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		return fmt.Errorf("failed to parse kubernetes node IP address. %v", nodeAddrStr)
 	}
 
-	if (config.OvnKubeNode.Mode == types.NodeModeDPUHost || config.OvnKubeNode.Mode == types.NodeModeDPU) &&
+	if (config.IsModeDPUHost() || config.IsModeDPU()) &&
 		config.OvnKubeNode.DPUNodeLeaseRenewInterval > 0 {
 		nc.dpuNodeLeaseManager = dpulease.NewManager(
 			nc.client,
@@ -781,7 +781,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 			time.Duration(config.OvnKubeNode.DPUNodeLeaseRenewInterval)*time.Second,
 			time.Duration(config.OvnKubeNode.DPUNodeLeaseDuration)*time.Second,
 		)
-		if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+		if config.IsModeDPUHost() {
 			if _, err := nc.dpuNodeLeaseManager.EnsureLease(ctx); err != nil {
 				return err
 			}
@@ -793,7 +793,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	var sbZone string
 	var err1 error
 
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		// There is no SBDB to connect to in DPU Host mode, so we will just take the default input config zone
 		sbZone = config.Default.Zone
 	} else {
@@ -826,7 +826,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		if nc.udnHostIsolationManager != nil {
 			if err = nc.udnHostIsolationManager.Start(ctx); err != nil {
 				return err
@@ -857,7 +857,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	klog.Infof("Node %s ready for ovn initialization with subnet %s", nc.name, util.JoinIPNets(subnets, ","))
 
 	// Create CNI Server
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		kclient, ok := nc.Kube.(*kube.Kube)
 		if !ok {
 			return fmt.Errorf("cannot get kubeclient for starting CNI server")
@@ -871,7 +871,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 
 	nodeAnnotator := kube.NewNodeAnnotator(nc.Kube, node.Name)
 
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		if err := configureGatewayInterfaceFromMgmtPort(); err != nil {
 			return err
 		}
@@ -896,7 +896,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 
 	// Set the node-encap-ips annotation with the configured encap IP.
 	// This encap IP is unavailable on the DPU host mode, so we don't need to set it there.
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		encapIPList := sets.New[string]()
 		encapIPList.Insert(strings.Split(config.Default.EffectiveEncapIP, ",")...)
 		if err := util.SetNodeEncapIPs(nodeAnnotator, encapIPList); err != nil {
@@ -909,7 +909,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	}
 
 	// Connect ovn-controller to SBDB
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
 			if err := auth.SetDBAuth(); err != nil {
 				return fmt.Errorf("unable to set the authentication towards OVN local dbs")
@@ -918,9 +918,9 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	}
 
 	// First part of gateway initialization. It will be completed by (nc *DefaultNodeNetworkController) Start()
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// IPv6 is not supported in DPU enabled nodes, error out if ovnkube is not set in IPv4 mode
-		if config.IPv6Mode && config.OvnKubeNode.Mode == types.NodeModeDPU {
+		if config.IPv6Mode && config.IsModeDPU() {
 			return fmt.Errorf("IPv6 mode is not supported on a DPU enabled node")
 		}
 		// Initialize gateway for OVS internal port or representor management port
@@ -955,7 +955,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	waiter := newStartupWaiter()
 
 	// Complete gateway initialization
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		err = nc.initGatewayDPUHost()
 		if err != nil {
 			return err
@@ -973,7 +973,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	// for at least one node in the given zone)
 	// NOTE: ovnkube-node in DPU-host mode has no SBDB to connect to. The encap port will be handled by the
 	// ovnkube-node running in DPU mode on behalf of the host.
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && config.Default.EncapPort != config.DefaultEncapPort {
+	if (config.IsModeDPU() || config.IsModeFull()) && config.Default.EncapPort != config.DefaultEncapPort {
 		if err := setEncapPort(ctx); err != nil {
 			return err
 		}
@@ -1009,8 +1009,8 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 
 	// Note(adrianc): DPU deployments are expected to support the new shared gateway changes, upgrade flow
 	// is not needed. Future upgrade flows will need to take DPUs into account.
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
-		if config.OvnKubeNode.Mode == types.NodeModeFull {
+	if config.IsModeDPU() || config.IsModeFull() {
+		if config.IsModeFull() {
 			// Configure route for svc towards shared gateway interface
 			if err := configureSvcRouteViaInterface(nc.routeManager, nc.Gateway.GetGatewayIface(), DummyNextHopIPs()); err != nil {
 				return err
@@ -1037,7 +1037,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 			defer nc.wg.Done()
 			nodeController.Run(stopCh)
 		}(nc.stopChan)
-	} else if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	} else if config.IsModeDPU() || config.IsModeFull() {
 		// attempt to cleanup the possibly stale bridge
 		_, stderr, err := util.RunOVSVsctl("--if-exists", "del-br", "br-ext")
 		if err != nil {
@@ -1061,7 +1061,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// If interconnect is disabled OR interconnect is running in single-zone-mode,
 		// the ovnkube-master is responsible for patching ICNI managed namespaces with
 		// "k8s.ovn.org/external-gw-pod-ips". In that case, we need ovnkube-node to flush
@@ -1092,13 +1092,13 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	}
 
 	if nc.dpuNodeLeaseManager != nil {
-		if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		if config.IsModeDPU() {
 			nc.wg.Add(1)
 			go func() {
 				defer nc.wg.Done()
 				nc.dpuNodeLeaseManager.RunUpdater(ctx)
 			}()
-		} else if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+		} else if config.IsModeDPUHost() {
 			if err := nc.dpuNodeLeaseManager.CheckStatus(ctx); err != nil {
 				klog.Warningf("Initial DPU node lease check failed: %v", err)
 			}
@@ -1110,7 +1110,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		}
 	}
 
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		if _, err := nc.watchPodsDPU(); err != nil {
 			return err
 		}
@@ -1129,7 +1129,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	}
 
 	// configure NFT/IPT rules for egressService
-	if config.OVNKubernetesFeature.EnableEgressService && config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.OVNKubernetesFeature.EnableEgressService && (config.IsModeDPUHost() || config.IsModeFull()) {
 		wf := nc.watchFactory.(*factory.WatchFactory)
 		c, err := egressservice.NewController(nc.stopChan, nodetypes.OvnKubeNodeSNATMark, nc.name,
 			wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
@@ -1375,7 +1375,7 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 		addrs = append(addrs, nodeIP.String())
 		klog.Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
 		// Only add to nftables if this is remote node
-		if config.OvnKubeNode.Mode != types.NodeModeDPU && node.Name != nc.name {
+		if (config.IsModeDPUHost() || config.IsModeFull()) && node.Name != nc.name {
 			nftElems = append(nftElems, &knftables.Element{
 				Set: types.NFTRemoteNodeIPsv4,
 				Key: []string{nodeIP.String()},
@@ -1388,14 +1388,14 @@ func (nc *DefaultNodeNetworkController) addOrUpdateNode(node *corev1.Node) error
 		addrs = append(addrs, nodeIP.String())
 		klog.Infof("Adding remote node %q, IP: %s to PMTUD blocking rules", node.Name, nodeIP)
 		// Only add to nftables if this is remote node
-		if config.OvnKubeNode.Mode != types.NodeModeDPU && node.Name != nc.name {
+		if (config.IsModeDPUHost() || config.IsModeFull()) && node.Name != nc.name {
 			nftElems = append(nftElems, &knftables.Element{
 				Set: types.NFTRemoteNodeIPsv6,
 				Key: []string{nodeIP.String()},
 			})
 		}
 	}
-	if config.OvnKubeNode.Mode != types.NodeModeDPU && len(nftElems) > 0 {
+	if (config.IsModeDPUHost() || config.IsModeFull()) && len(nftElems) > 0 {
 		if err := nodenft.UpdateNFTElements(nftElems); err != nil {
 			return fmt.Errorf("unable to update NFT elements for node %q, error: %w", node.Name, err)
 		}
@@ -1456,7 +1456,7 @@ func (nc *DefaultNodeNetworkController) syncNodes(objs []interface{}) error {
 	var keepNFTSetElemsV4, keepNFTSetElemsV6 []*knftables.Element
 	var errors []error
 
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		return nil
 	}
 

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -606,11 +606,7 @@ func configureGatewayInterfaceFromMgmtPort() error {
 
 func exportManagementPortAnnotation(netdevName string, nodeAnnotator kube.Annotator) error {
 	klog.Infof("Exporting management port annotation for default network: netdev '%v'", netdevName)
-	deviceID, err := util.GetDeviceIDFromNetdevice(netdevName)
-	if err != nil {
-		return err
-	}
-	cfg, err := util.GetNetworkDeviceDetails(deviceID)
+	cfg, err := util.GetDPUOps().ResolveDeviceDetails(netdevName)
 	if err != nil {
 		return err
 	}
@@ -670,7 +666,7 @@ func getMgmtPortAndRepNameModeDPU(node *corev1.Node) (string, string, error) {
 	if !ok {
 		return "", "", fmt.Errorf("failed to find management port details for %s network", types.DefaultNetworkName)
 	}
-	rep, err := util.GetSriovnetOps().GetVfRepresentorDPU(fmt.Sprintf("%d", cfg.PfId), fmt.Sprintf("%d", cfg.FuncId))
+	rep, err := util.GetDPUOps().GetPortRepresentor(fmt.Sprintf("%d", cfg.PfId), fmt.Sprintf("%d", cfg.FuncId))
 	return "", rep, err
 }
 

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -247,7 +247,7 @@ func canHandleBridgeEgressIP() bool {
 	return util.IsNetworkSegmentationSupportEnabled() &&
 		config.OVNKubernetesFeature.EnableInterconnect &&
 		config.Gateway.Mode != config.GatewayModeDisabled &&
-		config.OvnKubeNode.Mode != types.NodeModeDPUHost
+		(config.IsModeDPU() || config.IsModeFull())
 }
 
 func (g *gateway) AddEgressIP(eip *egressipv1.EgressIP) error {
@@ -445,7 +445,7 @@ func gatewayInitInternal(nodeName, gwIntf, egressGatewayIntf string, gwNextHops 
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// Set static FDB entry for sharedGW MAC.
 		// If `GatewayIfaceRep` port is present, use it instead of LOCAL (bridge name).
 		gwport := gatewayBridge.GetBridgeName()                           // Default is LOCAL port for the bridge.
@@ -484,7 +484,7 @@ func (g *gateway) GetGatewayBridgeIface() string {
 }
 
 func (g *gateway) GetGatewayIface() string {
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		if g.openflowManager == nil {
 			return ""
 		}
@@ -496,7 +496,7 @@ func (g *gateway) GetGatewayIface() string {
 
 // SetDefaultGatewayBridgeMAC updates the mac address for the OFM used to render flows with
 func (g *gateway) SetDefaultGatewayBridgeMAC(macAddr net.HardwareAddr) {
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		return
 	}
 	g.openflowManager.setDefaultBridgeMAC(macAddr)
@@ -504,14 +504,14 @@ func (g *gateway) SetDefaultGatewayBridgeMAC(macAddr net.HardwareAddr) {
 }
 
 func (g *gateway) SetDefaultPodNetworkAdvertised(isPodNetworkAdvertised bool) {
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		return
 	}
 	g.openflowManager.defaultBridge.GetNetworkConfig(types.DefaultNetworkName).Advertised.Store(isPodNetworkAdvertised)
 }
 
 func (g *gateway) GetDefaultPodNetworkAdvertised() bool {
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		return false
 	}
 	return g.openflowManager.defaultBridge.GetNetworkConfig(types.DefaultNetworkName).Advertised.Load()
@@ -520,7 +520,7 @@ func (g *gateway) GetDefaultPodNetworkAdvertised() bool {
 // SetDefaultBridgeGARPDropFlows will enable flows to drop GARPs if the openflow
 // manager has been initialized.
 func (g *gateway) SetDefaultBridgeGARPDropFlows(isDropped bool) {
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		return
 	}
 
@@ -533,7 +533,7 @@ func (g *gateway) SetDefaultBridgeGARPDropFlows(isDropped bool) {
 // Reconcile handles triggering updates to different components of a gateway, like OFM, Services
 func (g *gateway) Reconcile() error {
 	klog.Info("Reconciling gateway with updates")
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		if g.openflowManager != nil {
 			if g.nodeIPManager == nil {
 				klog.V(5).Info("Skipping gateway OpenFlow reconcile because node IP manager is not initialized yet")
@@ -548,7 +548,7 @@ func (g *gateway) Reconcile() error {
 	}
 	// TBD updateSNATRules() gets node host-cidr by accessing gateway.nodeIPManager, which does not
 	// exist in dpu-host mode.
-	if config.OvnKubeNode.Mode == types.NodeModeFull {
+	if config.IsModeFull() {
 		err := g.updateSNATRules()
 		if err != nil {
 			return err

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -78,7 +78,7 @@ func getGatewayNextHops() ([]net.IP, string, error) {
 		}
 	}
 	gatewayIntf := config.Gateway.Interface
-	if gatewayIntf != "" && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if gatewayIntf != "" && (config.IsModeDPU() || config.IsModeFull()) {
 		if bridgeName, _, err := util.RunOVSVsctl("port-to-br", gatewayIntf); err == nil {
 			// This is an OVS bridge's internal port
 			gatewayIntf = bridgeName
@@ -341,7 +341,7 @@ func (nc *DefaultNodeNetworkController) initGatewayMainStart(gw *gateway, waiter
 	var portClaimWatcher *portClaimWatcher
 
 	var err error
-	if config.Gateway.NodeportEnable && config.OvnKubeNode.Mode == types.NodeModeFull {
+	if config.Gateway.NodeportEnable && config.IsModeFull() {
 		loadBalancerHealthChecker = newLoadBalancerHealthChecker(nc.name, nc.watchFactory)
 		portClaimWatcher, err = newPortClaimWatcher(nc.recorder)
 		if err != nil {
@@ -528,7 +528,7 @@ func CleanupClusterNode(name string) error {
 		klog.Errorf("Failed to cleanup Gateway, error: %v", err)
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		stdout, stderr, err := util.RunOVSVsctl("--", "--if-exists", "remove", "Open_vSwitch", ".", "external_ids",
 			"ovn-bridge-mappings")
 		if err != nil {
@@ -536,7 +536,7 @@ func CleanupClusterNode(name string) error {
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		// Clean up legacy IPTables rules for management port
 		managementport.DelLegacyMgtPortIptRules()
 
@@ -551,7 +551,7 @@ func (nc *DefaultNodeNetworkController) updateGatewayMAC(link netlink.Link) erro
 	// TBD-merge for dpu-host mode: if interface mac of the dpu-host interface that connects to the
 	// gateway bridge on the dpu changes, we need to update dpu's gatewayBridge.macAddress L3 gateway
 	// annotation (see BridgeForInterface)
-	if config.OvnKubeNode.Mode != types.NodeModeFull {
+	if config.IsModeDPU() || config.IsModeDPUHost() {
 		return nil
 	}
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -675,7 +675,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovs-appctl -t /var/run/openvswitch/ovs-vswitchd.1234.ctl fdb/add %s %s 0 %s", brphys, brphys, hostMAC),
 		})
-		// GetDPUHostInterface
+		// GetDPUHostRepInterface
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 list-ports " + brphys,
 			Output: hostRep,
@@ -697,7 +697,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface " + uplinkPort + " ofport",
 			Output: "7",
 		})
-		// GetDPUHostInterface
+		// GetDPUHostRepInterface
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 list-ports " + brphys,
 			Output: hostRep,

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -16,12 +16,11 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func initLocalGateway(hostSubnets []*net.IPNet, mgmtPort managementport.Interface) error {
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		return nil
 	}
 
@@ -89,7 +88,7 @@ func getLocalAddrs() (map[string]net.IPNet, error) {
 }
 
 func cleanupLocalnetGateway(physnet string) error {
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if config.IsModeDPUHost() {
 		return nil
 	}
 	stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1739,7 +1739,7 @@ func newGateway(
 		}
 		gw.nodeIPManager = newAddressManager(nodeName, kube, mgmtPort, watchFactory, gwBridge)
 
-		if config.OvnKubeNode.Mode == types.NodeModeFull {
+		if config.IsModeFull() {
 			// Delete stale masquerade resources if there are any. This is to make sure that there
 			// are no Linux resources with IP from old masquerade subnet when masquerade subnet
 			// gets changed as part of day2 operation.
@@ -1829,7 +1829,7 @@ func newNodePortWatcher(
 	// of the node. If someone on the node is trying to access the NodePort service, those packets
 	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
 	// NodePortIP:NodePort to ClusterServiceIP:Port. We don't need to do this on DPU.
-	if config.OvnKubeNode.Mode == types.NodeModeFull {
+	if config.IsModeFull() {
 		if config.Gateway.Mode == config.GatewayModeLocal {
 			if err := initLocalGatewayIPTables(); err != nil {
 				return nil, err
@@ -1868,7 +1868,7 @@ func newNodePortWatcher(
 
 	// used to tell addServiceRules which rules to add
 	dpuMode := false
-	if config.OvnKubeNode.Mode != types.NodeModeFull {
+	if config.IsModeDPU() || config.IsModeDPUHost() {
 		dpuMode = true
 	}
 
@@ -1891,7 +1891,7 @@ func newNodePortWatcher(
 }
 
 func cleanupSharedGateway() error {
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// NicToBridge() may be created before-hand, only delete the patch port here
 		stdout, stderr, err := util.RunOVSVsctl("--columns=name", "--no-heading", "find", "port",
 			"external_ids:ovn-localnet-port!=_")
@@ -1933,7 +1933,7 @@ func cleanupSharedGateway() error {
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		cleanupSharedGatewayIPTChains()
 	}
 	return nil

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -132,7 +132,7 @@ func NewUserDefinedNetworkGateway(netInfo util.NetInfo, node *corev1.Node, nodeL
 		return nil, fmt.Errorf("unable to dereference default node network controller gateway object")
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && gw.openflowManager == nil {
+	if (config.IsModeDPU() || config.IsModeFull()) && gw.openflowManager == nil {
 		return nil, fmt.Errorf("openflow manager has not been provided for network: %s", netInfo.GetNetworkName())
 	}
 
@@ -215,7 +215,7 @@ func (udng *UserDefinedNetworkGateway) addMarkChain() error {
 // AddNetwork will be responsible to create all plumbings
 // required by this UDN on the gateway side
 func (udng *UserDefinedNetworkGateway) AddNetwork() error {
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && udng.openflowManager == nil {
+	if (config.IsModeDPU() || config.IsModeFull()) && udng.openflowManager == nil {
 		return fmt.Errorf("openflow manager has not been provided for network: %s", udng.NetInfo.GetNetworkName())
 	}
 
@@ -239,7 +239,7 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 			udng.GetNetworkName(), err)
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		mgmtPortName := util.GetNetworkScopedK8sMgmtHostIntfName(uint(udng.GetNetworkID()))
 		mplink, err := util.LinkByName(mgmtPortName)
 		if err != nil {
@@ -267,7 +267,7 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 
 	udng.updateAdvertisementStatus()
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		// create the iprules for this network
 		if err = udng.updateUDNVRFIPRules(); err != nil {
 			return fmt.Errorf("failed to update IP rules for network %s: %w", udng.GetNetworkName(), err)
@@ -282,7 +282,7 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		var mgmtIPs []*net.IPNet
 		for _, subnet := range nodeSubnets {
 			mgmtIPs = append(mgmtIPs, udng.GetNodeManagementIP(subnet))
@@ -321,7 +321,7 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		if err := udng.addMarkChain(); err != nil {
 			return fmt.Errorf("failed to add the service masquerade chain: %w", err)
 		}
@@ -342,7 +342,7 @@ func (udng *UserDefinedNetworkGateway) GetNetworkRuleMetadata() string {
 // DelNetwork has returned succesfully.
 func (udng *UserDefinedNetworkGateway) DelNetwork() error {
 	var errs []error
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
 		// delete the iprules for this network
 		if err := udng.ruleManager.DeleteWithMetadata(udng.GetNetworkRuleMetadata()); err != nil {
@@ -353,19 +353,19 @@ func (udng *UserDefinedNetworkGateway) DelNetwork() error {
 			errs = append(errs, fmt.Errorf("unable to delete VRF device %s for network %s, err: %v", vrfDeviceName, udng.GetNetworkName(), err))
 		}
 	}
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// delete the openflows for this network
 		if udng.openflowManager != nil {
 			udng.openflowManager.delNetwork(udng.NetInfo)
 		}
 	}
-	if udng.openflowManager != nil || config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+	if udng.openflowManager != nil || config.IsModeDPUHost() {
 		if err := udng.gateway.Reconcile(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile default gateway for network %s, err: %v", udng.GetNetworkName(), err))
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		err := udng.deleteAdvertisedUDNIsolationRules()
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to remove advertised UDN isolation rules for network %s: %w", udng.GetNetworkName(), err))
@@ -759,7 +759,7 @@ func (udng *UserDefinedNetworkGateway) Reconcile() {
 func (udng *UserDefinedNetworkGateway) doReconcile() error {
 	klog.Infof("Reconciling gateway with updates for UDN %s", udng.GetNetworkName())
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// shouldn't happen
 		if udng.openflowManager == nil || udng.openflowManager.defaultBridge == nil {
 			return fmt.Errorf("openflow manager with default bridge configuration has not been provided for network %s", udng.GetNetworkName())
@@ -768,7 +768,7 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 
 	udng.updateAdvertisementStatus()
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// update bridge configuration
 		netConfig := udng.openflowManager.defaultBridge.GetNetworkConfig(udng.GetNetworkName())
 		if netConfig == nil {
@@ -777,7 +777,7 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 		netConfig.Advertised.Store(udng.isNetworkAdvertised)
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		if err := udng.updateUDNVRFIPRules(); err != nil {
 			return fmt.Errorf("error while updating ip rule for UDN %s: %s", udng.GetNetworkName(), err)
 		}
@@ -787,7 +787,7 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 		}
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// add below OpenFlows based on the gateway mode and whether the network is advertised or not:
 		// table=1, n_packets=0, n_bytes=0, priority=16,ip,nw_dst=128.192.0.2 actions=LOCAL (Both gateway modes)
 		// table=1, n_packets=0, n_bytes=0, priority=15,ip,nw_dst=128.192.0.0/14 actions=output:3 (shared gateway mode)
@@ -799,7 +799,7 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 		udng.openflowManager.requestFlowSync()
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		if err := udng.updateAdvertisedUDNIsolationRules(); err != nil {
 			return fmt.Errorf("error while updating advertised UDN isolation rules for network %s: %w", udng.GetNetworkName(), err)
 		}

--- a/go-controller/pkg/node/managementport/portDeviceManager.go
+++ b/go-controller/pkg/node/managementport/portDeviceManager.go
@@ -81,7 +81,7 @@ func (mpdm *MgmtPortDeviceManager) Init() error {
 			// the device plugin still exposes the same port and that we should
 			// consume the same VF index.
 			for _, d := range allDeviceIDs {
-				mgmtDetails, err := util.GetNetworkDeviceDetails(d)
+				mgmtDetails, err := util.GetDPUOps().ResolveDeviceDetails(d)
 				if err == nil && mgmtDetails.PfId == annotatedMgmtPortDetails.PfId && mgmtDetails.FuncId == annotatedMgmtPortDetails.FuncId {
 					deviceId = d
 					break
@@ -104,7 +104,7 @@ func (mpdm *MgmtPortDeviceManager) Init() error {
 				return fmt.Errorf("failed to reserve manage port device %v of resource %s for network %s: %v",
 					deviceId, mpdm.deviceAllocator.ResourceName(), network, err)
 			}
-			curMgmtPortDetails, err := util.GetNetworkDeviceDetails(deviceId)
+			curMgmtPortDetails, err := util.GetDPUOps().ResolveDeviceDetails(deviceId)
 			if err != nil {
 				return fmt.Errorf("failed to get network manage port device details for device %s network %s: %v", deviceId, network, err)
 			}
@@ -168,7 +168,7 @@ func (mpdm *MgmtPortDeviceManager) AllocateDeviceIDForNetwork(network string) er
 			return fmt.Errorf("failed to get manage port device of resource %s for network %s: %v",
 				mpdm.deviceAllocator.ResourceName(), network, err)
 		}
-		mgmtPortDetails, err = util.GetNetworkDeviceDetails(deviceId)
+		mgmtPortDetails, err = util.GetDPUOps().ResolveDeviceDetails(deviceId)
 		if err != nil {
 			mpdm.deviceAllocator.ReleaseResourcesDeviceID(network)
 			return fmt.Errorf("failed to get network manage port device details for device %s: %v", deviceId, err)
@@ -197,7 +197,7 @@ func (mpdm *MgmtPortDeviceManager) AllocateDeviceIDForDefaultNetwork() (*util.Ne
 			return nil, fmt.Errorf("failed to get manage port device of resource %s for default network: %v",
 				mpdm.deviceAllocator.ResourceName(), err)
 		}
-		mgmtPortDetails, err = util.GetNetworkDeviceDetails(deviceId)
+		mgmtPortDetails, err = util.GetDPUOps().ResolveDeviceDetails(deviceId)
 		if err != nil {
 			mpdm.deviceAllocator.ReleaseResourcesDeviceID(ovntypes.DefaultNetworkName)
 			return nil, fmt.Errorf("failed to get network manage port device details for device %s: %v", deviceId, err)

--- a/go-controller/pkg/node/managementport/port_dpu_linux.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux.go
@@ -173,7 +173,7 @@ func (mp *managementPortNetdev) create() error {
 		return err
 	}
 
-	if link.Attrs().Name != mp.ifName && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if link.Attrs().Name != mp.ifName && (config.IsModeDPU() || config.IsModeFull()) {
 		if _, stderr, err := util.RunOVSVsctl("set", "Open_vSwitch", ".",
 			"external-ids:ovn-orig-mgmt-port-netdev-name="+link.Attrs().Name); err != nil {
 			return fmt.Errorf("failed to store original mgmt port interface name: %s", stderr)

--- a/go-controller/pkg/node/managementport/port_linux.go
+++ b/go-controller/pkg/node/managementport/port_linux.go
@@ -101,12 +101,20 @@ func NewManagementPortController(
 			}
 		}
 		if deviceID == "" {
-			var err error
-			deviceID, err = util.GetDeviceIDFromNetdevice(netdevDevName)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get PCI device ID for %s: %v", netdevDevName, err)
+			if util.IsSimulatedDPU() {
+				// Simulated DPUs use veth/virtio netdevices without a PCI sysfs link; the
+				// netdev name is the opaque device id (see SimulatedDPUOps.ResolveDeviceDetails).
+				// Annotation may not be visible on the in-memory node yet on first start.
+				deviceID = netdevDevName
+				klog.Infof("Management port device ID: %s (simulated DPU; netdev as opaque id)", deviceID)
+			} else {
+				var err error
+				deviceID, err = util.GetDeviceIDFromNetdevice(netdevDevName)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get PCI device ID for %s: %v", netdevDevName, err)
+				}
+				klog.Infof("Management port PCI device ID: %s (resolved from netdev %s)", deviceID, netdevDevName)
 			}
-			klog.Infof("Management port PCI device ID: %s (resolved from netdev %s)", deviceID, netdevDevName)
 		}
 		c.ports[netdevPort] = newManagementPortNetdev(deviceID, cfg, routeManager)
 	}

--- a/go-controller/pkg/node/managementport/port_linux.go
+++ b/go-controller/pkg/node/managementport/port_linux.go
@@ -78,9 +78,9 @@ func NewManagementPortController(
 
 	var hasOVS, hasNetdev, hasRepresentor bool
 	switch {
-	case config.OvnKubeNode.Mode == types.NodeModeDPU:
+	case config.IsModeDPU():
 		hasRepresentor = true
-	case config.OvnKubeNode.Mode == types.NodeModeDPUHost:
+	case config.IsModeDPUHost():
 		hasNetdev = true
 	case config.OvnKubeNode.MgmtPortNetdev != "":
 		hasRepresentor = true
@@ -154,7 +154,7 @@ func (c *managementPortController) start(stopChan <-chan struct{}) error {
 	}
 
 	if config.Gateway.NodeportEnable {
-		if config.OvnKubeNode.Mode == types.NodeModeFull {
+		if config.IsModeFull() {
 			// (TODO): Internal Traffic Policy is not supported in DPU mode
 			if err := initMgmPortRoutingRules(c.cfg); err != nil {
 				return err
@@ -217,7 +217,7 @@ func tearDownManagementPortConfig(link netlink.Link) error {
 		return err
 	}
 
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		return nil
 	}
 	nft, err := nodenft.GetNFTablesHelper()
@@ -644,7 +644,7 @@ func unconfigureMgmtNetdevicePort(mgmtPortName string) error {
 	}
 
 	savedName := ""
-	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if config.IsModeDPU() || config.IsModeFull() {
 		// Get original interface name saved at OVS database
 		stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".", "external-ids:ovn-orig-mgmt-port-netdev-name")
 		if err != nil {

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -1262,6 +1262,16 @@ var _ = Describe("Management Port tests", func() {
 			netdevImpl := mgmtPortImpl.ports[netdevPort].(*managementPortNetdev)
 			Expect(netdevImpl.deviceID).To(Equal("0000:03:00.2"))
 		})
+		It("Creates managementPortNetdev for dpu-host in simulated DPU when annotation is missing", func() {
+			config.OvnKubeNode.Mode = types.NodeModeDPUHost
+			config.OvnKubeNode.SimulateDPU = true
+			simNetdev := "eth0-1"
+			mgmtPort, err := NewManagementPortController(node, hostSubnets, simNetdev, rep, nil, netInfo)
+			Expect(err).NotTo(HaveOccurred())
+			mgmtPortImpl := mgmtPort.(*managementPortController)
+			netdevImpl := mgmtPortImpl.ports[netdevPort].(*managementPortNetdev)
+			Expect(netdevImpl.deviceID).To(Equal(simNetdev))
+		})
 		It("Fails to create managementPortNetdev when PCI resolution fails and annotation is missing", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
 			util.SetFileSystemOps(origFsOps)

--- a/go-controller/pkg/node/managementport/port_udn_linux.go
+++ b/go-controller/pkg/node/managementport/port_udn_linux.go
@@ -128,7 +128,7 @@ func NewUDNManagementPortController(
 		c.ports[netdevPort] = newUDNManagementPortNetdev(cfg, mgmtIfName, mpdev.DeviceId)
 		c.ports[representorPort] = newUDNManagementPortRep(cfg, repDeviceName)
 	case types.NodeModeDPU:
-		repDeviceName, err := util.GetSriovnetOps().GetVfRepresentorDPU(fmt.Sprintf("%d", mpdev.PfId), fmt.Sprintf("%d", mpdev.FuncId))
+		repDeviceName, err := util.GetDPUOps().GetPortRepresentor(fmt.Sprintf("%d", mpdev.PfId), fmt.Sprintf("%d", mpdev.FuncId))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get management port representor for pfID %v vfID %v network %s: %v",
 				mpdev.PfId, mpdev.FuncId, netInfo.GetNetworkName(), err)
@@ -258,8 +258,8 @@ func syncUDNManagementPort(cfg *udnManagementPortConfig, mgmtIfName string, mpde
 				}
 			}
 		}
-	} else if ovsRepIfName != "" {
-		repDeviceName, _ := util.GetSriovnetOps().GetVfRepresentorDPU(fmt.Sprintf("%d", mpdev.PfId), fmt.Sprintf("%d", mpdev.FuncId))
+	} else if config.IsModeDPU() && ovsRepIfName != "" {
+		repDeviceName, _ := util.GetDPUOps().GetPortRepresentor(fmt.Sprintf("%d", mpdev.PfId), fmt.Sprintf("%d", mpdev.FuncId))
 		if repDeviceName != ovsRepIfName {
 			err = DeleteManagementPortRepInterface(cfg.GetNetworkName(), ovsRepIfName, ovsRepIfName)
 			if err != nil {

--- a/go-controller/pkg/node/managementport/port_udn_linux.go
+++ b/go-controller/pkg/node/managementport/port_udn_linux.go
@@ -98,7 +98,7 @@ func NewUDNManagementPortController(
 
 	// in full mode and MgmtPortDPResourceName is empty, OVS internal management port can be used, otherwise, management
 	// port must has been allocated for this network
-	if (config.OvnKubeNode.Mode != types.NodeModeFull || config.OvnKubeNode.MgmtPortDPResourceName != "") && mpdev == nil {
+	if ((config.IsModeDPU() || config.IsModeDPUHost()) || config.OvnKubeNode.MgmtPortDPResourceName != "") && mpdev == nil {
 		return nil, fmt.Errorf("management port resource not allocated for network %s (annotation missing or invalid)", cfg.GetNetworkName())
 	}
 
@@ -113,7 +113,7 @@ func NewUDNManagementPortController(
 		ports: map[string]udnManagementPort{},
 	}
 
-	if config.OvnKubeNode.Mode == types.NodeModeFull && config.OvnKubeNode.MgmtPortDPResourceName == "" {
+	if config.IsModeFull() && config.OvnKubeNode.MgmtPortDPResourceName == "" {
 		c.ports[ovsPort] = newUDNManagementPortOVS(cfg, mgmtIfName)
 		return c, nil
 	}
@@ -198,7 +198,7 @@ func syncUDNManagementPort(cfg *udnManagementPortConfig, mgmtIfName string, mpde
 		"--columns", "name",
 		"find", "Interface", "type=internal", fmt.Sprintf("name=%s", mgmtIfName))
 
-	if config.OvnKubeNode.MgmtPortDPResourceName == "" && config.OvnKubeNode.Mode == types.NodeModeFull {
+	if config.OvnKubeNode.MgmtPortDPResourceName == "" && config.IsModeFull() {
 		// expect internal OVS management port interface
 		if ovsRepIfName != "" {
 			klog.V(5).Infof("Expected management port OVS internal interface, delete stale management port representor %s for network %s",
@@ -225,7 +225,7 @@ func syncUDNManagementPort(cfg *udnManagementPortConfig, mgmtIfName string, mpde
 		return nil
 	}
 
-	if config.OvnKubeNode.Mode != types.NodeModeDPU {
+	if config.IsModeDPUHost() || config.IsModeFull() {
 		if ovsInternalIfName != "" {
 			klog.V(5).Infof("Expected management port OVS netdev interface, bring down stale management port internal interface %s for network %s",
 				mgmtIfName, cfg.GetNetworkName())

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -74,7 +74,7 @@ func newAddressManagerInternal(nodeName string, k kube.Interface, mgmtPort manag
 		syncPeriod:            30 * time.Second,
 	}
 	mgr.nodeAnnotator = kube.NewNodeAnnotator(k, nodeName)
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		if err := mgr.updateHostCIDRs(); err != nil {
 			klog.Errorf("Failed to update host-cidrs annotations on node %s: %v", nodeName, err)
 			return nil
@@ -160,7 +160,7 @@ func (c *addressManager) notifyAddressesChanged() {
 type subscribeFn func() (bool, chan netlink.AddrUpdate, error)
 
 func (c *addressManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) {
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		return
 	}
 
@@ -309,7 +309,7 @@ func (c *addressManager) handleNodePrimaryAddrChange() {
 		klog.Errorf("Address Manager failed to check node primary address change: %v", err)
 		return
 	}
-	if nodePrimaryAddrChanged && config.Default.EncapIP == "" && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+	if nodePrimaryAddrChanged && config.Default.EncapIP == "" && (config.IsModeDPU() || config.IsModeFull()) {
 		klog.Infof("Node primary address changed to %v. Updating OVN encap IP.", c.nodePrimaryAddr)
 		c.updateOVNEncapIPAndReconnect(c.nodePrimaryAddr)
 	}
@@ -367,7 +367,7 @@ func (c *addressManager) updateNodeAddressAnnotations() error {
 }
 
 func (c *addressManager) updateHostCIDRs() error {
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		// For DPU mode, we don't need to update the host-cidrs annotation.
 		return nil
 	}
@@ -534,7 +534,7 @@ func (c *addressManager) refreshGatewayIfIndex() {
 }
 
 func (c *addressManager) sync() {
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		return
 	}
 	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {

--- a/go-controller/pkg/node/obj_retry_node.go
+++ b/go-controller/pkg/node/obj_retry_node.go
@@ -179,7 +179,7 @@ func (h *nodeEventHandler) AddResource(obj interface{}, _ bool) error {
 		node := obj.(*corev1.Node)
 		// if it's our node that is changing, then nothing to do as we dont add our own IP to the nftables rules
 		if node.Name == h.nc.name {
-			if config.OvnKubeNode.Mode != types.NodeModeDPU {
+			if config.IsModeDPUHost() || config.IsModeFull() {
 				if util.NodeDontSNATSubnetAnnotationExist(node) {
 					err := managementport.UpdateNoSNATSubnetsSets(node, util.ParseNodeDontSNATSubnetsList)
 					if err != nil {
@@ -243,7 +243,7 @@ func (h *nodeEventHandler) UpdateResource(oldObj, newObj interface{}, _ bool) er
 
 		// if it's our node that is changing, then nothing to do as we dont add our own IP to the nftables rules
 		if newNode.Name == h.nc.name {
-			if config.OvnKubeNode.Mode != types.NodeModeDPU && !reflect.DeepEqual(oldNode.Annotations, newNode.Annotations) {
+			if (config.IsModeDPUHost() || config.IsModeFull()) && !reflect.DeepEqual(oldNode.Annotations, newNode.Annotations) {
 				// if node's dont SNAT subnet annotation changed sync nftables
 				if util.NodeDontSNATSubnetAnnotationChanged(oldNode, newNode) {
 					err := managementport.UpdateNoSNATSubnetsSets(newNode, util.ParseNodeDontSNATSubnetsList)
@@ -269,7 +269,7 @@ func (h *nodeEventHandler) UpdateResource(oldObj, newObj interface{}, _ bool) er
 			return nil
 		}
 
-		if config.OvnKubeNode.Mode != types.NodeModeDPU && util.NodeHostCIDRsAnnotationChanged(oldNode, newNode) {
+		if (config.IsModeDPUHost() || config.IsModeFull()) && util.NodeHostCIDRsAnnotationChanged(oldNode, newNode) {
 			// remote node that is changing
 			// Use GetNodeAddresses to get new node IPs
 			newIPsv4, newIPsv6, err := util.GetNodeAddresses(config.IPv4Mode, config.IPv6Mode, newNode)
@@ -330,7 +330,7 @@ func (h *nodeEventHandler) DeleteResource(obj, _ interface{}) error {
 
 	case factory.NodeType:
 		h.nc.deleteNode(obj.(*corev1.Node))
-		if config.OvnKubeNode.Mode != types.NodeModeDPU {
+		if config.IsModeDPUHost() || config.IsModeFull() {
 			_ = managementport.UpdateNoSNATSubnetsSets(obj.(*corev1.Node), func(_ *corev1.Node) ([]string, error) {
 				return []string{}, nil
 			})

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	nodetypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/types"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -332,7 +331,7 @@ func bootstrapOVSFlows(nodeName string) error {
 	}
 
 	var bridgeMACAddress net.HardwareAddr
-	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if config.IsModeDPU() {
 		hostRep, err := util.GetDPUHostInterface(bridge)
 		if err != nil {
 			return err

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -332,11 +332,7 @@ func bootstrapOVSFlows(nodeName string) error {
 
 	var bridgeMACAddress net.HardwareAddr
 	if config.IsModeDPU() {
-		hostRep, err := util.GetDPUHostInterface(bridge)
-		if err != nil {
-			return err
-		}
-		bridgeMACAddress, err = util.GetSriovnetOps().GetRepresentorPeerMacAddress(hostRep)
+		bridgeMACAddress, err = util.GetDPUOps().GetHostGatewayMACAddress(bridge, nodeName)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/node/user_defined_node_network_controller.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -77,7 +76,7 @@ func (nc *UserDefinedNodeNetworkController) Start(_ context.Context) error {
 	klog.Infof("Starting UDN node network controller for network %s", nc.GetNetworkName())
 
 	// enable adding ovs ports for dpu pods in both primary and secondary user-defined networks
-	if (config.OVNKubernetesFeature.EnableMultiNetwork || util.IsNetworkSegmentationSupportEnabled()) && config.OvnKubeNode.Mode == types.NodeModeDPU {
+	if (config.OVNKubernetesFeature.EnableMultiNetwork || util.IsNetworkSegmentationSupportEnabled()) && config.IsModeDPU() {
 		handler, err := nc.watchPodsDPU()
 		if err != nil {
 			return err

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -90,7 +90,7 @@ func makeNodeRouterTargetIPs(node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, ho
 
 	// TODO: For all scenarios the lbAddress should be set to hostAddressesStr but this is breaking CI needs more investigation
 	lbAddresses := node.hostAddressesStr()
-	if config.OvnKubeNode.Mode == types.NodeModeFull {
+	if config.IsModeFull() {
 		lbAddresses = node.l3gatewayAddressesStr()
 	}
 

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +17,8 @@ import (
 	"github.com/k8snetworkplumbingwg/sriovnet"
 
 	"k8s.io/klog/v2"
+
+	"github.com/ovn-kubernetes/dpu-simulator/lib/dpusim"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 )
@@ -172,15 +173,6 @@ func (n *SwitchdevDPUOps) GetDeviceAddress(repName string) (string, error) {
 
 type SimulatedDPUOps struct{}
 
-// Update when simulation code uses different constants
-const (
-	SimulationHostGatewayInterface      = "eth0-0"
-	SimulationHostGatewayInterfaceIndex = 0
-	SimulationHostGatewayPeerInterface  = "rep0-0"
-)
-
-var reSimulationNetdevFunc = regexp.MustCompile(`(\d+)-(\d+)$`)
-
 // generateMACForHostToDpu returns a deterministic MAC for a host-to-DPU data
 // interface. The hash is over nodeName + role("host" or "dpu"); the index is
 // encoded in the last octet so each channel in a pair has a unique MAC.
@@ -188,12 +180,12 @@ var reSimulationNetdevFunc = regexp.MustCompile(`(\d+)-(\d+)$`)
 // locally administered.
 func (s *SimulatedDPUOps) generateMACForHostToDpu(nodeName, role string, index int) string {
 	h := sha256.Sum256([]byte(nodeName + "\x00" + role))
-	return fmt.Sprintf("52:54:00:%02x:%02x:%02x", h[0], h[1], index&0xff)
+	return fmt.Sprintf("%s:%02x:%02x:%02x", dpusim.MacOUI, h[0], h[1], index&0xff)
 }
 
 // getDPURepresentor builds rep<pfId>-<funcId> and verifies the link exists.
 func (s *SimulatedDPUOps) getDPURepresentor(pfId, funcId string) (string, error) {
-	rep := fmt.Sprintf("rep%s-%s", pfId, funcId)
+	rep := fmt.Sprintf(dpusim.DPURepresentorFmt, pfId, funcId)
 	if _, err := GetNetLinkOps().LinkByName(rep); err != nil {
 		return "", fmt.Errorf("simulated representor %s not found: %v", rep, err)
 	}
@@ -201,7 +193,7 @@ func (s *SimulatedDPUOps) getDPURepresentor(pfId, funcId string) (string, error)
 }
 
 func (s *SimulatedDPUOps) GetDPUHostRepInterface(_ string) (string, error) {
-	return SimulationHostGatewayPeerInterface, nil
+	return dpusim.HostGatewayPeerInterface, nil
 }
 
 func (s *SimulatedDPUOps) GetHostGatewayMACAddress(_, nodeName string) (net.HardwareAddr, error) {
@@ -210,7 +202,7 @@ func (s *SimulatedDPUOps) GetHostGatewayMACAddress(_, nodeName string) (net.Hard
 	}
 
 	// TODO: This identifies a need to have an API to get reliable information from the host (requested by the DPU)
-	macStr := s.generateMACForHostToDpu(nodeName, "host", SimulationHostGatewayInterfaceIndex)
+	macStr := s.generateMACForHostToDpu(nodeName, "host", dpusim.HostGatewayInterfaceIndex)
 	mac, err := net.ParseMAC(macStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse generated MAC %s: %v", macStr, err)
@@ -221,7 +213,7 @@ func (s *SimulatedDPUOps) GetHostGatewayMACAddress(_, nodeName string) (net.Hard
 }
 
 func (s *SimulatedDPUOps) ResolveDeviceDetails(deviceID string) (*NetworkDeviceDetails, error) {
-	matches := reSimulationNetdevFunc.FindStringSubmatch(deviceID)
+	matches := dpusim.ReSimulationNetdevFunc.FindStringSubmatch(deviceID)
 	if len(matches) != 3 {
 		return nil, fmt.Errorf("interface %s does not match simulated naming pattern *<pfId>-<funcId>", deviceID)
 	}

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/k8snetworkplumbingwg/sriovnet"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -43,10 +44,11 @@ type DPUOps interface {
 	// nodeName is the K8s node name of the host this DPU operates behalf of.
 	GetHostGatewayMACAddress(bridgeName, nodeName string) (net.HardwareAddr, error)
 
-	// ResolveDeviceDetails probes a netdev (e.g. VF) interface and returns device
-	// details including PF and VF indices. In simulation this follows the
-	// pattern <prefix><pfId>-<funcId> (e.g. "eth0-1" → PfId=0, FuncId=1).
-	ResolveDeviceDetails(netdevName string) (*NetworkDeviceDetails, error)
+	// ResolveDeviceDetails returns PF and VF indices for a device identified
+	// by either a PCI address (e.g. "0000:03:00.2") or a netdev name
+	// (e.g. "eth0-1"). It is up to the implementation to interpret the deviceID
+	// for the underlying platform.
+	ResolveDeviceDetails(deviceID string) (*NetworkDeviceDetails, error)
 
 	// GetPortRepresentor finds the DPU-side representor (VF representor in the case of switchdev hardware)
 	// for the given PF and function indices. On simulation this follows the
@@ -56,30 +58,42 @@ type DPUOps interface {
 	// GetDeviceAddress returns an opaque, platform-specific identifier for
 	// a representor interface. On switchdev hardware this is a PCI address
 	// (e.g. "0000:01:00.2"); on simulated platforms it is the netdev name
-	// itself.
-	GetDeviceAddress(repName string) string
+	// itself. On switchdev, failure to resolve PCI for the representor is an error.
+	GetDeviceAddress(repName string) (string, error)
 }
 
 // ---------------------------------------------------------------------------
 // DPUOps singleton
 // ---------------------------------------------------------------------------
 
-var dpuOps DPUOps
+var (
+	dpuOps     DPUOps
+	dpuOpsOnce sync.Once
+)
+
+func initDPUOps() {
+	if IsSimulatedDPU() {
+		dpuOps = &SimulatedDPUOps{}
+		klog.Infof("DPUOps initialised: Simulated DPU environment")
+	} else {
+		dpuOps = &SwitchdevDPUOps{}
+		klog.Infof("DPUOps initialised: Switchdev hardware DPU environment")
+	}
+}
 
 // GetDPUOps returns the current DPUOps singleton. If the singleton has not
 // been initialised, it defaults to SwitchdevDPUOps (SR-IOV / switchdev hardware).
 func GetDPUOps() DPUOps {
-	if dpuOps == nil {
-		if config.IsModeDPU() || config.IsModeDPUHost() {
-			if config.OvnKubeNode.SimulateDPU {
-				dpuOps = &SimulatedDPUOps{}
-				klog.Infof("DPUOps initialised: simulated DPU environment")
-				return dpuOps
-			}
-		}
-		dpuOps = &SwitchdevDPUOps{}
-	}
+	dpuOpsOnce.Do(initDPUOps)
 	return dpuOps
+}
+
+// IsSimulatedDPU returns true if we are in a Simulated DPU environment.
+func IsSimulatedDPU() bool {
+	if config.IsModeDPU() || config.IsModeDPUHost() {
+		return config.OvnKubeNode.SimulateDPU
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------
@@ -122,29 +136,28 @@ func (n *SwitchdevDPUOps) GetHostGatewayMACAddress(bridgeName, _ string) (net.Ha
 	return GetSriovnetOps().GetRepresentorPeerMacAddress(hostRep)
 }
 
-func (n *SwitchdevDPUOps) ResolveDeviceDetails(netdevName string) (*NetworkDeviceDetails, error) {
-	deviceID, err := GetDeviceIDFromNetdevice(netdevName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read sysfs device link for %s: %v", netdevName, err)
+func (n *SwitchdevDPUOps) ResolveDeviceDetails(deviceID string) (*NetworkDeviceDetails, error) {
+	if IsPCIDeviceName(deviceID) {
+		return GetNetworkDeviceDetails(deviceID)
 	}
-	return GetNetworkDeviceDetails(deviceID)
+	// deviceID is a netdev name – look up its PCI address via sysfs first.
+	pciAddr, err := GetDeviceIDFromNetdevice(deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read sysfs device link for %s: %v", deviceID, err)
+	}
+	return GetNetworkDeviceDetails(pciAddr)
 }
 
 func (n *SwitchdevDPUOps) GetPortRepresentor(pfId, funcId string) (string, error) {
 	return GetSriovnetOps().GetVfRepresentorDPU(pfId, funcId)
 }
 
-func (n *SwitchdevDPUOps) GetRepresentorForPod(pfId, vfId string) (string, error) {
-	return GetSriovnetOps().GetVfRepresentorDPU(pfId, vfId)
-}
-
-func (n *SwitchdevDPUOps) GetDeviceAddress(repName string) string {
+func (n *SwitchdevDPUOps) GetDeviceAddress(repName string) (string, error) {
 	addr, err := GetSriovnetOps().GetPCIFromDeviceName(repName)
 	if err != nil {
-		klog.Warningf("Failed to get PCI address for %s: %v, using device name", repName, err)
-		return repName
+		return "", err
 	}
-	return addr
+	return addr, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -205,22 +218,22 @@ func (s *SimulatedDPUOps) GetHostGatewayMACAddress(_, nodeName string) (net.Hard
 	return mac, nil
 }
 
-func (s *SimulatedDPUOps) ResolveDeviceDetails(netdevName string) (*NetworkDeviceDetails, error) {
-	matches := reSimulationNetdevFunc.FindStringSubmatch(netdevName)
+func (s *SimulatedDPUOps) ResolveDeviceDetails(deviceID string) (*NetworkDeviceDetails, error) {
+	matches := reSimulationNetdevFunc.FindStringSubmatch(deviceID)
 	if len(matches) != 3 {
-		return nil, fmt.Errorf("interface %s does not match simulated naming pattern *<pfId>-<funcId>", netdevName)
+		return nil, fmt.Errorf("interface %s does not match simulated naming pattern *<pfId>-<funcId>", deviceID)
 	}
 	pfId, err := strconv.Atoi(matches[1])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse PF index from %q: %v", netdevName, err)
+		return nil, fmt.Errorf("failed to parse PF index from %q: %v", deviceID, err)
 	}
 	funcId, err := strconv.Atoi(matches[2])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse Function index from %q: %v", netdevName, err)
+		return nil, fmt.Errorf("failed to parse Function index from %q: %v", deviceID, err)
 	}
-	klog.Infof("Interface %s resolved as simulated netdev: PfId=%d, FuncId=%d", netdevName, pfId, funcId)
+	klog.Infof("Device %s resolved as simulated netdev: PfId=%d, FuncId=%d", deviceID, pfId, funcId)
 	return &NetworkDeviceDetails{
-		DeviceId: netdevName,
+		DeviceId: deviceID,
 		PfId:     pfId,
 		FuncId:   funcId,
 	}, nil
@@ -230,6 +243,6 @@ func (s *SimulatedDPUOps) GetPortRepresentor(pfId, funcId string) (string, error
 	return s.getDPURepresentor(pfId, funcId)
 }
 
-func (s *SimulatedDPUOps) GetDeviceAddress(repName string) string {
-	return repName
+func (s *SimulatedDPUOps) GetDeviceAddress(repName string) (string, error) {
+	return repName, nil
 }

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -16,8 +16,10 @@ import (
 	"sync"
 
 	"github.com/k8snetworkplumbingwg/sriovnet"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+
 	"k8s.io/klog/v2"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 )
 
 // DPU operations abstraction.
@@ -198,7 +200,7 @@ func (s *SimulatedDPUOps) getDPURepresentor(pfId, funcId string) (string, error)
 	return rep, nil
 }
 
-func (s *SimulatedDPUOps) GetDPUHostInterface(bridgeName string) (string, error) {
+func (s *SimulatedDPUOps) GetDPUHostInterface(_ string) (string, error) {
 	return SimulationHostGatewayPeerInterface, nil
 }
 

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package util
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/k8snetworkplumbingwg/sriovnet"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"k8s.io/klog/v2"
+)
+
+// DPU operations abstraction.
+//
+// DPUOps is the central interface that hides DPU operational details
+// (SR-IOV, switchdev, sysfs) behind a uniform API. All DPU and DPU Host
+// mode code should go through GetDPUOps() rather than calling SriovnetOps
+// directly.
+//
+// Two concrete implementations exist today:
+//   - SwitchdevDPUOps - SR-IOV / switchdev hardware (NVIDIA BlueField, etc.)
+//   - SimulatedDPUOps - simulated DPU environments (Kind, VMs with virtio)
+//
+// The singleton is selected by the --simulate-dpu configuration flag.
+// When the flag is absent (the default), SwitchdevDPUOps is used.
+type DPUOps interface {
+	// GetDPUHostInterface returns the host representor interface attached to bridge
+	// On switchdev hardware this discovers the VF/SF representor via sriovnet.
+	// On simulated platforms this is either a veth peer or virtio interface.
+	GetDPUHostInterface(bridgeName string) (string, error)
+
+	// GetHostGatewayMACAddress returns the MAC address of the host-side
+	// interface that corresponds to the DPU-side Host representor.
+	// nodeName is the K8s node name of the host this DPU operates behalf of.
+	GetHostGatewayMACAddress(bridgeName, nodeName string) (net.HardwareAddr, error)
+
+	// ResolveDeviceDetails probes a netdev (e.g. VF) interface and returns device
+	// details including PF and VF indices. In simulation this follows the
+	// pattern <prefix><pfId>-<funcId> (e.g. "eth0-1" → PfId=0, FuncId=1).
+	ResolveDeviceDetails(netdevName string) (*NetworkDeviceDetails, error)
+
+	// GetPortRepresentor finds the DPU-side representor (VF representor in the case of switchdev hardware)
+	// for the given PF and function indices. On simulation this follows the
+	// pattern rep<pfId>-<funcId> (e.g. "rep0-1").
+	GetPortRepresentor(pfId, funcId string) (string, error)
+
+	// GetDeviceAddress returns an opaque, platform-specific identifier for
+	// a representor interface. On switchdev hardware this is a PCI address
+	// (e.g. "0000:01:00.2"); on simulated platforms it is the netdev name
+	// itself.
+	GetDeviceAddress(repName string) string
+}
+
+// ---------------------------------------------------------------------------
+// DPUOps singleton
+// ---------------------------------------------------------------------------
+
+var dpuOps DPUOps
+
+// GetDPUOps returns the current DPUOps singleton. If the singleton has not
+// been initialised, it defaults to SwitchdevDPUOps (SR-IOV / switchdev hardware).
+func GetDPUOps() DPUOps {
+	if dpuOps == nil {
+		if config.IsModeDPU() || config.IsModeDPUHost() {
+			if config.OvnKubeNode.SimulateDPU {
+				dpuOps = &SimulatedDPUOps{}
+				klog.Infof("DPUOps initialised: simulated DPU environment")
+				return dpuOps
+			}
+		}
+		dpuOps = &SwitchdevDPUOps{}
+	}
+	return dpuOps
+}
+
+// ---------------------------------------------------------------------------
+// SwitchdevDPUOps - SR-IOV / switchdev hardware (NVIDIA BlueField, etc.)
+// ---------------------------------------------------------------------------
+
+type SwitchdevDPUOps struct{}
+
+func (n *SwitchdevDPUOps) GetDPUHostInterface(bridgeName string) (string, error) {
+	portsToInterfaces, err := getBridgePortsInterfaces(bridgeName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, ifaces := range portsToInterfaces {
+		for _, iface := range ifaces {
+			stdout, stderr, err := RunOVSVsctl("get", "Interface", strings.TrimSpace(iface), "Name")
+			if err != nil {
+				return "", fmt.Errorf("failed to get Interface %q Name on bridge %q:, stderr: %q, error: %v",
+					iface, bridgeName, stderr, err)
+
+			}
+			flavor, err := GetSriovnetOps().GetRepresentorPortFlavour(stdout)
+			if err == nil && flavor == sriovnet.PORT_FLAVOUR_PCI_PF {
+				// host representor interface found
+				return stdout, nil
+			}
+			continue
+		}
+	}
+	// No host interface found in provided bridge
+	return "", fmt.Errorf("dpu host interface was not found for bridge %q", bridgeName)
+}
+
+func (n *SwitchdevDPUOps) GetHostGatewayMACAddress(bridgeName, _ string) (net.HardwareAddr, error) {
+	hostRep, err := n.GetDPUHostInterface(bridgeName)
+	if err != nil {
+		return nil, err
+	}
+	return GetSriovnetOps().GetRepresentorPeerMacAddress(hostRep)
+}
+
+func (n *SwitchdevDPUOps) ResolveDeviceDetails(netdevName string) (*NetworkDeviceDetails, error) {
+	deviceID, err := GetDeviceIDFromNetdevice(netdevName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read sysfs device link for %s: %v", netdevName, err)
+	}
+	return GetNetworkDeviceDetails(deviceID)
+}
+
+func (n *SwitchdevDPUOps) GetPortRepresentor(pfId, funcId string) (string, error) {
+	return GetSriovnetOps().GetVfRepresentorDPU(pfId, funcId)
+}
+
+func (n *SwitchdevDPUOps) GetRepresentorForPod(pfId, vfId string) (string, error) {
+	return GetSriovnetOps().GetVfRepresentorDPU(pfId, vfId)
+}
+
+func (n *SwitchdevDPUOps) GetDeviceAddress(repName string) string {
+	addr, err := GetSriovnetOps().GetPCIFromDeviceName(repName)
+	if err != nil {
+		klog.Warningf("Failed to get PCI address for %s: %v, using device name", repName, err)
+		return repName
+	}
+	return addr
+}
+
+// ---------------------------------------------------------------------------
+// SimulatedDPUOps - simulated DPU environments (Kind containers, VMs)
+//
+// Uses interface naming conventions instead of sysfs / switchdev:
+//   - Host interfaces: <prefix><pfId>-<funcId>  (e.g. eth0-1)
+//   - DPU representors: rep<pfId>-<funcId>      (e.g. rep0-1)
+// ---------------------------------------------------------------------------
+
+type SimulatedDPUOps struct{}
+
+// Update when simulation code uses different constants
+const (
+	SimulationHostGatewayInterface      = "eth0-0"
+	SimulationHostGatewayInterfaceIndex = 0
+	SimulationHostGatewayPeerInterface  = "rep0-0"
+)
+
+var reSimulationNetdevFunc = regexp.MustCompile(`(\d+)-(\d+)$`)
+
+// generateMACForHostToDpu returns a deterministic MAC for a host-to-DPU data
+// interface. The hash is over nodeName + role("host" or "dpu"); the index is
+// encoded in the last octet so each channel in a pair has a unique MAC.
+// OUI 52:54:00 is commonly used for QEMU/virtio and marks the address as
+// locally administered.
+func (s *SimulatedDPUOps) generateMACForHostToDpu(nodeName, role string, index int) string {
+	h := sha256.Sum256([]byte(nodeName + "\x00" + role))
+	return fmt.Sprintf("52:54:00:%02x:%02x:%02x", h[0], h[1], index&0xff)
+}
+
+// getDPURepresentor builds rep<pfId>-<funcId> and verifies the link exists.
+func (s *SimulatedDPUOps) getDPURepresentor(pfId, funcId string) (string, error) {
+	rep := fmt.Sprintf("rep%s-%s", pfId, funcId)
+	if _, err := GetNetLinkOps().LinkByName(rep); err != nil {
+		return "", fmt.Errorf("simulated representor %s not found: %v", rep, err)
+	}
+	return rep, nil
+}
+
+func (s *SimulatedDPUOps) GetDPUHostInterface(bridgeName string) (string, error) {
+	return SimulationHostGatewayPeerInterface, nil
+}
+
+func (s *SimulatedDPUOps) GetHostGatewayMACAddress(_, nodeName string) (net.HardwareAddr, error) {
+	if nodeName == "" {
+		return nil, fmt.Errorf("nodeName must be provided for simulated GetHostGatewayMACAddress")
+	}
+
+	// TODO: This identifies a need to have an API to get reliable information from the host (requested by the DPU)
+	macStr := s.generateMACForHostToDpu(nodeName, "host", SimulationHostGatewayInterfaceIndex)
+	mac, err := net.ParseMAC(macStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse generated MAC %s: %v", macStr, err)
+	}
+
+	klog.Infof("Derived host gateway peer MAC %s for node %s", mac, nodeName)
+	return mac, nil
+}
+
+func (s *SimulatedDPUOps) ResolveDeviceDetails(netdevName string) (*NetworkDeviceDetails, error) {
+	matches := reSimulationNetdevFunc.FindStringSubmatch(netdevName)
+	if len(matches) != 3 {
+		return nil, fmt.Errorf("interface %s does not match simulated naming pattern *<pfId>-<funcId>", netdevName)
+	}
+	pfId, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse PF index from %q: %v", netdevName, err)
+	}
+	funcId, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Function index from %q: %v", netdevName, err)
+	}
+	klog.Infof("Interface %s resolved as simulated netdev: PfId=%d, FuncId=%d", netdevName, pfId, funcId)
+	return &NetworkDeviceDetails{
+		DeviceId: netdevName,
+		PfId:     pfId,
+		FuncId:   funcId,
+	}, nil
+}
+
+func (s *SimulatedDPUOps) GetPortRepresentor(pfId, funcId string) (string, error) {
+	return s.getDPURepresentor(pfId, funcId)
+}
+
+func (s *SimulatedDPUOps) GetDeviceAddress(repName string) string {
+	return repName
+}

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -36,10 +36,10 @@ import (
 // The singleton is selected by the --simulate-dpu configuration flag.
 // When the flag is absent (the default), SwitchdevDPUOps is used.
 type DPUOps interface {
-	// GetDPUHostInterface returns the host representor interface attached to bridge
+	// GetDPUHostRepInterface returns the host representor interface attached to bridge
 	// On switchdev hardware this discovers the VF/SF representor via sriovnet.
 	// On simulated platforms this is either a veth peer or virtio interface.
-	GetDPUHostInterface(bridgeName string) (string, error)
+	GetDPUHostRepInterface(bridgeName string) (string, error)
 
 	// GetHostGatewayMACAddress returns the MAC address of the host-side
 	// interface that corresponds to the DPU-side Host representor.
@@ -104,7 +104,7 @@ func IsSimulatedDPU() bool {
 
 type SwitchdevDPUOps struct{}
 
-func (n *SwitchdevDPUOps) GetDPUHostInterface(bridgeName string) (string, error) {
+func (n *SwitchdevDPUOps) GetDPUHostRepInterface(bridgeName string) (string, error) {
 	portsToInterfaces, err := getBridgePortsInterfaces(bridgeName)
 	if err != nil {
 		return "", err
@@ -131,7 +131,7 @@ func (n *SwitchdevDPUOps) GetDPUHostInterface(bridgeName string) (string, error)
 }
 
 func (n *SwitchdevDPUOps) GetHostGatewayMACAddress(bridgeName, _ string) (net.HardwareAddr, error) {
-	hostRep, err := n.GetDPUHostInterface(bridgeName)
+	hostRep, err := n.GetDPUHostRepInterface(bridgeName)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (s *SimulatedDPUOps) getDPURepresentor(pfId, funcId string) (string, error)
 	return rep, nil
 }
 
-func (s *SimulatedDPUOps) GetDPUHostInterface(_ string) (string, error) {
+func (s *SimulatedDPUOps) GetDPUHostRepInterface(_ string) (string, error) {
 	return SimulationHostGatewayPeerInterface, nil
 }
 

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 
 	"github.com/k8snetworkplumbingwg/sriovnet"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/vishvananda/netlink"
 
 	"k8s.io/klog/v2"
@@ -241,13 +240,6 @@ func NicToBridge(iface string) (string, error) {
 		fmt.Sprintf("other_config:hwaddr=%s", ifaceLink.Attrs().HardwareAddr),
 		"--", "--may-exist", "add-port", bridge, iface,
 		"--", "set", "port", iface, "other-config:transient=true",
-	}
-
-	if config.Gateway.DPUHostGatewayRepresentorInterface != "" {
-		ovsArgs = append(ovsArgs,
-			"--", "--may-exist", "add-port", bridge, config.Gateway.DPUHostGatewayRepresentorInterface,
-			"--", "set", "port", config.Gateway.DPUHostGatewayRepresentorInterface, "other-config:transient=true")
-		klog.Infof("Adding host representor interface %s to bridge %s", config.Gateway.DPUHostGatewayRepresentorInterface, bridge)
 	}
 	stdout, stderr, err := RunOVSVsctl(ovsArgs...)
 	if err != nil {

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -232,14 +232,16 @@ func NicToBridge(iface string) (string, error) {
 	}
 
 	bridge := GetBridgeName(iface)
-	stdout, stderr, err := RunOVSVsctl(
+	ovsArgs := []string{
 		"--", "--may-exist", "add-br", bridge,
 		"--", "br-set-external-id", bridge, "bridge-id", bridge,
 		"--", "br-set-external-id", bridge, "bridge-uplink", iface,
 		"--", "set", "bridge", bridge, "fail-mode=standalone",
 		fmt.Sprintf("other_config:hwaddr=%s", ifaceLink.Attrs().HardwareAddr),
 		"--", "--may-exist", "add-port", bridge, iface,
-		"--", "set", "port", iface, "other-config:transient=true")
+		"--", "set", "port", iface, "other-config:transient=true",
+	}
+	stdout, stderr, err := RunOVSVsctl(ovsArgs...)
 	if err != nil {
 		klog.Errorf("Failed to create OVS bridge, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return "", err

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/k8snetworkplumbingwg/sriovnet"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/vishvananda/netlink"
 
 	"k8s.io/klog/v2"
@@ -240,6 +241,13 @@ func NicToBridge(iface string) (string, error) {
 		fmt.Sprintf("other_config:hwaddr=%s", ifaceLink.Attrs().HardwareAddr),
 		"--", "--may-exist", "add-port", bridge, iface,
 		"--", "set", "port", iface, "other-config:transient=true",
+	}
+
+	if config.Gateway.DPUHostGatewayRepresentorInterface != "" {
+		ovsArgs = append(ovsArgs,
+			"--", "--may-exist", "add-port", bridge, config.Gateway.DPUHostGatewayRepresentorInterface,
+			"--", "set", "port", config.Gateway.DPUHostGatewayRepresentorInterface, "other-config:transient=true")
+		klog.Infof("Adding host representor interface %s to bridge %s", config.Gateway.DPUHostGatewayRepresentorInterface, bridge)
 	}
 	stdout, stderr, err := RunOVSVsctl(ovsArgs...)
 	if err != nil {

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/k8snetworkplumbingwg/sriovnet"
 	"github.com/vishvananda/netlink"
 
 	"k8s.io/klog/v2"
@@ -359,31 +358,4 @@ func BridgeToNic(bridge string) error {
 	}
 	klog.Infof("Successfully deleted OVS bridge %q", bridge)
 	return nil
-}
-
-// GetDPUHostInterface returns the host representor interface attached to bridge
-func GetDPUHostInterface(bridgeName string) (string, error) {
-	portsToInterfaces, err := getBridgePortsInterfaces(bridgeName)
-	if err != nil {
-		return "", err
-	}
-
-	for _, ifaces := range portsToInterfaces {
-		for _, iface := range ifaces {
-			stdout, stderr, err := RunOVSVsctl("get", "Interface", strings.TrimSpace(iface), "Name")
-			if err != nil {
-				return "", fmt.Errorf("failed to get Interface %q Name on bridge %q:, stderr: %q, error: %v",
-					iface, bridgeName, stderr, err)
-
-			}
-			flavor, err := GetSriovnetOps().GetRepresentorPortFlavour(stdout)
-			if err == nil && flavor == sriovnet.PORT_FLAVOUR_PCI_PF {
-				// host representor interface found
-				return stdout, nil
-			}
-			continue
-		}
-	}
-	// No host interface found in provided bridge
-	return "", fmt.Errorf("dpu host interface was not found for bridge %q", bridgeName)
 }

--- a/go-controller/pkg/util/sriovnet_linux.go
+++ b/go-controller/pkg/util/sriovnet_linux.go
@@ -185,8 +185,12 @@ func GetNetdevNameFromDeviceId(deviceId string, deviceInfo nadapi.DeviceInfo) (s
 		}
 
 		netdevices, err = GetSriovnetOps().GetNetDevicesFromPci(deviceId)
-	} else { // Auxiliary network device
+	} else if IsAuxDeviceName(deviceId) {
 		netdevices, err = GetSriovnetOps().GetNetDevicesFromAux(deviceId)
+	} else {
+		// In simulated DPU environments the device ID is already the netdev name; return it directly.
+		klog.V(2).Infof("Device ID %s is not PCI/Aux, treating as simulated netdev name", deviceId)
+		return deviceId, nil
 	}
 	if err != nil {
 		return "", err

--- a/go-controller/pkg/util/sriovnet_linux.go
+++ b/go-controller/pkg/util/sriovnet_linux.go
@@ -187,10 +187,12 @@ func GetNetdevNameFromDeviceId(deviceId string, deviceInfo nadapi.DeviceInfo) (s
 		netdevices, err = GetSriovnetOps().GetNetDevicesFromPci(deviceId)
 	} else if IsAuxDeviceName(deviceId) {
 		netdevices, err = GetSriovnetOps().GetNetDevicesFromAux(deviceId)
-	} else {
-		// In simulated DPU environments the device ID is already the netdev name; return it directly.
+	} else if IsSimulatedDPU() {
+		// Simulated DPU: device ID is the opaque netdev name (veth/virtio), not PCI/Aux.
 		klog.V(2).Infof("Device ID %s is not PCI/Aux, treating as simulated netdev name", deviceId)
 		return deviceId, nil
+	} else {
+		return "", fmt.Errorf("cannot determine netdevice for device id %q (expected PCI or auxiliary device address)", deviceId)
 	}
 	if err != nil {
 		return "", err

--- a/go-controller/pkg/util/sriovnet_linux_test.go
+++ b/go-controller/pkg/util/sriovnet_linux_test.go
@@ -94,6 +94,11 @@ func TestIsAuxDeviceName(t *testing.T) {
 			aux:    "not an auxiliary device name",
 			expect: false,
 		},
+		{
+			desc:   "underscores only",
+			aux:    "abc_def_1",
+			expect: false,
+		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -46,7 +46,7 @@ var OvnConflictBackoff = wait.Backoff{
 
 var (
 	rePciDeviceName = regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[01][0-9a-f]\.[0-7]$`)
-	reAuxDeviceName = regexp.MustCompile(`^\w+.\w+.\d+$`)
+	reAuxDeviceName = regexp.MustCompile(`^\w+\.\w+\.\d+$`)
 )
 
 // IsPCIDeviceName check if passed device id is a PCI device name

--- a/go-controller/vendor/github.com/ovn-kubernetes/dpu-simulator/lib/dpusim/LICENSE
+++ b/go-controller/vendor/github.com/ovn-kubernetes/dpu-simulator/lib/dpusim/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/go-controller/vendor/github.com/ovn-kubernetes/dpu-simulator/lib/dpusim/constants.go
+++ b/go-controller/vendor/github.com/ovn-kubernetes/dpu-simulator/lib/dpusim/constants.go
@@ -1,0 +1,48 @@
+// Package dpusim provides shared constants for the DPU simulation
+// environment. Both dpu-sim itself and OVN-Kubernetes import this module
+// so naming conventions stay in sync.
+package dpusim
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Host-to-DPU data interface format strings.
+// Use with fmt.Sprintf(..., index).
+const (
+	HostDataIfFmt = "eth0-%d" // host-side data interface  (e.g. eth0-0, eth0-1)
+	DPUDataIfFmt  = "rep0-%d" // DPU-side representor      (e.g. rep0-0, rep0-1)
+
+	// DPURepresentorFmt builds a representor name from string PF and function
+	// IDs: fmt.Sprintf(DPURepresentorFmt, pfId, funcId) → "rep0-1".
+	DPURepresentorFmt = "rep%s-%s"
+)
+
+// Well-known simulation interfaces and their indices.
+const (
+	HostGatewayInterfaceIndex = 0
+	MgmtPortInterfaceIndex    = 1
+
+	HostGatewayInterface     = "eth0-0" // fmt.Sprintf(HostDataIfFmt, HostGatewayInterfaceIndex)
+	HostGatewayPeerInterface = "rep0-0" // fmt.Sprintf(DPUDataIfFmt, HostGatewayInterfaceIndex)
+	MgmtPortNetDevName       = "eth0-1" // fmt.Sprintf(HostDataIfFmt, MgmtPortInterfaceIndex)
+)
+
+// ReSimulationNetdevFunc matches the trailing <pfId>-<funcId> suffix on
+// simulated interface names (e.g. "eth0-1" → ["eth0-1","0","1"]).
+var ReSimulationNetdevFunc = regexp.MustCompile(`(\d+)-(\d+)$`)
+
+// MacOUI is the locally-administered OUI used for deterministic MACs in
+// simulated DPU environments (QEMU/virtio convention).
+const MacOUI = "52:54:00"
+
+// HostDataIf returns the host-side data interface name for the given index.
+func HostDataIf(index int) string {
+	return fmt.Sprintf(HostDataIfFmt, index)
+}
+
+// DPUDataIf returns the DPU-side representor name for the given index.
+func DPUDataIf(index int) string {
+	return fmt.Sprintf(DPUDataIfFmt, index)
+}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -418,6 +418,9 @@ github.com/openshift/client-go/network/listers/network/v1alpha1
 # github.com/openshift/custom-resource-status v1.1.2
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
+# github.com/ovn-kubernetes/dpu-simulator/lib/dpusim v0.0.0-20260507161134-3aec48e5cb25
+## explicit; go 1.25.0
+github.com/ovn-kubernetes/dpu-simulator/lib/dpusim
 # github.com/ovn-kubernetes/libovsdb v0.8.2-0.20260302130604-c07ce22366ac
 ## explicit; go 1.24.0
 github.com/ovn-kubernetes/libovsdb/cache

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -166,7 +166,7 @@ spec:
         - name: OVN_GATEWAY_MODE
           value: {{ default "shared" .Values.global.gatewayMode }}
         - name: OVN_GATEWAY_OPTS
-          value: {{ default "" .Values.global.gatewayOpts | quote }}
+          value: {{ .Values.gatewayOpts | default .Values.global.gatewayOpts | default "" | quote }}
         - name: OVN_HYBRID_OVERLAY_ENABLE
           value: {{ default "" .Values.global.enableHybridOverlay | quote }}
         - name: OVN_ADMIN_NETWORK_POLICY_ENABLE

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -167,6 +167,10 @@ spec:
           value: {{ default "shared" .Values.global.gatewayMode }}
         - name: OVN_GATEWAY_OPTS
           value: {{ .Values.gatewayOpts | default .Values.global.gatewayOpts | default "" | quote }}
+        - name: OVN_SIMULATE_DPU
+          value: {{ default "false" .Values.global.simulateDpu | quote }}
+        - name: OVN_DPU_HOST_GATEWAY_REPRESENTOR_INTERFACE
+          value: {{ default "" .Values.global.dpuHostGatewayRepresentorInterface | quote }}
         - name: OVN_HYBRID_OVERLAY_ENABLE
           value: {{ default "" .Values.global.enableHybridOverlay | quote }}
         - name: OVN_ADMIN_NETWORK_POLICY_ENABLE

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/values.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/values.yaml
@@ -4,6 +4,10 @@ logFileMaxBackups: 5
 logFileMaxAge: 5
 ovnControllerLogLevel: 4
 
+# Optional gateway options override for the dpu-host daemonset.
+# When set, takes precedence over global.gatewayOpts.
+gatewayOpts: ""
+
 # The netdevice or deviceplugin resourcename that specifies pool of devices
 # that can be used for management ports has to be specified.
 # mgmtPortVFResourceName will override nodeMgmtPortNetdev if both are specified

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -168,6 +168,10 @@ spec:
           value: {{ default "shared" .Values.global.gatewayMode }}
         - name: OVN_GATEWAY_OPTS
           value: {{ default "" .Values.global.gatewayOpts | quote }}
+        - name: OVN_SIMULATE_DPU
+          value: {{ default "false" .Values.global.simulateDpu | quote }}
+        - name: OVN_DPU_HOST_GATEWAY_REPRESENTOR_INTERFACE
+          value: {{ default "" .Values.global.dpuHostGatewayRepresentorInterface | quote }}
         - name: OVN_HYBRID_OVERLAY_ENABLE
           value: {{ default "" .Values.global.enableHybridOverlay | quote }}
         - name: OVN_ADMIN_NETWORK_POLICY_ENABLE

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -322,6 +322,10 @@ spec:
           value: {{ default "shared" .Values.global.gatewayMode }}
         - name: OVN_GATEWAY_OPTS
           value: {{ default "" .Values.global.gatewayOpts | quote }}
+        - name: OVN_SIMULATE_DPU
+          value: {{ default "false" .Values.global.simulateDpu | quote }}
+        - name: OVN_DPU_HOST_GATEWAY_REPRESENTOR_INTERFACE
+          value: {{ default "" .Values.global.dpuHostGatewayRepresentorInterface | quote }}
         - name: OVN_HYBRID_OVERLAY_ENABLE
           value: {{ default "" .Values.global.enableHybridOverlay | quote }}
         - name: OVN_ADMIN_NETWORK_POLICY_ENABLE

--- a/helm/ovn-kubernetes/values-no-ic.yaml
+++ b/helm/ovn-kubernetes/values-no-ic.yaml
@@ -31,6 +31,10 @@ global:
   gatewayMode: shared
   # -- Optional extra gateway options
   gatewayOpts: ""
+  # -- Use simulated DPU operations instead of SR-IOV/switchdev hardware (for Kind/VM-based DPU simulation)
+  simulateDpu: false
+  # -- The DPU-side representor interface for the host's uplink (PF). Required for simulated environments where switchdev metadata is unavailable.
+  dpuHostGatewayRepresentorInterface: ""
   # -- This allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
   unprivilegedMode: false
   # -- The v4 join subnet used for assigning join switch IPv4 addresses
@@ -152,7 +156,7 @@ global:
   # -- Maximum period in seconds for which an IPFIX flow record is cached and aggregated before being sent
   # @default 60
   ipfixCacheActiveTimeout: ""
-  # -- OVN remote probe interval in ms 
+  # -- OVN remote probe interval in ms
   # @default 100000
   remoteProbeInterval: 100000
   # -- Enable monitoring all data from SB DB instead of conditionally monitoring the data relevant to this node only
@@ -161,7 +165,7 @@ global:
   # -- ovn-controller wait time in ms before clearing OpenFlow rules during start up
   # @default 0
   ofctrlWaitBeforeClear: ""
-  # -- Separate log file for libovsdb client 
+  # -- Separate log file for libovsdb client
   libovsdbClientLogFile: ""
   # -- Label for indicating that the node is managing its own network
   noHostSubnetLabel: ""

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -27,6 +27,10 @@ global:
   gatewayMode: shared
   # -- Optional extra gateway options
   gatewayOpts: ""
+  # -- Use simulated DPU operations instead of SR-IOV/switchdev hardware (for Kind/VM-based DPU simulation)
+  simulateDpu: false
+  # -- The DPU-side representor interface for the host's uplink (PF). Required for simulated environments where switchdev metadata is unavailable.
+  dpuHostGatewayRepresentorInterface: ""
   # -- This allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
   unprivilegedMode: false
   # -- The v4 join subnet used for assigning join switch IPv4 addresses

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -33,6 +33,10 @@ global:
   gatewayMode: shared
   # -- Optional extra gateway options
   gatewayOpts: ""
+  # -- Use simulated DPU operations instead of SR-IOV/switchdev hardware (for Kind/VM-based DPU simulation)
+  simulateDpu: false
+  # -- The DPU-side representor interface for the host's uplink (PF). Required for simulated environments where switchdev metadata is unavailable.
+  dpuHostGatewayRepresentorInterface: ""
   # -- This allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
   unprivilegedMode: false
   # -- The v4 join subnet used for assigning join switch IPv4 addresses
@@ -161,7 +165,7 @@ global:
   # -- Maximum period in seconds for which an IPFIX flow record is cached and aggregated before being sent
   # @default 60
   ipfixCacheActiveTimeout: ""
-  # -- OVN remote probe interval in ms 
+  # -- OVN remote probe interval in ms
   # @default 100000
   remoteProbeInterval: 100000
   # -- Enable monitoring all data from SB DB instead of conditionally monitoring the data relevant to this node only
@@ -170,7 +174,7 @@ global:
   # -- ovn-controller wait time in ms before clearing OpenFlow rules during start up
   # @default 0
   ofctrlWaitBeforeClear: ""
-  # -- Separate log file for libovsdb client 
+  # -- Separate log file for libovsdb client
   libovsdbClientLogFile: ""
   image:
     # -- Image repository for ovn-kubernetes components

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/openshift/api v0.0.0-20260311143357-f6ee4c095675 // indirect
 	github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
+	github.com/ovn-kubernetes/dpu-simulator/lib/dpusim v0.0.0-20260507161134-3aec48e5cb25 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -378,6 +378,8 @@ github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d h1:T+9HFgEEcnu
 github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d/go.mod h1:tIA3XSb/WsC/Fg0YNRfs/JrMrloBKPGF+NKVutd7nMI=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
+github.com/ovn-kubernetes/dpu-simulator/lib/dpusim v0.0.0-20260507161134-3aec48e5cb25 h1:uujE+MtjuaWOz1+nt5uwj193CQEXOKR8qzhsRRV7t9o=
+github.com/ovn-kubernetes/dpu-simulator/lib/dpusim v0.0.0-20260507161134-3aec48e5cb25/go.mod h1:fkgl6NeQ4GO+DImnBM1MQKA5fT3BeALC+pOBaNvlVLs=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## 📑 Description
This is a new feature to support DPU simulation using Kind or VMs. Kind uses veths for simulated VF/VFrep pairs. VMs uses virtio & OvS bridges on the host to provide VF/VFrep like connectivity.

## Additional Information for reviewers
 - DPU Host chart: gateway options can be overridden.
 - New dpu-host-gateway-representor-interface: optional netdev added to the external OVS bridge when the gateway is a NIC (bootstrap without a pre-created bridge).
 - SimulateDPU wired through Helm values and DPU node templates; ovnkube.sh passes the flag. SimulateDPU will let OVN-Kubernetes know that it is running in a DPU Simulation
 - Refactor: DPU vs DPU Host mode checks consolidated behind a small helper so the control flow reads more clearly (positive branches).
 -  A New go implementation file dpuops_linux.go adds DPUOps with SwitchdevDPUOps (hardware) vs SimulatedDPUOps (naming pattern *<pfId>-<funcId>). Gateway / management paths use the new DPUOps instead of hard-coding switchdev-DPU-only behavior. A new Config: SimulateDPU selects simulated ops when in DPU or DPU Host mode.
 - DPU CNI path uses GetDPUOps().ResolveDeviceDetails so DeviceID can be PCI (real hardware) or a netdev name (simulation). Management port device manager uses the same resolver when matching allocated devices to annotations. 
 - If DeviceID is not PCI and not a valid aux SF name, it is treated as a netdev (simulated DPU). Aux device regex was fixed so only literal dots match (\w+\.\w+\.\d+, and not “any character”). Stricter parsing (length check), and clearer errors. Test extended for non-matching strings like abc_def_1.

## ✅ Checks
- [N] My code requires changes to the documentation
- [N] if so, I have updated the documentation as required
- [Y] My code requires tests
- [Y] if so, I have added and/or updated the tests as required
- [Y] All the tests have passed in the CI

## How to verify it
The end to end test https://github.com/wizhaoredhat/dpu-sim deploys Kind and OVN-Kubernetes in DPU Host and DPU modes. I then run https://github.com/ovn-kubernetes/kubernetes-traffic-flow-tests on the DPU simulation cluster and this is the test case summary:
```
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: ====== Test Case Summary ======
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: 
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: --- Passing Flows (48) ---
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (1) POD_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 38.043 Gbps, RX Bitrate: 12.638 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (1) POD_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 39.023 Gbps, RX Bitrate: 39.338 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (2) POD_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 17.29 Gbps, RX Bitrate: 5.7442 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (2) POD_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 19.715 Gbps, RX Bitrate: 19.874 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (3) POD_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 36.089 Gbps, RX Bitrate: 35.801 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (3) POD_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 35.2 Gbps, RX Bitrate: 35.484 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (4) POD_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 25.294 Gbps, RX Bitrate: 25.093 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (4) POD_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 28.867 Gbps, RX Bitrate: 29.1 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (5) POD_TO_CLUSTER_IP_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 38.998 Gbps, RX Bitrate: 12.956 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (5) POD_TO_CLUSTER_IP_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 36.296 Gbps, RX Bitrate: 36.588 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (6) POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 16.076 Gbps, RX Bitrate: 5.3413 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (6) POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 17.971 Gbps, RX Bitrate: 18.115 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (7) POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 35.488 Gbps, RX Bitrate: 11.79 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (7) POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 34.992 Gbps, RX Bitrate: 35.274 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (8) POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 25.023 Gbps, RX Bitrate: 8.3133 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (8) POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 24.602 Gbps, RX Bitrate: 24.8 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (9) POD_TO_NODE_PORT_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 43.303 Gbps, RX Bitrate: 42.957 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (9) POD_TO_NODE_PORT_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 36.619 Gbps, RX Bitrate: 36.914 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (10) POD_TO_NODE_PORT_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 12.94 Gbps, RX Bitrate: 12.837 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (10) POD_TO_NODE_PORT_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 19.258 Gbps, RX Bitrate: 19.413 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (11) POD_TO_NODE_PORT_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 35.243 Gbps, RX Bitrate: 11.709 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (11) POD_TO_NODE_PORT_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 35.274 Gbps, RX Bitrate: 35.558 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (12) POD_TO_NODE_PORT_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 31.694 Gbps, RX Bitrate: 31.442 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (12) POD_TO_NODE_PORT_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 25.167 Gbps, RX Bitrate: 25.37 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (13) HOST_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 71.218 Gbps, RX Bitrate: 70.648 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (13) HOST_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 66.169 Gbps, RX Bitrate: 66.703 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (14) HOST_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 47.662 Gbps, RX Bitrate: 15.834 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (14) HOST_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 47.025 Gbps, RX Bitrate: 47.404 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (15) HOST_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 35.804 Gbps, RX Bitrate: 11.903 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (15) HOST_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 35.609 Gbps, RX Bitrate: 35.896 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (16) HOST_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 14.212 Gbps, RX Bitrate: 14.098 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (16) HOST_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 16.547 Gbps, RX Bitrate: 16.68 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (17) HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 30.103 Gbps, RX Bitrate: 10.001 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (17) HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 28.679 Gbps, RX Bitrate: 28.911 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (18) HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 12.12 Gbps, RX Bitrate: 12.024 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (18) HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 14.424 Gbps, RX Bitrate: 14.539 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (19) HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 27.449 Gbps, RX Bitrate: 9.1194 Gbps, succeeded
2026-04-16 16:14:25.926 INFO    [th:140175849270784]: Test ID: (19) HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 26.56 Gbps, RX Bitrate: 26.774 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (20) HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 24.785 Gbps, RX Bitrate: 8.2344 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (20) HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 23.895 Gbps, RX Bitrate: 24.087 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (21) HOST_TO_NODE_PORT_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 31.892 Gbps, RX Bitrate: 31.637 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (21) HOST_TO_NODE_PORT_TO_POD_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 28.785 Gbps, RX Bitrate: 29.017 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (22) HOST_TO_NODE_PORT_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 11.403 Gbps, RX Bitrate: 11.312 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (22) HOST_TO_NODE_PORT_TO_POD_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 14.571 Gbps, RX Bitrate: 14.688 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (23) HOST_TO_NODE_PORT_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 27.314 Gbps, RX Bitrate: 27.097 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (23) HOST_TO_NODE_PORT_TO_HOST_SAME_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 26.681 Gbps, RX Bitrate: 26.896 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (24) HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: false, TX Bitrate: 24.365 Gbps, RX Bitrate: 8.0946 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Test ID: (24) HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE, Test Type: IPERF_TCP, Reverse: true, TX Bitrate: 23.929 Gbps, RX Bitrate: 24.122 Gbps, succeeded
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: 
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: --- Failing Flows (0) ---
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: 
2026-04-16 16:14:25.927 INFO    [th:140175849270784]: Cleaning pods and services with label tft-tests in namespace default
2026-04-16 16:14:26.007 INFO    [th:140175849270784]: Cleaning multi-networkpolicies and admin-networkpolicies with label tft-tests in namespace default
2026-04-16 16:14:26.180 INFO    [th:140175849270784]: Cleaning external containers external-perf-server (if present)
2026-04-16 16:14:26.203 INFO    [th:140175849270784]: test completed with success (duration: 00:08:41.2105)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulated DPU mode for testing without physical DPU hardware
  * DPU operations abstraction to support simulated and hardware paths

* **Configuration Changes**
  * New flags/Helm values to enable simulated DPU and set gateway representor interface
  * DaemonSet env vars added for simulation and representor config

* **Improvements**
  * Unified mode detection for consistent behavior across node modes
  * More robust device/representor resolution and clearer auxiliary-device validation

* **Tests**
  * Added test for simulated-DPU management port creation

* **CI**
  * New DPU Offload GitHub Actions workflow for end-to-end testing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->