### PR TITLE
CI: Free ~17G more disk space to prevent KubeVirt e2e failures

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -12,6 +12,12 @@ runs:
         echo "=== Remove Android SDK ==="
         sudo rm -rf /usr/local/lib/android/sdk
 
+        echo "=== Remove unused toolchains ==="
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /opt/az
+
         echo "=== Apt cleanup ==="
         sudo apt-get update
         if command -v eatmydata >/dev/null 2>&1; then


### PR DESCRIPTION
## 📑 Description

Remove unused pre-installed toolchains (.NET SDK, Haskell/GHC, Swift, Azure CLI leftovers)
from the \`free-disk-space\` CI action, freeing ~17G of additional disk space on GitHub-hosted
runners to prevent KubeVirt e2e test failures caused by disk exhaustion.

_If PR is about \`failing-tests or flakes\`, please post the related issues/tests in a comment and do not use \`Fixes\`_

Related failing CI run: https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/24576050962/job/71862658423?pr=6246

## Additional Information for reviewers

KubeVirt live migration e2e tests (\`kv-live-migration\` jobs) hit disk space exhaustion on the
72G GitHub runners. The existing cleanup frees ~17G (Android SDK + swap), but the 4-node KIND
cluster with KubeVirt VM images needs ~35G. After cleanup only ~13G of headroom remained, and
the first VM creation + image preloading consumed that within 7 minutes, leaving **60 MB free**
and causing all subsequent live migration tests to stall with 600s timeout failures.

Evidence from a [recent CI run](https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/24576050962/job/71862658423?pr=6246):

| Time | Event | Free Space |
|------|-------|-----------|
| 16:59 | After current cleanup | 35G |
| 17:08 | KIND cluster + images loaded | 13G |
| 17:15 | First VM created → **disk full** | **60 MB** |

This PR removes directories not used by any ovn-kubernetes CI job:

| Directory | Size | What |
|-----------|------|------|
| \`/usr/share/dotnet\` | 4.6G | .NET SDK & runtime |
| \`/usr/local/.ghcup\` | 3.7G | Haskell toolchain (GHC) |
| \`/usr/share/swift\` | 3.3G | Swift language toolchain |
| \`/opt/az\` | ~0.5G | Azure CLI leftover dirs |
| **Total** | **~17G** | |

This brings post-cleanup free space from ~35G to ~50G, leaving ~30G of headroom after KIND
cluster setup — more than enough for the ~7G growth during KubeVirt VM operations.

Only \`.github/actions/free-disk-space/action.yml\` is changed.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

1. Check that the \`free-disk-space\` step in CI logs now shows the additional
   "Remove unused toolchains" section and reports more free space after cleanup (~50G vs ~35G).
2. Verify KubeVirt e2e jobs (\`kv-live-migration\`) no longer fail with disk exhaustion
   (no \`running out of disk space\` warnings, no 600s migration timeouts).
3. \`rm -rf\` on non-existent paths is a no-op, so this is safe on runners that may not have
   all of these directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI cleanup to remove additional unused toolchains and runtimes, freeing more disk space.
  * Adjusted cleanup sequence to run these removals earlier, improving overall build environment efficiency and reducing leftover artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->