### PR TITLE
Fix namespace handle leak in VRF manager

### DIFF
--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -83,11 +83,19 @@ func (vrfm *Controller) runInternal(stopChan <-chan struct{}, doneWg *sync.WaitG
 	}
 	subscribed, linkUpdateCh, err := subscribe()
 	if err != nil {
+		if closeErr := currentNs.Close(); closeErr != nil {
+			klog.Warningf("VRF Manager: failed to close namespace handle: %v", closeErr)
+		}
 		return fmt.Errorf("error during netlink subscribe, err: %v", err)
 	}
 	doneWg.Add(1)
 	go func() {
 		defer doneWg.Done()
+		defer func() {
+			if err := currentNs.Close(); err != nil {
+				klog.Warningf("VRF Manager: failed to close namespace handle: %v", err)
+			}
+		}()
 		err = currentNs.Do(func(_ ns.NetNS) error {
 			linkSyncTimer := time.NewTicker(reconcilePeriod)
 			defer linkSyncTimer.Stop()


### PR DESCRIPTION
VRF manager can leak file descriptors by not closing the namespace handle returned by ns.GetCurrentNS(). This adds proper cleanup using defer to ensure the handle is closed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
This PR fixes a file descriptor leak in the VRF manager where the namespace handle returned by `ns.GetCurrentNS()` is never closed. this change add proper cleanup using defer to ensure the namespace handle is closed when the function exits.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers

example reference-

https://github.com/containernetworking/plugins/blob/main/pkg/ns/ns_linux.go#L253-L258


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a resource leak by ensuring network namespace handles are reliably closed during related background operations.
  * Failures encountered when closing these handles are now recorded as warnings to aid diagnostics.
  * Improves runtime stability and reduces long-running resource consumption under error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->