### PR TITLE
Add condition metrics for RA, CUDN, and VTEP resources

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -17,6 +17,7 @@ Measurement accuracy can be impacted by other parallel processing that might be 
 ## Change log
 This list is to help notify if there are additions, changes or removals to metrics. Latest changes are at the top of this list.
 
+- Add `ovnkube_clustermanager_route_advertisement_condition`, `ovnkube_clustermanager_cluster_user_defined_network_condition`, and `ovnkube_clustermanager_vtep_condition` condition metrics
 - Add `transport` label to `ovnkube_clustermanager_cluster_user_defined_networks` to distinguish CUDNs by transport type (Default, EVPN, NoOverlay)
 - Add metrics to track logfile size for ovnkube processes - ovnkube_node_logfile_size_bytes and ovnkube_controller_logfile_size_bytes
 - Remove ovnkube_controller_ovn_cli_latency_seconds metrics since we have moved most of the OVN DB operations to libovsdb.

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -1404,12 +1404,6 @@ func (c *Controller) updateRAStatus(ra *ratypes.RouteAdvertisements, hadUpdates 
 		cstatus = metav1.ConditionFalse
 	}
 
-	// Always record the metric, even if we skip the API update.
-	// This ensures the metric is correct after leader restarts when the informer
-	// fires synthetic creates and the existing condition hasn't changed.
-	// This relies on RecordRouteAdvertisementCondition being cheap (in-memory only, no I/O).
-	metrics.RecordRouteAdvertisementCondition(ra.Name, conditionTypeAccepted, cstatus)
-
 	var updateStatus bool
 	condition := meta.FindStatusCondition(ra.Status.Conditions, conditionTypeAccepted)
 	switch {
@@ -1423,6 +1417,10 @@ func (c *Controller) updateRAStatus(ra *ratypes.RouteAdvertisements, hadUpdates 
 		updateStatus = true
 	}
 	if !updateStatus {
+		// Record the metric from the existing API-confirmed condition so it is
+		// populated after controller restarts, where the informer fires synthetic
+		// creates for all RAs but the condition hasn't changed.
+		metrics.RecordRouteAdvertisementCondition(ra.Name, conditionTypeAccepted, cstatus)
 		return nil
 	}
 
@@ -1462,6 +1460,7 @@ func (c *Controller) updateRAStatus(ra *ratypes.RouteAdvertisements, hadUpdates 
 	if err != nil {
 		return fmt.Errorf("failed to apply status for RouteAdvertisements %q: %w", ra.Name, err)
 	}
+	metrics.RecordRouteAdvertisementCondition(ra.Name, conditionTypeAccepted, cstatus)
 
 	return nil
 }

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -46,14 +46,16 @@ import (
 	vteplisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/listers/vtep/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 const (
-	generateName = "ovnk-generated-"
-	fieldManager = "clustermanager-routeadvertisements-controller"
+	generateName          = "ovnk-generated-"
+	fieldManager          = "clustermanager-routeadvertisements-controller"
+	conditionTypeAccepted = "Accepted"
 	// rawConfigPriority is set to an arbitrary value that still allows users to
 	// override if needed.
 	rawConfigPriority = 10
@@ -282,6 +284,10 @@ func (c *Controller) reconcile(name string) error {
 	ra, err := c.raLister.Get(name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get RouteAdvertisements %q: %w", name, err)
+	}
+
+	if ra == nil {
+		metrics.DeleteRouteAdvertisementCondition(name)
 	}
 
 	hadUpdates, err := c.reconcileRouteAdvertisements(name, ra)
@@ -1393,8 +1399,19 @@ func (c *Controller) updateRAStatus(ra *ratypes.RouteAdvertisements, hadUpdates 
 		return nil
 	}
 
+	cstatus := metav1.ConditionTrue
+	if err != nil {
+		cstatus = metav1.ConditionFalse
+	}
+
+	// Always record the metric, even if we skip the API update.
+	// This ensures the metric is correct after leader restarts when the informer
+	// fires synthetic creates and the existing condition hasn't changed.
+	// This relies on RecordRouteAdvertisementCondition being cheap (in-memory only, no I/O).
+	metrics.RecordRouteAdvertisementCondition(ra.Name, conditionTypeAccepted, cstatus)
+
 	var updateStatus bool
-	condition := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
+	condition := meta.FindStatusCondition(ra.Status.Conditions, conditionTypeAccepted)
 	switch {
 	case condition == nil:
 		fallthrough
@@ -1410,12 +1427,10 @@ func (c *Controller) updateRAStatus(ra *ratypes.RouteAdvertisements, hadUpdates 
 	}
 
 	status := "Accepted"
-	cstatus := metav1.ConditionTrue
 	reason := "Accepted"
 	msg := "ovn-kubernetes cluster-manager validated the resource and requested the necessary configuration changes"
 	if err != nil {
 		status = fmt.Sprintf("Not Accepted: %v", err)
-		cstatus = metav1.ConditionFalse
 		msg = err.Error()
 		switch {
 		case errors.Is(err, errConfig):
@@ -1432,7 +1447,7 @@ func (c *Controller) updateRAStatus(ra *ratypes.RouteAdvertisements, hadUpdates 
 		raapply.RouteAdvertisements(ra.Name).WithStatus(
 			raapply.RouteAdvertisementsStatus().WithStatus(status).WithConditions(
 				metaapply.Condition().
-					WithType("Accepted").
+					WithType(conditionTypeAccepted).
 					WithStatus(cstatus).
 					WithLastTransitionTime(metav1.NewTime(time.Now())).
 					WithReason(reason).

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 
 	corev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/api/meta"
@@ -2442,15 +2441,15 @@ exit
 					expectedTrue = 1.0
 					expectedFalse = 0.0
 				}
-				valTrue, found := getRAConditionMetricValue(t, tt.reconcile, "Accepted", "true")
+				valTrue, found := getRAConditionMetricValue(tt.reconcile, "Accepted", "true")
 				g.Expect(found).To(gomega.BeTrue(), "condition metric status=true should exist")
 				g.Expect(valTrue).To(gomega.Equal(expectedTrue))
-				valFalse, found := getRAConditionMetricValue(t, tt.reconcile, "Accepted", "false")
+				valFalse, found := getRAConditionMetricValue(tt.reconcile, "Accepted", "false")
 				g.Expect(found).To(gomega.BeTrue(), "condition metric status=false should exist")
 				g.Expect(valFalse).To(gomega.Equal(expectedFalse))
 			} else {
-				_, foundTrue := getRAConditionMetricValue(t, tt.reconcile, "Accepted", "true")
-				_, foundFalse := getRAConditionMetricValue(t, tt.reconcile, "Accepted", "false")
+				_, foundTrue := getRAConditionMetricValue(tt.reconcile, "Accepted", "true")
+				_, foundFalse := getRAConditionMetricValue(tt.reconcile, "Accepted", "false")
 				g.Expect(foundTrue || foundFalse).To(gomega.BeFalse(), "condition metrics should not exist for deleted RA")
 			}
 
@@ -2869,44 +2868,7 @@ func TestUpdates(t *testing.T) {
 	}
 }
 
-func findMetricFamily(t *testing.T, name string) *dto.MetricFamily {
-	t.Helper()
-	mfs, err := prometheus.DefaultGatherer.Gather()
-	if err != nil {
-		t.Fatalf("failed to gather metrics: %v", err)
-	}
-	for _, mf := range mfs {
-		if mf.GetName() == name {
-			return mf
-		}
-	}
-	return nil
-}
-
-func getRAConditionMetricValue(t *testing.T, nameLabel, conditionLabel, statusLabel string) (float64, bool) {
-	t.Helper()
+func getRAConditionMetricValue(nameLabel, conditionLabel, statusLabel string) (float64, bool) {
 	metricName := prometheus.BuildFQName(types.MetricOvnkubeNamespace, types.MetricOvnkubeSubsystemClusterManager, "route_advertisement_condition")
-	mf := findMetricFamily(t, metricName)
-	if mf == nil {
-		return 0, false
-	}
-	for _, metric := range mf.GetMetric() {
-		if labelValue(metric.GetLabel(), "name") == nameLabel &&
-			labelValue(metric.GetLabel(), "condition") == conditionLabel &&
-			labelValue(metric.GetLabel(), "status") == statusLabel {
-			if metric.GetGauge() != nil {
-				return metric.GetGauge().GetValue(), true
-			}
-		}
-	}
-	return 0, false
-}
-
-func labelValue(labels []*dto.LabelPair, name string) string {
-	for _, label := range labels {
-		if label.GetName() == name {
-			return label.GetValue()
-		}
-	}
-	return ""
+	return ovntest.GetConditionMetricValue(metricName, nameLabel, conditionLabel, statusLabel)
 }

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -21,6 +21,8 @@ import (
 	frrfake "github.com/metallb/frr-k8s/pkg/client/clientset/versioned/fake"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 
 	corev1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/api/meta"
@@ -41,6 +43,7 @@ import (
 	userdefinednetworkv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -497,6 +500,11 @@ func init() {
 	// an old codegen and the informer has no shutdown method)
 	config.IPv4Mode = true
 
+	// Set feature flags before any test calls RegisterClusterManagerFunctional().
+	// The sync.Once in registration captures whichever flags are set on the first call.
+	config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+	config.OVNKubernetesFeature.EnableEVPN = true
+
 	// Disable WatchListClient feature gate for tests.
 	// Fake clientsets from third-party libraries don't yet support WatchList semantics
 	// introduced in K8s 1.35, causing informers to hang waiting for bookmark events.
@@ -505,6 +513,8 @@ func init() {
 }
 
 func TestController_reconcile(t *testing.T) {
+	metrics.RegisterClusterManagerFunctional()
+
 	frrNamespace := "frrNamespace"
 	tests := []struct {
 		name                 string
@@ -2410,17 +2420,38 @@ exit
 			// we just need the inital sync
 			nm.Stop()
 
+			// Clean up condition metric timeseries from the global Prometheus registry
+			// so they don't leak into subsequent subtests.
+			t.Cleanup(func() { metrics.DeleteRouteAdvertisementCondition(tt.reconcile) })
+
 			if err := c.reconcile(tt.reconcile); (err != nil) != tt.wantErr {
 				t.Fatalf("Controller.reconcile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			// verify RA status is set as expected
+			// verify RA status and condition metric are set as expected
 			if tt.ra != nil {
 				ra, err := fakeClientset.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Get(context.Background(), tt.reconcile, metav1.GetOptions{})
 				g.Expect(err).ToNot(gomega.HaveOccurred())
 				accepted := meta.FindStatusCondition(ra.Status.Conditions, "Accepted")
 				g.Expect(accepted).NotTo(gomega.BeNil())
 				g.Expect(accepted.Status).To(gomega.Equal(tt.expectAcceptedStatus), accepted.Message)
+				// verify condition metric is set as expected
+				expectedTrue := 0.0
+				expectedFalse := 1.0
+				if tt.expectAcceptedStatus == metav1.ConditionTrue {
+					expectedTrue = 1.0
+					expectedFalse = 0.0
+				}
+				valTrue, found := getRAConditionMetricValue(t, tt.reconcile, "Accepted", "true")
+				g.Expect(found).To(gomega.BeTrue(), "condition metric status=true should exist")
+				g.Expect(valTrue).To(gomega.Equal(expectedTrue))
+				valFalse, found := getRAConditionMetricValue(t, tt.reconcile, "Accepted", "false")
+				g.Expect(found).To(gomega.BeTrue(), "condition metric status=false should exist")
+				g.Expect(valFalse).To(gomega.Equal(expectedFalse))
+			} else {
+				_, foundTrue := getRAConditionMetricValue(t, tt.reconcile, "Accepted", "true")
+				_, foundFalse := getRAConditionMetricValue(t, tt.reconcile, "Accepted", "false")
+				g.Expect(foundTrue || foundFalse).To(gomega.BeFalse(), "condition metrics should not exist for deleted RA")
 			}
 
 			// verify FRRConfigurations have been created/updated/deleted as expected
@@ -2836,4 +2867,46 @@ func TestUpdates(t *testing.T) {
 			g.Consistently(matchReconciledRAs).WithArguments(tt.expectedReconcile).Should(gomega.Succeed())
 		})
 	}
+}
+
+func findMetricFamily(t *testing.T, name string) *dto.MetricFamily {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	return nil
+}
+
+func getRAConditionMetricValue(t *testing.T, nameLabel, conditionLabel, statusLabel string) (float64, bool) {
+	t.Helper()
+	metricName := prometheus.BuildFQName(types.MetricOvnkubeNamespace, types.MetricOvnkubeSubsystemClusterManager, "route_advertisement_condition")
+	mf := findMetricFamily(t, metricName)
+	if mf == nil {
+		return 0, false
+	}
+	for _, metric := range mf.GetMetric() {
+		if labelValue(metric.GetLabel(), "name") == nameLabel &&
+			labelValue(metric.GetLabel(), "condition") == conditionLabel &&
+			labelValue(metric.GetLabel(), "status") == statusLabel {
+			if metric.GetGauge() != nil {
+				return metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func labelValue(labels []*dto.LabelPair, name string) string {
+	for _, label := range labels {
+		if label.GetName() == name {
+			return label.GetValue()
+		}
+	}
+	return ""
 }

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -306,7 +306,6 @@ func (c *Controller) initializeController() error {
 
 	c.initializeNamespaceTracker(cudnNADs)
 	c.seedCUDNCountMetrics(cudnNADs)
-	seedCUDNConditionMetrics(cudnNADs)
 
 	if util.IsEVPNEnabled() {
 		// Recover VID allocations from existing EVPN CUDNs.
@@ -1093,6 +1092,10 @@ func (c *Controller) updateClusterUDNStatus(cudn *userdefinednetworkv1.ClusterUs
 
 	// Apply status if either NetworkCreated or TransportAccepted condition changed
 	if !networkCreatedOrUpdated && !transportUpdated {
+		// Record the metric from the existing API-confirmed conditions so it is
+		// populated after controller restarts, where the informer fires synthetic
+		// creates for all CUDNs but the conditions haven't changed.
+		recordCUDNConditionMetrics(cudn)
 		return nil
 	}
 	conditionsApply := make([]*metaapplyv1.ConditionApplyConfiguration, len(cudn.Status.Conditions))

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -306,6 +306,7 @@ func (c *Controller) initializeController() error {
 
 	c.initializeNamespaceTracker(cudnNADs)
 	c.seedCUDNCountMetrics(cudnNADs)
+	seedCUDNConditionMetrics(cudnNADs)
 
 	if util.IsEVPNEnabled() {
 		// Recover VID allocations from existing EVPN CUDNs.
@@ -973,6 +974,7 @@ func (c *Controller) syncClusterUDN(cudn *userdefinednetworkv1.ClusterUserDefine
 			klog.Infof("Finalizer removed from ClusterUserDefinedNetwork %q", cudn.Name)
 			delete(c.namespaceTracker, cudnName)
 			c.cudnMetricUncounted(cudnName, &cudn.Spec.Network)
+			metrics.DeleteCUDNCondition(cudnName)
 			metrics.DeleteDynamicUDNNodeCount(util.GenerateCUDNNetworkName(cudn.Name))
 			c.releaseEVPNIDsForNetwork(cudnName)
 		}
@@ -1117,6 +1119,7 @@ func (c *Controller) updateClusterUDNStatus(cudn *userdefinednetworkv1.ClusterUs
 		return fmt.Errorf("failed to update ClusterUserDefinedNetwork status %q: %w", cudnName, err)
 	}
 	klog.Infof("Updated status ClusterUserDefinedNetwork %q", cudn.Name)
+	recordCUDNConditionMetrics(cudn)
 
 	return nil
 }

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_metrics.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_metrics.go
@@ -100,3 +100,33 @@ func cudnMetricLabels(spec *userdefinednetworkv1.NetworkSpec) (role, topology, t
 	}
 	return
 }
+
+// cudnMetricConditions is the set of conditions that are recorded as metrics.
+var cudnMetricConditions = sets.New(
+	conditionTypeNetworkCreated,
+	conditionTypeTransportAccepted,
+)
+
+// seedCUDNConditionMetrics establishes correct condition metric baselines from
+// existing CUDNs at startup, so the metrics are populated after leader restarts
+// without waiting for a condition transition.
+func seedCUDNConditionMetrics(cudnNADs cudnToNADs) {
+	for _, entry := range cudnNADs {
+		if !controllerutil.ContainsFinalizer(entry.cudn, template.FinalizerUserDefinedNetwork) {
+			continue
+		}
+		recordCUDNConditionMetrics(entry.cudn)
+	}
+}
+
+// recordCUDNConditionMetrics records condition metrics for a CUDN that is not being deleted.
+func recordCUDNConditionMetrics(cudn *userdefinednetworkv1.ClusterUserDefinedNetwork) {
+	if cudn == nil || !cudn.DeletionTimestamp.IsZero() {
+		return
+	}
+	for _, condition := range cudn.Status.Conditions {
+		if cudnMetricConditions.Has(condition.Type) {
+			metrics.RecordCUDNCondition(cudn.Name, condition.Type, condition.Status)
+		}
+	}
+}

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_metrics.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_metrics.go
@@ -104,20 +104,8 @@ func cudnMetricLabels(spec *userdefinednetworkv1.NetworkSpec) (role, topology, t
 // cudnMetricConditions is the set of conditions that are recorded as metrics.
 var cudnMetricConditions = sets.New(
 	conditionTypeNetworkCreated,
-	conditionTypeTransportAccepted,
+	ConditionTypeTransportAccepted,
 )
-
-// seedCUDNConditionMetrics establishes correct condition metric baselines from
-// existing CUDNs at startup, so the metrics are populated after leader restarts
-// without waiting for a condition transition.
-func seedCUDNConditionMetrics(cudnNADs cudnToNADs) {
-	for _, entry := range cudnNADs {
-		if !controllerutil.ContainsFinalizer(entry.cudn, template.FinalizerUserDefinedNetwork) {
-			continue
-		}
-		recordCUDNConditionMetrics(entry.cudn)
-	}
-}
 
 // recordCUDNConditionMetrics records condition metrics for a CUDN that is not being deleted.
 func recordCUDNConditionMetrics(cudn *userdefinednetworkv1.ClusterUserDefinedNetwork) {

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -15,7 +15,6 @@ import (
 	netv1clientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	netv1fakeclientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,6 +40,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 
@@ -3192,57 +3192,21 @@ func setNADEVPNVIDs(nad *netv1.NetworkAttachmentDefinition, macVID, ipVID int) e
 // getCUDNCountMetricValue returns the current gauge value for the CUDN count metric with the given labels.
 func getCUDNCountMetricValue(role, topology, transport string) (float64, bool) {
 	metricName := prometheus.BuildFQName(ovntypes.MetricOvnkubeNamespace, ovntypes.MetricOvnkubeSubsystemClusterManager, "cluster_user_defined_networks")
-	mf := findMetricFamily(metricName)
+	mf := ovntest.FindMetricFamily(metricName)
 	if mf == nil {
 		return 0, false
 	}
 	for _, metric := range mf.GetMetric() {
-		if metricLabelValue(metric.GetLabel(), "role") == role &&
-			metricLabelValue(metric.GetLabel(), "topology") == topology &&
-			metricLabelValue(metric.GetLabel(), "transport") == transport {
+		if ovntest.MetricLabelValue(metric.GetLabel(), "role") == role &&
+			ovntest.MetricLabelValue(metric.GetLabel(), "topology") == topology &&
+			ovntest.MetricLabelValue(metric.GetLabel(), "transport") == transport {
 			return metric.GetGauge().GetValue(), true
 		}
 	}
 	return 0, false
 }
 
-// findMetricFamily returns the MetricFamily with the given name from the default Prometheus gatherer.
-func findMetricFamily(name string) *dto.MetricFamily {
-	GinkgoHelper()
-	mfs, err := prometheus.DefaultGatherer.Gather()
-	Expect(err).NotTo(HaveOccurred(), "failed to gather metrics")
-	for _, mf := range mfs {
-		if mf.GetName() == name {
-			return mf
-		}
-	}
-	return nil
-}
-
 func getCUDNConditionMetricValue(nameLabel, conditionLabel, statusLabel string) (float64, bool) {
 	metricName := prometheus.BuildFQName(ovntypes.MetricOvnkubeNamespace, ovntypes.MetricOvnkubeSubsystemClusterManager, "cluster_user_defined_network_condition")
-	mf := findMetricFamily(metricName)
-	if mf == nil {
-		return 0, false
-	}
-	for _, metric := range mf.GetMetric() {
-		if metricLabelValue(metric.GetLabel(), "name") == nameLabel &&
-			metricLabelValue(metric.GetLabel(), "condition") == conditionLabel &&
-			metricLabelValue(metric.GetLabel(), "status") == statusLabel {
-			if metric.GetGauge() != nil {
-				return metric.GetGauge().GetValue(), true
-			}
-		}
-	}
-	return 0, false
-}
-
-// metricLabelValue returns the value of the label with the given name, or empty string if not found.
-func metricLabelValue(labels []*dto.LabelPair, name string) string {
-	for _, label := range labels {
-		if label.GetName() == name {
-			return label.GetValue()
-		}
-	}
-	return ""
+	return ovntest.GetConditionMetricValue(metricName, nameLabel, conditionLabel, statusLabel)
 }

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -2600,6 +2601,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			cudn.Finalizers = nil
 			c = newTestController(template.RenderNetAttachDefManifest, cudn, testNs)
 			Expect(c.Run()).To(Succeed())
+			DeferCleanup(metrics.DeleteCUDNCondition, cudn.Name)
 
 			Eventually(func() []metav1.Condition {
 				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
@@ -2628,6 +2630,7 @@ var _ = Describe("User Defined Network Controller", func() {
 
 			c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 			Expect(c.Run()).To(Succeed())
+			DeferCleanup(metrics.DeleteCUDNCondition, cudn.Name)
 
 			Eventually(func() []metav1.Condition {
 				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
@@ -2651,6 +2654,7 @@ var _ = Describe("User Defined Network Controller", func() {
 			cudn.Finalizers = nil
 			c = newTestController(template.RenderNetAttachDefManifest, cudn, testNs)
 			Expect(c.Run()).To(Succeed())
+			DeferCleanup(metrics.DeleteCUDNCondition, cudn.Name)
 
 			Eventually(func() []metav1.Condition {
 				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
@@ -2673,6 +2677,86 @@ var _ = Describe("User Defined Network Controller", func() {
 				val, _ := getCUDNCountMetricValue("Secondary", "Layer2", "Default")
 				return val
 			}).Should(Equal(expected), "CUDN count metric should decrement by exactly one after deletion")
+		})
+
+		It("should record NetworkCreated=True condition metric on successful CUDN creation", func() {
+			testNs := testNamespace("cond-ns")
+			cudn := testLayer2SecondaryClusterUDN("cond-cudn", testNs.Name)
+
+			c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs)
+			Expect(c.Run()).To(Succeed())
+			DeferCleanup(metrics.DeleteCUDNCondition, cudn.Name)
+
+			Eventually(func(g Gomega) {
+				cudn, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(normalizeConditions(filterTransportConditions(cudn.Status.Conditions))).To(Equal([]metav1.Condition{{
+					Type:    "NetworkCreated",
+					Status:  "True",
+					Reason:  "NetworkAttachmentDefinitionCreated",
+					Message: "NetworkAttachmentDefinition has been created in following namespaces: [cond-ns]",
+				}}))
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				val, found := getCUDNConditionMetricValue(cudn.Name, "NetworkCreated", "true")
+				g.Expect(found).To(BeTrue(), "condition metric should exist")
+				g.Expect(val).To(Equal(1.0))
+				valFalse, foundFalse := getCUDNConditionMetricValue(cudn.Name, "NetworkCreated", "false")
+				g.Expect(foundFalse).To(BeTrue(), "condition metric status=false should exist")
+				g.Expect(valFalse).To(Equal(0.0))
+			}).Should(Succeed(), "NetworkCreated condition metrics should be recorded")
+		})
+
+		It("should remove condition metrics on CUDN deletion", func() {
+			testNs := testNamespace("cond-del-ns")
+			cudn := testLayer2SecondaryClusterUDN("cond-del-cudn", testNs.Name)
+
+			c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs)
+			Expect(c.Run()).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				val, found := getCUDNConditionMetricValue(cudn.Name, "NetworkCreated", "true")
+				g.Expect(found).To(BeTrue(), "condition metric should exist")
+				g.Expect(val).To(Equal(1.0))
+			}).Should(Succeed(), "NetworkCreated condition metric status=true should be 1 after creation")
+
+			markCUDNForDeletion(cudn.Name)
+
+			Eventually(func() bool {
+				_, foundTrue := getCUDNConditionMetricValue(cudn.Name, "NetworkCreated", "true")
+				_, foundFalse := getCUDNConditionMetricValue(cudn.Name, "NetworkCreated", "false")
+				return foundTrue || foundFalse
+			}).Should(BeFalse(), "both condition metric timeseries should be removed after deletion")
+		})
+
+		It("should record TransportAccepted condition metric for EVPN CUDN with accepted RA", func() {
+			testNs := testNamespace("cond-evpn-ns")
+			vtep := testVTEP("cond-vtep")
+			cudn := testEVPNClusterUDN("cond-evpn-cudn", vtep.Name, testNs.Name)
+
+			c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
+			Expect(c.Run()).To(Succeed())
+			DeferCleanup(metrics.DeleteCUDNCondition, cudn.Name)
+
+			createAcceptedRA("cond-ra", cudn.Labels)
+
+			Eventually(func(g Gomega) {
+				cudnObj, err := cs.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Get(context.Background(), cudn.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				tc := meta.FindStatusCondition(cudnObj.Status.Conditions, "TransportAccepted")
+				g.Expect(tc).NotTo(BeNil(), "TransportAccepted condition should exist")
+				g.Expect(tc.Status).To(Equal(metav1.ConditionTrue))
+			}).Should(Succeed(), "TransportAccepted status condition should be True")
+
+			Eventually(func(g Gomega) {
+				valTrue, found := getCUDNConditionMetricValue(cudn.Name, "TransportAccepted", "true")
+				g.Expect(found).To(BeTrue(), "condition metric status=true should exist")
+				g.Expect(valTrue).To(Equal(1.0))
+				valFalse, foundFalse := getCUDNConditionMetricValue(cudn.Name, "TransportAccepted", "false")
+				g.Expect(foundFalse).To(BeTrue(), "condition metric status=false should exist")
+				g.Expect(valFalse).To(Equal(0.0))
+			}).Should(Succeed(), "TransportAccepted condition metrics should be recorded")
 		})
 
 	})
@@ -3133,6 +3217,24 @@ func findMetricFamily(name string) *dto.MetricFamily {
 		}
 	}
 	return nil
+}
+
+func getCUDNConditionMetricValue(nameLabel, conditionLabel, statusLabel string) (float64, bool) {
+	metricName := prometheus.BuildFQName(ovntypes.MetricOvnkubeNamespace, ovntypes.MetricOvnkubeSubsystemClusterManager, "cluster_user_defined_network_condition")
+	mf := findMetricFamily(metricName)
+	if mf == nil {
+		return 0, false
+	}
+	for _, metric := range mf.GetMetric() {
+		if metricLabelValue(metric.GetLabel(), "name") == nameLabel &&
+			metricLabelValue(metric.GetLabel(), "condition") == conditionLabel &&
+			metricLabelValue(metric.GetLabel(), "status") == statusLabel {
+			if metric.GetGauge() != nil {
+				return metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
 }
 
 // metricLabelValue returns the value of the label with the given name, or empty string if not found.

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_test.go
@@ -2733,7 +2733,7 @@ var _ = Describe("User Defined Network Controller", func() {
 		It("should record TransportAccepted condition metric for EVPN CUDN with accepted RA", func() {
 			testNs := testNamespace("cond-evpn-ns")
 			vtep := testVTEP("cond-vtep")
-			cudn := testEVPNClusterUDN("cond-evpn-cudn", vtep.Name, testNs.Name)
+			cudn := testEVPNClusterUDN("cond-evpn-cudn", &udnv1.EVPNConfig{VTEP: vtep.Name, MACVRF: &udnv1.VRFConfig{VNI: 100}}, testNs.Name)
 
 			c = newTestControllerWithNetworkManager(template.RenderNetAttachDefManifest, cudn, testNs, vtep)
 			Expect(c.Run()).To(Succeed())

--- a/go-controller/pkg/clustermanager/vtep/controller.go
+++ b/go-controller/pkg/clustermanager/vtep/controller.go
@@ -35,6 +35,7 @@ import (
 	vtepscheme "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/clientset/versioned/scheme"
 	vteplisters "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/listers/vtep/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -151,6 +152,8 @@ func (c *Controller) reconcileVTEP(key string) error {
 	vtep, err := c.vtepLister.Get(vtepName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// Clean up condition metric timeseries for the deleted VTEP.
+			metrics.DeleteVTEPCondition(vtepName)
 			c.requeueConflictingVTEPs(vtepName)
 			return nil
 		}

--- a/go-controller/pkg/clustermanager/vtep/controller.go
+++ b/go-controller/pkg/clustermanager/vtep/controller.go
@@ -152,8 +152,6 @@ func (c *Controller) reconcileVTEP(key string) error {
 	vtep, err := c.vtepLister.Get(vtepName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// Clean up condition metric timeseries for the deleted VTEP.
-			metrics.DeleteVTEPCondition(vtepName)
 			c.requeueConflictingVTEPs(vtepName)
 			return nil
 		}
@@ -263,6 +261,7 @@ func (c *Controller) handleVTEPDeletion(vtep *vtepv1.VTEP) error {
 		return fmt.Errorf("failed to remove finalizer from VTEP %s: %w", vtep.Name, err)
 	}
 	klog.Infof("Removed finalizer from VTEP %s, deletion unblocked", vtep.Name)
+	metrics.DeleteVTEPCondition(vtep.Name)
 	return nil
 }
 

--- a/go-controller/pkg/clustermanager/vtep/controller_test.go
+++ b/go-controller/pkg/clustermanager/vtep/controller_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1628,41 +1627,7 @@ var _ = ginkgo.Describe("vtepNameInMessage", func() {
 	})
 })
 
-func findMetricFamily(name string) *dto.MetricFamily {
-	ginkgo.GinkgoHelper()
-	mfs, err := prometheus.DefaultGatherer.Gather()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to gather metrics")
-	for _, mf := range mfs {
-		if mf.GetName() == name {
-			return mf
-		}
-	}
-	return nil
-}
-
 func getVTEPConditionMetricValue(nameLabel, conditionLabel, statusLabel string) (float64, bool) {
 	metricName := prometheus.BuildFQName(ovntypes.MetricOvnkubeNamespace, ovntypes.MetricOvnkubeSubsystemClusterManager, "vtep_condition")
-	mf := findMetricFamily(metricName)
-	if mf == nil {
-		return 0, false
-	}
-	for _, metric := range mf.GetMetric() {
-		if metricLabelValue(metric.GetLabel(), "name") == nameLabel &&
-			metricLabelValue(metric.GetLabel(), "condition") == conditionLabel &&
-			metricLabelValue(metric.GetLabel(), "status") == statusLabel {
-			if metric.GetGauge() != nil {
-				return metric.GetGauge().GetValue(), true
-			}
-		}
-	}
-	return 0, false
-}
-
-func metricLabelValue(labels []*dto.LabelPair, name string) string {
-	for _, label := range labels {
-		if label.GetName() == name {
-			return label.GetValue()
-		}
-	}
-	return ""
+	return ovntest.GetConditionMetricValue(metricName, nameLabel, conditionLabel, statusLabel)
 }

--- a/go-controller/pkg/clustermanager/vtep/controller_test.go
+++ b/go-controller/pkg/clustermanager/vtep/controller_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +28,9 @@ import (
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
 	vtepfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -149,12 +153,23 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
+	markVTEPForDeletion := func(name string) {
+		ginkgo.GinkgoHelper()
+		v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		now := metav1.Now()
+		v.DeletionTimestamp = &now
+		_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
 	ginkgo.BeforeEach(func() {
 		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 		config.OVNKubernetesFeature.EnableRouteAdvertisements = true
 		config.OVNKubernetesFeature.EnableEVPN = true
+		metrics.RegisterClusterManagerFunctional()
 		config.Gateway.Mode = config.GatewayModeLocal
 	})
 
@@ -171,6 +186,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		ginkgo.It("sets Accepted=False for a VTEP with mode Managed", func() {
 			vtep := newVTEP("managed-vtep", vtepv1.VTEPModeManaged, "100.64.0.0/24")
 			start(vtep)
+			ginkgo.DeferCleanup(metrics.DeleteVTEPCondition, "managed-vtep")
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
 				return getVTEPCondition(fakeVTEP, "managed-vtep", conditionTypeAccepted)
@@ -187,6 +203,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 		ginkgo.It("sets Accepted=True for a VTEP with mode Unmanaged", func() {
 			vtep := newVTEP("unmanaged-vtep", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
 			start(vtep)
+			ginkgo.DeferCleanup(metrics.DeleteVTEPCondition, "unmanaged-vtep")
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
 				return getVTEPCondition(fakeVTEP, "unmanaged-vtep", conditionTypeAccepted)
@@ -266,12 +283,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				return getVTEPFinalizers(fakeVTEP, "delete-vtep")
 			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "delete-vtep", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now := metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			markVTEPForDeletion("delete-vtep")
 
 			gomega.Eventually(func() ([]string, error) {
 				return getVTEPFinalizers(fakeVTEP, "delete-vtep")
@@ -287,19 +299,14 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 				return getVTEPFinalizers(fakeVTEP, "blocked-vtep")
 			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "blocked-vtep", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now := metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			markVTEPForDeletion("blocked-vtep")
 
 			gomega.Consistently(func() ([]string, error) {
 				return getVTEPFinalizers(fakeVTEP, "blocked-vtep")
 			}).WithTimeout(3 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
 			// Delete the CUDN — the VTEP should now be garbage-collected
-			err = fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
+			err := fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
 				context.Background(), "test-cudn", metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -605,12 +612,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			}
 
 			// Delete vtep-c: vtep-a and vtep-b still overlap, both stay Accepted=False
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-c", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now := metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			markVTEPForDeletion("vtep-c")
 
 			gomega.Consistently(func() (*metav1.Condition, error) {
 				return getVTEPCondition(fakeVTEP, "vtep-a", conditionTypeAccepted)
@@ -621,12 +623,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			}).WithTimeout(2 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionFalse))
 
 			// Delete vtep-b: vtep-a is the only one left, no more conflicts
-			v, err = fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-b", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now = metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			markVTEPForDeletion("vtep-b")
 
 			gomega.Eventually(func() (*metav1.Condition, error) {
 				return getVTEPCondition(fakeVTEP, "vtep-a", conditionTypeAccepted)
@@ -1105,12 +1102,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
 			// Simulate deletion of the VTEP (sets DeletionTimestamp, blocked by finalizer)
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-cudn-del", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now := metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			markVTEPForDeletion("vtep-cudn-del")
 
 			// Finalizer should remain because CUDN still references the VTEP
 			gomega.Consistently(func() ([]string, error) {
@@ -1119,7 +1111,7 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 
 			// Delete the CUDN -- this should trigger the CUDN controller
 			// which re-queues the deleting VTEP
-			err = fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
+			err := fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
 				context.Background(), "cudn-ref", metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1149,15 +1141,10 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
 			// Request VTEP deletion
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-multi-ref", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now := metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			markVTEPForDeletion("vtep-multi-ref")
 
 			// Delete first CUDN -- VTEP should still be blocked by cudn-two
-			err = fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
+			err := fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
 				context.Background(), "cudn-one", metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1197,15 +1184,10 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
 
 			// Request VTEP deletion
-			v, err := fakeVTEP.K8sV1().VTEPs().Get(context.Background(), "vtep-norequeue", metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			now := metav1.Now()
-			v.DeletionTimestamp = &now
-			_, err = fakeVTEP.K8sV1().VTEPs().Update(context.Background(), v, metav1.UpdateOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			markVTEPForDeletion("vtep-norequeue")
 
 			// Delete the non-EVPN CUDN -- should NOT unblock the VTEP
-			err = fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
+			err := fakeClientset.UserDefinedNetworkClient.K8sV1().ClusterUserDefinedNetworks().Delete(
 				context.Background(), "cudn-plain", metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1520,6 +1502,68 @@ var _ = ginkgo.Describe("VTEP Controller", func() {
 			))
 		})
 	})
+
+	ginkgo.Context("VTEP condition metrics", func() {
+		ginkgo.It("should record Accepted=True condition metric for an Unmanaged VTEP", func() {
+			vtep := newVTEP("metrics-unmanaged", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
+			start(vtep)
+			ginkgo.DeferCleanup(metrics.DeleteVTEPCondition, "metrics-unmanaged")
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "metrics-unmanaged", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionTrue))
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				valTrue, found := getVTEPConditionMetricValue("metrics-unmanaged", "Accepted", "true")
+				g.Expect(found).To(gomega.BeTrue(), "condition metric status=true should exist")
+				g.Expect(valTrue).To(gomega.Equal(1.0))
+				valFalse, found := getVTEPConditionMetricValue("metrics-unmanaged", "Accepted", "false")
+				g.Expect(found).To(gomega.BeTrue(), "condition metric status=false should exist")
+				g.Expect(valFalse).To(gomega.Equal(0.0))
+			}).Should(gomega.Succeed(), "Accepted condition metrics should be recorded")
+		})
+
+		ginkgo.It("should record Accepted=False condition metric for a Managed VTEP", func() {
+			vtep := newVTEP("metrics-managed", vtepv1.VTEPModeManaged, "100.64.0.0/24")
+			start(vtep)
+			ginkgo.DeferCleanup(metrics.DeleteVTEPCondition, "metrics-managed")
+
+			gomega.Eventually(func() (*metav1.Condition, error) {
+				return getVTEPCondition(fakeVTEP, "metrics-managed", conditionTypeAccepted)
+			}).WithTimeout(5 * time.Second).Should(gomega.HaveField("Status", metav1.ConditionFalse))
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				valTrue, found := getVTEPConditionMetricValue("metrics-managed", "Accepted", "true")
+				g.Expect(found).To(gomega.BeTrue(), "condition metric status=true should exist")
+				g.Expect(valTrue).To(gomega.Equal(0.0))
+				valFalse, found := getVTEPConditionMetricValue("metrics-managed", "Accepted", "false")
+				g.Expect(found).To(gomega.BeTrue(), "condition metric status=false should exist")
+				g.Expect(valFalse).To(gomega.Equal(1.0))
+			}).Should(gomega.Succeed(), "Accepted condition metrics should be recorded")
+		})
+
+		ginkgo.It("should remove condition metrics on VTEP deletion", func() {
+			vtep := newVTEP("metrics-delete", vtepv1.VTEPModeUnmanaged, "100.64.0.0/24")
+			start(vtep)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				_, found := getVTEPConditionMetricValue("metrics-delete", "Accepted", "true")
+				g.Expect(found).To(gomega.BeTrue(), "condition metric should exist before deletion")
+			}).Should(gomega.Succeed())
+
+			gomega.Eventually(func() ([]string, error) {
+				return getVTEPFinalizers(fakeVTEP, "metrics-delete")
+			}).WithTimeout(5 * time.Second).Should(gomega.ContainElement(finalizerVTEP))
+
+			markVTEPForDeletion("metrics-delete")
+
+			gomega.Eventually(func() bool {
+				_, foundTrue := getVTEPConditionMetricValue("metrics-delete", "Accepted", "true")
+				_, foundFalse := getVTEPConditionMetricValue("metrics-delete", "Accepted", "false")
+				return foundTrue || foundFalse
+			}).Should(gomega.BeFalse(), "condition metrics should be removed after deletion")
+		})
+	})
 })
 
 var _ = ginkgo.Describe("vtepNameInMessage", func() {
@@ -1583,3 +1627,42 @@ var _ = ginkgo.Describe("vtepNameInMessage", func() {
 		gomega.Expect(vtepNameInMessage(msg, "vtep-bbb")).To(gomega.BeTrue())
 	})
 })
+
+func findMetricFamily(name string) *dto.MetricFamily {
+	ginkgo.GinkgoHelper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to gather metrics")
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	return nil
+}
+
+func getVTEPConditionMetricValue(nameLabel, conditionLabel, statusLabel string) (float64, bool) {
+	metricName := prometheus.BuildFQName(ovntypes.MetricOvnkubeNamespace, ovntypes.MetricOvnkubeSubsystemClusterManager, "vtep_condition")
+	mf := findMetricFamily(metricName)
+	if mf == nil {
+		return 0, false
+	}
+	for _, metric := range mf.GetMetric() {
+		if metricLabelValue(metric.GetLabel(), "name") == nameLabel &&
+			metricLabelValue(metric.GetLabel(), "condition") == conditionLabel &&
+			metricLabelValue(metric.GetLabel(), "status") == statusLabel {
+			if metric.GetGauge() != nil {
+				return metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func metricLabelValue(labels []*dto.LabelPair, name string) string {
+	for _, label := range labels {
+		if label.GetName() == name {
+			return label.GetValue()
+		}
+	}
+	return ""
+}

--- a/go-controller/pkg/clustermanager/vtep/status.go
+++ b/go-controller/pkg/clustermanager/vtep/status.go
@@ -30,17 +30,9 @@ const (
 	reasonEVPNIPv6NotSupported    = "EVPNIPv6NotSupported"
 )
 
-// updateStatusCondition records the condition metric and applies the status
-// condition to the VTEP resource. The API update is skipped if the condition
-// already matches, but the metric is always recorded to stay correct after
-// leader restarts.
+// updateStatusCondition applies the status condition to the VTEP resource.
+// The API update is skipped if the condition already matches.
 func (c *Controller) updateStatusCondition(vtep *vtepv1.VTEP, conditionType string, status metav1.ConditionStatus, reason, message string) error {
-	// Always record the metric, even if we skip the API update.
-	// This ensures the metric is correct after leader restarts when the informer
-	// fires synthetic creates and the existing condition hasn't changed.
-	// This relies on RecordVTEPCondition being cheap (in-memory only, no I/O).
-	metrics.RecordVTEPCondition(vtep.Name, conditionType, status)
-
 	const maxMessageLen = 32768
 	if len(message) >= maxMessageLen {
 		message = message[:maxMessageLen-1]
@@ -51,6 +43,10 @@ func (c *Controller) updateStatusCondition(vtep *vtepv1.VTEP, conditionType stri
 		existingCondition.Status == status &&
 		existingCondition.Reason == reason &&
 		existingCondition.Message == message {
+		// Record the metric from the existing API-confirmed condition so it is
+		// populated after controller restarts, where the informer fires synthetic
+		// creates for all VTEPs but the condition hasn't changed.
+		metrics.RecordVTEPCondition(vtep.Name, conditionType, status)
 		return nil
 	}
 
@@ -85,5 +81,6 @@ func (c *Controller) updateStatusCondition(vtep *vtepv1.VTEP, conditionType stri
 		klog.Errorf("Failed to update status condition %q for VTEP %s: %v", conditionType, vtep.Name, err)
 		return fmt.Errorf("failed to update status condition %q for VTEP %s: %w", conditionType, vtep.Name, err)
 	}
+	metrics.RecordVTEPCondition(vtep.Name, conditionType, status)
 	return nil
 }

--- a/go-controller/pkg/clustermanager/vtep/status.go
+++ b/go-controller/pkg/clustermanager/vtep/status.go
@@ -15,6 +15,7 @@ import (
 
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
 	vtepapply "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/applyconfiguration/vtep/v1"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 )
 
 const (
@@ -29,7 +30,17 @@ const (
 	reasonEVPNIPv6NotSupported    = "EVPNIPv6NotSupported"
 )
 
+// updateStatusCondition records the condition metric and applies the status
+// condition to the VTEP resource. The API update is skipped if the condition
+// already matches, but the metric is always recorded to stay correct after
+// leader restarts.
 func (c *Controller) updateStatusCondition(vtep *vtepv1.VTEP, conditionType string, status metav1.ConditionStatus, reason, message string) error {
+	// Always record the metric, even if we skip the API update.
+	// This ensures the metric is correct after leader restarts when the informer
+	// fires synthetic creates and the existing condition hasn't changed.
+	// This relies on RecordVTEPCondition being cheap (in-memory only, no I/O).
+	metrics.RecordVTEPCondition(vtep.Name, conditionType, status)
+
 	const maxMessageLen = 32768
 	if len(message) >= maxMessageLen {
 		message = message[:maxMessageLen-1]

--- a/go-controller/pkg/metrics/cluster_manager.go
+++ b/go-controller/pkg/metrics/cluster_manager.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
@@ -131,6 +133,33 @@ var metricUDNNodesRendered = prometheus.NewGaugeVec(
 	},
 )
 
+var metricRouteAdvertisementCondition = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemClusterManager,
+	Name:      "route_advertisement_condition",
+	Help: "Status condition of RouteAdvertisements resources. " +
+		"Value is 1 for the active status, 0 for the inactive status. " +
+		"Use the 'condition' and 'status' labels to select.",
+}, []string{"name", "condition", "status"})
+
+var metricCUDNCondition = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemClusterManager,
+	Name:      "cluster_user_defined_network_condition",
+	Help: "Status condition of ClusterUserDefinedNetwork resources. " +
+		"Value is 1 for the active status, 0 for the inactive status. " +
+		"Use the 'condition' and 'status' labels to select.",
+}, []string{"name", "condition", "status"})
+
+var metricVTEPCondition = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemClusterManager,
+	Name:      "vtep_condition",
+	Help: "Status condition of VTEP resources. " +
+		"Value is 1 for the active status, 0 for the inactive status. " +
+		"Use the 'condition' and 'status' labels to select.",
+}, []string{"name", "condition", "status"})
+
 // RegisterClusterManagerBase registers ovnkube cluster manager base metrics with the Prometheus registry.
 // This function should only be called once.
 func RegisterClusterManagerBase() {
@@ -173,8 +202,15 @@ func RegisterClusterManagerFunctional() {
 		}
 		prometheus.MustRegister(metricUDNCount)
 		prometheus.MustRegister(metricCUDNCount)
+		prometheus.MustRegister(metricCUDNCondition)
 		if config.OVNKubernetesFeature.EnableDynamicUDNAllocation {
 			prometheus.MustRegister(metricUDNNodesRendered)
+		}
+		if config.OVNKubernetesFeature.EnableRouteAdvertisements {
+			prometheus.MustRegister(metricRouteAdvertisementCondition)
+		}
+		if config.OVNKubernetesFeature.EnableEVPN {
+			prometheus.MustRegister(metricVTEPCondition)
 		}
 		if err := prometheus.Register(MetricResourceRetryFailuresCount); err != nil {
 			var alreadyRegistered prometheus.AlreadyRegisteredError
@@ -248,4 +284,53 @@ func SetDynamicUDNNodeCount(networkName string, nodeCount float64) {
 // DeleteDynamicUDNNodeCount when CUDN/UDN is deleted.
 func DeleteDynamicUDNNodeCount(networkName string) {
 	metricUDNNodesRendered.DeleteLabelValues(networkName)
+}
+
+// recordCondition emits both status="true" and status="false" timeseries for a
+// condition gauge; exactly one is 1, the other is 0.
+//
+// NOTE: this assumes callers never emit ConditionUnknown. If ConditionUnknown
+// is passed, both the status="true" and status="false" timeseries will be 0.
+// Should ConditionUnknown become a possible value in the future, a dedicated
+// metric (or an additional label value) will be needed to track it.
+func recordCondition(metric *prometheus.GaugeVec, name, condition string, status metav1.ConditionStatus) {
+	metric.WithLabelValues(name, condition, "true").Set(boolFloat64(status == metav1.ConditionTrue))
+	metric.WithLabelValues(name, condition, "false").Set(boolFloat64(status == metav1.ConditionFalse))
+}
+
+// RecordRouteAdvertisementCondition records the condition metric for a RouteAdvertisements resource.
+func RecordRouteAdvertisementCondition(name, condition string, status metav1.ConditionStatus) {
+	recordCondition(metricRouteAdvertisementCondition, name, condition, status)
+}
+
+// DeleteRouteAdvertisementCondition removes all condition timeseries for a deleted RouteAdvertisements resource.
+func DeleteRouteAdvertisementCondition(name string) {
+	metricRouteAdvertisementCondition.DeletePartialMatch(prometheus.Labels{"name": name})
+}
+
+// RecordCUDNCondition records the condition metric for a ClusterUserDefinedNetwork resource.
+func RecordCUDNCondition(name, condition string, status metav1.ConditionStatus) {
+	recordCondition(metricCUDNCondition, name, condition, status)
+}
+
+// DeleteCUDNCondition removes all condition timeseries for a deleted ClusterUserDefinedNetwork resource.
+func DeleteCUDNCondition(name string) {
+	metricCUDNCondition.DeletePartialMatch(prometheus.Labels{"name": name})
+}
+
+// RecordVTEPCondition records the condition metric for a VTEP resource.
+func RecordVTEPCondition(name, condition string, status metav1.ConditionStatus) {
+	recordCondition(metricVTEPCondition, name, condition, status)
+}
+
+// DeleteVTEPCondition removes all condition timeseries for a deleted VTEP resource.
+func DeleteVTEPCondition(name string) {
+	metricVTEPCondition.DeletePartialMatch(prometheus.Labels{"name": name})
+}
+
+func boolFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
 }

--- a/go-controller/pkg/testing/metrics.go
+++ b/go-controller/pkg/testing/metrics.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// FindMetricFamily returns the MetricFamily with the given name from the
+// default Prometheus gatherer. Returns nil if not found.
+func FindMetricFamily(name string) *dto.MetricFamily {
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		panic(fmt.Sprintf("failed to gather metrics: %v", err))
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	return nil
+}
+
+// MetricLabelValue returns the value of the label with the given name from
+// a slice of Prometheus label pairs. Returns empty string if not found.
+func MetricLabelValue(labels []*dto.LabelPair, name string) string {
+	for _, label := range labels {
+		if label.GetName() == name {
+			return label.GetValue()
+		}
+	}
+	return ""
+}
+
+// GetConditionMetricValue looks up a condition gauge metric by name,
+// condition, and status labels. Returns the gauge value and whether the
+// metric was found.
+func GetConditionMetricValue(metricName, nameLabel, conditionLabel, statusLabel string) (float64, bool) {
+	mf := FindMetricFamily(metricName)
+	if mf == nil {
+		return 0, false
+	}
+	for _, metric := range mf.GetMetric() {
+		if MetricLabelValue(metric.GetLabel(), "name") == nameLabel &&
+			MetricLabelValue(metric.GetLabel(), "condition") == conditionLabel &&
+			MetricLabelValue(metric.GetLabel(), "status") == statusLabel {
+			if metric.GetGauge() != nil {
+				return metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}


### PR DESCRIPTION
## 📑 Description
Add condition metrics for RouteAdvertisements, ClusterUserDefinedNetwork, and VTEP resources, following the kube-state-metrics condition+status label pattern.  These metrics expose the control-plane health of EVPN-related resources, enabling operators to detect configuration issues such as rejected RouteAdvertisements, failed network creation, or VTEP allocation failures.

New metrics:
- ovnkube_clustermanager_route_advertisement_condition{name, condition, status}
- ovnkube_clustermanager_cluster_user_defined_network_condition{name, condition, status}
- ovnkube_clustermanager_vtep_condition{name, condition, status}

Depends on PR: #6265

## Additional Information for reviewers

**Metric pattern:** Both `status="true"` and `status="false"` timeseries are emitted per condition; exactly one is 1, the other is 0. No `status="unknown"` — our controllers never produce `ConditionUnknown`. Registration is gated on `EnableRouteAdvertisements` (RA) and `EnableEVPN` (VTEP). CUDN condition is always registered.

**Leader restart handling:**

- **CUDN**: Seeds metrics at init via `seedCUDNConditionMetrics` in `initializeController` (before workers start). Records after successful `ApplyStatus` at runtime.
- **RA / VTEP**: Records metrics before the early-return guard in status update functions. The informer fires synthetic creates on startup that trigger reconciles for all existing resources, ensuring metrics are populated.

**Deletion cleanup:** `DeletePartialMatch` on the `name` label removes all timeseries when a resource is deleted — in the `NotFound` path (RA, VTEP) or on finalizer removal (CUDN).


## ✅ Checks
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI

## How to verify it
Unit tests included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds condition metrics for RouteAdvertisements, ClusterUserDefinedNetworks (CUDNs), and VTEPs; CUDN count metric includes transport label.
* **Behavior**
  * Metrics are initialized at startup, recorded even when status updates are skipped, and removed when resources are deleted or not found; CUDN counts use explicit increment/decrement semantics.
* **Documentation**
  * Observability docs updated to describe the new metrics and transport labeling.
* **Tests**
  * Tests expanded to register, validate, and clean up metrics and label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->