### PR TITLE
Batch iptables and IP rule creation for secondary egress IP

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -846,30 +846,87 @@ func (c *Controller) applyPodConfig(existingPodIPsConfig *podIPConfigList, updat
 	if updatedPodIPsConfig == nil {
 		return fmt.Errorf("unexpected nil updated config")
 	}
-	newPodIPConfigs := newPodIPConfigList()
+	// Each podIPConfig is either v4 or v6 (pIC.v6), giving us three independent
+	// batches to apply: netlink IP rules, IPv4 iptables SNAT rules, IPv6 iptables SNAT rules.
+	var ipRulesToApply []netlink.Rule
+	var ipv4RulesToApply []iptables.RuleArg
+	var ipv6RulesToApply []iptables.RuleArg
+	var configsNeedingIPRule []*podIPConfig
+	var configsNeedingIPv4Table []*podIPConfig
+	var configsNeedingIPv6Table []*podIPConfig
+
 	for _, newConfig := range updatedPodIPsConfig.elems {
-		if !existingPodIPsConfig.hasWithoutError(newConfig) {
-			newPodIPConfigs.insert(*newConfig)
+		existing := existingPodIPsConfig.findEqual(newConfig)
+		needsIPRule := existing == nil || existing.ipRuleFailed
+		needsIPTable := existing == nil || existing.ipTableRuleFailed
+
+		if needsIPRule {
+			ipRulesToApply = append(ipRulesToApply, newConfig.ipRule)
+			configsNeedingIPRule = append(configsNeedingIPRule, newConfig)
 		}
-	}
-	for _, newPodIPConfig := range newPodIPConfigs.elems {
-		if err := c.ruleManager.Add(newPodIPConfig.ipRule); err != nil {
-			existingPodIPsConfig.insertOverwriteFailed(*newPodIPConfig)
-			return err
-		}
-		if newPodIPConfig.v6 {
-			if err := c.iptablesManager.EnsureRule(utiliptables.TableNAT, iptChainName, utiliptables.ProtocolIPv6, newPodIPConfig.ipTableRule); err != nil {
-				existingPodIPsConfig.insertOverwriteFailed(*newPodIPConfig)
-				return fmt.Errorf("unable to ensure iptables rules: %v", err)
-			}
-		} else {
-			if err := c.iptablesManager.EnsureRule(utiliptables.TableNAT, iptChainName, utiliptables.ProtocolIPv4, newPodIPConfig.ipTableRule); err != nil {
-				existingPodIPsConfig.insertOverwriteFailed(*newPodIPConfig)
-				return fmt.Errorf("failed to ensure rules (%+v) in chain %s: %v", newPodIPConfig.ipTableRule, iptChainName, err)
+		if needsIPTable {
+			if newConfig.v6 {
+				ipv6RulesToApply = append(ipv6RulesToApply, newConfig.ipTableRule)
+				configsNeedingIPv6Table = append(configsNeedingIPv6Table, newConfig)
+			} else {
+				ipv4RulesToApply = append(ipv4RulesToApply, newConfig.ipTableRule)
+				configsNeedingIPv4Table = append(configsNeedingIPv4Table, newConfig)
 			}
 		}
-		existingPodIPsConfig.insertOverwrite(*newPodIPConfig)
 	}
+
+	if len(ipRulesToApply) == 0 && len(ipv4RulesToApply) == 0 && len(ipv6RulesToApply) == 0 {
+		return nil
+	}
+
+	// Batch 1: netlink IP rules
+	if len(ipRulesToApply) > 0 {
+		if err := c.ruleManager.AddRules(ipRulesToApply); err != nil {
+			for _, cfg := range configsNeedingIPRule {
+				existingPodIPsConfig.insertOverwriteIPRuleFailed(*cfg)
+			}
+			return fmt.Errorf("failed to add IP rules in batch: %v", err)
+		}
+		for _, cfg := range configsNeedingIPRule {
+			existingPodIPsConfig.insertOverwriteIPRuleApplied(*cfg)
+			// For fresh configs where iptables is still pending, mark ipTableRuleFailed=true
+			// so an early-return from a later batch failure doesn't strand them in (false,false) state.
+			if cfg.v6 {
+				existingPodIPsConfig.markIPTablePending(cfg, configsNeedingIPv6Table)
+			} else {
+				existingPodIPsConfig.markIPTablePending(cfg, configsNeedingIPv4Table)
+			}
+		}
+	}
+
+	// Batch 2: IPv4 iptables SNAT rules
+	if len(ipv4RulesToApply) > 0 {
+		if err := c.iptablesManager.EnsureRules(utiliptables.TableNAT, iptChainName,
+			utiliptables.ProtocolIPv4, ipv4RulesToApply); err != nil {
+			for _, cfg := range configsNeedingIPv4Table {
+				existingPodIPsConfig.insertOverwriteIPTableRuleFailed(*cfg)
+			}
+			return fmt.Errorf("failed to ensure IPv4 iptables rules in batch: %v", err)
+		}
+		for _, cfg := range configsNeedingIPv4Table {
+			existingPodIPsConfig.insertOverwriteIPTableRuleApplied(*cfg)
+		}
+	}
+
+	// Batch 3: IPv6 iptables SNAT rules
+	if len(ipv6RulesToApply) > 0 {
+		if err := c.iptablesManager.EnsureRules(utiliptables.TableNAT, iptChainName,
+			utiliptables.ProtocolIPv6, ipv6RulesToApply); err != nil {
+			for _, cfg := range configsNeedingIPv6Table {
+				existingPodIPsConfig.insertOverwriteIPTableRuleFailed(*cfg)
+			}
+			return fmt.Errorf("failed to ensure IPv6 iptables rules in batch: %v", err)
+		}
+		for _, cfg := range configsNeedingIPv6Table {
+			existingPodIPsConfig.insertOverwriteIPTableRuleApplied(*cfg)
+		}
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/node/controllers/egressip/pod.go
+++ b/go-controller/pkg/node/controllers/egressip/pod.go
@@ -25,10 +25,11 @@ import (
 // podIPConfig holds pod specific info to implement egress IP for secondary host networks for a single pod IP. A pod may
 // contain multiple IPs (one for single stack, 2 for dual stack).
 type podIPConfig struct {
-	failed      bool // used for retry
-	v6          bool
-	ipTableRule iptables.RuleArg
-	ipRule      netlink.Rule
+	ipRuleFailed      bool // used for retry: true if the netlink IP rule failed to apply
+	ipTableRuleFailed bool // used for retry: true if the iptables SNAT rule failed to apply
+	v6                bool
+	ipTableRule       iptables.RuleArg
+	ipRule            netlink.Rule
 }
 
 func newPodIPConfig() *podIPConfig {
@@ -62,13 +63,14 @@ func (pICL *podIPConfigList) len() int {
 	return len(pICL.elems)
 }
 
-func (pICL *podIPConfigList) hasWithoutError(pIC2 *podIPConfig) bool {
+// findEqual returns the existing podIPConfig that is logically equal to pIC2, or nil if not found.
+func (pICL *podIPConfigList) findEqual(pIC2 *podIPConfig) *podIPConfig {
 	for _, pIC := range pICL.elems {
-		if pIC.equal(pIC2) && !pIC.failed {
-			return true
+		if pIC.equal(pIC2) {
+			return pIC
 		}
 	}
-	return false
+	return nil
 }
 
 func (pICL *podIPConfigList) has(pIC2 *podIPConfig) bool {
@@ -96,10 +98,87 @@ func (pICL *podIPConfigList) remove(idxs ...int) {
 }
 
 // insertOverwriteFailed should be used to add elements to the podIPConfigList that have failed to be applied.
+// It marks both ipRuleFailed and ipTableRuleFailed so the config is fully retried next cycle.
 func (pICL *podIPConfigList) insertOverwriteFailed(pICs ...podIPConfig) {
 	for _, pIC := range pICs {
-		pIC.failed = true
+		pIC.ipRuleFailed = true
+		pIC.ipTableRuleFailed = true
 		pICL.insertOverwrite(pIC)
+	}
+}
+
+// insertOverwriteIPRuleFailed marks the config as having failed at the netlink IP-rule step.
+// For existing configs, it preserves the iptables state. For fresh configs, it marks both
+// dimensions as failed since the IP rule failure means iptables was never attempted.
+func (pICL *podIPConfigList) insertOverwriteIPRuleFailed(pICs ...podIPConfig) {
+	for _, pIC := range pICs {
+		if ex := pICL.findEqual(&pIC); ex != nil {
+			ex.ipRuleFailed = true
+		} else {
+			pIC.ipRuleFailed = true
+			pIC.ipTableRuleFailed = true
+			pICL.insertOverwrite(pIC)
+		}
+	}
+}
+
+// insertOverwriteIPTableRuleFailed marks the config as having failed at the iptables-rule step.
+// For existing configs, it preserves the IP rule state. For fresh configs, it marks both
+// dimensions as failed since this should only be called for configs where IP rules succeeded.
+func (pICL *podIPConfigList) insertOverwriteIPTableRuleFailed(pICs ...podIPConfig) {
+	for _, pIC := range pICs {
+		if ex := pICL.findEqual(&pIC); ex != nil {
+			ex.ipTableRuleFailed = true
+		} else {
+			pIC.ipRuleFailed = true
+			pIC.ipTableRuleFailed = true
+			pICL.insertOverwrite(pIC)
+		}
+	}
+}
+
+// insertOverwriteIPRuleApplied marks the config as having successfully applied the IP rule.
+// For existing configs, it clears ipRuleFailed. For fresh configs, it inserts the config
+// with both dimensions marked as applied.
+func (pICL *podIPConfigList) insertOverwriteIPRuleApplied(pICs ...podIPConfig) {
+	for _, pIC := range pICs {
+		if ex := pICL.findEqual(&pIC); ex != nil {
+			ex.ipRuleFailed = false
+		} else {
+			pIC.ipRuleFailed = false
+			pIC.ipTableRuleFailed = false
+			pICL.insertOverwrite(pIC)
+		}
+	}
+}
+
+// insertOverwriteIPTableRuleApplied marks the config as having successfully applied the iptables rule.
+// For existing configs, it clears ipTableRuleFailed. For fresh configs, it inserts the config
+// with both dimensions marked as applied.
+func (pICL *podIPConfigList) insertOverwriteIPTableRuleApplied(pICs ...podIPConfig) {
+	for _, pIC := range pICs {
+		if ex := pICL.findEqual(&pIC); ex != nil {
+			ex.ipTableRuleFailed = false
+		} else {
+			pIC.ipRuleFailed = false
+			pIC.ipTableRuleFailed = false
+			pICL.insertOverwrite(pIC)
+		}
+	}
+}
+
+// markIPTablePending marks a config as having pending iptables rules if it's found in the
+// configsNeedingIPTable list.
+func (pICL *podIPConfigList) markIPTablePending(cfg *podIPConfig, configsNeedingIPTable []*podIPConfig) {
+	// Check if this config needs iptables rules applied
+	for _, iptCfg := range configsNeedingIPTable {
+		if cfg.equal(iptCfg) {
+			// Found - mark iptables as pending
+			if ex := pICL.findEqual(cfg); ex != nil {
+				ex.ipTableRuleFailed = true
+			}
+			return
+		}
 	}
 }
 

--- a/go-controller/pkg/node/iprulemanager/fake.go
+++ b/go-controller/pkg/node/iprulemanager/fake.go
@@ -18,6 +18,9 @@ func (f *FakeControllerWithError) Run(_ <-chan struct{}, _ time.Duration) {
 func (f *FakeControllerWithError) Add(_ netlink.Rule) error {
 	return nil
 }
+func (f *FakeControllerWithError) AddRules(_ []netlink.Rule) error {
+	return nil
+}
 func (f *FakeControllerWithError) AddWithMetadata(_ netlink.Rule, _ string) error {
 	return nil
 }

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -19,6 +19,7 @@ import (
 type Interface interface {
 	Run(stopCh <-chan struct{}, syncPeriod time.Duration)
 	Add(rule netlink.Rule) error
+	AddRules(rules []netlink.Rule) error
 	AddWithMetadata(rule netlink.Rule, metadata string) error
 	Delete(rule netlink.Rule) error
 	DeleteWithMetadata(metadata string) error
@@ -96,6 +97,35 @@ func (rm *Controller) AddWithMetadata(rule netlink.Rule, metadata string) error 
 		}
 	}
 	rm.rules = append(rm.rules, ipRule{rule: &rule, metadata: metadata})
+	return rm.reconcile()
+}
+
+// AddRules ensures multiple IP rules are applied in batch with a single reconcile.
+func (rm *Controller) AddRules(rules []netlink.Rule) error {
+	if len(rules) == 0 {
+		return nil
+	}
+	klog.V(5).Infof("IP Rule manager: adding %d rules in batch", len(rules))
+
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	// Check which rules are not already managed and add them
+	for _, rule := range rules {
+		found := false
+		for _, existingRule := range rm.rules {
+			if areNetlinkRulesEqual(existingRule.rule, &rule) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Make a copy of the rule to avoid pointer issues
+			ruleCopy := rule
+			rm.rules = append(rm.rules, ipRule{rule: &ruleCopy}) // empty metadata
+		}
+	}
+
 	return rm.reconcile()
 }
 

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
@@ -233,4 +233,197 @@ var _ = ginkgo.XDescribe("IP Rule Manager", func() {
 			}).WithTimeout(time.Second).Should(gomega.Succeed())
 		})
 	})
+
+	ginkgo.Context("AddRules batch", func() {
+		ginkgo.It("ensure multiple rules exist when added in batch", func() {
+			var _, testIPNet2, _ = net.ParseCIDR("192.168.2.5/24")
+			var _, testIPNet3, _ = net.ParseCIDR("192.168.3.5/24")
+
+			ruleWithDst2 := netlink.NewRule()
+			ruleWithDst2.Priority = 3001
+			ruleWithDst2.Table = 254
+			ruleWithDst2.Dst = testIPNet2
+
+			ruleWithDst3 := netlink.NewRule()
+			ruleWithDst3.Priority = 3002
+			ruleWithDst3.Table = 254
+			ruleWithDst3.Dst = testIPNet3
+
+			rules := []netlink.Rule{*ruleWithDst, *ruleWithDst2, *ruleWithDst3}
+
+			gomega.Expect(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					return c.AddRules(rules)
+				})
+			}()).Should(gomega.Succeed())
+
+			gomega.Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					existingRules, err := netlink.RuleList(netlink.FAMILY_ALL)
+					if err != nil {
+						return err
+					}
+					if ok, _ := isNetlinkRuleInSlice(existingRules, ruleWithDst); !ok {
+						return fmt.Errorf("failed to find rule %q", ruleWithDst.String())
+					}
+					if ok, _ := isNetlinkRuleInSlice(existingRules, ruleWithDst2); !ok {
+						return fmt.Errorf("failed to find rule %q", ruleWithDst2.String())
+					}
+					if ok, _ := isNetlinkRuleInSlice(existingRules, ruleWithDst3); !ok {
+						return fmt.Errorf("failed to find rule %q", ruleWithDst3.String())
+					}
+					return nil
+				})
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("handles empty slice without error", func() {
+			rules := []netlink.Rule{}
+			gomega.Expect(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					return c.AddRules(rules)
+				})
+			}()).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("deduplicates when adding same rule multiple times in batch", func() {
+			rules := []netlink.Rule{*ruleWithDst, *ruleWithDst}
+
+			gomega.Expect(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					return c.AddRules(rules)
+				})
+			}()).Should(gomega.Succeed())
+
+			gomega.Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					existingRules, err := netlink.RuleList(netlink.FAMILY_ALL)
+					if err != nil {
+						return err
+					}
+					// Count how many times the rule appears
+					count := 0
+					for _, r := range existingRules {
+						if areNetlinkRulesEqual(&r, ruleWithDst) {
+							count++
+						}
+					}
+					if count != 1 {
+						return fmt.Errorf("expected rule to appear once, but found %d times", count)
+					}
+					return nil
+				})
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("deduplicates when rule already managed via Add()", func() {
+			// Add one rule via Add()
+			gomega.Expect(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					return c.Add(*ruleWithDst)
+				})
+			}()).Should(gomega.Succeed())
+
+			gomega.Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					rules, err := netlink.RuleList(netlink.FAMILY_ALL)
+					if err != nil {
+						return err
+					}
+					if ok, _ := isNetlinkRuleInSlice(rules, ruleWithDst); !ok {
+						return fmt.Errorf("failed to find rule %q", ruleWithDst.String())
+					}
+					return nil
+				})
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
+
+			// Now add the same rule via AddRules()
+			rules := []netlink.Rule{*ruleWithDst, *ruleWithSrc}
+			gomega.Expect(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					return c.AddRules(rules)
+				})
+			}()).Should(gomega.Succeed())
+
+			gomega.Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					existingRules, err := netlink.RuleList(netlink.FAMILY_ALL)
+					if err != nil {
+						return err
+					}
+					// Both rules should exist
+					if ok, _ := isNetlinkRuleInSlice(existingRules, ruleWithDst); !ok {
+						return fmt.Errorf("failed to find rule with dst")
+					}
+					if ok, _ := isNetlinkRuleInSlice(existingRules, ruleWithSrc); !ok {
+						return fmt.Errorf("failed to find rule with src")
+					}
+					// Check ruleWithDst appears only once
+					count := 0
+					for _, r := range existingRules {
+						if areNetlinkRulesEqual(&r, ruleWithDst) {
+							count++
+						}
+					}
+					if count != 1 {
+						return fmt.Errorf("expected ruleWithDst to appear once, but found %d times", count)
+					}
+					return nil
+				})
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("ensure batch-added rules are restored if removed", func() {
+			var _, testIPNet2, _ = net.ParseCIDR("192.168.2.5/24")
+			ruleWithDst2 := netlink.NewRule()
+			ruleWithDst2.Priority = 3001
+			ruleWithDst2.Table = 254
+			ruleWithDst2.Dst = testIPNet2
+
+			rules := []netlink.Rule{*ruleWithDst, *ruleWithDst2}
+
+			gomega.Expect(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					return c.AddRules(rules)
+				})
+			}()).Should(gomega.Succeed())
+
+			gomega.Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					existingRules, err := netlink.RuleList(netlink.FAMILY_ALL)
+					if err != nil {
+						return err
+					}
+					if ok, _ := isNetlinkRuleInSlice(existingRules, ruleWithDst); !ok {
+						return fmt.Errorf("failed to find rule %q", ruleWithDst.String())
+					}
+					if ok, _ := isNetlinkRuleInSlice(existingRules, ruleWithDst2); !ok {
+						return fmt.Errorf("failed to find rule %q", ruleWithDst2.String())
+					}
+					return nil
+				})
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
+
+			// Delete one of the batch-added rules
+			gomega.Expect(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					return netlink.RuleDel(ruleWithDst)
+				})
+			}()).Should(gomega.Succeed())
+
+			// Check that rule is restored by the controller
+			gomega.Eventually(func() error {
+				return testNS.Do(func(ns.NetNS) error {
+					existingRules, err := netlink.RuleList(netlink.FAMILY_ALL)
+					if err != nil {
+						return err
+					}
+					if ok, _ := isNetlinkRuleInSlice(existingRules, ruleWithDst); !ok {
+						return fmt.Errorf("failed to find restored rule %q", ruleWithDst.String())
+					}
+					return nil
+				})
+			}).WithTimeout(time.Second).Should(gomega.Succeed())
+		})
+	})
 })

--- a/go-controller/pkg/node/iptables/iptables_manager.go
+++ b/go-controller/pkg/node/iptables/iptables_manager.go
@@ -193,6 +193,47 @@ func (c *Controller) EnsureRule(table iptables.Table, chain iptables.Chain, prot
 	return c.reconcile()
 }
 
+// EnsureRules adds multiple iptable rules in batch and reconciles only once.
+func (c *Controller) EnsureRules(table iptables.Table, chain iptables.Chain, proto iptables.Protocol, ruleArgs []RuleArg) error {
+	if len(ruleArgs) == 0 {
+		return nil
+	}
+	klog.Infof("IPTables manager: ensure %d rules (batch) - table %s, chain %s, protocol %s", len(ruleArgs), table, chain, proto)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ruleIndex := rulesIndex{
+		Table: table,
+		Chain: chain,
+		Proto: proto,
+	}
+
+	existingRuleArgs, exists := c.store[ruleIndex]
+	if !exists {
+		rules := newRules()
+		rules.ruleArgs = make([]RuleArg, 0, len(ruleArgs))
+		rules.ruleArgs = append(rules.ruleArgs, ruleArgs...)
+		c.store[ruleIndex] = rules
+	} else {
+		// Add only the rules that don't already exist
+		for _, ruleArg := range ruleArgs {
+			found := false
+			for _, existingRuleArg := range existingRuleArgs.ruleArgs {
+				if existingRuleArg.equal(ruleArg) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				existingRuleArgs.ruleArgs = append(existingRuleArgs.ruleArgs, ruleArg)
+			}
+		}
+		c.store[ruleIndex] = existingRuleArgs
+	}
+
+	return c.reconcile()
+}
+
 func (c *Controller) GetChainRuleArgs(table iptables.Table, chain iptables.Chain, proto iptables.Protocol) ([]RuleArg, error) {
 	if proto == iptables.ProtocolIPv4 {
 		return c.GetIPv4ChainRuleArgs(table, chain)

--- a/go-controller/pkg/node/iptables/iptables_manager_test.go
+++ b/go-controller/pkg/node/iptables/iptables_manager_test.go
@@ -262,6 +262,149 @@ var _ = ginkgo.Describe("IPTables Manager", func() {
 			}).WithTimeout(oneSecTimeout).Should(gomega.BeFalse())
 		})
 	})
+
+	ginkgo.Context("Batch Ensure IPv4 Rules", func() {
+		testRuleArgs := []RuleArg{
+			{
+				[]string{"-s", "192.168.1.10/32", "-o", "eth0", "-j", "SNAT", "--to-source", "1.1.1.10"},
+			},
+			{
+				[]string{"-s", "192.168.1.11/32", "-o", "eth0", "-j", "SNAT", "--to-source", "1.1.1.11"},
+			},
+			{
+				[]string{"-s", "192.168.1.12/32", "-o", "eth0", "-j", "SNAT", "--to-source", "1.1.1.12"},
+			},
+		}
+
+		ginkgo.It("ensure multiple rules exist in batch", func() {
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv4, testRuleArgs)
+			})).Should(gomega.Succeed())
+
+			gomega.Eventually(func() bool {
+				return containsRuleArgs(testNS, c.iptV4, utiliptables.TableNAT, testChainName, testRuleArgs)
+			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("batch ensure with empty slice should succeed", func() {
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv4, []RuleArg{})
+			})).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("batch ensure should deduplicate existing rules", func() {
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv4, testRuleArgs[:2])
+			})).Should(gomega.Succeed())
+
+			gomega.Eventually(func() bool {
+				return containsRuleArgs(testNS, c.iptV4, utiliptables.TableNAT, testChainName, testRuleArgs[:2])
+			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
+
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv4, testRuleArgs)
+			})).Should(gomega.Succeed())
+
+			gomega.Eventually(func() bool {
+				return containsRuleArgs(testNS, c.iptV4, utiliptables.TableNAT, testChainName, testRuleArgs)
+			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
+
+			gomega.Eventually(func() int {
+				var count int
+				err := testNS.Do(func(ns.NetNS) error {
+					existingRuleArgs, err := getChainRuleArgs(c.iptV4, utiliptables.TableNAT, testChainName)
+					if err != nil {
+						return err
+					}
+					count = len(existingRuleArgs)
+					return nil
+				})
+				if err != nil {
+					return -1
+				}
+				return count
+			}).WithTimeout(oneSecTimeout).Should(gomega.Equal(3))
+		})
+
+		ginkgo.It("batch ensure recovers following manual removal", func() {
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv4, testRuleArgs)
+			})).Should(gomega.Succeed())
+
+			gomega.Eventually(func() bool {
+				return containsRuleArgs(testNS, c.iptV4, utiliptables.TableNAT, testChainName, testRuleArgs)
+			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
+
+			gomega.Eventually(testNS.Do).WithArguments(func(ns.NetNS) error {
+				return c.iptV4.DeleteRule(utiliptables.TableNAT, testChainName, testRuleArgs[0].Args...)
+			}).WithTimeout(oneSecTimeout).Should(gomega.Succeed())
+
+			gomega.Eventually(func() bool {
+				return containsRuleArgs(testNS, c.iptV4, utiliptables.TableNAT, testChainName, testRuleArgs)
+			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.Context("Batch Ensure IPv6 Rules", func() {
+		testRuleArgs := []RuleArg{
+			{
+				[]string{"-s", "2001:0:0:3::1/128", "-o", "eth0", "-j", "SNAT", "--to-source", "2001::10"},
+			},
+			{
+				[]string{"-s", "2001:0:0:3::2/128", "-o", "eth0", "-j", "SNAT", "--to-source", "2001::11"},
+			},
+			{
+				[]string{"-s", "2001:0:0:3::3/128", "-o", "eth0", "-j", "SNAT", "--to-source", "2001::12"},
+			},
+		}
+
+		ginkgo.It("ensure multiple IPv6 rules exist in batch", func() {
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv6, testRuleArgs)
+			})).Should(gomega.Succeed())
+
+			gomega.Eventually(func() bool {
+				return containsRuleArgs(testNS, c.iptV6, utiliptables.TableNAT, testChainName, testRuleArgs)
+			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("batch ensure IPv6 with empty slice should succeed", func() {
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv6, []RuleArg{})
+			})).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("batch ensure IPv6 should deduplicate existing rules", func() {
+			// First, add some rules
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv6, testRuleArgs[:2])
+			})).Should(gomega.Succeed())
+
+			gomega.Eventually(func() bool {
+				return containsRuleArgs(testNS, c.iptV6, utiliptables.TableNAT, testChainName, testRuleArgs[:2])
+			}).WithTimeout(oneSecTimeout).Should(gomega.BeTrue())
+
+			gomega.Expect(testNS.Do(func(ns.NetNS) error {
+				return c.EnsureRules(utiliptables.TableNAT, testChainName, utiliptables.ProtocolIPv6, testRuleArgs)
+			})).Should(gomega.Succeed())
+
+			gomega.Eventually(func() int {
+				var count int
+				err := testNS.Do(func(ns.NetNS) error {
+					existingRuleArgs, err := getChainRuleArgs(c.iptV6, utiliptables.TableNAT, testChainName)
+					if err != nil {
+						return err
+					}
+					count = len(existingRuleArgs)
+					return nil
+				})
+				if err != nil {
+					return -1
+				}
+				return count
+			}).WithTimeout(oneSecTimeout).Should(gomega.Equal(3))
+		})
+	})
 })
 
 func commandExists(cmd string) bool {


### PR DESCRIPTION
Secondary egress IP creates one iptables SNAT rule per pod IP to redirect traffic from OVN to host network stack. Previously, each rule triggered a separate iptables reconcile operation, causing:
1. Initial setup delay when number of PODs present in an egressIP namespace is large in number.
2. When a new POD is added to a namespace which already have an egressIP configured and contains lots of PODs, many iptables reconcilation happens and that induces lots of delay.

This commitv aims to gather all iptables rules which should be created and aims to run iptables reconcile() once.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply IP routing rules and IPv4/IPv6 NAT rules in ordered batches; new batch APIs to add multiple IP-rule and NAT entries in one call.

* **Performance Improvements**
  * Fewer reconciliations by consolidating rule changes into single batch operations.

* **Bug Fixes**
  * Distinct failure tracking for routing vs NAT steps and batch-scoped error handling to avoid leaving configs unmanaged.

* **Tests**
  * Added IPv4/IPv6 tests for batch install, empty-batch no-op, deduplication, and recovery after manual deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->