### PR TITLE
Skip event recording for suppressed errors in node reconciliation

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -943,6 +943,9 @@ func (bnc *BaseNetworkController) recordNodeErrorEvent(node *corev1.Node, nodeEr
 		// TBD, noop for UDN for now
 		return
 	}
+	if types.IsSuppressedError(nodeErr) {
+		return
+	}
 	nodeRef, err := ref.GetReference(scheme.Scheme, node)
 	if err != nil {
 		klog.Errorf("Couldn't get a reference to node %s to post an event: %v", node.Name, err)

--- a/go-controller/pkg/types/errors.go
+++ b/go-controller/pkg/types/errors.go
@@ -43,5 +43,17 @@ func IsSuppressedError(err error) bool {
 		}
 		return suppress
 	}
+	if unwrapper, ok := err.(interface{ Unwrap() []error }); ok {
+		errs := unwrapper.Unwrap()
+		if len(errs) == 0 {
+			return false
+		}
+		for _, e := range errs {
+			if !IsSuppressedError(e) {
+				return false
+			}
+		}
+		return true
+	}
 	return errors.As(err, &suppressedError)
 }

--- a/go-controller/pkg/types/errors_test.go
+++ b/go-controller/pkg/types/errors_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
+)
+
+func TestIsSuppressedError(t *testing.T) {
+	suppressed := NewSuppressedError(fmt.Errorf("annotation not set"))
+	plain := fmt.Errorf("real failure")
+	wrapped := fmt.Errorf("outer: %w", suppressed)
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"single suppressed", suppressed, true},
+		{"single plain", plain, false},
+		{"wrapped suppressed", wrapped, true},
+		{"join all suppressed", utilerrors.Join(suppressed, NewSuppressedError(fmt.Errorf("other"))), true},
+		{"join mixed", utilerrors.Join(suppressed, plain), false},
+		{"join all plain", utilerrors.Join(plain, fmt.Errorf("another")), false},
+		{"join single suppressed", utilerrors.Join(suppressed), true},
+		{"join single plain", utilerrors.Join(plain), false},
+		{"nested join all suppressed", utilerrors.Join(wrapped, suppressed), true},
+		{"nested join mixed", utilerrors.Join(wrapped, plain), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSuppressedError(tt.err); got != tt.want {
+				t.Errorf("IsSuppressedError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
After the move to the level-driven node controller [0], recordNodeErrorEvent is called on every failed reconciliation. Errors already wrapped as SuppressedError (e.g. missing chassis-id annotation on a remote node before ovnkube-node starts) generate excessive Warning events. The old retry framework checked IsSuppressedError before recording events but this check was not carried over.

Add the IsSuppressedError check in recordNodeErrorEvent so transient errors still retry via the workqueue but do not produce events. Also fix IsSuppressedError to handle utilerrors.Join correctly -- only treat a joined error as suppressed when all children are suppressed, matching the existing kerrors.Aggregate behavior.

[0] https://github.com/ovn-kubernetes/ovn-kubernetes/commit/97982888f57e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error handling now correctly identifies and suppresses unnecessary warning events for suppressed errors, preventing erroneous alerts
  * Extended error detection to properly recognize composite error types with multiple underlying errors

* **Tests**
  * Added test coverage for error suppression scenarios and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->