### PR TITLE
Fixes panic due to chassis delete with nil predicate value

### DIFF
--- a/go-controller/pkg/libovsdb/ops/template_var.go
+++ b/go-controller/pkg/libovsdb/ops/template_var.go
@@ -54,13 +54,16 @@ func deleteChassisTemplateVarVariablesOps(nbClient libovsdbclient.Client,
 		deleteTemplate.Variables[name] = ""
 	}
 	modelClient := newModelClient(nbClient)
-	return modelClient.DeleteOps(ops, operationModel{
+	opModel := operationModel{
 		Model:            deleteTemplate,
-		ModelPredicate:   predicate,
 		OnModelMutations: []interface{}{&deleteTemplate.Variables},
 		ErrNotFound:      false,
 		BulkOp:           true,
-	})
+	}
+	if predicate != nil {
+		opModel.ModelPredicate = predicate
+	}
+	return modelClient.DeleteOps(ops, opModel)
 }
 
 // DeleteChassisTemplateVarVariablesOps removes all variables listed as


### PR DESCRIPTION
deleteChassisTemplateVarVariablesOps would pass a typed interface with nil value to ModelPredicate which would cause libovsdb to panic.

Fixes: #6295


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal operation handling logic for template variable management to improve code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->