### PR TITLE
Bump frr to 10.6.0 to fix additional coredumps

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -596,6 +596,23 @@ install_metallb() {
     'kind_path = os.path.join(build_path, "kind")' \
     'kind_path = "kind"'
 
+  # MetalLB v0.15.3 still pins its in-cluster FRR speaker containers to 10.4.1.
+  # Keep the pinned upstream string for patching, but replace the actual
+  # deployed image so CI exercises the same FRR build as the rest of our BGP
+  # setup and coredump debugging.
+  replace_in_file_or_exit \
+    config/frr/speaker-patch.yaml \
+    "${FRR_K8S_UPSTREAM_FRR_IMAGE}" \
+    "${FRR_DEPLOYED_IMAGE}"
+  replace_in_file_or_exit \
+    config/manifests/metallb-frr.yaml \
+    "${FRR_K8S_UPSTREAM_FRR_IMAGE}" \
+    "${FRR_DEPLOYED_IMAGE}"
+  replace_in_file_or_exit \
+    charts/metallb/values.yaml \
+    "tag: ${FRR_K8S_UPSTREAM_FRR_IMAGE##*:}" \
+    "tag: ${FRR_DEPLOYED_IMAGE##*:}"
+
   pip install -r dev-env/requirements.txt
 
   local ip_family ipv6_network

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1151,7 +1151,7 @@ get_kubevirt_release_url() {
 
 readonly FRR_K8S_VERSION=v0.0.21
 readonly FRR_K8S_UPSTREAM_FRR_IMAGE=quay.io/frrouting/frr:10.4.1
-readonly FRR_DEPLOYED_IMAGE=quay.io/frrouting/frr:10.5.3
+readonly FRR_DEPLOYED_IMAGE=quay.io/frrouting/frr:10.6.0
 # Override to test newer FRR builds in the in-cluster frr-k8s daemonset
 # without changing the pinned frr-k8s release.
 FRR_K8S_FRR_IMAGE=${FRR_K8S_FRR_IMAGE:-${FRR_DEPLOYED_IMAGE}}
@@ -1178,13 +1178,14 @@ clone_frr() {
     # https://github.com/FRRouting/frr/pull/15714).
     #
     # Bump to 10.4.1 for upstream demo was posted here: https://github.com/metallb/frr-k8s/pull/404
-    # We bump further to 10.5.3 to include additional fixes for EVPN and coredumps:
+    # We bump further to 10.6.0 to include additional fixes for EVPN and coredumps:
     # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3907335193
     # https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5874#issuecomment-3898408592
     # https://github.com/FRRouting/frr/pull/20496
     #
-    # Note: 10.5.3 is aligned with current metallb trunk:
-    # https://github.com/metallb/metallb/pull/2993
+    # Note: 10.6.0 carries the bfdd coredump fix:
+    # https://github.com/FRRouting/frr/pull/19822
+    # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6299
     replace_in_file_or_exit \
       hack/demo/demo.sh \
       "${FRR_K8S_UPSTREAM_FRR_IMAGE}" \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Bump frr to 10.6.0 across the board.

Fixes #6299

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * MetalLB installation enforces the intended FRR speaker image across manifests and Helm chart values.
  * Installation now verifies expected substitutions and will abort if replacements aren’t found.
  * Default FRR image bumped to 10.6.0; release notes updated to reference 10.6.0 and the bfdd coredump fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->