### PR TITLE
cleanup stale L2 primary UDN tunnel ID annotations on restart

### DIFF
--- a/go-controller/pkg/clustermanager/user_defined_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/user_defined_network_cluster_manager.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/node"
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
@@ -97,9 +98,11 @@ func (sncm *userDefinedNetworkClusterManager) isTopologyManaged(nInfo util.NetIn
 	return false
 }
 
-// CleanupStaleNetworks cleans of stale data from the OVN database
-// corresponding to networks not included in validNetworks, which are considered
-// stale.
+// CleanupStaleNetworks cleans up stale node annotations (node-subnets, network-ids,
+// tunnel IDs) for networks not included in validNetworks.
+// Stale network names are discovered from per-network annotation sources:
+//   - k8s.ovn.org/node-subnets (covers L3 UDNs)
+//   - k8s.ovn.org/udn-layer2-node-gateway-router-lrp-tunnel-ids (covers L2 primary UDNs with IC)
 func (sncm *userDefinedNetworkClusterManager) CleanupStaleNetworks(validNetworks ...util.NetInfo) error {
 	existingNetworksMap := map[string]struct{}{}
 	for _, network := range validNetworks {
@@ -113,30 +116,47 @@ func (sncm *userDefinedNetworkClusterManager) CleanupStaleNetworks(validNetworks
 	}
 
 	for _, node := range existingNodes {
+		// node-subnets covers L3 UDNs
 		nodeNetworks, err := util.GetNodeSubnetAnnotationNetworkNames(node)
 		if err != nil {
-			continue
+			nodeNetworks = nil
 		}
-
-		for i := range nodeNetworks {
-			netName := nodeNetworks[i]
+		for _, netName := range nodeNetworks {
 			if netName == ovntypes.DefaultNetworkName {
 				continue
 			}
-
 			if _, ok := existingNetworksMap[netName]; ok {
-				// network still exists, no cleanup to do
 				continue
 			}
-
 			if _, ok := staleNetworkControllers[netName]; ok {
-				// dummy controller already created for the stale network
 				continue
 			}
-
-			oc, err := sncm.newDummyLayer3NetworkController(netName)
+			oc, err := sncm.newDummyNetworkController(ovntypes.Layer3Topology, netName)
 			if err != nil {
-				klog.Errorf("Failed to delete stale subnet annotation for network %s: %v", netName, err)
+				klog.Errorf("Failed to create dummy controller for stale network %s: %v", netName, err)
+				continue
+			}
+			staleNetworkControllers[netName] = oc
+		}
+
+		// tunnel IDs cover L2 primary UDNs with IC
+		tunnelNetworks, err := util.GetNodeUDNLayer2TunnelIDAnnotationNetworkNames(node)
+		if err != nil {
+			tunnelNetworks = nil
+		}
+		for _, netName := range tunnelNetworks {
+			if netName == ovntypes.DefaultNetworkName {
+				continue
+			}
+			if _, ok := existingNetworksMap[netName]; ok {
+				continue
+			}
+			if _, ok := staleNetworkControllers[netName]; ok {
+				continue
+			}
+			oc, err := sncm.newDummyNetworkController(ovntypes.Layer2Topology, netName)
+			if err != nil {
+				klog.Errorf("Failed to create dummy controller for stale network %s: %v", netName, err)
 				continue
 			}
 			staleNetworkControllers[netName] = oc
@@ -144,18 +164,20 @@ func (sncm *userDefinedNetworkClusterManager) CleanupStaleNetworks(validNetworks
 	}
 
 	for netName, oc := range staleNetworkControllers {
-		klog.Infof("Cleanup subnet annotation for stale network %s", netName)
+		klog.Infof("Cleanup stale network %s", netName)
 		err = oc.Cleanup()
 		if err != nil {
-			klog.Errorf("Failed to delete stale subnet annotation for network %s: %v", netName, err)
+			klog.Errorf("Failed to clean up stale network %s: %v", netName, err)
 		}
 	}
 	return nil
 }
 
-// newDummyNetworkController creates a dummy network controller used to clean up specific network
-func (sncm *userDefinedNetworkClusterManager) newDummyLayer3NetworkController(netName string) (networkmanager.NetworkController, error) {
-	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: netName}, Topology: ovntypes.Layer3Topology})
+// newDummyNetworkController creates a minimal network controller used only to
+// clean up stale node annotations for the given network. It skips the full
+// init() path and only sets up what Cleanup() requires: a nodeAllocator.
+func (sncm *userDefinedNetworkClusterManager) newDummyNetworkController(topoType, netName string) (networkmanager.NetworkController, error) {
+	netInfo, _ := util.NewNetInfo(&ovncnitypes.NetConf{NetConf: types.NetConf{Name: netName}, Topology: topoType})
 	nc := newNetworkClusterController(
 		netInfo,
 		sncm.ovnClient,
@@ -165,6 +187,8 @@ func (sncm *userDefinedNetworkClusterManager) newDummyLayer3NetworkController(ne
 		nil,
 		sncm.nodeReconciler,
 	)
-	err := nc.init()
-	return nc, err
+	if nc.hasNodeAllocation() {
+		nc.nodeAllocator = node.NewNodeAllocator(ovntypes.InvalidID, nc.GetNetInfo(), nc.watchFactory.NodeCoreInformer().Lister(), nc.kube, nil)
+	}
+	return nc, nil
 }

--- a/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
+++ b/go-controller/pkg/clustermanager/user_defined_network_unit_test.go
@@ -449,6 +449,88 @@ var _ = ginkgo.Describe("Cluster Controller Manager", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("Cleanup L2 primary UDN with IC discovers stale networks via tunnel ID annotation", func() {
+			app.Action = func(ctx *cli.Context) error {
+				nodes := []corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node1",
+							Annotations: map[string]string{
+								"k8s.ovn.org/node-subnets":                                  "{\"default\":[\"10.244.0.0/24\"]}",
+								"k8s.ovn.org/network-ids":                                   "{\"default\":\"0\"}",
+								"k8s.ovn.org/udn-layer2-node-gateway-router-lrp-tunnel-ids": "{\"l2-primary\":\"5\"}",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node2",
+							Annotations: map[string]string{
+								"k8s.ovn.org/node-subnets":                                  "{\"default\":[\"10.244.1.0/24\"]}",
+								"k8s.ovn.org/network-ids":                                   "{\"default\":\"0\"}",
+								"k8s.ovn.org/udn-layer2-node-gateway-router-lrp-tunnel-ids": "{\"l2-primary\":\"6\"}",
+							},
+						},
+					},
+				}
+				kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
+					Items: nodes,
+				})
+				fakeClient := &util.OVNClusterManagerClientset{
+					KubeClient:            kubeFakeClient,
+					NetworkAttchDefClient: fakenadclient.NewSimpleClientset(),
+				}
+
+				gomega.Expect(initConfig(ctx, config.OVNKubernetesFeatureConfig{
+					EnableMultiNetwork: true,
+					EnableInterconnect: true,
+				})).To(gomega.Succeed())
+				var err error
+				f, err = factory.NewClusterManagerWatchFactory(fakeClient)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = f.Start()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				checkTunnelIDsCleaned := func() error {
+					for _, n := range nodes {
+						updatedNode, err := f.GetNode(n.Name)
+						if err != nil {
+							return err
+						}
+						// default annotations should remain
+						_, err = util.ParseNodeHostSubnetAnnotation(updatedNode, ovntypes.DefaultNetworkName)
+						if err != nil {
+							return fmt.Errorf("default subnet annotation missing on node %s: %v", updatedNode.Name, err)
+						}
+						// l2-primary tunnel ID should be cleaned
+						if util.HasUDNLayer2NodeGRLRPTunnelID(updatedNode, "l2-primary") {
+							return fmt.Errorf("tunnel ID annotation for l2-primary still present on node %s", updatedNode.Name)
+						}
+					}
+					return nil
+				}
+
+				nodeController = newClusterManagerNodeController(f)
+
+				sncm, err := newUserDefinedNetworkClusterManager(fakeClient, f, networkmanager.Default().Interface(), recorder, nodeController)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// No valid networks passed — l2-primary should be detected as stale
+				// via tunnel ID annotation and cleaned up.
+				err = sncm.CleanupStaleNetworks()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(checkTunnelIDsCleaned).ShouldNot(gomega.HaveOccurred())
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 		ginkgo.Context("persistent IP allocations", func() {
 			const (
 				claimName   = "claim1"

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -548,6 +548,21 @@ func UpdateUDNLayer2NodeGRLRPTunnelIDs(annotations map[string]string, netName st
 	return annotations, nil
 }
 
+// GetNodeUDNLayer2TunnelIDAnnotationNetworkNames returns the network names present in
+// the UDNLayer2NodeGRLRPTunnelIDAnnotation on the given node. Used by stale network
+// cleanup to discover L2 primary UDN networks that don't appear in node-subnets.
+func GetNodeUDNLayer2TunnelIDAnnotationNetworkNames(node *corev1.Node) ([]string, error) {
+	tunnelIDsMap, err := parseNetworkMapAnnotation(node.Annotations, types.UDNLayer2NodeGRLRPTunnelIDAnnotation)
+	if err != nil {
+		return nil, err
+	}
+	networks := make([]string, 0, len(tunnelIDsMap))
+	for netName := range tunnelIDsMap {
+		networks = append(networks, netName)
+	}
+	return networks, nil
+}
+
 func UDNLayer2NodeUsesTransitRouter(node *corev1.Node) bool {
 	return node.Annotations[Layer2TopologyVersion] == TransitRouterTopoVersion
 }


### PR DESCRIPTION
Also scan udn-layer2-node-gateway-router-lrp-tunnel-ids when discovering stale networks, since L2 primary UDNs with IC don't write node-subnets.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale network cleanup now also removes networks referenced in L2 interconnect tunnel-ID annotations, not just subnet annotations.
  * Improved resilience when reading node annotations so other nodes are still processed if one node’s annotation lookup fails.
  * Ensures default node subnet annotations are preserved while clearing stale L2 tunnel-ID state.

* **Tests**
  * Added a unit test verifying stale L2 tunnel-ID annotations are cleaned from nodes while preserving default subnet annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->