### PR TITLE
ci: Skip frr coredumps again

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -15,6 +15,10 @@ DUALSTACK_CONVERSION?=false
 COREDUMP_DIR?=/tmp/kind/logs/coredumps
 # Processes to skip when checking for coredumps (pipe-separated for grep)
 # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5782
+# https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6299
+#
+# Don't remove this skip until we trust frr enough not to puke coredumps that
+# often.
 SKIPPED_COREDUMPS?=zebra|bgpd|mgmtd|bfdd
 
 # Check for coredumps and fail if any are found (excluding skipped processes)

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,12 +13,15 @@ DUALSTACK_CONVERSION?=false
 # Coredump detection settings
 # Directory where kind clusters store coredumps
 COREDUMP_DIR?=/tmp/kind/logs/coredumps
+# Processes to skip when checking for coredumps (pipe-separated for grep)
+# https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5782
+SKIPPED_COREDUMPS?=zebra|bgpd|mgmtd|bfdd
 
-# Check for coredumps and fail if any are found
+# Check for coredumps and fail if any are found (excluding skipped processes)
 # Usage: $(call check-coredumps)
 define check-coredumps
 	@if [ -d "$(COREDUMP_DIR)" ]; then \
-		coredumps=$$(find "$(COREDUMP_DIR)" -maxdepth 1 -type f 2>/dev/null); \
+		coredumps=$$(find "$(COREDUMP_DIR)" -maxdepth 1 -type f 2>/dev/null | grep -v -E '$(SKIPPED_COREDUMPS)' || true); \
 		if [ -n "$$coredumps" ]; then \
 			echo "ERROR: Coredumps found:"; \
 			echo "$$coredumps"; \

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1169,6 +1169,9 @@ func wrappedTestFramework(basename string) *framework.Framework {
 		logLocation := "/var/log"
 		coredumpDir := "/tmp/kind/logs/coredumps"
 		dbLocation := "/var/lib/openvswitch"
+		// https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5782
+		skippedCoredumps := []string{"zebra", "bgpd", "mgmtd", "bfdd"}
+
 		// Check for coredumps on host
 		var coredumpFiles []string
 		files, err := os.ReadDir(coredumpDir)
@@ -1177,7 +1180,14 @@ func wrappedTestFramework(basename string) *framework.Framework {
 				if file.IsDir() {
 					continue
 				}
-				coredumpFiles = append(coredumpFiles, file.Name())
+				fileName := file.Name()
+				if slices.ContainsFunc(skippedCoredumps, func(s string) bool {
+					return strings.Contains(fileName, s)
+				}) {
+					framework.Logf("Ignoring coredump for skipped process: %s", fileName)
+					continue
+				}
+				coredumpFiles = append(coredumpFiles, fileName)
 			}
 		}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

- **Revert "e2e: do not skip frr service coredumps"**
- **Add a note suggesting we should continue skipping frr coredumps**

Fixes #6299

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced coredump detection in test infrastructure to filter out coredumps from specific system processes, reducing test noise and false failures.
  * Added configurable option to customize which process coredumps should be excluded from detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->