### PR TITLE
test: fix layer2 UDN controller test flake in kubevirt live-migration

### DIFF
--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -1450,24 +1450,20 @@ func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.Test
 
 	objects = append(objects, extraObjects...)
 
+	if !config.OVNKubernetesFeature.EnableInterconnect {
+		// In non-IC unit tests, seed the default-network pod annotation before
+		// starting the informers to avoid a race where the UDN controller's
+		// WatchPods reads the pod from the informer cache before the cache
+		// reflects a post-startup Update, causing it to clobber the "default"
+		// annotation. IC tests set their own annotations on the pod directly.
+		defaultNetworkPodInfo := podInfo
+		defaultNetworkPodInfo.udnPodInfos = map[string]*udnPodInfo{}
+		setPodAnnotations(pod, defaultNetworkPodInfo)
+	}
+
 	fakeOvn.startWithDBSetup(initialDB, objects...)
 	podInfo.populateLogicalSwitchCache(fakeOvn)
 
-	// on IC, the test itself spits out the pod with the
-	// annotations set, since on production it would be the
-	// clustermanager to annotate the pod.
-	if !config.OVNKubernetesFeature.EnableInterconnect {
-		By("asserting the pod originally does *not* feature the OVN pod networks annotation")
-		// pod exists, networks annotations don't
-		pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		_, ok := pod.Annotations[util.OvnPodAnnotationName]
-		if ok {
-			return fmt.Errorf("expected pod annotation %q", util.OvnPodAnnotationName)
-		}
-	}
 	if err = fakeOvn.networkManager.Start(); err != nil {
 		return err
 	}
@@ -1479,23 +1475,6 @@ func setupFakeOvnForLayer2Topology(fakeOvn *FakeOVN, initialDB libovsdbtest.Test
 	err = fullL2UDNController.init()
 	if err != nil {
 		return fmt.Errorf("failed to initialize %s controller: %w", userDefinedNetworkName, err)
-	}
-
-	if !config.OVNKubernetesFeature.EnableInterconnect {
-		// In non-IC unit tests, seed the default-network pod annotation directly.
-		// This helper only validates UDN topology in NBDB, so starting the default
-		// controller path here would add unrelated default-network objects. IC tests
-		// do not assert the full default annotation in this setup path.
-		pod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podInfo.namespace).Get(context.Background(), podInfo.podName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		defaultNetworkPodInfo := podInfo
-		defaultNetworkPodInfo.udnPodInfos = map[string]*udnPodInfo{}
-		setPodAnnotations(pod, defaultNetworkPodInfo)
-		if _, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Update(context.Background(), pod, metav1.UpdateOptions{}); err != nil {
-			return err
-		}
 	}
 	By("asserting the pod (once reconciled) *features* the OVN pod networks annotation")
 	userDefinedNetController, doesControllerExist := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]


### PR DESCRIPTION
## 📑 Description

fixes #6280.

The test `OVN Multi-Homed pod operations for layer 2 network reconciles a new kubevirt-related pod during its live-migration phases on a layer2 topology with user defined secondary network, when target pod is not yet ready` was intermittently failing because of a race condition in the test setup function `setupFakeOvnForLayer2Topology`.

**Root cause:** The "default" network pod annotation was being seeded via a `Pods().Update()` call *after* informers had already started. When `WatchPods()` subsequently fired, the UDN controller read the pod from the informer cache, which hadn't yet reflected the Update. This caused the controller to write only the secondary network annotation (`namespace1/blue-net`), clobbering the `"default"` annotation.

**Fix:** Move the default-network annotation seeding to *before* `startWithDBSetup()`, setting it directly on the pod object before it enters the fake client and informer cache. This eliminates the race entirely since the informer cache has the `"default"` annotation from the moment it first sees the pod.

## Additional Information for reviewers

The change is confined to `setupFakeOvnForLayer2Topology` in `layer2_user_defined_network_controller_test.go`. No production code is modified.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

Run the previously flaky test repeatedly:

```
cd go-controller && ginkgo -focus="on a layer2 topology with user defined secondary network, when target pod is not yet ready" -v --repeat=99 ./pkg/ovn/
```

Before this fix, the test would intermittently fail with a timeout showing that the pod annotation only contained the secondary network. After this fix, all 100 runs pass consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified a layer‑2 topology test by applying the default OVN pod network annotation earlier for non‑interconnect scenarios, removing the prior initial fetch/update step. This lets the fake controller/informers start without that extra cycle. The test still verifies the annotation appears after reconciliation; interconnect behavior and annotation handoff remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->