### PR TITLE
EVPN: add allowas-in origin for BGP neighbors

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -1204,6 +1204,7 @@ func TestController_reconcile(t *testing.T) {
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
   vni 1000
    route-target import 65000:1000
@@ -1248,6 +1249,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
   vni 1000
    route-target import 65000:1000
@@ -1292,6 +1294,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -1354,6 +1357,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -1503,6 +1507,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
   vni 1000
    route-target import 65000:1000
@@ -1563,6 +1568,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -1628,6 +1634,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor fd00::1 activate
+  neighbor fd00::1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -1695,6 +1702,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
   vni 1000
    route-target import 65000:1000
@@ -1756,6 +1764,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -1839,6 +1848,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -1871,6 +1881,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -1942,6 +1953,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -2025,6 +2037,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -2057,6 +2070,7 @@ exit
 					RawConfig: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit

--- a/go-controller/pkg/clustermanager/routeadvertisements/evpn_rawconfig.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/evpn_rawconfig.go
@@ -16,6 +16,7 @@ import (
 //	router bgp <asn>                    <- genGlobalEVPNSection
 //	 address-family l2vpn evpn
 //	  neighbor <ip> activate
+//	  neighbor <ip> allowas-in origin
 //	  advertise-all-vni
 //	  vni <id>                          <- (one per MAC-VRF with RT, section only added when MAC-VRF RT is set)
 //	   route-target import <rt>
@@ -74,6 +75,7 @@ exit-vrf
 //	router bgp <asn>
 //	 address-family l2vpn evpn
 //	  neighbor <ip> activate
+//	  neighbor <ip> allowas-in origin
 //	  advertise-all-vni
 //	  vni <id>                          <- (Section only added when MAC-VRF RT is set)
 //	   route-target import <rt>
@@ -90,6 +92,10 @@ func genGlobalEVPNSection(asn uint32, neighbors []string, macVRFs []*vrfConfig) 
 
 	for _, neighbor := range neighbors {
 		fmt.Fprintf(&buf, "  neighbor %s activate\n", neighbor)
+		// Needed for eBGP peers sharing our ASN; no-op for iBGP. Applied
+		// unconditionally because the peer type may be unknown (e.g.
+		// `remote-as auto`, not yet supported by frr-k8s but anticipated).
+		fmt.Fprintf(&buf, "  neighbor %s allowas-in origin\n", neighbor)
 	}
 	buf.WriteString("  advertise-all-vni\n")
 

--- a/go-controller/pkg/clustermanager/routeadvertisements/evpn_rawconfig_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/evpn_rawconfig_test.go
@@ -27,6 +27,7 @@ func TestGenerateEVPNRawConfig(t *testing.T) {
 			want: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -45,6 +46,7 @@ exit
 			want: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
   vni 1000
    route-target import 65000:1000
@@ -71,6 +73,7 @@ exit
 			want: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -106,6 +109,7 @@ exit
 			want: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   advertise-all-vni
  exit-address-family
 exit
@@ -144,7 +148,9 @@ exit
 			want: `router bgp 65000
  address-family l2vpn evpn
   neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 allowas-in origin
   neighbor 192.168.1.2 activate
+  neighbor 192.168.1.2 allowas-in origin
   advertise-all-vni
   vni 1000
    route-target import 65000:1000


### PR DESCRIPTION
Without this, eBGP peers sharing the same ASN reject each other's routes due to AS-loop detection. Adding "allowas-in origin" per neighbor allows routes originated by same-ASN peers while still preventing actual routing loops. The directive is a no-op for iBGP and is applied unconditionally to support future dynamic ASN scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced EVPN BGP neighbor configuration generation to include `allowas-in origin` directive for each configured neighbor, improving BGP peer handling in FRR configurations for both IPv4 and IPv6 neighbors.

* **Tests**
  * Updated test expectations to verify the new EVPN configuration output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->