### PR TITLE
Bump ovnkube-id webhook server MinTLS version from 1.0 to 1.2

### DIFF
--- a/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
+++ b/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
@@ -373,7 +373,7 @@ func runWebhook(ctx context.Context, restCfg *rest.Config) error {
 
 	cfg := &tls.Config{
 		NextProtos: []string{"h2"},
-		MinVersion: tls.VersionTLS10,
+		MinVersion: tls.VersionTLS12,
 	}
 
 	certPath := filepath.Join(cliCfg.certDir, "tls.crt")


### PR DESCRIPTION
SonarQube scan tagged this as high sev and recommended moving to 1.2 or higher

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated webhook server TLS configuration to require minimum TLS 1.2, disallowing TLS 1.0 and earlier protocol versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->