### PR TITLE
Migrate ovs external_ids bash ovs-vsctl calls to libovsdb

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -453,7 +453,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	startTime := time.Now()
 
 	if runMode.cleanupNode {
-		return ovnnode.CleanupClusterNode(runMode.identity)
+		return ovnnode.CleanupClusterNode(ctx.Done(), runMode.identity)
 	}
 
 	watchFactory, err := newWatchFactory(runMode, ovnClientset)

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -453,7 +453,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	startTime := time.Now()
 
 	if runMode.cleanupNode {
-		return ovnnode.CleanupClusterNode(ctx.Done(), runMode.identity)
+		return ovnnode.CleanupClusterNode(runMode.identity)
 	}
 
 	watchFactory, err := newWatchFactory(runMode, ovnClientset)

--- a/go-controller/pkg/libovsdb/ops/model.go
+++ b/go-controller/pkg/libovsdb/ops/model.go
@@ -88,6 +88,8 @@ func getUUID(model model.Model) string {
 		return t.UUID
 	case *vswitchd.Bridge:
 		return t.UUID
+	case *vswitchd.OpenvSwitch:
+		return t.UUID
 	default:
 		panic(fmt.Sprintf("getUUID: unknown model %T", t))
 	}
@@ -163,6 +165,8 @@ func setUUID(model model.Model, uuid string) {
 	case *vswitchd.Port:
 		t.UUID = uuid
 	case *vswitchd.Bridge:
+		t.UUID = uuid
+	case *vswitchd.OpenvSwitch:
 		t.UUID = uuid
 	default:
 		panic(fmt.Sprintf("setUUID: unknown model %T", t))
@@ -336,6 +340,8 @@ func copyIndexes(model model.Model) model.Model {
 		return &vswitchd.Port{UUID: t.UUID, Name: t.Name}
 	case *vswitchd.Bridge:
 		return &vswitchd.Bridge{UUID: t.UUID, Name: t.Name}
+	case *vswitchd.OpenvSwitch:
+		return &vswitchd.OpenvSwitch{UUID: t.UUID}
 	default:
 		panic(fmt.Sprintf("copyIndexes: unknown model %T", t))
 	}
@@ -409,6 +415,8 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]*vswitchd.Port{}
 	case *vswitchd.Bridge:
 		return &[]*vswitchd.Bridge{}
+	case *vswitchd.OpenvSwitch:
+		return &[]*vswitchd.OpenvSwitch{}
 	default:
 		panic(fmt.Sprintf("getModelList: unknown model %T", t))
 	}

--- a/go-controller/pkg/libovsdb/ops/ovs/openvswitch.go
+++ b/go-controller/pkg/libovsdb/ops/ovs/openvswitch.go
@@ -37,3 +37,9 @@ func GetOpenvSwitch(ovsClient libovsdbclient.Client) (*vswitchd.OpenvSwitch, err
 func UpdateOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, kv map[string]string) error {
 	return libovsdbops.UpdateOpenvSwitchExternalIDs(ovsClient, kv)
 }
+
+// RemoveOpenvSwitchExternalIDs is the libovsdb equivalent of
+// `ovs-vsctl --if-exists remove Open_vSwitch . external_ids <key> ...`.
+func RemoveOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, keys ...string) error {
+	return libovsdbops.RemoveOpenvSwitchExternalIDs(ovsClient, keys...)
+}

--- a/go-controller/pkg/libovsdb/ops/ovs/openvswitch.go
+++ b/go-controller/pkg/libovsdb/ops/ovs/openvswitch.go
@@ -9,11 +9,14 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
 
-// Get OpenvSwitch entry from the cache
+// GetOpenvSwitch returns the singleton Open_vSwitch row from the cache.
+// When no row exists, the returned error wraps libovsdbclient.ErrNotFound so
+// callers can detect that case via errors.Is.
 func GetOpenvSwitch(ovsClient libovsdbclient.Client) (*vswitchd.OpenvSwitch, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
@@ -23,8 +26,14 @@ func GetOpenvSwitch(ovsClient libovsdbclient.Client) (*vswitchd.OpenvSwitch, err
 		return nil, err
 	}
 	if len(openvSwitchList) == 0 {
-		return nil, fmt.Errorf("no openvSwitch entry found")
+		return nil, fmt.Errorf("no openvSwitch entry found: %w", libovsdbclient.ErrNotFound)
 	}
 
-	return openvSwitchList[0], err
+	return openvSwitchList[0], nil
+}
+
+// UpdateOpenvSwitchExternalIDs is the libovsdb equivalent of
+// `ovs-vsctl set Open_vSwitch . external_ids:key=value ...`.
+func UpdateOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, kv map[string]string) error {
+	return libovsdbops.UpdateOpenvSwitchExternalIDs(ovsClient, kv)
 }

--- a/go-controller/pkg/libovsdb/ops/vswitchdb.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb.go
@@ -39,6 +39,31 @@ func UpdateOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, kv map[string
 	return err
 }
 
+// RemoveOpenvSwitchExternalIDs removes the given keys from the Open_vSwitch
+// row's external_ids. Keys that are not present, and a missing row, are both
+// no-ops.
+func RemoveOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	// modelClient interprets a map field with empty string values as a
+	// delete-by-key mutation (see buildMutationsFromFields).
+	ids := make(map[string]string, len(keys))
+	for _, k := range keys {
+		ids[k] = ""
+	}
+	ovs := &vswitchd.OpenvSwitch{ExternalIDs: ids}
+	opModel := operationModel{
+		Model:            ovs,
+		ModelPredicate:   func(*vswitchd.OpenvSwitch) bool { return true },
+		OnModelMutations: []interface{}{&ovs.ExternalIDs},
+		ErrNotFound:      false,
+		BulkOp:           false,
+	}
+	m := newModelClient(ovsClient)
+	return m.Delete(opModel)
+}
+
 // FindOVSPortsWithPredicate returns all OVS ports matching the predicate.
 func FindOVSPortsWithPredicate(ovsClient libovsdbclient.Client, p ovsPortPredicate) ([]*vswitchd.Port, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)

--- a/go-controller/pkg/libovsdb/ops/vswitchdb.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb.go
@@ -18,6 +18,27 @@ import (
 // OVS port predicates for filtering
 type ovsPortPredicate func(*vswitchd.Port) bool
 
+// UpdateOpenvSwitchExternalIDs merges the given map into the Open_vSwitch
+// row's external_ids. Every entry in the map is inserted or overwritten;
+// existing keys that are not in the map are left alone. Returns ErrNotFound
+// if the row does not exist.
+func UpdateOpenvSwitchExternalIDs(ovsClient libovsdbclient.Client, kv map[string]string) error {
+	if len(kv) == 0 {
+		return nil
+	}
+	ovs := &vswitchd.OpenvSwitch{ExternalIDs: kv}
+	opModel := operationModel{
+		Model:            ovs,
+		ModelPredicate:   func(*vswitchd.OpenvSwitch) bool { return true },
+		OnModelMutations: []interface{}{&ovs.ExternalIDs},
+		ErrNotFound:      true,
+		BulkOp:           false,
+	}
+	m := newModelClient(ovsClient)
+	_, err := m.CreateOrUpdate(opModel)
+	return err
+}
+
 // FindOVSPortsWithPredicate returns all OVS ports matching the predicate.
 func FindOVSPortsWithPredicate(ovsClient libovsdbclient.Client, p ovsPortPredicate) ([]*vswitchd.Port, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)

--- a/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
@@ -384,3 +384,78 @@ func TestUpdateOpenvSwitchExternalIDs(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveOpenvSwitchExternalIDs(t *testing.T) {
+	tests := []struct {
+		desc                string
+		initialExternalIDs  map[string]string
+		removeKeys          []string
+		expectedExternalIDs map[string]string
+		setupNoOpenvSwitch  bool
+	}{
+		{
+			desc:                "removes a single existing key, preserves unrelated keys",
+			initialExternalIDs:  map[string]string{"ovn-bridge-mappings": "physnet1:br1", "system-id": "node-a"},
+			removeKeys:          []string{"ovn-bridge-mappings"},
+			expectedExternalIDs: map[string]string{"system-id": "node-a"},
+		},
+		{
+			desc:                "removes multiple keys",
+			initialExternalIDs:  map[string]string{"a": "1", "b": "2", "c": "3"},
+			removeKeys:          []string{"a", "c"},
+			expectedExternalIDs: map[string]string{"b": "2"},
+		},
+		{
+			desc:                "removing a non-existent key is a no-op",
+			initialExternalIDs:  map[string]string{"system-id": "node-a"},
+			removeKeys:          []string{"ovn-bridge-mappings"},
+			expectedExternalIDs: map[string]string{"system-id": "node-a"},
+		},
+		{
+			desc:                "no-op for empty key list",
+			initialExternalIDs:  map[string]string{"system-id": "node-a"},
+			removeKeys:          nil,
+			expectedExternalIDs: map[string]string{"system-id": "node-a"},
+		},
+		{
+			desc:               "missing Open_vSwitch row is not an error (matches --if-exists)",
+			removeKeys:         []string{"ovn-bridge-mappings"},
+			setupNoOpenvSwitch: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			setup := libovsdbtest.TestSetup{}
+			if !tt.setupNoOpenvSwitch {
+				setup.OVSData = []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: tt.initialExternalIDs},
+				}
+			}
+
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(setup)
+			if err != nil {
+				t.Fatalf("failed to set up test harness: %v", err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			if err := RemoveOpenvSwitchExternalIDs(ovsClient, tt.removeKeys...); err != nil {
+				t.Fatalf("RemoveOpenvSwitchExternalIDs() error = %v", err)
+			}
+
+			if tt.setupNoOpenvSwitch {
+				return
+			}
+			expected := []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: tt.expectedExternalIDs},
+			}
+			matcher := libovsdbtest.HaveData(expected)
+			success, err := matcher.Match(ovsClient)
+			if !success {
+				t.Fatalf("post-condition mismatch: %v", matcher.FailureMessage(ovsClient))
+			}
+			if err != nil {
+				t.Fatalf("matcher encountered error: %v", err)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
@@ -4,8 +4,11 @@
 package ops
 
 import (
+	"errors"
 	"fmt"
 	"testing"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
@@ -302,6 +305,81 @@ func TestDeletePortWithInterfaces(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tt.desc, err))
+			}
+		})
+	}
+}
+
+func TestUpdateOpenvSwitchExternalIDs(t *testing.T) {
+	tests := []struct {
+		desc                string
+		initialExternalIDs  map[string]string
+		update              map[string]string
+		expectedExternalIDs map[string]string
+		setupNoOpenvSwitch  bool
+		expectErrIs         error
+	}{
+		{
+			desc:                "sets a new key on empty external_ids",
+			initialExternalIDs:  nil,
+			update:              map[string]string{"ovn-encap-ip": "10.0.0.1"},
+			expectedExternalIDs: map[string]string{"ovn-encap-ip": "10.0.0.1"},
+		},
+		{
+			desc:                "overwrites an existing key, preserves unrelated keys",
+			initialExternalIDs:  map[string]string{"ovn-encap-ip": "10.0.0.1", "system-id": "node-a"},
+			update:              map[string]string{"ovn-encap-ip": "10.0.0.2"},
+			expectedExternalIDs: map[string]string{"ovn-encap-ip": "10.0.0.2", "system-id": "node-a"},
+		},
+		{
+			desc:                "no-op for empty update",
+			initialExternalIDs:  map[string]string{"system-id": "node-a"},
+			update:              nil,
+			expectedExternalIDs: map[string]string{"system-id": "node-a"},
+		},
+		{
+			desc:               "returns ErrNotFound when no Open_vSwitch row exists",
+			update:             map[string]string{"ovn-encap-ip": "10.0.0.1"},
+			setupNoOpenvSwitch: true,
+			expectErrIs:        libovsdbclient.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			setup := libovsdbtest.TestSetup{}
+			if !tt.setupNoOpenvSwitch {
+				setup.OVSData = []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: tt.initialExternalIDs},
+				}
+			}
+
+			ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(setup)
+			if err != nil {
+				t.Fatalf("failed to set up test harness: %v", err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			err = UpdateOpenvSwitchExternalIDs(ovsClient, tt.update)
+			if tt.expectErrIs != nil {
+				if !errors.Is(err, tt.expectErrIs) {
+					t.Fatalf("expected error %v, got %v", tt.expectErrIs, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UpdateOpenvSwitchExternalIDs() error = %v", err)
+			}
+
+			expected := []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: tt.expectedExternalIDs},
+			}
+			matcher := libovsdbtest.HaveData(expected)
+			success, err := matcher.Match(ovsClient)
+			if !success {
+				t.Fatalf("post-condition mismatch: %v", matcher.FailureMessage(ovsClient))
+			}
+			if err != nil {
+				t.Fatalf("matcher encountered error: %v", err)
 			}
 		})
 	}

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -4,6 +4,7 @@
 package bridgeconfig
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -13,8 +14,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/egressip"
 	nodetypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/types"
 	nodeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/util"
@@ -88,7 +92,7 @@ type BridgeConfiguration struct {
 	dropGARP   bool
 }
 
-func NewBridgeConfiguration(intfName, nodeName,
+func NewBridgeConfiguration(ovsClient libovsdbclient.Client, intfName, nodeName,
 	physicalNetworkName string,
 	nodeSubnets, gwIPs []*net.IPNet,
 	advertised bool) (*BridgeConfiguration, error) {
@@ -228,7 +232,7 @@ func NewBridgeConfiguration(intfName, nodeName,
 		}
 	}
 
-	res.interfaceID, err = bridgedGatewayNodeSetup(nodeName, res.bridgeName, physicalNetworkName)
+	res.interfaceID, err = bridgedGatewayNodeSetup(ovsClient, nodeName, res.bridgeName, physicalNetworkName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
@@ -567,7 +571,7 @@ func getIntfName(gatewayIntf string) (string, error) {
 
 // bridgedGatewayNodeSetup enables forwarding on bridge interface, sets up the physical network name mappings for the bridge,
 // and returns an ifaceID created from the bridge name and the node name
-func bridgedGatewayNodeSetup(nodeName, bridgeName, physicalNetworkName string) (string, error) {
+func bridgedGatewayNodeSetup(ovsClient libovsdbclient.Client, nodeName, bridgeName, physicalNetworkName string) (string, error) {
 	// IPv6 forwarding is enabled globally
 	if config.IPv4Mode {
 		err := util.SetforwardingModeForInterface(bridgeName)
@@ -580,21 +584,27 @@ func bridgedGatewayNodeSetup(nodeName, bridgeName, physicalNetworkName string) (
 	// that provides connectivity to that network. It is in the form of physnet1:br1,physnet2:br2.
 	// Note that there may be multiple ovs bridge mappings, be sure not to override
 	// the mappings for the other physical network
-	stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
-		"external_ids:ovn-bridge-mappings")
-	if err != nil {
-		return "", fmt.Errorf("failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
+	existing := ""
+	if ovs, err := ovsops.GetOpenvSwitch(ovsClient); err != nil {
+		if !errors.Is(err, libovsdbclient.ErrNotFound) {
+			return "", fmt.Errorf("failed to get Open_vSwitch row: %w", err)
+		}
+		// no row yet => no existing mappings
+	} else {
+		existing = ovs.ExternalIDs["ovn-bridge-mappings"]
 	}
+
 	// skip the existing mapping setting for the specified physicalNetworkName
 	mapString := ""
-	bridgeMappings := strings.Split(stdout, ",")
-	for _, bridgeMapping := range bridgeMappings {
-		m := strings.Split(bridgeMapping, ":")
-		if network := m[0]; network != physicalNetworkName {
-			if len(mapString) != 0 {
-				mapString += ","
+	if existing != "" {
+		for _, bridgeMapping := range strings.Split(existing, ",") {
+			m := strings.Split(bridgeMapping, ":")
+			if network := m[0]; network != physicalNetworkName {
+				if len(mapString) != 0 {
+					mapString += ","
+				}
+				mapString += bridgeMapping
 			}
-			mapString += bridgeMapping
 		}
 	}
 	if len(mapString) != 0 {
@@ -602,11 +612,10 @@ func bridgedGatewayNodeSetup(nodeName, bridgeName, physicalNetworkName string) (
 	}
 	mapString += physicalNetworkName + ":" + bridgeName
 
-	_, stderr, err = util.RunOVSVsctl("set", "Open_vSwitch", ".",
-		fmt.Sprintf("external_ids:ovn-bridge-mappings=%s", mapString))
-	if err != nil {
-		return "", fmt.Errorf("failed to set ovn-bridge-mappings for ovs bridge %s"+
-			", stderr:%s (%v)", bridgeName, stderr, err)
+	if err := ovsops.UpdateOpenvSwitchExternalIDs(ovsClient, map[string]string{
+		"ovn-bridge-mappings": mapString,
+	}); err != nil {
+		return "", fmt.Errorf("failed to set ovn-bridge-mappings for ovs bridge %s: %w", bridgeName, err)
 	}
 
 	ifaceID := bridgeName + "_" + nodeName

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -692,6 +692,7 @@ func getMgmtPortAndRepName(node *corev1.Node) (string, string, error) {
 }
 
 func createNodeManagementPortController(
+	ovsClient client.Client,
 	node *corev1.Node,
 	subnets []*net.IPNet,
 	nodeAnnotator kube.Annotator,
@@ -713,7 +714,7 @@ func createNodeManagementPortController(
 			return nil, err
 		}
 	}
-	return managementport.NewManagementPortController(node, subnets, netdevName, rep, routeManager, netInfo)
+	return managementport.NewManagementPortController(ovsClient, node, subnets, netdevName, rep, routeManager, netInfo)
 }
 
 // getOVNSBZone returns the zone name stored in the Southbound db.
@@ -875,6 +876,7 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 
 	// Setup management ports
 	nc.mgmtPortController, err = createNodeManagementPortController(
+		nc.ovsClient,
 		node,
 		subnets,
 		nodeAnnotator,

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -15,6 +15,8 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/klog/v2"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
@@ -373,16 +375,16 @@ func setupUDPAggregationUplink(ifname string) error {
 	return nil
 }
 
-func gatewayInitInternal(nodeName, gwIntf, egressGatewayIntf string, gwNextHops []net.IP, nodeSubnets, gwIPs []*net.IPNet,
+func gatewayInitInternal(ovsClient libovsdbclient.Client, nodeName, gwIntf, egressGatewayIntf string, gwNextHops []net.IP, nodeSubnets, gwIPs []*net.IPNet,
 	advertised bool, nodeAnnotator kube.Annotator) (
 	*bridgeconfig.BridgeConfiguration, *bridgeconfig.BridgeConfiguration, error) {
-	gatewayBridge, err := bridgeconfig.NewBridgeConfiguration(gwIntf, nodeName, types.PhysicalNetworkName, nodeSubnets, gwIPs, advertised)
+	gatewayBridge, err := bridgeconfig.NewBridgeConfiguration(ovsClient, gwIntf, nodeName, types.PhysicalNetworkName, nodeSubnets, gwIPs, advertised)
 	if err != nil {
 		return nil, nil, fmt.Errorf("bridge for interface failed for %s: %w", gwIntf, err)
 	}
 	var egressGWBridge *bridgeconfig.BridgeConfiguration
 	if egressGatewayIntf != "" {
-		egressGWBridge, err = bridgeconfig.NewBridgeConfiguration(egressGatewayIntf, nodeName, types.PhysicalNetworkExGwName, nodeSubnets, nil, false)
+		egressGWBridge, err = bridgeconfig.NewBridgeConfiguration(ovsClient, egressGatewayIntf, nodeName, types.PhysicalNetworkExGwName, nodeSubnets, nil, false)
 		if err != nil {
 			return nil, nil, fmt.Errorf("bridge for interface failed for %s: %w", egressGatewayIntf, err)
 		}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -16,9 +16,13 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
@@ -512,28 +516,40 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 	return err
 }
 
-// CleanupClusterNode cleans up OVS resources on the k8s node on ovnkube-node daemonset deletion.
-// This is going to be a best effort cleanup.
-func CleanupClusterNode(name string) error {
-	var err error
-
+// CleanupClusterNode cleans up OVS resources on the k8s node on ovnkube-node
+// daemonset deletion. Best-effort: OVS-side cleanup is skipped on DPU-host
+// (no OVS to clean) or when the OVSDB client cannot be created; iptables
+// and nftables cleanup runs only on DPU-host or full nodes (the DPU has
+// no host-side rules to clean).
+func CleanupClusterNode(stopChan <-chan struct{}, name string) error {
 	klog.V(5).Infof("Cleaning up gateway resources on node: %q", name)
-	if config.Gateway.Mode == config.GatewayModeLocal || config.Gateway.Mode == config.GatewayModeShared {
-		err = cleanupLocalnetGateway(types.LocalNetworkName)
+
+	var ovsClient libovsdbclient.Client
+	if config.IsModeDPU() || config.IsModeFull() {
+		c, err := libovsdb.NewOVSClient(stopChan)
 		if err != nil {
-			klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", err)
+			klog.Warningf("Skipping OVS-side cleanup: failed to initialize libovsdb vswitchd client: %v", err)
+		} else {
+			ovsClient = c
 		}
-		err = cleanupSharedGateway()
-	}
-	if err != nil {
-		klog.Errorf("Failed to cleanup Gateway, error: %v", err)
 	}
 
-	if config.IsModeDPU() || config.IsModeFull() {
-		stdout, stderr, err := util.RunOVSVsctl("--", "--if-exists", "remove", "Open_vSwitch", ".", "external_ids",
-			"ovn-bridge-mappings")
-		if err != nil {
-			klog.Errorf("Failed to delete ovn-bridge-mappings, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+	if config.Gateway.Mode == config.GatewayModeLocal || config.Gateway.Mode == config.GatewayModeShared {
+		if ovsClient != nil {
+			if err := cleanupLocalnetGateway(ovsClient, types.LocalNetworkName); err != nil {
+				klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", err)
+			}
+		}
+		// cleanupSharedGateway handles both the OVS-side (no-op when ovsClient
+		// is nil) and the host-side iptables chains.
+		if err := cleanupSharedGateway(ovsClient); err != nil {
+			klog.Errorf("Failed to cleanup Gateway, error: %v", err)
+		}
+	}
+
+	if ovsClient != nil && (config.IsModeDPU() || config.IsModeFull()) {
+		if err := ovsops.RemoveOpenvSwitchExternalIDs(ovsClient, "ovn-bridge-mappings"); err != nil {
+			klog.Errorf("Failed to delete ovn-bridge-mappings: %v", err)
 		}
 	}
 

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -279,6 +279,7 @@ func (nc *DefaultNodeNetworkController) initGatewayPreStart(
 			nc.linkManager,
 			nc.networkManager,
 			config.Gateway.Mode,
+			nc.ovsClient,
 		)
 	case config.GatewayModeDisabled:
 		var chassisID string
@@ -487,7 +488,7 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 	var err error
 
 	gw := nc.Gateway.(*gateway)
-	gw.nodeIPManager = newAddressManager(nc.name, nc.Kube, nil, nc.watchFactory, nil)
+	gw.nodeIPManager = newAddressManager(nc.name, nc.Kube, nil, nc.watchFactory, nil, nc.ovsClient)
 	if config.Gateway.NodeportEnable {
 		if err := initSharedGatewayIPTables(); err != nil {
 			return err

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -521,12 +521,18 @@ func (nc *DefaultNodeNetworkController) initGatewayDPUHost() error {
 // (no OVS to clean) or when the OVSDB client cannot be created; iptables
 // and nftables cleanup runs only on DPU-host or full nodes (the DPU has
 // no host-side rules to clean).
-func CleanupClusterNode(stopChan <-chan struct{}, name string) error {
+func CleanupClusterNode(name string) error {
 	klog.V(5).Infof("Cleaning up gateway resources on node: %q", name)
 
 	var ovsClient libovsdbclient.Client
 	if config.IsModeDPU() || config.IsModeFull() {
-		c, err := libovsdb.NewOVSClient(stopChan)
+		// NewOVSClient closes its client when the stop channel fires; use a
+		// dedicated never-shared channel so an in-flight cleanup transaction
+		// can't be torn down mid-operation. Close on return so the libovsdb
+		// lifecycle goroutine exits cleanly.
+		cleanupStopCh := make(chan struct{})
+		defer close(cleanupStopCh)
+		c, err := libovsdb.NewOVSClient(cleanupStopCh)
 		if err != nil {
 			klog.Warningf("Skipping OVS-side cleanup: failed to initialize libovsdb vswitchd client: %v", err)
 		} else {
@@ -534,20 +540,26 @@ func CleanupClusterNode(stopChan <-chan struct{}, name string) error {
 		}
 	}
 
+	var err error
 	if config.Gateway.Mode == config.GatewayModeLocal || config.Gateway.Mode == config.GatewayModeShared {
 		if ovsClient != nil {
-			if err := cleanupLocalnetGateway(ovsClient, types.LocalNetworkName); err != nil {
-				klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", err)
+			if localErr := cleanupLocalnetGateway(ovsClient, types.LocalNetworkName); localErr != nil {
+				klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", localErr)
+				err = localErr
 			}
 		}
 		// cleanupSharedGateway handles both the OVS-side (no-op when ovsClient
 		// is nil) and the host-side iptables chains.
-		if err := cleanupSharedGateway(ovsClient); err != nil {
-			klog.Errorf("Failed to cleanup Gateway, error: %v", err)
+		if sharedErr := cleanupSharedGateway(ovsClient); sharedErr != nil {
+			klog.Errorf("Failed to cleanup Gateway, error: %v", sharedErr)
+			err = sharedErr
 		}
 	}
 
-	if ovsClient != nil && (config.IsModeDPU() || config.IsModeFull()) {
+	// Only strip ovn-bridge-mappings once gateway cleanup has fully
+	// succeeded — otherwise we leave bridges/flows behind without the
+	// external_ids that would let a retry re-attach them.
+	if err == nil && ovsClient != nil && (config.IsModeDPU() || config.IsModeFull()) {
 		if err := ovsops.RemoveOpenvSwitchExternalIDs(ovsClient, "ovn-bridge-mappings"); err != nil {
 			klog.Errorf("Failed to delete ovn-bridge-mappings: %v", err)
 		}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -213,17 +213,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
-		if setNodeIP {
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-encap-ip=192.168.1.10",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-appctl --timeout=5 -t ovn-controller exit --restart",
-			})
-		}
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
 			Output: "0",
@@ -265,6 +254,15 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 
 		// Setup mock filesystem for ovs-vswitchd.pid file needed by ovs-appctl commands
 		Expect(util.SetupMockOVSPidFile()).To(Succeed())
+
+		if setNodeIP {
+			// addressManager.sync() will call updateOVNEncapIPAndReconnect,
+			// which writes ovn-encap-ip via libovsdb (asserted after Init)
+			// and asks ovn-controller to reconnect.
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: "ovn-appctl --timeout=5 -t ovn-controller exit --restart",
+			})
+		}
 
 		err = util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
@@ -390,6 +388,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Expect(err).NotTo(HaveOccurred())
 
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
+			ovsClient, ovsCleanup := newTestOVSClient()
+			defer ovsCleanup.Cleanup()
 			sharedGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),
@@ -405,6 +405,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeShared,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.initFunc()
@@ -418,6 +419,15 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			// Start does two things, starts nodeIPManager which spawns a go routine and also starts openflow manager by spawning a go routine
 			//sharedGw.Start()
 			sharedGw.nodeIPManager.sync()
+			if setNodeIP {
+				// updateOVNEncapIPAndReconnect should have written the
+				// node primary IP into Open_vSwitch.external_ids.
+				expectedAddr, perr := netlink.ParseAddr(eth0CIDR)
+				Expect(perr).NotTo(HaveOccurred())
+				ovs, gerr := ovsops.GetOpenvSwitch(ovsClient)
+				Expect(gerr).NotTo(HaveOccurred())
+				Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-encap-ip", expectedAddr.IP.String()))
+			}
 			// we cannot start openflow manager directly because it spawns a go routine
 			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
 			sharedGw.openflowManager.syncFlows()
@@ -582,6 +592,9 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 	brphys, hostMAC, hostCIDR, dpuIP string, gatewayVLANID uint) {
 	const mtu string = "1400"
 	const clusterCIDR string = "10.1.0.0/16"
+	// addressManager.sync() short-circuits when Mode == DPU, so the
+	// encap-update path never fires here. Keep the field empty to avoid
+	// polluting later tests.
 	app.Action = func(ctx *cli.Context) error {
 		const (
 			nodeName   string = "node1"
@@ -811,6 +824,8 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
+			ovsClient, ovsCleanup := newTestOVSClient()
+			defer ovsCleanup.Cleanup()
 			sharedGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),
@@ -826,6 +841,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeShared,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.initFunc()
@@ -1165,11 +1181,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
-		// IP already configured, do not try to set it or restart ovn-controller
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			Output: "192.168.1.10",
-		})
+		// Encap IP reconciliation moved to libovsdb; addressManager.sync()
+		// is gated off via config.Default.EncapIP for this test.
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
 			Output: "0",
@@ -1209,6 +1222,13 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 
 		// Setup mock filesystem for ovs-vswitchd.pid file needed by ovs-appctl commands
 		Expect(util.SetupMockOVSPidFile()).To(Succeed())
+
+		// addressManager.sync() will call updateOVNEncapIPAndReconnect,
+		// which writes ovn-encap-ip via libovsdb (asserted after Init) and
+		// asks ovn-controller to reconnect.
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovn-appctl --timeout=5 -t ovn-controller exit --restart",
+		})
 
 		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
@@ -1319,6 +1339,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
+			ovsClient, ovsCleanup := newTestOVSClient()
+			defer ovsCleanup.Cleanup()
 			localGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),
@@ -1334,6 +1356,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = localGw.initFunc()
@@ -1348,6 +1371,11 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			// Start does two things, starts nodeIPManager which spawns a go routine and also starts openflow manager by spawning a go routine
 			// localGw.Start()
 			localGw.nodeIPManager.sync()
+			// updateOVNEncapIPAndReconnect should have written the node
+			// primary IP into Open_vSwitch.external_ids.
+			localOVS, lerr := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(lerr).NotTo(HaveOccurred())
+			Expect(localOVS.ExternalIDs).To(HaveKeyWithValue("ovn-encap-ip", expectedAddr.IP.String()))
 			// we cannot start openflow manager directly because it spawns a go routine
 			// FIXME: extract openflow manager func from the spawning of a go routine so it can be called directly below.
 			localGw.openflowManager.syncFlows()

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -284,6 +284,9 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 		nft := nodenft.SetFakeNFTablesHelper()
 
+		ovsClient, ovsCleanup := newTestOVSClient()
+		defer ovsCleanup.Cleanup()
+
 		// Make Management port
 		hostSubnets := ovntest.MustParseIPNets(nodeSubnet)
 		rm := routemanager.NewController()
@@ -291,7 +294,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return(nil)
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))
-		mp, err := managementport.NewManagementPortController(&existingNode, hostSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, &existingNode, hostSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{
@@ -383,8 +386,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Expect(err).NotTo(HaveOccurred())
 
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
-			ovsClient, ovsCleanup := newTestOVSClient()
-			defer ovsCleanup.Cleanup()
 			sharedGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),
@@ -1252,6 +1253,9 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 
 		nft := nodenft.SetFakeNFTablesHelper()
 
+		ovsClient, ovsCleanup := newTestOVSClient()
+		defer ovsCleanup.Cleanup()
+
 		// Make Management port
 		hostSubnets := ovntest.MustParseIPNets(nodeSubnet)
 		rm := routemanager.NewController()
@@ -1259,7 +1263,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return(nil)
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))
-		mp, err := managementport.NewManagementPortController(&existingNode, hostSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, &existingNode, hostSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		if util.IsNetworkSegmentationSupportEnabled() {
@@ -1329,8 +1333,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			Expect(err).NotTo(HaveOccurred())
 			ifAddrs := ovntest.MustParseIPNets(eth0CIDR)
-			ovsClient, ovsCleanup := newTestOVSClient()
-			defer ovsCleanup.Cleanup()
 			localGw, err := newGateway(
 				nodeName,
 				ovntest.MustParseIPNets(nodeSubnet),

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -37,6 +37,7 @@ import (
 	udnfakeclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
@@ -402,6 +403,9 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			err = sharedGw.initFunc()
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
@@ -833,6 +837,9 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":"+brphys))
 			err = sharedGw.initFunc()
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(stop, wg)
@@ -1342,6 +1349,9 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			err = localGw.initFunc()
 			Expect(err).NotTo(HaveOccurred())
 			err = localGw.Init(stop, wg)

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -182,14 +182,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-			Output: "",
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + types.PhysicalNetworkName + ":breth0",
-		})
-
+		// ovn-bridge-mappings get/set are now handled via libovsdb in
+		// bridgeconfig.bridgedGatewayNodeSetup; no fexec entries needed.
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 			Output: systemID,
@@ -663,13 +657,8 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + brphys + " mac_in_use",
 			Output: uplinkMAC,
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-			Output: "",
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + types.PhysicalNetworkName + ":" + brphys,
-		})
+		// ovn-bridge-mappings get/set are now handled via libovsdb in
+		// bridgeconfig.bridgedGatewayNodeSetup; no fexec entries needed.
 		// GetNodeChassisID
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
@@ -1150,14 +1139,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-			Output: "",
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + types.PhysicalNetworkName + ":breth0",
-		})
-
+		// ovn-bridge-mappings get/set are now handled via libovsdb in
+		// bridgeconfig.bridgedGatewayNodeSetup; no fexec entries needed.
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 			Output: systemID,

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -108,7 +108,11 @@ func cleanupLocalnetGateway(ovsClient libovsdbclient.Client, physnet string) err
 		return nil
 	}
 	for _, bridgeMapping := range strings.Split(mappings, ",") {
-		m := strings.Split(bridgeMapping, ":")
+		m := strings.SplitN(bridgeMapping, ":", 2)
+		if len(m) != 2 || m[1] == "" {
+			klog.Warningf("Ignoring malformed ovn-bridge-mappings entry %q", bridgeMapping)
+			continue
+		}
 		if physnet == m[0] {
 			bridgeName := m[1]
 			if _, stderr, err := util.RunOVSVsctl("--", "--if-exists", "del-br", bridgeName); err != nil {

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -7,6 +7,7 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -14,7 +15,10 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -87,26 +91,31 @@ func getLocalAddrs() (map[string]net.IPNet, error) {
 	return localAddrSet, nil
 }
 
-func cleanupLocalnetGateway(physnet string) error {
+func cleanupLocalnetGateway(ovsClient libovsdbclient.Client, physnet string) error {
 	if config.IsModeDPUHost() {
 		return nil
 	}
-	stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
-		"external_ids:ovn-bridge-mappings")
+	ovs, err := ovsops.GetOpenvSwitch(ovsClient)
 	if err != nil {
-		return fmt.Errorf("failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
+		if errors.Is(err, libovsdbclient.ErrNotFound) {
+			// Nothing configured yet — nothing to clean up.
+			return nil
+		}
+		return fmt.Errorf("failed to get Open_vSwitch row: %w", err)
 	}
-	bridgeMappings := strings.Split(stdout, ",")
-	for _, bridgeMapping := range bridgeMappings {
+	mappings := ovs.ExternalIDs["ovn-bridge-mappings"]
+	if mappings == "" {
+		return nil
+	}
+	for _, bridgeMapping := range strings.Split(mappings, ",") {
 		m := strings.Split(bridgeMapping, ":")
 		if physnet == m[0] {
 			bridgeName := m[1]
-			_, stderr, err = util.RunOVSVsctl("--", "--if-exists", "del-br", bridgeName)
-			if err != nil {
+			if _, stderr, err := util.RunOVSVsctl("--", "--if-exists", "del-br", bridgeName); err != nil {
 				return fmt.Errorf("failed to ovs-vsctl del-br %s stderr:%s (%v)", bridgeName, stderr, err)
 			}
 			break
 		}
 	}
-	return err
+	return nil
 }

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -72,7 +72,7 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 	}
 
 	k := &kube.Kube{KClient: fakeClient.KubeClient}
-	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, false)
+	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, nil, false)
 	localHostNetEp := "192.168.18.15/32"
 	ip, ipnet, _ := net.ParseCIDR(localHostNetEp)
 	ipFullNet := net.IPNet{IP: ip, Mask: ipnet.Mask}
@@ -122,7 +122,7 @@ func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNNodeC
 	}
 
 	k := &kube.Kube{KClient: fakeClient.KubeClient}
-	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, false)
+	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, nil, n.watchFactory, nil, nil, false)
 	localHostNetEp := "192.168.18.15/32"
 	ip, ipnet, _ := net.ParseCIDR(localHostNetEp)
 	ipFullNet := net.IPNet{IP: ip, Mask: ipnet.Mask}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -5,6 +5,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -31,6 +32,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/egressip"
@@ -1893,8 +1895,8 @@ func newNodePortWatcher(
 	return npw, nil
 }
 
-func cleanupSharedGateway() error {
-	if config.IsModeDPU() || config.IsModeFull() {
+func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
+	if (config.IsModeDPU() || config.IsModeFull()) && ovsClient != nil {
 		// NicToBridge() may be created before-hand, only delete the patch port here
 		stdout, stderr, err := util.RunOVSVsctl("--columns=name", "--no-heading", "find", "port",
 			"external_ids:ovn-localnet-port!=_")
@@ -1910,16 +1912,20 @@ func cleanupSharedGateway() error {
 		}
 
 		// Get the OVS bridge name from ovn-bridge-mappings
-		stdout, stderr, err = util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
-			"external_ids:ovn-bridge-mappings")
+		ovs, err := ovsops.GetOpenvSwitch(ovsClient)
 		if err != nil {
-			return fmt.Errorf("failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
+			if errors.Is(err, libovsdbclient.ErrNotFound) {
+				return nil
+			}
+			return fmt.Errorf("failed to get Open_vSwitch row: %w", err)
+		}
+		mappings := ovs.ExternalIDs["ovn-bridge-mappings"]
+		if mappings == "" {
+			return nil
 		}
 
-		// skip the existing mapping setting for the specified physicalNetworkName
 		bridgeName := ""
-		bridgeMappings := strings.Split(stdout, ",")
-		for _, bridgeMapping := range bridgeMappings {
+		for _, bridgeMapping := range strings.Split(mappings, ",") {
 			m := strings.Split(bridgeMapping, ":")
 			if network := m[0]; network == types.PhysicalNetworkName {
 				bridgeName = m[1]

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1926,7 +1926,11 @@ func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
 
 		bridgeName := ""
 		for _, bridgeMapping := range strings.Split(mappings, ",") {
-			m := strings.Split(bridgeMapping, ":")
+			m := strings.SplitN(bridgeMapping, ":", 2)
+			if len(m) != 2 {
+				klog.Warningf("Ignoring malformed ovn-bridge-mappings entry %q", bridgeMapping)
+				continue
+			}
 			if network := m[0]; network == types.PhysicalNetworkName {
 				bridgeName = m[1]
 				break

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1700,7 +1700,7 @@ func newGateway(
 
 	advertised := util.IsPodNetworkAdvertisedAtNode(networkManager.GetNetwork(types.DefaultNetworkName), nodeName)
 	gwBridge, exGwBridge, err := gatewayInitInternal(
-		nodeName, gwIntf, egressGWIntf, gwNextHops, subnets, gwIPs, advertised, nodeAnnotator)
+		ovsClient, nodeName, gwIntf, egressGWIntf, gwNextHops, subnets, gwIPs, advertised, nodeAnnotator)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -26,6 +26,8 @@ import (
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
@@ -1681,6 +1683,7 @@ func newGateway(
 	linkManager *linkmanager.Controller,
 	networkManager networkmanager.Interface,
 	gatewayMode config.GatewayMode,
+	ovsClient libovsdbclient.Client,
 ) (*gateway, error) {
 	klog.Info("Creating new gateway")
 	gw := &gateway{
@@ -1737,7 +1740,7 @@ func newGateway(
 			gw.bridgeEIPAddrManager = egressip.NewBridgeEIPAddrManager(nodeName, gwBridge.GetBridgeName(), linkManager, kube, watchFactory.EgressIPInformer(), watchFactory.NodeCoreInformer())
 			gwBridge.SetEIPMarkIPs(gw.bridgeEIPAddrManager.GetCache())
 		}
-		gw.nodeIPManager = newAddressManager(nodeName, kube, mgmtPort, watchFactory, gwBridge)
+		gw.nodeIPManager = newAddressManager(nodeName, kube, mgmtPort, watchFactory, gwBridge, ovsClient)
 
 		if config.IsModeFull() {
 			// Delete stale masquerade resources if there are any. This is to make sure that there

--- a/go-controller/pkg/node/gateway_shared_intf_test.go
+++ b/go-controller/pkg/node/gateway_shared_intf_test.go
@@ -258,7 +258,7 @@ var _ = Describe("DeleteEndpointSlice", func() {
 
 		// Initialize nodeIPManager (required for GetLocalEligibleEndpointAddresses)
 		k := &kube.Kube{KClient: fakeClient.KubeClient}
-		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, false)
+		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, nil, false)
 	})
 
 	AfterEach(func() {
@@ -379,7 +379,7 @@ var _ = Describe("SyncServices", func() {
 		npw.networkManager = networkmanager.Default().Interface()
 
 		k := &kube.Kube{KClient: fakeClient.KubeClient}
-		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, false)
+		npw.nodeIPManager = newAddressManagerInternal(nodeName, k, nil, watcher, nil, nil, false)
 	})
 
 	AfterEach(func() {

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -164,13 +164,8 @@ func setUpGatewayFakeOVSCommands(fexec *ovntest.FakeExec) {
 			Output: "net.ipv4.conf.breth0.forwarding = 1",
 		})
 	}
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-		Output: "",
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + types.PhysicalNetworkName + ":breth0",
-	})
+	// ovn-bridge-mappings get/set are now handled via libovsdb in
+	// bridgeconfig.bridgedGatewayNodeSetup; no fexec entries needed.
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 		Output: "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6",

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	factoryMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory/mocks"
 	kubemocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube/mocks"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iprulemanager"
@@ -690,6 +691,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}
 			err = localGw.initFunc()
@@ -923,6 +927,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}
 			err = localGw.initFunc()
@@ -1123,6 +1130,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}
 			Expect(localGw.initFunc()).To(Succeed())
@@ -1363,6 +1373,9 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-bridge-mappings", types.PhysicalNetworkName+":breth0"))
 			stop := make(chan struct{})
 			wg := &sync.WaitGroup{}
 			err = localGw.initFunc()

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -622,7 +622,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		nodeAnnotatorMock := &kubemocks.Annotator{}
@@ -858,7 +858,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		nodeAnnotatorMock := &kubemocks.Annotator{}
@@ -1066,7 +1066,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, netInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		nodeAnnotatorMock := &kubemocks.Annotator{}
@@ -1304,7 +1304,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", rm, mutableNetInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", rm, mutableNetInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		nodeAnnotatorMock := &kubemocks.Annotator{}

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/knftables"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	rafakeclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/clientset/versioned/fake"
 	udnfakeclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
@@ -41,6 +43,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	coreinformermocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/informers/core/v1"
 	v1mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -192,10 +195,6 @@ func setUpGatewayFakeOVSCommands(fexec *ovntest.FakeExec) {
 		Output: "7",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-		Output: "192.168.1.10",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 ofport",
 		Output: "7",
 	})
@@ -289,11 +288,17 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		mgtPort        = fmt.Sprintf("%s%s", types.K8sMgmtIntfNamePrefix, netID)
 		v4NodeIP       = "192.168.1.10/24"
 		v6NodeIP       = "fc00:f853:ccd:e793::3/64"
+		ovsClient      libovsdbclient.Client
+		ovsCleanup     *libovsdbtest.Context
 	)
 	BeforeEach(func() {
 		// Restore global default values before each testcase
 		err := config.PrepareTestConfig()
 		Expect(err).NotTo(HaveOccurred())
+		// Skip the encap-update path inside addressManager.sync() — these tests
+		// don't fake ovn-appctl and aren't exercising encap reconciliation.
+		config.Default.EncapIP = "test-encap-ip"
+		ovsClient, ovsCleanup = newTestOVSClient()
 		// Ensure gateway tests never rely on host iptables binaries.
 		util.SetFakeIPTablesHelpers()
 
@@ -363,6 +368,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 	AfterEach(func() {
 		close(stopCh)
 		wg.Wait()
+		ovsCleanup.Cleanup()
 		Expect(testNS.Close()).To(Succeed())
 		Expect(testutils.UnmountNS(testNS)).To(Succeed())
 	})
@@ -686,6 +692,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})
@@ -918,6 +925,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})
@@ -1117,6 +1125,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})
@@ -1356,6 +1365,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})

--- a/go-controller/pkg/node/managementport/port_dpu_linux.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux.go
@@ -17,7 +17,10 @@ import (
 
 	"k8s.io/klog/v2"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -30,17 +33,19 @@ type managementPortRepresentor struct {
 	ifName     string
 	repDevName string
 	link       netlink.Link
+	ovsClient  libovsdbclient.Client
 }
 
 // newManagementPortRepresentor creates a new managementPort representor
 // For management port representor only.
 // name is types.K8sMgmtIntfName (on dpu mode node) or types.K8sMgmtIntfName+"_0" (on full mode)
 // repDevName is the representor VF device name
-func newManagementPortRepresentor(name, repDevName string, cfg *managementPortConfig) *managementPortRepresentor {
+func newManagementPortRepresentor(name, repDevName string, cfg *managementPortConfig, ovsClient libovsdbclient.Client) *managementPortRepresentor {
 	return &managementPortRepresentor{
 		cfg:        cfg,
 		ifName:     name,
 		repDevName: repDevName,
+		ovsClient:  ovsClient,
 	}
 }
 
@@ -53,7 +58,7 @@ func (mp *managementPortRepresentor) create() error {
 	}
 
 	if link.Attrs().Name != mp.ifName {
-		if err := syncMgmtPortInterface(mp.ifName, false); err != nil {
+		if err := syncMgmtPortInterface(mp.ovsClient, mp.ifName, false); err != nil {
 			return fmt.Errorf("failed to check existing management port: %v", err)
 		}
 	}
@@ -115,16 +120,18 @@ type managementPortNetdev struct {
 	deviceID     string
 	cfg          *managementPortConfig
 	routeManager *routemanager.Controller
+	ovsClient    libovsdbclient.Client
 }
 
 // newManagementPortNetdev creates a new managementPortNetdev.
 // deviceID is the PCI device ID (e.g., "0000:03:00.2") used to identify the VF.
-func newManagementPortNetdev(deviceID string, cfg *managementPortConfig, routeManager *routemanager.Controller) *managementPortNetdev {
+func newManagementPortNetdev(deviceID string, cfg *managementPortConfig, routeManager *routemanager.Controller, ovsClient libovsdbclient.Client) *managementPortNetdev {
 	return &managementPortNetdev{
 		ifName:       types.K8sMgmtIntfName,
 		deviceID:     deviceID,
 		cfg:          cfg,
 		routeManager: routeManager,
+		ovsClient:    ovsClient,
 	}
 }
 
@@ -158,7 +165,7 @@ func (mp *managementPortNetdev) create() error {
 	}
 
 	if link.Attrs().Name != mp.ifName {
-		err = syncMgmtPortInterface(mp.ifName, false)
+		err = syncMgmtPortInterface(mp.ovsClient, mp.ifName, false)
 		if err != nil {
 			return fmt.Errorf("failed to sync management port: %v", err)
 		}
@@ -174,9 +181,10 @@ func (mp *managementPortNetdev) create() error {
 	}
 
 	if link.Attrs().Name != mp.ifName && (config.IsModeDPU() || config.IsModeFull()) {
-		if _, stderr, err := util.RunOVSVsctl("set", "Open_vSwitch", ".",
-			"external-ids:ovn-orig-mgmt-port-netdev-name="+link.Attrs().Name); err != nil {
-			return fmt.Errorf("failed to store original mgmt port interface name: %s", stderr)
+		if err := ovsops.UpdateOpenvSwitchExternalIDs(mp.ovsClient, map[string]string{
+			"ovn-orig-mgmt-port-netdev-name": link.Attrs().Name,
+		}); err != nil {
+			return fmt.Errorf("failed to store original mgmt port interface name: %w", err)
 		}
 	}
 

--- a/go-controller/pkg/node/managementport/port_dpu_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux_test.go
@@ -19,16 +19,21 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	kubeMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube/mocks"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 	multinetworkmocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks/multinetwork"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,6 +63,8 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	var netlinkOpsMock *utilMocks.NetLinkOps
 	var execMock *ovntest.FakeExec
 	var nodeAnnotatorMock *kubeMocks.Annotator
+	var ovsClient libovsdbclient.Client
+	var ovsCleanup *libovsdbtest.Context
 
 	BeforeEach(func() {
 		Expect(config.PrepareTestConfig()).To(Succeed())
@@ -70,10 +77,18 @@ var _ = Describe("Mananagement port DPU tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		util.SetNetLinkOpMockInst(netlinkOpsMock)
 		nftables.SetFakeNFTablesHelper()
+
+		ovsClient, ovsCleanup, err = libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+			OVSData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		util.SetNetLinkOpMockInst(origNetlinkOps)
+		ovsCleanup.Cleanup()
 	})
 
 	Context("Create Management port DPU", func() {
@@ -106,7 +121,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 		})
 
 		It("Fails if set Name to ovn-k8s-mp0 fails", func() {
-			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", nil)
+			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", nil, ovsClient)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: "enp3s0f0v0", MTU: 1400})
 
@@ -141,7 +156,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nodeName:    "k8s-worker0",
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", cfg)
+			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", cfg, ovsClient)
 			nodeAnnotatorMock.On("Set", mock.Anything, map[string]string{"default": expectedMgmtPortMac.String()}).Return(nil)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: "enp3s0f0v0", MTU: 1500})
@@ -196,7 +211,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nodeName:    "k8s-worker0",
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", cfg)
+			mgmtPortDpu := newManagementPortRepresentor(types.K8sMgmtIntfName+"_0", "enp3s0f0v0", cfg, ovsClient)
 			nodeAnnotatorMock.On("Set", mock.Anything, map[string]string{"default": expectedMgmtPortMac.String()}).Return(nil)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: types.K8sMgmtIntfName + "_0", MTU: config.Default.MTU})
@@ -301,7 +316,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpuHost := newManagementPortNetdev(deviceID, cfg, nil)
+			mgmtPortDpuHost := newManagementPortNetdev(deviceID, cfg, nil, ovsClient)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: "enp3s0f0v0", MTU: 1500, HardwareAddr: currentMgmtPortMac})
@@ -316,9 +331,6 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil)
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
-			execMock.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=enp3s0f0v0",
-			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.
@@ -328,6 +340,10 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			err = mgmtPortDpuHost.create()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("createPlatformManagementPort error"))
+
+			ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ovs.ExternalIDs).To(HaveKeyWithValue("ovn-orig-mgmt-port-netdev-name", "enp3s0f0v0"))
 		})
 
 		It("Does not configure VF if already configured as ovn-k8s-mp0", func() {
@@ -338,7 +354,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPortDpuHost := newManagementPortNetdev(deviceID, cfg, nil)
+			mgmtPortDpuHost := newManagementPortNetdev(deviceID, cfg, nil, ovsClient)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: types.K8sMgmtIntfName, MTU: 1400, HardwareAddr: expectedMgmtPortMac})
@@ -397,7 +413,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				netInfo:     netInfoMock,
 			}
 			Expect(SetupManagementPortNFTSets()).To(Succeed())
-			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil)
+			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil, ovsClient)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: types.K8sMgmtIntfName, MTU: 1400, HardwareAddr: expectedMgmtPortMac,
@@ -424,7 +440,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				netInfo:     netInfoMock,
 			}
 			Expect(SetupManagementPortNFTSets()).To(Succeed())
-			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil)
+			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil, ovsClient)
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: types.K8sMgmtIntfName, MTU: 1400, HardwareAddr: expectedMgmtPortMac,
@@ -449,7 +465,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil)
+			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil, ovsClient)
 
 			// createPlatformManagementPort fails
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(nil, fmt.Errorf("link gone")).Once()
@@ -481,7 +497,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
 			}
-			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil)
+			mgmtPort := newManagementPortNetdev(deviceID, cfg, nil, ovsClient)
 
 			// createPlatformManagementPort fails
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(nil, fmt.Errorf("link gone")).Once()

--- a/go-controller/pkg/node/managementport/port_linux.go
+++ b/go-controller/pkg/node/managementport/port_linux.go
@@ -8,6 +8,7 @@ package managementport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -21,7 +22,10 @@ import (
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -57,6 +61,7 @@ type managementPortController struct {
 
 // NewManagementPortController creates a new ManagementPorts
 func NewManagementPortController(
+	ovsClient libovsdbclient.Client,
 	node *corev1.Node,
 	hostSubnets []*net.IPNet,
 	netdevDevName string,
@@ -90,7 +95,7 @@ func NewManagementPortController(
 	}
 
 	if hasOVS {
-		c.ports[ovsPort] = newManagementPortOVS(cfg, routeManager)
+		c.ports[ovsPort] = newManagementPortOVS(cfg, routeManager, ovsClient)
 	}
 	if hasNetdev {
 		var deviceID string
@@ -116,14 +121,14 @@ func NewManagementPortController(
 				klog.Infof("Management port PCI device ID: %s (resolved from netdev %s)", deviceID, netdevDevName)
 			}
 		}
-		c.ports[netdevPort] = newManagementPortNetdev(deviceID, cfg, routeManager)
+		c.ports[netdevPort] = newManagementPortNetdev(deviceID, cfg, routeManager, ovsClient)
 	}
 	if hasRepresentor {
 		ifName := types.K8sMgmtIntfName
 		if hasNetdev {
 			ifName += "_0"
 		}
-		c.ports[representorPort] = newManagementPortRepresentor(ifName, repDevName, cfg)
+		c.ports[representorPort] = newManagementPortRepresentor(ifName, repDevName, cfg, ovsClient)
 	}
 
 	// setup NFT sets early as gateway initialization depends on it
@@ -176,19 +181,21 @@ func (c *managementPortController) start(stopChan <-chan struct{}) error {
 type managementPortOVS struct {
 	cfg          *managementPortConfig
 	routeManager *routemanager.Controller
+	ovsClient    libovsdbclient.Client
 }
 
 // newManagementPort creates a new newManagementPort
-func newManagementPortOVS(cfg *managementPortConfig, routeManager *routemanager.Controller) *managementPortOVS {
+func newManagementPortOVS(cfg *managementPortConfig, routeManager *routemanager.Controller, ovsClient libovsdbclient.Client) *managementPortOVS {
 	return &managementPortOVS{
 		cfg:          cfg,
 		routeManager: routeManager,
+		ovsClient:    ovsClient,
 	}
 }
 
 func (mp *managementPortOVS) create() error {
 	for _, mgmtPortName := range []string{types.K8sMgmtIntfName, types.K8sMgmtIntfName + "_0"} {
-		if err := syncMgmtPortInterface(mgmtPortName, true); err != nil {
+		if err := syncMgmtPortInterface(mp.ovsClient, mgmtPortName, true); err != nil {
 			return fmt.Errorf("failed to sync management port: %v", err)
 		}
 	}
@@ -593,7 +600,7 @@ func createPlatformManagementPort(interfaceName string, cfg *managementPortConfi
 // syncMgmtPortInterface verifies if no other interface configured as management port. This may happen if another
 // interface had been used as management port or Node was running in different mode.
 // If old management port is found, its IP configuration is flushed and interface renamed.
-func syncMgmtPortInterface(mgmtPortName string, isExpectedToBeInternal bool) error {
+func syncMgmtPortInterface(ovsClient libovsdbclient.Client, mgmtPortName string, isExpectedToBeInternal bool) error {
 	// Query both type and name, because with type only stdout will be empty for both non-existing port and representor netdevice
 	stdout, _, _ := util.RunOVSVsctl("--no-headings",
 		"--data", "bare",
@@ -602,7 +609,7 @@ func syncMgmtPortInterface(mgmtPortName string, isExpectedToBeInternal bool) err
 		"find", "Interface", "name="+mgmtPortName)
 	if stdout == "" {
 		// Not found on the bridge. But could be that interface with the same name exists
-		return unconfigureMgmtNetdevicePort(mgmtPortName)
+		return unconfigureMgmtNetdevicePort(ovsClient, mgmtPortName)
 	}
 
 	// Found existing port. Check its type
@@ -636,7 +643,7 @@ func unconfigureMgmtRepresentorPort(mgmtPortName string) error {
 	return DeleteManagementPortRepInterface(types.DefaultNetworkName, mgmtPortName, savedName)
 }
 
-func unconfigureMgmtNetdevicePort(mgmtPortName string) error {
+func unconfigureMgmtNetdevicePort(ovsClient libovsdbclient.Client, mgmtPortName string) error {
 	link, err := util.GetNetLinkOps().LinkByName(mgmtPortName)
 	if err != nil {
 		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
@@ -654,11 +661,13 @@ func unconfigureMgmtNetdevicePort(mgmtPortName string) error {
 	savedName := ""
 	if config.IsModeDPU() || config.IsModeFull() {
 		// Get original interface name saved at OVS database
-		stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".", "external-ids:ovn-orig-mgmt-port-netdev-name")
+		ovs, err := ovsops.GetOpenvSwitch(ovsClient)
 		if err != nil {
-			klog.Warningf("Failed to get external-ds:ovn-orig-mgmt-port-netdev-name: %s", stderr)
+			if !errors.Is(err, libovsdbclient.ErrNotFound) {
+				klog.Warningf("Failed to get Open_vSwitch row: %v", err)
+			}
 		} else {
-			savedName = stdout
+			savedName = ovs.ExternalIDs["ovn-orig-mgmt-port-netdev-name"]
 		}
 	}
 

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/knftables"
 	anpfake "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/fake"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewallfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	egressipv1fake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
@@ -35,14 +37,17 @@ import (
 	networkqosfake "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/networkqos/v1alpha1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 	multinetworkmocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks/multinetwork"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -306,7 +311,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 		netdevName, rep := "", ""
 
-		mgmtPortController, err := NewManagementPortController(&existingNode, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
+		mgmtPortController, err := NewManagementPortController(nil, &existingNode, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 		stop := make(chan struct{})
 		err = mgmtPortController.Start(stop)
@@ -403,7 +408,7 @@ func testManagementPortDPU(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.
 
 		netdevName, rep := "pf0vf0", "pf0vf0"
 
-		mgmtPortController, err := NewManagementPortController(node, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
+		mgmtPortController, err := NewManagementPortController(nil, node, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 		stop := make(chan struct{})
 		err = mgmtPortController.Start(stop)
@@ -510,7 +515,7 @@ func testManagementPortDPUHost(ctx *cli.Context, fexec *ovntest.FakeExec, testNS
 
 		netdevName, rep := "pf0vf0", ""
 
-		mgmtPortController, err := NewManagementPortController(node, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
+		mgmtPortController, err := NewManagementPortController(nil, node, nodeSubnetCIDRs, netdevName, rep, rm, netInfo)
 		Expect(err).NotTo(HaveOccurred())
 		stop := make(chan struct{})
 		err = mgmtPortController.Start(stop)
@@ -548,6 +553,10 @@ var _ = Describe("Management Port tests", func() {
 		netlinkMockErr := fmt.Errorf("netlink mock error")
 		fakeExecErr := fmt.Errorf("face exec error")
 		linkMock := &mocks.Link{}
+		var (
+			ovsClient  libovsdbclient.Client
+			ovsCleanup *libovsdbtest.Context
+		)
 
 		BeforeEach(func() {
 			Expect(config.PrepareTestConfig()).To(Succeed())
@@ -559,12 +568,20 @@ var _ = Describe("Management Port tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			util.SetNetLinkOpMockInst(netlinkOpsMock)
 			nodenft.SetFakeNFTablesHelper()
+
+			ovsClient, ovsCleanup, err = libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs"},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
 			netlinkOpsMock.AssertExpectations(t)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			util.SetNetLinkOpMockInst(origNetlinkOps)
+			ovsCleanup.Cleanup()
 		})
 
 		Context("Syncing netdevice interface", func() {
@@ -575,7 +592,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
 				netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -587,7 +604,7 @@ var _ = Describe("Management Port tests", func() {
 				linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: mgmtPortName})
 				netlinkOpsMock.On("AddrList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Addr{}, netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -595,17 +612,18 @@ var _ = Describe("Management Port tests", func() {
 				execMock.AddFakeCmdsNoOutputNoError([]string{
 					"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
 				})
-				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name",
-					Output: netdevName,
-				})
+				// ovn-orig-mgmt-port-netdev-name is now read via libovsdb;
+				// seed it on the harness instead of the fexec.
+				Expect(ovsops.UpdateOpenvSwitchExternalIDs(ovsClient, map[string]string{
+					"ovn-orig-mgmt-port-netdev-name": netdevName,
+				})).To(Succeed())
 				netlinkOpsMock.On("LinkByName", netdevName).Return(nil, netlinkMockErr)
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(linkMock, nil)
 				netlinkOpsMock.On("AddrList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Addr{}, nil)
 				netlinkOpsMock.On("RouteList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Route{}, nil)
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -613,10 +631,11 @@ var _ = Describe("Management Port tests", func() {
 				execMock.AddFakeCmdsNoOutputNoError([]string{
 					"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
 				})
-				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name",
-					Output: netdevName,
-				})
+				// ovn-orig-mgmt-port-netdev-name is now read via libovsdb;
+				// seed it on the harness instead of the fexec.
+				Expect(ovsops.UpdateOpenvSwitchExternalIDs(ovsClient, map[string]string{
+					"ovn-orig-mgmt-port-netdev-name": netdevName,
+				})).To(Succeed())
 				netlinkOpsMock.On("LinkByName", netdevName).Return(nil, netlinkMockErr)
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(linkMock, nil)
 				linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: mgmtPortName})
@@ -625,17 +644,18 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 				netlinkOpsMock.On("LinkSetName", linkMock, netdevName).Return(netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 			It("Unconfigures old management port netdevice", func() {
 				execMock.AddFakeCmdsNoOutputNoError([]string{
 					"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
 				})
-				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name",
-					Output: netdevName,
-				})
+				// ovn-orig-mgmt-port-netdev-name is now read via libovsdb;
+				// seed it on the harness instead of the fexec.
+				Expect(ovsops.UpdateOpenvSwitchExternalIDs(ovsClient, map[string]string{
+					"ovn-orig-mgmt-port-netdev-name": netdevName,
+				})).To(Succeed())
 				netlinkOpsMock.On("LinkByName", netdevName).Return(nil, netlinkMockErr)
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(linkMock, nil)
 				netlinkOpsMock.On("AddrList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Addr{}, nil)
@@ -643,7 +663,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 				netlinkOpsMock.On("LinkSetName", linkMock, netdevName).Return(nil)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -655,7 +675,7 @@ var _ = Describe("Management Port tests", func() {
 					Output: "internal," + mgmtPortName,
 				})
 
-				err := syncMgmtPortInterface(mgmtPortName, true)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, true)
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("Fails to remove port from the bridge", func() {
@@ -668,7 +688,7 @@ var _ = Describe("Management Port tests", func() {
 					Err: fakeExecErr,
 				})
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -681,7 +701,7 @@ var _ = Describe("Management Port tests", func() {
 					"ovs-vsctl --timeout=15 --if-exists del-port br-int " + mgmtPortName,
 				})
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -700,7 +720,7 @@ var _ = Describe("Management Port tests", func() {
 					Err: fakeExecErr,
 				})
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -719,7 +739,7 @@ var _ = Describe("Management Port tests", func() {
 
 				// Return error here, so we know that function didn't returned earlier
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -734,7 +754,7 @@ var _ = Describe("Management Port tests", func() {
 				})
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -752,7 +772,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("AddrList", linkMock, netlink.FAMILY_ALL).Return([]netlink.Addr{}, nil)
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -774,7 +794,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 				netlinkOpsMock.On("LinkSetName", linkMock, repName).Return(netlinkMockErr)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -796,7 +816,7 @@ var _ = Describe("Management Port tests", func() {
 				netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 				netlinkOpsMock.On("LinkSetName", linkMock, repName).Return(nil)
 
-				err := syncMgmtPortInterface(mgmtPortName, false)
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -1222,7 +1242,7 @@ var _ = Describe("Management Port tests", func() {
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))
 		It("Creates managementPort by default", func() {
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).ToNot(BeNil())
@@ -1231,7 +1251,7 @@ var _ = Describe("Management Port tests", func() {
 		})
 		It("Creates managementPortRepresentor for Ovnkube Node mode dpu", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPU
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).To(BeNil())
@@ -1244,7 +1264,7 @@ var _ = Describe("Management Port tests", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
 			nodeWithAnnotation := node.DeepCopy()
 			nodeWithAnnotation.Annotations[util.OvnNodeManagementPort] = `{"default":{"DeviceId":"0000:05:00.7","PfId":1,"FuncId":3}}`
-			mgmtPort, err := NewManagementPortController(nodeWithAnnotation, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, nodeWithAnnotation, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[netdevPort]).ToNot(BeNil())
@@ -1253,7 +1273,7 @@ var _ = Describe("Management Port tests", func() {
 		})
 		It("Creates managementPortNetdev for dpu-host falling back to sysfs when annotation is missing", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).To(BeNil())
@@ -1266,7 +1286,7 @@ var _ = Describe("Management Port tests", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
 			config.OvnKubeNode.SimulateDPU = true
 			simNetdev := "eth0-1"
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, simNetdev, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, simNetdev, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			netdevImpl := mgmtPortImpl.ports[netdevPort].(*managementPortNetdev)
@@ -1279,7 +1299,7 @@ var _ = Describe("Management Port tests", func() {
 			mockFsOpsFail.On("Readlink", mock.AnythingOfType("string")).Return("", fmt.Errorf("no such file"))
 			util.SetFileSystemOps(mockFsOpsFail)
 
-			_, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			_, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to get PCI device ID"))
 		})
@@ -1287,7 +1307,7 @@ var _ = Describe("Management Port tests", func() {
 			config.OvnKubeNode.MgmtPortNetdev = netdevName
 			nodeWithAnnotation := node.DeepCopy()
 			nodeWithAnnotation.Annotations[util.OvnNodeManagementPort] = `{"default":{"DeviceId":"0000:05:00.7","PfId":1,"FuncId":3}}`
-			mgmtPort, err := NewManagementPortController(nodeWithAnnotation, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, nodeWithAnnotation, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).To(BeNil())
@@ -1300,7 +1320,7 @@ var _ = Describe("Management Port tests", func() {
 		})
 		It("Creates managementPortNetdev and managementPortRepresentor for full mode falling back to sysfs", func() {
 			config.OvnKubeNode.MgmtPortNetdev = netdevName
-			mgmtPort, err := NewManagementPortController(node, hostSubnets, netdevName, rep, nil, netInfo)
+			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtPortImpl := mgmtPort.(*managementPortController)
 			Expect(mgmtPortImpl.ports[ovsPort]).To(BeNil())

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -567,6 +567,9 @@ var _ = Describe("Management Port tests", func() {
 			err := util.SetExec(execMock)
 			Expect(err).NotTo(HaveOccurred())
 			util.SetNetLinkOpMockInst(netlinkOpsMock)
+			// Restore global netlink ops unconditionally — registered here so a
+			// failing assertion in AfterEach cannot leak the mock to other specs.
+			DeferCleanup(func() { util.SetNetLinkOpMockInst(origNetlinkOps) })
 			nodenft.SetFakeNFTablesHelper()
 
 			ovsClient, ovsCleanup, err = libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
@@ -575,13 +578,12 @@ var _ = Describe("Management Port tests", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { ovsCleanup.Cleanup() })
 		})
 
 		AfterEach(func() {
 			netlinkOpsMock.AssertExpectations(t)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
-			util.SetNetLinkOpMockInst(origNetlinkOps)
-			ovsCleanup.Cleanup()
 		})
 
 		Context("Syncing netdevice interface", func() {

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -624,29 +624,33 @@ func (c *addressManager) getPrimaryHostEgressIPs() (sets.Set[string], error) {
 
 // updateOVNEncapIPAndReconnect updates encap IP to OVS when the node primary IP changed.
 func (c *addressManager) updateOVNEncapIPAndReconnect(newIP net.IP) {
+	alreadyConfigured := false
 	ovs, err := ovsops.GetOpenvSwitch(c.ovsClient)
 	if err != nil {
 		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v", err)
 	} else if encapIP := ovs.ExternalIDs["ovn-encap-ip"]; encapIP != "" && newIP.String() == encapIP {
 		klog.V(4).Infof("Will not update encap IP %s - it is already configured", newIP.String())
-		return
+		alreadyConfigured = true
 	}
 
+	if !alreadyConfigured {
+		if err := ovsops.UpdateOpenvSwitchExternalIDs(c.ovsClient, map[string]string{
+			"ovn-encap-ip": newIP.String(),
+		}); err != nil {
+			klog.Errorf("Error setting OVS encap IP %s: %v", newIP.String(), err)
+			return
+		}
+	}
 	config.Default.EffectiveEncapIP = newIP.String()
-	if err := ovsops.UpdateOpenvSwitchExternalIDs(c.ovsClient, map[string]string{
-		"ovn-encap-ip": newIP.String(),
-	}); err != nil {
-		klog.Errorf("Error setting OVS encap IP %s: %v", newIP.String(), err)
-		return
-	}
 
-	// force ovn-controller to reconnect SB with new encap IP immediately.
-	// otherwise there will be a max delay of 200s due to the 100s
-	// ovn-controller inactivity probe.
-	_, stderr, err := util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart")
-	if err != nil {
-		klog.Errorf("Failed to exit ovn-controller %v %q", err, stderr)
-		return
+	if !alreadyConfigured {
+		// force ovn-controller to reconnect SB with new encap IP immediately.
+		// otherwise there will be a max delay of 200s due to the 100s
+		// ovn-controller inactivity probe. Best-effort: still let the
+		// annotation below converge on failure.
+		if _, stderr, err := util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart"); err != nil {
+			klog.Errorf("Failed to exit ovn-controller %v %q", err, stderr)
+		}
 	}
 
 	// Update node-encap-ips annotation

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -21,9 +21,12 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -36,6 +39,7 @@ type addressManager struct {
 	cidrs         sets.Set[string]
 	nodeAnnotator kube.Annotator
 	mgmtPort      managementport.Interface
+	ovsClient     libovsdbclient.Client
 	// useNetlink indicates the addressManager should use machine
 	// information from netlink. Set to false for testcases.
 	useNetlink bool
@@ -55,20 +59,21 @@ type addressManager struct {
 }
 
 // initializes a new address manager which will hold all the IPs on a node
-func newAddressManager(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration) *addressManager {
-	return newAddressManagerInternal(nodeName, k, mgmtPort, watchFactory, gwBridge, true)
+func newAddressManager(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration, ovsClient libovsdbclient.Client) *addressManager {
+	return newAddressManagerInternal(nodeName, k, mgmtPort, watchFactory, gwBridge, ovsClient, true)
 }
 
 // newAddressManagerInternal creates a new address manager; this function is
 // only expose for testcases to disable netlink subscription to ensure
 // reproducibility of unit tests.
-func newAddressManagerInternal(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration, useNetlink bool) *addressManager {
+func newAddressManagerInternal(nodeName string, k kube.Interface, mgmtPort managementport.Interface, watchFactory factory.NodeWatchFactory, gwBridge *bridgeconfig.BridgeConfiguration, ovsClient libovsdbclient.Client, useNetlink bool) *addressManager {
 	mgr := &addressManager{
 		nodeName:              nodeName,
 		watchFactory:          watchFactory,
 		cidrs:                 sets.New[string](),
 		mgmtPort:              mgmtPort,
 		gatewayBridge:         gwBridge,
+		ovsClient:             ovsClient,
 		OnMasqueradeIPChanged: func() {},
 		useNetlink:            useNetlink,
 		syncPeriod:            30 * time.Second,
@@ -619,41 +624,26 @@ func (c *addressManager) getPrimaryHostEgressIPs() (sets.Set[string], error) {
 
 // updateOVNEncapIPAndReconnect updates encap IP to OVS when the node primary IP changed.
 func (c *addressManager) updateOVNEncapIPAndReconnect(newIP net.IP) {
-	checkCmd := []string{
-		"get",
-		"Open_vSwitch",
-		".",
-		"external_ids:ovn-encap-ip",
-	}
-	encapIP, stderr, err := util.RunOVSVsctl(checkCmd...)
+	ovs, err := ovsops.GetOpenvSwitch(c.ovsClient)
 	if err != nil {
-		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v, %q", err, stderr)
-	} else {
-		encapIP = strings.TrimSuffix(encapIP, "\n")
-		if len(encapIP) > 0 && newIP.String() == encapIP {
-			klog.V(4).Infof("Will not update encap IP %s - it is already configured", newIP.String())
-			return
-		}
+		klog.Warningf("Unable to retrieve configured ovn-encap-ip from OVS: %v", err)
+	} else if encapIP := ovs.ExternalIDs["ovn-encap-ip"]; encapIP != "" && newIP.String() == encapIP {
+		klog.V(4).Infof("Will not update encap IP %s - it is already configured", newIP.String())
+		return
 	}
 
 	config.Default.EffectiveEncapIP = newIP.String()
-	confCmd := []string{
-		"set",
-		"Open_vSwitch",
-		".",
-		fmt.Sprintf("external_ids:ovn-encap-ip=%s", newIP),
-	}
-
-	_, stderr, err = util.RunOVSVsctl(confCmd...)
-	if err != nil {
-		klog.Errorf("Error setting OVS encap IP %s: %v %q", newIP.String(), err, stderr)
+	if err := ovsops.UpdateOpenvSwitchExternalIDs(c.ovsClient, map[string]string{
+		"ovn-encap-ip": newIP.String(),
+	}); err != nil {
+		klog.Errorf("Error setting OVS encap IP %s: %v", newIP.String(), err)
 		return
 	}
 
 	// force ovn-controller to reconnect SB with new encap IP immediately.
 	// otherwise there will be a max delay of 200s due to the 100s
 	// ovn-controller inactivity probe.
-	_, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart")
+	_, stderr, err := util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit", "--restart")
 	if err != nil {
 		klog.Errorf("Failed to exit ovn-controller %v %q", err, stderr)
 		return

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -27,15 +28,30 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	mgmtportmock "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
 	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilMocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// newTestOVSClient starts an in-memory OVSDB harness seeded with an empty
+// Open_vSwitch root row so tests that wire an addressManager have a real
+// libovsdb client. Mirrors the pattern used in pkg/metrics/ovs_test.go.
+func newTestOVSClient() (libovsdbclient.Client, *libovsdbtest.Context) {
+	client, ctx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs"},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return client, ctx
+}
 
 func ipEvent(ipStr string, isAdd bool, addrChan chan netlink.AddrUpdate) *net.IPNet {
 	ipNet := ovntest.MustParseIPNet(ipStr)
@@ -65,6 +81,7 @@ type testCtx struct {
 	mgmtPortIP4  *net.IPNet
 	mgmtPortIP6  *net.IPNet
 	subscribed   uint32
+	ovsCleanup   *libovsdbtest.Context
 }
 
 var _ = Describe("Node IP Handler event tests", func() {
@@ -83,10 +100,6 @@ var _ = Describe("Node IP Handler event tests", func() {
 		// Restore global default values before each testcase
 		Expect(config.PrepareTestConfig()).To(Succeed())
 		fexec := ovntest.NewFakeExec()
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			Output: "10.1.1.10",
-		})
 		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
 		useNetlink := false
 		tc = configureKubeOVNContext(nodeName, useNetlink)
@@ -114,6 +127,7 @@ var _ = Describe("Node IP Handler event tests", func() {
 		close(tc.stopCh)
 		tc.doneWg.Wait()
 		tc.watchFactory.Shutdown()
+		tc.ovsCleanup.Cleanup()
 		close(tc.addrChan)
 		util.ResetRunner()
 	})
@@ -245,10 +259,6 @@ var _ = Describe("Node IP Handler DPUHost event filtering", func() {
 		Expect(config.PrepareTestConfig()).To(Succeed())
 		config.OvnKubeNode.Mode = ovntypes.NodeModeDPUHost
 		fexec := ovntest.NewFakeExec()
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			Output: "10.1.1.10",
-		})
 		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
 		tc = configureKubeOVNContext(nodeName, false)
 		tc.ipManager.gatewayIfIndex = gwIfIndex
@@ -272,6 +282,7 @@ var _ = Describe("Node IP Handler DPUHost event filtering", func() {
 		close(tc.stopCh)
 		tc.doneWg.Wait()
 		tc.watchFactory.Shutdown()
+		tc.ovsCleanup.Cleanup()
 		close(tc.addrChan)
 		util.ResetRunner()
 	})
@@ -337,6 +348,103 @@ var _ = Describe("Node IP Handler DPUHost event filtering", func() {
 	})
 })
 
+var _ = Describe("addressManager.updateOVNEncapIPAndReconnect", func() {
+	const ovnAppctlExitRestart = "ovn-appctl --timeout=5 -t ovn-controller exit --restart"
+
+	var (
+		fexec      *ovntest.FakeExec
+		ovsClient  libovsdbclient.Client
+		ovsCleanup *libovsdbtest.Context
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		fexec = ovntest.NewFakeExec()
+		Expect(util.SetExec(fexec)).To(Succeed())
+		Expect(util.SetupMockOVSPidFile()).To(Succeed())
+	})
+
+	AfterEach(func() {
+		if ovsCleanup != nil {
+			ovsCleanup.Cleanup()
+		}
+		util.ResetRunner()
+	})
+
+	// startHarness seeds the singleton Open_vSwitch row's external_ids with
+	// the given pairs (nil for none) and returns an addressManager wired with
+	// the libovsdb client and a real NodeAnnotator backed by a fake kube
+	// client — both are reached by the function under test.
+	const harnessNodeName = "node1"
+	startHarness := func(initial map[string]string) *addressManager {
+		client, ctx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+			OVSData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", ExternalIDs: initial},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		ovsClient = client
+		ovsCleanup = ctx
+		fakeClient := fake.NewSimpleClientset(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: harnessNodeName},
+		})
+		k := &kube.Kube{KClient: fakeClient}
+		return &addressManager{
+			nodeName:      harnessNodeName,
+			ovsClient:     ovsClient,
+			nodeAnnotator: kube.NewNodeAnnotator(k, harnessNodeName),
+		}
+	}
+
+	currentEncapIP := func() string {
+		got := []*vswitchd.OpenvSwitch{}
+		Expect(ovsClient.List(context.Background(), &got)).To(Succeed())
+		Expect(got).To(HaveLen(1))
+		return got[0].ExternalIDs["ovn-encap-ip"]
+	}
+
+	It("is a no-op when the encap IP is already configured", func() {
+		am := startHarness(map[string]string{"ovn-encap-ip": "10.1.1.10"})
+		// fexec has no expectations; if ovn-appctl runs, it fails the test.
+		am.updateOVNEncapIPAndReconnect(net.ParseIP("10.1.1.10"))
+		Expect(currentEncapIP()).To(Equal("10.1.1.10"))
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue())
+	})
+
+	It("writes the encap IP and restarts ovn-controller when it differs", func() {
+		am := startHarness(map[string]string{"ovn-encap-ip": "10.1.1.10"})
+		fexec.AddFakeCmdsNoOutputNoError([]string{ovnAppctlExitRestart})
+		am.updateOVNEncapIPAndReconnect(net.ParseIP("10.1.1.20"))
+		Expect(currentEncapIP()).To(Equal("10.1.1.20"))
+		Expect(config.Default.EffectiveEncapIP).To(Equal("10.1.1.20"))
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue())
+	})
+
+	It("writes the encap IP when no prior value exists", func() {
+		am := startHarness(nil)
+		fexec.AddFakeCmdsNoOutputNoError([]string{ovnAppctlExitRestart})
+		am.updateOVNEncapIPAndReconnect(net.ParseIP("10.1.1.10"))
+		Expect(currentEncapIP()).To(Equal("10.1.1.10"))
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue())
+	})
+
+	It("preserves unrelated external_ids while updating the encap IP", func() {
+		am := startHarness(map[string]string{
+			"ovn-encap-ip": "10.1.1.10",
+			"system-id":    "node-a",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{ovnAppctlExitRestart})
+		am.updateOVNEncapIPAndReconnect(net.ParseIP("10.1.1.20"))
+
+		got := []*vswitchd.OpenvSwitch{}
+		Expect(ovsClient.List(context.Background(), &got)).To(Succeed())
+		Expect(got[0].ExternalIDs).To(Equal(map[string]string{
+			"ovn-encap-ip": "10.1.1.20",
+			"system-id":    "node-a",
+		}))
+	})
+})
+
 var _ = Describe("refreshGatewayIfIndex", func() {
 	const nodeName = "node1"
 
@@ -345,6 +453,7 @@ var _ = Describe("refreshGatewayIfIndex", func() {
 		config.Gateway.Interface = ""
 		tc := configureKubeOVNContext(nodeName, false)
 		defer tc.watchFactory.Shutdown()
+		defer tc.ovsCleanup.Cleanup()
 
 		tc.ipManager.gatewayIfIndex = 42
 		tc.ipManager.refreshGatewayIfIndex()
@@ -356,6 +465,7 @@ var _ = Describe("refreshGatewayIfIndex", func() {
 		config.Gateway.Interface = "nonexistent0"
 		tc := configureKubeOVNContext(nodeName, false)
 		defer tc.watchFactory.Shutdown()
+		defer tc.ovsCleanup.Cleanup()
 
 		nlMock := new(utilMocks.NetLinkOps)
 		util.SetNetLinkOpMockInst(nlMock)
@@ -373,6 +483,7 @@ var _ = Describe("refreshGatewayIfIndex", func() {
 		config.Gateway.Interface = "breth0"
 		tc := configureKubeOVNContext(nodeName, false)
 		defer tc.watchFactory.Shutdown()
+		defer tc.ovsCleanup.Cleanup()
 
 		nlMock := new(utilMocks.NetLinkOps)
 		linkMock := new(netlink_mocks.Link)
@@ -395,6 +506,7 @@ var _ = Describe("Node IP Handler helper tests", func() {
 		Expect(config.PrepareTestConfig()).To(Succeed())
 		tc := configureKubeOVNContext(nodeName, false)
 		defer tc.watchFactory.Shutdown()
+		defer tc.ovsCleanup.Cleanup()
 
 		tc.ipManager.Lock()
 		tc.ipManager.cidrs.Insert(tc.mgmtPortIP4.String())
@@ -409,6 +521,7 @@ var _ = Describe("Node IP Handler helper tests", func() {
 		Expect(config.PrepareTestConfig()).To(Succeed())
 		tc := configureKubeOVNContext(nodeName, false)
 		defer tc.watchFactory.Shutdown()
+		defer tc.ovsCleanup.Cleanup()
 
 		tc.ipManager.addHandlerForAddrChange()
 
@@ -457,10 +570,6 @@ var _ = Describe("Node IP Handler tests", func() {
 
 	BeforeEach(func() {
 		fexec := ovntest.NewFakeExec()
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 get Open_vSwitch . external_ids:ovn-encap-ip",
-			Output: dummyBrInternalIPv4,
-		})
 		Expect(util.SetExec(fexec)).ShouldNot(HaveOccurred())
 		// Restore global default values before each testcase
 		Expect(config.PrepareTestConfig()).To(Succeed())
@@ -474,6 +583,7 @@ var _ = Describe("Node IP Handler tests", func() {
 		close(tc.stopCh)
 		tc.doneWg.Wait()
 		tc.watchFactory.Shutdown()
+		tc.ovsCleanup.Cleanup()
 		Expect(tc.ns.Close()).ShouldNot(HaveOccurred())
 		util.ResetRunner()
 	})
@@ -670,7 +780,14 @@ func configureKubeOVNContext(nodeName string, useNetlink bool) *testCtx {
 
 	fakeBridgeConfiguration := bridgeconfig.TestBridgeConfig("breth0")
 
+	// Skip the encap-update path inside addressManager.sync() — these tests
+	// don't fake ovn-appctl and aren't exercising encap reconciliation.
+	config.Default.EncapIP = "test-encap-ip"
+
+	ovsClient, ovsCleanup := newTestOVSClient()
+	tc.ovsCleanup = ovsCleanup
+
 	k := &kube.Kube{KClient: tc.fakeClient}
-	tc.ipManager = newAddressManagerInternal(nodeName, k, mpmock, tc.watchFactory, fakeBridgeConfiguration, useNetlink)
+	tc.ipManager = newAddressManagerInternal(nodeName, k, mpmock, tc.watchFactory, fakeBridgeConfiguration, ovsClient, useNetlink)
 	return tc
 }

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
-	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -21,6 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	udnfakeclient "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
@@ -35,6 +37,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/vrfmanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	coreinformermocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/informers/core/v1"
 	v1mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -180,10 +183,16 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 		kubeMock         kubemocks.Interface
 		v4NodeIP         = "192.168.1.10/24"
 		v6NodeIP         = "fc00:f853:ccd:e793::3/64"
+		ovsClient        libovsdbclient.Client
+		ovsCleanup       *libovsdbtest.Context
 	)
 	BeforeEach(func() {
 		// Restore global default values before each testcase
 		Expect(config.PrepareTestConfig()).To(Succeed())
+		// Skip the encap-update path inside addressManager.sync() — these tests
+		// don't fake ovn-appctl and aren't exercising encap reconciliation.
+		config.Default.EncapIP = "test-encap-ip"
+		ovsClient, ovsCleanup = newTestOVSClient()
 		// Use a larger masq subnet to allow OF manager to allocate IPs for UDNs.
 		config.Gateway.V6MasqueradeSubnet = "fd69::/112"
 		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/17"
@@ -262,6 +271,7 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 	AfterEach(func() {
 		close(stopCh)
 		wg.Wait()
+		ovsCleanup.Cleanup()
 		Expect(testNS.Close()).To(Succeed())
 		Expect(testutils.UnmountNS(testNS)).To(Succeed())
 		util.ResetRunner()
@@ -410,6 +420,7 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 				nil,
 				networkmanager.Default().Interface(),
 				config.GatewayModeLocal,
+				ovsClient,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			stop := make(chan struct{})

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -373,7 +373,7 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 		mgtPortMAC = util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(ipNet).IP).String()
 		// Make Management port
 		nodeSubnets := ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet)
-		mp, err := managementport.NewManagementPortController(node, nodeSubnets, "", "", routeManager, NetInfo)
+		mp, err := managementport.NewManagementPortController(ovsClient, node, nodeSubnets, "", "", routeManager, NetInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = testNS.Do(func(ns.NetNS) error {


### PR DESCRIPTION
Replaces `ovs-vsctl get/set/remove` bash calls against `Open_vSwitch.external_ids` with libovsdb client operations. Until now the libovsdb OVS client has only been used for metrics collection.

Specifically:
  - `ovn-encap-ip`, address manager when the node primary IP changes.                                                                                                                                                                    
  - `ovn-bridge-mappings`, from `bridgedGatewayNodeSetup` and cleared during node cleanup.                                                                                                                                                   
  - `ovn-orig-mgmt-port-netdev-name` — written by the management portsetup paths (full, DPU, DPU-host).       

Adds two helpers in `pkg/libovsdb/ops/ovs` - `UpdateOpenvSwitchExternalIDs` and `RemoveOpenvSwitchExternalIDs`

`CleanupClusterNode` is refactored with new changes.  OVS-side cleanup is skipped for DPU mode, but iptables and nftables cleanup always runs

Test coverage extended to assert the libovsdb writes directly via `ovsops.GetOpenvSwitch`, instead of the `ovs-vsctl` fexec expectations.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Threaded an OVSDB client through gateway, management-port, and node IP flows; added helpers to set/remove Open vSwitch external IDs.

* **Bug Fixes**
  * Node cleanup is cancellation-aware.
  * Improved handling when Open_vSwitch row is absent and safer external-IDs update/remove semantics.
  * Preserve and restore original management netdev names via OVS external IDs.

* **Tests**
  * Tests migrated to an in-memory OVSDB harness and updated to assert OVSDB-driven state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->