### PR TITLE
Update retest-action base image from Alpine 3.10 to 3.21

### DIFF
--- a/.github/actions/retest-action/Dockerfile
+++ b/.github/actions/retest-action/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.10
+FROM alpine:3.21
 
 RUN apk add --no-cache curl jq
 


### PR DESCRIPTION
Alpine 3.10 has been end-of-life since May 2021. While the action's attack surface is narrow (curl and jq calling the GitHub API), using a supported base image is standard practice.

Alpine 3.21 is the current stable release. The action only uses curl and jq via a POSIX shell script, so this carries no compatibility risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image to a newer version for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->