### PR TITLE
E2E tests for CUDN with transport NoOverlay routing unmanaged

### DIFF
--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1240,7 +1240,21 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 				}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
 
 				// Check CUDN TransportAccepted condition is True after RA is created
-				if cudnATemplate.Spec.Network.Transport != "" && cudnATemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
+				expectedTransportMsg := func(t udnv1.TransportOption) string {
+					switch t {
+					case udnv1.TransportOptionNoOverlay:
+						return "Transport has been configured as 'no-overlay'."
+					case udnv1.TransportOptionEVPN:
+						return "Transport has been configured as 'EVPN'."
+					default:
+						return ""
+					}
+				}
+				expectedMsgByCUDN := map[string]string{
+					cudnA.Name: expectedTransportMsg(cudnATemplate.Spec.Network.Transport),
+					cudnB.Name: expectedTransportMsg(cudnBTemplate.Spec.Network.Transport),
+				}
+				if expectedMsgByCUDN[cudnA.Name] != "" || expectedMsgByCUDN[cudnB.Name] != "" {
 					ginkgo.By("ensure CUDN TransportAccepted condition is True")
 					for _, cudnName := range []string{cudnA.Name, cudnB.Name} {
 						gomega.Eventually(func(g gomega.Gomega) {
@@ -1251,7 +1265,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							for _, condition := range conditions {
 								if condition.Type == "TransportAccepted" {
 									g.Expect(string(condition.Status)).To(gomega.Equal("True"))
-									g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
+									g.Expect(condition.Message).To(gomega.Equal(expectedMsgByCUDN[cudnName]))
 									return
 								}
 							}

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1239,6 +1239,27 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					return condition.Reason
 				}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
 
+				// Check CUDN TransportAccepted condition is True after RA is created
+				if cudnATemplate.Spec.Network.Transport != "" && cudnATemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
+					ginkgo.By("ensure CUDN TransportAccepted condition is True")
+					for _, cudnName := range []string{cudnA.Name, cudnB.Name} {
+						gomega.Eventually(func(g gomega.Gomega) {
+							cudnObj, err := f.DynamicClient.Resource(clusterUDNGVR).Get(context.Background(), cudnName, metav1.GetOptions{}, "status")
+							g.Expect(err).NotTo(gomega.HaveOccurred())
+							conditions, err := getConditions(cudnObj)
+							g.Expect(err).NotTo(gomega.HaveOccurred())
+							for _, condition := range conditions {
+								if condition.Type == "TransportAccepted" {
+									g.Expect(string(condition.Status)).To(gomega.Equal("True"))
+									g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
+									return
+								}
+							}
+							g.Expect(false).To(gomega.BeTrue(), "TransportAccepted condition not found in CUDN %s", cudnName)
+						}, 30*time.Second, time.Second).Should(gomega.Succeed())
+					}
+				}
+
 				ginkgo.By("ensure routes from UDNs are learned by the external FRR router")
 				serverContainerIPs := getBGPServerContainerIPs(f)
 				for _, serverContainerIP := range serverContainerIPs {
@@ -1656,6 +1677,9 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in same UDN network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+						if cudnATemplate.Spec.Network.Transport == udnv1.TransportOptionNoOverlay {
+							e2eskipper.Skipf("ETP=Cluster cross-node NodePort not supported for NoOverlay networks, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6316")
+						}
 						clientPod := podsNetA[0]
 						// The service is backed by pods in podsNetA.
 						// We want to hit the nodeport on a different node.
@@ -1698,6 +1722,9 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in different UDN network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+						if cudnATemplate.Spec.Network.Transport == udnv1.TransportOptionNoOverlay {
+							e2eskipper.Skipf("ETP=Cluster cross-node NodePort not supported for NoOverlay networks, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6316")
+						}
 						clientPod := podsNetA[0]
 						// The service is backed by podNetB.
 						// We want to hit the nodeport on a different node from the client.
@@ -1916,6 +1943,59 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							CIDR:       "2014:100:200::0/60",
 							HostSubnet: 64,
 						}},
+					},
+				},
+			},
+		},
+	),
+	ginkgo.Entry("Layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+		&udnv1.ClusterUserDefinedNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "bgp-l3-noovl-unmgd-net-a",
+				Labels: map[string]string{"bgp-l3-noovl-unmgd-net-a": ""},
+			},
+			Spec: udnv1.ClusterUserDefinedNetworkSpec{
+				Network: udnv1.NetworkSpec{
+					Topology: udnv1.NetworkTopologyLayer3,
+					Layer3: &udnv1.Layer3Config{
+						Role: "Primary",
+						Subnets: []udnv1.Layer3Subnet{{
+							CIDR:       "102.102.0.0/16",
+							HostSubnet: 24,
+						}, {
+							CIDR:       "2013:100:200::0/60",
+							HostSubnet: 64,
+						}},
+					},
+					Transport: udnv1.TransportOptionNoOverlay,
+					NoOverlay: &udnv1.NoOverlayConfig{
+						OutboundSNAT: udnv1.SNATDisabled,
+						Routing:      udnv1.RoutingUnmanaged,
+					},
+				},
+			},
+		}, &udnv1.ClusterUserDefinedNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "bgp-l3-noovl-unmgd-net-b",
+				Labels: map[string]string{"bgp-l3-noovl-unmgd-net-b": ""},
+			},
+			Spec: udnv1.ClusterUserDefinedNetworkSpec{
+				Network: udnv1.NetworkSpec{
+					Topology: udnv1.NetworkTopologyLayer3,
+					Layer3: &udnv1.Layer3Config{
+						Role: "Primary",
+						Subnets: []udnv1.Layer3Subnet{{
+							CIDR:       "103.103.0.0/16",
+							HostSubnet: 24,
+						}, {
+							CIDR:       "2014:100:200::0/60",
+							HostSubnet: 64,
+						}},
+					},
+					Transport: udnv1.TransportOptionNoOverlay,
+					NoOverlay: &udnv1.NoOverlayConfig{
+						OutboundSNAT: udnv1.SNATDisabled,
+						Routing:      udnv1.RoutingUnmanaged,
 					},
 				},
 			},


### PR DESCRIPTION
Test for east west traffic in CUDN with transport NoOverlay routing Unmanaged (28 tests).

ETP=Cluster cross-node NodePort forwarding is broken for NoOverlay CUDN networks. Tracked in https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6316. Skip the two failing tests conditionally when the network transport is NoOverlay:
 - [ETP=Cluster] UDN pod to a different node nodeport service in same UDN network
 - [ETP=Cluster] UDN pod to a different node nodeport service in different UDN network

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
E2E test cases for east west traffic NoOverlay unmanaged CUDN
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added post-creation validation verifying each endpoint reaches TransportAccepted=true and shows a transport-specific message for non-Geneve transports.
  * Updated cross-node NodePort cluster tests to skip scenarios when the source transport is `no-overlay`.
  * Expanded Layer3 advertised-network test matrix with a `no-overlay` scenario covering disabled outbound SNAT and unmanaged routing for both endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->