### PR TITLE
Fix IPv6 CIDR flapping in k8s.ovn.org/host-cidrs annotation

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -551,7 +551,7 @@ func (c *addressManager) sync() {
 			return
 		}
 		for _, link := range links {
-			foundAddrs, err := util.GetNetLinkOps().AddrList(link, getSupportedIPFamily())
+			foundAddrs, err := util.GetNetLinkOps().AddrList(link, 0)
 			if err != nil {
 				klog.Errorf("Failed sync due to being unable to list addresses for %q: %v", link.Attrs().Name, err)
 				return


### PR DESCRIPTION
## Problem

The k8s.ovn.org/host-cidrs annotation flaps on IPv4-only clusters that have IPv6 addresses configured on nodes (e.g., via SLAAC from network Router Advertisements). IPv6 addresses appear and disappear from the annotation every 30 seconds, causing continuous annotation churn.

## Root Cause                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                 
Inconsistency between two code paths:                                                                                                                                                                                                          
                  
  1. Netlink watcher (event-driven):                                                                                                                                                                                                             
    - [Code lines](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/go-controller/pkg/node/node_ip_handler_linux.go#L242-L257) 
    - Subscribes to ALL address events without IP family filtering                                                                                                                                                                               
    - [Detects both IPv4 and IPv6 addresses](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/go-controller/pkg/node/node_ip_handler_linux.go#L210-L225)                                                                                                                                                                                                       
                                                                                                                          
  2. sync() function (periodic, every 30s):                                                                                                                                                                                                      
    - [Code lines  ](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/go-controller/pkg/node/node_ip_handler_linux.go#L554)  
    - On IPv4-only clusters, [getSupportedIPFamily()   ](https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/node/node_ip_handler_linux.go#L672-L680    )                                                                        
    - Only scans IPv4 addresses, filters out IPv6                                                                                                                                                                                                
    - Updates annotation to IPv4 only       

## The cycle:  
                                                                                   
  T=0s:  Netlink watcher adds IPv6 → annotation has IPv4 + IPv6                                                                                                                                                                                  
  T=30s: sync() scans only IPv4    → annotation updated to IPv4 only
  T=30s: Netlink watcher re-adds   → annotation has IPv4 + IPv6                                                                                                                                                                                  
  T=60s: sync() removes IPv6 again → flapping continues...  

## Why This Happens in Customer Environments                                                                                                                                                                                                      
                                                                                                                                                                                                                                                 
Even though OpenShift clusters are configured as IPv4-only (clusterNetwork and serviceNetwork are IPv4), nodes can have IPv6 addresses because:                                                                                                
                  
  1. RHEL CoreOS has SLAAC enabled by default:                                                                                                                                                                                                   
  net.ipv6.conf.all.autoconf = 1
  net.ipv6.conf.all.accept_ra = 1                                                                                                                                                                                                                
  2. Datacenter network infrastructure broadcasts IPv6 Router Advertisements:
    - Network routers/switches advertise IPv6 prefixes (e.g., 2620:52:0:2ef8::/64)
    - Independent of OpenShift cluster configuration                                                                                                                                                                                             
  3. Nodes autoconfigure IPv6 global addresses via SLAAC (RFC 4862):                                                                                                                                                                             
    - When nodes receive RAs → kernel creates IPv6 addresses                                                                                                                                                                                     
    - These addresses are real and exist on interfaces                                                                                                                                                                                           
    - The k8s.ovn.org/host-cidrs annotation should reflect actual node state    

## Solution                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                 
  Change sync() to scan ALL IP families, matching the netlink watcher behavior:                                                                                                                                                                  
   
  -foundAddrs, err := util.GetNetLinkOps().AddrList(link, getSupportedIPFamily())                                                                                                                                                               
  +foundAddrs, err := util.GetNetLinkOps().AddrList(link, 0)

