### PR TITLE
services: fix nil ops bug and add ITP=Local support for UDN-enabled services

### DIFF
--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -181,12 +181,30 @@ func (r *repair) runBeforeSync(useTemplates bool, netInfo util.NetInfo, nodes ma
 				}
 			}
 		} else {
-			if ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(r.nbClient, ops, netInfo.GetNetworkScopedClusterRouterName(), udnDelPredicate); err != nil {
+			routerName := netInfo.GetNetworkScopedClusterRouterName()
+			if ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(r.nbClient, ops, routerName, udnDelPredicate); err != nil {
 				klog.Errorf("Failed to create a delete logical router static route op: %v", err)
+			}
+			udnPolicyDelPredicate := func(policy *nbdb.LogicalRouterPolicy) bool {
+				if policy.ExternalIDs[types.NetworkExternalID] == netInfo.GetNetworkName() &&
+					policy.ExternalIDs[types.TopologyExternalID] == netInfo.TopologyType() {
+					if serviceKey, exists := policy.ExternalIDs[types.UDNEnabledServiceExternalID]; exists {
+						if !r.unsyncedServices.Has(serviceKey) {
+							return true
+						}
+						if !util.IsUDNEnabledService(serviceKey) {
+							return true
+						}
+					}
+				}
+				return false
+			}
+			if ops, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(r.nbClient, ops, routerName, udnPolicyDelPredicate); err != nil {
+				klog.Errorf("Failed to create a delete logical router policy op: %v", err)
 			}
 		}
 		if _, err = libovsdbops.TransactAndCheck(r.nbClient, ops); err != nil {
-			klog.Errorf("Failed to delete logical router static routes: %v", err)
+			klog.Errorf("Failed to delete logical router static routes/policies: %v", err)
 		}
 	}
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -786,22 +786,32 @@ func (c *Controller) getServiceNamespacedNameFromEndpointSlice(endpointSlice *di
 
 func (c *Controller) cleanupUDNEnabledServiceRoute(key string) error {
 	klog.Infof("Removing UDN enabled service route for service %s in network: %s", key, c.netInfo.GetNetworkName())
-	delPredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+
+	routeDelPredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
 		return route.ExternalIDs[types.NetworkExternalID] == c.netInfo.GetNetworkName() &&
 			route.ExternalIDs[types.TopologyExternalID] == c.netInfo.TopologyType() &&
 			route.ExternalIDs[types.UDNEnabledServiceExternalID] == key
+	}
+	policyDelPredicate := func(policy *nbdb.LogicalRouterPolicy) bool {
+		return policy.ExternalIDs[types.NetworkExternalID] == c.netInfo.GetNetworkName() &&
+			policy.ExternalIDs[types.TopologyExternalID] == c.netInfo.TopologyType() &&
+			policy.ExternalIDs[types.UDNEnabledServiceExternalID] == key
 	}
 
 	var ops []ovsdb.Operation
 	var err error
 	if c.netInfo.TopologyType() == types.Layer2Topology && !globalconfig.Layer2UsesTransitRouter {
 		for _, node := range c.nodeInfos {
-			if ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, c.netInfo.GetNetworkScopedGWRouterName(node.name), delPredicate); err != nil {
+			if ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, c.netInfo.GetNetworkScopedGWRouterName(node.name), routeDelPredicate); err != nil {
 				return err
 			}
 		}
 	} else {
-		if ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, c.netInfo.GetNetworkScopedClusterRouterName(), delPredicate); err != nil {
+		routerName := c.netInfo.GetNetworkScopedClusterRouterName()
+		if ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, routerName, routeDelPredicate); err != nil {
+			return err
+		}
+		if ops, err = libovsdbops.DeleteLogicalRouterPolicyWithPredicateOps(c.nbClient, ops, routerName, policyDelPredicate); err != nil {
 			return err
 		}
 	}
@@ -817,6 +827,60 @@ func (c *Controller) configureUDNEnabledServiceRoute(service *corev1.Service) er
 		types.TopologyExternalID:          c.netInfo.TopologyType(),
 		types.UDNEnabledServiceExternalID: ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}.String(),
 	}
+
+	useNodeLocalPolicy := util.ServiceInternalTrafficPolicyLocal(service) &&
+		(c.netInfo.TopologyType() != types.Layer2Topology || globalconfig.Layer2UsesTransitRouter)
+
+	if useNodeLocalPolicy {
+		return c.configureUDNEnabledServicePolicy(service, extIDs)
+	}
+	return c.configureUDNEnabledServiceStaticRoute(service, extIDs)
+}
+
+func (c *Controller) configureUDNEnabledServicePolicy(service *corev1.Service, extIDs map[string]string) error {
+	routerName := c.netInfo.GetNetworkScopedClusterRouterName()
+	l3Prefix := "ip4"
+	if utilnet.IsIPv6String(service.Spec.ClusterIP) {
+		l3Prefix = "ip6"
+	}
+
+	var ops []ovsdb.Operation
+	for _, nodeInfo := range c.nodeInfos {
+		mgmtIP, err := util.MatchFirstIPFamily(utilnet.IsIPv6String(service.Spec.ClusterIP), nodeInfo.mgmtIPs)
+		if err != nil {
+			return err
+		}
+
+		match := fmt.Sprintf(`inport == "%s%s" && %s.dst == %s`,
+			types.RouterToSwitchPrefix,
+			nodeInfo.switchName,
+			l3Prefix,
+			service.Spec.ClusterIP)
+
+		policy := nbdb.LogicalRouterPolicy{
+			Priority:    types.UDNEnabledServicePolicyPriority,
+			Match:       match,
+			Action:      nbdb.LogicalRouterPolicyActionReroute,
+			Nexthops:    []string{mgmtIP.String()},
+			ExternalIDs: extIDs,
+		}
+
+		p := func(item *nbdb.LogicalRouterPolicy) bool {
+			return item.Priority == policy.Priority && item.Match == policy.Match
+		}
+
+		ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(c.nbClient, ops, routerName, &policy, p,
+			&policy.Nexthops, &policy.Action)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := libovsdbops.TransactAndCheck(c.nbClient, ops)
+	return err
+}
+
+func (c *Controller) configureUDNEnabledServiceStaticRoute(service *corev1.Service, extIDs map[string]string) error {
 	routesEqual := func(a, b *nbdb.LogicalRouterStaticRoute) bool {
 		return a.IPPrefix == b.IPPrefix &&
 			a.ExternalIDs[types.NetworkExternalID] == b.ExternalIDs[types.NetworkExternalID] &&
@@ -842,7 +906,7 @@ func (c *Controller) configureUDNEnabledServiceRoute(service *corev1.Service) er
 		if c.netInfo.TopologyType() == types.Layer2Topology && !globalconfig.Layer2UsesTransitRouter {
 			routerName = nodeInfo.gatewayRouterName
 		}
-		ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, nil, routerName, &staticRoute, func(item *nbdb.LogicalRouterStaticRoute) bool {
+		ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, routerName, &staticRoute, func(item *nbdb.LogicalRouterStaticRoute) bool {
 			return routesEqual(item, &staticRoute)
 		})
 		if err != nil {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -128,6 +128,7 @@ const (
 	UDNHostCIDRPolicyPriority             = "99"
 	HybridOverlaySubnetPriority           = 1002
 	HybridOverlayReroutePriority          = 501
+	UDNEnabledServicePolicyPriority       = 400
 	DefaultNoRereoutePriority             = 102
 	EgressSVCReroutePriority              = 101
 	EgressIPReroutePriority               = 100


### PR DESCRIPTION
## Description

This PR fixes a bug in `configureUDNEnabledServiceRoute()` and adds support for `internalTrafficPolicy: Local` on UDN-enabled default services.

### Bug fix: nil ops accumulation (line 845)

`CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps` was called with `nil` instead of the accumulating `ops` slice. In multi-node-per-zone deployments, this caused only the last node's route operations to be committed per sync cycle. Routes would eventually accumulate across syncs (as node events trigger `RequestFullSync`), but the behavior was incorrect — compare with the cleanup path at line 799 which correctly passes `ops`.

### New: per-node LR policies for ITP=Local

For UDN-enabled services with `internalTrafficPolicy: Local`, the static route approach (one route per node with the same IP prefix) creates ECMP in non-IC deployments where multiple nodes share the same cluster router. This PR adds an alternative path using per-node **logical router policies** with `inport` match:

```
match:  inport == "rtos-<node-switch>" && ip4.dst == 172.30.0.10
action: reroute -> <that node's management port IP>
```

Each node's traffic enters the cluster router through its own LRP, so the `inport` match ensures traffic from node X always routes to node X's management port.

For services without ITP=Local, the existing static route behavior is preserved (with the nil→ops fix applied).

### Note on DNS scattering (OCPBUGS-55179)

Investigation revealed that DNS scattering from UDN pods is primarily caused by the **default network's OVN load balancer**, not by ECMP static routes in the UDN cluster router. In per-zone deployments, each zone's UDN cluster router already has a single nexthop per service (no ECMP). After traffic reaches the management port, the default network's `dns-default` LB distributes queries across all backends because the service uses `internalTrafficPolicy: Cluster`. The DNS operator enforces this setting. A complete fix for DNS node-locality requires the DNS operator to support `internalTrafficPolicy: Local` on the `dns-default` service.

### Files Changed

- `go-controller/pkg/types/const.go` — Add `UDNEnabledServicePolicyPriority` constant (400)
- `go-controller/pkg/ovn/controller/services/services_controller.go` — Split route config into policy (ITP=Local) and static route (ITP=Cluster) paths; fix `nil` → `ops` bug; update cleanup to handle both policies and routes
- `go-controller/pkg/ovn/controller/services/repair.go` — Add stale policy cleanup parallel to existing static route cleanup

## How to verify it

### nil→ops bug fix
In a non-IC deployment with multiple nodes, verify that all nodes' static routes are committed in a single sync (not just the last node's).

### ITP=Local per-node policies
1. Create a UDN namespace with L3 topology
2. Create a ClusterIP service with `internalTrafficPolicy: Local` that is UDN-enabled
3. Verify OVN NB has per-node LR policies on the UDN cluster router with `inport` match
4. Verify traffic from each node stays node-local

### DNS scattering (partial — requires DNS operator change)
DNS node-locality for UDN pods requires a separate change in the DNS operator to set `internalTrafficPolicy: Local` on `dns-default`. With that change plus this PR, UDN DNS traffic would:
1. Hit per-node LR policy on UDN cluster router → local management port
2. Enter default network's node switch → per-node LB (local endpoint only)
3. Reach local dns-default pod

## Checks
- [x] All unit tests pass
- [x] `go build ./...` clean
- [ ] E2E tests pending