### PR TITLE
Fix IPsec for interconnect and libreswan 5.3+ compatibility

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1144,6 +1144,11 @@ local-nb-ovsdb() {
   ovn-nbctl set NB_Global . name=${K8S_NODE}
   ovn-nbctl set NB_Global . options:name=${K8S_NODE}
 
+  [[ "true" == "${ENABLE_IPSEC}" ]] && {
+    ovn-nbctl set NB_Global . ipsec=true
+    echo "=============== nb-ovsdb ========== reconfigured for ipsec"
+  }
+
   tail --follow=name ${OVN_LOGDIR}/ovsdb-server-nb.log &
   ovn_tail_pid=$!
 

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
@@ -204,8 +204,11 @@ spec:
           ulimit -n 1024
 
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
-          # Check kernel modules
-          /usr/libexec/ipsec/_stackmanager start
+          # Check kernel modules only for libreswan version <= 5.2. The _stackmanager binary is
+          # removed from 5.3 onwards, so this check is not needed on later versions.
+          if [ -e /usr/libexec/ipsec/_stackmanager ]; then
+            /usr/libexec/ipsec/_stackmanager start
+          fi
           # Check nss database status
           /usr/sbin/ipsec --checknss
           # Start the pluto IKE daemon

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -84,6 +84,8 @@ spec:
           value: {{ default "-vconsole:info -vfile:info" .Values.nbLogLevel | quote }}
         - name: OVN_NORTHD_BACKOFF_INTERVAL
           value: {{ default "0" .Values.northdBackoffInterval | quote }}
+        - name: ENABLE_IPSEC
+          value: {{ hasKey .Values.global "enableIpsec" | ternary .Values.global.enableIpsec false | quote }}
         - name: OVN_KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -84,6 +84,8 @@ spec:
           value: {{ default "shared" .Values.global.gatewayMode }}
         - name: OVN_ROUTE_ADVERTISEMENTS_ENABLE
           value: {{ hasKey .Values.global "enableRouteAdvertisements" | ternary .Values.global.enableRouteAdvertisements false | quote }}
+        - name: ENABLE_IPSEC
+          value: {{ hasKey .Values.global "enableIpsec" | ternary .Values.global.enableIpsec false | quote }}
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-zone-controller/templates/ovnkube-zone-controller.yaml
@@ -106,6 +106,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ENABLE_IPSEC
+          value: {{ hasKey .Values.global "enableIpsec" | ternary .Values.global.enableIpsec false | quote }}
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]


### PR DESCRIPTION
  - Add `ENABLE_IPSEC` to interconnect helm charts (single-node-zone, zone-controller, single-node-zone-dpu)
  - Configure `local-nb-ovsdb()` to set `nb_global.ipsec=true`
  - Skip `_stackmanager` execution for libreswan 5.3+ (binary was removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ENABLE_IPSEC` configuration option to control IPsec functionality across deployments.

* **Improvements**
  * Enhanced kernel module compatibility by conditionally invoking IPsec startup procedures based on system availability, preventing failures with certain library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->