### PR TITLE
helm: use 'with' to prevent nil pointer on dockerConfigSecret

### DIFF
--- a/helm/ovn-kubernetes/templates/ovn-setup.yaml
+++ b/helm/ovn-kubernetes/templates/ovn-setup.yaml
@@ -112,14 +112,19 @@ spec:
     - "PodNetwork"
 {{- end }}
 
-{{- if (and .Values.global.dockerConfigSecret .Values.global.dockerConfigSecret.create) }}
+{{- with .Values.global.dockerConfigSecret }}
+{{- if .create }}
+{{- $imagePullSecretName := required "global.imagePullSecretName is required when dockerConfigSecret.create=true" $.Values.global.imagePullSecretName -}}
+{{- $registry := required "dockerConfigSecret.registry is required when dockerConfigSecret.create=true" .registry -}}
+{{- $auth := required "dockerConfigSecret.auth is required when dockerConfigSecret.create=true" .auth -}}
 ---
 apiVersion: v1
-type: kubernetes.io/dockerconfigjson
 kind: Secret
+type: kubernetes.io/dockerconfigjson
 metadata:
-  namespace: {{ .Values.global.namespace }}
-  name: {{ .Values.global.imagePullSecretName }}
+  namespace: {{ $.Values.global.namespace }}
+  name: {{ $imagePullSecretName }}
 data:
-  .dockerconfigjson: {{ include "dockerconfigjson" .Values.global.dockerConfigSecret | b64enc }}
+  .dockerconfigjson: {{ include "dockerconfigjson" (dict "registry" $registry "auth" $auth) | b64enc }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Replace the truthiness check with 'with' block to properly guard
against nil pointer dereference when dockerConfigSecret is not
provided. Add required validations for imagePullSecretName and
auth fields. This follows Helm's best practice for handling
nested optional values. This also fixes kind.sh deployment failure
due to missing dockerConfigSecret in values-single-node-zone.yaml
and values-multi-node-zone.yaml.

Signed-off-by: Guo Hao <guohao_117@outlook.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker registry secret creation is now gated by a top-level toggle and create flag.
  * Required inputs enforced: image pull secret name, registry, and auth.
  * Secret metadata now uses the global namespace and a computed secret name.
  * Secret payload is narrowed to include only registry and auth fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->