### PR TITLE
Avoid reuse of CUDN VRF names in BGP e2e tests

### DIFF
--- a/test/e2e/network_segmentation_utils.go
+++ b/test/e2e/network_segmentation_utils.go
@@ -4,9 +4,56 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	"k8s.io/utils/net"
 )
+
+// cudnGatewayRouterName returns the name of the OVN gateway router for the
+// given ClusterUserDefinedNetwork on the given node. The format is:
+//
+//	GR_cluster_udn_<sanitized-cudn-name>_<node>
+//
+// where the sanitization (dashes/slashes -> dots, trailing underscore)
+// matches what the production code uses in go-controller/pkg/util/multi_network.go
+func cudnGatewayRouterName(cudnName, nodeName string) string {
+	return types.GWRouterPrefix + util.GetUserDefinedNetworkPrefix(types.CUDNPrefix+cudnName) + nodeName
+}
+
+// cudnGRRoutesForNode returns the output of `ovn-nbctl lr-route-list` for
+// the CUDN gateway router of the given CUDN on the given node.
+func cudnGRRoutesForNode(k8sClient kubernetes.Interface, cudnName, nodeName string) (string, error) {
+	ns := deploymentconfig.Get().OVNKubernetesNamespace()
+	nbPods, err := k8sClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=ovnkube-node",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to locate ovnkube-node pod on %s: %w", nodeName, err)
+	}
+	if len(nbPods.Items) == 0 {
+		return "", fmt.Errorf("no ovnkube-node pod found on node %s", nodeName)
+	}
+	nbPod := nbPods.Items[0]
+	if len(nbPod.Spec.Containers) == 0 {
+		return "", fmt.Errorf("no containers found in ovnkube-node pod %s on node %s", nbPod.Name, nodeName)
+	}
+	nbContainerName := nbPod.Spec.Containers[0].Name
+	if nbContainerName == "" {
+		return "", fmt.Errorf("first container has no name in ovnkube-node pod %s on node %s", nbPod.Name, nodeName)
+	}
+	return e2ekubectl.RunKubectl(ns,
+		"exec", nbPod.Name, "-c", nbContainerName, "--",
+		"ovn-nbctl", "--no-leader-only", "lr-route-list",
+		cudnGatewayRouterName(cudnName, nodeName))
+}
 
 // podIPsForUserDefinedPrimaryNetwork returns the v4 or v6 IPs for a pod on the UDN
 func getPodAnnotationIPsForPrimaryNetworkByIPFamily(k8sClient kubernetes.Interface, podNamespace string, podName string, networkName string, family net.IPFamily) (string, error) {

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -918,8 +918,10 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 		ginkgo.Entry("layer3",
 			&udnv1.ClusterUserDefinedNetwork{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bgp-udn-layer3-network",
-					Labels:       map[string]string{"bgp-udn-layer3-network": ""},
+					// Keep generated CUDN names under the Linux 15-byte interface
+					// limit so the VRF name is unique instead of network ID based.
+					GenerateName: "bgp-l3-",
+					Labels:       map[string]string{"bgp-l3": ""},
 				},
 				Spec: udnv1.ClusterUserDefinedNetworkSpec{
 					Network: udnv1.NetworkSpec{
@@ -939,7 +941,7 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 			},
 			&rav1.RouteAdvertisements{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-udn-layer3-network-ra",
+					Name: "bgp-l3-ra",
 				},
 				Spec: rav1.RouteAdvertisementsSpec{
 					NetworkSelectors: apitypes.NetworkSelectors{
@@ -947,7 +949,7 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
 							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
 								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-udn-layer3-network": ""},
+									MatchLabels: map[string]string{"bgp-l3": ""},
 								},
 							},
 						},
@@ -963,8 +965,8 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 		ginkgo.Entry("layer2",
 			&udnv1.ClusterUserDefinedNetwork{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "bgp-udn-layer2-network",
-					Labels:       map[string]string{"bgp-udn-layer2-network": ""},
+					GenerateName: "bgp-l2-",
+					Labels:       map[string]string{"bgp-l2": ""},
 				},
 				Spec: udnv1.ClusterUserDefinedNetworkSpec{
 					Network: udnv1.NetworkSpec{
@@ -978,7 +980,7 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 			},
 			&rav1.RouteAdvertisements{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "bgp-udn-layer2-network-ra",
+					Name: "bgp-l2-ra",
 				},
 				Spec: rav1.RouteAdvertisementsSpec{
 					NetworkSelectors: apitypes.NetworkSelectors{
@@ -986,7 +988,7 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
 							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
 								NetworkSelector: metav1.LabelSelector{
-									MatchLabels: map[string]string{"bgp-udn-layer2-network": ""},
+									MatchLabels: map[string]string{"bgp-l2": ""},
 								},
 							},
 						},
@@ -1242,8 +1244,8 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 				for _, serverContainerIP := range serverContainerIPs {
 					for _, node := range nodes.Items {
 						if cudnA.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
-							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnATemplate.Name)
-							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnBTemplate.Name)
+							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnA.Name)
+							checkL3NodePodRoute(node, serverContainerIP, routerContainerName, types.CUDNPrefix+cudnB.Name)
 						} else {
 							checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnATemplate.Spec.Network.Layer2.Subnets)
 							checkL2NodePodRoute(node, serverContainerIP, routerContainerName, cudnBTemplate.Spec.Network.Layer2.Subnets)
@@ -1382,9 +1384,9 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						clientPod := podsNetA[0]
 						srvPod := podsNetA[1]
 
-						clientPodStatus, err := getPodAnnotationForAttachment(clientPod, namespacedName(clientPod.Namespace, cudnATemplate.Name))
+						clientPodStatus, err := getPodAnnotationForAttachment(clientPod, namespacedName(clientPod.Namespace, cudnA.Name))
 						framework.ExpectNoError(err)
-						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnATemplate.Name))
+						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnA.Name))
 						framework.ExpectNoError(err)
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(getFirstCIDROfFamily(ipFamily, srvPodStatus.IPs).IP.String(), "8080") + "/clientip",
 							getFirstCIDROfFamily(ipFamily, clientPodStatus.IPs).IP.String(), false
@@ -1395,9 +1397,9 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						clientPod := podsNetA[0]
 						srvPod := podsNetA[2]
 
-						clientPodStatus, err := getPodAnnotationForAttachment(clientPod, namespacedName(clientPod.Namespace, cudnATemplate.Name))
+						clientPodStatus, err := getPodAnnotationForAttachment(clientPod, namespacedName(clientPod.Namespace, cudnA.Name))
 						framework.ExpectNoError(err)
-						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnATemplate.Name))
+						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnA.Name))
 						framework.ExpectNoError(err)
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(getFirstCIDROfFamily(ipFamily, srvPodStatus.IPs).IP.String(), "8080") + "/clientip",
 							getFirstCIDROfFamily(ipFamily, clientPodStatus.IPs).IP.String(), false
@@ -1408,7 +1410,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						clientPod := podsNetA[2]
 						srvPod := podNetB
 
-						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnBTemplate.Name))
+						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnB.Name))
 						framework.ExpectNoError(err)
 						var (
 							curlOutput string
@@ -1418,7 +1420,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						// - "loose": Pod connectivity is allowed, test expects success
 						// - anything else (including unset): Treated as "strict", pod connectivity is blocked
 						if os.Getenv("ADVERTISED_UDN_ISOLATION_MODE") == "loose" {
-							clientPodStatus, err := getPodAnnotationForAttachment(clientPod, namespacedName(clientPod.Namespace, cudnATemplate.Name))
+							clientPodStatus, err := getPodAnnotationForAttachment(clientPod, namespacedName(clientPod.Namespace, cudnA.Name))
 							framework.ExpectNoError(err)
 
 							// With the above underlay routing configuration client pod can reach server pod.
@@ -1438,14 +1440,14 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						clientPod := podsNetA[0]
 						srvPod := podNetB
 
-						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnBTemplate.Name))
+						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnB.Name))
 						framework.ExpectNoError(err)
 						var (
 							curlOutput string
 							curlErr    bool
 						)
 						if os.Getenv("ADVERTISED_UDN_ISOLATION_MODE") == "loose" {
-							clientPodStatus, err := getPodAnnotationForAttachment(clientPod, namespacedName(clientPod.Namespace, cudnATemplate.Name))
+							clientPodStatus, err := getPodAnnotationForAttachment(clientPod, namespacedName(clientPod.Namespace, cudnA.Name))
 							framework.ExpectNoError(err)
 
 							curlOutput = getFirstCIDROfFamily(ipFamily, clientPodStatus.IPs).IP.String()
@@ -1463,7 +1465,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						clientPod := podNetDefault
 						srvPod := podNetB
 
-						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnBTemplate.Name))
+						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnB.Name))
 						framework.ExpectNoError(err)
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(getFirstCIDROfFamily(ipFamily, srvPodStatus.IPs).IP.String(), "8080") + "/clientip",
 							curlConnectionTimeoutCode, true
@@ -1474,7 +1476,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						clientPod := podNetDefault
 						srvPod := podsNetA[0]
 
-						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnATemplate.Name))
+						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnA.Name))
 						framework.ExpectNoError(err)
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(getFirstCIDROfFamily(ipFamily, srvPodStatus.IPs).IP.String(), "8080") + "/clientip",
 							curlConnectionTimeoutCode, true
@@ -1533,7 +1535,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						clientNode := podsNetA[0].Spec.NodeName
 						srvPod := podsNetA[0]
 
-						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnATemplate.Name))
+						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnA.Name))
 						framework.ExpectNoError(err)
 						return clientNode, "", net.JoinHostPort(getFirstCIDROfFamily(ipFamily, srvPodStatus.IPs).IP.String(), "8080") + "/clientip",
 							curlConnectionTimeoutCode, true
@@ -1544,7 +1546,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						clientNode := podsNetA[2].Spec.NodeName
 						srvPod := podsNetA[0]
 
-						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnATemplate.Name))
+						srvPodStatus, err := getPodAnnotationForAttachment(srvPod, namespacedName(srvPod.Namespace, cudnA.Name))
 						framework.ExpectNoError(err)
 						return clientNode, "", net.JoinHostPort(getFirstCIDROfFamily(ipFamily, srvPodStatus.IPs).IP.String(), "8080") + "/clientip",
 							curlConnectionTimeoutCode, true
@@ -1879,8 +1881,8 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 	ginkgo.Entry("Layer3",
 		&udnv1.ClusterUserDefinedNetwork{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "bgp-udn-layer3-network-a",
-				Labels: map[string]string{"bgp-udn-layer3-network-a": ""},
+				GenerateName: "bgp-l3a-",
+				Labels:       map[string]string{"bgp-l3a": ""},
 			},
 			Spec: udnv1.ClusterUserDefinedNetworkSpec{
 				Network: udnv1.NetworkSpec{
@@ -1899,8 +1901,8 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 			},
 		}, &udnv1.ClusterUserDefinedNetwork{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "bgp-udn-layer3-network-b",
-				Labels: map[string]string{"bgp-udn-layer3-network-b": ""},
+				GenerateName: "bgp-l3b-",
+				Labels:       map[string]string{"bgp-l3b": ""},
 			},
 			Spec: udnv1.ClusterUserDefinedNetworkSpec{
 				Network: udnv1.NetworkSpec{
@@ -1922,8 +1924,8 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 	ginkgo.Entry("Layer2",
 		&udnv1.ClusterUserDefinedNetwork{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "bgp-udn-layer2-network-a",
-				Labels: map[string]string{"bgp-udn-layer2-network-a": ""},
+				GenerateName: "bgp-l2a-",
+				Labels:       map[string]string{"bgp-l2a": ""},
 			},
 			Spec: udnv1.ClusterUserDefinedNetworkSpec{
 				Network: udnv1.NetworkSpec{
@@ -1936,8 +1938,8 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 			},
 		}, &udnv1.ClusterUserDefinedNetwork{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "bgp-udn-layer2-network-b",
-				Labels: map[string]string{"bgp-udn-layer2-network-b": ""},
+				GenerateName: "bgp-l2b-",
+				Labels:       map[string]string{"bgp-l2b": ""},
 			},
 			Spec: udnv1.ClusterUserDefinedNetworkSpec{
 				Network: udnv1.NetworkSpec{

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -770,10 +771,10 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 			externalServerV4CIDR, externalServerV6CIDR, err := bgpNetwork.IPv4IPv6Subnets()
 			framework.ExpectNoError(err, "must get BGP network subnets")
 			framework.Logf("the network cidrs to be imported are v4=%s and v6=%s", externalServerV4CIDR, externalServerV6CIDR)
-			var nodeIPv6LLA string
-			if isDualStackCluster(nodes) {
+			var frrIPv6LLA string
+			if isIPv6Supported(f.ClientSet) {
 				var err error
-				nodeIPv6LLA, err = GetNodeIPv6LinkLocalAddressForEth0(routerContainerName)
+				frrIPv6LLA, err = GetNodeIPv6LinkLocalAddressForEth0(routerContainerName)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 			for _, node := range nodes.Items {
@@ -796,7 +797,7 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 						routes, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), bgpRouteCommand)
 						framework.ExpectNoError(err, "failed to get BGP routes from node")
 						framework.Logf("Routes in node %s", routes)
-						return strings.Contains(routes, nodeIPv6LLA)
+						return strings.Contains(routes, frrIPv6LLA)
 					}, 30*time.Second).Should(gomega.BeTrue())
 				}
 			}
@@ -811,6 +812,66 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 					} else {
 						ginkgo.Fail("unexpected topology: neither Layer3 nor Layer2 network spec is set")
 					}
+				}
+			}
+
+			layer2LocalGateway := cudnTemplate.Spec.Network.Layer2 != nil && IsGatewayModeLocal(f.ClientSet)
+			if layer2LocalGateway {
+				ginkgo.By("ensure CUDN VRF has a BGP-imported route to the external server CIDR")
+			} else {
+				ginkgo.By("ensure CUDN gateway router has a BGP-imported route to the external server CIDR")
+			}
+			for _, node := range nodes.Items {
+				nodeName := node.Name
+				for _, tc := range []struct {
+					cidr, nextHop string
+				}{
+					{externalServerV4CIDR, frrContainerIPv4},
+					{externalServerV6CIDR, frrIPv6LLA},
+				} {
+					if tc.cidr == "" || tc.nextHop == "" {
+						continue
+					}
+					isV6 := utilnet.IsIPv6CIDRString(tc.cidr)
+					if isV6 && !isIPv6Supported(f.ClientSet) {
+						continue
+					}
+					if !isV6 && !isIPv4Supported(f.ClientSet) {
+						continue
+					}
+					if layer2LocalGateway {
+						framework.Logf("Checking on node %s for CUDN VRF %s route to %s via %s", nodeName, cUDN.Name, tc.cidr, tc.nextHop)
+						gomega.Eventually(func() bool {
+							found, err := hasRouteInCUDNVRF(node, cUDN.Name, tc.cidr, tc.nextHop)
+							if err != nil {
+								framework.Logf("failed to check CUDN VRF route on node %s: %v", nodeName, err)
+								return false
+							}
+							return found
+						}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+							"route for %s via %s not found in CUDN VRF %s on node %s",
+							tc.cidr, tc.nextHop, cUDN.Name, nodeName)
+						continue
+					}
+					// Assert the GR has a static-route line matching
+					// the CIDR and the expected next hop, that is the external FRR
+					// container IP.
+					gomega.Eventually(func() bool {
+						routes, err := cudnGRRoutesForNode(f.ClientSet, cUDN.Name, nodeName)
+						if err != nil {
+							framework.Logf("failed to list CUDN GR routes on node %s: %v", nodeName, err)
+							return false
+						}
+						framework.Logf("CUDN GR routes on node %s:\n%s", nodeName, routes)
+						for _, line := range strings.Split(routes, "\n") {
+							if strings.Contains(line, tc.cidr) && strings.Contains(line, tc.nextHop) {
+								return true
+							}
+						}
+						return false
+					}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(),
+						"CUDN %q GR on node %s is missing a route %s -> %s",
+						cUDN.Name, nodeName, tc.cidr, tc.nextHop)
 				}
 			}
 
@@ -3329,4 +3390,58 @@ func checkRouteInFRR(node corev1.Node, podCIDR, routerContainerName string, isIP
 		framework.Logf("Routes in FRR for %s: %s", podCIDR, routes)
 		return strings.Contains(routes, nodeIP[0])
 	}, 30*time.Second).Should(gomega.BeTrue(), "route for %s via %s not found on %s", podCIDR, nodeIP[0], routerContainerName)
+}
+
+func hasRouteInCUDNVRF(node corev1.Node, cudnName, cidr, nextHop string) (bool, error) {
+	if len(cudnName) > 15 {
+		return false, fmt.Errorf("CUDN name %q is too long to be used as the Linux VRF device name", cudnName)
+	}
+
+	routeCommand := []string{"ip", "--json", "route", "show", "vrf", cudnName, cidr}
+	if utilnet.IsIPv6CIDRString(cidr) {
+		routeCommand = []string{"ip", "-6", "--json", "route", "show", "vrf", cudnName, cidr}
+	}
+
+	out, err := infraprovider.Get().ExecK8NodeCommand(node.GetName(), routeCommand)
+	if err != nil {
+		return false, fmt.Errorf("failed to get routes from CUDN VRF %s on node %s: %w", cudnName, node.Name, err)
+	}
+	routes := []kernelRoute{}
+	if err := json.Unmarshal([]byte(out), &routes); err != nil {
+		return false, fmt.Errorf("failed to parse routes from CUDN VRF %s on node %s: %w; output: %s", cudnName, node.Name, err, out)
+	}
+	framework.Logf("Routes in CUDN VRF %s on node %s for %s: %s", cudnName, node.Name, cidr, out)
+	return hasBGPRoute(routes, cidr, nextHop), nil
+}
+
+type kernelRoute struct {
+	Dst      string               `json:"dst"`
+	Gateway  string               `json:"gateway"`
+	Protocol string               `json:"protocol"`
+	Nexthops []kernelRouteNexthop `json:"nexthops"`
+}
+
+type kernelRouteNexthop struct {
+	Gateway string `json:"gateway"`
+}
+
+func hasBGPRoute(routes []kernelRoute, cidr, nextHop string) bool {
+	for _, route := range routes {
+		if route.Dst == cidr && route.Protocol == "bgp" && routeHasGateway(route, nextHop) {
+			return true
+		}
+	}
+	return false
+}
+
+func routeHasGateway(route kernelRoute, nextHop string) bool {
+	if route.Gateway == nextHop {
+		return true
+	}
+	for _, nexthop := range route.Nexthops {
+		if nexthop.Gateway == nextHop {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Addresses issue https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5952.

- e2e: check CUDN GR routes before continuing BGP pod-to-external test, to narrow down the failure to the behaviour observed in the linked issue and not just to a generic `curl` failure
- BGP e2e: avoid reuse of CUDN VRF names, so that we don't end up with stale VRF entries in bgpd cache, triggering the flake

See https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5952#issuecomment-4344886302 for a detailed analysis of the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added assertions that verify gateways import IPv4/IPv6 BGP routes with expected next-hops, using polling and clear failure messages.
  * Corrected IPv6 next-hop verification to use the proper node-side link-local address when applicable.
  * Updated route-advertisement fixtures, labels, and generated names for more reliable matching.
  * Fixed isolation tests to reference actual created resource names.
  * Added e2e helpers to locate node-side components and query gateway route tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->