### PR TITLE
Refactor ovnkubeidentity webhook server into separate package for testability

### DIFF
--- a/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
+++ b/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
@@ -5,14 +5,11 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,14 +17,9 @@ import (
 	"time"
 
 	"github.com/urfave/cli/v2"
-	"golang.org/x/sys/unix"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/probe"
@@ -35,13 +27,11 @@ import (
 	utilpointer "k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"
+	identitywebhook "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/cmd/ovnkube-identity/webhook"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovnwebhook"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
@@ -306,120 +296,15 @@ func main() {
 }
 
 func runWebhook(ctx context.Context, restCfg *rest.Config) error {
-	// We cannot use the default implementation of the webhook server because we need to enable SO_REUSEPORT
-	// on the socket to allow for two instances running at the same time (required during upgrades).
-	// The webhook server is set up and started in a very similar way to the default one:
-	// https://github.com/ovn-kubernetes/ovn-kubernetes/blob/7c0838bb46d6de202f509abe47609c8da09311b2/go-controller/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go#L212
-
-	client, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		return fmt.Errorf("error creating clientset: %v", err)
-	}
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	webhookMux := http.NewServeMux()
-
-	nodeWebhook := admission.WithValidator(
-		scheme.Scheme,
-		ovnwebhook.NewNodeAdmissionWebhook(cliCfg.enableHybridOverlay, cliCfg.extraAllowedUsers.Value()...),
-	).WithRecoverPanic(true)
-
-	nodeHandler, err := admission.StandaloneWebhook(
-		nodeWebhook,
-		admission.StandaloneOptions{
-			Logger:      logger.WithName("node.network-identity"),
-			MetricsPath: "node.network-identity",
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to setup the node admission webhook: %w", err)
-	}
-	webhookMux.Handle("/node", nodeHandler)
-
-	informerFactory := informers.NewSharedInformerFactory(client, 10*time.Minute)
-	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
-	informerFactory.Start(stopCh)
-	klog.Infof("Waiting for caches to sync")
-	cache.WaitForCacheSync(ctx.Done(), nodeInformer.HasSynced)
-
-	nodeLister := listers.NewNodeLister(nodeInformer.GetIndexer())
-	podWebhook := admission.WithValidator(
-		scheme.Scheme,
-		ovnwebhook.NewPodAdmissionWebhook(nodeLister, cliCfg.podAdmissionConditions, cliCfg.extraAllowedUsers.Value()...),
-	).WithRecoverPanic(true)
-	podHandler, err := admission.StandaloneWebhook(
-		podWebhook,
-		admission.StandaloneOptions{
-			Logger:      logger.WithName("pod.network-identity"),
-			MetricsPath: "pod.network-identity",
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to setup the pod admission webhook: %w", err)
-	}
-	webhookMux.Handle("/pod", podHandler)
-
-	cfg := &tls.Config{
-		NextProtos: []string{"h2"},
-		MinVersion: tls.VersionTLS12,
-	}
-
-	certPath := filepath.Join(cliCfg.certDir, "tls.crt")
-	keyPath := filepath.Join(cliCfg.certDir, "tls.key")
-	certWatcher, err := certwatcher.New(certPath, keyPath)
-	if err != nil {
-		return fmt.Errorf("failed to setup certwatcher: %v", err)
-	}
-	cfg.GetCertificate = certWatcher.GetCertificate
-
-	go func() {
-		if err := certWatcher.Start(ctx); err != nil {
-			klog.Fatalf("Certificate watcher failed to start: %v", err)
-		}
-	}()
-	srv := &http.Server{
-		Handler:           webhookMux,
-		IdleTimeout:       90 * time.Second,
-		ReadHeaderTimeout: 32 * time.Second,
-	}
-
-	l := net.ListenConfig{
-		Control: func(_, _ string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				// Enable SO_REUSEPORT
-				err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
-				if err != nil {
-					klog.Fatalf("Failed to set SO_REUSEPORT: %v", err)
-				}
-			})
-		},
-	}
-
-	innerListener, err := l.Listen(ctx, "tcp", net.JoinHostPort(cliCfg.host, strconv.Itoa(cliCfg.port)))
-	if err != nil {
-		return fmt.Errorf("failed to create the listener: %v", err)
-	}
-	listener := tls.NewListener(innerListener, cfg)
-
-	idleWebhookConnectionsClosed := make(chan struct{})
-	defer func() {
-		klog.Infof("Waiting for the webhook server to gracefully close")
-		<-idleWebhookConnectionsClosed
-	}()
-	go func() {
-		<-ctx.Done()
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-		defer cancel()
-		if err := srv.Shutdown(ctx); err != nil {
-			klog.Errorf("Failed shutting down the HTTP server: %v", err)
-		}
-		close(idleWebhookConnectionsClosed)
-	}()
-
-	klog.Infof("Starting the webhook server")
-	return srv.Serve(listener)
+	return identitywebhook.Run(ctx, restCfg, identitywebhook.Config{
+		EnableHybridOverlay:     cliCfg.enableHybridOverlay,
+		ExtraAllowedUsers:       cliCfg.extraAllowedUsers.Value(),
+		CSRAcceptanceConditions: cliCfg.csrAcceptanceConditions,
+		PodAdmissionConditions:  cliCfg.podAdmissionConditions,
+		CertDir:                 cliCfg.certDir,
+		Host:                    cliCfg.host,
+		Port:                    cliCfg.port,
+	})
 }
 
 func runCSRApproverManager(ctx context.Context, leaderID string, restCfg *rest.Config) error {

--- a/go-controller/cmd/ovnkube-identity/webhook/webhook.go
+++ b/go-controller/cmd/ovnkube-identity/webhook/webhook.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package webhook
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovnwebhook"
+)
+
+var logger = klog.NewKlogr()
+
+// Config contains configuration for the webhook server
+type Config struct {
+	EnableHybridOverlay     bool
+	ExtraAllowedUsers       []string
+	CSRAcceptanceConditions []csrapprover.CSRAcceptanceCondition
+	PodAdmissionConditions  []ovnwebhook.PodAdmissionConditionOption
+	CertDir                 string
+	Host                    string
+	Port                    int
+}
+
+// Run starts the webhook server
+func Run(ctx context.Context, restCfg *rest.Config, config Config) error {
+	// We cannot use the default implementation of the webhook server because we need to enable SO_REUSEPORT
+	// on the socket to allow for two instances running at the same time (required during upgrades).
+	// The webhook server is set up and started in a very similar way to the default one:
+	// https://github.com/ovn-kubernetes/ovn-kubernetes/blob/7c0838bb46d6de202f509abe47609c8da09311b2/go-controller/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go#L212
+
+	client, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("error creating clientset: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	webhookMux := http.NewServeMux()
+
+	nodeWebhook := admission.WithValidator(
+		scheme.Scheme,
+		ovnwebhook.NewNodeAdmissionWebhook(config.EnableHybridOverlay, config.ExtraAllowedUsers...),
+	).WithRecoverPanic(true)
+
+	nodeHandler, err := admission.StandaloneWebhook(
+		nodeWebhook,
+		admission.StandaloneOptions{
+			Logger:      logger.WithName("node.network-identity"),
+			MetricsPath: "node.network-identity",
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to setup the node admission webhook: %w", err)
+	}
+	webhookMux.Handle("/node", nodeHandler)
+
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 10*time.Minute)
+	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
+	informerFactory.Start(stopCh)
+	klog.Infof("Waiting for caches to sync")
+	cache.WaitForCacheSync(ctx.Done(), nodeInformer.HasSynced)
+
+	nodeLister := listers.NewNodeLister(nodeInformer.GetIndexer())
+	podWebhook := admission.WithValidator(
+		scheme.Scheme,
+		ovnwebhook.NewPodAdmissionWebhook(nodeLister, config.PodAdmissionConditions, config.ExtraAllowedUsers...),
+	).WithRecoverPanic(true)
+	podHandler, err := admission.StandaloneWebhook(
+		podWebhook,
+		admission.StandaloneOptions{
+			Logger:      logger.WithName("pod.network-identity"),
+			MetricsPath: "pod.network-identity",
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to setup the pod admission webhook: %w", err)
+	}
+	webhookMux.Handle("/pod", podHandler)
+
+	cfg := &tls.Config{
+		NextProtos: []string{"h2"},
+		MinVersion: tls.VersionTLS12,
+	}
+
+	certPath := filepath.Join(config.CertDir, "tls.crt")
+	keyPath := filepath.Join(config.CertDir, "tls.key")
+	certWatcher, err := certwatcher.New(certPath, keyPath)
+	if err != nil {
+		return fmt.Errorf("failed to setup certwatcher: %v", err)
+	}
+	cfg.GetCertificate = certWatcher.GetCertificate
+
+	go func() {
+		if err := certWatcher.Start(ctx); err != nil {
+			klog.Fatalf("Certificate watcher failed to start: %v", err)
+		}
+	}()
+	srv := &http.Server{
+		Handler:           webhookMux,
+		IdleTimeout:       90 * time.Second,
+		ReadHeaderTimeout: 32 * time.Second,
+	}
+
+	l := net.ListenConfig{
+		Control: func(_, _ string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				// Enable SO_REUSEPORT
+				err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+				if err != nil {
+					klog.Fatalf("Failed to set SO_REUSEPORT: %v", err)
+				}
+			})
+		},
+	}
+
+	innerListener, err := l.Listen(ctx, "tcp", net.JoinHostPort(config.Host, strconv.Itoa(config.Port)))
+	if err != nil {
+		return fmt.Errorf("failed to create the listener: %v", err)
+	}
+	listener := tls.NewListener(innerListener, cfg)
+
+	idleWebhookConnectionsClosed := make(chan struct{})
+	defer func() {
+		klog.Infof("Waiting for the webhook server to gracefully close")
+		<-idleWebhookConnectionsClosed
+	}()
+	go func() {
+		<-ctx.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			klog.Errorf("Failed shutting down the HTTP server: %v", err)
+		}
+		close(idleWebhookConnectionsClosed)
+	}()
+
+	klog.Infof("Starting the webhook server")
+	return srv.Serve(listener)
+}

--- a/go-controller/cmd/ovnkube-identity/webhook/webhook.go
+++ b/go-controller/cmd/ovnkube-identity/webhook/webhook.go
@@ -154,18 +154,16 @@ func Run(ctx context.Context, restCfg *rest.Config, config Config) error {
 	listener := tls.NewListener(innerListener, cfg)
 
 	idleWebhookConnectionsClosed := make(chan struct{})
-	defer func() {
-		klog.Infof("Waiting for the webhook server to gracefully close")
-		<-idleWebhookConnectionsClosed
-	}()
+
 	go func() {
 		<-ctx.Done()
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 		defer cancel()
+		defer close(idleWebhookConnectionsClosed)
+
 		if err := srv.Shutdown(ctx); err != nil {
 			klog.Errorf("Failed shutting down the HTTP server: %v", err)
 		}
-		close(idleWebhookConnectionsClosed)
 	}()
 
 	klog.Infof("Starting the webhook server")
@@ -173,6 +171,11 @@ func Run(ctx context.Context, restCfg *rest.Config, config Config) error {
 	err = srv.Serve(listener)
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("webhook server failed: %w", err)
+	}
+
+	if ctx.Err() != nil {
+		klog.Infof("Waiting for the webhook server to gracefully close")
+		<-idleWebhookConnectionsClosed
 	}
 
 	return nil

--- a/go-controller/cmd/ovnkube-identity/webhook/webhook.go
+++ b/go-controller/cmd/ovnkube-identity/webhook/webhook.go
@@ -6,6 +6,7 @@ package webhook
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -41,6 +42,9 @@ type Config struct {
 	CertDir                 string
 	Host                    string
 	Port                    int
+
+	// This field is a constructor used for creating clients and is intended for testing.
+	NewKubernetesClient func(*rest.Config) (kubernetes.Interface, error)
 }
 
 // Run starts the webhook server
@@ -50,7 +54,14 @@ func Run(ctx context.Context, restCfg *rest.Config, config Config) error {
 	// The webhook server is set up and started in a very similar way to the default one:
 	// https://github.com/ovn-kubernetes/ovn-kubernetes/blob/7c0838bb46d6de202f509abe47609c8da09311b2/go-controller/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go#L212
 
-	client, err := kubernetes.NewForConfig(restCfg)
+	newKubernetesClient := config.NewKubernetesClient
+	if newKubernetesClient == nil {
+		newKubernetesClient = func(cfg *rest.Config) (kubernetes.Interface, error) {
+			return kubernetes.NewForConfig(cfg)
+		}
+	}
+
+	kubeClient, err := newKubernetesClient(restCfg)
 	if err != nil {
 		return fmt.Errorf("error creating clientset: %v", err)
 	}
@@ -158,5 +169,12 @@ func Run(ctx context.Context, restCfg *rest.Config, config Config) error {
 	}()
 
 	klog.Infof("Starting the webhook server")
-	return srv.Serve(listener)
+
+	err = srv.Serve(listener)
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("webhook server failed: %w", err)
+	}
+
+	return nil
+
 }

--- a/go-controller/cmd/ovnkube-identity/webhook/webhook_test.go
+++ b/go-controller/cmd/ovnkube-identity/webhook/webhook_test.go
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package webhook_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/cmd/ovnkube-identity/webhook"
+	ovntesting "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = BeforeSuite(func() {
+	Expect(configv1.Install(k8sscheme.Scheme)).To(Succeed())
+})
+
+var _ = Describe("Run", func() {
+	var config webhook.Config
+
+	BeforeEach(func() {
+		// Pick a free ephemeral port for each test
+		config = newWebhookConfig(getFreePort())
+	})
+
+	JustBeforeEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		doneCh := make(chan struct{})
+
+		DeferCleanup(func() {
+			cancel()
+			Eventually(doneCh).Within(10 * time.Second).Should(BeClosed())
+		})
+
+		go func() {
+			defer GinkgoRecover()
+
+			err := webhook.Run(ctx, &rest.Config{
+				Host: "https://localhost:6443",
+			}, config)
+
+			close(doneCh)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+	})
+
+	It("should always register the \"/node\" webhook endpoint", func() {
+		assertWebhookRequestSuccess(config.Host, config.Port, "node", createNodeAdmissionReviewJSON())
+	})
+
+	It("should support SO_REUSEPORT by allowing multiple servers on the same port", func() {
+		// Wait for the first server to be ready
+		waitForServerReady(config.Host, config.Port)
+
+		// Use the same port as the first server
+		config2 := newWebhookConfig(config.Port)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		doneCh := make(chan struct{})
+		errCh := make(chan error, 1)
+
+		go func() {
+			if err := webhook.Run(ctx, &rest.Config{}, config2); err != nil {
+				fmt.Printf("Run() returned err: %v\n", err)
+				select {
+				case errCh <- err:
+				default:
+				}
+			}
+
+			close(doneCh)
+		}()
+
+		Consistently(errCh).Within(500 * time.Millisecond).ShouldNot(Receive())
+
+		// Verify both servers are working
+		waitForServerReady(config.Host, config.Port)
+
+		cancel()
+		Eventually(doneCh).Within(10 * time.Second).Should(BeClosed())
+	})
+
+	It("should reload certificates when they change", func() {
+		// Wait for server to start and get the initial certificate
+		var originalCert *tls.Certificate
+		Eventually(func(g Gomega) {
+			cert, err := getServerCertificate(config.Host, config.Port)
+			g.Expect(err).NotTo(HaveOccurred())
+			originalCert = cert
+		}).Within(5 * time.Second).Should(Succeed())
+
+		// Generate new certificates
+		newCertPEM, newKeyPEM, err := ovntesting.GenerateTestCertificate()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Update the certificate files
+		certPath := filepath.Join(config.CertDir, "tls.crt")
+		keyPath := filepath.Join(config.CertDir, "tls.key")
+
+		Expect(os.WriteFile(certPath, newCertPEM, 0600)).To(Succeed())
+		Expect(os.WriteFile(keyPath, newKeyPEM, 0600)).To(Succeed())
+
+		// Verify the server picked up the new certificate
+		Eventually(func(g Gomega) {
+			newCert, err := getServerCertificate(config.Host, config.Port)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Compare certificate bytes to verify it changed
+			g.Expect(newCert.Certificate[0]).NotTo(Equal(originalCert.Certificate[0]),
+				"Server should be using new certificate after rotation")
+		}).Within(3 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+	})
+})
+
+func newWebhookConfig(port int) webhook.Config {
+	tempDir, err := os.MkdirTemp("", "webhook-test-*")
+	Expect(err).NotTo(HaveOccurred())
+
+	DeferCleanup(func() {
+		_ = os.RemoveAll(tempDir)
+	})
+
+	// Generate valid test certificates
+	certPEM, keyPEM, err := ovntesting.GenerateTestCertificate()
+	Expect(err).NotTo(HaveOccurred())
+
+	// Write test certificates
+	certPath := filepath.Join(tempDir, "tls.crt")
+	Expect(os.WriteFile(certPath, certPEM, 0600)).To(Succeed())
+
+	keyPath := filepath.Join(tempDir, "tls.key")
+	Expect(os.WriteFile(keyPath, keyPEM, 0600)).To(Succeed())
+
+	return webhook.Config{
+		CertDir: tempDir,
+		Host:    "localhost",
+		Port:    port,
+		NewKubernetesClient: func(_ *rest.Config) (kubernetes.Interface, error) {
+			return k8sfake.NewClientset(), nil
+		},
+	}
+}
+
+func getFreePort() int {
+	listener, err := net.Listen("tcp", "localhost:0")
+	Expect(err).NotTo(HaveOccurred())
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	return port
+}
+
+func waitForServerReady(host string, port int) {
+	Eventually(func(g Gomega) {
+		conn, err := tls.Dial("tcp", net.JoinHostPort(host, strconv.Itoa(port)), &tls.Config{
+			InsecureSkipVerify: true,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		conn.Close()
+	}).Within(5 * time.Second).Should(Succeed())
+}
+
+func getServerCertificate(host string, port int) (*tls.Certificate, error) {
+	conn, err := tls.Dial("tcp", net.JoinHostPort(host, strconv.Itoa(port)), &tls.Config{
+		InsecureSkipVerify: true,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer conn.Close()
+
+	// Get the peer certificate presented by the server
+	state := conn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return nil, fmt.Errorf("no peer certificates received")
+	}
+
+	// Convert to tls.Certificate format for comparison
+	cert := &tls.Certificate{
+		Certificate: [][]byte{state.PeerCertificates[0].Raw},
+	}
+
+	return cert, nil
+}
+
+func assertWebhookRequestSuccess(host string, port int, endpoint string, payload []byte) {
+	httpClient := createWebhookClient()
+
+	Eventually(func(g Gomega) {
+		resp, err := httpClient.Post(
+			fmt.Sprintf("https://%s/%s", net.JoinHostPort(host, strconv.Itoa(port)), endpoint),
+			"application/json",
+			bytes.NewBuffer(payload),
+		)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	}).Within(5 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+}
+
+func createNodeAdmissionReviewJSON() []byte {
+	return createAdmissionReviewJSON(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	})
+}
+
+func createAdmissionReviewJSON(obj any) []byte {
+	raw, err := json.Marshal(obj)
+	Expect(err).NotTo(HaveOccurred())
+
+	objMeta, err := meta.Accessor(obj)
+	Expect(err).NotTo(HaveOccurred())
+
+	admissionReview := &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "admission.k8s.io/v1",
+			Kind:       "AdmissionReview",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       "test-uid",
+			Name:      objMeta.GetName(),
+			Namespace: objMeta.GetNamespace(),
+			Operation: admissionv1.Create,
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+		},
+	}
+
+	admJSON, err := json.Marshal(admissionReview)
+	Expect(err).NotTo(HaveOccurred())
+
+	return admJSON
+}
+
+func createWebhookClient() *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				// For testing, skip certificate verification
+				// In production, you'd load the CA cert and verify
+				InsecureSkipVerify: true,
+			},
+			// Force HTTP/2
+			ForceAttemptHTTP2: true,
+		},
+	}
+}
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
+}

--- a/go-controller/pkg/testing/tls.go
+++ b/go-controller/pkg/testing/tls.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+)
+
+// GenerateTestCertificate generates a self-signed certificate for testing.
+// Returns PEM-encoded certificate and private key bytes.
+func GenerateTestCertificate() (certPEM, keyPEM []byte, err error) {
+	// Generate a new ECDSA private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	// Create a certificate template
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour) // Valid for 1 year
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"OVN Kubernetes Test"},
+			CommonName:   "localhost",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+	}
+
+	// Create the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	// Encode certificate to PEM
+	certPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	// Encode private key to PEM
+	keyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	keyPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: keyBytes,
+	})
+
+	return certPEM, keyPEM, nil
+}
+
+// CreateTestCertificateFiles generates a self-signed certificate for testing
+// and writes it to temporary files. Returns the paths to the cert and key files.
+// The caller is responsible for cleaning up the temporary files.
+func CreateTestCertificateFiles() (certFile, keyFile string, err error) {
+	// Use shared test utility to generate certificate
+	certPEM, keyPEM, err := GenerateTestCertificate()
+	if err != nil {
+		return "", "", err
+	}
+
+	// Write cert to temp file
+	certTempFile, err := os.CreateTemp("", "test-cert-*.pem")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create cert temp file: %w", err)
+	}
+	certFile = certTempFile.Name()
+
+	if _, err = certTempFile.Write(certPEM); err != nil {
+		certTempFile.Close()
+		os.Remove(certFile)
+		return "", "", fmt.Errorf("failed to write cert to file: %w", err)
+	}
+	certTempFile.Close()
+
+	// Write key to temp file
+	keyTempFile, err := os.CreateTemp("", "test-key-*.pem")
+	if err != nil {
+		os.Remove(certFile)
+		return "", "", fmt.Errorf("failed to create key temp file: %w", err)
+	}
+	keyFile = keyTempFile.Name()
+
+	if _, err = keyTempFile.Write(keyPEM); err != nil {
+		keyTempFile.Close()
+		os.Remove(certFile)
+		os.Remove(keyFile)
+		return "", "", fmt.Errorf("failed to write key to file: %w", err)
+	}
+	keyTempFile.Close()
+
+	return certFile, keyFile, nil
+}


### PR DESCRIPTION
## 📑 Description

Extract webhook server logic from _ovnkubeidentity.go_ into a separate webhook package to facilitate unit testing for existing functionality and upcoming changes. 

Also added unit tests for existing functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved webhook initialization into a dedicated module with a new public entrypoint; adds graceful shutdown, dynamic TLS certificate reloading, support for concurrent instances (SO_REUSEPORT), and clearer lifecycle handling.
* **Tests**
  * Added end-to-end webhook server tests validating admission endpoints, readiness, concurrent-instance behavior, and certificate rotation.
  * Added TLS certificate generation utilities for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->