### PR TITLE
Fixing heading alignment

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -9,6 +9,7 @@
   --md-sidebar-width: var(--ok-sidebar-base);
   --ok-content-max: min(56.25rem, 90vw);
   --md-header-height: clamp(80px, 15vh, 140px);
+  --text-emphasis: #ffffffa6;
 }
 
 /* THEME SYSTEM: Defines distinct color palettes for Light (default) and Dark (slate) modes*/
@@ -22,6 +23,7 @@
   --ok-sidebar-border: #a855f7;
   --ok-sidebar-bg: rgba(255, 255, 255, 0.96);
   --ok-sidebar-edge: rgba(168, 85, 247, 0.14);
+  --text-emphasis: #000000d1;
   --ok-sidebar-gradient: linear-gradient(
     to right,
     var(--ok-sidebar-edge) 0%,
@@ -88,10 +90,9 @@
 
 
 .md-typeset h1 {
-  color: var(--md-default-fg-color--light);
   line-height: 1.3;
   margin: 0 0 clamp(-0.25rem, 0.5vw, 0.75rem) 0;
-  font-weight: 400;
+  color: var(--text-emphasis);
 }
 
 /* ANCHOR LINKS: Styles hoverable section links with smooth transitions and a temporary "copy confirmation" tooltip for better navigation UX. */


### PR DESCRIPTION
I have opted to keep the justify text alignment as it provides a clean, professional, and balanced visual structure to the layout. To address the uneven spacing (rivers) that can occur with justification:

Removed Font Weight: Reducing the weight prevents the "blocked-in" look and makes the spacing gaps less noticeable.

Color Adjustment: To ensure the text remains distinguishable from the rest of the content without using bolding, I updated the color to a Translucent Black (000000a6) and for dark mode to white (ffffffd1). This provides high contrast and clear hierarchy while maintaining a clean aesthetic.

Before 

<img width="919" height="612" alt="Screenshot From 2026-04-30 14-34-55" src="https://github.com/user-attachments/assets/2bc4c0ea-6282-418b-8ca9-e358aea9f4d8" />

After (light mode)

<img width="919" height="612" alt="Screenshot From 2026-04-30 23-22-24" src="https://github.com/user-attachments/assets/f05d5e01-ce24-473f-9bb7-9e06d2d1fc68" />

After (dark mode)

<img width="919" height="612" alt="Screenshot From 2026-04-30 23-22-32" src="https://github.com/user-attachments/assets/6a3e4e18-d0fc-478b-82fe-ae5cd8e729a6" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Documentation h1 now uses the theme's emphasis color with a light-mode override and no forced font weight, improving visual consistency across themes.
* **Bug Fixes**
  * Fixed sidebar background gradient so it renders correctly across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->