### PR TITLE
E2E: handle empty EgressIP status in service e2e tests

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1274,6 +1274,10 @@ spec:
 				if len(egressIP.Items) > 1 {
 					framework.Failf("Didn't expect to retrieve more than one egress IP during the execution of this test, saw: %v", len(egressIP.Items))
 				}
+				if len(egressIP.Items[0].Status.Items) == 0 {
+					framework.Logf("EgressIP %s is not assigned to node %s yet", egressIP, egressNode)
+					return false, nil
+				}
 				return egressIP.Items[0].Status.Items[0].Node == egressNode, nil
 			})
 			if err != nil {
@@ -2692,6 +2696,10 @@ spec:
 			json.Unmarshal([]byte(egressIPStdout), &egressIP)
 			if len(egressIP.Items) > 1 {
 				framework.Failf("Didn't expect to retrieve more than one egress IP during the execution of this test, saw: %v", len(egressIP.Items))
+			}
+			if len(egressIP.Items[0].Status.Items) == 0 {
+				framework.Logf("EgressIP %s is not assigned to node %s yet", egressIP1.String(), nonBackendNodeName)
+				return false, nil
 			}
 			return egressIP.Items[0].Status.Items[0].Node == nonBackendNodeName, nil
 		})


### PR DESCRIPTION
Fixes one of the flake seen for https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6094.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced EgressIP assignment validation in end-to-end tests to properly handle intermediate states where the EgressIP object exists but status hasn't been populated yet, improving test reliability and preventing premature failures during the assignment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->