### PR TITLE
chassis-id: relax uuid requirement

### DIFF
--- a/go-controller/pkg/libovsdb/ops/chassis.go
+++ b/go-controller/pkg/libovsdb/ops/chassis.go
@@ -5,9 +5,6 @@ package ops
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/google/uuid"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -175,21 +172,5 @@ func CreateOrUpdateChassis(sbClient libovsdbclient.Client, chassis *sbdb.Chassis
 		return err
 	}
 
-	return nil
-}
-
-// validateRequestedChassisOption is a guard to ensure a caller is using the chassis-id (uuid format)
-// for the requested chassis option.
-func validateRequestedChassisOption(options map[string]string) error {
-	if len(options) == 0 {
-		return nil
-	}
-	chassisID, ok := options[RequestedChassis]
-	if !ok || chassisID == "" {
-		return nil
-	}
-	if _, err := uuid.Parse(chassisID); err != nil {
-		return fmt.Errorf("requested-chassis must be a valid UUID, got %q", chassisID)
-	}
 	return nil
 }

--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -190,9 +190,6 @@ func CreateOrUpdateLogicalRouterPort(nbClient libovsdbclient.Client, router *nbd
 // and returns the corresponding ops
 func CreateOrUpdateLogicalRouterPortOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, router *nbdb.LogicalRouter,
 	lrp *nbdb.LogicalRouterPort, chassis *nbdb.GatewayChassis, fields ...interface{}) ([]ovsdb.Operation, error) {
-	if err := validateRequestedChassisOption(lrp.Options); err != nil {
-		return nil, err
-	}
 	opModels := []operationModel{}
 	if chassis != nil {
 		opModels = append(opModels, operationModel{

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -363,9 +363,6 @@ func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []o
 	opModels := make([]operationModel, 0, len(lsps)+1)
 
 	for _, lsp := range lsps {
-		if err := validateRequestedChassisOption(lsp.Options); err != nil {
-			return nil, err
-		}
 		opModel := createOrUpdateLogicalSwitchPortOpModelWithCustomFields(sw, lsp, createLSP, customFields)
 		opModels = append(opModels, opModel)
 	}


### PR DESCRIPTION
In 3b14133 validation was added to ensure a client trying to update chassis-id used a uuid format. However, OVS system ID allows using non-uuid formats. Therefore this guard is not accurate and should be removed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal validation logic for logical router ports and logical switch ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->