### PR TITLE
Fix OVS ARP Storm with UDNs

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -809,6 +809,10 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 				nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch))
 	}
 
+	if util.IsNetworkSegmentationSupportEnabled() {
+		dftFlows = append(dftFlows, b.arpFilterFlows(bridgeMacAddress)...)
+	}
+
 	if config.IPv4Mode {
 		physicalIP, err := util.MatchFirstIPNetFamily(false, bridgeIPs)
 		if err != nil {
@@ -1260,6 +1264,53 @@ func (b *BridgeConfiguration) allowNodeIPGARPFlows(nodeIPs []net.IP) []string {
 			flows = append(flows, generateGratuitousARPAllowFlow(netConfig.OfPortPatch, nodeIP, priority))
 		}
 
+	}
+	return flows
+}
+
+// arpFilterFlows ensures only the default network GR replies to ARP requests
+// for the local node IP. When an ARP request arrives on br-ex, the priority-10
+// fan-out rule replicates it to every patch port. All CUDN GRs share the same
+// node IP on their external interface, so every one of them generates an ARP
+// reply. These duplicate replies flood the physical network and cause remote
+// nodes to passively learn lots of MAC_Bindings, driving ovs-vswitchd CPU up.
+//
+// Only ARP replies (arp_op=2) are filtered, not ARP requests (arp_op=1).
+// ARP requests are broadcast and reaching multiple GRs is harmless — the
+// storm is caused by multiple GRs all *replying* for the same node IP.
+//
+// Three flows per node IP (IPv4 only, ARP is IPv4):
+//   - priority 12: allow ARP replies from the default network patch port
+//   - priority 12: allow ARP replies from LOCAL (the kernel's breth0 interface)
+//   - priority 11: drop ARP replies from any other port (CUDN patch ports)
+//
+// Must be called with bridge.mutex held.
+func (b *BridgeConfiguration) arpFilterFlows(bridgeMacAddress string) []string {
+	defaultNetConfig, found := b.netConfig[types.DefaultNetworkName]
+	if !found || defaultNetConfig.OfPortPatch == "" {
+		return nil
+	}
+
+	var flows []string
+	for _, ip := range b.ips {
+		if ip.IP.To4() == nil {
+			continue
+		}
+		// allow ARP replies for the node IP from the default network patch port
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=12, table=0, in_port=%s, dl_src=%s, arp, arp_op=2, arp_spa=%s, "+
+				"actions=output:NORMAL",
+				nodetypes.DefaultOpenFlowCookie, defaultNetConfig.OfPortPatch, bridgeMacAddress, ip.IP))
+		// allow ARP replies for the node IP from the kernel (LOCAL port)
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=12, table=0, in_port=LOCAL, arp, arp_op=2, arp_spa=%s, "+
+				"actions=output:NORMAL",
+				nodetypes.DefaultOpenFlowCookie, ip.IP))
+		// drop ARP replies for the node IP from all other ports (CUDN patch ports)
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=11, table=0, dl_src=%s, arp, arp_op=2, arp_spa=%s, "+
+				"actions=drop",
+				nodetypes.DefaultOpenFlowCookie, bridgeMacAddress, ip.IP))
 	}
 	return flows
 }


### PR DESCRIPTION
## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network segmentation behavior by tightening ARP reply handling on the host bridge.
  * Added ARP reply filtering so replies are accepted only from the expected ingress paths, helping reduce the risk of incorrect responses.
  * When the default network path information isn’t available, the filtering rules are not applied to avoid unintended disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->