### PR TITLE
FUP Fixes for VTEP unmanaged mode PR

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -1156,7 +1156,7 @@ func vtepCIDRPrefixSelectors(cidrs []string) []frrtypes.PrefixSelector {
 		} else {
 			le = 32
 		}
-		selectors = append(selectors, frrtypes.PrefixSelector{Prefix: cidr, LE: le})
+		selectors = append(selectors, frrtypes.PrefixSelector{Prefix: cidr, LE: le, GE: le})
 	}
 	return selectors
 }

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -1589,7 +1589,7 @@ exit
 					Routers: []*testRouter{
 						{ASN: 65000, VRF: "blue", Prefixes: []string{"10.2.1.0/24"}},
 						{ASN: 65000, Prefixes: []string{"100.64.0.1/32"}, Neighbors: []*testNeighbor{
-							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32}}},
+							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}}},
 						}},
 					},
 				},
@@ -1655,7 +1655,7 @@ exit
 					Routers: []*testRouter{
 						{ASN: 65000, VRF: "blue6", Prefixes: []string{"fd02::/64"}},
 						{ASN: 65000, Prefixes: []string{"fd64::1/128"}, Neighbors: []*testNeighbor{
-							{ASN: 65000, Address: "fd00::1", Advertise: []string{"fd64::1/128"}, Receive: []testPrefixSelector{{Prefix: "fd64::/64", LE: 128}}},
+							{ASN: 65000, Address: "fd00::1", Advertise: []string{"fd64::1/128"}, Receive: []testPrefixSelector{{Prefix: "fd64::/64", LE: 128, GE: 128}}},
 						}},
 					},
 				},
@@ -1717,7 +1717,7 @@ exit
 							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"10.1.0.0/16"}},
 						}},
 						{ASN: 65000, Prefixes: []string{"100.64.0.1/32"}, Neighbors: []*testNeighbor{
-							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32}}},
+							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}}},
 						}},
 					},
 				},
@@ -1798,7 +1798,7 @@ exit
 						{ASN: 65000, VRF: "blue", Prefixes: []string{"10.2.1.0/24"}},
 						{ASN: 65000, VRF: "green", Prefixes: []string{"10.3.1.0/24"}},
 						{ASN: 65000, Prefixes: []string{"100.64.0.1/32"}, Neighbors: []*testNeighbor{
-							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32}}},
+							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}}},
 						}},
 					},
 				},
@@ -1869,7 +1869,7 @@ exit
 					Routers: []*testRouter{
 						{ASN: 65000, VRF: "blue", Prefixes: []string{"10.2.1.0/24"}},
 						{ASN: 65000, Prefixes: []string{"100.64.0.1/32"}, Neighbors: []*testNeighbor{
-							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32}}},
+							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}}},
 						}},
 					},
 				},
@@ -1902,7 +1902,7 @@ exit
 					Routers: []*testRouter{
 						{ASN: 65000, VRF: "blue", Prefixes: []string{"10.2.2.0/24"}},
 						{ASN: 65000, Prefixes: []string{"100.64.0.2/32"}, Neighbors: []*testNeighbor{
-							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.2/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32}}},
+							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.2/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}}},
 						}},
 					},
 				},
@@ -1987,7 +1987,7 @@ exit
 						{ASN: 65000, VRF: "blue", Prefixes: []string{"10.2.1.0/24"}},
 						{ASN: 65000, VRF: "green", Prefixes: []string{"10.3.1.0/24"}},
 						{ASN: 65000, Prefixes: []string{"100.64.0.1/32", "200.10.0.1/32"}, Neighbors: []*testNeighbor{
-							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32", "200.10.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32}, {Prefix: "200.10.0.0/16", LE: 32}}},
+							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32", "200.10.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}, {Prefix: "200.10.0.0/16", LE: 32, GE: 32}}},
 						}},
 					},
 				},
@@ -2058,7 +2058,7 @@ exit
 					Routers: []*testRouter{
 						{ASN: 65000, VRF: "blue", Prefixes: []string{"10.2.1.0/24"}},
 						{ASN: 65000, Prefixes: []string{"100.64.0.1/32"}, Neighbors: []*testNeighbor{
-							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32}}},
+							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}}},
 						}},
 					},
 				},

--- a/go-controller/pkg/clustermanager/vtep/controller.go
+++ b/go-controller/pkg/clustermanager/vtep/controller.go
@@ -453,12 +453,15 @@ func (c *Controller) validateNodeVTEPIPs(vtep *vtepv1.VTEP) error {
 }
 
 func (c *Controller) handleManagedModeNotSupported(vtep *vtepv1.VTEP) error {
-	vtepRef, err := reference.GetReference(vtepscheme.Scheme, vtep)
-	if err != nil {
-		return fmt.Errorf("failed to get object reference for VTEP %s: %w", vtep.Name, err)
+	existingCond := meta.FindStatusCondition(vtep.Status.Conditions, conditionTypeAccepted)
+	if existingCond == nil || existingCond.Status != metav1.ConditionFalse || existingCond.Reason != reasonManagedModeNotSupported {
+		vtepRef, err := reference.GetReference(vtepscheme.Scheme, vtep)
+		if err != nil {
+			return fmt.Errorf("failed to get object reference for VTEP %s: %w", vtep.Name, err)
+		}
+		c.eventRecorder.Event(vtepRef, corev1.EventTypeWarning, reasonManagedModeNotSupported,
+			"Managed VTEP mode is not yet implemented; only Unmanaged mode is currently supported")
 	}
-	c.eventRecorder.Event(vtepRef, corev1.EventTypeWarning, reasonManagedModeNotSupported,
-		"Managed VTEP mode is not yet implemented; only Unmanaged mode is currently supported")
 
 	return c.updateStatusCondition(vtep, conditionTypeAccepted, metav1.ConditionFalse,
 		reasonManagedModeNotSupported,


### PR DESCRIPTION
Addresses comments we agreed to do as FUP documented here: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route advertisement matching tightened so advertised prefixes are matched at exact host-length for IPv4/IPv6, improving precision of route selection.
  * VTEP status reporting refined to avoid emitting duplicate warning events for unsupported managed mode while still marking the VTEP as not accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->