### PR TITLE
Fix broken link to KIND guide in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ In some cases, other changes may conflict with your PR. If this happens, you wil
 
 ## Development Environment Setup
 
-You can easily setup a developer environment by following the instructions [here](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/kind.md).
+You can easily setup a developer environment by following the instructions [here](https://ovn-kubernetes.io/installation/launching-ovn-kubernetes-on-kind/).
 
 ## Sign Your Commits
 

--- a/docs/installation/launching-ovn-kubernetes-on-kind.md
+++ b/docs/installation/launching-ovn-kubernetes-on-kind.md
@@ -8,7 +8,7 @@ KIND (Kubernetes in Docker) deployment of OVN kubernetes is a fast and easy mean
 - Docker run time or podman
 - [KIND](https://kubernetes.io/docs/setup/learning-environment/kind/)
    - Installation instructions can be found at https://github.com/kubernetes-sigs/kind#installation-and-usage. 
-   - NOTE: The OVN-Kubernetes [ovn-kubernetes/contrib/kind.sh](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/contrib/kind.sh) and [ovn-kubernetes/contrib/kind.yaml.j2](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/contrib/kind.yaml.j2) files provision port 11337. If firewalld is enabled, this port will need to be unblocked:
+   - NOTE: The [ovn-kubernetes/contrib/kind.sh](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/contrib/kind.sh) and [ovn-kubernetes/contrib/kind.yaml.j2](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/contrib/kind.yaml.j2) files provision port 11337. If firewalld is enabled, this port will need to be unblocked:
 
       ```
       sudo firewall-cmd --permanent --add-port=11337/tcp; sudo firewall-cmd --reload


### PR DESCRIPTION
Description:

The link to the KIND installation guide in CONTRIBUTING.md was pointing to a non-existent path (docs/kind.md). This PR updates the reference to the correct file location to ensure contributors can easily access the local development setup instructions.

Changes:

Updated CONTRIBUTING.md:87 to point from docs/kind.md to docs/installation/launching-ovn-kubernetes-on-kind.md.

Screen recording Before:

https://github.com/user-attachments/assets/57e2e5d3-ba3b-4eef-bc59-373d9bd14ee5

Screen recording After:

https://github.com/user-attachments/assets/c2666f3d-3d82-4fab-8e95-00dd67eb3316









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Development Environment Setup reference in contributing guidelines to point to the official OVN-Kubernetes kind installation guide.
  * Clarified the Prerequisites note for kind-based installs, refining the link text and wording about unblocking port 11337 when firewalld is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->