### PR TITLE
services: accumulate ops across nodes in configureUDNEnabledServiceRoute

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -845,7 +845,7 @@ func (c *Controller) configureUDNEnabledServiceRoute(service *corev1.Service) er
 		if c.netInfo.TopologyType() == types.Layer2Topology && !globalconfig.Layer2UsesTransitRouter {
 			routerName = nodeInfo.gatewayRouterName
 		}
-		ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, nil, routerName, &staticRoute, func(item *nbdb.LogicalRouterStaticRoute) bool {
+		ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(c.nbClient, ops, routerName, &staticRoute, func(item *nbdb.LogicalRouterStaticRoute) bool {
 			return routesEqual(item, &staticRoute)
 		})
 		if err != nil {

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -1580,6 +1580,102 @@ func TestSyncServices(t *testing.T) {
 	}
 }
 
+// TestConfigureUDNEnabledServiceRouteMultiNode verifies that
+// configureUDNEnabledServiceRoute creates static routes for all nodes,
+// not just the last one. Regression test for a bug where nil was passed
+// instead of the accumulating ops slice.
+func TestConfigureUDNEnabledServiceRouteMultiNode(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	ns := "testns"
+	serviceName := "kubernetes"
+	serviceClusterIP := "192.168.1.1"
+
+	config.IPv4Mode = true
+	config.IPv6Mode = false
+
+	l3UDN, err := getSampleUDNNetInfo(ns, types.Layer3Topology)
+	if err != nil {
+		t.Fatalf("Error creating UDN net info: %v", err)
+	}
+
+	clusterRouterName := l3UDN.GetNetworkScopedClusterRouterName()
+
+	nodeAMgmtIP := "192.168.200.2"
+	nodeBMgmtIP := "192.168.201.2"
+
+	initialDb := []libovsdbtest.TestData{
+		&nbdb.LogicalRouter{
+			UUID: clusterRouterName,
+			Name: clusterRouterName,
+		},
+	}
+
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{NBData: initialDb}, nil)
+	if err != nil {
+		t.Fatalf("Error creating NB test harness: %v", err)
+	}
+	defer cleanup.Cleanup()
+
+	controller := &Controller{
+		nbClient: nbClient,
+		netInfo:  l3UDN,
+		nodeInfos: []nodeInfo{
+			{
+				name:    nodeA,
+				mgmtIPs: []net.IP{net.ParseIP(nodeAMgmtIP)},
+			},
+			{
+				name:    nodeB,
+				mgmtIPs: []net.IP{net.ParseIP(nodeBMgmtIP)},
+			},
+		},
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+		Spec: corev1.ServiceSpec{
+			Type:       corev1.ServiceTypeClusterIP,
+			ClusterIP:  serviceClusterIP,
+			ClusterIPs: []string{serviceClusterIP},
+		},
+	}
+
+	err = controller.configureUDNEnabledServiceRoute(service)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	dstIP := nbdb.LogicalRouterStaticRoutePolicyDstIP
+	extIDs := map[string]string{
+		types.NetworkExternalID:           l3UDN.GetNetworkName(),
+		types.TopologyExternalID:          l3UDN.TopologyType(),
+		types.UDNEnabledServiceExternalID: ns + "/" + serviceName,
+	}
+
+	expectedDb := []libovsdbtest.TestData{
+		&nbdb.LogicalRouter{
+			UUID:         clusterRouterName,
+			Name:         clusterRouterName,
+			StaticRoutes: []string{"route-node-a", "route-node-b"},
+		},
+		&nbdb.LogicalRouterStaticRoute{
+			UUID:        "route-node-a",
+			IPPrefix:    serviceClusterIP,
+			Nexthop:     nodeAMgmtIP,
+			Policy:      &dstIP,
+			ExternalIDs: extIDs,
+		},
+		&nbdb.LogicalRouterStaticRoute{
+			UUID:        "route-node-b",
+			IPPrefix:    serviceClusterIP,
+			Nexthop:     nodeBMgmtIP,
+			Policy:      &dstIP,
+			ExternalIDs: extIDs,
+		},
+	}
+
+	g.Expect(nbClient).To(libovsdbtest.HaveData(expectedDb))
+}
+
 func nodeLogicalSwitch(nodeName string, lbGroups []string, namespacedServiceNames ...string) *nbdb.LogicalSwitch {
 	return nodeLogicalSwitchForNetwork(nodeName, lbGroups, &util.DefaultNetInfo{}, namespacedServiceNames...)
 }


### PR DESCRIPTION
## Summary
- Fix `configureUDNEnabledServiceRoute()` passing `nil` instead of the accumulating `ops` slice to `CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps()`, causing only the last node's static route to be committed
- Add regression test `TestConfigureUDNEnabledServiceRouteMultiNode` verifying routes are created for all nodes

Affects non-IC multi-node deployments only. IC deployments (default since OCP 4.14) are unaffected since each node's controller has a single-node `nodeInfos` slice.

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6355

## Test plan
- [x] Unit test `TestConfigureUDNEnabledServiceRouteMultiNode` — 2-node L3 UDN, verifies static routes on cluster router for both nodes
- [x] `make lint` passes
- [x] `make test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where UDN-enabled service routes were not properly accumulated across multiple nodes, ensuring all node routes are correctly configured in multi-node deployments.

* **Tests**
  * Added comprehensive test coverage for multi-node UDN-enabled service route configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->