### PR TITLE
Fix managed BGP empty-cluster unit test race

### DIFF
--- a/go-controller/pkg/clustermanager/managedbgp/controller_test.go
+++ b/go-controller/pkg/clustermanager/managedbgp/controller_test.go
@@ -527,23 +527,43 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer controller.Stop()
 
-			// Create and immediately delete a node to trigger reconciliation
+			waitForBaseNeighbors := func(expected ...string) {
+				gomega.Eventually(func() error {
+					baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if len(baseConfig.Spec.BGP.Routers) != 1 {
+						return fmt.Errorf("expected one BGP router, got %d", len(baseConfig.Spec.BGP.Routers))
+					}
+					neighbors := baseConfig.Spec.BGP.Routers[0].Neighbors
+					if len(neighbors) != len(expected) {
+						return fmt.Errorf("expected neighbors %v, got %v", expected, neighbors)
+					}
+					for i, expectedAddress := range expected {
+						if neighbors[i].Address != expectedAddress {
+							return fmt.Errorf("expected neighbor %d to be %q, got %q", i, expectedAddress, neighbors[i].Address)
+						}
+					}
+					return nil
+				}, 2*time.Second).Should(gomega.Succeed())
+			}
+
+			// Should create the base config with no neighbors when no nodes exist.
+			waitForBaseNeighbors()
+
+			// Add a node and wait until the controller has reconciled it before
+			// deleting it. Otherwise the test can race with the queued add event.
 			tempNode := createNode("temp", "10.0.0.99", "")
 			_, err = fakeClient.CoreV1().Nodes().Create(context.TODO(), tempNode, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			waitForBaseNeighbors("10.0.0.99")
+
 			err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), "temp", metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// Should still create base config, just with no neighbors
-			gomega.Eventually(func() bool {
-				bc, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
-				return err == nil && bc != nil
-			}, 2*time.Second).Should(gomega.BeTrue())
-
-			baseConfig, err := frrFakeClient.ApiV1beta1().FRRConfigurations(config.ManagedBGP.FRRNamespace).Get(context.TODO(), BaseFRRConfigName(), metav1.GetOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(baseConfig.Spec.BGP.Routers).To(gomega.HaveLen(1))
-			gomega.Expect(baseConfig.Spec.BGP.Routers[0].Neighbors).To(gomega.BeEmpty())
+			// Should return to no neighbors after the last node is deleted.
+			waitForBaseNeighbors()
 		})
 	})
 


### PR DESCRIPTION
The empty-cluster managed BGP unit test created and immediately deleted a temporary node, then only waited for the base `FRRConfiguration` to exist before asserting that it had no neighbors.

That raced with queued add reconcile path. In the failed run, the add reconcile for the temporary node won the race and updated the base`FRRConfiguration` with the transient node address before the delete reconcile returned it to the empty state:
```
Updating base FRRConfiguration ovnk-managed-c9ae298d71aa4275

Expected
    <[]v1beta1.Neighbor | len:1, cap:1>: [
	{
	    ASN: 64512,
	    Address: "10.0.0.99",
	    DisableMP: true,
	},
    ]
to be empty
```
https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/23807727033/job/69385823697?pr=6093

The solution is to wait for the expected state transitions in the `FRRConfiguration` explicitly:
1. empty base config
2. temporary node neighbor present
3. empty again after deletion.

Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6305

---
The steps involved in the test are essentially:
1.  create temp node
2.  delete temp node immediately
3.  assert FRRConfiguration has no neighbors

So there are two queued reconciles: one for the node add, one for the node delete. If the assertion (point 3 above) lands _after_ the add reconcile but _before_ the delete reconcile, the test fails, since it finds one neighbor instead of no neighbors.
To reproduce the failure, just add a sleep between node creation and node deletion, to make the "bad" ordering more likely:

```
  --- a/go-controller/pkg/clustermanager/managedbgp/controller_test.go
  +++ b/go-controller/pkg/clustermanager/managedbgp/controller_test.go
  @@ -530,6 +530,7 @@ var _ = ginkgo.Describe("Managed BGP Controller", func() {
   			tempNode := createNode("temp", "10.0.0.99", "")
   			_, err = fakeClient.CoreV1().Nodes().Create(context.TODO(), tempNode, metav1.CreateOptions{})
   			gomega.Expect(err).NotTo(gomega.HaveOccurred())
  +			time.Sleep(10 * time.Millisecond)
   			err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), "temp", metav1.DeleteOptions{})
   			gomega.Expect(err).NotTo(gomega.HaveOccurred())
```
