### PR TITLE
Update stale pod checks to use latest info from the kube client

### DIFF
--- a/go-controller/pkg/controllermanager/node_controller_manager.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager.go
@@ -13,6 +13,7 @@ import (
 
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -563,14 +564,15 @@ func (ncm *NodeControllerManager) checkForStaleOVSRepresentorInterfaces() {
 	// list Pods and calculate the expected iface-ids.
 	// Note: we do this after scanning ovs interfaces to avoid deleting ports of pods that where just scheduled
 	// on the node.
-	pods, err := ncm.watchFactory.GetPods("")
+	// Use ncm.Kube instead of watchFactory to avoid cache staleness, since CNI may use kube client directly to create pod
+	pods, err := ncm.Kube.(*kube.Kube).KClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		klog.Errorf("Failed to list pods. %v", err)
 		return
 	}
 	expectedPodUIDs := make(map[string]struct{})
-	for _, pod := range pods {
-		if pod.Spec.NodeName == ncm.name && !util.PodWantsHostNetwork(pod) {
+	for _, pod := range pods.Items {
+		if pod.Spec.NodeName == ncm.name && !util.PodWantsHostNetwork(&pod) {
 			// Note: wf (WatchFactory) *usually* returns pods assigned to this node, however we dont rely on it
 			// and add this check to filter out pods assigned to other nodes. (e.g when ovnkube master and node
 			// share the same process)


### PR DESCRIPTION
Watch factory may have stale info, which could cause an interface deletion of a recently created pod

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
This shouldn't have perf impact because this function in only run every minute
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal pod listing mechanism in the node controller for improved efficiency in managing OVS representer interfaces. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->