### PR TITLE
set mac address on VF representor

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -469,8 +469,9 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 			return nil, nil, err
 		}
 
-		if isVFIO {
-			// 3. it's not possible to set mac address within container netns for VFIO case, hence set it through VF representor
+		// 3. it's not possible to set mac address within container netns for VFIO case,
+		// hence set it through VF representor (PCI device IDs only).
+		if util.IsPCIDeviceName(deviceID) {
 			if err := util.SetVFHardwreAddress(deviceID, ifInfo.MAC); err != nil {
 				return nil, nil, err
 			}

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -732,11 +732,16 @@ func TestSetupSriovInterface(t *testing.T) {
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below two mock calls are needed for the moveIfToNetns() call that internally invokes them
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				{OnCallMethodName: "LinkSetNsFd", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
+				// The below two mock calls are needed for SetVFHardwreAddress()
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetVfHardwareAddr", OnCallMethodArgType: []string{"*mocks.Link", "int", "net.HardwareAddr"}, RetArgList: []interface{}{nil}},
 				// The below mock call is for the LinkByName() of the host representor
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
@@ -762,11 +767,16 @@ func TestSetupSriovInterface(t *testing.T) {
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below two mock calls are needed for the moveIfToNetns() call that internally invokes them
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				{OnCallMethodName: "LinkSetNsFd", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
+				// The below two mock calls are needed for SetVFHardwreAddress()
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetVfHardwareAddr", OnCallMethodArgType: []string{"*mocks.Link", "int", "net.HardwareAddr"}, RetArgList: []interface{}{nil}},
 				// The below mock call is for the LinkByName() of the host representor
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 			},


### PR DESCRIPTION
## 📑 Description

When Kata container cold plugs a VF network interface, it rebinds the VF as VFIO deivce. The VF's mac address need to be set on VF representor, so the guest VM kernel can set the VF mac address, and kata-agent can find the VF for configuring network on it.

Fixes #6387


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * SR‑IOV interface setup adjusted: MAC assignment for virtual functions now occurs later with stricter PCI-device checks, immediate error reporting, and more reliable host/representor resolution.
* **Tests**
  * Unit tests updated to reflect the revised SR‑IOV setup flow and adjusted mock expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->