### PR TITLE
CUDN outboundSNAT support: implementation + misc traffic path fixes [OLD]

### DIFF
--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
@@ -36,6 +36,7 @@ type SpecGetter interface {
 	GetLocalnet() *userdefinednetworkv1.LocalnetConfig
 	GetTransport() userdefinednetworkv1.TransportOption
 	GetEVPN() *userdefinednetworkv1.EVPNConfig
+	GetNoOverlay() *userdefinednetworkv1.NoOverlayConfig
 }
 
 func RenderNetAttachDefManifest(obj client.Object, targetNamespace string, opts ...RenderOption) (*netv1.NetworkAttachmentDefinition, error) {
@@ -206,6 +207,14 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter, opts *
 		netConfSpec.EVPN = renderEVPNConfig(spec, opts)
 	}
 
+	if spec.GetTransport() == userdefinednetworkv1.TransportOptionNoOverlay {
+		noOverlayCfg := spec.GetNoOverlay()
+		if noOverlayCfg != nil {
+			// Convert CRD SNATOption enum ("Enabled"/"Disabled") to internal format ("enabled"/"disabled")
+			netConfSpec.OutboundSNAT = strings.ToLower(string(noOverlayCfg.OutboundSNAT))
+		}
+	}
+
 	if netConfSpec.AllowPersistentIPs && !config.OVNKubernetesFeature.EnablePersistentIPs {
 		return nil, fmt.Errorf("allowPersistentIPs is set but persistentIPs is Disabled")
 	}
@@ -271,6 +280,9 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter, opts *
 
 	if netConfSpec.Transport != "" {
 		cniNetConf["transport"] = netConfSpec.Transport
+	}
+	if netConfSpec.OutboundSNAT != "" {
+		cniNetConf["outboundSNAT"] = netConfSpec.OutboundSNAT
 	}
 	if netConfSpec.EVPN != nil {
 		cniNetConf["evpn"] = netConfSpec.EVPN

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -89,6 +89,12 @@ type NetConf struct {
 	// When omitted, the default OVN overlay transport is used.
 	Transport string `json:"transport,omitempty"`
 
+	// OutboundSNAT configures SNAT behavior for outbound traffic from pods
+	// on user-defined networks in no-overlay mode.
+	// Valid values are "enabled" and "disabled".
+	// Only valid when Transport is "no-overlay".
+	OutboundSNAT string `json:"outboundSNAT,omitempty"`
+
 	// EVPNConfig contains configuration for EVPN mode.
 	// Only valid when Transport is "evpn".
 	EVPN *EVPNConfig `json:"evpn,omitempty"`
@@ -140,6 +146,7 @@ func (n NetConf) MarshalJSON() ([]byte, error) {
 		AllowPersistentIPs    bool        `json:"allowPersistentIPs,omitempty"`
 		PhysicalNetworkName   string      `json:"physicalNetworkName,omitempty"`
 		Transport             string      `json:"transport,omitempty"`
+		OutboundSNAT          string      `json:"outboundSNAT,omitempty"`
 		EVPN                  *EVPNConfig `json:"evpn,omitempty"`
 		DeviceID              string      `json:"deviceID,omitempty"`
 		LogFile               string      `json:"logFile,omitempty"`
@@ -168,6 +175,7 @@ func (n NetConf) MarshalJSON() ([]byte, error) {
 		AllowPersistentIPs:    n.AllowPersistentIPs,
 		PhysicalNetworkName:   n.PhysicalNetworkName,
 		Transport:             n.Transport,
+		OutboundSNAT:          n.OutboundSNAT,
 		EVPN:                  n.EVPN,
 		DeviceID:              n.DeviceID,
 		LogFile:               n.LogFile,

--- a/go-controller/pkg/cni/types/types_test.go
+++ b/go-controller/pkg/cni/types/types_test.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+)
+
+func TestNetConfMarshalJSONIncludesOutboundSNAT(t *testing.T) {
+	conf := NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "test-network",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Transport:    "no-overlay",
+		OutboundSNAT: "enabled",
+	}
+
+	data, err := json.Marshal(conf)
+	if err != nil {
+		t.Fatalf("failed to marshal NetConf: %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal marshaled NetConf: %v", err)
+	}
+
+	if got["outboundSNAT"] != "enabled" {
+		t.Fatalf("expected outboundSNAT to be marshaled, got %v from %s", got["outboundSNAT"], data)
+	}
+}

--- a/go-controller/pkg/crd/userdefinednetwork/v1/spec.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/spec.go
@@ -30,6 +30,11 @@ func (s *UserDefinedNetworkSpec) GetEVPN() *EVPNConfig {
 	return nil
 }
 
+func (s *UserDefinedNetworkSpec) GetNoOverlay() *NoOverlayConfig {
+	// UDN (namespace-scoped) does not support no-overlay transport
+	return nil
+}
+
 func (s *NetworkSpec) GetTopology() NetworkTopology {
 	return s.Topology
 }
@@ -52,4 +57,8 @@ func (s *NetworkSpec) GetTransport() TransportOption {
 
 func (s *NetworkSpec) GetEVPN() *EVPNConfig {
 	return s.EVPN
+}
+
+func (s *NetworkSpec) GetNoOverlay() *NoOverlayConfig {
+	return s.NoOverlay
 }

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -403,6 +403,13 @@ var QoSRuleEgressIP = newObjectIDsType(qos, EgressIPOwnerType, []ExternalIDKey{
 	IPFamilyKey,
 })
 
+var QoSAdvertisedNetwork = newObjectIDsType(qos, AdvertisedNetworkOwnerType, []ExternalIDKey{
+	ObjectNameKey,
+	NetworkKey,
+	NodeIDKey,
+	IPFamilyKey,
+})
+
 var NetworkQoS = newObjectIDsType(qos, NetworkQoSOwnerType, []ExternalIDKey{
 	ObjectNameKey,
 	// rule index

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -35,18 +35,25 @@ type BridgeUDNConfiguration struct {
 	NodeSubnets   []*net.IPNet
 	Advertised    atomic.Bool
 	ManagementIPs []*net.IPNet
+	// Transport mode for this network ("no-overlay", "evpn", or "" for default network)
+	Transport string
+	// OutboundSNAT setting for this network ("enabled", "disabled", or "")
+	OutboundSNAT string
 }
 
 func (netConfig *BridgeUDNConfiguration) ShallowCopy() *BridgeUDNConfiguration {
 	copy := &BridgeUDNConfiguration{
-		PatchPort:   netConfig.PatchPort,
-		OfPortPatch: netConfig.OfPortPatch,
-		MasqCTMark:  netConfig.MasqCTMark,
-		PktMark:     netConfig.PktMark,
-		V4MasqIPs:   netConfig.V4MasqIPs,
-		V6MasqIPs:   netConfig.V6MasqIPs,
-		Subnets:     netConfig.Subnets,
-		NodeSubnets: netConfig.NodeSubnets,
+		PatchPort:     netConfig.PatchPort,
+		OfPortPatch:   netConfig.OfPortPatch,
+		MasqCTMark:    netConfig.MasqCTMark,
+		PktMark:       netConfig.PktMark,
+		V4MasqIPs:     netConfig.V4MasqIPs,
+		V6MasqIPs:     netConfig.V6MasqIPs,
+		Subnets:       netConfig.Subnets,
+		NodeSubnets:   netConfig.NodeSubnets,
+		ManagementIPs: netConfig.ManagementIPs,
+		Transport:     netConfig.Transport,
+		OutboundSNAT:  netConfig.OutboundSNAT,
 	}
 	copy.Advertised.Store(netConfig.Advertised.Load())
 	return copy
@@ -325,6 +332,8 @@ func (b *BridgeConfiguration) AddNetworkConfig(nInfo util.NetInfo, nodeSubnets, 
 			ManagementIPs: mgmtIPs,
 			Subnets:       nInfo.Subnets(),
 			NodeSubnets:   nodeSubnets,
+			Transport:     nInfo.Transport(),
+			OutboundSNAT:  nInfo.OutboundSNAT(),
 		}
 		netConfig.Advertised.Store(util.IsPodNetworkAdvertisedAtNode(nInfo, b.nodeName))
 

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -605,6 +605,18 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 		if ofPortPhys != "" {
 			for _, netConfig := range b.patchedNetConfigs() {
+				// table0, for UDN no-overlay networks, handle cross-node traffic
+				// that has already been SNATed to node IP by the gateway router.
+				if !netConfig.IsDefaultNetwork() && netConfig.Transport == types.NetworkTransportNoOverlay && config.Gateway.Mode == config.GatewayModeShared {
+					// In shared gateway mode, commit to conntrack and send directly to physical port.
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=99, in_port=%s, dl_src=%s, %s, nw_src=%s, "+
+							"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV4,
+							physicalIP.IP, config.Default.ConntrackZone,
+							netConfig.MasqCTMark, ofPortPhys))
+				}
+
 				// table0, packets coming from egressIP pods that have mark 1008 on them
 				// will be SNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
 				// SNATs these into egressIP prior to reaching external bridge.
@@ -706,6 +718,18 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 		if ofPortPhys != "" {
 			for _, netConfig := range b.patchedNetConfigs() {
+				// table0, for UDN no-overlay networks, handle cross-node traffic
+				// that has already been SNATed to node IP by the gateway router.
+				if !netConfig.IsDefaultNetwork() && netConfig.Transport == types.NetworkTransportNoOverlay && config.Gateway.Mode == config.GatewayModeShared {
+					// In shared gateway mode, commit to conntrack and send directly to physical port.
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=99, in_port=%s, dl_src=%s, %s, %s_src=%s, "+
+							"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV6,
+							protoPrefixV6, physicalIP.IP, config.Default.ConntrackZone,
+							netConfig.MasqCTMark, ofPortPhys))
+				}
+
 				// table0, packets coming from egressIP pods that have mark 1008 on them
 				// will be DNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
 				// DNATs these into egressIP prior to reaching external bridge.

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -135,6 +135,39 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 			}
 		}
 
+		// table 0, NodePort reply traffic from advertised no-overlay UDNs, Host -> OVN.
+		// In local gateway mode these packets re-enter breth0 from LOCAL with the
+		// UDN pod subnet as source and the OVN masquerade IP as destination. If they
+		// use the generic priority-500 OVN masquerade flow below, they reach table 2
+		// with skb_mark=0 and match the advertised-subnet isolation drop instead of
+		// the UDN pkt_mark dispatch flow. Restore the UDN packet mark before the
+		// existing OVN masquerade conntrack path. Priority 550 matches the advertised
+		// UDN Host -> Service exception used later in this function.
+		if config.Gateway.Mode == config.GatewayModeLocal && util.IsRouteAdvertisementsEnabled() {
+			for _, netConfig := range b.patchedNetConfigs() {
+				if netConfig.IsDefaultNetwork() || netConfig.Transport != types.NetworkTransportNoOverlay || !netConfig.Advertised.Load() {
+					continue
+				}
+				var udnAdvertisedSubnets []*net.IPNet
+				for _, clusterEntry := range netConfig.Subnets {
+					udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
+				}
+				matchingIPFamilySubnet, err := util.MatchFirstIPNetFamily(false, udnAdvertisedSubnets)
+				if err != nil {
+					klog.Infof("Unable to determine IPV4 UDN subnet for Host -> OVN reply SVC traffic: %v", err)
+					continue
+				}
+				// Example flow:
+				// table=0, priority=550, in_port=LOCAL, ip, nw_src=<UDN pod subnet>, nw_dst=<OVN masquerade IP>
+				// actions=set_field:<UDN pkt_mark>->pkt_mark,ct(zone=<OVN masq zone>,nat,table=5)
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=550, in_port=%s, %s, %s_src=%s, %s_dst=%s,"+
+						"actions=set_field:%s->pkt_mark,ct(zone=%d,nat,table=5)",
+						nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefixV4, protoPrefixV4,
+						matchingIPFamilySubnet.String(), protoPrefixV4, config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String(),
+						netConfig.PktMark, config.Default.OVNMasqConntrackZone))
+			}
+		}
 		// table 0, Reply SVC traffic from Host -> OVN, unSNAT and goto table 5
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=500, in_port=%s, %s, %s_dst=%s,"+
@@ -200,6 +233,34 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 			}
 		}
 
+		// table 0, NodePort reply traffic from advertised no-overlay UDNs, Host -> OVN.
+		// See the IPv4 block above for why these packets need the UDN packet mark
+		// restored before entering the existing OVN masquerade conntrack path.
+		if config.Gateway.Mode == config.GatewayModeLocal && util.IsRouteAdvertisementsEnabled() {
+			for _, netConfig := range b.patchedNetConfigs() {
+				if netConfig.IsDefaultNetwork() || netConfig.Transport != types.NetworkTransportNoOverlay || !netConfig.Advertised.Load() {
+					continue
+				}
+				var udnAdvertisedSubnets []*net.IPNet
+				for _, clusterEntry := range netConfig.Subnets {
+					udnAdvertisedSubnets = append(udnAdvertisedSubnets, clusterEntry.CIDR)
+				}
+				matchingIPFamilySubnet, err := util.MatchFirstIPNetFamily(true, udnAdvertisedSubnets)
+				if err != nil {
+					klog.Infof("Unable to determine IPV6 UDN subnet for Host -> OVN reply SVC traffic: %v", err)
+					continue
+				}
+				// Example flow:
+				// table=0, priority=550, in_port=LOCAL, ipv6, ipv6_src=<UDN pod subnet>, ipv6_dst=<OVN masquerade IP>
+				// actions=set_field:<UDN pkt_mark>->pkt_mark,ct(zone=<OVN masq zone>,nat,table=5)
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=550, in_port=%s, %s, %s_src=%s, %s_dst=%s,"+
+						"actions=set_field:%s->pkt_mark,ct(zone=%d,nat,table=5)",
+						nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefixV6, protoPrefixV6,
+						matchingIPFamilySubnet.String(), protoPrefixV6, config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String(),
+						netConfig.PktMark, config.Default.OVNMasqConntrackZone))
+			}
+		}
 		// table 0, Reply SVC traffic from Host -> OVN, unSNAT and goto table 5
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=500, in_port=%s, %s, %s_dst=%s,"+

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package bridgeconfig
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
+	nodetypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+)
+
+func TestAdvertisedNoOverlayUDNServiceReplyFlowsRestorePacketMark(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+
+	config.IPv4Mode = true
+	config.IPv6Mode = true
+	config.Gateway.Mode = config.GatewayModeLocal
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+
+	bridgeMAC, err := net.ParseMAC("5e:21:2c:5b:b9:d0")
+	if err != nil {
+		t.Fatalf("failed to parse bridge mac: %v", err)
+	}
+
+	bridge := &BridgeConfiguration{
+		ofPortPhys: "1",
+		ofPortHost: nodetypes.OvsLocalPort,
+		ips: []*net.IPNet{
+			mustParseCIDR(t, "172.18.0.2/16"),
+			mustParseCIDR(t, "fc00:f853:ccd:e793::2/64"),
+		},
+		macAddress: bridgeMAC,
+		netConfig: map[string]*BridgeUDNConfiguration{
+			types.DefaultNetworkName: {
+				OfPortPatch: "2",
+				MasqCTMark:  nodetypes.CtMarkOVN,
+				Subnets: []config.CIDRNetworkEntry{
+					{CIDR: mustParseCIDR(t, "10.244.0.0/16")},
+					{CIDR: mustParseCIDR(t, "fd00:10:244::/64")},
+				},
+			},
+			"blue": {
+				OfPortPatch: "11",
+				PktMark:     "0x1009",
+				V4MasqIPs: &udn.MasqueradeIPs{
+					GatewayRouter:  mustParseCIDR(t, "169.254.0.13/17"),
+					ManagementPort: mustParseCIDR(t, "169.254.0.14/17"),
+				},
+				V6MasqIPs: &udn.MasqueradeIPs{
+					GatewayRouter:  mustParseCIDR(t, "fd69::d/112"),
+					ManagementPort: mustParseCIDR(t, "fd69::e/112"),
+				},
+				Subnets: []config.CIDRNetworkEntry{
+					{CIDR: mustParseCIDR(t, "102.102.0.0/16")},
+					{CIDR: mustParseCIDR(t, "2013:100:200::/60")},
+				},
+				Transport: types.NetworkTransportNoOverlay,
+			},
+			"red": {
+				OfPortPatch: "12",
+				PktMark:     "0x100a",
+				V4MasqIPs: &udn.MasqueradeIPs{
+					GatewayRouter:  mustParseCIDR(t, "169.254.0.15/17"),
+					ManagementPort: mustParseCIDR(t, "169.254.0.16/17"),
+				},
+				V6MasqIPs: &udn.MasqueradeIPs{
+					GatewayRouter:  mustParseCIDR(t, "fd69::f/112"),
+					ManagementPort: mustParseCIDR(t, "fd69::10/112"),
+				},
+				Subnets: []config.CIDRNetworkEntry{
+					{CIDR: mustParseCIDR(t, "103.103.0.0/16")},
+					{CIDR: mustParseCIDR(t, "2014:100:200::/60")},
+				},
+				Transport: types.NetworkTransportNoOverlay,
+			},
+		},
+	}
+	bridge.netConfig["blue"].Advertised.Store(true)
+
+	flows, err := bridge.flowsForDefaultBridge(nil)
+	if err != nil {
+		t.Fatalf("failed to generate default bridge flows: %v", err)
+	}
+
+	assertContainsFlow(t, flows, fmt.Sprintf("priority=550, in_port=LOCAL, ip, ip_src=102.102.0.0/16, ip_dst=%s,actions=set_field:0x1009->pkt_mark,ct(zone=%d,nat,table=5)",
+		config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String(), config.Default.OVNMasqConntrackZone))
+	assertContainsFlow(t, flows, fmt.Sprintf("priority=550, in_port=LOCAL, ipv6, ipv6_src=2013:100:200::/60, ipv6_dst=%s,actions=set_field:0x1009->pkt_mark,ct(zone=%d,nat,table=5)",
+		config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String(), config.Default.OVNMasqConntrackZone))
+	assertNotContainsFlow(t, flows, "priority=550, in_port=LOCAL, ip, ip_src=103.103.0.0/16")
+	assertNotContainsFlow(t, flows, "priority=550, in_port=LOCAL, ipv6, ipv6_src=2014:100:200::/60")
+}
+
+func assertContainsFlow(t *testing.T, flows []string, expected string) {
+	t.Helper()
+	for _, flow := range flows {
+		if strings.Contains(flow, expected) {
+			return
+		}
+	}
+	t.Fatalf("expected flow containing %q, got:\n%s", expected, strings.Join(flows, "\n"))
+}
+
+func assertNotContainsFlow(t *testing.T, flows []string, unexpected string) {
+	t.Helper()
+	for _, flow := range flows {
+		if strings.Contains(flow, unexpected) {
+			t.Fatalf("unexpected flow containing %q: %s", unexpected, flow)
+		}
+	}
+}
+
+func mustParseCIDR(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("failed to parse CIDR %q: %v", cidr, err)
+	}
+	ipNet.IP = ip
+	return ipNet
+}

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -220,6 +220,9 @@ func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {
 	if r1.Table != r2.Table {
 		return false
 	}
+	if !areRuleFamiliesEqual(r1.Family, r2.Family) {
+		return false
+	}
 	if r1.Type != r2.Type {
 		return false
 	}
@@ -228,6 +231,10 @@ func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {
 	}
 
 	return areIPNetsEqual(r1.Src, r2.Src) && areIPNetsEqual(r1.Dst, r2.Dst)
+}
+
+func areRuleFamiliesEqual(f1, f2 int) bool {
+	return f1 == f2 || f1 == netlink.FAMILY_ALL || f2 == netlink.FAMILY_ALL
 }
 
 func areIPNetsEqual(n1, n2 *net.IPNet) bool {

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"runtime"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -18,6 +19,42 @@ import (
 
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 )
+
+func TestAreNetlinkRulesEqualChecksFamily(t *testing.T) {
+	v4Rule := netlink.NewRule()
+	v4Rule.Priority = 2000
+	v4Rule.Table = 1020
+	v4Rule.Family = netlink.FAMILY_V4
+	v4Rule.Mark = 0x1003
+
+	v6Rule := netlink.NewRule()
+	v6Rule.Priority = v4Rule.Priority
+	v6Rule.Table = v4Rule.Table
+	v6Rule.Family = netlink.FAMILY_V6
+	v6Rule.Mark = v4Rule.Mark
+
+	if areNetlinkRulesEqual(v4Rule, v6Rule) {
+		t.Fatalf("expected IPv4 and IPv6 rules with the same mark/table to be different")
+	}
+}
+
+func TestAreNetlinkRulesEqualTreatsFamilyAllAsWildcard(t *testing.T) {
+	v4Rule := netlink.NewRule()
+	v4Rule.Priority = 2000
+	v4Rule.Table = 1020
+	v4Rule.Family = netlink.FAMILY_V4
+	v4Rule.Mark = 0x1003
+
+	anyFamilyRule := netlink.NewRule()
+	anyFamilyRule.Priority = v4Rule.Priority
+	anyFamilyRule.Table = v4Rule.Table
+	anyFamilyRule.Family = netlink.FAMILY_ALL
+	anyFamilyRule.Mark = v4Rule.Mark
+
+	if !areNetlinkRulesEqual(v4Rule, anyFamilyRule) {
+		t.Fatalf("expected FAMILY_ALL to match a specific rule family")
+	}
+}
 
 // FIXME(mk) - Within GH VM, if I need to create a new NetNs. I see the following error:
 // "failed to create new network namespace: mount --make-rshared /run/user/1001/netns failed: "operation not permitted""

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -468,7 +468,24 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 					udnRules = append(udnRules, rule)
 				}
 			}
-			Expect(udnRules).To(HaveLen(3))
+			Expect(udnRules).To(HaveLen(4))
+			var v4PacketMarkRule, v6PacketMarkRule, v4MasqIPRule, v6MasqIPRule bool
+			for _, rule := range udnRules {
+				switch {
+				case rule.Family == netlink.FAMILY_V4 && rule.Mark != 0:
+					v4PacketMarkRule = true
+				case rule.Family == netlink.FAMILY_V6 && rule.Mark != 0:
+					v6PacketMarkRule = true
+				case rule.Family == netlink.FAMILY_V4 && rule.Dst != nil:
+					v4MasqIPRule = true
+				case rule.Family == netlink.FAMILY_V6 && rule.Dst != nil:
+					v6MasqIPRule = true
+				}
+			}
+			Expect(v4PacketMarkRule).To(BeTrue())
+			Expect(v6PacketMarkRule).To(BeTrue())
+			Expect(v4MasqIPRule).To(BeTrue())
+			Expect(v6MasqIPRule).To(BeTrue())
 
 			By("delete the network and ensure its associated VRF device is also deleted")
 			cnode := node.DeepCopy()

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -982,13 +982,40 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 			}
 		}
 
-		snat := libovsdbops.BuildSNATWithMatch(
-			&masqIP.ManagementPort.IP,
-			localPodSubnet,
-			outputPort,
-			extIDs,
-			snatMatch,
-		)
+		// For noOverlay mode with outboundSNAT enabled in local gateway mode, add exempted_ext_ips
+		// to prevent SNATing pod-to-pod traffic within the same CUDN while still SNATing pod-to-external traffic.
+		// This SNAT is on ovn_cluster_router, which is used in local gateway mode.
+		var snat *nbdb.NAT
+		if bsnc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+			bsnc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
+			config.Gateway.Mode == config.GatewayModeLocal {
+			snatMatch = ""
+			v4UUID, v6UUID, err := getNoOverlaySNATExemptionAsUUID(bsnc.addressSetFactory, bsnc.GetNetInfo(), bsnc.controllerName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
+			}
+			// Use the appropriate UUID based on IP family
+			exemptedExtIPs := v4UUID
+			if ipFamily == utilnet.IPv6 {
+				exemptedExtIPs = v6UUID
+			}
+			snat = libovsdbops.BuildSNATWithExemptedExtIPs(
+				&masqIP.ManagementPort.IP,
+				localPodSubnet,
+				outputPort,
+				extIDs,
+				snatMatch,
+				exemptedExtIPs,
+			)
+		} else {
+			snat = libovsdbops.BuildSNATWithMatch(
+				&masqIP.ManagementPort.IP,
+				localPodSubnet,
+				outputPort,
+				extIDs,
+				snatMatch,
+			)
+		}
 		snats = append(snats, snat)
 	}
 

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -979,6 +979,9 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 			additionalSNATMatch := getClusterNodesDestinationBasedSNATMatch(ipFamily, nodeIPsAS, svcIPsAS)
 			if additionalSNATMatch != "" {
 				snatMatch = fmt.Sprintf("%s && %s", snatMatch, additionalSNATMatch)
+				if bsnc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay {
+					snatMatch = fmt.Sprintf("%s && %s", snatMatch, getNoOverlayUDNReplyTrafficSNATExclusionMatch())
+				}
 			}
 		}
 
@@ -1024,6 +1027,14 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 
 func getMasqueradeManagementIPSNATMatch(dstMac string) string {
 	return fmt.Sprintf("eth.dst == %s", dstMac)
+}
+
+// getNoOverlayUDNReplyTrafficSNATExclusionMatch returns the NAT match fragment
+// that keeps marked NodePort/backend reply traffic out of UDN SNAT. Those
+// replies must keep the backend pod source IP so the NodePort node can match
+// its existing service conntrack reverse-NAT state.
+func getNoOverlayUDNReplyTrafficSNATExclusionMatch() string {
+	return fmt.Sprintf("pkt.mark != %d", types.UDNNodePortReplyTrafficConnectionMark)
 }
 
 // getClusterNodesDestinationBasedSNATMatch creates destination-based SNAT match

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -987,20 +987,30 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 
 		// For noOverlay mode with outboundSNAT enabled in local gateway mode, add exempted_ext_ips
 		// to prevent SNATing pod-to-pod traffic within the same CUDN while still SNATing pod-to-external traffic.
-		// This SNAT is on ovn_cluster_router, which is used in local gateway mode.
+		// This SNAT is on ovn_cluster_router, which is used in local gateway mode. For advertised no-overlay
+		// UDNs, preserve marked reply traffic from external-initiated connections so replies keep the pod IP.
 		var snat *nbdb.NAT
 		if bsnc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
 			bsnc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
 			config.Gateway.Mode == config.GatewayModeLocal {
 			snatMatch = ""
+			if isUDNAdvertised {
+				snatMatch = getNoOverlayUDNReplyTrafficSNATExclusionMatch()
+			}
 			v4UUID, v6UUID, err := getNoOverlaySNATExemptionAsUUID(bsnc.addressSetFactory, bsnc.GetNetInfo(), bsnc.controllerName)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
 			}
 			// Use the appropriate UUID based on IP family
 			exemptedExtIPs := v4UUID
+			family := "IPv4"
 			if ipFamily == utilnet.IPv6 {
 				exemptedExtIPs = v6UUID
+				family = "IPv6"
+			}
+			if exemptedExtIPs == "" {
+				return nil, fmt.Errorf("missing no-overlay SNAT exemption address set UUID for network %q, controller %q, IP family %s",
+					bsnc.GetNetworkName(), bsnc.controllerName, family)
 			}
 			snat = libovsdbops.BuildSNATWithExemptedExtIPs(
 				&masqIP.ManagementPort.IP,

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -890,7 +890,13 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 		if util.IsNoOverlaySNATExemptionNeeded(gw.netInfo) {
 			// Get the no-overlay SNAT exemption address set UUIDs
 			addressSetFactory := addressset.NewOvnAddressSetFactory(gw.nbClient, config.IPv4Mode, config.IPv6Mode)
-			v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(addressSetFactory, gw.netInfo, types.DefaultNetworkControllerName)
+			// Use the correct controller name: default-network-controller for default network,
+			// <networkName>-network-controller for user-defined networks
+			controllerName := types.DefaultNetworkControllerName
+			if gw.netInfo.IsUserDefinedNetwork() {
+				controllerName = getNetworkControllerName(gw.netInfo.GetNetworkName())
+			}
+			v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(addressSetFactory, gw.netInfo, controllerName)
 			if err != nil {
 				return fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
 			}

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -1107,6 +1107,9 @@ func GetNetworkScopedClusterSubnetSNATMatch(nbClient libovsdbclient.Client, netI
 	if destinationMatch == "" {
 		return "", fmt.Errorf("could not build a destination based SNAT match because no addressSet %v exists for IP family %v", dbIDs, ipFamily)
 	}
+	if netInfo.IsUserDefinedNetwork() && netInfo.Transport() == types.NetworkTransportNoOverlay {
+		destinationMatch = fmt.Sprintf("%s && %s", destinationMatch, getNoOverlayUDNReplyTrafficSNATExclusionMatch())
+	}
 	if !layer2OldTopo {
 		return destinationMatch, nil
 	}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -2252,6 +2252,19 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 				gomega.Expect(match).To(gomega.Equal(expectedMatch))
 			})
 
+			ginkgo.It("excludes marked reply traffic for advertised Layer3 no-overlay user-defined networks", func() {
+				netInfo.topology = types.Layer3Topology
+				netInfo.transport = types.NetworkTransportNoOverlay
+				netInfo.userDefined = true
+				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				v4Hash, _ := as.GetASHashNames()
+				expectedMatch := fmt.Sprintf("ip4.dst == $%s && pkt.mark != %d", v4Hash, types.UDNNodePortReplyTrafficConnectionMark)
+				gomega.Expect(match).To(gomega.Equal(expectedMatch))
+			})
+
 			ginkgo.It("returns destination match for Layer2 topology with transit router", func() {
 				originalValue := config.Layer2UsesTransitRouter
 				defer func() { config.Layer2UsesTransitRouter = originalValue }()

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
@@ -1022,6 +1024,101 @@ func (oc *Layer3UserDefinedNetworkController) addOrUpdateUDNNodeSubnetEgressSNAT
 	return nil
 }
 
+// buildAdvertisedUDNNodePortReplyQoS builds the per-node logical-switch QoS
+// rules used to identify backend reply traffic for advertised no-overlay UDNs.
+// hostSubnets are the UDN pod subnets allocated to nodeName. Matching tracked
+// replies from those subnets are marked so UDN SNAT rows can skip them and keep
+// the backend pod IP visible to the NodePort node.
+func (oc *Layer3UserDefinedNetworkController) buildAdvertisedUDNNodePortReplyQoS(nodeName string, hostSubnets []*net.IPNet) []*nbdb.QoS {
+	var v4SrcMatches, v6SrcMatches []string
+	for _, hostSubnet := range hostSubnets {
+		if utilnet.IsIPv6CIDR(hostSubnet) {
+			v6SrcMatches = append(v6SrcMatches, fmt.Sprintf("ip6.src == %s", hostSubnet))
+		} else {
+			v4SrcMatches = append(v4SrcMatches, fmt.Sprintf("ip4.src == %s", hostSubnet))
+		}
+	}
+
+	buildQoS := func(ipFamily egressIPFamilyValue, srcMatches []string) *nbdb.QoS {
+		match := srcMatches[0]
+		if len(srcMatches) > 1 {
+			match = fmt.Sprintf("(%s)", strings.Join(srcMatches, " || "))
+		}
+		return &nbdb.QoS{
+			Priority:    types.UDNNodePortReplyQoSRulePriority,
+			Action:      map[string]int{"mark": types.UDNNodePortReplyTrafficConnectionMark},
+			Direction:   nbdb.QoSDirectionFromLport,
+			Match:       fmt.Sprintf("%s && ct.trk && ct.rpl", match),
+			ExternalIDs: getAdvertisedNetworkNodePortReplyQoSDBIDs(oc.controllerName, oc.GetNetworkID(), nodeName, ipFamily).GetExternalIDs(),
+		}
+	}
+
+	qoses := make([]*nbdb.QoS, 0, 2)
+	if len(v4SrcMatches) > 0 {
+		qoses = append(qoses, buildQoS(IPFamilyValueV4, v4SrcMatches))
+	}
+	if len(v6SrcMatches) > 0 {
+		qoses = append(qoses, buildQoS(IPFamilyValueV6, v6SrcMatches))
+	}
+	return qoses
+}
+
+// syncAdvertisedUDNNodePortReplyQoS reconciles the reply-marker QoS rules for a
+// node's network-scoped switch. enabled means the UDN pod network is advertised
+// from nodeName; when it is false, or when the network is not no-overlay, any
+// existing reply-marker QoS rows for this node are removed.
+//
+// The QoS rows are tied to route-advertised no-overlay UDNs rather than generic
+// BGP state: BGP advertisement exposes the traffic path, while no-overlay makes
+// preserving backend reply tuples necessary for cross-node NodePort service
+// reverse NAT.
+func (oc *Layer3UserDefinedNetworkController) syncAdvertisedUDNNodePortReplyQoS(nodeName string, hostSubnets []*net.IPNet, enabled bool) error {
+	if oc.GetNetInfo().Transport() != types.NetworkTransportNoOverlay {
+		enabled = false
+	}
+
+	switchName := oc.GetNetworkScopedSwitchName(nodeName)
+	if enabled {
+		qoses := oc.buildAdvertisedUDNNodePortReplyQoS(nodeName, hostSubnets)
+		if len(qoses) == 0 {
+			return nil
+		}
+		ops, err := libovsdbops.CreateOrUpdateQoSesOps(oc.nbClient, nil, qoses...)
+		if err != nil {
+			return fmt.Errorf("failed to create or update advertised UDN NodePort reply QoS rules for network %q on node %q: %w", oc.GetNetworkName(), nodeName, err)
+		}
+		ops, err = libovsdbops.AddQoSesToLogicalSwitchOps(oc.nbClient, ops, switchName, qoses...)
+		if err != nil {
+			return fmt.Errorf("failed to add advertised UDN NodePort reply QoS rules to switch %q for network %q: %w", switchName, oc.GetNetworkName(), err)
+		}
+		if _, err = libovsdbops.TransactAndCheck(oc.nbClient, ops); err != nil {
+			return fmt.Errorf("failed to transact advertised UDN NodePort reply QoS rules for network %q on node %q: %w", oc.GetNetworkName(), nodeName, err)
+		}
+		return nil
+	}
+
+	qosIDs := getAdvertisedNetworkNodePortReplyQoSDBIDs(oc.controllerName, oc.GetNetworkID(), nodeName, "")
+	qoses, err := libovsdbops.FindQoSesWithPredicate(oc.nbClient, libovsdbops.GetPredicate[*nbdb.QoS](qosIDs, nil))
+	if err != nil {
+		return fmt.Errorf("failed to find advertised UDN NodePort reply QoS rules for network %q on node %q: %w", oc.GetNetworkName(), nodeName, err)
+	}
+	if len(qoses) == 0 {
+		return nil
+	}
+	ops, err := libovsdbops.RemoveQoSesFromLogicalSwitchOps(oc.nbClient, nil, switchName, qoses...)
+	if err != nil {
+		return fmt.Errorf("failed to remove advertised UDN NodePort reply QoS rules from switch %q for network %q: %w", switchName, oc.GetNetworkName(), err)
+	}
+	ops, err = libovsdbops.DeleteQoSesOps(oc.nbClient, ops, qoses...)
+	if err != nil {
+		return fmt.Errorf("failed to delete advertised UDN NodePort reply QoS rules for network %q on node %q: %w", oc.GetNetworkName(), nodeName, err)
+	}
+	if _, err = libovsdbops.TransactAndCheck(oc.nbClient, ops); err != nil {
+		return fmt.Errorf("failed to transact advertised UDN NodePort reply QoS cleanup for network %q on node %q: %w", oc.GetNetworkName(), nodeName, err)
+	}
+	return nil
+}
+
 func (oc *Layer3UserDefinedNetworkController) addNode(node *corev1.Node) ([]*net.IPNet, error) {
 	// Node subnet for the layer3 UDN is allocated by cluster manager.
 	// Make sure that the node is allocated with the subnet before proceeding
@@ -1037,6 +1134,9 @@ func (oc *Layer3UserDefinedNetworkController) addNode(node *corev1.Node) ([]*net
 	}
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
 		isUDNAdvertised := util.IsPodNetworkAdvertisedAtNode(oc, node.Name)
+		if err := oc.syncAdvertisedUDNNodePortReplyQoS(node.Name, hostSubnets, isUDNAdvertised); err != nil {
+			return nil, err
+		}
 		if err := oc.addOrUpdateUDNNodeSubnetEgressSNAT(hostSubnets, node, isUDNAdvertised); err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -502,6 +502,11 @@ func (oc *Layer3UserDefinedNetworkController) Cleanup() error {
 	cleanupLoadBalancerGroups(oc.nbClient, oc.GetNetInfo(),
 		oc.switchLoadBalancerGroupUUID, oc.clusterLoadBalancerGroupUUID, oc.routerLoadBalancerGroupUUID)
 
+	// Cleanup noOverlay SNAT exemption address set
+	if err := cleanupNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName); err != nil {
+		klog.Warningf("Failed to cleanup noOverlay SNAT exemption address set for network %s: %v", netName, err)
+	}
+
 	return nil
 }
 
@@ -765,6 +770,16 @@ func (oc *Layer3UserDefinedNetworkController) init() error {
 		oc.switchLoadBalancerGroupUUID = switchLBGroupUUID
 		oc.routerLoadBalancerGroupUUID = routerLBGroupUUID
 	}
+
+	// Initialize noOverlay SNAT exemption address set when using noOverlay transport with outboundSNAT enabled
+	// This is needed for both local and shared gateway modes
+	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled {
+		if _, err := initNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName); err != nil {
+			return fmt.Errorf("failed to initialize noOverlay SNAT exemption address set for network %s: %w", oc.GetNetworkName(), err)
+		}
+	}
+
 	return nil
 }
 
@@ -835,6 +850,16 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 		errs = append(errs, errors...)
 	}
 
+	// Sync noOverlay SNAT exemption address set BEFORE gateway initialization
+	// This must happen before the gateway creates SNAT rules that reference the address set
+	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
+		(nSyncs.syncNode || nSyncs.syncGw) {
+		if err := oc.syncNoOverlaySNATExemptionAddressSetForLocalZoneNodes(node); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {
 		if nSyncs.syncGw {
 			gwManager := oc.gatewayManagerForNode(node.Name)
@@ -902,6 +927,44 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 		oc.recordNodeErrorEvent(node, err)
 	}
 	return err
+}
+
+func (oc *Layer3UserDefinedNetworkController) syncNoOverlaySNATExemptionAddressSetForLocalZoneNodes(currentNode *corev1.Node) error {
+	if oc.GetNetInfo().Transport() != types.NetworkTransportNoOverlay ||
+		oc.GetNetInfo().OutboundSNAT() != types.NoOverlaySNATEnabled {
+		return nil
+	}
+
+	localNodesByName := map[string]*corev1.Node{}
+	if currentNode != nil {
+		if _, local := oc.localZoneNodes.Load(currentNode.Name); local {
+			localNodesByName[currentNode.Name] = currentNode
+		}
+	}
+
+	nodes, err := oc.watchFactory.GetNodes()
+	if err != nil {
+		return fmt.Errorf("failed to list nodes while syncing no-overlay SNAT exemption address set: %w", err)
+	}
+	for _, node := range nodes {
+		if _, local := oc.localZoneNodes.Load(node.Name); local {
+			localNodesByName[node.Name] = node
+		}
+	}
+
+	localNodeIPs := sets.New[string]()
+	for _, node := range localNodesByName {
+		hostAddrs, err := util.GetNodeHostAddrs(node)
+		if err != nil {
+			return fmt.Errorf("failed to get host addresses for node %s: %w", node.Name, err)
+		}
+		localNodeIPs.Insert(hostAddrs...)
+	}
+
+	if err := syncNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName, localNodeIPs.UnsortedList()); err != nil {
+		return fmt.Errorf("failed to sync no-overlay SNAT exemption address set: %w", err)
+	}
+	return nil
 }
 
 func (oc *Layer3UserDefinedNetworkController) addUpdateRemoteNodeEvent(node *corev1.Node, syncZoneIc bool) error {
@@ -995,7 +1058,8 @@ func (oc *Layer3UserDefinedNetworkController) deleteNodeEvent(node *corev1.Node)
 	klog.V(5).Infof("Deleting Node %q for network %s. Removing the node from "+
 		"various caches", node.Name, oc.GetNetworkName())
 
-	if _, local := oc.localZoneNodes.Load(node.Name); local {
+	_, nodeWasLocal := oc.localZoneNodes.Load(node.Name)
+	if nodeWasLocal {
 		if err := oc.deleteNode(node.Name); err != nil {
 			return err
 		}
@@ -1024,6 +1088,11 @@ func (oc *Layer3UserDefinedNetworkController) deleteNodeEvent(node *corev1.Node)
 	}
 	oc.syncZoneICFailed.Delete(node.Name)
 	oc.localZoneNodes.Delete(node.Name)
+	if nodeWasLocal {
+		if err := oc.syncNoOverlaySNATExemptionAddressSetForLocalZoneNodes(nil); err != nil {
+			return err
+		}
+	}
 	oc.syncEIPNodeRerouteFailed.Delete(node.Name)
 	return nil
 }

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -30,6 +30,7 @@ import (
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	zoneic "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -1258,6 +1259,51 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 		fakeOvn.shutdown()
 	})
 
+	It("fails to build local gateway SNAT when the exemption address set UUID is missing", func() {
+		config.Gateway.Mode = config.GatewayModeLocal
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+		config.Default.Zone = nodeName
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16"
+
+		fakeOvn.start()
+
+		cudnNetInfo := userDefinedNetInfo{
+			netName:        userDefinedNetworkName,
+			nadName:        namespacedName(ns, nadName),
+			topology:       types.Layer3Topology,
+			clustersubnets: "10.100.0.0/16",
+			hostsubnets:    "10.100.1.0/24",
+			isPrimary:      true,
+			transport:      types.NetworkTransportNoOverlay,
+			outboundSNAT:   string(types.NoOverlaySNATEnabled),
+		}
+		netInfo, err := util.NewNetInfo(cudnNetInfo.netconf())
+		Expect(err).NotTo(HaveOccurred())
+		mutableNetInfo := util.NewMutableNetInfo(netInfo)
+		mutableNetInfo.SetNetworkID(2)
+
+		bsnc := &BaseUserDefinedNetworkController{
+			BaseNetworkController: BaseNetworkController{
+				controllerName:      getNetworkControllerName(userDefinedNetworkName),
+				ReconcilableNetInfo: util.NewReconcilableNetInfo(mutableNetInfo),
+				addressSetFactory:   fakeOvn.controller.addressSetFactory,
+			},
+		}
+
+		_, localPodSubnet, err := net.ParseCIDR("10.100.1.0/24")
+		Expect(err).NotTo(HaveOccurred())
+
+		snats, err := bsnc.buildUDNEgressSNAT(
+			[]*net.IPNet{localPodSubnet},
+			types.RouterToSwitchPrefix+bsnc.GetNetworkScopedName(nodeName),
+			false,
+		)
+		Expect(err).To(MatchError(ContainSubstring("missing no-overlay SNAT exemption address set UUID")))
+		Expect(snats).To(BeNil())
+	})
+
 	// Test 1: Verify SNAT with exempted_ext_ips is created on ovn_cluster_router in LOCAL gateway mode
 	It("creates SNAT with exempted address set in local gateway mode on ovn-cluster-router", func() {
 		// Step 1: Set config.Gateway.Mode = config.GatewayModeLocal
@@ -1328,6 +1374,26 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 
 			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
 			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
+
+			nodeIPsAS, err := fakeOvn.controller.addressSetFactory.EnsureAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeIPsAS.AddAddresses([]string{"192.168.126.202"})).To(Succeed())
+			svcIPsAS, err := fakeOvn.controller.addressSetFactory.EnsureAddressSet(udnenabledsvc.GetAddressSetDBIDs())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(svcIPsAS.AddAddresses([]string{"10.96.0.0/16"})).To(Succeed())
+
+			By("Verifying advertised no-overlay reply traffic is excluded from local gateway SNAT")
+			_, localPodSubnet, err := net.ParseCIDR("10.100.1.0/24")
+			Expect(err).NotTo(HaveOccurred())
+			snats, err := userDefinedNetController.bnc.buildUDNEgressSNAT(
+				[]*net.IPNet{localPodSubnet},
+				types.RouterToSwitchPrefix+userDefinedNetController.bnc.GetNetworkScopedName(nodeName),
+				true,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(snats).To(HaveLen(1))
+			Expect(snats[0].Match).To(Equal(fmt.Sprintf("pkt.mark != %d", types.UDNNodePortReplyTrafficConnectionMark)))
+			Expect(snats[0].ExemptedExtIPs).NotTo(BeNil())
 
 			// Step 4: Start watching nodes to trigger addUpdateLocalNodeEvent()
 			By("Starting node watch on L3 UDN controller")

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -49,6 +50,8 @@ type userDefinedNetInfo struct {
 	allowPersistentIPs bool
 	ipamClaimReference string
 	hasEVPN            bool
+	transport          string // e.g., types.NetworkTransportNoOverlay
+	outboundSNAT       string // e.g., types.NoOverlaySNATEnabled
 }
 
 const (
@@ -1241,6 +1244,182 @@ var _ = Describe("Layer3 UDN Transport Mode - Interconnect", func() {
 	})
 })
 
+var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
+	var (
+		fakeOvn *FakeOVN
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		fakeOvn = NewFakeOVN(false)
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	// Test 1: Verify SNAT with exempted_ext_ips is created on ovn_cluster_router in LOCAL gateway mode
+	It("creates SNAT with exempted address set in local gateway mode on ovn-cluster-router", func() {
+		// Step 1: Set config.Gateway.Mode = config.GatewayModeLocal
+		By("Step 1: Setting up LOCAL gateway mode configuration")
+		config.Gateway.Mode = config.GatewayModeLocal
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+		config.Default.Zone = nodeName
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16" // Broader subnet to accommodate network ID 2
+
+		app := cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		// Step 2: Create a Layer3 CUDN with no-overlay transport and outboundSNAT enabled
+		By("Step 2: Creating Layer3 CUDN with no-overlay transport and outboundSNAT enabled")
+		cudnNetInfo := userDefinedNetInfo{
+			netName:        userDefinedNetworkName,
+			nadName:        namespacedName(ns, nadName),
+			topology:       types.Layer3Topology,
+			clustersubnets: "10.100.0.0/16",
+			hostsubnets:    "10.100.1.0/24",
+			isPrimary:      true,
+			transport:      types.NetworkTransportNoOverlay,
+			outboundSNAT:   string(types.NoOverlaySNATEnabled),
+		}
+
+		app.Action = func(*cli.Context) error {
+			// Create NAD with no-overlay transport and outboundSNAT enabled
+			netConf := cudnNetInfo.netconf()
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			n := newUDNNamespace(ns)
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, cudnNetInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			podInfo := dummyTestPod(ns, cudnNetInfo)
+
+			By("Starting fakeOvn with database setup (without node initially)")
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{Name: nodeName},
+					},
+				},
+				&corev1.NamespaceList{Items: []corev1.Namespace{*n}},
+				&corev1.NodeList{Items: []corev1.Node{}}, // Empty - will add node after watch starts
+				&corev1.PodList{Items: []corev1.Pod{*newMultiHomedPod(podInfo, cudnNetInfo)}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+			podInfo.populateLogicalSwitchCache(fakeOvn)
+
+			fexec := util.GetExec().(*testing.FakeExec)
+			fexec.AddFakeCmdsNoOutputNoError([]string{"ovn-nbctl --timeout=15 --columns=_uuid list Load_Balancer_Group"})
+
+			// Step 3: Initialize the CUDN controller
+			By("Step 3: Initializing CUDN controller")
+			fullL3UDNController := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(fullL3UDNController).ToNot(BeNil())
+			Expect(fullL3UDNController.init()).To(Succeed())
+
+			userDefinedNetController, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+
+			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
+
+			// Step 4: Start watching nodes to trigger addUpdateLocalNodeEvent()
+			By("Starting node watch on L3 UDN controller")
+			Expect(fakeOvn.registerUDNNodeHandler(userDefinedNetworkName)).To(Succeed())
+
+			By("Adding node to trigger addUpdateLocalNodeEvent()")
+			// Add the node AFTER starting the watch so the watch catches the ADD event
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			By("Node created successfully")
+
+			// Wait for node processing to complete
+			By("Waiting for NAT entries to be created on ovn_cluster_router")
+			Eventually(func() error {
+				// Step 5: Query the OVN NB database to find NAT entries on the CUDN's ovn_cluster_router
+				clusterRouterName := userDefinedNetController.bnc.GetNetworkScopedClusterRouterName()
+
+				lr := &nbdb.LogicalRouter{Name: clusterRouterName}
+				lr, err = libovsdbops.GetLogicalRouter(fakeOvn.nbClient, lr)
+				if err != nil {
+					return fmt.Errorf("failed to get logical router %s: %v", clusterRouterName, err)
+				}
+
+				if len(lr.Nat) == 0 {
+					return fmt.Errorf("no NAT entries found on router %s", clusterRouterName)
+				}
+
+				// Step 6: Verify NAT entries have exempted_ext_ips set
+				foundSNATWithExemption := false
+				for _, natUUID := range lr.Nat {
+					nat := &nbdb.NAT{UUID: natUUID}
+					nat, err = libovsdbops.GetNAT(fakeOvn.nbClient, nat)
+					if err != nil {
+						continue
+					}
+
+					if nat.Type == nbdb.NATTypeSNAT && nat.ExemptedExtIPs != nil && *nat.ExemptedExtIPs != "" {
+						foundSNATWithExemption = true
+
+						// Get the address set to verify UUID and contents
+						dbIDs := libovsdbops.NewDbObjectIDs(
+							libovsdbops.AddressSetNoOverlaySNATExemption,
+							userDefinedNetController.bnc.controllerName,
+							map[libovsdbops.ExternalIDKey]string{
+								libovsdbops.ObjectNameKey: "no-overlay-snat-exemption",
+								libovsdbops.NetworkKey:    userDefinedNetworkName,
+							},
+						)
+						as, err := fakeOvn.controller.addressSetFactory.GetAddressSet(dbIDs)
+						if err != nil {
+							return fmt.Errorf("failed to get address set: %v", err)
+						}
+
+						// Verify the NAT's ExemptedExtIPs field contains the actual address set UUID
+						v4UUID, v6UUID := as.GetASUUID()
+						expectedUUID := v4UUID // For IPv4 mode
+						if config.IPv6Mode && !config.IPv4Mode {
+							expectedUUID = v6UUID
+						}
+						if *nat.ExemptedExtIPs != expectedUUID {
+							return fmt.Errorf("NAT ExemptedExtIPs (%s) does not match address set UUID (%s)",
+								*nat.ExemptedExtIPs, expectedUUID)
+						}
+
+						// Verify the address set contains both cluster subnet and node host IP
+						ipv4Addrs, ipv6Addrs := as.GetAddresses()
+						allAddrs := append(ipv4Addrs, ipv6Addrs...)
+						expectedAddrs := []string{"10.100.0.0/16", "192.168.126.202"}
+						for _, expectedAddr := range expectedAddrs {
+							if !slices.Contains(allAddrs, expectedAddr) {
+								return fmt.Errorf("address set does not contain %s, has: %v", expectedAddr, allAddrs)
+							}
+						}
+						break
+					}
+				}
+
+				if !foundSNATWithExemption {
+					return fmt.Errorf("no SNAT with ExemptedExtIPs found on router %s", clusterRouterName)
+				}
+
+				return nil
+			}).WithTimeout(5 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+
+			return nil
+		}
+
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
+
+})
+
 func newPodWithPrimaryUDN(
 	nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC, namespace string,
 	primaryUDNConfig userDefinedNetInfo,
@@ -1341,6 +1520,12 @@ func (sni *userDefinedNetInfo) netconf() *ovncnitypes.NetConf {
 
 	if sni.hasEVPN {
 		netconf.Transport = types.NetworkTransportEVPN
+	}
+	if sni.transport != "" {
+		netconf.Transport = sni.transport
+	}
+	if sni.outboundSNAT != "" {
+		netconf.OutboundSNAT = sni.outboundSNAT
 	}
 
 	return netconf

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1418,6 +1418,160 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 		Expect(app.Run([]string{app.Name})).To(Succeed())
 	})
 
+	// Test 2: Verify SNAT with exempted_ext_ips is created on GR_<node> in SHARED gateway mode
+	It("creates SNAT with exempted address set in shared gateway mode on gateway router", func() {
+		// Step 1: Set config.Gateway.Mode = config.GatewayModeShared
+		config.Gateway.Mode = config.GatewayModeShared
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+		config.Default.Zone = nodeName
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16" // Broader subnet to accommodate network ID 2
+
+		app := cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		// Step 2: Create a Layer3 CUDN with no-overlay transport and outboundSNAT enabled
+		cudnNetInfo := userDefinedNetInfo{
+			netName:        userDefinedNetworkName,
+			nadName:        namespacedName(ns, nadName),
+			topology:       types.Layer3Topology,
+			clustersubnets: "10.100.0.0/16",
+			hostsubnets:    "10.100.1.0/24",
+			isPrimary:      true,
+			transport:      types.NetworkTransportNoOverlay,
+			outboundSNAT:   string(types.NoOverlaySNATEnabled),
+		}
+
+		app.Action = func(*cli.Context) error {
+			// Create NAD with no-overlay transport and outboundSNAT enabled
+			netConf := cudnNetInfo.netconf()
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			n := newUDNNamespace(ns)
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, cudnNetInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			podInfo := dummyTestPod(ns, cudnNetInfo)
+
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{Name: nodeName},
+					},
+				},
+				&corev1.NamespaceList{Items: []corev1.Namespace{*n}},
+				&corev1.NodeList{Items: []corev1.Node{}}, // Empty - will add node after watch starts
+				&corev1.PodList{Items: []corev1.Pod{*newMultiHomedPod(podInfo, cudnNetInfo)}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+			podInfo.populateLogicalSwitchCache(fakeOvn)
+
+			fexec := util.GetExec().(*testing.FakeExec)
+			fexec.AddFakeCmdsNoOutputNoError([]string{"ovn-nbctl --timeout=15 --columns=_uuid list Load_Balancer_Group"})
+
+			// Step 3: Initialize the CUDN controller
+			fullL3UDNController := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(fullL3UDNController).ToNot(BeNil())
+			Expect(fullL3UDNController.init()).To(Succeed())
+
+			userDefinedNetController, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+
+			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
+
+			// Step 4: Create and advertise a pod on the CUDN to trigger gateway SNAT creation
+			By("Starting node watch on L3 UDN controller for shared gateway mode")
+			Expect(fakeOvn.registerUDNNodeHandler(userDefinedNetworkName)).To(Succeed())
+			Expect(userDefinedNetController.bnc.WatchPods()).To(Succeed())
+
+			By("Adding node to trigger gateway creation with SNAT+exemption")
+			// Add the node AFTER starting the watch so the watch catches the ADD event
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			By("Node created, gateway should be initialized")
+
+			// Wait for pod and gateway processing to complete
+			Eventually(func() error {
+				// Step 5: Query the OVN NB database to find NAT entries on GR_<nodeName>
+				gwRouterName := userDefinedNetController.bnc.GetNetInfo().GetNetworkScopedGWRouterName(nodeName)
+				lr := &nbdb.LogicalRouter{Name: gwRouterName}
+				lr, err = libovsdbops.GetLogicalRouter(fakeOvn.nbClient, lr)
+				if err != nil {
+					return fmt.Errorf("failed to get gateway router %s: %v", gwRouterName, err)
+				}
+
+				if len(lr.Nat) == 0 {
+					return fmt.Errorf("no NAT entries found on gateway router %s", gwRouterName)
+				}
+
+				// Step 6: Verify NAT entries have exempted_ext_ips set
+				foundSNATWithExemption := false
+				for _, natUUID := range lr.Nat {
+					nat := &nbdb.NAT{UUID: natUUID}
+					nat, err = libovsdbops.GetNAT(fakeOvn.nbClient, nat)
+					if err != nil {
+						continue
+					}
+
+					if nat.Type == nbdb.NATTypeSNAT && nat.ExemptedExtIPs != nil && *nat.ExemptedExtIPs != "" {
+						foundSNATWithExemption = true
+
+						// Get the address set to verify UUID and contents
+						dbIDs := libovsdbops.NewDbObjectIDs(
+							libovsdbops.AddressSetNoOverlaySNATExemption,
+							userDefinedNetController.bnc.controllerName,
+							map[libovsdbops.ExternalIDKey]string{
+								libovsdbops.ObjectNameKey: "no-overlay-snat-exemption",
+								libovsdbops.NetworkKey:    userDefinedNetController.bnc.GetNetworkName(),
+							},
+						)
+						as, err := fakeOvn.controller.addressSetFactory.GetAddressSet(dbIDs)
+						if err != nil {
+							return fmt.Errorf("failed to get address set: %v", err)
+						}
+
+						// Verify the NAT's ExemptedExtIPs field contains the actual address set UUID
+						v4UUID, v6UUID := as.GetASUUID()
+						expectedUUID := v4UUID // For IPv4 mode
+						if config.IPv6Mode && !config.IPv4Mode {
+							expectedUUID = v6UUID
+						}
+						if *nat.ExemptedExtIPs != expectedUUID {
+							return fmt.Errorf("NAT ExemptedExtIPs (%s) does not match address set UUID (%s)",
+								*nat.ExemptedExtIPs, expectedUUID)
+						}
+
+						// Verify the address set contains both cluster subnet and node host IP
+						ipv4Addrs, ipv6Addrs := as.GetAddresses()
+						allAddrs := append(ipv4Addrs, ipv6Addrs...)
+						expectedAddrs := []string{"10.100.0.0/16", "192.168.126.202"}
+						for _, expectedAddr := range expectedAddrs {
+							if !slices.Contains(allAddrs, expectedAddr) {
+								return fmt.Errorf("address set does not contain %s, has: %v", expectedAddr, allAddrs)
+							}
+						}
+						break
+					}
+				}
+
+				if !foundSNATWithExemption {
+					return fmt.Errorf("no SNAT with ExemptedExtIPs found on gateway router %s", gwRouterName)
+				}
+
+				return nil
+			}).WithTimeout(10 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+
+			return nil
+		}
+
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
 })
 
 func newPodWithPrimaryUDN(

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -85,6 +85,7 @@ type testNetInfo struct {
 	outboundSNAT string
 	subnets      []config.CIDRNetworkEntry
 	transport    string
+	userDefined  bool
 }
 
 func (ni *testNetInfo) TopologyType() string {
@@ -101,6 +102,16 @@ func (ni *testNetInfo) Transport() string {
 
 func (ni *testNetInfo) OutboundSNAT() string {
 	return ni.outboundSNAT
+}
+
+func (ni *testNetInfo) IsUserDefinedNetwork() bool {
+	if ni.userDefined {
+		return true
+	}
+	if ni.NetInfo == nil {
+		return false
+	}
+	return ni.NetInfo.IsUserDefinedNetwork()
 }
 
 type FakeOVN struct {

--- a/go-controller/pkg/ovn/udn_isolation.go
+++ b/go-controller/pkg/ovn/udn_isolation.go
@@ -265,6 +265,8 @@ func (oc *DefaultNetworkController) getUDNOpenPortDbIDs(podNamespacedName string
 // advertisedNetworkSubnetsKey is the object name key for the global advertised networks addressset and the global deny ACL
 const advertisedNetworkSubnetsKey = "advertised-network-subnets"
 
+const advertisedNetworkNodePortReplyQoSKey = "advertised-network-nodeport-reply"
+
 // GetAdvertisedNetworkSubnetsAddressSetDBIDs returns the DB IDs for the advertised network subnets addressset
 func GetAdvertisedNetworkSubnetsAddressSetDBIDs() *libovsdbops.DbObjectIDs {
 	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetAdvertisedNetwork, types.DefaultNetworkControllerName, map[libovsdbops.ExternalIDKey]string{
@@ -288,6 +290,23 @@ func GetAdvertisedNetworkSubnetsPassACLdbIDs(controller, networkName string, net
 			libovsdbops.ObjectNameKey: networkName,
 			libovsdbops.NetworkKey:    strconv.Itoa(networkID),
 		})
+}
+
+// getAdvertisedNetworkNodePortReplyQoSDBIDs returns stable IDs for the QoS rows
+// that mark NodePort/backend replies on an advertised UDN node switch. The
+// owner type is AdvertisedNetwork because the rows are created only while the
+// node advertises this UDN. ipFamily may be empty when building a cleanup predicate for
+// both IPv4 and IPv6 rows.
+func getAdvertisedNetworkNodePortReplyQoSDBIDs(controller string, networkID int, nodeName string, ipFamily egressIPFamilyValue) *libovsdbops.DbObjectIDs {
+	objectIDs := map[libovsdbops.ExternalIDKey]string{
+		libovsdbops.ObjectNameKey: advertisedNetworkNodePortReplyQoSKey,
+		libovsdbops.NetworkKey:    strconv.Itoa(networkID),
+		libovsdbops.NodeIDKey:     nodeName,
+	}
+	if ipFamily != "" {
+		objectIDs[libovsdbops.IPFamilyKey] = string(ipFamily)
+	}
+	return libovsdbops.NewDbObjectIDs(libovsdbops.QoSAdvertisedNetwork, controller, objectIDs)
 }
 
 // BuildAdvertisedNetworkSubnetsDropACL builds the advertised network subnets drop ACL:

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -156,8 +156,10 @@ const (
 	LabelUserDefinedServiceName = "k8s.ovn.org/service-name"
 
 	// Packet marking
-	EgressIPNodeConnectionMark         = "1008"
-	EgressIPReplyTrafficConnectionMark = 42
+	EgressIPNodeConnectionMark            = "1008"
+	EgressIPReplyTrafficConnectionMark    = 42
+	UDNNodePortReplyTrafficConnectionMark = 43
+	UDNNodePortReplyQoSRulePriority       = EgressIPRerouteQoSRulePriority
 
 	// primary user defined network's default join subnet value
 	// users can configure custom values using NADs

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -742,8 +742,9 @@ type userDefinedNetInfo struct {
 	defaultGatewayIPs   []net.IP
 	managementIPs       []net.IP
 
-	transport string
-	evpn      *ovncnitypes.EVPNConfig
+	transport    string
+	evpn         *ovncnitypes.EVPNConfig
+	outboundSNAT string
 }
 
 func (nInfo *userDefinedNetInfo) GetNetInfo() NetInfo {
@@ -881,8 +882,7 @@ func (nInfo *userDefinedNetInfo) Transport() string {
 
 // OutboundSNAT() string returns the outbound SNAT configuration for this network when using no-overlay transport.
 func (nInfo *userDefinedNetInfo) OutboundSNAT() string {
-	// TODO: implement per-network no-overlay outbound SNAT configuration
-	return ""
+	return nInfo.outboundSNAT
 }
 
 // EVPNVTEPName returns the name of the VTEP CR for EVPN
@@ -1072,6 +1072,9 @@ func (nInfo *userDefinedNetInfo) canReconcile(other NetInfo) bool {
 	if nInfo.EVPNIPVRFRouteTarget() != other.EVPNIPVRFRouteTarget() {
 		return false
 	}
+	if nInfo.OutboundSNAT() != other.OutboundSNAT() {
+		return false
+	}
 
 	lessCIDRNetworkEntry := func(a, b config.CIDRNetworkEntry) bool { return a.String() < b.String() }
 	if !cmp.Equal(nInfo.subnets, other.Subnets(), cmpopts.SortSlices(lessCIDRNetworkEntry)) {
@@ -1116,6 +1119,7 @@ func (nInfo *userDefinedNetInfo) copy() *userDefinedNetInfo {
 		managementIPs:         nInfo.managementIPs,
 		transport:             nInfo.transport,
 		evpn:                  nInfo.evpn,
+		outboundSNAT:          nInfo.outboundSNAT,
 	}
 	// copy mutables
 	c.mutableNetInfo.copyFrom(&nInfo.mutableNetInfo)
@@ -1141,6 +1145,7 @@ func newLayer3NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		mtu:            netconf.MTU,
 		transport:      netconf.Transport,
 		evpn:           netconf.EVPN,
+		outboundSNAT:   netconf.OutboundSNAT,
 		mutableNetInfo: mutableNetInfo{
 			id:   types.InvalidID,
 			nads: sets.Set[string]{},

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1924,14 +1924,11 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
 						// This should avoid the mentioned issue.
 						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
+							// The IPv6 fwmark rule bug from issue #5846 made dual-stack IPv6
+							// time out with curl 28. With the fwmark rule installed, IPv6
+							// follows the same known-broken path as IPv4 and fails with curl 56.
+							out = curlConnectionResetCode
 							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
 						}
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
 					}),
@@ -1968,14 +1965,11 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
 						// This should avoid the mentioned issue.
 						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
+							// The IPv6 fwmark rule bug from issue #5846 made dual-stack IPv6
+							// time out with curl 28. With the fwmark rule installed, IPv6
+							// follows the same known-broken path as IPv4 and fails with curl 56.
+							out = curlConnectionResetCode
 							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
 						}
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
 					}),
@@ -2042,14 +2036,11 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
 						// This should avoid the mentioned issue.
 						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
+							// The IPv6 fwmark rule bug from issue #5846 made dual-stack IPv6
+							// time out with curl 28. With the fwmark rule installed, IPv6
+							// follows the same known-broken path as IPv4 and fails with curl 56.
+							out = curlConnectionResetCode
 							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
 						}
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
 					}),

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -753,6 +753,25 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				return condition.Reason
 			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
 
+			// Check CUDN TransportAccepted condition is True after RA is created
+			if cudnTemplate.Spec.Network.Transport != "" && cudnTemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
+				ginkgo.By("ensure CUDN TransportAccepted condition is True")
+				gomega.Eventually(func(g gomega.Gomega) {
+					cudnObj, err := f.DynamicClient.Resource(clusterUDNGVR).Get(context.Background(), cUDN.Name, metav1.GetOptions{}, "status")
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					conditions, err := getConditions(cudnObj)
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					for _, condition := range conditions {
+						if condition.Type == "TransportAccepted" {
+							g.Expect(string(condition.Status)).To(gomega.Equal("True"))
+							g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
+							return
+						}
+					}
+					g.Expect(false).To(gomega.BeTrue(), "TransportAccepted condition not found in CUDN %s", cUDN.Name)
+				}, 30*time.Second, time.Second).Should(gomega.Succeed())
+			}
+
 			gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
 
 			// -----------------               ------------------                         ---------------------
@@ -875,11 +894,26 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				}
 			}
 
-			ginkgo.By("queries to the external server are not SNATed (uses podIP)")
+			expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
+				cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+
+			if expectSNAT {
+				ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
+			} else {
+				ginkgo.By("queries to the external server are not SNATed (uses podIP)")
+			}
 			for _, serverContainerIP := range serverContainerIPs {
-				podIP, err := getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 0)
+				podIPs, err := getPodAnnotationIPsForAttachment(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
+				podIP := ""
+				for _, podIPNet := range podIPs {
+					if utilnet.IsIPv6(podIPNet.IP) == utilnet.IsIPv6String(serverContainerIP) {
+						podIP = podIPNet.IP.String()
+						break
+					}
+				}
+				gomega.Expect(podIP).NotTo(gomega.BeEmpty(), "no pod IP matches external server IP family for server %s", serverContainerIP)
 				framework.Logf("Client pod IP address=%s", podIP)
 
 				ginkgo.By(fmt.Sprintf("Sending request to node IP %s "+
@@ -895,23 +929,27 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 					framework.Poll,
 					60*time.Second)
 				framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-				if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
-					if isIPv4Supported(f.ClientSet) && isIPv6Supported(f.ClientSet) {
-						// for dualstack we need to fetch the IP at index1
-						// if singlestack IPV6 the original podIP at index0 is the correct one
-						// FIXME: This util call assumes the first index will always be the IPv4 address
-						// and second index will always be the IPv6 address
-						// which is not always the case.
-						podIP, err = getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 1)
+
+				if expectSNAT {
+					// When OutboundSNAT is enabled, traffic to external destinations
+					// is masqueraded to the node IP. Verify the source is NOT the pod IP.
+					sourceIP := strings.Split(stdout, ":")[0]
+					if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
+						sourceIP = strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
 					}
-					// For IPv6 addresses, need to handle the brackets in the output
-					outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
-					gomega.Expect(outputIP).To(gomega.Equal(podIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					gomega.Expect(sourceIP).NotTo(gomega.Equal(podIP),
+						fmt.Sprintf("Expected SNAT for pod %s but traffic was not SNATed, output: %v", echoClientPodName, stdout))
 				} else {
-					// Original IPv4 handling
-					gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(podIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
+						// For IPv6 addresses, need to handle the brackets in the output
+						outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
+						gomega.Expect(outputIP).To(gomega.Equal(podIP),
+							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					} else {
+						// Original IPv4 handling
+						gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(podIP),
+							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					}
 				}
 			}
 		},
@@ -950,6 +988,106 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
 								NetworkSelector: metav1.LabelSelector{
 									MatchLabels: map[string]string{"bgp-l3": ""},
+								},
+							},
+						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
+					},
+				},
+			},
+		),
+		ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
+			&udnv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-",
+					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+				},
+				Spec: udnv1.ClusterUserDefinedNetworkSpec{
+					Network: udnv1.NetworkSpec{
+						Topology: udnv1.NetworkTopologyLayer3,
+						Layer3: &udnv1.Layer3Config{
+							Role: "Primary",
+							Subnets: []udnv1.Layer3Subnet{{
+								CIDR:       "103.103.0.0/16",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "2014:100:200::0/60",
+								HostSubnet: 64,
+							}},
+						},
+						Transport: udnv1.TransportOptionNoOverlay,
+						NoOverlay: &udnv1.NoOverlayConfig{
+							OutboundSNAT: udnv1.SNATEnabled,
+							Routing:      udnv1.RoutingUnmanaged,
+						},
+					},
+				},
+			},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+								},
+							},
+						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
+					},
+				},
+			},
+		),
+		ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+			&udnv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-",
+					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+				},
+				Spec: udnv1.ClusterUserDefinedNetworkSpec{
+					Network: udnv1.NetworkSpec{
+						Topology: udnv1.NetworkTopologyLayer3,
+						Layer3: &udnv1.Layer3Config{
+							Role: "Primary",
+							Subnets: []udnv1.Layer3Subnet{{
+								CIDR:       "103.103.0.0/16",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "2014:100:200::0/60",
+								HostSubnet: 64,
+							}},
+						},
+						Transport: udnv1.TransportOptionNoOverlay,
+						NoOverlay: &udnv1.NoOverlayConfig{
+							OutboundSNAT: udnv1.SNATDisabled,
+							Routing:      udnv1.RoutingUnmanaged,
+						},
+					},
+				},
+			},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
 								},
 							},
 						},
@@ -2384,10 +2522,40 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			},
 		}
 	}
+	layer3NoOverlaySNATEnabledUnmanagedSpecGen := func() *udnv1.NetworkSpec {
+		return &udnv1.NetworkSpec{
+			Topology: udnv1.NetworkTopologyLayer3,
+			Layer3: &udnv1.Layer3Config{
+				Role:    udnv1.NetworkRolePrimary,
+				Subnets: randomL3CUDNSubnets(),
+			},
+			Transport: udnv1.TransportOptionNoOverlay,
+			NoOverlay: &udnv1.NoOverlayConfig{
+				OutboundSNAT: udnv1.SNATEnabled,
+				Routing:      udnv1.RoutingUnmanaged,
+			},
+		}
+	}
+	layer3NoOverlaySNATDisabledUnmanagedSpecGen := func() *udnv1.NetworkSpec {
+		return &udnv1.NetworkSpec{
+			Topology: udnv1.NetworkTopologyLayer3,
+			Layer3: &udnv1.Layer3Config{
+				Role:    udnv1.NetworkRolePrimary,
+				Subnets: randomL3CUDNSubnets(),
+			},
+			Transport: udnv1.TransportOptionNoOverlay,
+			NoOverlay: &udnv1.NoOverlayConfig{
+				OutboundSNAT: udnv1.SNATDisabled,
+				Routing:      udnv1.RoutingUnmanaged,
+			},
+		}
+	}
 
 	networksToTest := []ginkgo.TableEntry{
 		ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT enabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATEnabledUnmanagedSpecGen),
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT disabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATDisabledUnmanagedSpecGen),
 		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF", feature.EVPN, cudnAdvertisedEVPN, layer3IPVRFNetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF", feature.EVPN, cudnAdvertisedEVPN, layer2MACVRFNetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF", feature.EVPN, cudnAdvertisedEVPN, layer2MACVRFIPVRFNetworkSpecGen),
@@ -2400,6 +2568,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		func(testedNetworkType networkType, networkSpecGen func() *udnv1.NetworkSpec) {
 			var testNamespace *corev1.Namespace
 			var testPod *corev1.Pod
+			var networkSpec *udnv1.NetworkSpec
 
 			getSameNode := func() string {
 				return testPod.Spec.NodeName
@@ -2418,7 +2587,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			}
 
 			ginkgo.BeforeEach(func() {
-				networkSpec := networkSpecGen()
+				networkSpec = networkSpecGen()
 				switch {
 				case networkSpec.Layer3 != nil:
 					networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
@@ -2456,7 +2625,14 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						if !ipFamilySet.Has(family) {
 							e2eskipper.Skipf("IP family %v not supported", family)
 						}
-						ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+						expectSNAT := networkSpec.NoOverlay != nil &&
+							networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+
+						if expectSNAT {
+							ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
+						} else {
+							ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+						}
 						for _, externalServer := range externalServers {
 							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2479,8 +2655,26 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							)
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
 							gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-							framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
-							testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+							if expectSNAT {
+								framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
+								// When OutboundSNAT is enabled, pod-to-external traffic is masqueraded
+								// to the node IP. Verify the source is NOT the pod IP.
+								ip, err := e2epodoutput.RunHostCmdWithRetries(
+									testPod.Namespace,
+									testPod.Name,
+									fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
+									polling,
+									timeout,
+								)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								sourceIP, _, err := net.SplitHostPort(ip)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								gomega.Expect(sourceIP).NotTo(gomega.Equal(testPodIP),
+									fmt.Sprintf("Expected SNAT for pod %s but traffic was not SNATed, output: %v", testPod.Name, ip))
+							} else {
+								framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
+								testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+							}
 						}
 					},
 					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),
@@ -2936,7 +3130,7 @@ var tmplDir = filepath.Join("testdata", "routeadvertisements")
 // neighbors in the network's VRF configured to advertised the provided
 // networks. Returns a temporary directory where the configuration is generated.
 func generateFRRConfiguration(neighborIPs, advertiseNetworks []string) (directory string, err error) {
-	// parse configuration templates
+	// parse configuration templatesex
 	var templates *template.Template
 	templates, err = template.ParseFS(ratestdata, filepath.Join(tmplDir, "frr", "*.tmpl"))
 	if err != nil {

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1161,6 +1161,26 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 		var ra *rav1.RouteAdvertisements
 		var hostNetworkPort int
 		ginkgo.Context("", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+			expectLocalGatewayNodePortFailure := func(ipFamily utilnet.IPFamily) (string, bool) {
+				if !IsGatewayModeLocal(f.ClientSet) {
+					return "", false
+				}
+				if cudnATemplate.Spec.Network.Transport == udnv1.TransportOptionNoOverlay {
+					// No-overlay advertised UDNs have explicit reply marking, so the
+					// different-node ETP=Local NodePort paths should succeed instead
+					// of using the overlay local-gateway expected-failure path.
+					return "", false
+				}
+
+				// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
+				// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
+				// This should avoid the mentioned issue.
+				// The IPv6 fwmark rule bug from issue #5846 made dual-stack IPv6
+				// time out with curl 28. With the fwmark rule installed, IPv6 follows
+				// the same known-broken path as IPv4 and fails with curl 56.
+				return curlConnectionResetCode, true
+			}
+
 			ginkgo.BeforeAll(func() {
 				ginkgo.By("Configuring primary UDN namespaces")
 				var err error
@@ -1918,18 +1938,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// The IPv6 fwmark rule bug from issue #5846 made dual-stack IPv6
-							// time out with curl 28. With the fwmark rule installed, IPv6
-							// follows the same known-broken path as IPv4 and fails with curl 56.
-							out = curlConnectionResetCode
-							errBool = true
-						}
+						out, errBool := expectLocalGatewayNodePortFailure(ipFamily)
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
 					}),
 
@@ -1958,19 +1967,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// The IPv6 fwmark rule bug from issue #5846 made dual-stack IPv6
-							// time out with curl 28. With the fwmark rule installed, IPv6
-							// follows the same known-broken path as IPv4 and fails with curl 56.
-							out = curlConnectionResetCode
-							errBool = true
-						}
+						out, errBool := expectLocalGatewayNodePortFailure(ipFamily)
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
 					}),
 				ginkgo.Entry("[ETP=LOCAL] UDN pod to the same node nodeport service in default network should not work",
@@ -2029,19 +2026,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// The IPv6 fwmark rule bug from issue #5846 made dual-stack IPv6
-							// time out with curl 28. With the fwmark rule installed, IPv6
-							// follows the same known-broken path as IPv4 and fails with curl 56.
-							out = curlConnectionResetCode
-							errBool = true
-						}
+						out, errBool := expectLocalGatewayNodePortFailure(ipFamily)
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
 					}),
 			)


### PR DESCRIPTION
Misc fixes for the no-overlay traffic paths introduced by https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6093 :

- Mark replies from no-overlay CUDN NodePort backend  so as to exclude them from UDN SNAT
- Preserve that same exclusion in LGW outboundSNAT=true
- Restore the UDN packet mark on the NodePort node reply path
- Include IP family when comparing managed IP rules, so IPv4 and IPv6 fwmark rules both get installed (fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846)
- Update e2e expectations now that no-overlay ETP=Local NodePort works and dual-stack IPv6 no longer times out



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable outbound SNAT for no‑overlay user‑defined networks; network attachments include outboundSNAT.
  * Lifecycle and sync for no‑overlay SNAT‑exemption address sets and per‑node QoS for advertised UDN reply traffic.
  * Bridge/flow rules to restore packet marks for advertised no‑overlay services.

* **Bug Fixes**
  * Corrected SNAT matching/exemptions for no‑overlay reply traffic.
  * Improved IP‑rule family matching for reconciliation.

* **Tests**
  * New unit and e2e coverage for outbound SNAT, reply‑traffic flows, QoS, and route‑advertisements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6390)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->