### PR TITLE
Drop manual zone-name node labeling

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1799,13 +1799,6 @@ remove_no_schedule_taint() {
   done
 }
 
-label_ovn_single_node_zones() {
-  KIND_NODES=$(kind_get_nodes)
-  for n in $KIND_NODES; do
-    kubectl label node "${n}" k8s.ovn.org/zone-name=${n} --overwrite
-  done
-}
-
 OPENSSL=""
 set_openssl_binary() {
   for s in openssl openssl3; do
@@ -1830,7 +1823,6 @@ scale_kind_cluster() {
   # change this to https://github.com/lobuhi/kindscaler once PR https://github.com/lobuhi/kindscaler/pull/1 is accepted
   git clone https://github.com/trozet/kindscaler /tmp/kindscaler
   /tmp/kindscaler/kindscaler.sh ${KIND_CLUSTER_NAME} -r worker -c ${KIND_NUM_WORKER}
-  label_ovn_single_node_zones
   if [ "$OVN_IMAGE" == local ]; then
     set_ovn_image
   fi

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -465,7 +465,6 @@ helm_prereqs() {
 
 create_ovn_kubernetes() {
     cd ${DIR}/../helm/ovn-kubernetes
-    label_ovn_single_node_zones
     value_file="values-single-node-zone.yaml"
     echo "value_file=${value_file}"
     # For multi-pod-subnet case, NET_CIDR_IPV4 is a list of CIDRs separated by comma.

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -946,56 +946,11 @@ function memory_trim_on_compaction_supported {
 }
 
 function get_node_zone() {
-  createKubeconfig=false
-  # DPU might have K8S_TOKEN/K8S_TOKENFILE and K8S_CACERT/K8S_CACERT_DATA provided to access DPU host (K8S_NODE here)
-  # which is in a different cluster. So we might need to create kubeconfig accordingly.
-  if [[ ${ovnkube_node_mode} == "dpu" ]]; then
-    if [[ -n ${K8S_TOKEN} ]] || [[ -n ${K8S_TOKEN_FILE} ]] || [[ -n ${K8S_CACERT_DATA} ]] || [[ -n ${K8S_CACERT} ]]; then
-      createKubeconfig=true
-    fi
-  fi
-
-  if [[ ${createKubeconfig} == "false" ]]; then
-    zone=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${k8s_cacert} \
-       get node ${K8S_NODE} -o=jsonpath={'.metadata.labels.k8s\.ovn\.org/zone-name'})
-  else
-    local dpuhost_k8s_apiserver=${K8S_APISERVER}
-    local dpuhost_k8s_token=${K8S_TOKEN}
-    local dpuhost_ca_config=""
-    if [[ -n ${K8S_TOKEN_FILE} ]]; then
-      dpuhost_k8s_token=$(cat ${K8S_TOKEN_FILE})
-    fi
-    if [[ -n ${K8S_CACERT_DATA} ]]; then
-      dpuhost_ca_config="certificate-authority-data: ${K8S_CACERT_DATA}"
-    elif [[ -n ${K8S_CACERT} ]]; then
-      dpuhost_ca_config="certificate-authority: ${K8S_CACERT}"
-    fi
-    zone=$(kubectl --kubeconfig=<(cat <<EOF
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: ${dpuhost_k8s_apiserver}
-    ${dpuhost_ca_config}
-  name: dpuhost-cluster
-contexts:
-- context:
-    cluster: dpuhost-cluster
-    user: dpu-user
-  name: dpuhost-context
-current-context: dpuhost-context
-users:
-- name: dpu-user
-  user:
-    token: ${dpuhost_k8s_token}
-EOF
-) get node ${K8S_NODE} -o=jsonpath={'.metadata.labels.k8s\.ovn\.org/zone-name'})
-
-  fi
-  if [ -z "$zone" ]; then
-    zone="${K8S_NODE}"
-  fi
-  echo "$zone"
+  # Single-node-zone is the only supported interconnect topology: each node is
+  # its own zone, named after the kube node. In DPU mode, K8S_NODE has already
+  # been overridden earlier in this script from the OVS external_id
+  # host-k8s-nodename, so it carries the DPU-host's node name.
+  echo "${K8S_NODE}"
 }
 
 function get_ovnkube_zone_db_ep() {

--- a/docs/installation/INSTALL.KUBEADM.md
+++ b/docs/installation/INSTALL.KUBEADM.md
@@ -469,11 +469,6 @@ Before starting OVN-Kubernetes, work around an issue where `br-int` is added by 
 ovs-vsctl add-br br-int
 ~~~
 
-Single-node-zone interconnect requires every node to be labeled with its zone name **before** the Helm install:
-~~~
-for n in node1 node2 node3; do kubectl label node $n k8s.ovn.org/zone-name=$n --overwrite; done
-~~~
-
 Next, install OVN-Kubernetes with the Helm chart, pointing `global.image.repository` at the image you just pushed (or use the public `ghcr.io/ovn-kubernetes/ovn-kubernetes/ovn-kube-ubuntu` image to skip the build steps above). If `helm` isn't already on the master, install it with `curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`.
 ~~~
 cd $HOME/work/src/github.com/ovn-kubernetes/ovn-kubernetes/helm/ovn-kubernetes

--- a/docs/installation/launching-ovn-kubernetes-with-dpu.md
+++ b/docs/installation/launching-ovn-kubernetes-with-dpu.md
@@ -22,11 +22,10 @@ A single VF net-device or a group of VF net-devices (configured as SR-IOV device
 
 ## K8s Settings on DPU Host
 
-The following node labels must be set on the DPU Host prior to installing OVN K8s CNI
+The following node label must be set on the DPU Host prior to installing OVN K8s CNI
 
 ```yaml
 k8s.ovn.org/dpu-host=
-k8s.ovn.org/zone-name="dpu-host node name"
 ```
 
 ## Launching OVN K8s DPU Host cluster using helm

--- a/docs/installation/launching-ovn-kubernetes-with-helm.md
+++ b/docs/installation/launching-ovn-kubernetes-with-helm.md
@@ -61,13 +61,6 @@ The chart uses `values-single-node-zone.yaml` by default.
 ## Step-by-step install
 
 
-- Set the zone label on each node (required for interconnect mode):
-```
-for n in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
-  kubectl label node "${n}" k8s.ovn.org/zone-name=${n} --overwrite
-done
-```
-
 - Run `helm install` with the appropriate `k8sAPIServer`, image repo and tag:
 ```
 # cd helm/ovn-kubernetes

--- a/helm/basic-deploy.sh
+++ b/helm/basic-deploy.sh
@@ -72,10 +72,6 @@ if [[ "$BUILD_IMAGE" == "true" ]]; then
   docker tag ovn-kube-ubuntu:latest "$IMG"
 fi
 
-for n in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
-  kubectl label node "${n}" k8s.ovn.org/zone-name=${n} --overwrite
-done
-
 # Deploy OVN-Kubernetes using Helm
 cd ${DIR}/ovn-kubernetes
 helm install ovn-kubernetes . -f ${VALUES_FILE} \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -674,12 +674,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		}
 
 		controlPlanePodName = "ovnkube-control-plane"
-		// in "one node per zone" config, ovnkube-controller doesn't create leader election lease
-		if !singleNodePerZone() {
-			controlPlaneLeaseName = "ovn-kubernetes-master-ovn-control-plane"
-		} else {
-			controlPlaneLeaseName = "ovn-kubernetes-master"
-		}
+		controlPlaneLeaseName = "ovn-kubernetes-master"
 
 		controlPlanePods, err := f.ClientSet.CoreV1().Pods(deploymentconfig.Get().OVNKubernetesNamespace()).List(context.Background(), metav1.ListOptions{
 			LabelSelector: "name=" + controlPlanePodName,

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1482,39 +1482,8 @@ passwd:
 			namespace = fr.Namespace.Name
 			workerNodeList, err := fr.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: labels.FormatLabels(map[string]string{"node-role.kubernetes.io/worker": ""})})
 			Expect(err).NotTo(HaveOccurred())
-			nodesByOVNZone := map[string][]corev1.Node{}
-			for _, workerNode := range workerNodeList.Items {
-				ovnZone, ok := workerNode.Labels["k8s.ovn.org/zone-name"]
-				if !ok {
-					ovnZone = "global"
-				}
-				_, ok = nodesByOVNZone[ovnZone]
-				if !ok {
-					nodesByOVNZone[ovnZone] = []corev1.Node{}
-				}
-				nodesByOVNZone[ovnZone] = append(nodesByOVNZone[ovnZone], workerNode)
-			}
-
-			selectedNodes = []corev1.Node{}
-			// If there is one global zone select the first three for the
-			// migration
-			if len(nodesByOVNZone) == 1 {
-				selectedNodes = []corev1.Node{
-					workerNodeList.Items[0],
-					workerNodeList.Items[1],
-					workerNodeList.Items[2],
-				}
-				// Otherwise select a pair of nodes from different OVN zones
-			} else {
-				for _, nodes := range nodesByOVNZone {
-					selectedNodes = append(selectedNodes, nodes[0])
-					if len(selectedNodes) == 3 {
-						break // we want just three of them
-					}
-				}
-			}
-
-			Expect(selectedNodes).To(HaveLen(3), "at least three nodes in different zones are needed for interconnect scenarios")
+			Expect(len(workerNodeList.Items)).To(BeNumerically(">=", 3), "at least three worker nodes are needed for interconnect live-migration scenarios")
+			selectedNodes = workerNodeList.Items[:3]
 
 			// Label the selected nodes with the generated namespaces, so we can
 			// configure VM nodeSelector with it and live migration will take only

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -57,8 +57,6 @@ const (
 	ovnGatewayMTUSupport = "k8s.ovn.org/gateway-mtu-support"
 )
 
-var singleNodePerZoneResult *bool
-
 type IpNeighbor struct {
 	Dst    string `json:"dst"`
 	Lladdr string `json:"lladdr"`
@@ -1457,27 +1455,8 @@ func isPreConfiguredUdnAddressesEnabled() bool {
 	return val == "true"
 }
 
-func singleNodePerZone() bool {
-	if singleNodePerZoneResult == nil {
-		args := []string{"get", "pods", "--selector=app=ovnkube-node", "-o", "jsonpath={.items[0].spec.containers[*].name}"}
-		containerNames := e2ekubectl.RunKubectlOrDie(deploymentconfig.Get().OVNKubernetesNamespace(), args...)
-		result := true
-		for _, containerName := range strings.Split(containerNames, " ") {
-			if containerName == "ovnkube-node" {
-				result = false
-				break
-			}
-		}
-		singleNodePerZoneResult = &result
-	}
-	return *singleNodePerZoneResult
-}
-
 func getNodeContainerName() string {
-	if singleNodePerZone() {
-		return "ovnkube-controller"
-	}
-	return "ovnkube-node"
+	return "ovnkube-controller"
 }
 
 // getNodeZone returns the node's zone


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
  Single-node-zone is the only supported interconnect topology. The k8s.ovn.org/zone-name label was only needed to group multiple nodes into a shared zone. In the single-node case it's just the kube node name that K8S_NODE already provides.                                      
                            
*The k8s.ovn.org/zone-name *annotation* set by ovnkube-node is unrelated and unchanged.*                    
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added workaround to pre-create the br-int bridge for Kubeadm installs.

* **Documentation**
  * Removed zone-name labeling requirements from Helm and Kubeadm guides.
  * Simplified DPU host node-label instructions; removed extra zone-name label.

* **Chores**
  * Removed automatic zone-name node-labeling steps from deployment scripts.

* **Tests**
  * Tests simplified to pick the first three workers, use a consistent control-plane lease name, and always target the controller container.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6401)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->