### PR TITLE
e2e: replace random allocations with ConfigMap-backed allocators

### DIFF
--- a/test/e2e/allocators/bgp.go
+++ b/test/e2e/allocators/bgp.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocators
+
+import (
+	"sync"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
+)
+
+const (
+	bgpKey = "bgp"
+
+	// VID valid range is 2-4094 (0, 1, 4095 are reserved)
+	vidMin = 2
+	vidMax = 4094
+
+	// VNI valid range is 1-16777215 (24-bit)
+	vniMax = 16777215
+	// Even offset so MACVRF VNIs are always even and don't correlate with VIDs.
+	vniOffset = vniMax/2 + 1
+)
+
+var (
+	bgpOnce              sync.Once
+	bgpPeer4, bgpPeer6   subnetSpec
+	bgpIPVRF4, bgpIPVRF6 subnetSpec
+	bgpVTEP4, bgpVTEP6   subnetSpec
+	bgpUDN4, bgpUDN6     subnetSpec
+)
+
+type BGPAllocation struct {
+	UDNSubnet      string
+	UDNSubnet6     string
+	BGPPeerSubnet  string
+	BGPPeerSubnet6 string
+	IPVRFSubnet    string
+	IPVRFSubnet6   string
+	VTEPSubnet     string
+	VTEPSubnet6    string
+	MACVRFVNI      int
+	MACVRFVID      int
+	IPVRFVNI       int
+	IPVRFVID       int
+}
+
+// AllocateBGP allocates non-overlapping UDN subnets, BGP peering subnets,
+// IP-VRF subnets, VTEP subnets, VNIs and VIDs for parallel test isolation
+// commonly needed in BGP test cases. All resources are derived from a single
+// integer allocated with AllocateInt. Deallocation is registered as a cleanup
+// function.
+func AllocateBGP(f *framework.Framework, cleanup infraapi.ContextCleanUp) (BGPAllocation, error) {
+	bgpOnce.Do(func() {
+		bgpPeer4 = newSubnetSpec(bgpPeerSubnets, nil)
+		bgpPeer6 = newSubnetSpec(bgpPeerSubnets6, nil)
+		bgpIPVRF4 = newSubnetSpec(ipvrfSubnets, nil)
+		bgpIPVRF6 = newSubnetSpec(ipvrfSubnets6, nil)
+		bgpVTEP4 = newSubnetSpec(vtepSubnets, nil)
+		bgpVTEP6 = newSubnetSpec(vtepSubnets6, nil)
+		bgpUDN4 = newSubnetSpec(udnSubnets, nil)
+		bgpUDN6 = newSubnetSpec(udnSubnets6, nil)
+	})
+
+	maxUsable := min(
+		bgpPeer4.usable(), bgpPeer6.usable(),
+		bgpIPVRF4.usable(), bgpIPVRF6.usable(),
+		bgpVTEP4.usable(), bgpVTEP6.usable(),
+		bgpUDN4.usable(), bgpUDN6.usable(),
+		(vidMax-vidMin+1)/2,
+		(vniMax-vniOffset+1)/2,
+	)
+
+	n, err := AllocateInt(f, bgpKey, maxUsable)
+	if err != nil {
+		return BGPAllocation{}, err
+	}
+
+	cleanup.AddCleanUpFn(func() error {
+		return DeallocateInt(f, bgpKey, n)
+	})
+
+	bgpV4Idx := bgpPeer4.nthFree(n)
+	bgpV6Idx := bgpPeer6.nthFree(n)
+	ipvrfV4Idx := bgpIPVRF4.nthFree(n)
+	ipvrfV6Idx := bgpIPVRF6.nthFree(n)
+	vtepV4Idx := bgpVTEP4.nthFree(n)
+	vtepV6Idx := bgpVTEP6.nthFree(n)
+	udnV4Idx := bgpUDN4.nthFree(n)
+	udnV6Idx := bgpUDN6.nthFree(n)
+
+	// Each allocation consumes two VIDs (MACVRF + IPVRF). MACVRF gets even
+	// VIDs and IPVRF gets odd VIDs so different allocations never collide.
+	macvrfVID := (n-1)*2 + vidMin
+	ipvrfVID := macvrfVID + 1
+	// Same stride-by-2 scheme for VNIs: MACVRF gets even, IPVRF gets odd.
+	macvrfVNI := (n-1)*2 + vniOffset
+	ipvrfVNI := macvrfVNI + 1
+
+	return BGPAllocation{
+		UDNSubnet:      bgpUDN4.cidr(udnV4Idx),
+		UDNSubnet6:     bgpUDN6.cidr(udnV6Idx),
+		BGPPeerSubnet:  bgpPeer4.cidr(bgpV4Idx),
+		BGPPeerSubnet6: bgpPeer6.cidr(bgpV6Idx),
+		IPVRFSubnet:    bgpIPVRF4.cidr(ipvrfV4Idx),
+		IPVRFSubnet6:   bgpIPVRF6.cidr(ipvrfV6Idx),
+		VTEPSubnet:     bgpVTEP4.cidr(vtepV4Idx),
+		VTEPSubnet6:    bgpVTEP6.cidr(vtepV6Idx),
+		MACVRFVNI:      macvrfVNI,
+		MACVRFVID:      macvrfVID,
+		IPVRFVNI:       ipvrfVNI,
+		IPVRFVID:       ipvrfVID,
+	}, nil
+}

--- a/test/e2e/allocators/int.go
+++ b/test/e2e/allocators/int.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocators
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"strconv"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var errAllocationFull = errors.New("allocation full")
+
+var allocatorBackoff = wait.Backoff{
+	Steps:    50,
+	Duration: 100 * time.Millisecond,
+}
+
+const (
+	configMapNamespace = "ovn-kubernetes-e2e-allocators"
+)
+
+// AllocateInt allocates and returns an integer that is not currently allocated
+// by previous calls to this function under the same key. The allocation range
+// is [1, max]. Within the range, the allocation is random. The allocation is
+// backed up by a config map in the tested cluster. The purpose is for test
+// cases to use this allocation directly or as a seed for other allocations that
+// need to avoid collisions when running in parallel. This is useful when the
+// orchestration handling the parallelization does not provide any context where
+// this allocation can happen. De-allocate with DeallocateInt.
+func AllocateInt(f *framework.Framework, key string, max int) (int, error) {
+	if max < 1 {
+		return 0, fmt.Errorf("max must be at least 1, got %d", max)
+	}
+
+	ctx := context.Background()
+
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: configMapNamespace}}
+	_, err := f.ClientSet.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return 0, fmt.Errorf("failed to ensure allocator namespace: %w", err)
+	}
+
+	cm := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: key}}
+	client := f.ClientSet.CoreV1().ConfigMaps(configMapNamespace)
+
+	_, err = client.Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return 0, fmt.Errorf("failed to ensure allocator config map: %w", err)
+	}
+
+	var allocated int
+	err = retry.OnError(
+		allocatorBackoff,
+		func(err error) bool {
+			return apierrors.IsConflict(err) || errors.Is(err, errAllocationFull)
+		},
+		func() error {
+			cm, err := client.Get(ctx, cm.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+
+			if len(cm.Data) >= max {
+				return fmt.Errorf("no free allocation in [1, %d] for key %q: %w", max, key, errAllocationFull)
+			}
+
+			start := rand.IntN(max)
+			idx := 0
+			for i := range max {
+				idx = (start+i)%max + 1
+				if _, ok := cm.Data[strconv.Itoa(idx)]; !ok {
+					break
+				}
+			}
+			cm.Data[strconv.Itoa(idx)] = ""
+			_, err = client.Update(ctx, cm, metav1.UpdateOptions{})
+			if err == nil {
+				allocated = idx
+			}
+			return err
+		},
+	)
+
+	if err == nil {
+		framework.Logf("AllocateInt: %s=%d", key, allocated)
+	}
+	return allocated, err
+}
+
+// DeallocateInt deallocates an integer previously allocated with AllocateInt.
+func DeallocateInt(f *framework.Framework, key string, index int) error {
+	ctx := context.Background()
+	client := f.ClientSet.CoreV1().ConfigMaps(configMapNamespace)
+
+	return retry.RetryOnConflict(allocatorBackoff, func() error {
+		cm, err := client.Get(ctx, key, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		delete(cm.Data, strconv.Itoa(index))
+		_, err = client.Update(ctx, cm, metav1.UpdateOptions{})
+		return err
+	})
+}

--- a/test/e2e/allocators/subnet_spec.go
+++ b/test/e2e/allocators/subnet_spec.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocators
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// subnetSpec partitions a large IP range into equal-size smaller subnets for
+// allocation. It is constructed from a "base/outer/inner" spec string where
+// base is the starting IP address, outer is the prefix length of the overall
+// range and inner is the prefix length of each allocated subnet. For example,
+// "10.0.0.0/8/20" represents 4096 /20 subnets within 10.0.0.0/8. Some of
+// those subnets can be excluded to avoid collisions with infrastructure
+// networks.
+type subnetSpec struct {
+	base     net.IP
+	bits     int
+	outer    int
+	inner    int
+	excluded sets.Set[int]
+}
+
+// newSubnetSpec creates a subnetSpec from a "base/outer/inner" spec string
+// and a list of CIDRs to exclude from allocation. Exclusions can be any
+// subnet: if one covers the entire outer range, it panics; if it has no
+// overlap with the outer range, it is ignored; otherwise all inner candidates
+// that overlap the exclusion are marked unavailable.
+func newSubnetSpec(spec string, exclusions []string) subnetSpec {
+	s, err := parseSubnetSpec(spec)
+	if err != nil {
+		panic(fmt.Sprintf("invalid subnet spec %q: %v", spec, err))
+	}
+
+	if len(exclusions) == 0 {
+		return s
+	}
+
+	// compute exclusions
+	outerNet := &net.IPNet{
+		IP:   s.base,
+		Mask: net.CIDRMask(s.outer, s.bits),
+	}
+	outerOnes, _ := outerNet.Mask.Size()
+	baseInt := new(big.Int).SetBytes(s.base.To16())
+	innerSize := new(big.Int).Lsh(big.NewInt(1), uint(s.bits-s.inner))
+	s.excluded = sets.New[int]()
+	for _, cidr := range exclusions {
+		_, exclNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("invalid exclusion %q for spec %q: %v", cidr, spec, err))
+		}
+
+		// exclusion is a super net, makes no sense
+		exclOnes, _ := exclNet.Mask.Size()
+		if exclNet.Contains(outerNet.IP) && exclOnes <= outerOnes {
+			panic(fmt.Sprintf("exclusion %q covers the entire subnet spec range %q", cidr, spec))
+		}
+
+		// exclusion does not overlap, safely ignore
+		if !overlaps(outerNet, exclNet) {
+			continue
+		}
+
+		// Some math to compute the inner subnet indices excluded
+		// get the first and last IP of the exclusion (as big int)
+		exclStartInt := new(big.Int).SetBytes(exclNet.IP.To16())
+		exclSize := new(big.Int).Lsh(big.NewInt(1), uint(s.bits-exclOnes))
+		exclEndInt := new(big.Int).Add(exclStartInt, exclSize)
+		exclEndInt.Sub(exclEndInt, big.NewInt(1))
+		// find out how many inner sized subnets fit from base IP to first IP of
+		// exclusion, that's the index of first inner subnet to exclude
+		// i = (ip - base) / innerSize.
+		startIdx := max(0, int(new(big.Int).Div(new(big.Int).Sub(exclStartInt, baseInt), innerSize).Int64()))
+		// find out how many inner sized subnets fit from base IP to last IP of
+		// exclusion, that's the index of the last inner subnet to exclude
+		endIdx := min(s.total()-1, int(new(big.Int).Div(new(big.Int).Sub(exclEndInt, baseInt), innerSize).Int64()))
+		for i := startIdx; i <= endIdx; i++ {
+			s.excluded.Insert(i)
+		}
+	}
+
+	return s
+}
+
+func overlaps(a, b *net.IPNet) bool {
+	return a.Contains(b.IP) || b.Contains(a.IP)
+}
+
+func parseSubnetSpec(spec string) (subnetSpec, error) {
+	lastSlash := strings.LastIndex(spec, "/")
+	if lastSlash < 0 {
+		return subnetSpec{}, fmt.Errorf("missing inner mask")
+	}
+	inner, err := strconv.Atoi(spec[lastSlash+1:])
+	if err != nil {
+		return subnetSpec{}, err
+	}
+	rest := spec[:lastSlash]
+	secondSlash := strings.LastIndex(rest, "/")
+	if secondSlash < 0 {
+		return subnetSpec{}, fmt.Errorf("missing outer mask")
+	}
+	outer, err := strconv.Atoi(rest[secondSlash+1:])
+	if err != nil {
+		return subnetSpec{}, err
+	}
+	base := net.ParseIP(rest[:secondSlash])
+	if base == nil {
+		return subnetSpec{}, fmt.Errorf("parsing base addr %q", rest[:secondSlash])
+	}
+	bits := 32
+	if base.To4() == nil {
+		bits = 128
+	}
+	return subnetSpec{base: base, bits: bits, outer: outer, inner: inner}, nil
+}
+
+func (s subnetSpec) total() int {
+	return 1 << (s.inner - s.outer)
+}
+
+func (s subnetSpec) usable() int {
+	return s.total() - s.excluded.Len()
+}
+
+func (s subnetSpec) nthFree(n int) int {
+	count := 0
+	for i := range s.total() {
+		if s.excluded.Has(i) {
+			continue
+		}
+		count++
+		if count == n {
+			return i
+		}
+	}
+	panic(fmt.Sprintf("nthFree: n=%d exceeds %d usable subnets in %s/%d/%d", n, s.usable(), s.base, s.outer, s.inner))
+}
+
+// cidr returns the CIDR of the idx-th /inner subnet within the /outer range.
+func (s subnetSpec) cidr(idx int) string {
+	if idx < 0 || idx >= s.total() {
+		panic(fmt.Sprintf("cidr: idx=%d exceeds %d total subnets in %s/%d/%d", idx, s.total(), s.base, s.outer, s.inner))
+	}
+	baseInt := new(big.Int).SetBytes(s.base.To16())
+	// each /inner subnet spans 2^(bits-inner) addresses; the idx-th starts
+	// at base + idx * 2^(bits-inner)
+	// e.g. for "10.0.0.0/8/20": idx=1408 → 10.0.0.0 + 1408*4096 → 10.88.0.0/20
+	offset := new(big.Int).Lsh(big.NewInt(int64(idx)), uint(s.bits-s.inner))
+	ip := make(net.IP, net.IPv6len)
+	new(big.Int).Add(baseInt, offset).FillBytes(ip)
+	return fmt.Sprintf("%s/%d", ip, s.inner)
+}

--- a/test/e2e/allocators/subnets.go
+++ b/test/e2e/allocators/subnets.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocators
+
+// These variables define subnets used for allocations in e2e tests. It aims to
+// be a central registry to track the ranges used for different purposes and
+// facilitate tracking for collision avoidance with other commonly used ranges
+// in test environments. Allocators defined in this package source from these
+// ranges to allocate. If need be, exclusions within these ranges can be defined
+// for the allocators, see newSubnetSpec.
+// TODO these would best be defined through DeploymentConfig
+
+var (
+	// avoiding:
+	// - 10.88.0.0/16		(podman default network, transit subnet)
+	// - 10.96.0.0/16  		(Kubernetes services)
+	// - 10.128.0.0/14 		(cluster default network)
+	// - 10.243.0.0/16 		(cluster default network)
+	// - 10.244.0.0/16 		(cluster default network)
+	// - 100.64.0.0/16 		(default join subnet)
+	// - 100.65.0.0/16 		(UDN primary join subnet)
+	// - 172.18.0.0/16 		(KIND primary network)
+	// - 172.19.0.0/16 		(XGW network)
+	// - 172.22.0.0/16 		(MetalLB client network)
+	// - 172.26.0.0/16 		(default BGP server network)
+	// - 172.30.0.0/16 		(Kubernetes services)
+	// - 169.254.169.0/29 	(masquerade subnet)
+	// - fd01::/48    		(cluster default network)
+	// - fd02::/112	   		(Kubernetes services)
+	// - fd98::/64     		(default join subnet)
+	// - fd69::/125			(masquerade subnet)
+	// - fd97::/64		    (transit subnet)
+
+	// UDN subnets, 1024 available
+	udnSubnets  = "10.0.0.0/10/20"
+	udnSubnets6 = "fd10::/42/52"
+
+	// BGP peering, 1024 available each
+	bgpPeerSubnets  = "172.25.0.0/19/29"
+	bgpPeerSubnets6 = "fd25::/102/112"
+
+	// EVPN IP-VRF subnets, 1024 available
+	ipvrfSubnets  = "172.27.0.0/19/29"
+	ipvrfSubnets6 = "fd27::/102/112"
+
+	// EVPN VTEP subnets, 1024 available
+	vtepSubnets  = "100.66.0.0/14/24"
+	vtepSubnets6 = "fd66:4200::/102/112"
+)

--- a/test/e2e/allocators/udn.go
+++ b/test/e2e/allocators/udn.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocators
+
+import (
+	"sync"
+)
+
+var (
+	udnOnce      sync.Once
+	udnV4, udnV6 subnetSpec
+)
+
+// AllocateUDNSubnets always allocates the same fixed UDN IPv4 and IPv6 subnet
+// within the dedicated UDN subnet broader range. Used when overlaps across UDNs
+// are not a concern but still prevents overlaps with other subnets.
+func AllocateUDNSubnets() (ipv4, ipv6 string) {
+	udnOnce.Do(func() {
+		udnV4 = newSubnetSpec(udnSubnets, nil)
+		udnV6 = newSubnetSpec(udnSubnets6, nil)
+	})
+
+	udnV4Idx := udnV4.nthFree(1)
+	udnV6Idx := udnV6.nthFree(1)
+	return udnV4.cidr(udnV4Idx), udnV6.cidr(udnV6Idx)
+}

--- a/test/e2e/evpn.go
+++ b/test/e2e/evpn.go
@@ -5,9 +5,7 @@ package e2e
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
-	"math/big"
 	"net"
 	"os"
 	"strings"
@@ -17,6 +15,7 @@ import (
 	vtepv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1"
 	vtepclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/clientset/versioned"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
 	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
@@ -1044,59 +1043,6 @@ func waitForVTEPAccepted(f *framework.Framework, vtepName string) error {
 	})
 }
 
-// =============================================================================
-// EVPN VID Utilities
-// =============================================================================
-
-func randomN(n int) int {
-	r, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
-	if err != nil {
-		panic(fmt.Sprintf("crypto/rand.Int failed: %v", err))
-	}
-	return int(r.Int64())
-}
-
-// randomVID generates a random VLAN ID in the valid range (2-4094).
-// VIDs 0, 1, and 4095 are reserved and should not be used.
-func randomVID() int {
-	return randomN(4093) + 2 // 2-4094
-}
-
-// randomVNI generates a random VXLAN Network Identifier in the valid 24-bit range (1-16777215).
-func randomVNI() int32 {
-	return int32(randomN(16777215)) + 1
-}
-
-// randomCUDNSubnets generates random non-overlapping CUDN subnets for parallel test isolation.
-// Uses /20 (4096 addresses) instead of /16 to allow randomizing both second and third octets,
-// giving ~4016 possible subnets within 10.0.0.0/8 while avoiding collisions with:
-//   - 10.88.0.0/16  (podman default network)
-//   - 10.96.0.0/16  (Kubernetes services)
-//   - 10.128.0.0/14 (default cluster network pod CIDRs)
-//   - 10.132.0.0/16 (UDN perf tests)
-//   - 10.243.0.0/16, 10.244.0.0/16 (pod CIDRs)
-//
-// Note: /20 supports up to 16 nodes with /24 per-node subnets for Layer3 topology.
-// This is sufficient for KIND e2e clusters.
-//
-// Returns IPv4 (/20) and IPv6 (/52) subnets.
-func randomCUDNSubnets() (ipv4, ipv6 string) {
-	// 4096 possible /20 subnets in 10.0.0.0/8 (256 second octets * 16 /20-aligned third octets)
-	// Exclude blocks overlapping known reservations (16 /20 blocks per second octet):
-	//   10.88, 10.96, 10.128-131 (10.128.0.0/14), 10.132, 10.243, 10.244 = 112 excluded → ~3952 usable
-	for {
-		second := randomN(256)
-		// 16 /20-aligned slots per second octet (256/16)
-		third := randomN(16) * 16 // 0, 16, 32, ..., 240
-		switch second {
-		case 88, 96, 128, 129, 130, 131, 132, 243, 244:
-			continue
-		}
-		n := second*16 + third/16
-		return fmt.Sprintf("10.%d.%d.0/20", second, third), fmt.Sprintf("fd00:%x::/52", n)
-	}
-}
-
 // subnetOffsetIP returns an IP at the given offset from the base of the subnet.
 // For example, subnetOffsetIP("10.199.128.0/20", 101) returns "10.199.128.101".
 func subnetOffsetIP(cidr string, offset int) string {
@@ -1114,52 +1060,6 @@ func subnetOffsetIP(cidr string, offset int) string {
 		return ip.To4().String()
 	}
 	return ip.String()
-}
-
-func randomL3CUDNSubnets() []udnv1.Layer3Subnet {
-	cudnIPv4, cudnIPv6 := randomCUDNSubnets()
-	return []udnv1.Layer3Subnet{{CIDR: udnv1.CIDR(cudnIPv4)}, {CIDR: udnv1.CIDR(cudnIPv6)}}
-}
-
-func randomL2CUDNSubnets() udnv1.DualStackCIDRs {
-	cudnIPv4, cudnIPv6 := randomCUDNSubnets()
-	return udnv1.DualStackCIDRs{udnv1.CIDR(cudnIPv4), udnv1.CIDR(cudnIPv6)}
-}
-
-// randomIPVRFAgnhostSubnets generates random IP-VRF agnhost subnets for parallel test isolation.
-// Uses /29 (8 IPs, 6 usable) which is sufficient for provider gateway + agnhost + FRR,
-// giving 8192 possible subnets within 172.27.0.0/16 to minimize collision probability.
-// The 172.27.0.0/16 space avoids collisions with:
-//   - 172.18.0.0/16 (KIND primary network)
-//   - 172.19.0.0/16 (XGW network)
-//   - 172.22.0.0/16 (MetalLB client network)
-//   - 172.26.0.0/16 (BGP server network)
-//
-// Returns IPv4 (/29) and IPv6 (/112) subnets.
-func randomIPVRFAgnhostSubnets() (ipv4, ipv6 string) {
-	// 8192 possible /29 subnets in 172.27.0.0/16
-	n := randomN(8192)
-	// 32 /29-aligned slots per third octet (256/8), so divide to get octet pair
-	third := n / 32
-	fourth := (n % 32) * 8
-	return fmt.Sprintf("172.27.%d.%d/29", third, fourth), fmt.Sprintf("fd01:%x::/112", n)
-}
-
-// randomVTEPSubnets generates random VTEP subnets for parallel test isolation.
-// Uses /24 (254 usable IPs)
-// Randomizes both second and third octets within RFC 6598 shared address space
-// (100.64.0.0/10), giving 15,872 possible /24 subnets while avoiding:
-//   - 100.64.0.0/16 (default join subnet)
-//   - 100.65.0.0/16 (UDN primary join subnet)
-//
-// 100.88.0.0/16 (transit subnet) is NOT excluded because transit IPs are purely
-// internal to OVN's logical network and never appear on physical interfaces.
-// Safe second octets: 66-127 (62 values).
-// Returns IPv4 (/24) and IPv6 (/112) subnets.
-func randomVTEPSubnets() (ipv4, ipv6 string) {
-	second := randomN(62) + 66 // 66-127
-	third := randomN(256)      // 0-255
-	return fmt.Sprintf("100.%d.%d.0/24", second, third), fmt.Sprintf("fd02:%x%02x::/112", second, third)
 }
 
 // =============================================================================
@@ -1295,8 +1195,7 @@ func runEVPNNetworkAndServers(
 	testName string,
 	ipFamilySet sets.Set[utilnet.IPFamily],
 	networkSpec *udnv1.NetworkSpec,
-	ipVRFAgnhostSubnets []string,
-	vtepSubnets []string,
+	bgpAlloc allocators.BGPAllocation,
 	bgpASN int,
 	bridgeName string,
 	vxlanName string,
@@ -1310,8 +1209,8 @@ func runEVPNNetworkAndServers(
 	hasMACVRF := networkSpec.EVPN != nil && networkSpec.EVPN.MACVRF != nil
 	hasIPVRF := networkSpec.EVPN != nil && networkSpec.EVPN.IPVRF != nil
 
-	ipVRFAgnhostSubnets = matchCIDRStringsByIPFamilySet(ipVRFAgnhostSubnets, ipFamilySet)
-	vtepSubnets = matchCIDRStringsByIPFamilySet(vtepSubnets, ipFamilySet)
+	ipVRFAgnhostSubnets := matchCIDRStringsByIPFamilySet([]string{bgpAlloc.IPVRFSubnet, bgpAlloc.IPVRFSubnet6}, ipFamilySet)
+	vtepSubnets := matchCIDRStringsByIPFamilySet([]string{bgpAlloc.VTEPSubnet, bgpAlloc.VTEPSubnet6}, ipFamilySet)
 
 	// Extract subnets from networkSpec for MAC-VRF agnhost IP derivation
 	cudnSubnetsFromSpec := getNetworkSubnetsFromSpec(networkSpec)
@@ -1336,8 +1235,8 @@ func runEVPNNetworkAndServers(
 
 	var macVRFVID int
 	if hasMACVRF {
-		macVRFVID = randomVID()
-		framework.Logf("Generated random VIDs for external FRR: MAC-VRF VID=%d", macVRFVID)
+		macVRFVID = bgpAlloc.MACVRFVID
+		framework.Logf("Allocated VIDs for external FRR: MAC-VRF VID=%d", macVRFVID)
 		framework.Logf("Setting up MAC-VRF on external FRR")
 		err = setupMACVRFOnExternalFRR(ictx, int(networkSpec.EVPN.MACVRF.VNI), macVRFVID, bridgeName, vxlanName)
 		if err != nil {
@@ -1361,11 +1260,8 @@ func runEVPNNetworkAndServers(
 	if hasIPVRF {
 		// Derive VRF name from VNI (unique per IP-VRF)
 		ipVRFName := fmt.Sprintf("vrf%d", networkSpec.EVPN.IPVRF.VNI)
-		ipVRFVID := randomVID()
-		for macVRFVID == ipVRFVID {
-			ipVRFVID = randomVID()
-		}
-		framework.Logf("Generated random VIDs for external FRR: IP-VRF VID=%d", ipVRFVID)
+		ipVRFVID := bgpAlloc.IPVRFVID
+		framework.Logf("Allocated VIDs for external FRR: IP-VRF VID=%d", ipVRFVID)
 		framework.Logf("Setting up IP-VRF on external FRR")
 		err = setupIPVRFOnExternalFRR(ictx, ipVRFName, int(networkSpec.EVPN.IPVRF.VNI), ipVRFVID, bridgeName, vxlanName)
 		if err != nil {

--- a/test/e2e/infraprovider/api/api.go
+++ b/test/e2e/infraprovider/api/api.go
@@ -75,10 +75,14 @@ type Underlay struct {
 	VlanID int
 }
 
+type ContextCleanUp interface {
+	AddCleanUpFn(func() error)
+}
+
 type Context interface {
+	ContextCleanUp
 	ExternalContainerContextProvider
 	ClusterContextProvider
-	AddCleanUpFn(func() error)
 }
 
 type ExternalContainerContextProvider interface {

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -24,6 +24,7 @@ import (
 	crdtypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/diagnostics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
@@ -48,7 +49,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/kubernetes/test/e2e/framework"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -1661,9 +1661,6 @@ passwd:
 			bgpASN = 64512
 		)
 		var (
-			// EVPN parameters: use random values for parallel test isolation.
-			macVRFVNI               = randomVNI()
-			ipVRFVNI                = randomVNI()
 			cudn                    *udnv1.ClusterUserDefinedNetwork
 			vm                      *kubevirtv1.VirtualMachine
 			vmi                     *kubevirtv1.VirtualMachineInstance
@@ -1671,7 +1668,6 @@ passwd:
 			staticIPv4, staticIPv6  string
 			staticMAC               = "02:00:00:00:00:01"
 			externalMACVRFContainer = infraapi.ExternalContainer{
-				Name:    fmt.Sprintf("iperf3-macvrf-%d", macVRFVNI),
 				Image:   images.Netshoot(),
 				CmdArgs: []string{"sleep", "infinity"},
 			}
@@ -1875,11 +1871,14 @@ write_files:
 			fr.Namespace = ns
 			namespace = fr.Namespace.Name
 
+			bgpAlloc, err := allocators.AllocateBGP(fr, providerCtx)
+			Expect(err).NotTo(HaveOccurred())
+
 			networkName := ""
 			// Each entry gets its own random subnet to avoid BGP route
 			// conflicts between entries (prior routed tests create RAs
 			// whose BGP routes may persist in FRR after async cleanup).
-			cidrIPv4, cidrIPv6 = randomCUDNSubnets()
+			cidrIPv4, cidrIPv6 = bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
 			staticIPv4 = subnetOffsetIP(cidrIPv4, 101)
 			staticIPv6 = subnetOffsetIP(cidrIPv6, 101)
 			dualCIDRs := filterDualStackCIDRs(fr.ClientSet, []udnv1.CIDR{udnv1.CIDR(cidrIPv4), udnv1.CIDR(cidrIPv6)})
@@ -1888,14 +1887,9 @@ write_files:
 			var externalContainer infraapi.ExternalContainer
 			var macVRFContainerIPs []string
 			if td.evpn != nil {
-				// Regenerate VNIs per attempt to avoid FRR zebra crashes
-				// when a flake-retry reuses VNIs before full cleanup
-				// (zebra_vxlan_if_vni_up assertion failure).
-				macVRFVNI = randomVNI()
-				ipVRFVNI = randomVNI()
-				td.evpn.MACVRF.VNI = macVRFVNI
-				td.evpn.IPVRF.VNI = ipVRFVNI
-				externalMACVRFContainer.Name = fmt.Sprintf("iperf3-macvrf-%d", macVRFVNI)
+				td.evpn.MACVRF.VNI = int32(bgpAlloc.MACVRFVNI)
+				td.evpn.IPVRF.VNI = int32(bgpAlloc.IPVRFVNI)
+				externalMACVRFContainer.Name = fmt.Sprintf("iperf3-macvrf-%d", bgpAlloc.MACVRFVNI)
 				// Shorten the CUDN name to fit Linux interface name limits.
 				// The name is used as testName for runEVPNNetworkAndServers which
 				// derives bridge/SVI names: worst-case SVI is "br<name>.4094"
@@ -1927,20 +1921,12 @@ write_files:
 
 				ipFamilies := sets.New(getSupportedIPFamiliesSlice(fr.ClientSet)...)
 
-				ipVRFAgnhostIPv4, ipVRFAgnhostIPv6 := randomIPVRFAgnhostSubnets()
-				ipVRFAgnhostSubnets := []string{ipVRFAgnhostIPv4, ipVRFAgnhostIPv6}
-				framework.Logf("Networks allocated for EVPN Agnhost servers: %v", ipVRFAgnhostSubnets)
 				// Use the kind network CIDRs as VTEP subnets for Unmanaged mode.
-				// In Unmanaged mode the node controller discovers each node's VTEP IP
-				// by matching its host-cidrs annotation against these CIDRs, so they
-				// must cover the existing node IPs. The external FRR container is also
-				// on the kind network, so VXLAN tunnels between nodes and FRR work
-				// without any additional routing.
-				kindNetwork, err := infraprovider.Get().GetNetwork("kind")
+				kindNetwork, err := infraprovider.Get().PrimaryNetwork()
 				Expect(err).NotTo(HaveOccurred())
-				vtepIPv4Subnet, _, err := kindNetwork.IPv4IPv6Subnets()
+				bgpAlloc.VTEPSubnet, _, err = kindNetwork.IPv4IPv6Subnets()
 				Expect(err).NotTo(HaveOccurred())
-				vtepSubnets := []string{vtepIPv4Subnet}
+				bgpAlloc.VTEPSubnet6 = ""
 
 				externalContainer = infraapi.ExternalContainer{
 					Name:    namespace + "-iperf",
@@ -1956,12 +1942,11 @@ write_files:
 					shortName,
 					ipFamilies,
 					&cudn.Spec.Network,
-					ipVRFAgnhostSubnets,
-					vtepSubnets,
+					bgpAlloc,
 					bgpASN,
 					"br"+shortName,
 					"vx"+shortName,
-					shortName+"-vtep",
+					sharedNodeIPsVTEPName,
 					&externalMACVRFContainer,
 					externalMACVRFContainer.Name,
 					&externalContainer,
@@ -2309,12 +2294,8 @@ ip route add %[3]s via %[4]s
 				role:     udnv1.NetworkRolePrimary,
 				ingress:  "routed",
 				evpn: &udnv1.EVPNConfig{
-					MACVRF: &udnv1.VRFConfig{
-						VNI: macVRFVNI,
-					},
-					IPVRF: &udnv1.VRFConfig{
-						VNI: ipVRFVNI,
-					},
+					MACVRF: &udnv1.VRFConfig{},
+					IPVRF:  &udnv1.VRFConfig{},
 				},
 			}),
 			Entry(nil, testData{

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -28,6 +28,7 @@ import (
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	udnclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
@@ -2055,15 +2056,6 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		bgpASN = 64512
 	)
 
-	randomBGPPeerSubnets := func() (ipv4, ipv6 string) {
-		// 8192 possible /29 subnets in 172.36.0.0/16
-		n := randomN(8192)
-		// 32 /29-aligned slots per third octet (256/8), so divide to get octet pair
-		third := n / 32
-		fourth := (n % 32) * 8
-		return fmt.Sprintf("172.36.%d.%d/29", third, fourth), fmt.Sprintf("fc00:%x::/112", n)
-	}
-
 	// configuration helper to setup infra
 	configureNetworkWithInfra := func(
 		f *framework.Framework,
@@ -2073,21 +2065,20 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		networkName string,
 		networkType networkType,
 		networkSpec *udnv1.NetworkSpec,
+		bgpAlloc allocators.BGPAllocation,
 	) (*corev1.Namespace, []string) {
 		ginkgo.GinkgoHelper()
+
+		framework.Logf("Configuring the infra for network %s of type %s with allocations %#v", networkName, networkType, bgpAlloc)
 
 		var servers []string
 		switch networkType {
 		case cudnAdvertisedVRFLite:
-			ginkgo.By("Running a BGP network with an agnhost server")
+			ginkgo.By("Running an external BGP network")
 			agnhostName := networkName + "-vrflite-agnhost"
 			agnhostNetworkName := agnhostName
-			bgpPeerSubnetV4, bgpPeerSubnetV6 := randomBGPPeerSubnets()
-			bgpPeerCIDRs := []string{bgpPeerSubnetV4, bgpPeerSubnetV6}
-			framework.Logf("Networks allocated for VRF-Lite BGP peers: %v", bgpPeerCIDRs)
-			bgpServerSubnetV4, bgpServerSubnetV6 := randomIPVRFAgnhostSubnets()
-			bgpServerCIDRs := []string{bgpServerSubnetV4, bgpServerSubnetV6}
-			framework.Logf("Networks allocated for VRF-Lite Agnhost servers: %v", bgpServerCIDRs)
+			bgpPeerCIDRs := []string{bgpAlloc.BGPPeerSubnet, bgpAlloc.BGPPeerSubnet6}
+			bgpServerCIDRs := []string{bgpAlloc.IPVRFSubnet, bgpAlloc.IPVRFSubnet6}
 			gomega.Expect(
 				runBGPNetworkAndServer(
 					f,
@@ -2102,36 +2093,23 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			).To(gomega.Succeed())
 			servers = append(servers, agnhostName)
 		case cudnAdvertisedEVPNUnmanagedSharedVTEP, cudnAdvertisedEVPNUnmanagedRandomVTEP:
-			ginkgo.By("Running a EVPN network with an agnhost server")
-			ipVRFAgnhostIPv4, ipVRFAgnhostIPv6 := randomIPVRFAgnhostSubnets()
-			ipVRFAgnhostSubnets := []string{ipVRFAgnhostIPv4, ipVRFAgnhostIPv6}
-			framework.Logf("Networks allocated for EVPN Agnhost servers: %v", ipVRFAgnhostSubnets)
+			ginkgo.By("Running an external EVPN network")
 
-			var vtepSubnets []string
-			var bridgeName, vxlanName, vtepName string
-			if networkType == cudnAdvertisedEVPNUnmanagedRandomVTEP {
-				// Random VTEP: per-network bridge, VTEP, and loopback IPs
-				vtepV4, _ := randomVTEPSubnets()
-				vtepSubnets = []string{vtepV4}
-				bridgeName = "br" + networkName
-				vxlanName = "vx" + networkName
-				vtepName = networkName + "-vtep"
-			} else {
-				// Shared VTEP: created by the first test that needs it,
-				// subsequent calls are idempotent (no-op). Never deleted.
-				// Bridge and VXLAN names are derived from testName so that
-				// multiple networks within the same test share one
-				// bridge+VXLAN on external FRR.
+			bridgeName := "br" + networkName
+			vxlanName := "vx" + networkName
+			vtepName := networkName + "-vtep"
+			// IPv6 VTEPs are not yet supported
+			bgpAlloc.VTEPSubnet6 = ""
+			if networkType != cudnAdvertisedEVPNUnmanagedRandomVTEP {
+				// KIND network subnet: node InternalIPs fall within this range,
+				// so the node-side controller can discover them via host-cidrs.
 				kindNetwork, err := infraprovider.Get().PrimaryNetwork()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				kindV4Subnet, _, err := kindNetwork.IPv4IPv6Subnets()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				vtepSubnets = []string{kindV4Subnet}
-				bridgeName = "br" + testName
-				vxlanName = "vx" + testName
+				bgpAlloc.VTEPSubnet = kindV4Subnet
 				vtepName = sharedNodeIPsVTEPName
 			}
-			framework.Logf("Networks used for EVPN VTEPs: %v (bridge=%s, vtep=%s)", vtepSubnets, bridgeName, vtepName)
 
 			macVRFContainer := infraapi.ExternalContainer{
 				Name:    networkName + "-macvrf-agnhost",
@@ -2152,8 +2130,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					networkName,
 					ipFamilySet,
 					networkSpec,
-					ipVRFAgnhostSubnets,
-					vtepSubnets,
+					bgpAlloc,
 					bgpASN,
 					bridgeName,
 					vxlanName,
@@ -2172,7 +2149,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			}
 		}
 
-		ginkgo.By("Configuring the namespace and network")
+		ginkgo.By("Configuring the namespace and CUDN")
 		testNamespace, err := createNamespaceWithPrimaryNetworkOfType(f, ictx, testName, networkName, networkType, networkSpec)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2330,68 +2307,68 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 	})
 
 	// define networks to test with
-	layer3NetworkSpecGen := func() *udnv1.NetworkSpec {
+	layer3NetworkSpecGen := func(udnIPv4, udnIPv6 string, _ allocators.BGPAllocation) *udnv1.NetworkSpec {
 		return &udnv1.NetworkSpec{
 			Topology: udnv1.NetworkTopologyLayer3,
 			Layer3: &udnv1.Layer3Config{
 				Role:    "Primary",
-				Subnets: randomL3CUDNSubnets(),
+				Subnets: []udnv1.Layer3Subnet{{CIDR: udnv1.CIDR(udnIPv4)}, {CIDR: udnv1.CIDR(udnIPv6)}},
 			},
 		}
 	}
-	layer2NetworkSpecGen := func() *udnv1.NetworkSpec {
+	layer2NetworkSpecGen := func(udnIPv4, udnIPv6 string, _ allocators.BGPAllocation) *udnv1.NetworkSpec {
 		return &udnv1.NetworkSpec{
 			Topology: udnv1.NetworkTopologyLayer2,
 			Layer2: &udnv1.Layer2Config{
 				Role:    "Primary",
-				Subnets: randomL2CUDNSubnets(),
+				Subnets: udnv1.DualStackCIDRs{udnv1.CIDR(udnIPv4), udnv1.CIDR(udnIPv6)},
 			},
 		}
 	}
-	layer2MACVRFNetworkSpecGen := func() *udnv1.NetworkSpec {
+	layer2MACVRFNetworkSpecGen := func(udnIPv4, udnIPv6 string, bgpAlloc allocators.BGPAllocation) *udnv1.NetworkSpec {
 		return &udnv1.NetworkSpec{
 			Topology: udnv1.NetworkTopologyLayer2,
 			Layer2: &udnv1.Layer2Config{
 				Role:    udnv1.NetworkRolePrimary,
-				Subnets: randomL2CUDNSubnets(),
+				Subnets: udnv1.DualStackCIDRs{udnv1.CIDR(udnIPv4), udnv1.CIDR(udnIPv6)},
 			},
 			Transport: udnv1.TransportOptionEVPN,
 			EVPN: &udnv1.EVPNConfig{
 				MACVRF: &udnv1.VRFConfig{
-					VNI: randomVNI(),
+					VNI: int32(bgpAlloc.MACVRFVNI),
 				},
 			},
 		}
 	}
-	layer2MACVRFIPVRFNetworkSpecGen := func() *udnv1.NetworkSpec {
+	layer2MACVRFIPVRFNetworkSpecGen := func(udnIPv4, udnIPv6 string, bgpAlloc allocators.BGPAllocation) *udnv1.NetworkSpec {
 		return &udnv1.NetworkSpec{
 			Topology: udnv1.NetworkTopologyLayer2,
 			Layer2: &udnv1.Layer2Config{
 				Role:    udnv1.NetworkRolePrimary,
-				Subnets: randomL2CUDNSubnets(),
+				Subnets: udnv1.DualStackCIDRs{udnv1.CIDR(udnIPv4), udnv1.CIDR(udnIPv6)},
 			},
 			Transport: udnv1.TransportOptionEVPN,
 			EVPN: &udnv1.EVPNConfig{
 				MACVRF: &udnv1.VRFConfig{
-					VNI: randomVNI(),
+					VNI: int32(bgpAlloc.MACVRFVNI),
 				},
 				IPVRF: &udnv1.VRFConfig{
-					VNI: randomVNI(),
+					VNI: int32(bgpAlloc.IPVRFVNI),
 				},
 			},
 		}
 	}
-	layer3IPVRFNetworkSpecGen := func() *udnv1.NetworkSpec {
+	layer3IPVRFNetworkSpecGen := func(udnIPv4, udnIPv6 string, bgpAlloc allocators.BGPAllocation) *udnv1.NetworkSpec {
 		return &udnv1.NetworkSpec{
 			Topology: udnv1.NetworkTopologyLayer3,
 			Layer3: &udnv1.Layer3Config{
 				Role:    udnv1.NetworkRolePrimary,
-				Subnets: randomL3CUDNSubnets(),
+				Subnets: []udnv1.Layer3Subnet{{CIDR: udnv1.CIDR(udnIPv4)}, {CIDR: udnv1.CIDR(udnIPv6)}},
 			},
 			Transport: udnv1.TransportOptionEVPN,
 			EVPN: &udnv1.EVPNConfig{
 				IPVRF: &udnv1.VRFConfig{
-					VNI: randomVNI(),
+					VNI: int32(bgpAlloc.IPVRFVNI),
 				},
 			},
 		}
@@ -2409,7 +2386,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 	}
 
 	ginkgo.DescribeTableSubtree("When the tested network is of type",
-		func(testedNetworkType networkType, networkSpecGen func() *udnv1.NetworkSpec) {
+		func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
 			var testNamespace *corev1.Namespace
 			var testPod *corev1.Pod
 
@@ -2430,7 +2407,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			}
 
 			ginkgo.BeforeEach(func() {
-				networkSpec := networkSpecGen()
+				bgpAlloc, err := allocators.AllocateBGP(f, ictx)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
+
+				networkSpec := networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
 				switch {
 				case networkSpec.Layer3 != nil:
 					networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
@@ -2446,6 +2427,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					testNetworkName,
 					testedNetworkType,
 					networkSpec,
+					bgpAlloc,
 				)
 			})
 
@@ -2696,7 +2678,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 
 				ginkgo.Describe("When there is other network", func() {
 
-					nilNetworkSpecGen := func() *udnv1.NetworkSpec {
+					nilNetworkSpecGen := func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec {
 						return nil
 					}
 
@@ -2717,7 +2699,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					}
 
 					ginkgo.DescribeTableSubtree("Of type",
-						func(networkType networkType, otherNetworkSpecGen func() *udnv1.NetworkSpec) {
+						func(networkType networkType, otherNetworkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
 							var otherNamespace *corev1.Namespace
 							var otherNetworkName string
 
@@ -2725,7 +2707,11 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 								otherNetworkName = testBaseName + "o"
 								otherNamespaceName := otherNetworkName
 
-								otherNetworkSpec := otherNetworkSpecGen()
+								otherBGPAlloc, err := allocators.AllocateBGP(f, ictx)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								otherUDNIPv4, otherUDNIPv6 := otherBGPAlloc.UDNSubnet, otherBGPAlloc.UDNSubnet6
+
+								otherNetworkSpec := otherNetworkSpecGen(otherUDNIPv4, otherUDNIPv6, otherBGPAlloc)
 								switch {
 								case otherNetworkSpec == nil:
 									otherNetworkName = "default"
@@ -2743,6 +2729,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 									otherNamespaceName,
 									networkType,
 									otherNetworkSpec,
+									otherBGPAlloc,
 								)
 							})
 
@@ -3171,11 +3158,11 @@ func runBGPNetworkAndServer(
 type networkType string
 
 const (
-	defaultNetwork               networkType = "DEFAULT"
-	udn                          networkType = "UDN"
-	cudn                         networkType = "CUDN"
-	cudnAdvertised               networkType = "CUDN_ADVERTISED"
-	cudnAdvertisedVRFLite        networkType = "CUDN_ADVERTISED_VRFLITE"
+	defaultNetwork                        networkType = "DEFAULT"
+	udn                                   networkType = "UDN"
+	cudn                                  networkType = "CUDN"
+	cudnAdvertised                        networkType = "CUDN_ADVERTISED"
+	cudnAdvertisedVRFLite                 networkType = "CUDN_ADVERTISED_VRFLITE"
 	cudnAdvertisedEVPNUnmanagedSharedVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_SHARED_VTEP"
 	cudnAdvertisedEVPNUnmanagedRandomVTEP networkType = "CUDN_ADVERTISED_EVPN_UNMANAGED_RANDOM_VTEP"
 )


### PR DESCRIPTION
Replace randomVID, randomVNI, randomCUDNSubnets, randomVTEPSubnets,
randomIPVRFAgnhostSubnets, and randomBGPPeerSubnets with allocators
backed by ConfigMaps for collision-free parallel test isolation.

Introduces the allocators package with:
- AllocateInt/DeallocateInt: ConfigMap-backed integer allocator with
  optimistic concurrency and retry on conflict or allocation-full.
- AllocateUDNSubnets: allocates fixed overlapping UDN subnets within an infra compatible range.
- AllocateBGP: allocates UDN BGP peer subnets, IP-VRF subnets, VTEP
  subnets, VNIs and VIDs from a single integer seed within an infra compatible range.

Narrow subnet ranges to 1024, we should not need anything bigger now
that we are not randomizing them.