### PR TITLE
contrib: refresh OVN pods on kind-helm.sh --deploy

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -93,6 +93,9 @@ set_common_default_params() {
   OVN_IMAGE=${OVN_IMAGE:-local}
   OVN_REPO=${OVN_REPO:-""}
   OVN_GITREF=${OVN_GITREF:-""}
+  # Pods to force-delete on --deploy so they respawn with the kind-loaded image.
+  # ovs-node excluded: restarting it under live ovnkube-node pods breaks the cluster.
+  OVN_DEPLOY_PODS=${OVN_DEPLOY_PODS:-"ovnkube-identity ovnkube-control-plane ovnkube-node"}
 
   # Subnet params
   # Input not currently validated. Modify outside script at your own risk.
@@ -1027,6 +1030,14 @@ install_jinjanator_renderer() {
 
 install_ovn_image() {
   install_image "${OVN_IMAGE}"
+}
+
+# Force-respawn OVN pods so their controllers pick up the kind-loaded image
+# on --deploy, where helm sees no spec diff (OVN_IMAGE tag is fixed).
+refresh_ovn_pods() {
+  for pod in ${OVN_DEPLOY_PODS}; do
+    kubectl delete pod -n ovn-kubernetes -l name="${pod}" --ignore-not-found
+  done
 }
 
 # install_image accepts the image name along with the tag as an argument and installs it.

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -629,6 +629,11 @@ if [ "$KIND_REMOVE_TAINT" == true ]; then
 fi
 create_ovn_kubernetes
 
+# --deploy: helm sees no spec diff (same OVN_IMAGE tag), so refresh pods manually.
+if [ "$KIND_CREATE" == false ] && [ "$KIND_LOCAL_REGISTRY" == false ]; then
+  refresh_ovn_pods
+fi
+
 install_online_ovn_kubernetes_crds
 if [ "$KIND_INSTALL_INGRESS" == true ]; then
   install_ingress


### PR DESCRIPTION
This was wrongfully dropped in 80be988d0, recover the funcionality so that pods are deleted for same tag redeploy. ovs-node is deliberately ommited.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * OVN pods are now refreshed by default so they respawn with updated images during kind cluster deployments.
  * During certain Helm deployment scenarios, the deployment forces a refresh of OVN components to ensure updated pods are running before CRDs are installed and deployment completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->