### PR TITLE
node: use ofPortHost in hostNetworkNormalActionFlows instead of hardcoded LOCAL

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -168,7 +168,7 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 			// table0, Geneve packets coming from LOCAL. Skip conntrack and send to external
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp6, udp_dst=%d, "+
-					"actions=output:%s", nodetypes.DefaultOpenFlowCookie, nodetypes.OvsLocalPort, config.Default.EncapPort, ofPortPhys))
+					"actions=output:%s", nodetypes.DefaultOpenFlowCookie, ofPortHost, config.Default.EncapPort, ofPortPhys))
 		}
 
 		physicalIP, err := util.MatchFirstIPNetFamily(true, bridgeIPs)
@@ -653,7 +653,7 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 					// Allow (a) OVN->host traffic on the same node
 					// (b) host->host traffic on the same node
 					if config.Gateway.Mode == config.GatewayModeShared || config.Gateway.Mode == config.GatewayModeLocal {
-						dftFlows = append(dftFlows, hostNetworkNormalActionFlows(netConfig, bridgeMacAddress, hostSubnets, false)...)
+						dftFlows = append(dftFlows, hostNetworkNormalActionFlows(netConfig, bridgeMacAddress, ofPortHost, hostSubnets, false)...)
 					}
 				} else {
 					//  for UDN we additionally SNAT the packet from masquerade IP -> node IP
@@ -754,7 +754,7 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 					// Allow (a) OVN->host traffic on the same node
 					// (b) host->host traffic on the same node
 					if config.Gateway.Mode == config.GatewayModeShared || config.Gateway.Mode == config.GatewayModeLocal {
-						dftFlows = append(dftFlows, hostNetworkNormalActionFlows(netConfig, bridgeMacAddress, hostSubnets, true)...)
+						dftFlows = append(dftFlows, hostNetworkNormalActionFlows(netConfig, bridgeMacAddress, ofPortHost, hostSubnets, true)...)
 					}
 				} else {
 					//  for UDN we additionally SNAT the packet from masquerade IP -> node IP
@@ -1044,7 +1044,7 @@ func getIPv(ipnet *net.IPNet) string {
 // when the localnet is mapped to breth0.
 // The expected srcMAC is the MAC address of breth0 and the expected hostSubnets is the host subnets found on the node
 // primary interface.
-func hostNetworkNormalActionFlows(netConfig *BridgeUDNConfiguration, srcMAC string, hostSubnets []*net.IPNet, isV6 bool) []string {
+func hostNetworkNormalActionFlows(netConfig *BridgeUDNConfiguration, srcMAC, ofPortHost string, hostSubnets []*net.IPNet, isV6 bool) []string {
 	var flows []string
 	var ipFamily, ipFamilyDest string
 
@@ -1088,7 +1088,7 @@ func hostNetworkNormalActionFlows(netConfig *BridgeUDNConfiguration, srcMAC stri
 		if utilnet.IsIPv6(hostSubnet.IP) != isV6 {
 			continue
 		}
-		flows = append(flows, formatFlow(nodetypes.OvsLocalPort, hostSubnet.String(), nodetypes.CtMarkHost))
+		flows = append(flows, formatFlow(ofPortHost, hostSubnet.String(), nodetypes.CtMarkHost))
 	}
 
 	if isV6 {
@@ -1116,7 +1116,7 @@ func hostNetworkNormalActionFlows(netConfig *BridgeUDNConfiguration, srcMAC stri
 
 			// Traffic path (a) for ICMP: OVN->localnet for local gw mode
 			// Traffic path (b) for ICMP: host->localnet for both gw modes
-			flows = append(flows, formatICMPFlow(nodetypes.OvsLocalPort, nodetypes.CtMarkHost, icmpType))
+			flows = append(flows, formatICMPFlow(ofPortHost, nodetypes.CtMarkHost, icmpType))
 		}
 	}
 	return flows


### PR DESCRIPTION
## 📑 Description
Fix host-network localnet flows so same-node host traffic matches the actual host-side ingress port on accelerated-gateway topologies.

The previous flow generation hardcoded `in_port=LOCAL` inside `hostNetworkNormalActionFlows()`. That works for plain `breth0` localnet mappings, but on accelerated gateway deployments the gateway IP lives on a VF and host packets enter through the VF representor. This patch threads `ofPortHost` into the helper and uses it for the host subnet and ICMP normal-action flows, matching the rest of `commonFlows()`.

Fixes: None

## Additional Information for reviewers
This is intentionally scoped to the host-network normal-action flows used for localnet delivery. On plain `breth0` topologies `ofPortHost` remains `LOCAL`, so the rendered flows are unchanged there.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it
Render or inspect the generated OpenFlow entries for an accelerated-gateway node with a localnet UDN. The priority 102 host-to-same-subnet localnet flow should use the VF representor `ofPortHost` value instead of `LOCAL`, while plain `breth0` deployments should continue rendering `LOCAL`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default network connectivity handling for both IPv4 and IPv6.
  * Fixed issues affecting host↔local network traffic and IPv6 neighbor discovery to ensure more reliable local networking and packet routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->