### PR TITLE
Fix data race in DPU management port tests

### DIFF
--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -413,6 +413,7 @@ func testManagementPortDPU(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.
 		stop := make(chan struct{})
 		err = mgmtPortController.Start(stop)
 		Expect(err).NotTo(HaveOccurred())
+		defer close(stop)
 		Eventually(func(g Gomega) {
 			l, err := netlink.LinkByName(mgtPort)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -520,6 +521,7 @@ func testManagementPortDPUHost(ctx *cli.Context, fexec *ovntest.FakeExec, testNS
 		stop := make(chan struct{})
 		err = mgmtPortController.Start(stop)
 		Expect(err).NotTo(HaveOccurred())
+		defer close(stop)
 		Eventually(func(g Gomega) {
 			l, err := netlink.LinkByName(mgtPort)
 			g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
testManagementPortDPU and testManagementPortDPUHost both create a stop channel and pass it to mgmtPortController.Start(stop), which spawns a background goroutine that periodically calls doReconcile -> checkRepresentorPortHealth -> util.GetNetLinkOps().LinkByName(...). However, this stop channel was never closed, so the goroutine leaked past the test. When the next test's BeforeEach called util.SetNetLinkOpMockInst(netlinkOpsMock) to replace the global mock, it raced with the leaked goroutine still reading the old mock instance.

Add defer close(stop) after mgmtPortController.Start(stop) in both functions, matching the pattern already used in testManagementPort.

Fixes #6411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of management port controller tests by ensuring proper cleanup and teardown of the controller run loop in both DPU and DPU-host test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6412)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->