### PR TITLE
Remove dead raft variable definitions from ovnkube.sh

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -63,10 +63,6 @@ fi
 # OVN_ACL_LOGGING_RATE_LIMIT - specify default ACL logging rate limit in messages per second (default: 20)
 # OVN_NB_PORT - ovn north db port (default 6641)
 # OVN_SB_PORT - ovn south db port (default 6642)
-# OVN_NB_RAFT_PORT - ovn north db raft port (default 6643)
-# OVN_SB_RAFT_PORT - ovn south db raft port (default 6644)
-# OVN_NB_RAFT_ELECTION_TIMER - ovn north db election timer in ms (default 1000)
-# OVN_SB_RAFT_ELECTION_TIMER - ovn south db election timer in ms (default 1000)
 # OVN_SSL_ENABLE - use SSL transport to NB/SB db and northd (default: no)
 # OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
 # OVN_MONITOR_ALL - ovn-controller monitor all data in SB DB
@@ -216,16 +212,8 @@ ovn_db_host=${K8S_NODE_IP:-""}
 ovn_nb_port=${OVN_NB_PORT:-6641}
 # OVN_SB_PORT - ovn south db port (default 6642)
 ovn_sb_port=${OVN_SB_PORT:-6642}
-# OVN_NB_RAFT_PORT - ovn north db port used for raft communication (default 6643)
-ovn_nb_raft_port=${OVN_NB_RAFT_PORT:-6643}
-# OVN_SB_RAFT_PORT - ovn south db port used for raft communication (default 6644)
-ovn_sb_raft_port=${OVN_SB_RAFT_PORT:-6644}
 # OVN_ENCAP_PORT - GENEVE UDP port (default 6081)
 ovn_encap_port=${OVN_ENCAP_PORT:-6081}
-# OVN_NB_RAFT_ELECTION_TIMER - ovn north db election timer in ms (default 1000)
-ovn_nb_raft_election_timer=${OVN_NB_RAFT_ELECTION_TIMER:-1000}
-# OVN_SB_RAFT_ELECTION_TIMER - ovn south db election timer in ms (default 1000)
-ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
 
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE:-}
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR:-}


### PR DESCRIPTION
## 📑 Description

Clean up leftover raft-related dead code from `dist/images/ovnkube.sh` that was missed by https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6303 (Remove central mode support).

The four shell variables (`ovn_nb_raft_port`, `ovn_sb_raft_port`, `ovn_nb_raft_election_timer`, `ovn_sb_raft_election_timer`) and their documentation comments are defined but never referenced anywhere in the codebase.

## Additional Information for reviewers

PR #6303 removed raft support (the `ovndb-raft-functions.sh` file, the `nb-ovsdb-raft`/`sb-ovsdb-raft` case entries, and the sourcing of the raft script), but left behind these variable definitions and their env var comments. A grep across the entire repo confirms these variables have zero consumers.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI
