### PR TITLE
Fix performance report

### DIFF
--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -63,8 +63,6 @@ jobs:
               cd ../..
             fi
 
-            # Clean up
-            rm -rf "$dir"
           fi
         done
 
@@ -101,7 +99,7 @@ jobs:
         fi
         
         # Find all metrics directories from extracted performance test data
-        METRICS_DIRS=$(find perf-data -name "metrics" -type d 2>/dev/null || true)
+        METRICS_DIRS=$(find . -path "*performance-test-data*/perf/metrics" -type d 2>/dev/null || true)
         
         if [ -z "$METRICS_DIRS" ]; then
           echo "::warning::No metrics directories found in artifacts, skipping indexing"
@@ -114,7 +112,7 @@ jobs:
         # Index each metrics directory
         for METRICS_DIR in $METRICS_DIRS; do
           # Extract workload name from path (e.g., perf-data/kubelet-density-cni/...)
-          WORKLOAD=$(echo "$METRICS_DIR" | cut -d'/' -f2)
+          WORKLOAD=$(echo "$METRICS_DIR" | cut -d'/' -f2 | sed 's/-performance-test-data-.*//')
           echo ""
           echo "=== Indexing metrics for workload: $WORKLOAD ==="
           echo "Metrics directory: $METRICS_DIR"
@@ -236,7 +234,7 @@ jobs:
       if: steps.get_prs.outputs.pr_numbers != '[]'
       run: |
         # Extract PR numbers from JSON array
-        PR_NUMBERS=$(echo '${{ steps.get_prs.outputs.pr_numbers }}' | python3 -c "import sys, json; print(' '.join(['--pr', str(pr) for pr in json.load(sys.stdin)]))")
+        PR_NUMBERS=$(echo '${{ steps.get_prs.outputs.pr_numbers }}' | python3 -c "import sys, json; print(' '.join(f'--pr {pr}' for pr in json.load(sys.stdin)))")
 
         if [ -n "$PR_NUMBERS" ]; then
           contrib/perf/post-pr-comment.py \

--- a/contrib/perf/get-pr-info.py
+++ b/contrib/perf/get-pr-info.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import os
 import sys
+import subprocess
 from pathlib import Path
 from typing import List
 
@@ -44,8 +45,8 @@ def get_prs_from_event_file(event_path: Path) -> List[int]:
     """
     Extract PR numbers from GitHub event file.
 
-    This is the most reliable method as it uses the workflow_run.pull_requests
-    data directly from the event payload.
+    For pull_request events, searches for PRs matching the head_branch.
+    For other events (schedule, etc.), returns empty list.
     """
     if not event_path.exists():
         print(f"Error: Event file not found: {event_path}", file=sys.stderr)
@@ -54,19 +55,45 @@ def get_prs_from_event_file(event_path: Path) -> List[int]:
     with open(event_path, 'r') as f:
         event_data = json.load(f)
 
-    # Get pull requests from workflow_run event
-    pull_requests = event_data.get('workflow_run', {}).get('pull_requests', [])
+    workflow_run = event_data.get('workflow_run', {})
 
-    pr_numbers = [pr['number'] for pr in pull_requests]
+    # Only search for PRs if the triggering workflow was a pull_request event
+    if workflow_run.get('event') != 'pull_request':
+        return []
 
-    return pr_numbers
+    head_branch = workflow_run.get('head_branch')
+    if not head_branch:
+        return []
+
+    print(f"Searching for PRs by head_branch: {head_branch}", file=sys.stderr)
+
+    # Use gh CLI to search for PRs by head branch
+    try:
+        result = subprocess.run(
+            ['gh', 'pr', 'list', '--head', head_branch, '--json', 'number', '--jq', '.[].number'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        if result.stdout.strip():
+            pr_numbers = [int(n) for n in result.stdout.strip().split('\n') if n]
+            if pr_numbers:
+                print(f"Found PR(s): {pr_numbers}", file=sys.stderr)
+            return pr_numbers
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"Warning: gh CLI failed: {e}", file=sys.stderr)
+        return []
+
+    return []
 
 
 def get_prs_from_api(owner: str, repo: str, run_id: int, token: str) -> List[int]:
     """
     Get PR numbers from workflow run via GitHub API.
 
-    Uses the workflow_run.pull_requests field from the API.
+    For pull_request events, searches for PRs matching the head_branch.
+    For other events (schedule, etc.), returns empty list.
     """
     url = f"https://api.github.com/repos/{owner}/{repo}/actions/runs/{run_id}"
     headers = {
@@ -78,11 +105,36 @@ def get_prs_from_api(owner: str, repo: str, run_id: int, token: str) -> List[int
     response.raise_for_status()
 
     data = response.json()
-    pull_requests = data.get('pull_requests', [])
 
-    pr_numbers = [pr['number'] for pr in pull_requests]
+    # Only search for PRs if this was a pull_request event
+    if data.get('event') != 'pull_request':
+        return []
 
-    return pr_numbers
+    head_branch = data.get('head_branch')
+    if not head_branch:
+        return []
+
+    print(f"Searching for PRs by head_branch: {head_branch}", file=sys.stderr)
+
+    # Use gh CLI to search for PRs by head branch
+    try:
+        result = subprocess.run(
+            ['gh', 'pr', 'list', '--head', head_branch, '--json', 'number', '--jq', '.[].number'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        if result.stdout.strip():
+            pr_numbers = [int(n) for n in result.stdout.strip().split('\n') if n]
+            if pr_numbers:
+                print(f"Found PR(s): {pr_numbers}", file=sys.stderr)
+            return pr_numbers
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"Warning: gh CLI failed: {e}", file=sys.stderr)
+        return []
+
+    return []
 
 
 def main():


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
The report was skipping :
- indexing results (due to the rm of the perf-data)
- capturing the baseline run and reporting the diff to the PR due to how I was capturing the PR #.

Both issues are addressed.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stopped removing extracted performance-artifact directories after report generation.
  * Improved discovery of workload metric directories from the workspace root.
  * Changed workload name extraction to strip the performance-test-data suffix for consistent IDs.
  * Switched PR detection to a branch-based CLI lookup with a safe fallback to no-PR when unavailable.
  * Adjusted how PR arguments are assembled when posting results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->