### PR TITLE
Eliminate Node.DeepCopy in cache operations

### DIFF
--- a/go-controller/pkg/controllers/node/node_controller.go
+++ b/go-controller/pkg/controllers/node/node_controller.go
@@ -566,18 +566,17 @@ func parseScopedNodeQueueKey(key string) (nodeName, netName string) {
 	return parts[0], parts[1]
 }
 
-// Get returns a deep copy of a cached node by name.
+// getCachedNode returns a cached node by name for read-only access.
+// WARNING: The returned node MUST NOT be modified. It is a shared reference
+// from the controller cache. All verified usages are read-only.
 func (c *NodeController) getCachedNode(netName, nodeName string) *corev1.Node {
 	c.stateMu.RLock()
 	defer c.stateMu.RUnlock()
-	node := c.nodeCache[netName][nodeName]
-	if node == nil {
-		return nil
-	}
-	return node.DeepCopy()
+	return c.nodeCache[netName][nodeName]
 }
 
-// Set stores a deep copy of a node.
+// setCachedNode stores a reference to the node in cache.
+// The node is from the k8s informer cache (immutable), safe to cache by reference.
 func (c *NodeController) setCachedNode(netName string, node *corev1.Node) {
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
@@ -589,19 +588,19 @@ func (c *NodeController) setCachedNode(netName string, node *corev1.Node) {
 		c.nodeCache[netName] = make(map[string]*corev1.Node)
 	}
 
-	c.nodeCache[netName][node.Name] = node.DeepCopy()
+	c.nodeCache[netName][node.Name] = node
 }
 
+// getLatestInformerNode returns the latest informer node for read-only access.
+// WARNING: The returned node MUST NOT be modified. It is a shared reference.
 func (c *NodeController) getLatestInformerNode(netName, nodeName string) *corev1.Node {
 	c.stateMu.RLock()
 	defer c.stateMu.RUnlock()
-	node := c.latestInformerNodeCache[netName][nodeName]
-	if node == nil {
-		return nil
-	}
-	return node.DeepCopy()
+	return c.latestInformerNodeCache[netName][nodeName]
 }
 
+// setLatestInformerNode stores a reference to the latest informer node in cache.
+// The node is from the k8s informer cache (immutable), safe to cache by reference.
 func (c *NodeController) setLatestInformerNode(netName string, node *corev1.Node) {
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
@@ -613,7 +612,7 @@ func (c *NodeController) setLatestInformerNode(netName string, node *corev1.Node
 		c.latestInformerNodeCache[netName] = make(map[string]*corev1.Node)
 	}
 
-	c.latestInformerNodeCache[netName][node.Name] = node.DeepCopy()
+	c.latestInformerNodeCache[netName][node.Name] = node
 }
 
 // Delete removes a node from the cache.


### PR DESCRIPTION
Strip unnecessary fields from cached node objects to reduce memory footprint.
Remove unnecessary DeepCopy() calls on Node objects in node_controller.go to improve performance and reduce memory allocations during node sync.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
Replace DeepCopy() with direct field access where mutation is not needed to improve performance.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized node caching: reads now return shared cached node references and stored entries are compacted to reduce memory usage and improve controller performance.

* **Documentation**
  * Clarified that cached node references must be treated as immutable to avoid accidental modification and ensure safe, predictable behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->