### PR TITLE
Configure advertised UDN nftables on node init

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -220,6 +220,13 @@ func NewDefaultNodeNetworkController(cnnci *CommonNodeNetworkControllerInfo, net
 			return nil, fmt.Errorf("failed to setup PMTUD nftables chain: %w", err)
 		}
 
+		if util.IsRouteAdvertisementsEnabled() {
+			err = configureAdvertisedUDNIsolationNFTables()
+			if err != nil {
+				return nil, fmt.Errorf("failed to setup advertised UDN isolation nftables: %w", err)
+			}
+		}
+
 		// Setup nftables sets for no-overlay SNAT exemption in LGW mode.
 		// In SGW mode, OVN address sets are used instead.
 		if config.Default.Transport == types.NetworkTransportNoOverlay && config.NoOverlay.OutboundSNAT == types.NoOverlaySNATEnabled && config.Gateway.Mode == config.GatewayModeLocal {

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -2195,6 +2195,37 @@ add element inet ovn-kubernetes remote-node-ips-v6 { 2002:db8:1::4 }
 			}()),
 		)
 	})
+
+	Describe("advertised UDN isolation nftables", func() {
+		const nodeName = "my-node"
+
+		BeforeEach(func() {
+			Expect(config.PrepareTestConfig()).To(Succeed())
+		})
+
+		It("sets up isolation sets for DPU host mode without NodePort", func() {
+			config.OvnKubeNode.Mode = types.NodeModeDPUHost
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+			config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+			config.Gateway.NodeportEnable = false
+
+			nft := nodenft.SetFakeNFTablesHelper()
+			ovnClient := util.GetOVNClientset()
+			wf, err := factory.NewNodeWatchFactory(ovnClient.GetNodeClientset(), nodeName)
+			Expect(err).NotTo(HaveOccurred())
+			defer wf.Shutdown()
+
+			routeManager := routemanager.NewController()
+			cnnci := NewCommonNodeNetworkControllerInfo(ovnClient.KubeClient, ovnClient.AdminPolicyRouteClient, wf, nil, nodeName, routeManager)
+			_, err = NewDefaultNodeNetworkController(cnnci, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = nft.ListElements(context.TODO(), "set", nftablesAdvertisedUDNsSetV4)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = nft.ListElements(context.TODO(), "set", nftablesAdvertisedUDNsSetV6)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 })
 
 // Helper function to create string pointer

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1900,11 +1900,6 @@ func newNodePortWatcher(
 				return nil, fmt.Errorf("unable to configure UDN nftables: %w", err)
 			}
 		}
-		if util.IsRouteAdvertisementsEnabled() {
-			if err := configureAdvertisedUDNIsolationNFTables(); err != nil {
-				return nil, fmt.Errorf("unable to configure UDN isolation nftables: %w", err)
-			}
-		}
 
 		var subnets []*net.IPNet
 		for _, subnet := range config.Default.ClusterSubnets {

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1230,6 +1230,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		config.Gateway.NodeportEnable = true
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.OVNKubernetesFeature.EnableRouteAdvertisements = true
+		Expect(configureAdvertisedUDNIsolationNFTables()).To(Succeed())
 		ifAddrs := ovntest.MustParseIPNets(v4NodeIP, v6NodeIP)
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
DPU-host mode updates advertised UDN isolation nftables for primary UDNs, but the base sets were only configured from the full-mode NodePort watcher path. That left DPU-host nodes without the advertised UDN subnet sets when NodePort was disabled.

Move the setup into default node controller initialization for full and DPU-host mode, and keep the existing route advertisements feature gate. Add a DPU-host test that covers NodePort-disabled startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds configuration for advertised User-Defined Network (UDN) isolation when route advertisements are enabled; initialization will now fail if that isolation setup cannot be applied.

* **Tests**
  * New test suite verifying advertised UDN isolation configuration in DPU host mode when NodePort is disabled.
  * Added an assertion ensuring advertised UDN isolation setup completes before further advertised-UDN checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->