### PR TITLE
Resolve simulated DPU representors by alias

### DIFF
--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -186,10 +186,22 @@ func (s *SimulatedDPUOps) generateMACForHostToDpu(nodeName, role string, index i
 // getDPURepresentor builds rep<pfId>-<funcId> and verifies the link exists.
 func (s *SimulatedDPUOps) getDPURepresentor(pfId, funcId string) (string, error) {
 	rep := fmt.Sprintf(dpusim.DPURepresentorFmt, pfId, funcId)
-	if _, err := GetNetLinkOps().LinkByName(rep); err != nil {
-		return "", fmt.Errorf("simulated representor %s not found: %v", rep, err)
+	if _, err := GetNetLinkOps().LinkByName(rep); err == nil {
+		return rep, nil
 	}
-	return rep, nil
+
+	links, err := GetNetLinkOps().LinkList()
+	if err != nil {
+		return "", fmt.Errorf("simulated representor %s not found and link list failed: %v", rep, err)
+	}
+	for _, link := range links {
+		attrs := link.Attrs()
+		if attrs != nil && attrs.Alias == rep {
+			klog.Infof("Resolved simulated representor %s by alias on netdev %s", rep, attrs.Name)
+			return attrs.Name, nil
+		}
+	}
+	return "", fmt.Errorf("simulated representor %s not found: link name or alias not present", rep)
 }
 
 func (s *SimulatedDPUOps) GetDPUHostRepInterface(_ string) (string, error) {


### PR DESCRIPTION
OVN-Kubernetes renames the simulated management representor to ovn-k8s-mp0 and preserves the original rep0-X name as the link alias. Fall back to alias lookup so DPU-mode restarts and Helm rollouts can find the representor after it has been renamed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DPU representor lookup to fall back to alias-based resolution when direct name matching fails, increasing reliability.

* **Improvements**
  * Refined error reporting to more clearly distinguish between failures listing links and missing representor definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->