### PR TITLE
ovn: drop dead IPAMClaim watch from ovnkube-controller

### DIFF
--- a/go-controller/pkg/ovn/base_event_handler.go
+++ b/go-controller/pkg/ovn/base_event_handler.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"reflect"
 
-	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,8 +35,7 @@ func hasResourceAnUpdateFunc(objType reflect.Type) bool {
 		factory.EgressIPPodType,
 		factory.EgressNodeType,
 		factory.NamespaceType,
-		factory.MultiNetworkPolicyType,
-		factory.IPAMClaimsType:
+		factory.MultiNetworkPolicyType:
 		return true
 	}
 	return false
@@ -116,17 +114,6 @@ func (h *baseNetworkControllerEventHandler) areResourcesEqual(objType reflect.Ty
 			mnp1.Annotations[ovnStatelessNetPolAnnotationName] == mnp2.Annotations[ovnStatelessNetPolAnnotationName] &&
 			mnp1.Annotations[PolicyForAnnotation] == mnp2.Annotations[PolicyForAnnotation]
 		return areEqual, nil
-
-	case factory.IPAMClaimsType:
-		ipamClaim1, ok := obj1.(*ipamclaimsapi.IPAMClaim)
-		if !ok {
-			return false, fmt.Errorf("could not cast obj1 of type %T to *ipamclaimsapi.IPAMClaim", obj1)
-		}
-		ipamClaim2, ok := obj2.(*ipamclaimsapi.IPAMClaim)
-		if !ok {
-			return false, fmt.Errorf("could not cast obj2 of type %T to *ipamclaimsapi.IPAMClaim", obj2)
-		}
-		return reflect.DeepEqual(ipamClaim1, ipamClaim2), nil
 	}
 
 	return false, fmt.Errorf("no object comparison for type %s", objType)
@@ -169,9 +156,6 @@ func (h *baseNetworkControllerEventHandler) getResourceFromInformerCache(objType
 
 	case factory.MultiNetworkPolicyType:
 		obj, err = watchFactory.GetMultiNetworkPolicy(namespace, name)
-
-	case factory.IPAMClaimsType:
-		obj, err = watchFactory.GetIPAMClaim(namespace, name)
 
 	default:
 		err = fmt.Errorf("object type %s not supported, cannot retrieve it from informers cache",

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -46,7 +46,6 @@ import (
 	lsm "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/routeimport"
 	zoneic "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/persistentips"
 	ovnretry "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -118,8 +117,6 @@ type BaseNetworkController struct {
 
 	// An utility to allocate the PodAnnotation to pods
 	podAnnotationAllocator *pod.PodAnnotationAllocator
-
-	ipamClaimsReconciler *persistentips.IPAMClaimReconciler
 
 	// A cache of all logical ports known to the controller
 	logicalPortCache *PortCache

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -101,8 +101,6 @@ type BaseNetworkController struct {
 	retryNetworkPolicies *ovnretry.RetryFramework
 	// retry framework for network policies
 	retryMultiNetworkPolicies *ovnretry.RetryFramework
-	// retry framework for IPAMClaims
-	retryIPAMClaims *ovnretry.RetryFramework
 
 	// nodeReconciler is the shared node controller used by controllers that
 	// reconcile node topology through pkg/controllers/node.
@@ -114,8 +112,6 @@ type BaseNetworkController struct {
 	podHandler *factory.Handler
 	// namespace events factory Handler
 	namespaceHandler *factory.Handler
-	// ipam claims events factory Handler
-	ipamClaimsHandler *factory.Handler
 
 	// A cache of all logical switches seen by the watcher and their subnets
 	lsManager *lsm.LogicalSwitchManager

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -4,14 +4,12 @@
 package ovn
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"reflect"
 	"strings"
 	"time"
 
-	ipamclaimsapi "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
 	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -35,7 +33,6 @@ import (
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/persistentips"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
@@ -98,8 +95,6 @@ func (bsnc *BaseUserDefinedNetworkController) AddUserDefinedNetworkResourceCommo
 				mp.Namespace, mp.Name, err)
 			return err
 		}
-	case factory.IPAMClaimsType:
-		return nil
 
 	default:
 		return bsnc.AddResourceCommon(objType, obj)
@@ -160,8 +155,6 @@ func (bsnc *BaseUserDefinedNetworkController) UpdateUserDefinedNetworkResourceCo
 				return err
 			}
 		}
-	case factory.IPAMClaimsType:
-		return nil
 
 	default:
 		return fmt.Errorf("object type %s not supported", objType)
@@ -203,25 +196,6 @@ func (bsnc *BaseUserDefinedNetworkController) DeleteUserDefinedNetworkResourceCo
 				mp.Namespace, mp.Name, err)
 			return err
 		}
-
-	case factory.IPAMClaimsType:
-		ipamClaim, ok := obj.(*ipamclaimsapi.IPAMClaim)
-		if !ok {
-			return fmt.Errorf("could not cast obj of type %T to *ipamclaimsapi.IPAMClaim", obj)
-		}
-
-		switchName, err := bsnc.getExpectedSwitchName(dummyPod())
-		if err != nil {
-			return err
-		}
-		ipAllocator := bsnc.lsManager.ForSwitch(switchName)
-		err = bsnc.ipamClaimsReconciler.Reconcile(ipamClaim, nil, ipAllocator)
-		if err != nil && !errors.Is(err, persistentips.ErrIgnoredIPAMClaim) {
-			return fmt.Errorf("error deleting IPAMClaim: %w", err)
-		} else if errors.Is(err, persistentips.ErrIgnoredIPAMClaim) {
-			return nil // let's avoid the log below, since nothing was released.
-		}
-		klog.Infof("Released IPs %q for network %q", ipamClaim.Status.IPs, ipamClaim.Spec.Network)
 
 	default:
 		return bsnc.DeleteResourceCommon(objType, obj)
@@ -895,19 +869,6 @@ func cleanupPolicyLogicalEntities(nbClient libovsdbclient.Client, ops []ovsdb.Op
 		return ops, fmt.Errorf("failed to get ops to delete address sets owned by controller %s", controllerName)
 	}
 	return ops, nil
-}
-
-// WatchIPAMClaims starts the watching of IPAMClaim resources and calls
-// back the appropriate handler logic
-func (bsnc *BaseUserDefinedNetworkController) WatchIPAMClaims() error {
-	if bsnc.ipamClaimsHandler != nil {
-		return nil
-	}
-	handler, err := bsnc.retryIPAMClaims.WatchResource()
-	if err != nil {
-		bsnc.ipamClaimsHandler = handler
-	}
-	return err
 }
 
 func (oc *BaseUserDefinedNetworkController) allowPersistentIPs() bool {

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -14,7 +14,6 @@ import (
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -489,18 +488,6 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 			continue
 		}
 
-		// if we allow for persistent IPs, then we need to check if this pod has an IPAM Claim
-		if bsnc.allowPersistentIPs() {
-			hasIPAMClaim, err := bsnc.hasIPAMClaim(pod, nadKey)
-			if err != nil {
-				return fmt.Errorf("unable to determine if pod %s has IPAM Claim: %w", podDesc, err)
-			}
-			// if there is an IPAM claim, don't release the pod IPs
-			if hasIPAMClaim {
-				continue
-			}
-		}
-
 		// Releasing IPs needs to happen last so that we can deterministically know that if delete failed that
 		// the IP of the pod needs to be released. Otherwise we could have a completed pod failed to be removed
 		// and we dont know if the IP was released or not, and subsequently could accidentally release the IP
@@ -515,73 +502,6 @@ func (bsnc *BaseUserDefinedNetworkController) removePodForUserDefinedNetwork(pod
 
 	}
 	return nil
-}
-
-// hasIPAMClaim determines whether a pod's IPAM is being handled by IPAMClaim CR.
-// pod passed should already be validated as having a network connection to nadKey
-func (bsnc *BaseUserDefinedNetworkController) hasIPAMClaim(pod *corev1.Pod, nadKey string) (bool, error) {
-	if !bsnc.AllowsPersistentIPs() {
-		return false, nil
-	}
-
-	var ipamClaimName string
-	var wasPersistentIPRequested bool
-	if bsnc.IsPrimaryNetwork() {
-		// 'k8s.ovn.org/primary-udn-ipamclaim' annotation has been deprecated. Maintain backward compatibility by
-		// using it as a fallback; when defaultNSE.IPAMClaimReference is set, it takes precedence.
-		if desiredClaimName, isIPAMClaimRequested := pod.Annotations[util.DeprecatedOvnUDNIPAMClaimName]; isIPAMClaimRequested && desiredClaimName != "" {
-			wasPersistentIPRequested = true
-			ipamClaimName = desiredClaimName
-		}
-		defaultNSE, err := util.GetK8sPodDefaultNetworkSelection(pod)
-		if err != nil {
-			return false, err
-		}
-		if defaultNSE != nil && defaultNSE.IPAMClaimReference != "" {
-			wasPersistentIPRequested = true
-			ipamClaimName = defaultNSE.IPAMClaimReference
-		}
-	} else {
-		// secondary network the IPAM claim reference is on the network selection element
-		on, networkMap, err := util.GetUDNPodNADToNetworkMapping(
-			pod,
-			bsnc.GetNetInfo(),
-			bsnc.networkManager.GetNetworkNameForNADKey,
-		)
-		if err != nil {
-			return false, fmt.Errorf("failed to get network mapping for pod %s/%s on network %s: %v",
-				pod.Namespace, pod.Name, bsnc.GetNetworkName(), err)
-		}
-		if !on {
-			klog.Warningf("Pod %s/%s is not scheduled on network %s", pod.Namespace, pod.Name, bsnc.GetNetworkName())
-			return false, nil
-		}
-		for key, network := range networkMap {
-			if key == nadKey {
-				if len(network.IPAMClaimReference) > 0 {
-					ipamClaimName = network.IPAMClaimReference
-					wasPersistentIPRequested = true
-				}
-				break
-			}
-		}
-	}
-
-	if !wasPersistentIPRequested || len(ipamClaimName) == 0 {
-		return false, nil
-	}
-
-	ipamClaim, err := bsnc.ipamClaimsReconciler.FindIPAMClaim(ipamClaimName, pod.Namespace)
-	if apierrors.IsNotFound(err) {
-		klog.Errorf("IPAMClaim %q for namespace: %q not found...will release IPs: %v",
-			ipamClaimName, pod.Namespace, err)
-		return false, nil
-	} else if err != nil {
-		return false, fmt.Errorf("failed to get IPAMClaim %s/%s: %w", pod.Namespace, ipamClaimName, err)
-	}
-
-	hasIPAMClaim := ipamClaim != nil && len(ipamClaim.Status.IPs) > 0
-	return hasIPAMClaim, nil
 }
 
 func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods []interface{}) error {
@@ -869,12 +789,6 @@ func cleanupPolicyLogicalEntities(nbClient libovsdbclient.Client, ops []ovsdb.Op
 		return ops, fmt.Errorf("failed to get ops to delete address sets owned by controller %s", controllerName)
 	}
 	return ops, nil
-}
-
-func (oc *BaseUserDefinedNetworkController) allowPersistentIPs() bool {
-	return config.OVNKubernetesFeature.EnablePersistentIPs &&
-		util.DoesNetworkRequireIPAM(oc.GetNetInfo()) &&
-		util.AllowsPersistentIPs(oc.GetNetInfo())
 }
 
 // buildUDNEgressSNAT is used to build the conditional SNAT required on L3 and L2 UDNs to

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -42,9 +42,6 @@ func (oc *BaseLayer2UserDefinedNetworkController) stop() {
 	oc.cancelableCtx.Cancel()
 	oc.wg.Wait()
 
-	if oc.ipamClaimsHandler != nil {
-		oc.watchFactory.RemoveIPAMClaimsHandler(oc.ipamClaimsHandler)
-	}
 	if oc.netPolicyHandler != nil {
 		oc.watchFactory.RemovePolicyHandler(oc.netPolicyHandler)
 	}
@@ -118,17 +115,6 @@ func (oc *BaseLayer2UserDefinedNetworkController) run() error {
 	// dependencies.
 	if err := oc.WatchNamespaces(); err != nil {
 		return err
-	}
-
-	// when on IC, it will be the NetworkController that returns the IPAMClaims
-	// IPs back to the pool
-	if oc.allocatesPodAnnotation() && oc.allowPersistentIPs() {
-		// WatchIPAMClaims should be started before WatchPods to prevent OVN-K
-		// master assigning IPs to pods without taking into account the persistent
-		// IPs set aside for the IPAMClaims
-		if err := oc.WatchIPAMClaims(); err != nil {
-			return err
-		}
 	}
 
 	if err := oc.WatchPods(); err != nil {
@@ -344,18 +330,6 @@ func (oc *BaseLayer2UserDefinedNetworkController) syncNodes(nodes []interface{})
 	}
 
 	return nil
-}
-
-func (oc *BaseLayer2UserDefinedNetworkController) syncIPAMClaims(ipamClaims []interface{}) error {
-	switchName, err := oc.getExpectedSwitchName(dummyPod())
-	if err != nil {
-		return err
-	}
-	return oc.ipamClaimsReconciler.Sync(ipamClaims, oc.lsManager.ForSwitch(switchName))
-}
-
-func dummyPod() *corev1.Pod {
-	return &corev1.Pod{Spec: corev1.PodSpec{NodeName: ""}}
 }
 
 // getDenyARPAndNSOnMACVRF provides ACLs to drop ARP and NS from pods to the

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -167,9 +167,6 @@ func (h *layer2UserDefinedNetworkControllerEventHandler) SyncFunc(objs []interfa
 		case factory.MultiNetworkPolicyType:
 			syncFunc = h.oc.syncMultiNetworkPolicies
 
-		case factory.IPAMClaimsType:
-			syncFunc = h.oc.syncIPAMClaims
-
 		default:
 			return fmt.Errorf("no sync function for object type %s", h.objType)
 		}
@@ -635,9 +632,6 @@ func (oc *Layer2UserDefinedNetworkController) SyncNodes(nodes []*corev1.Node) er
 
 func (oc *Layer2UserDefinedNetworkController) initRetryFramework() {
 	oc.retryPods = oc.newRetryFramework(factory.PodType)
-	if oc.allocatesPodAnnotation() && oc.AllowsPersistentIPs() {
-		oc.retryIPAMClaims = oc.newRetryFramework(factory.IPAMClaimsType)
-	}
 
 	// When a user-defined network is enabled as a primary network for namespace,
 	// then watch for namespace and network policy events.

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -38,7 +38,6 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/routeimport"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/topology"
 	zoneinterconnect "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/persistentips"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -318,21 +317,11 @@ func NewLayer2UserDefinedNetworkController(
 	}
 
 	if oc.allocatesPodAnnotation() {
-		var claimsReconciler persistentips.PersistentAllocations
-		if oc.allowPersistentIPs() {
-			ipamClaimsReconciler := persistentips.NewIPAMClaimReconciler(
-				oc.kube,
-				oc.GetNetInfo(),
-				oc.watchFactory.IPAMClaimsInformer().Lister(),
-			)
-			oc.ipamClaimsReconciler = ipamClaimsReconciler
-			claimsReconciler = ipamClaimsReconciler
-		}
 		oc.podAnnotationAllocator = pod.NewPodAnnotationAllocator(
 			oc.GetNetInfo(),
 			cnci.watchFactory.PodCoreInformer().Lister(),
 			cnci.kube,
-			claimsReconciler)
+			nil)
 	}
 
 	// enable multicast support for UDN only for primaries + multicast enabled

--- a/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
@@ -25,7 +25,6 @@ import (
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	lsm "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/persistentips"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -205,21 +204,11 @@ func NewLocalnetUserDefinedNetworkController(
 	}
 
 	if oc.allocatesPodAnnotation() {
-		var claimsReconciler persistentips.PersistentAllocations
-		if oc.allowPersistentIPs() {
-			ipamClaimsReconciler := persistentips.NewIPAMClaimReconciler(
-				oc.kube,
-				oc.GetNetInfo(),
-				oc.watchFactory.IPAMClaimsInformer().Lister(),
-			)
-			oc.ipamClaimsReconciler = ipamClaimsReconciler
-			claimsReconciler = ipamClaimsReconciler
-		}
 		oc.podAnnotationAllocator = pod.NewPodAnnotationAllocator(
 			netInfo,
 			cnci.watchFactory.PodCoreInformer().Lister(),
 			cnci.kube,
-			claimsReconciler)
+			nil)
 	}
 
 	// disable multicast support for UDNs

--- a/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/localnet_user_defined_network_controller.go
@@ -138,9 +138,6 @@ func (h *LocalnetUserDefinedNetworkControllerEventHandler) SyncFunc(objs []inter
 		case factory.MultiNetworkPolicyType:
 			syncFunc = h.oc.syncMultiNetworkPolicies
 
-		case factory.IPAMClaimsType:
-			syncFunc = h.oc.syncIPAMClaims
-
 		default:
 			return fmt.Errorf("no sync function for object type %s", h.objType)
 		}
@@ -330,9 +327,6 @@ func (oc *LocalnetUserDefinedNetworkController) SyncNodes(nodes []*corev1.Node) 
 
 func (oc *LocalnetUserDefinedNetworkController) initRetryFramework() {
 	oc.retryPods = oc.newRetryFramework(factory.PodType)
-	if oc.allocatesPodAnnotation() && oc.AllowsPersistentIPs() {
-		oc.retryIPAMClaims = oc.newRetryFramework(factory.IPAMClaimsType)
-	}
 
 	// For secondary networks, we don't have to watch namespace events if
 	// multi-network policy support is not enabled. We don't support


### PR DESCRIPTION
In IC mode, the gate `allocatesPodAnnotation() && allowPersistentIPs()` is always false for L2/Localnet UDN, so the IPAMClaim watch and its delete-reconciler in ovnkube-controller are unreachable. Cluster-manager owns IPAMClaim lifecycle. Keep ipamClaimsReconciler for hasIPAMClaim()'s FindIPAMClaim lookup.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed persistent IP claims management infrastructure across network controllers
  * Simplified event handler logic and controller initialization processes
  * Updated IP address release behavior to consistently apply standard allocation rules
  * Removed unused helper methods and related code dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->