### PR TITLE
Ensure node IP address set for advertised SNAT

### DIFF
--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -477,7 +477,8 @@ func (cm *ControllerManager) Start(ctx context.Context) error {
 
 	if config.OVNKubernetesFeature.EnableEgressIP {
 		cm.eIPController = ovn.NewEIPController(cm.nbClient, cm.kube, cm.watchFactory, cm.recorder, cm.portCache, cm.networkManager.Interface(),
-			addressset.NewOvnAddressSetFactory(cm.nbClient, config.IPv4Mode, config.IPv6Mode), config.IPv4Mode, config.IPv6Mode, zone, ovntypes.DefaultNetworkControllerName)
+			addressset.NewOvnAddressSetFactory(cm.nbClient, config.IPv4Mode, config.IPv6Mode), cm.addressSetManager,
+			config.IPv4Mode, config.IPv6Mode, zone, ovntypes.DefaultNetworkControllerName)
 		// FIXME(martinkennelly): remove when EIP controller is fully extracted from from DNC and started here. Ensure SyncLocalNodeZonesCache is re-enabled in EIP controller.
 		if err = cm.eIPController.SyncLocalNodeZonesCache(); err != nil {
 			klog.Warningf("Failed to sync EgressIP controllers local node node cache: %v", err)

--- a/go-controller/pkg/libovsdb/ops/db_object_types.go
+++ b/go-controller/pkg/libovsdb/ops/db_object_types.go
@@ -35,6 +35,7 @@ const (
 	HybridNodeRouteOwnerType    ownerType = "HybridNodeRoute"
 	EgressIPOwnerType           ownerType = "EgressIP"
 	EgressServiceOwnerType      ownerType = "EgressService"
+	ClusterNodeIPsOwnerType     ownerType = "ClusterNodeIPs"
 	MulticastNamespaceOwnerType ownerType = "MulticastNS"
 	MulticastClusterOwnerType   ownerType = "MulticastCluster"
 	NetpolNodeOwnerType         ownerType = "NetpolNode"
@@ -141,6 +142,12 @@ var AddressSetEgressIP = newObjectIDsType(addressSet, EgressIPOwnerType, []Exter
 	ObjectNameKey,
 	IPFamilyKey,
 	NetworkKey,
+})
+
+var AddressSetClusterNodeIPs = newObjectIDsType(addressSet, ClusterNodeIPsOwnerType, []ExternalIDKey{
+	// cluster-wide address set name
+	ObjectNameKey,
+	IPFamilyKey,
 })
 
 var AddressSetEgressService = newObjectIDsType(addressSet, EgressServiceOwnerType, []ExternalIDKey{

--- a/go-controller/pkg/libovsdb/util/address_set.go
+++ b/go-controller/pkg/libovsdb/util/address_set.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
@@ -21,6 +23,81 @@ func DeleteAddrSetsWithoutACLRef(predicateIDs *libovsdbops.DbObjectIDs, nbClient
 
 func DeleteAddrSetsWithoutACLRefAnyController(dbOwnerType *libovsdbops.ObjectIDsType, nbClient libovsdbclient.Client) error {
 	return deleteAddrSetsWithoutACLRef(nil, dbOwnerType, nbClient)
+}
+
+// DeleteAddrSetsWithoutMatchRef deletes address sets related to predicateIDs
+// when they are not referenced from ACL, NAT, or logical router policy matches.
+func DeleteAddrSetsWithoutMatchRef(predicateIDs *libovsdbops.DbObjectIDs, nbClient libovsdbclient.Client) error {
+	addrSets, err := libovsdbops.FindAddressSetsWithPredicate(
+		nbClient,
+		libovsdbops.GetPredicate[*nbdb.AddressSet](predicateIDs, nil),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to find address sets with predicate: %w", err)
+	}
+	if len(addrSets) == 0 {
+		return nil
+	}
+
+	addrSetNames := sets.New[string]()
+	for _, addrSet := range addrSets {
+		addrSetNames.Insert(addrSet.Name)
+	}
+	referencedNames, err := addressSetNamesReferencedInMatches(nbClient, addrSetNames)
+	if err != nil {
+		return err
+	}
+
+	staleAddressSets := make([]*nbdb.AddressSet, 0, len(addrSets))
+	for _, addrSet := range addrSets {
+		if !referencedNames.Has(addrSet.Name) {
+			staleAddressSets = append(staleAddressSets, addrSet)
+		}
+	}
+	if len(staleAddressSets) == 0 {
+		return nil
+	}
+	if err := libovsdbops.DeleteAddressSets(nbClient, staleAddressSets...); err != nil {
+		return fmt.Errorf("failed to delete address sets without match references: %w", err)
+	}
+	return nil
+}
+
+func addressSetNamesReferencedInMatches(nbClient libovsdbclient.Client, addressSetNames sets.Set[string]) (sets.Set[string], error) {
+	referencedNames := sets.New[string]()
+	recordReferences := func(match string) {
+		for addressSetName := range addressSetNames {
+			if strings.Contains(match, addressSetName) {
+				referencedNames.Insert(addressSetName)
+			}
+		}
+	}
+
+	_, err := libovsdbops.FindACLsWithPredicate(nbClient, func(acl *nbdb.ACL) bool {
+		recordReferences(acl.Match)
+		return false
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find ACLs referencing address sets: %w", err)
+	}
+
+	_, err = libovsdbops.FindNATsWithPredicate(nbClient, func(nat *nbdb.NAT) bool {
+		recordReferences(nat.Match)
+		return false
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find NATs referencing address sets: %w", err)
+	}
+
+	_, err = libovsdbops.FindLogicalRouterPoliciesWithPredicate(nbClient, func(policy *nbdb.LogicalRouterPolicy) bool {
+		recordReferences(policy.Match)
+		return false
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find logical router policies referencing address sets: %w", err)
+	}
+
+	return referencedNames, nil
 }
 
 func deleteAddrSetsWithoutACLRef(predicateIDs *libovsdbops.DbObjectIDs, dbOwnerType *libovsdbops.ObjectIDsType, nbClient libovsdbclient.Client) error {

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -70,6 +70,13 @@ type podSelectorAddressSet struct {
 	legacyNetpolMode bool
 }
 
+const (
+	ClusterNodeIPsAddrSetName                = "node-ips"
+	ClusterNodeIPsEgressIPBackRef            = "egressip"
+	ClusterNodeIPsEgressServiceBackRef       = "egressservice"
+	ClusterNodeIPsRouteAdvertisementsBackRef = "route-advertisements"
+)
+
 // AddressSetManager manages shared address sets with pod IPs based on provided pod and namespace selectors.
 // It shared across network controllers.
 type AddressSetManager struct {
@@ -105,6 +112,9 @@ type AddressSetManager struct {
 	hostNetworkNamespaceIPsPerNode map[string][]string
 	// local cache of address sets that select HostNetworkNamespace
 	hostNetworkSelectingAddrSets sets.Set[string]
+
+	clusterNodeIPsLock     sync.RWMutex
+	clusterNodeIPsBackRefs sets.Set[string]
 }
 
 func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInformer coreinformers.NamespaceInformer,
@@ -122,6 +132,7 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 		getNetworkNameForNADKey:        getNetworkNameForNADKey,
 		hostNetworkSelectingAddrSets:   sets.New[string](),
 		hostNetworkNamespaceIPsPerNode: make(map[string][]string),
+		clusterNodeIPsBackRefs:         sets.New[string](),
 	}
 	podCfg := &controller.ControllerConfig[corev1.Pod]{
 		RateLimiter:    workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -193,6 +204,79 @@ func (m *AddressSetManager) initialSync() error {
 		}
 	}
 	return libovsdbutil.DeleteAddrSetsWithoutACLRefAnyController(libovsdbops.AddressSetPodSelector, m.nbClient)
+}
+
+// getClusterNodeIPsAddrSetDbIDs returns the DB IDs for the shared cluster node IP address set.
+func getClusterNodeIPsAddrSetDbIDs() *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetClusterNodeIPs, ovntypes.DefaultNetworkControllerName,
+		map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: ClusterNodeIPsAddrSetName,
+		})
+}
+
+// EnsureClusterNodeIPsAddressSet registers a controller-lifetime user of the
+// shared cluster node IP address set and returns its DB IDs. The address set is
+// populated from node k8s.ovn.org/host-cidrs annotations through
+// util.GetNodeAddresses. Users do not deregister because each backref
+// represents a feature controller, not an individual object.
+func (m *AddressSetManager) EnsureClusterNodeIPsAddressSet(backRef string) (*libovsdbops.DbObjectIDs, error) {
+	dbIDs := getClusterNodeIPsAddrSetDbIDs()
+	if backRef == "" {
+		return nil, fmt.Errorf("cluster node IP address set backref is empty")
+	}
+	m.clusterNodeIPsLock.Lock()
+	defer m.clusterNodeIPsLock.Unlock()
+
+	if m.clusterNodeIPsBackRefs.Has(backRef) {
+		return dbIDs, nil
+	}
+
+	m.clusterNodeIPsBackRefs.Insert(backRef)
+	if err := m.syncClusterNodeIPsAddressSetLocked(); err != nil {
+		m.clusterNodeIPsBackRefs.Delete(backRef)
+		return nil, err
+	}
+	return dbIDs, nil
+}
+
+func (m *AddressSetManager) clusterNodeIPsAddressSetInUse() bool {
+	m.clusterNodeIPsLock.RLock()
+	defer m.clusterNodeIPsLock.RUnlock()
+	return m.clusterNodeIPsBackRefs.Len() > 0
+}
+
+func (m *AddressSetManager) syncClusterNodeIPsAddressSet() error {
+	m.clusterNodeIPsLock.Lock()
+	defer m.clusterNodeIPsLock.Unlock()
+
+	return m.syncClusterNodeIPsAddressSetLocked()
+}
+
+func (m *AddressSetManager) syncClusterNodeIPsAddressSetLocked() error {
+	if m.clusterNodeIPsBackRefs.Len() == 0 {
+		return nil
+	}
+
+	as, err := addressset.NewOvnAddressSetFactory(m.nbClient, config.IPv4Mode, config.IPv6Mode).EnsureAddressSet(getClusterNodeIPsAddrSetDbIDs())
+	if err != nil {
+		return fmt.Errorf("cannot ensure address set %s exists: %w", ClusterNodeIPsAddrSetName, err)
+	}
+
+	nodes, err := m.nodeLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+	v4NodeAddrs, v6NodeAddrs, err := util.GetNodeAddresses(config.IPv4Mode, config.IPv6Mode, nodes...)
+	if err != nil {
+		return fmt.Errorf("failed to get node addresses: %w", err)
+	}
+	allAddresses := make([]net.IP, 0, len(v4NodeAddrs)+len(v6NodeAddrs))
+	allAddresses = append(allAddresses, v4NodeAddrs...)
+	allAddresses = append(allAddresses, v6NodeAddrs...)
+	if err := as.SetAddresses(util.StringSlice(allAddresses)); err != nil {
+		return fmt.Errorf("failed to set node IP address set addresses: %w", err)
+	}
+	return nil
 }
 
 // EnsureAddressSet returns address set for requested (podSelector, namespaceSelector, namespace, nodeSelector).
@@ -511,6 +595,9 @@ func (m *AddressSetManager) nodeNeedUpdate(old, new *corev1.Node) bool {
 		// if node labels change, we need to reconcile address sets that use a node selector
 		return true
 	}
+	if util.NodeHostCIDRsAnnotationChanged(old, new) && m.clusterNodeIPsAddressSetInUse() {
+		return true
+	}
 	// only check annotations that are used in getHostNamespaceAddressesForNode
 	if util.NodeSubnetAnnotationChangedForNetwork(old, new, ovntypes.DefaultNetworkName) || util.NodeIDAnnotationChanged(old, new) ||
 		old.Annotations[util.OvnNodeIfAddr] != new.Annotations[util.OvnNodeIfAddr] {
@@ -527,6 +614,7 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 	// update host network IPs first to have fresh info for addr set reconcile
 	// don't return error immediately to let other changes like node selector be propagated
 	hostNetworkErr := m.updateHostNetworkIPs(nodeKey)
+	clusterNodeIPsErr := m.syncClusterNodeIPsAddressSet()
 
 	// find address sets that could be affected by this node event
 	// Get all existing keys, then lock address sets per key and check if they are affected.
@@ -560,10 +648,11 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("failed to reconcile address set %s for node %s: %v", addrSetKey, nodeKey, err)
+			return utilerrors.Join(hostNetworkErr, clusterNodeIPsErr,
+				fmt.Errorf("failed to reconcile address set %s for node %s: %v", addrSetKey, nodeKey, err))
 		}
 	}
-	return hostNetworkErr
+	return utilerrors.Join(hostNetworkErr, clusterNodeIPsErr)
 }
 
 func (m *AddressSetManager) updateHostNetworkIPs(nodeName string) error {

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -196,6 +196,49 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// address set will not be created
 		gomega.Consistently(addressSetManager.nbClient, 100*time.Millisecond, 20*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{}))
 	})
+
+	ginkgo.It("reconciles the registered cluster node IP address set on node events", func() {
+		node1 := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "node1",
+				Annotations: map[string]string{util.OVNNodeHostCIDRs: `["10.0.0.1/24"]`},
+			},
+		}
+		node2 := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "node2",
+				Annotations: map[string]string{util.OVNNodeHostCIDRs: `["10.0.0.2/24"]`},
+			},
+		}
+		startAddrSetManagerWithNodes(initialDB, nil, nil, []corev1.Node{node1, node2})
+
+		addressSetFactory := addressset.NewOvnAddressSetFactory(libovsdbNBClient, config.IPv4Mode, config.IPv6Mode)
+		expectNodeIPs := func(expected ...string) {
+			gomega.Eventually(func() []string {
+				as, err := addressSetFactory.GetAddressSet(getClusterNodeIPsAddrSetDbIDs())
+				if err != nil {
+					return nil
+				}
+				v4Addresses, v6Addresses := as.GetAddresses()
+				return append(v4Addresses, v6Addresses...)
+			}).Should(gomega.ConsistOf(expected))
+		}
+
+		_, err := addressSetManager.EnsureClusterNodeIPsAddressSet(ClusterNodeIPsRouteAdvertisementsBackRef)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		expectNodeIPs("10.0.0.1", "10.0.0.2")
+
+		node2Copy := node2.DeepCopy()
+		node2Copy.Annotations[util.OVNNodeHostCIDRs] = `["10.0.0.2/24","10.0.0.20/24"]`
+		_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2Copy, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		expectNodeIPs("10.0.0.1", "10.0.0.2", "10.0.0.20")
+
+		err = clientSet.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		expectNodeIPs("10.0.0.2", "10.0.0.20")
+	})
+
 	ginkgo.It("creates one address set for multiple users with the same selector", func() {
 		namespace1 := *testing.NewNamespace(namespaceName1)
 		podSelector := &metav1.LabelSelector{

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/persistentips"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -939,10 +940,12 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 		// For advertised networks, we need to SNAT any traffic leaving the
 		// pods from these networks towards the node IPs in the cluster. In
 		// order to do such a conditional SNAT, we need an address set that
-		// contains the node IPs in the cluster. Given that egressIP feature
-		// already has an address set containing these nodeIPs owned by the
-		// default network controller, let's re-use it.
-		nodeIPsASIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
+		// contains the node IPs in the cluster. Re-use the shared cluster node
+		// IP address set owned by the address set manager.
+		nodeIPsASIDs, err := bsnc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsRouteAdvertisementsBackRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to ensure cluster node IP address set for route advertisements: %w", err)
+		}
 		nodeIPsAS, err = bsnc.addressSetFactory.GetAddressSet(nodeIPsASIDs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get address set with IDs %v: %w", nodeIPsASIDs, err)

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -786,6 +786,9 @@ func (oc *DefaultNetworkController) run(_ context.Context) error {
 			return err
 		}
 	}
+	if err := cleanupDeprecatedClusterNodeIPsAddressSet(oc.nbClient); err != nil {
+		return err
+	}
 
 	if config.OVNKubernetesFeature.EnableMultiExternalGateway {
 		if err = oc.apbExternalRouteController.Run(oc.wg, 1); err != nil {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	networkmanager "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	egresssvc "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	ovnretry "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
@@ -63,7 +64,7 @@ type egressIPNoReroutePolicyName string
 type egressIPQoSRuleName string
 
 const (
-	NodeIPAddrSetName             egressIPAddrSetName = "node-ips"
+	NodeIPAddrSetName             egressIPAddrSetName = addresssetmanager.ClusterNodeIPsAddrSetName
 	EgressIPServedPodsAddrSetName egressIPAddrSetName = "egressip-served-pods"
 	// the possible values for LRP DB objects for EIPs
 	IPFamilyValueV4         egressIPFamilyValue         = "ip4"
@@ -170,6 +171,17 @@ func getEgressIPNATDbIDs(eIPName, podNamespace, podName string, ipFamily egressI
 	})
 }
 
+func getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDs() *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetEgressIP, types.DefaultNetworkControllerName,
+		map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: addresssetmanager.ClusterNodeIPsAddrSetName,
+		})
+}
+
+func cleanupDeprecatedClusterNodeIPsAddressSet(nbClient libovsdbclient.Client) error {
+	return libovsdbutil.DeleteAddrSetsWithoutMatchRef(getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDs(), nbClient)
+}
+
 // EgressIPController configures OVN to support EgressIP
 type EgressIPController struct {
 	// libovsdb northbound client interface
@@ -207,6 +219,8 @@ type EgressIPController struct {
 	retryEgressIPPods *ovnretry.RetryFramework
 	// An address set factory that creates address sets
 	addressSetFactory addressset.AddressSetFactory
+	// Shared address set manager that owns cluster-wide node IP address sets.
+	addressSetManager *addresssetmanager.AddressSetManager
 	// Northbound database zone name to which this Controller is connected to - aka local zone
 	zone string
 	v4   bool
@@ -223,6 +237,7 @@ func NewEIPController(
 	portCache *PortCache,
 	networkmanager networkmanager.Interface,
 	addressSetFactor addressset.AddressSetFactory,
+	addressSetManager *addresssetmanager.AddressSetManager,
 	v4 bool,
 	v6 bool,
 	zone string,
@@ -241,6 +256,7 @@ func NewEIPController(
 		controllerName:    controllerName,
 		networkManager:    networkmanager,
 		addressSetFactory: addressSetFactor,
+		addressSetManager: addressSetManager,
 		zone:              zone,
 		v4:                v4,
 		v6:                v6,
@@ -2404,7 +2420,11 @@ func (e *EgressIPController) initClusterEgressPolicies(_ []interface{}) error {
 		klog.Warningf("Failed to get a local zone node name: %v", err)
 	}
 	subnets := util.GetAllClusterSubnetsFromEntries(defaultNetInfo.Subnets())
-	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, defaultNetInfo, subnets, e.controllerName, defaultNetInfo.GetNetworkScopedClusterRouterName()); err != nil {
+	clusterNodeIPsAddrSetDbIDs, err := e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
+	if err != nil {
+		return fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
+	}
+	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, defaultNetInfo, subnets, e.controllerName, defaultNetInfo.GetNetworkScopedClusterRouterName(), clusterNodeIPsAddrSetDbIDs); err != nil {
 		return fmt.Errorf("failed to initialize networks cluster logical router egress policies for the default network: %v", err)
 	}
 
@@ -2420,7 +2440,7 @@ func (e *EgressIPController) initClusterEgressPolicies(_ []interface{}) error {
 		if err != nil {
 			return err
 		}
-		if err = InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, network, subnets, e.controllerName, routerName); err != nil {
+		if err = InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, network, subnets, e.controllerName, routerName, clusterNodeIPsAddrSetDbIDs); err != nil {
 			return fmt.Errorf("failed to initialize networks cluster logical router egress policies for network %s: %v", network.GetNetworkName(), err)
 		}
 		return nil
@@ -2430,7 +2450,7 @@ func (e *EgressIPController) initClusterEgressPolicies(_ []interface{}) error {
 // InitClusterEgressPolicies creates the global no reroute policies and address-sets
 // required by the egressIP and egressServices features.
 func InitClusterEgressPolicies(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory, ni util.NetInfo,
-	clusterSubnets []*net.IPNet, controllerName, routerName string) error {
+	clusterSubnets []*net.IPNet, controllerName, routerName string, clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs) error {
 	if len(clusterSubnets) == 0 {
 		return nil
 	}
@@ -2475,13 +2495,15 @@ func InitClusterEgressPolicies(nbClient libovsdbclient.Client, addressSetFactory
 
 	// ensure the address-set for storing nodeIPs exists
 	// The address set with controller name 'default' is shared with all networks
-	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
-	if _, err = addressSetFactory.EnsureAddressSet(dbIDs); err != nil {
+	if clusterNodeIPsAddrSetDbIDs == nil {
+		return fmt.Errorf("cluster node IP address set DB IDs are required")
+	}
+	if _, err = addressSetFactory.EnsureAddressSet(clusterNodeIPsAddrSetDbIDs); err != nil {
 		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
 	}
 
 	// ensure the address-set for storing egressIP pods exists
-	dbIDs = getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, ni.GetNetworkName(), controllerName)
+	dbIDs := getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, ni.GetNetworkName(), controllerName)
 	_, err = addressSetFactory.EnsureAddressSet(dbIDs)
 	if err != nil {
 		return fmt.Errorf("cannot ensure that addressSet for egressIP pods %s exists for network %s: %v", EgressIPServedPodsAddrSetName, ni.GetNetworkName(), err)
@@ -2921,13 +2943,21 @@ func (e *EgressIPController) addExternalGWPodSNATOps(ni util.NetInfo, ops []ovsd
 				return nil, err
 			}
 
+			isNetworkAdvertised := util.IsPodNetworkAdvertisedAtNode(ni, pod.Spec.NodeName)
+			var clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs
+			if isNetworkAdvertised && !util.IsNoOverlaySNATExemptionNeeded(ni) {
+				clusterNodeIPsAddrSetDbIDs, err = e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
+				if err != nil {
+					return nil, fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
+				}
+			}
 			// Handle each pod IP individually since each IP family needs its own SNAT match
 			for _, podIP := range podIPs {
 				ipFamily := utilnet.IPv4
 				if utilnet.IsIPv6CIDR(podIP) {
 					ipFamily = utilnet.IPv6
 				}
-				snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(e.nbClient, ni, pod.Spec.NodeName, util.IsPodNetworkAdvertisedAtNode(ni, pod.Spec.NodeName), ipFamily)
+				snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(e.nbClient, ni, pod.Spec.NodeName, isNetworkAdvertised, ipFamily, clusterNodeIPsAddrSetDbIDs)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get SNAT match for node %s for network %s: %w", pod.Spec.NodeName, ni.GetNetworkName(), err)
 				}
@@ -3546,11 +3576,15 @@ func (e *EgressIPController) ensureRouterPoliciesForNetwork(ni util.NetInfo, nod
 	if err != nil {
 		return err
 	}
-	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, ni, subnets, e.controllerName, routerName); err != nil {
+	clusterNodeIPsAddrSetDbIDs, err := e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
+	if err != nil {
+		return fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
+	}
+	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, ni, subnets, e.controllerName, routerName, clusterNodeIPsAddrSetDbIDs); err != nil {
 		return fmt.Errorf("failed to initialize networks cluster logical router egress policies for the default network: %v", err)
 	}
 	err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, ni.GetNetworkName(), routerName,
-		e.controllerName, listers.NewNodeLister(e.watchFactory.NodeInformer().GetIndexer()), e.v4, e.v6)
+		e.controllerName, listers.NewNodeLister(e.watchFactory.NodeInformer().GetIndexer()), e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
 	if err != nil {
 		return fmt.Errorf("failed to ensure no reroute node policies for network %s: %v", ni.GetNetworkName(), err)
 	}
@@ -3823,10 +3857,14 @@ func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
 	e.nodeUpdateMutex.Lock()
 	defer e.nodeUpdateMutex.Unlock()
 	nodeLister := listers.NewNodeLister(e.watchFactory.NodeInformer().GetIndexer())
+	clusterNodeIPsAddrSetDbIDs, err := e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
+	if err != nil {
+		return fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
+	}
 	// ensure default network is processed
 	defaultNetInfo := e.networkManager.GetNetwork(types.DefaultNetworkName)
-	err := ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, defaultNetInfo.GetNetworkName(), defaultNetInfo.GetNetworkScopedClusterRouterName(),
-		e.controllerName, nodeLister, e.v4, e.v6)
+	err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, defaultNetInfo.GetNetworkName(), defaultNetInfo.GetNetworkScopedClusterRouterName(),
+		e.controllerName, nodeLister, e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
 	if err != nil {
 		return fmt.Errorf("failed to ensure default no reroute policies for nodes for default network: %v", err)
 	}
@@ -3842,7 +3880,7 @@ func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
 			return err
 		}
 		err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, network.GetNetworkName(), routerName,
-			e.controllerName, nodeLister, e.v4, e.v6)
+			e.controllerName, nodeLister, e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
 		if err != nil {
 			return fmt.Errorf("failed to ensure default no reroute policies for nodes for network %s: %v", network.GetNetworkName(), err)
 		}
@@ -3857,11 +3895,10 @@ func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
 // i.e: ensuring that an egress pod can still communicate with a hostNetwork pod / service backed by hostNetwork pods
 // without using egressIPs.
 // sample: 101 ip4.src == $a12749576804119081385 && ip4.dst == $a11079093880111560446 allow pkt_mark=1008
-// All the cluster node's addresses are considered. This is to avoid race conditions after a VIP moves from one node
-// to another where we might process events out of order. For the same reason this function needs to be called under
-// lock.
+// All node addresses are listed here to decide which IP family policies are required.
 func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-	network, router, controller string, nodeLister listers.NodeLister, v4, v6 bool) error {
+	network, router, controller string, nodeLister listers.NodeLister, v4, v6 bool,
+	clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs) error {
 	nodes, err := nodeLister.List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list nodes: %v", err)
@@ -3870,24 +3907,19 @@ func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressS
 	if err != nil {
 		return fmt.Errorf("failed to get node addresses: %v", err)
 	}
-	allAddresses := make([]net.IP, 0, len(v4NodeAddrs)+len(v6NodeAddrs))
-	allAddresses = append(allAddresses, v4NodeAddrs...)
-	allAddresses = append(allAddresses, v6NodeAddrs...)
 
-	var as addressset.AddressSet
 	// all networks reference the same node IP address set
-	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
-	if as, err = addressSetFactory.GetAddressSet(dbIDs); err != nil {
-		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
+	if clusterNodeIPsAddrSetDbIDs == nil {
+		return fmt.Errorf("cluster node IP address set DB IDs are required")
 	}
-
-	if err = as.SetAddresses(util.StringSlice(allAddresses)); err != nil {
-		return fmt.Errorf("unable to set IPs to no re-route address set %s: %w", NodeIPAddrSetName, err)
+	as, err := addressSetFactory.GetAddressSet(clusterNodeIPsAddrSetDbIDs)
+	if err != nil {
+		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
 	}
 
 	ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS := as.GetASHashNames()
 	// fetch the egressIP pods address-set
-	dbIDs = getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, network, controller)
+	dbIDs := getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, network, controller)
 	if as, err = addressSetFactory.GetAddressSet(dbIDs); err != nil {
 		return fmt.Errorf("cannot ensure that addressSet %s exists %v", EgressIPServedPodsAddrSetName, err)
 	}

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -27,6 +27,7 @@ import (
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	egresssvc "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/syncmap"
@@ -92,6 +93,98 @@ type nodeInfo struct {
 }
 
 var egressPodLabel = map[string]string{"egress": "needed"}
+
+var _ = ginkgo.Describe("Deprecated cluster node IP address set cleanup", func() {
+	var fakeOvn *FakeOVN
+
+	ginkgo.AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	ginkgo.It("cleans up unreferenced deprecated cluster node IP address sets", func() {
+		oldDefaultV4AS, oldDefaultV6AS := addressset.GetTestDbAddrSets(
+			getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork(types.DefaultNetworkName),
+			[]string{"10.0.0.1", "fd00::1"},
+		)
+		oldBlueV4AS, oldBlueV6AS := addressset.GetTestDbAddrSets(
+			getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork("blue"),
+			[]string{"10.0.0.2", "fd00::2"},
+		)
+		fakeOvn = NewFakeOVN(false)
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{oldDefaultV4AS, oldDefaultV6AS, oldBlueV4AS, oldBlueV6AS},
+		})
+
+		gomega.Expect(cleanupDeprecatedClusterNodeIPsAddressSet(fakeOvn.nbClient)).To(gomega.Succeed())
+
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveEmptyData())
+	})
+
+	ginkgo.It("keeps deprecated cluster node IP address sets while referenced by matches", func() {
+		oldDefaultV4AS, oldDefaultV6AS := addressset.GetTestDbAddrSets(
+			getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork(types.DefaultNetworkName),
+			[]string{"10.0.0.1", "fd00::1"},
+		)
+		oldBlueV4AS, oldBlueV6AS := addressset.GetTestDbAddrSets(
+			getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork("blue"),
+			[]string{"10.0.0.2", "fd00::2"},
+		)
+		nat := &nbdb.NAT{
+			UUID:       "nat-UUID",
+			Type:       nbdb.NATTypeSNAT,
+			LogicalIP:  "10.128.0.0/14",
+			ExternalIP: "172.18.0.2",
+			Match:      fmt.Sprintf("ip4.dst == $%s", oldBlueV4AS.Name),
+		}
+		lrp := &nbdb.LogicalRouterPolicy{
+			UUID:     "lrp-UUID",
+			Priority: types.DefaultNoRereoutePriority,
+			Action:   nbdb.LogicalRouterPolicyActionAllow,
+			Match:    fmt.Sprintf("ip6.dst == $%s", oldDefaultV6AS.Name),
+		}
+		acl := libovsdbops.BuildACL(
+			"acl",
+			nbdb.ACLDirectionFromLport,
+			types.DefaultAllowPriority,
+			fmt.Sprintf("ip4.src == $%s || ip6.src == $%s", oldDefaultV4AS.Name, oldBlueV6AS.Name),
+			nbdb.ACLActionAllow,
+			types.OvnACLLoggingMeter,
+			"",
+			false,
+			nil,
+			nil,
+			types.DefaultACLTier,
+		)
+		acl.UUID = "acl-UUID"
+		router := &nbdb.LogicalRouter{
+			UUID:     "router-UUID",
+			Name:     "router",
+			Nat:      []string{nat.UUID},
+			Policies: []string{lrp.UUID},
+		}
+		logicalSwitch := &nbdb.LogicalSwitch{
+			UUID: "switch-UUID",
+			ACLs: []string{acl.UUID},
+		}
+		expectedDB := []libovsdbtest.TestData{
+			oldDefaultV4AS,
+			oldDefaultV6AS,
+			oldBlueV4AS,
+			oldBlueV6AS,
+			nat,
+			lrp,
+			acl,
+			router,
+			logicalSwitch,
+		}
+		fakeOvn = NewFakeOVN(false)
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: expectedDB})
+
+		gomega.Expect(cleanupDeprecatedClusterNodeIPsAddressSet(fakeOvn.nbClient)).To(gomega.Succeed())
+
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDB))
+	})
+})
 
 var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func() {
 	var (
@@ -385,7 +478,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 				},
 				&nbdb.LogicalRouterPolicy{
 					Priority:    types.DefaultNoRereoutePriority,
-					Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+					Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 					Action:      nbdb.LogicalRouterPolicyActionAllow,
 					Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					UUID:        "no-reroute-node-UUID",
@@ -597,7 +690,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 				},
 				&nbdb.LogicalRouterPolicy{
 					Priority:    types.DefaultNoRereoutePriority,
-					Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+					Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 					Action:      nbdb.LogicalRouterPolicyActionAllow,
 					Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 					UUID:        "no-reroute-node-UUID",
@@ -857,7 +950,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -1222,7 +1315,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -1638,7 +1731,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -1982,7 +2075,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -2420,7 +2513,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -2762,7 +2855,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						primarySNAT,
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -2916,7 +3009,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -3223,7 +3316,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 							getEgressIPLRPReRouteDbIDs(eIP.Name, egressPod.Namespace, egressPod.Name, IPFamilyValueV4, types.DefaultNetworkName, fakeOvn.controller.eIPC.controllerName).GetExternalIDs()),
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -12240,7 +12333,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -12373,7 +12466,7 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 						},
 						&nbdb.LogicalRouterPolicy{
 							Priority:    types.DefaultNoRereoutePriority,
-							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a712973235162149816",
+							Match:       "(ip4.src == $a8519615025667110816 || ip4.src == $a13607449821398607916) && ip4.dst == $a1042611113178530741",
 							Action:      nbdb.LogicalRouterPolicyActionAllow,
 							Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
 							UUID:        "no-reroute-node-UUID",
@@ -15609,6 +15702,20 @@ func buildEgressIPServedPodsAddressSets(ips []string, network, controller string
 
 // returns the address set with externalID "k8s.ovn.org/name": "node-ips"
 func buildEgressIPNodeAddressSets(ips []string) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
-	return addressset.GetTestDbAddrSets(dbIDs, ips)
+	return addressset.GetTestDbAddrSets(getClusterNodeIPsAddrSetDbIDsForTest(), ips)
+}
+
+func getDeprecatedEgressIPClusterNodeIPsAddrSetDbIDsForNetwork(network string) *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetEgressIP, types.DefaultNetworkControllerName,
+		map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: addresssetmanager.ClusterNodeIPsAddrSetName,
+			libovsdbops.NetworkKey:    network,
+		})
+}
+
+func getClusterNodeIPsAddrSetDbIDsForTest() *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetClusterNodeIPs, types.DefaultNetworkControllerName,
+		map[libovsdbops.ExternalIDKey]string{
+			libovsdbops.ObjectNameKey: addresssetmanager.ClusterNodeIPsAddrSetName,
+		})
 }

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -698,11 +698,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					v6lrsr,
 				}
 				expectedEgressSvcAddrSet := []string{"10.128.1.5", "fe00:10:128:1::5"}
-
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -721,11 +717,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					v4lrp1,
 					v6lrp1,
 				}
-
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				ginkgo.By("removing the EgressService its lrps will be removed")
@@ -734,10 +726,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 
 				clusterRouter.Policies = []string{}
 				expectedDatabaseState = []libovsdbtest.TestData{clusterRouter}
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), []string{})
 
@@ -866,11 +855,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					v6lrpic,
 				}
 				expectedEgressSvcAddrSet := []string{"10.128.1.5", "fe00:10:128:1::5"}
-
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -882,10 +867,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 
 				clusterRouter.Policies = []string{}
 				expectedDatabaseState = []libovsdbtest.TestData{clusterRouter}
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), []string{})
 				return nil
@@ -1034,11 +1016,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedEgressSvcAddrSet := []string{"10.128.1.5"}
 				expectedDatabaseState[0].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID", "reroute-static-route-UUID-v6"}
-
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1063,10 +1041,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedEgressSvcAddrSet = []string{"10.128.1.5", "fe00:10:128:1::5"}
 				expectedDatabaseState[0].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID", "reroute-static-route-UUID-v6"}
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1096,11 +1071,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedEgressSvcAddrSet = []string{"10.128.1.5", "10.128.1.7"}
 				expectedDatabaseState[0].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID", "reroute-static-route-UUID-v6"}
-
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1118,11 +1089,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedEgressSvcAddrSet = []string{}
 				expectedDatabaseState[0].(*nbdb.LogicalRouter).StaticRoutes = []string{"reroute-static-route-UUID", "reroute-static-route-UUID-v6"}
-
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1137,11 +1104,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				}
 				expectedDatabaseState = append(expectedDatabaseState, v4DefaultReRoute)
 				expectedDatabaseState = append(expectedDatabaseState, v6DefaultReRoute)
-
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
@@ -1306,11 +1269,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					svc1v6iclrp1,
 				}
 				var expectedEgressSvcAddrSet []string
-
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1345,23 +1304,25 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					svc2v6lrp1remote,
 				}
 				expectedEgressSvcAddrSet = []string{"10.128.1.6", "fe00:10:128:1::6"}
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
 				ginkgo.By("updating the second node host cidr the node ip no re-route address set will be updated")
-				nodeIPsASdbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkControllerName)
-				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
-
 				node2.ObjectMeta.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\", \"%s\", \"%s\"]", node2IPv4+"/24", node2IPv6+"/64", vipIPv4+"/24", vipIPv6+"/64")
 				node2.ResourceVersion = "3"
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6, vipIPv4, vipIPv6})
+				clusterRouter.Policies = []string{"svc2v4lrp1remote-UUID", "svc2v6lrp1remote-UUID", "svc1v4lrsr1-UUID", "svc1v6lrsr1-UUID"}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+					svc1v4iclrp1,
+					svc1v6iclrp1,
+					svc2v4lrp1remote,
+					svc2v6lrp1remote,
+				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6, vipIPv4, vipIPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				node2.ObjectMeta.Annotations[util.OVNNodeHostCIDRs] = fmt.Sprintf("[\"%s\", \"%s\"]", node2IPv4+"/24", node2IPv6+"/64")
@@ -1369,14 +1330,20 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
+				clusterRouter.Policies = []string{"svc2v4lrp1remote-UUID", "svc2v6lrp1remote-UUID", "svc1v4lrsr1-UUID", "svc1v6lrsr1-UUID"}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+					svc1v4iclrp1,
+					svc1v6iclrp1,
+					svc2v4lrp1remote,
+					svc2v6lrp1remote,
+				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node1IPv4, node2IPv4, node1IPv6, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				ginkgo.By("deleting the first node, the node ip no re-route address set will be updated and service resources will be deleted")
 				err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, metav1.DeleteOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-				fakeOVN.asf.EventuallyExpectAddressSetWithAddresses(nodeIPsASdbIDs, []string{node2IPv4, node2IPv6})
 
 				clusterRouter.Policies = []string{"svc2v4lrp1remote-UUID", "svc2v6lrp1remote-UUID"}
 				expectedDatabaseState = []libovsdbtest.TestData{
@@ -1385,10 +1352,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 					svc2v6lrp1remote,
 				}
 				expectedEgressSvcAddrSet = []string{"10.128.1.6", "fe00:10:128:1::6"}
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, []string{node2IPv4, node2IPv6})
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), expectedEgressSvcAddrSet)
 
@@ -1400,12 +1364,8 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 				expectedDatabaseState = []libovsdbtest.TestData{
 					clusterRouter,
 				}
-				for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
-					expectedDatabaseState = append(expectedDatabaseState, lrp)
-					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-				}
+				expectedDatabaseState = appendDefaultNoRerouteData(expectedDatabaseState, clusterRouter, controllerName, nil)
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-				fakeOVN.asf.EventuallyExpectEmptyAddressSetExist(nodeIPsASdbIDs)
 				fakeOVN.asf.ExpectAddressSetWithAddresses(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName), []string{})
 				return nil
 			}
@@ -1443,11 +1403,26 @@ func egressServiceRouterPolicy(uuid, key, addr, nexthop string) *nbdb.LogicalRou
 	}
 }
 
+func appendDefaultNoRerouteData(expected []libovsdbtest.TestData, clusterRouter *nbdb.LogicalRouter, controllerName string, nodeIPs []string) []libovsdbtest.TestData {
+	for _, lrp := range getDefaultNoReroutePolicies(controllerName) {
+		expected = append(expected, lrp)
+		clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+	}
+	nodeIPsASv4, nodeIPsASv6 := addressset.GetTestDbAddrSets(getClusterNodeIPsAddrSetDbIDsForTest(), nodeIPs)
+	if config.IPv4Mode {
+		expected = append(expected, nodeIPsASv4)
+	}
+	if config.IPv6Mode {
+		expected = append(expected, nodeIPsASv6)
+	}
+	return expected
+}
+
 func getDefaultNoReroutePolicies(controllerName string) []*nbdb.LogicalRouterPolicy {
 	allLRPS := []*nbdb.LogicalRouterPolicy{}
 	egressSvcPodsV4, egressSvcPodsV6 := addressset.GetHashNamesForAS(egresssvc.GetEgressServiceAddrSetDbIDs(controllerName))
 	egressipPodsV4, egressipPodsV6 := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, ovntypes.DefaultNetworkName, controllerName))
-	nodeIPsV4, nodeIPsV6 := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, ovntypes.DefaultNetworkName, controllerName))
+	nodeIPsV4, nodeIPsV6 := addressset.GetHashNamesForAS(getClusterNodeIPsAddrSetDbIDsForTest())
 	v4ExtIDs := getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV4, ovntypes.DefaultNetworkName, controllerName).GetExternalIDs()
 	v6ExtIDs := getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV6, ovntypes.DefaultNetworkName, controllerName).GetExternalIDs()
 

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/gatewayrouter"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -51,6 +52,7 @@ type GatewayManager struct {
 	watchFactory            *factory.WatchFactory
 	getNetworkNameForNADKey func(nadKey string) string
 	nodeAnnotationCache     *nodecontroller.NodeAnnotationCache
+	addressSetManager       *addresssetmanager.AddressSetManager
 	// Cluster wide Load_Balancer_Group UUID.
 	// Includes all node switches and node gateway routers.
 	clusterLoadBalancerGroupUUID string
@@ -76,6 +78,7 @@ func NewGatewayManagerForLayer2Topology(
 	netInfo util.NetInfo,
 	watchFactory *factory.WatchFactory,
 	nodeAnnotationCache *nodecontroller.NodeAnnotationCache,
+	addressSetManager *addresssetmanager.AddressSetManager,
 	useTransitRouter bool,
 	opts ...GatewayOption,
 ) *GatewayManager {
@@ -94,6 +97,7 @@ func NewGatewayManagerForLayer2Topology(
 		netInfo,
 		watchFactory,
 		nodeAnnotationCache,
+		addressSetManager,
 		opts...,
 	)
 }
@@ -106,6 +110,7 @@ func NewGatewayManager(
 	netInfo util.NetInfo,
 	watchFactory *factory.WatchFactory,
 	nodeAnnotationCache *nodecontroller.NodeAnnotationCache,
+	addressSetManager *addresssetmanager.AddressSetManager,
 	opts ...GatewayOption,
 ) *GatewayManager {
 	return newGWManager(
@@ -119,6 +124,7 @@ func NewGatewayManager(
 		netInfo,
 		watchFactory,
 		nodeAnnotationCache,
+		addressSetManager,
 		opts...,
 	)
 }
@@ -131,6 +137,7 @@ func newGWManager(
 	netInfo util.NetInfo,
 	watchFactory *factory.WatchFactory,
 	nodeAnnotationCache *nodecontroller.NodeAnnotationCache,
+	addressSetManager *addresssetmanager.AddressSetManager,
 	opts ...GatewayOption) *GatewayManager {
 	gwManager := &GatewayManager{
 		nodeName:            nodeName,
@@ -144,6 +151,7 @@ func newGWManager(
 		netInfo:             netInfo,
 		watchFactory:        watchFactory,
 		nodeAnnotationCache: nodeAnnotationCache,
+		addressSetManager:   addressSetManager,
 	}
 
 	for _, opt := range opts {
@@ -891,6 +899,15 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 			}
 		}
 
+		isNetworkAdvertised := gw.isRoutingAdvertised(nodeName)
+		var clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs
+		if isNetworkAdvertised && !util.IsNoOverlaySNATExemptionNeeded(gw.netInfo) {
+			clusterNodeIPsAddrSetDbIDs, err = gw.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsRouteAdvertisementsBackRef)
+			if err != nil {
+				return fmt.Errorf("failed to ensure cluster node IP address set for route advertisements: %w", err)
+			}
+		}
+
 		// Default SNAT rules. DisableSNATMultipleGWs=false in LGW (traffic egresses via mp0) always.
 		// We are not checking for gateway mode to be shared explicitly to reduce topology differences.
 		for _, entry := range gwConfig.clusterSubnets {
@@ -906,7 +923,7 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 				ipFamily = utilnet.IPv6
 			}
 			snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(gw.nbClient, gw.netInfo, nodeName,
-				gw.isRoutingAdvertised(nodeName), ipFamily)
+				isNetworkAdvertised, ipFamily, clusterNodeIPsAddrSetDbIDs)
 			if err != nil {
 				return fmt.Errorf("failed to get SNAT match for node %s for network %s: %w", nodeName, gw.netInfo.GetNetworkName(), err)
 			}
@@ -1074,7 +1091,7 @@ func (gw *GatewayManager) gatewayInit(
 // - For Layer2 topology, the match is the output port of the GR to the join switch and the destination must be a nodeIP in the cluster.
 // - For Layer3 topology, the match is the destination must be a nodeIP in the cluster.
 func GetNetworkScopedClusterSubnetSNATMatch(nbClient libovsdbclient.Client, netInfo util.NetInfo, nodeName string,
-	isNetworkAdvertised bool, ipFamily utilnet.IPFamily) (string, error) {
+	isNetworkAdvertised bool, ipFamily utilnet.IPFamily, clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs) (string, error) {
 	layer2OldTopo := netInfo.TopologyType() == types.Layer2Topology && !config.Layer2UsesTransitRouter
 	if !isNetworkAdvertised {
 		if !layer2OldTopo {
@@ -1086,15 +1103,17 @@ func GetNetworkScopedClusterSubnetSNATMatch(nbClient libovsdbclient.Client, netI
 	}
 
 	// if the network is advertised, we need to ensure that the SNAT exists with the correct conditional destination match
-	dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
+	if clusterNodeIPsAddrSetDbIDs == nil {
+		return "", fmt.Errorf("cluster node IP address set DB IDs are required for advertised network %s", netInfo.GetNetworkName())
+	}
 	addressSetFactory := addressset.NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
-	addrSet, err := addressSetFactory.GetAddressSet(dbIDs)
+	addrSet, err := addressSetFactory.GetAddressSet(clusterNodeIPsAddrSetDbIDs)
 	if err != nil {
-		return "", fmt.Errorf("cannot ensure that addressSet %v exists: %w", dbIDs, err)
+		return "", fmt.Errorf("cannot ensure that addressSet %v exists: %w", clusterNodeIPsAddrSetDbIDs, err)
 	}
 	destinationMatch := getClusterNodesDestinationBasedSNATMatch(ipFamily, addrSet)
 	if destinationMatch == "" {
-		return "", fmt.Errorf("could not build a destination based SNAT match because no addressSet %v exists for IP family %v", dbIDs, ipFamily)
+		return "", fmt.Errorf("could not build a destination based SNAT match because no addressSet %v exists for IP family %v", clusterNodeIPsAddrSetDbIDs, ipFamily)
 	}
 	if !layer2OldTopo {
 		return destinationMatch, nil
@@ -1693,12 +1712,18 @@ func (oc *DefaultNetworkController) AddPodSNATOps(
 
 	isNetworkAdvertised := oc.isPodNetworkAdvertisedAtNode(nodeName)
 	gwRouterName := oc.GetNetworkScopedGWRouterName(nodeName)
+	var clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs
 
 	if util.IsNoOverlaySNATExemptionNeeded(oc.GetNetInfo()) {
 		// Get the no-overlay SNAT exemption address set UUIDs
 		v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
+		}
+	} else if isNetworkAdvertised {
+		clusterNodeIPsAddrSetDbIDs, err = oc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsRouteAdvertisementsBackRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to ensure cluster node IP address set for route advertisements: %w", err)
 		}
 	}
 
@@ -1716,7 +1741,7 @@ func (oc *DefaultNetworkController) AddPodSNATOps(
 			exemptedExtIPs = v4UUID
 		}
 
-		snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(oc.nbClient, oc.GetNetInfo(), nodeName, isNetworkAdvertised, ipFamily)
+		snatMatch, err := GetNetworkScopedClusterSubnetSNATMatch(oc.nbClient, oc.GetNetInfo(), nodeName, isNetworkAdvertised, ipFamily, clusterNodeIPsAddrSetDbIDs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get SNAT match for node %s for network %s: %w", nodeName, oc.GetNetInfo().GetNetworkName(), err)
 		}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -69,16 +69,16 @@ func generateAdvertisedUDNIsolationExpectedNB(testData []libovsdbtest.TestData, 
 func generateGatewayInitExpectedNB(testData []libovsdbtest.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter,
 	expectedNodeSwitch *nbdb.LogicalSwitch, nodeName string, clusterIPSubnets []*net.IPNet, hostSubnets []*net.IPNet,
 	l3GatewayConfig *util.L3GatewayConfig, joinLRPIPs, defLRPIPs []*net.IPNet, skipSnat bool, nodeMgmtPortIP,
-	gatewayMTU string) []libovsdbtest.TestData {
+	gatewayMTU string, nodeIPsForClusterNodeIPAS ...string) []libovsdbtest.TestData {
 	return generateGatewayInitExpectedNBWithPodNetworkAdvertised(testData, expectedOVNClusterRouter, expectedNodeSwitch,
 		nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, nodeMgmtPortIP,
-		gatewayMTU, false) // Default to no pod network advertised
+		gatewayMTU, false, nodeIPsForClusterNodeIPAS...) // Default to no pod network advertised
 }
 
 func generateGatewayInitExpectedNBWithPodNetworkAdvertised(testData []libovsdbtest.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter,
 	expectedNodeSwitch *nbdb.LogicalSwitch, nodeName string, clusterIPSubnets []*net.IPNet, hostSubnets []*net.IPNet,
 	l3GatewayConfig *util.L3GatewayConfig, joinLRPIPs, defLRPIPs []*net.IPNet, skipSnat bool, nodeMgmtPortIP,
-	gatewayMTU string, isPodNetworkAdvertised bool) []libovsdbtest.TestData {
+	gatewayMTU string, isPodNetworkAdvertised bool, nodeIPsForClusterNodeIPAS ...string) []libovsdbtest.TestData {
 
 	GRName := "GR_" + nodeName
 	gwSwitchPort := types.JoinSwitchToGWRouterPrefix + GRName
@@ -230,7 +230,11 @@ func generateGatewayInitExpectedNBWithPodNetworkAdvertised(testData []libovsdbte
 	})
 	var egressNodeIPsASv4, egressNodeIPsASv6 *nbdb.AddressSet
 	if config.OVNKubernetesFeature.EnableEgressIP {
-		egressNodeIPsASv4, egressNodeIPsASv6 = buildEgressIPNodeAddressSets(physicalIPs)
+		nodeIPs := physicalIPs
+		if len(nodeIPsForClusterNodeIPAS) > 0 {
+			nodeIPs = nodeIPsForClusterNodeIPAS
+		}
+		egressNodeIPsASv4, egressNodeIPsASv6 = buildEgressIPNodeAddressSets(nodeIPs)
 		if config.IPv4Mode {
 			testData = append(testData, egressNodeIPsASv4)
 		}
@@ -2110,6 +2114,7 @@ func newGatewayManager(ovn *FakeOVN, nodeName string) *GatewayManager {
 		controller.GetNetInfo(),
 		ovn.watcher,
 		nodecontroller.NewNodeAnnotationCache(),
+		ovn.addressSetManager,
 		WithLoadBalancerGroups(
 			controller.routerLoadBalancerGroupUUID,
 			controller.clusterLoadBalancerGroupUUID,
@@ -2150,7 +2155,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 	ginkgo.Context("when network is not advertised", func() {
 		ginkgo.It("returns empty match for Layer3 topology", func() {
 			netInfo.topology = types.Layer3Topology
-			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4)
+			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(match).To(gomega.BeEmpty())
 		})
@@ -2160,7 +2165,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 			defer func() { config.Layer2UsesTransitRouter = originalValue }()
 			config.Layer2UsesTransitRouter = true
 			netInfo.topology = types.Layer2Topology
-			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4)
+			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(match).To(gomega.BeEmpty())
 		})
@@ -2170,7 +2175,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 			defer func() { config.Layer2UsesTransitRouter = originalValue }()
 			config.Layer2UsesTransitRouter = false
 			netInfo.topology = types.Layer2Topology
-			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4)
+			match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, false, utilnet.IPv4, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			expectedMatch := fmt.Sprintf("outport == %q", types.GWRouterToExtSwitchPrefix+netInfo.GetNetworkScopedGWRouterName(nodeName))
 			gomega.Expect(match).To(gomega.Equal(expectedMatch))
@@ -2191,7 +2196,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 
 				ginkgo.It("returns empty match for Layer3 topology", func() {
 					netInfo.topology = types.Layer3Topology
-					match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
+					match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, nil)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(match).To(gomega.BeEmpty())
 				})
@@ -2201,7 +2206,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 				ginkgo.BeforeEach(func() {
 					config.Gateway.Mode = config.GatewayModeLocal
 					addressSetFactory = addressset.NewOvnAddressSetFactory(fakeOvn.nbClient, config.IPv4Mode, config.IPv6Mode)
-					dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
+					dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
 					as, err := addressSetFactory.EnsureAddressSet(dbIDs)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					err = as.AddAddresses([]string{"10.0.0.1"})
@@ -2210,9 +2215,10 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 
 				ginkgo.It("returns destination match for Layer3 topology", func() {
 					netInfo.topology = types.Layer3Topology
-					match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
+					dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
+					match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, dbIDs)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+					as, err := addressSetFactory.GetAddressSet(dbIDs)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					v4Hash, _ := as.GetASHashNames()
 					expectedMatch := fmt.Sprintf("ip4.dst == $%s", v4Hash)
@@ -2224,7 +2230,7 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 		ginkgo.Context("when outbound SNAT is disabled", func() {
 			ginkgo.BeforeEach(func() {
 				addressSetFactory = addressset.NewOvnAddressSetFactory(fakeOvn.nbClient, config.IPv4Mode, config.IPv6Mode)
-				dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
+				dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
 				as, err := addressSetFactory.EnsureAddressSet(dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = as.AddAddresses([]string{"10.0.0.1"})
@@ -2233,9 +2239,10 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 
 			ginkgo.It("returns destination match for Layer3 topology", func() {
 				netInfo.topology = types.Layer3Topology
-				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
+				dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
+				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+				as, err := addressSetFactory.GetAddressSet(dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				v4Hash, _ := as.GetASHashNames()
 				expectedMatch := fmt.Sprintf("ip4.dst == $%s", v4Hash)
@@ -2247,9 +2254,10 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 				defer func() { config.Layer2UsesTransitRouter = originalValue }()
 				config.Layer2UsesTransitRouter = true
 				netInfo.topology = types.Layer2Topology
-				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
+				dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
+				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+				as, err := addressSetFactory.GetAddressSet(dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				v4Hash, _ := as.GetASHashNames()
 				expectedMatch := fmt.Sprintf("ip4.dst == $%s", v4Hash)
@@ -2261,9 +2269,10 @@ var _ = ginkgo.Describe("GetNetworkScopedClusterSubnetSNATMatch", func() {
 				defer func() { config.Layer2UsesTransitRouter = originalValue }()
 				config.Layer2UsesTransitRouter = false
 				netInfo.topology = types.Layer2Topology
-				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4)
+				dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
+				match, err := GetNetworkScopedClusterSubnetSNATMatch(fakeOvn.nbClient, netInfo, nodeName, true, utilnet.IPv4, dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				as, err := addressSetFactory.GetAddressSet(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+				as, err := addressSetFactory.GetAddressSet(dbIDs)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				v4Hash, _ := as.GetASHashNames()
 				expectedMatch := fmt.Sprintf("outport == %q && ip4.dst == $%s", types.GWRouterToExtSwitchPrefix+netInfo.GetNetworkScopedGWRouterName(nodeName), v4Hash)
@@ -2324,7 +2333,7 @@ var _ = ginkgo.Describe("AddPodSNATOps", func() {
 		controller = fakeOvn.controller
 
 		// Create address set for node IPs (required for SNAT match)
-		dbIDs := getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName)
+		dbIDs := getClusterNodeIPsAddrSetDbIDsForTest()
 		nodeIPAddrSet, asErr := controller.addressSetFactory.EnsureAddressSet(dbIDs)
 		gomega.Expect(asErr).NotTo(gomega.HaveOccurred())
 		asErr = nodeIPAddrSet.AddAddresses([]string{nodeIP, nodeIPv6})

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -1209,6 +1209,7 @@ func (oc *Layer2UserDefinedNetworkController) newGatewayManager(nodeName string)
 		oc.GetNetInfo(),
 		oc.watchFactory,
 		oc.nodeAnnotationCache,
+		oc.addressSetManager,
 		config.Layer2UsesTransitRouter,
 		oc.gatewayOptions()...,
 	)

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -1193,6 +1193,7 @@ func (oc *Layer3UserDefinedNetworkController) newGatewayManager(nodeName string)
 		oc.GetNetInfo(),
 		oc.watchFactory,
 		oc.nodeAnnotationCache,
+		oc.addressSetManager,
 		oc.gatewayOptions()...,
 	)
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -874,6 +874,7 @@ func (oc *DefaultNetworkController) newGatewayManager(nodeName string) *GatewayM
 		oc.GetNetInfo(),
 		oc.watchFactory,
 		nodecontroller.NewNodeAnnotationCache(),
+		oc.addressSetManager,
 		oc.gatewayOptions()...,
 	)
 	return gatewayManager

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -41,6 +41,7 @@ import (
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/sbdb"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -963,11 +964,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		err = util.SetL3GatewayConfig(nodeAnnotator, l3GatewayConfig)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if config.OVNKubernetesFeature.EnableEgressIP {
-			physicalIPs := []string{}
-			for _, ip := range l3GatewayConfig.IPAddresses {
-				physicalIPs = append(physicalIPs, ip.IP.String())
-			}
-			egressNodeIPsASv4, egressNodeIPsASv6 := buildEgressIPNodeAddressSets(physicalIPs)
+			egressNodeIPsASv4, egressNodeIPsASv6 := buildEgressIPNodeAddressSets([]string{node1.NodeIP})
 			if config.IPv4Mode {
 				dbSetup.NBData = append(dbSetup.NBData, egressNodeIPsASv4)
 			}
@@ -995,19 +992,22 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		recorder = record.NewFakeRecorder(10)
+		netManager := networkmanager.Default()
+		addressSetManager := addresssetmanager.NewAddressSetManager(f.PodCoreInformer(), f.NamespaceInformer(),
+			f.NodeCoreInformer(), nbClient, netManager.Interface().GetNetworkNameForNADKey)
 		oc, err = NewOvnController(
 			fakeClient,
 			f,
 			stopChan,
 			nil,
-			networkmanager.Default().Interface(),
+			netManager.Interface(),
 			nbClient,
 			sbClient,
 			recorder,
 			wg,
 			nil,
 			NewPortCache(stopChan),
-			nil,
+			addressSetManager,
 		)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(oc).NotTo(gomega.BeNil())
@@ -1063,7 +1063,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
 			expectedNBDatabaseState = append(expectedNBDatabaseState, expectedTransitSwitch())
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
@@ -1113,7 +1113,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
 			expectedNBDatabaseState = append(expectedNBDatabaseState, expectedTransitSwitch())
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
@@ -1149,7 +1149,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
 			expectedNBDatabaseState = append(expectedNBDatabaseState, expectedTransitSwitch())
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 
@@ -1172,10 +1172,10 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		newNodeSNAT("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3"),
 	}
 	extraNatsWithMatch := []*nbdb.NAT{ // used for pod network advertised test
-		newNodeSNATWithMatch("stale-nodeNAT-UUID-1", "10.1.0.3", Node1GatewayRouterIP, "ip4.dst == $a712973235162149816"),
-		newNodeSNATWithMatch("stale-nodeNAT-UUID-2", "10.2.0.3", Node1GatewayRouterIP, "ip4.dst == $a712973235162149816"),
-		newNodeSNATWithMatch("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP, "ip4.dst == $a712973235162149816"),
-		newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a712973235162149816"),
+		newNodeSNATWithMatch("stale-nodeNAT-UUID-1", "10.1.0.3", Node1GatewayRouterIP, "ip4.dst == $a1042611113178530741"),
+		newNodeSNATWithMatch("stale-nodeNAT-UUID-2", "10.2.0.3", Node1GatewayRouterIP, "ip4.dst == $a1042611113178530741"),
+		newNodeSNATWithMatch("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP, "ip4.dst == $a1042611113178530741"),
+		newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a1042611113178530741"),
 	}
 	ginkgo.DescribeTable(
 		"reconciles pod network SNATs from syncGateway",
@@ -1235,12 +1235,12 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 					expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 						expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 						[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-						skipSnat, node1.NodeMgmtPortIP, "1400")
+						skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
 				} else {
 					expectedNBDatabaseState = generateGatewayInitExpectedNBWithPodNetworkAdvertised(expectedNBDatabaseState, expectedOVNClusterRouter,
 						expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 						[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-						skipSnat, node1.NodeMgmtPortIP, "1400", true)
+						skipSnat, node1.NodeMgmtPortIP, "1400", true, node1.NodeIP)
 					addrSet, err := oc.addressSetFactory.GetAddressSet(GetAdvertisedNetworkSubnetsAddressSetDBIDs())
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					expectedNBDatabaseState = generateAdvertisedUDNIsolationExpectedNB(expectedNBDatabaseState, oc.GetNetworkName(), oc.GetNetworkID(), clusterSubnets, expectedNodeSwitch, addrSet)
@@ -1296,9 +1296,9 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				return oc.Reconcile(mutableNetInfo)
 			},
 			// won't be deleted on this node since this pod belongs to node-1 and is advertised so we keep this SNAT
-			newNodeSNATWithMatch("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP, "ip4.dst == $a712973235162149816"),
+			newNodeSNATWithMatch("stale-nodeNAT-UUID-3", "10.0.0.3", Node1GatewayRouterIP, "ip4.dst == $a1042611113178530741"),
 			// won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to node-1
-			newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a712973235162149816"),
+			newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a1042611113178530741"),
 		),
 		ginkgo.Entry(
 			"When pod network is advertised and DisableSNATMultipleGWs is false",
@@ -1309,7 +1309,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				mutableNetInfo.SetPodNetworkAdvertisedVRFs(map[string][]string{"node1": {"vrf"}})
 				return oc.Reconcile(mutableNetInfo)
 			},
-			newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a712973235162149816"), // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
+			newNodeSNATWithMatch("stale-nodeNAT-UUID-4", "10.0.0.3", "172.16.16.3", "ip4.dst == $a1042611113178530741"), // won't be deleted on this node but will be deleted on the node whose IP is 172.16.16.3 since this pod belongs to this node
 		),
 	)
 
@@ -1326,7 +1326,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			expectedNBDatabaseState = generateGatewayInitExpectedNB(expectedNBDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
 				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
-				skipSnat, node1.NodeMgmtPortIP, "1400")
+				skipSnat, node1.NodeMgmtPortIP, "1400", node1.NodeIP)
 			expectedNBDatabaseState = append(expectedNBDatabaseState, expectedTransitSwitch())
 			gomega.Eventually(oc.nbClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -27,6 +27,7 @@ import (
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	anpcontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/admin_network_policy"
 	egresssvc_zone "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
 	networkconnectcontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/networkconnect"
@@ -446,8 +447,22 @@ func (oc *DefaultNetworkController) InitEgressServiceZoneController() (*egresssv
 	}
 
 	if !config.OVNKubernetesFeature.EnableEgressIP {
-		initClusterEgressPolicies = InitClusterEgressPolicies
-		ensureNodeNoReroutePolicies = ensureDefaultNoRerouteNodePolicies
+		initClusterEgressPolicies = func(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
+			ni util.NetInfo, clusterSubnets []*net.IPNet, controllerName, routerName string) error {
+			clusterNodeIPsAddrSetDbIDs, err := oc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressServiceBackRef)
+			if err != nil {
+				return fmt.Errorf("failed to ensure cluster node IP address set for EgressService: %w", err)
+			}
+			return InitClusterEgressPolicies(nbClient, addressSetFactory, ni, clusterSubnets, controllerName, routerName, clusterNodeIPsAddrSetDbIDs)
+		}
+		ensureNodeNoReroutePolicies = func(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
+			network, router, controller string, nodeLister listers.NodeLister, v4, v6 bool) error {
+			clusterNodeIPsAddrSetDbIDs, err := oc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressServiceBackRef)
+			if err != nil {
+				return fmt.Errorf("failed to ensure cluster node IP address set for EgressService: %w", err)
+			}
+			return ensureDefaultNoRerouteNodePolicies(nbClient, addressSetFactory, network, router, controller, nodeLister, v4, v6, clusterNodeIPsAddrSetDbIDs)
+		}
 		createDefaultNodeRouteToExternal = libovsdbutil.CreateDefaultRouteToExternal
 	}
 

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -278,6 +278,9 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 	}
 
 	o.portCache = NewPortCache(o.stopChan)
+	o.addressSetManager = addresssetmanager.NewAddressSetManager(o.watcher.PodCoreInformer(),
+		o.watcher.NamespaceInformer(), o.watcher.NodeCoreInformer(), o.nbClient, o.networkManager.Interface().GetNetworkNameForNADKey)
+
 	kubeOVN := &kube.KubeOVN{
 		Kube:      kube.Kube{KClient: o.fakeClient.KubeClient},
 		EIPClient: o.fakeClient.EgressIPClient,
@@ -290,13 +293,12 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 		o.portCache,
 		o.networkManager.Interface(),
 		o.asf,
+		o.addressSetManager,
 		config.IPv4Mode,
 		config.IPv6Mode,
 		"",
 		types.DefaultNetworkControllerName,
 	)
-	o.addressSetManager = addresssetmanager.NewAddressSetManager(o.watcher.PodCoreInformer(),
-		o.watcher.NamespaceInformer(), o.watcher.NodeCoreInformer(), o.nbClient, o.networkManager.Interface().GetNetworkNameForNADKey)
 
 	if o.asf == nil {
 		o.eIPController.addressSetFactory = addressset.NewOvnAddressSetFactory(o.nbClient, config.IPv4Mode, config.IPv6Mode)


### PR DESCRIPTION
Route-advertised networks use the shared node-ips address set to build conditional gateway SNAT matches. Ensure and populate that address set before programming advertised gateway SNAT so route advertisements do not depend on EgressIP being enabled.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a centralized, cluster-wide "node IPs" address set reused by Egress IP, EgressService, SNAT/gateway and route-advertisement logic; controllers ensure it exists when needed.
  * Startup and reconciliation now clean up deprecated node-IP sets and synchronize cluster node IPs on node annotation or lifecycle changes.
* **Tests**
  * Added/updated tests covering cluster node-IP address-set reconciliation, cleanup, and related policy/SNAT/gateway behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->