### PR TITLE
Support manual DPU simulator Helm installs

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ovn-kubernetes
+          persist-credentials: false
 
       - name: Checkout dpu-simulator
         uses: actions/checkout@v4
@@ -42,6 +43,7 @@ jobs:
           repository: ovn-kubernetes/dpu-simulator
           ref: ${{ env.DPU_SIM_REF }}
           path: dpu-simulator
+          persist-credentials: false
 
       - name: Set up Go from dpu-simulator
         uses: actions/setup-go@v5
@@ -131,3 +133,112 @@ jobs:
         if: always()
         working-directory: dpu-simulator
         run: ./bin/dpu-sim --config config-kind-ovnk-offload.yaml --ovn-kubernetes-path "$OVN_KUBERNETES_PATH" --cleanup || true
+
+  kind-dpu-no-overlay:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      DPU_SIM_PATH: ${{ github.workspace }}/dpu-simulator
+      DPU_SIM_CONFIG: config-kind-ovnk-offload.yaml
+      KIND_EXPERIMENTAL_PROVIDER: docker
+    steps:
+      - name: Checkout OVN-Kubernetes (PR/push)
+        uses: actions/checkout@v4
+        with:
+          path: ovn-kubernetes
+          persist-credentials: false
+
+      - name: Checkout dpu-simulator
+        uses: actions/checkout@v4
+        with:
+          repository: ovn-kubernetes/dpu-simulator
+          ref: ${{ env.DPU_SIM_REF }}
+          path: dpu-simulator
+          persist-credentials: false
+
+      - name: Set up Go from dpu-simulator
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: dpu-simulator/go.mod
+          cache: true
+
+      - name: Install libvirt development headers
+        run: sudo apt-get update && sudo apt-get install -y libvirt-dev
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up Python for traffic flow tests
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install kind
+        run: |
+          KIND_VERSION=v0.31.0
+          curl -fsSLo /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          curl -fsSLo /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64.sha256sum"
+          (cd /tmp && sha256sum -c kind-linux-amd64.sha256sum)
+          chmod +x /tmp/kind-linux-amd64
+          sudo mv /tmp/kind-linux-amd64 /usr/local/bin/kind
+
+      - name: Build dpu-simulator
+        working-directory: dpu-simulator
+        run: make build
+
+      - name: Disable containerd image store
+        # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
+        run: |
+          sudo mkdir -p /etc/docker
+          [ -s "/etc/docker/daemon.json" ] && {
+            cat "/etc/docker/daemon.json" | jq '. + {"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+          } || {
+            echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.$$
+          }
+          sudo mv -f /etc/docker/daemon.$$ /etc/docker/daemon.json
+          sudo systemctl restart docker
+
+      - name: Deploy no-overlay DPU simulator with Helm
+        working-directory: ovn-kubernetes
+        run: ./contrib/kind-dpu-sim-no-overlay.sh
+
+      - name: TFT Python venv
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim tft venv --config "${DPU_SIM_CONFIG}"
+
+      - name: Run traffic flow tests
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim tft run --config "${DPU_SIM_CONFIG}"
+
+      - name: Export kind logs on failure
+        if: failure()
+        run: |
+          mkdir -p /tmp/kind-dpu-no-overlay-logs
+          for cluster in dpu-sim-host dpu-sim-host-kind dpu-sim-dpu dpu-sim-dpu-kind; do
+            kind export logs /tmp/kind-dpu-no-overlay-logs --name "${cluster}" 2>/dev/null || true
+          done
+          kubectl --kubeconfig dpu-simulator/kubeconfig/dpu-sim-host.kubeconfig get pods -A -o wide \
+            > /tmp/kind-dpu-no-overlay-logs/dpu-sim-host-pods.txt 2>&1 || true
+          kubectl --kubeconfig dpu-simulator/kubeconfig/dpu-sim-dpu.kubeconfig get pods -A -o wide \
+            > /tmp/kind-dpu-no-overlay-logs/dpu-sim-dpu-pods.txt 2>&1 || true
+
+      - name: Upload kind logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-dpu-no-overlay-logs
+          path: /tmp/kind-dpu-no-overlay-logs
+          if-no-files-found: ignore
+
+      - name: Upload TFT results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dpu-no-overlay-tft-results
+          path: dpu-simulator/kubernetes-traffic-flow-tests/ft-logs
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        working-directory: dpu-simulator
+        run: ./bin/dpu-sim --config "${DPU_SIM_CONFIG}" --ovn-kubernetes-path "$OVN_KUBERNETES_PATH" --cleanup || true

--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Run traffic flow tests
         working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft run --config config-kind-ovnk-offload.yaml
+        run: ./bin/dpu-sim tft run --check --config config-kind-ovnk-offload.yaml
 
       - name: Export kind logs on failure
         if: failure()
@@ -208,7 +208,7 @@ jobs:
 
       - name: Run traffic flow tests
         working-directory: dpu-simulator
-        run: ./bin/dpu-sim tft run --config "${DPU_SIM_CONFIG}"
+        run: ./bin/dpu-sim tft run --check --config "${DPU_SIM_CONFIG}"
 
       - name: Export kind logs on failure
         if: failure()

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1312,6 +1312,9 @@ fi\
   fi
   ./demo.sh
   popd || exit 1
+  if frr_k8s_remote_enabled && [ -n "${DPU_SIM_GATEWAY_NETWORK:-}" ]; then
+    configure_dpu_sim_frr_gateway_peers
+  fi
   if  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
     # Enable IPv6 forwarding in FRR
     $OCI_BIN exec frr sysctl -w net.ipv6.conf.all.forwarding=1
@@ -1498,10 +1501,15 @@ wait_for_frr_k8s() {
     kubectl rollout status -n frr-k8s-system daemonset frr-k8s-daemon --timeout 2m
     return
   fi
-  local ds
+  local ds found=false
   for ds in $(kubectl -n frr-k8s-system get daemonset -l dpu-sim.ovn.org/frr-remote=true -o name); do
+    found=true
     kubectl rollout status -n frr-k8s-system "${ds}" --timeout 2m
   done
+  if [ "${found}" != true ]; then
+    echo "No local or remote FRR-K8S daemonsets were found in namespace frr-k8s-system" >&2
+    return 1
+  fi
 }
 
 apply_frr_k8s_receive_config() {
@@ -1509,6 +1517,9 @@ apply_frr_k8s_receive_config() {
   # exchange routes
   pushd "${FRR_TMP_DIR}"/frr-k8s/hack/demo/configs || exit 1
   sed 's/mode: all/mode: filtered/g' receive_all.yaml > receive_filtered.yaml
+  if frr_k8s_remote_enabled && [ -n "${DPU_SIM_GATEWAY_NETWORK:-}" ]; then
+    configure_dpu_sim_frr_receive_config receive_filtered.yaml
+  fi
   # Allow receiving the bgp external server's prefix
   sed -i '/mode: filtered/a\            prefixes:\n            - prefix: '"${BGP_SERVER_NET_SUBNET_IPV4}"'' receive_filtered.yaml
   # If IPv6 is enabled, add the IPv6 prefix as well

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1445,8 +1445,7 @@ destroy_bgp() {
 install_frr_k8s_crds() {
   echo "Installing frr-k8s CRDs ..."
   clone_frr
-  kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
-  kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/frrk8s.metallb.io_frrnodestates.yaml
+  kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/
 }
 
 install_frr_k8s() {

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -333,8 +333,10 @@ build_ovn_image() {
 }
 
 run_kubectl() {
-  # Skip kubeconfig export in container mode - it overwrites container IPs with localhost.
-  if [ "$RUN_IN_CONTAINER" != true ]; then
+  # In deploy mode, KUBECONFIG points at an existing cluster and must not be
+  # merged with `kind export kubeconfig`; repeated merges can duplicate entries.
+  # In container mode, export would also overwrite reachable container IPs with localhost.
+  if [ "$RUN_IN_CONTAINER" != true ] && [ "${KIND_CREATE:-true}" == true ]; then
     kind export kubeconfig --name ${KIND_CLUSTER_NAME}
   fi
 
@@ -735,9 +737,40 @@ delete_metallb_dir() {
   rm -rf "${METALLB_DIR}"
 }
 
+wait_for_ovn_daemonset() {
+  local ds=$1
+  local required=${2:-true}
+  local endtime=$3
+
+  if ! kubectl -n ovn-kubernetes get daemonset "${ds}" >/dev/null 2>&1; then
+    if [ "${required}" = true ]; then
+      echo "DaemonSet ${ds} was not found in namespace ovn-kubernetes" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  local timeout
+  timeout=$(calculate_timeout ${endtime})
+  echo "Waiting for k8s to launch all ${ds} pods (timeout ${timeout})..."
+  # `kubectl rollout status` errors on DaemonSets with updateStrategy=OnDelete
+  # (upgrade-ovn.sh sets ovs-node to OnDelete so helm upgrade doesn't roll
+  # OVS out from under still-running ovnkube-node pods). For OnDelete DSes
+  # we can't observe rollout progress; just wait for pods to be Ready.
+  local strategy
+  strategy=$(kubectl -n ovn-kubernetes get daemonset ${ds} \
+    -o=jsonpath='{.spec.updateStrategy.type}' 2>/dev/null)
+  if [ "${strategy}" = "OnDelete" ]; then
+    kubectl wait -n ovn-kubernetes --for=condition=ready pods \
+      -l app=${ds} --timeout=${timeout}s
+  else
+    kubectl rollout status daemonset -n ovn-kubernetes ${ds} --timeout ${timeout}s
+  fi
+}
+
 # kubectl_wait_pods will set a total timeout of 300s for IPv4 and 480s for IPv6. It will first wait for all
 # DaemonSets to complete with kubectl rollout. This command will block until all pods of the DS are actually up.
-# Next, it waits for ovnkube-control-plane pods to post "Ready".
+# Next, it waits for ovnkube-control-plane pods to post "Ready" when that deployment is part of the mode.
 # Last, it will do the same with all pods in the kube-system namespace.
 kubectl_wait_pods() {
   # IPv6 cluster seems to take a little longer to come up, so extend the wait time.
@@ -749,28 +782,31 @@ kubectl_wait_pods() {
   # We will make sure that we timeout all commands at current seconds + the desired timeout.
   endtime=$(( SECONDS + OVN_TIMEOUT ))
 
-  for ds in ovnkube-node ovs-node; do
-    timeout=$(calculate_timeout ${endtime})
-    echo "Waiting for k8s to launch all ${ds} pods (timeout ${timeout})..."
-    # `kubectl rollout status` errors on DaemonSets with updateStrategy=OnDelete
-    # (upgrade-ovn.sh sets ovs-node to OnDelete so helm upgrade doesn't roll
-    # OVS out from under still-running ovnkube-node pods). For OnDelete DSes
-    # we can't observe rollout progress; just wait for pods to be Ready.
-    strategy=$(kubectl -n ovn-kubernetes get daemonset ${ds} \
-      -o=jsonpath='{.spec.updateStrategy.type}' 2>/dev/null)
-    if [ "${strategy}" = "OnDelete" ]; then
-      kubectl wait -n ovn-kubernetes --for=condition=ready pods \
-        -l app=${ds} --timeout=${timeout}s
-    else
-      kubectl rollout status daemonset -n ovn-kubernetes ${ds} --timeout ${timeout}s
-    fi
-  done
+  case "${DPU_MODE:-none}" in
+    dpu)
+      wait_for_ovn_daemonset ovnkube-node-dpu true ${endtime}
+      ;;
+    host)
+      wait_for_ovn_daemonset ovnkube-node-dpu-host true ${endtime}
+      wait_for_ovn_daemonset ovnkube-node false ${endtime}
+      wait_for_ovn_daemonset ovs-node false ${endtime}
+      ;;
+    *)
+      wait_for_ovn_daemonset ovnkube-node true ${endtime}
+      wait_for_ovn_daemonset ovs-node true ${endtime}
+      ;;
+  esac
 
-  for name in ovnkube-control-plane; do
+  if [ "${DPU_MODE:-none}" != "dpu" ]; then
+    local name
+    name=ovnkube-control-plane
     timeout=$(calculate_timeout ${endtime})
     echo "Waiting for k8s to create ${name} pods (timeout ${timeout})..."
     kubectl wait pods -n ovn-kubernetes -l name=${name} --for condition=Ready --timeout=${timeout}s
-  done
+  fi
+
+  restart_dpu_sim_multus_after_ovnk
+  restart_dpu_sim_system_deployments_after_ovnk
 
   timeout=$(calculate_timeout ${endtime})
   if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=${timeout}s ; then
@@ -916,7 +952,11 @@ docker_create_second_disconnected_interface() {
 }
 
 enable_multi_net() {
-  install_multus
+  if [ "${DPU_MODE:-none}" == "none" ]; then
+    install_multus
+  else
+    echo "Skipping multus-cni installation; DPU simulator mode expects Multus to be installed by dpu-simulator"
+  fi
   install_mpolicy_crd
   install_ipamclaim_crd
   docker_create_second_disconnected_interface "underlay"  # localnet scenarios require an extra interface
@@ -1247,7 +1287,18 @@ deploy_frr_external_container() {
     # Add route-reflector-client for IPv6 neighbors
     sed -i '/neighbor fc00.*remote-as 64512/a \ neighbor {{ . }} route-reflector-client' frr/frr.conf.tmpl
   fi
-  ./demo.sh
+  if [ "${OCI_BIN}" == "podman" ]; then
+    # frr-k8s' demo script prefers docker when both docker and podman are
+    # installed. Keep it on the same runtime as kind-helm.sh so later podman
+    # operations can find the external frr container.
+    local docker_wrapper_dir
+    docker_wrapper_dir=$(mktemp -d)
+    ln -s "$(command -v podman)" "${docker_wrapper_dir}/docker"
+    PATH="${docker_wrapper_dir}:${PATH}" ./demo.sh
+    rm -rf "${docker_wrapper_dir}"
+  else
+    ./demo.sh
+  fi
   popd || exit 1
   if  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
     # Enable IPv6 forwarding in FRR
@@ -1379,6 +1430,13 @@ destroy_bgp() {
   fi
 }
 
+install_frr_k8s_crds() {
+  echo "Installing frr-k8s CRDs ..."
+  clone_frr
+  kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+  kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/frrk8s.metallb.io_frrnodestates.yaml
+}
+
 install_frr_k8s() {
   local bgp_port=${1:-0}
   echo "Installing frr-k8s ..."
@@ -1415,15 +1473,27 @@ install_frr_k8s() {
       exit 1
     }
   fi
+  install_frr_k8s_host_api_crds
   kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml
+  create_frr_k8s_remote_kubeconfig_secret
+  configure_frr_k8s_remote_daemonsets
 }
 
 wait_for_frr_k8s() {
-  kubectl wait -n frr-k8s-system deployment frr-k8s-statuscleaner --for condition=Available --timeout 2m
-  kubectl rollout status -n frr-k8s-system daemonset frr-k8s-daemon --timeout 2m
+  if kubectl -n frr-k8s-system get deployment frr-k8s-statuscleaner >/dev/null 2>&1; then
+    kubectl wait -n frr-k8s-system deployment frr-k8s-statuscleaner --for condition=Available --timeout 2m
+  fi
+  if kubectl -n frr-k8s-system get daemonset frr-k8s-daemon >/dev/null 2>&1; then
+    kubectl rollout status -n frr-k8s-system daemonset frr-k8s-daemon --timeout 2m
+    return
+  fi
+  local ds
+  for ds in $(kubectl -n frr-k8s-system get daemonset -l dpu-sim.ovn.org/frr-remote=true -o name); do
+    kubectl rollout status -n frr-k8s-system "${ds}" --timeout 2m
+  done
 }
 
-configure_frr_k8s() {
+apply_frr_k8s_receive_config() {
   # apply a BGP peer configration with the external gateway that does not
   # exchange routes
   pushd "${FRR_TMP_DIR}"/frr-k8s/hack/demo/configs || exit 1
@@ -1443,10 +1513,12 @@ configure_frr_k8s() {
   
   # frr-k8s webhook is declaring readiness before its endpoint is serving.
   # Let's do our own probing. Also will print logs in case of failure so we get
-  # insights on why this is hapenning 
+  # insights on why this is hapenning. In remote mode the host API does not use
+  # the DPU-cluster webhook service, so skip this probe.
   local r
   r=0
-  timeout 60s bash -x <<EOF || r=$?
+  if ! frr_k8s_remote_enabled; then
+    timeout 60s bash -x <<EOF || r=$?
 echo "Attempting to reach frr-k8s webhook"
 kind export kubeconfig --name ovn
 while true; do
@@ -1459,16 +1531,22 @@ echo "Couldn't reach frr-k8s webhook, trying in 1s..."
 sleep 1s
 done
 EOF
+  fi
   echo "r=$r"
   if [ "$r" -ne "0" ]; then
     kubectl describe pod -n frr-k8s-system -l app=frr-k8s-webhook-server
     kubectl logs -n frr-k8s-system -l app=frr-k8s-webhook-server
   fi
 
-  kubectl apply -n frr-k8s-system -f receive_filtered.yaml
+  local kubectl_cmd=(kubectl)
+  if frr_k8s_remote_enabled; then
+    kubectl_cmd=(kubectl --kubeconfig "$(frr_k8s_host_kubeconfig)")
+  fi
+  "${kubectl_cmd[@]}" apply -n frr-k8s-system -f receive_filtered.yaml
   popd || exit 1
+}
 
-  rm -rf "${FRR_TMP_DIR}"
+configure_frr_k8s_routes() {
   # Add routes for pod networks dynamically into the github runner for return traffic to pass back
   if [ "$ADVERTISE_DEFAULT_NETWORK" = "true" ]; then
     echo "Adding routes for Kubernetes pod networks..."
@@ -1505,6 +1583,13 @@ EOF
       fi
     done
   fi
+
+  rm -rf "${FRR_TMP_DIR}"
+}
+
+configure_frr_k8s() {
+  apply_frr_k8s_receive_config
+  configure_frr_k8s_routes
 }
 
 setup_coredumps() {

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -768,15 +768,21 @@ wait_for_ovn_daemonset() {
   fi
 }
 
-# kubectl_wait_pods will set a total timeout of 300s for IPv4 and 480s for IPv6. It will first wait for all
-# DaemonSets to complete with kubectl rollout. This command will block until all pods of the DS are actually up.
-# Next, it waits for ovnkube-control-plane pods to post "Ready" when that deployment is part of the mode.
-# Last, it will do the same with all pods in the kube-system namespace.
+# kubectl_wait_pods will set a total timeout of 300s for IPv4 and 480s for IPv6,
+# unless KIND_HELM_OVN_TIMEOUT is set. It will first wait for all DaemonSets to
+# complete with kubectl rollout. This command will block until all pods of the
+# DS are actually up. Next, it waits for ovnkube-control-plane pods to post
+# "Ready" when that deployment is part of the mode. Last, it will do the same
+# with all pods in the kube-system namespace.
 kubectl_wait_pods() {
   # IPv6 cluster seems to take a little longer to come up, so extend the wait time.
-  OVN_TIMEOUT=300
+  OVN_TIMEOUT=${KIND_HELM_OVN_TIMEOUT:-300}
+  if ! [[ "${OVN_TIMEOUT}" =~ ^[0-9]+$ ]]; then
+    echo "Invalid KIND_HELM_OVN_TIMEOUT: ${OVN_TIMEOUT}"
+    exit 1
+  fi
   if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
-    OVN_TIMEOUT=480
+    OVN_TIMEOUT=${KIND_HELM_OVN_TIMEOUT:-480}
   fi
 
   # We will make sure that we timeout all commands at current seconds + the desired timeout.
@@ -806,7 +812,6 @@ kubectl_wait_pods() {
   fi
 
   restart_dpu_sim_multus_after_ovnk
-  restart_dpu_sim_system_deployments_after_ovnk
 
   timeout=$(calculate_timeout ${endtime})
   if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=${timeout}s ; then
@@ -1289,16 +1294,23 @@ deploy_frr_external_container() {
   fi
   if [ "${OCI_BIN}" == "podman" ]; then
     # frr-k8s' demo script prefers docker when both docker and podman are
-    # installed. Keep it on the same runtime as kind-helm.sh so later podman
-    # operations can find the external frr container.
-    local docker_wrapper_dir
-    docker_wrapper_dir=$(mktemp -d)
-    ln -s "$(command -v podman)" "${docker_wrapper_dir}/docker"
-    PATH="${docker_wrapper_dir}:${PATH}" ./demo.sh
-    rm -rf "${docker_wrapper_dir}"
-  else
-    ./demo.sh
+    # installed. Force its podman path, and avoid its host-network fallback
+    # because podman cannot later attach a host-network container to bgpnet.
+    replace_in_file_or_exit \
+      ./demo.sh \
+      'CLI=docker' \
+      'CLI=podman'
+    replace_in_file_or_exit \
+      ./demo.sh \
+      'CLI_BR_NET_BY_SUBNET_FN="docker_get_br_net_by_subnet"' \
+      'CLI_BR_NET_BY_SUBNET_FN="podman_get_br_net_by_subnet"'
+    sed -i '/^pushd \.\/frr\/ && {/i\
+if [ "$CLI" = "podman" ]; then\
+    NETWORK=${FRR_K8S_DEMO_NETWORK:-kind}\
+fi\
+' ./demo.sh
   fi
+  ./demo.sh
   popd || exit 1
   if  [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
     # Enable IPv6 forwarding in FRR

--- a/contrib/kind-dpu-sim-lib.sh
+++ b/contrib/kind-dpu-sim-lib.sh
@@ -109,9 +109,33 @@ install_frr_k8s_host_api_crds() {
   host_kubeconfig=$(frr_k8s_host_kubeconfig)
   ensure_frr_k8s_namespace "${host_kubeconfig}"
   kubectl --kubeconfig "${host_kubeconfig}" apply \
-    -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
-  kubectl --kubeconfig "${host_kubeconfig}" apply \
-    -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/frrk8s.metallb.io_frrnodestates.yaml
+    -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/
+  ensure_frr_k8s_host_api_rbac "${host_kubeconfig}"
+}
+
+ensure_frr_k8s_host_api_rbac() {
+  local host_kubeconfig=$1
+
+  local frr_rbac_dir="${FRR_TMP_DIR}/frr-k8s/config/rbac"
+  local host_rbac_dir="${FRR_TMP_DIR}/frr-k8s/config/host-api-rbac"
+  mkdir -p "${host_rbac_dir}"
+  cp \
+    "${frr_rbac_dir}/service_account.yaml" \
+    "${frr_rbac_dir}/role.yaml" \
+    "${frr_rbac_dir}/secrets_role.yaml" \
+    "${frr_rbac_dir}/role_binding.yaml" \
+    "${host_rbac_dir}/"
+  cat > "${host_rbac_dir}/kustomization.yaml" <<'EOF'
+namespace: frr-k8s-system
+namePrefix: frr-k8s-
+resources:
+- service_account.yaml
+- role.yaml
+- secrets_role.yaml
+- role_binding.yaml
+EOF
+
+  kubectl --kubeconfig "${host_kubeconfig}" apply -k "${host_rbac_dir}"
 }
 
 create_frr_k8s_remote_kubeconfig_secret() {
@@ -151,6 +175,10 @@ configure_frr_k8s_remote_daemonsets() {
     fi
     ds_name="frr-k8s-daemon-${safe_name:0:45}"
     echo "Creating remote frr-k8s daemonset ${ds_name}: host node ${host_node}, DPU node ${dpu_node}"
+    # These DaemonSets run in the DPU cluster. Only the FRR-K8S
+    # controller container uses the host API so it watches host
+    # FRRConfiguration objects with the host node name. Keep frr-status
+    # on the DPU API because it reports the local daemon pod status.
     jq \
       --arg name "${ds_name}" \
       --arg host_node "${host_node}" \
@@ -162,10 +190,11 @@ configure_frr_k8s_remote_daemonsets() {
        | .spec.selector.matchLabels["dpu-sim.ovn.org/frr-host-node"] = $host_node
        | .spec.template.metadata.labels["dpu-sim.ovn.org/frr-remote"] = "true"
        | .spec.template.metadata.labels["dpu-sim.ovn.org/frr-host-node"] = $host_node
+       | .spec.template.metadata.annotations["kubectl.kubernetes.io/default-container"] = "controller"
        | .spec.template.spec.nodeSelector = {"kubernetes.io/hostname": $dpu_node}
-       | (.spec.template.spec.containers[] | select(.name == "frr-k8s").args) |= ((. // []) | map(if startswith("--node-name=") then "--node-name=" + $host_node else . end))
-       | (.spec.template.spec.containers[] | select(.name == "frr-k8s").env) |= ((. // []) + [{"name":"KUBECONFIG","value":"/var/run/host-kubeconfig/kubeconfig"}])
-       | (.spec.template.spec.containers[] | select(.name == "frr-k8s").volumeMounts) |= ((. // []) + [{"name":"host-kubeconfig","mountPath":"/var/run/host-kubeconfig","readOnly":true}])
+       | (.spec.template.spec.containers[] | select(.name == "frr-k8s" or .name == "controller").args) |= ((. // []) | map(if startswith("--node-name=") then "--node-name=" + $host_node else . end))
+       | (.spec.template.spec.containers[] | select(.name == "frr-k8s" or .name == "controller").env) |= ((. // []) + [{"name":"KUBECONFIG","value":"/var/run/host-kubeconfig/kubeconfig"}])
+       | (.spec.template.spec.containers[] | select(.name == "frr-k8s" or .name == "controller").volumeMounts) |= ((. // []) + [{"name":"host-kubeconfig","mountPath":"/var/run/host-kubeconfig","readOnly":true}])
        | .spec.template.spec.volumes = ((.spec.template.spec.volumes // []) + [{"name":"host-kubeconfig","secret":{"secretName":"frr-k8s-host-kubeconfig"}}])' \
       "${source_json}" | kubectl apply -f -
   done

--- a/contrib/kind-dpu-sim-lib.sh
+++ b/contrib/kind-dpu-sim-lib.sh
@@ -87,6 +87,117 @@ frr_k8s_host_kubeconfig() {
   printf '%s' "${FRR_K8S_HOST_KUBECONFIG:-${FRR_K8S_REMOTE_KUBECONFIG}}"
 }
 
+dpu_sim_container_network_ipv4() {
+  local container=$1
+  local network=$2
+
+  $OCI_BIN inspect "${container}" | jq -r --arg network "${network}" \
+    '.[0].NetworkSettings.Networks[$network].IPAddress // empty'
+}
+
+configure_dpu_sim_frr_gateway_peers() {
+  if ! frr_k8s_remote_enabled; then
+    return
+  fi
+  if [ -z "${DPU_SIM_GATEWAY_NETWORK:-}" ]; then
+    return
+  fi
+
+  echo "Connecting external FRR to DPU gateway network ${DPU_SIM_GATEWAY_NETWORK}"
+  if ! $OCI_BIN network inspect "${DPU_SIM_GATEWAY_NETWORK}" >/dev/null 2>&1; then
+    echo "DPU simulator gateway network does not exist: ${DPU_SIM_GATEWAY_NETWORK}" >&2
+    exit 1
+  fi
+  if [ -z "$(dpu_sim_container_network_ipv4 frr "${DPU_SIM_GATEWAY_NETWORK}")" ]; then
+    $OCI_BIN network connect "${DPU_SIM_GATEWAY_NETWORK}" frr
+  fi
+
+  DPU_SIM_FRR_IPV4=$(dpu_sim_container_network_ipv4 frr "${DPU_SIM_GATEWAY_NETWORK}")
+  if [ -z "${DPU_SIM_FRR_IPV4}" ]; then
+    echo "Failed to determine external FRR IP on ${DPU_SIM_GATEWAY_NETWORK}" >&2
+    exit 1
+  fi
+  echo "External FRR DPU gateway network IPv4: ${DPU_SIM_FRR_IPV4}"
+
+  local -a node_ips=()
+  local -a pairs=()
+  local pair dpu_node node_ip
+  IFS=',' read -ra pairs <<< "${FRR_K8S_REMOTE_NODE_MAP}"
+  for pair in "${pairs[@]}"; do
+    dpu_node="${pair#*=}"
+    node_ip=$(dpu_sim_container_network_ipv4 "${dpu_node}" "${DPU_SIM_GATEWAY_NETWORK}")
+    if [ -z "${node_ip}" ]; then
+      echo "Failed to determine ${dpu_node} IP on ${DPU_SIM_GATEWAY_NETWORK}" >&2
+      exit 1
+    fi
+    node_ips+=("${node_ip}")
+  done
+
+  local attempts=0 daemon_status
+  while ! daemon_status=$($OCI_BIN exec frr vtysh -c "show daemons" 2>&1); do
+    if (( ++attempts > 30 )); then
+      echo "error: FRR daemons did not become ready after 30 attempts"
+      echo "last daemon status: $daemon_status"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  local vtysh_cmds=(-c "configure terminal" -c "router bgp 64512")
+  for node_ip in "${node_ips[@]}"; do
+    vtysh_cmds+=(-c "neighbor ${node_ip} remote-as 64512")
+  done
+  vtysh_cmds+=(-c "address-family ipv4 unicast")
+  for node_ip in "${node_ips[@]}"; do
+    vtysh_cmds+=(-c "neighbor ${node_ip} activate")
+    vtysh_cmds+=(-c "neighbor ${node_ip} route-reflector-client")
+  done
+  vtysh_cmds+=(-c "exit-address-family" -c "end" -c "write memory")
+  $OCI_BIN exec frr vtysh "${vtysh_cmds[@]}"
+}
+
+configure_dpu_sim_frr_receive_config() {
+  local receive_config=$1
+
+  if ! frr_k8s_remote_enabled; then
+    return
+  fi
+  if [ -z "${DPU_SIM_GATEWAY_NETWORK:-}" ]; then
+    return
+  fi
+
+  DPU_SIM_FRR_IPV4=${DPU_SIM_FRR_IPV4:-$(dpu_sim_container_network_ipv4 frr "${DPU_SIM_GATEWAY_NETWORK}")}
+  if [ -z "${DPU_SIM_FRR_IPV4}" ]; then
+    echo "Failed to determine external FRR IP on ${DPU_SIM_GATEWAY_NETWORK}" >&2
+    exit 1
+  fi
+  sed -i -E "s/(address: )[0-9.]+/\\1${DPU_SIM_FRR_IPV4}/g" "${receive_config}"
+
+  local filtered
+  filtered=$(mktemp)
+  awk '
+    function indentation(line) {
+      match(line, /[^ ]/)
+      return RSTART ? RSTART - 1 : length(line)
+    }
+    skip && indentation($0) <= skip_indent && $0 !~ /^[[:space:]]*$/ {
+      skip = 0
+    }
+    !skip && $0 ~ /^[[:space:]]*- address: / {
+      addr = $0
+      sub(/^[[:space:]]*- address: /, "", addr)
+      gsub(/"/, "", addr)
+      if (addr ~ /:/) {
+        skip = 1
+        skip_indent = indentation($0)
+        next
+      }
+    }
+    !skip { print }
+  ' "${receive_config}" > "${filtered}"
+  mv "${filtered}" "${receive_config}"
+}
+
 ensure_frr_k8s_namespace() {
   local kubeconfig=${1:-}
   local kubectl_cmd=(kubectl)

--- a/contrib/kind-dpu-sim-lib.sh
+++ b/contrib/kind-dpu-sim-lib.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+restart_dpu_sim_multus_after_ovnk() {
+  if [ "${DPU_MODE:-none}" == "none" ] || [ "${ENABLE_MULTI_NET:-false}" != true ]; then
+    return
+  fi
+
+  if ! kubectl -n kube-system get daemonset kube-multus-ds >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "Restarting dpu-simulator Multus after OVN-Kubernetes is ready..."
+  kubectl -n kube-system rollout restart daemonset/kube-multus-ds
+  kubectl -n kube-system rollout status daemonset/kube-multus-ds --timeout 2m
+}
+
+resume_dpu_sim_system_deployment() {
+  local namespace=$1
+  local name=$2
+  local kubeconfig=${3:-}
+  local kubectl_cmd=(kubectl)
+
+  if [ -n "${kubeconfig}" ]; then
+    kubectl_cmd=(kubectl --kubeconfig "${kubeconfig}")
+  fi
+
+  if ! "${kubectl_cmd[@]}" -n "${namespace}" get deployment "${name}" >/dev/null 2>&1; then
+    return
+  fi
+
+  local replicas
+  replicas=$("${kubectl_cmd[@]}" -n "${namespace}" get deployment "${name}" -o jsonpath='{.metadata.annotations.dpu-sim\.io/suspend-replicas}')
+  if [ -n "${replicas}" ]; then
+    echo "Restoring dpu-simulator deployment ${namespace}/${name} to ${replicas} replicas..."
+    "${kubectl_cmd[@]}" -n "${namespace}" patch deployment "${name}" --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/replicas\",\"value\":${replicas}},{\"op\":\"remove\",\"path\":\"/metadata/annotations/dpu-sim.io~1suspend-replicas\"}]"
+  fi
+
+  "${kubectl_cmd[@]}" -n "${namespace}" rollout restart deployment/"${name}"
+  "${kubectl_cmd[@]}" -n "${namespace}" rollout status deployment/"${name}" --timeout 2m
+}
+
+restart_dpu_sim_system_deployments_after_ovnk() {
+  if [ "${DPU_MODE:-none}" == "none" ]; then
+    return
+  fi
+
+  if [ "${DPU_MODE}" == "host" ]; then
+    echo "Leaving dpu-simulator host system deployments suspended until DPU OVN-Kubernetes is installed"
+    return
+  fi
+
+  resume_dpu_sim_system_deployment kube-system coredns
+  resume_dpu_sim_system_deployment local-path-storage local-path-provisioner
+
+  if [ "${DPU_MODE}" == "dpu" ] && [ -n "${FRR_K8S_HOST_KUBECONFIG:-}" ]; then
+    echo "Restoring dpu-simulator host system deployments after DPU OVN-Kubernetes is ready..."
+    resume_dpu_sim_system_deployment kube-system coredns "${FRR_K8S_HOST_KUBECONFIG}"
+    resume_dpu_sim_system_deployment local-path-storage local-path-provisioner "${FRR_K8S_HOST_KUBECONFIG}"
+  fi
+}
+
+frr_k8s_remote_enabled() {
+  [[ -n "${FRR_K8S_REMOTE_KUBECONFIG:-}" || -n "${FRR_K8S_REMOTE_NODE_MAP:-}" ]]
+}
+
+validate_frr_k8s_remote() {
+  if ! frr_k8s_remote_enabled; then
+    return
+  fi
+  if [[ -z "${FRR_K8S_REMOTE_KUBECONFIG:-}" || -z "${FRR_K8S_REMOTE_NODE_MAP:-}" ]]; then
+    echo "FRR-K8S remote mode requires both FRR_K8S_REMOTE_KUBECONFIG and FRR_K8S_REMOTE_NODE_MAP" >&2
+    exit 1
+  fi
+  if [[ ! -f "${FRR_K8S_REMOTE_KUBECONFIG}" ]]; then
+    echo "FRR-K8S remote kubeconfig does not exist: ${FRR_K8S_REMOTE_KUBECONFIG}" >&2
+    exit 1
+  fi
+  if [[ -n "${FRR_K8S_HOST_KUBECONFIG:-}" && ! -f "${FRR_K8S_HOST_KUBECONFIG}" ]]; then
+    echo "FRR-K8S host kubeconfig does not exist: ${FRR_K8S_HOST_KUBECONFIG}" >&2
+    exit 1
+  fi
+}
+
+frr_k8s_host_kubeconfig() {
+  printf '%s' "${FRR_K8S_HOST_KUBECONFIG:-${FRR_K8S_REMOTE_KUBECONFIG}}"
+}
+
+ensure_frr_k8s_namespace() {
+  local kubeconfig=${1:-}
+  local kubectl_cmd=(kubectl)
+  if [ -n "${kubeconfig}" ]; then
+    kubectl_cmd=(kubectl --kubeconfig "${kubeconfig}")
+  fi
+
+  "${kubectl_cmd[@]}" create namespace frr-k8s-system --dry-run=client -o yaml | \
+    "${kubectl_cmd[@]}" apply -f -
+}
+
+install_frr_k8s_host_api_crds() {
+  validate_frr_k8s_remote
+  if ! frr_k8s_remote_enabled; then
+    return
+  fi
+
+  echo "Installing frr-k8s CRDs into the remote host API ..."
+  local host_kubeconfig
+  host_kubeconfig=$(frr_k8s_host_kubeconfig)
+  ensure_frr_k8s_namespace "${host_kubeconfig}"
+  kubectl --kubeconfig "${host_kubeconfig}" apply \
+    -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+  kubectl --kubeconfig "${host_kubeconfig}" apply \
+    -f "${FRR_TMP_DIR}"/frr-k8s/config/crd/bases/frrk8s.metallb.io_frrnodestates.yaml
+}
+
+create_frr_k8s_remote_kubeconfig_secret() {
+  validate_frr_k8s_remote
+  if ! frr_k8s_remote_enabled; then
+    return
+  fi
+
+  kubectl -n frr-k8s-system create secret generic frr-k8s-host-kubeconfig \
+    --from-file=kubeconfig="${FRR_K8S_REMOTE_KUBECONFIG}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+configure_frr_k8s_remote_daemonsets() {
+  validate_frr_k8s_remote
+  if ! frr_k8s_remote_enabled; then
+    return
+  fi
+
+  local source_json="${FRR_TMP_DIR}/frr-k8s-daemon.json"
+  kubectl -n frr-k8s-system get daemonset frr-k8s-daemon -o json > "${source_json}"
+  kubectl -n frr-k8s-system delete daemonset -l dpu-sim.ovn.org/frr-remote=true --ignore-not-found
+
+  local pair host_node dpu_node safe_name ds_name
+  IFS=',' read -ra pairs <<< "${FRR_K8S_REMOTE_NODE_MAP}"
+  for pair in "${pairs[@]}"; do
+    host_node="${pair%%=*}"
+    dpu_node="${pair#*=}"
+    if [[ -z "${host_node}" || -z "${dpu_node}" || "${pair}" != *"="* ]]; then
+      echo "Invalid FRR_K8S_REMOTE_NODE_MAP entry: ${pair}" >&2
+      exit 1
+    fi
+    safe_name=$(printf '%s' "${host_node}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/^-*//;s/-*$//')
+    if [[ -z "${safe_name}" ]]; then
+      echo "Invalid host node name for FRR_K8S_REMOTE_NODE_MAP entry: ${pair}" >&2
+      exit 1
+    fi
+    ds_name="frr-k8s-daemon-${safe_name:0:45}"
+    echo "Creating remote frr-k8s daemonset ${ds_name}: host node ${host_node}, DPU node ${dpu_node}"
+    jq \
+      --arg name "${ds_name}" \
+      --arg host_node "${host_node}" \
+      --arg dpu_node "${dpu_node}" \
+      'del(.metadata.uid, .metadata.resourceVersion, .metadata.generation, .metadata.creationTimestamp, .metadata.managedFields, .status)
+       | .metadata.name = $name
+       | .metadata.labels["dpu-sim.ovn.org/frr-remote"] = "true"
+       | .metadata.labels["dpu-sim.ovn.org/frr-host-node"] = $host_node
+       | .spec.selector.matchLabels["dpu-sim.ovn.org/frr-host-node"] = $host_node
+       | .spec.template.metadata.labels["dpu-sim.ovn.org/frr-remote"] = "true"
+       | .spec.template.metadata.labels["dpu-sim.ovn.org/frr-host-node"] = $host_node
+       | .spec.template.spec.nodeSelector = {"kubernetes.io/hostname": $dpu_node}
+       | (.spec.template.spec.containers[] | select(.name == "frr-k8s").args) |= ((. // []) | map(if startswith("--node-name=") then "--node-name=" + $host_node else . end))
+       | (.spec.template.spec.containers[] | select(.name == "frr-k8s").env) |= ((. // []) + [{"name":"KUBECONFIG","value":"/var/run/host-kubeconfig/kubeconfig"}])
+       | (.spec.template.spec.containers[] | select(.name == "frr-k8s").volumeMounts) |= ((. // []) + [{"name":"host-kubeconfig","mountPath":"/var/run/host-kubeconfig","readOnly":true}])
+       | .spec.template.spec.volumes = ((.spec.template.spec.volumes // []) + [{"name":"host-kubeconfig","secret":{"secretName":"frr-k8s-host-kubeconfig"}}])' \
+      "${source_json}" | kubectl apply -f -
+  done
+
+  kubectl -n frr-k8s-system delete daemonset frr-k8s-daemon --ignore-not-found
+}

--- a/contrib/kind-dpu-sim-no-overlay.sh
+++ b/contrib/kind-dpu-sim-no-overlay.sh
@@ -69,6 +69,24 @@ resolve_kind_provider() {
   exit 1
 }
 
+cleanup_bgp_artifacts() {
+  local provider=$1
+
+  if ! command -v "${provider}" >/dev/null 2>&1; then
+    return
+  fi
+
+  if "${provider}" ps -a --format '{{.Names}}' | grep -Eq '^bgpserver$'; then
+    "${provider}" rm -f bgpserver
+  fi
+  if "${provider}" ps -a --format '{{.Names}}' | grep -Eq '^frr$'; then
+    "${provider}" rm -f frr
+  fi
+  if "${provider}" network ls --format '{{.Name}}' | grep -Eq '^bgpnet$'; then
+    "${provider}" network rm bgpnet || true
+  fi
+}
+
 DPU_SIM_PATH=$(resolve_dpu_sim_path)
 KIND_EXPERIMENTAL_PROVIDER=$(resolve_kind_provider)
 export KIND_EXPERIMENTAL_PROVIDER
@@ -153,6 +171,8 @@ install_ovnk_host() {
 install_ovnk_dpu() {
   # shellcheck disable=SC1090
   source "${FRR_ENV}"
+  export DPU_SIM_GATEWAY_NETWORK
+  export DPU_SIM_GATEWAY_SUBNET
 
   pushd "${OVN_KUBERNETES_PATH}"
   ./contrib/kind-helm.sh \
@@ -189,6 +209,8 @@ fi
 echo "Using KIND_EXPERIMENTAL_PROVIDER=${KIND_EXPERIMENTAL_PROVIDER}"
 echo "Using KIND_HELM_OVN_TIMEOUT=${KIND_HELM_OVN_TIMEOUT}"
 echo "Using BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4}"
+
+cleanup_bgp_artifacts "${KIND_EXPERIMENTAL_PROVIDER}"
 
 pushd "${DPU_SIM_PATH}"
 ./bin/dpu-sim \

--- a/contrib/kind-dpu-sim-no-overlay.sh
+++ b/contrib/kind-dpu-sim-no-overlay.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+OVN_KUBERNETES_PATH=${OVN_KUBERNETES_PATH:-$(cd "${SCRIPT_DIR}/.." && pwd)}
+
+resolve_dpu_sim_path() {
+  if [ -n "${DPU_SIM_PATH:-}" ]; then
+    if [ ! -d "${DPU_SIM_PATH}" ]; then
+      echo "error: DPU_SIM_PATH does not exist: ${DPU_SIM_PATH}" >&2
+      exit 1
+    fi
+    cd "${DPU_SIM_PATH}" && pwd
+    return
+  fi
+
+  local candidates=(
+    "${OVN_KUBERNETES_PATH}/../dpu-simulator"
+    "${OVN_KUBERNETES_PATH}/../../ovn-kubernetes/dpu-simulator"
+  )
+
+  local gopath=${GOPATH:-}
+  if [ -z "${gopath}" ] && command -v go >/dev/null 2>&1; then
+    gopath=$(go env GOPATH 2>/dev/null || true)
+  fi
+  if [ -n "${gopath}" ]; then
+    local entry
+    local -a gopath_entries
+    IFS=: read -ra gopath_entries <<< "${gopath}"
+    for entry in "${gopath_entries[@]}"; do
+      candidates+=("${entry}/src/github.com/ovn-kubernetes/dpu-simulator")
+    done
+  fi
+
+  local path
+  for path in "${candidates[@]}"; do
+    if [ -d "${path}" ]; then
+      cd "${path}" && pwd
+      return
+    fi
+  done
+
+  echo "error: could not locate dpu-simulator checkout" >&2
+  echo "set DPU_SIM_PATH to the dpu-simulator repository path" >&2
+  exit 1
+}
+
+resolve_kind_provider() {
+  if [ -n "${KIND_EXPERIMENTAL_PROVIDER:-}" ]; then
+    echo "${KIND_EXPERIMENTAL_PROVIDER}"
+    return
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    echo "docker"
+    return
+  fi
+
+  if command -v podman >/dev/null 2>&1; then
+    echo "podman"
+    return
+  fi
+
+  echo "error: could not locate podman or docker" >&2
+  echo "set KIND_EXPERIMENTAL_PROVIDER to the Kind provider to use" >&2
+  exit 1
+}
+
+DPU_SIM_PATH=$(resolve_dpu_sim_path)
+KIND_EXPERIMENTAL_PROVIDER=$(resolve_kind_provider)
+export KIND_EXPERIMENTAL_PROVIDER
+KIND_HELM_OVN_TIMEOUT=${KIND_HELM_OVN_TIMEOUT:-900}
+export KIND_HELM_OVN_TIMEOUT
+BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4:-172.27.0.0/16}
+BGP_SERVER_NET_SUBNET_IPV6=${BGP_SERVER_NET_SUBNET_IPV6:-fc00:f853:ccd:e797::/64}
+export BGP_SERVER_NET_SUBNET_IPV4
+export BGP_SERVER_NET_SUBNET_IPV6
+DPU_SIM_CONFIG=${DPU_SIM_CONFIG:-config-kind-ovnk-offload.yaml}
+HOST_CLUSTER=${HOST_CLUSTER:-dpu-sim-host}
+DPU_CLUSTER=${DPU_CLUSTER:-dpu-sim-dpu}
+HOST_KUBECONFIG="${DPU_SIM_PATH}/kubeconfig/${HOST_CLUSTER}.kubeconfig"
+DPU_KUBECONFIG="${DPU_SIM_PATH}/kubeconfig/${DPU_CLUSTER}.kubeconfig"
+HOST_VALUES="${DPU_SIM_PATH}/kubeconfig/helm-values/${HOST_CLUSTER}-ovn-kubernetes-dpu-host-values.yaml"
+DPU_VALUES="${DPU_SIM_PATH}/kubeconfig/helm-values/${DPU_CLUSTER}-ovn-kubernetes-dpu-values.yaml"
+FRR_ENV="${DPU_SIM_PATH}/kubeconfig/helm-values/${DPU_CLUSTER}-frr-k8s.env"
+
+kubectl_host() {
+  kubectl --kubeconfig "${HOST_KUBECONFIG}" "$@"
+}
+
+kubectl_dpu() {
+  kubectl --kubeconfig "${DPU_KUBECONFIG}" "$@"
+}
+
+cluster_command_arg() {
+  local kubeconfig=$1
+  local selector=$2
+  local arg_name=$3
+  local command
+
+  command=$(kubectl --kubeconfig "${kubeconfig}" -n kube-system get pod \
+    -l "${selector}" -o jsonpath='{.items[0].spec.containers[0].command}')
+  printf '%s\n' "${command}" | tr '",' '\n' | awk -v prefix="--${arg_name}=" '
+    index($0, prefix) == 1 {
+      print substr($0, length(prefix) + 1)
+      exit
+    }
+  '
+}
+
+host_cluster_cidrs() {
+  local net_cidr svc_cidr
+
+  net_cidr=$(cluster_command_arg "${HOST_KUBECONFIG}" "component=kube-controller-manager" "cluster-cidr")
+  svc_cidr=$(cluster_command_arg "${HOST_KUBECONFIG}" "component=kube-apiserver" "service-cluster-ip-range")
+
+  if [ -z "${net_cidr}" ] || [ -z "${svc_cidr}" ]; then
+    echo "error: could not determine host cluster pod/service CIDRs" >&2
+    exit 1
+  fi
+
+  echo "${net_cidr} ${svc_cidr}"
+}
+
+install_ovnk_host() {
+  local cidrs host_net_cidr host_svc_cidr
+
+  cidrs=$(host_cluster_cidrs)
+  read -r host_net_cidr host_svc_cidr <<< "${cidrs}"
+  echo "Using host cluster pod CIDR ${host_net_cidr}"
+  echo "Using host cluster service CIDR ${host_svc_cidr}"
+
+  pushd "${OVN_KUBERNETES_PATH}"
+  NET_CIDR_IPV4="${host_net_cidr}" \
+  SVC_CIDR_IPV4="${host_svc_cidr}" \
+    ./contrib/kind-helm.sh \
+    --deploy \
+    --cluster-name "${HOST_CLUSTER}" \
+    --kubeconfig "${HOST_KUBECONFIG}" \
+    --dpu-mode host \
+    --network-segmentation-enable \
+    --multi-network-enable \
+    --route-advertisements-enable \
+    --no-overlay-enable \
+    --advertise-default-network \
+    --extra-values "${HOST_VALUES}"
+  popd
+}
+
+install_ovnk_dpu() {
+  # shellcheck disable=SC1090
+  source "${FRR_ENV}"
+
+  pushd "${OVN_KUBERNETES_PATH}"
+  ./contrib/kind-helm.sh \
+    --deploy \
+    --cluster-name "${DPU_CLUSTER}" \
+    --kubeconfig "${DPU_KUBECONFIG}" \
+    --dpu-mode dpu \
+    --multi-network-enable \
+    --network-segmentation-enable \
+    --route-advertisements-enable \
+    --no-overlay-enable \
+    --advertise-default-network \
+    --extra-values "${DPU_VALUES}" \
+    --frr-k8s-host-kubeconfig "${FRR_K8S_HOST_KUBECONFIG}" \
+    --frr-k8s-remote-kubeconfig "${FRR_K8S_REMOTE_KUBECONFIG}" \
+    --frr-k8s-remote-node-map "${FRR_K8S_REMOTE_NODE_MAP}"
+  popd
+}
+
+wait_for_ovn() {
+  kubectl_host wait --for=condition=Ready nodes --all --timeout=25m
+  kubectl_dpu wait --for=condition=Ready nodes --all --timeout=25m
+  kubectl_host -n ovn-kubernetes wait --for=condition=Ready pods --all --timeout=10m
+  kubectl_dpu -n ovn-kubernetes wait --for=condition=Ready pods --all --timeout=10m
+  kubectl_dpu -n frr-k8s-system wait --for=condition=Ready pods --all --timeout=10m
+}
+
+if [ ! -x "${DPU_SIM_PATH}/bin/dpu-sim" ]; then
+  echo "error: ${DPU_SIM_PATH}/bin/dpu-sim does not exist or is not executable" >&2
+  echo "run 'make build' in the dpu-simulator repository first" >&2
+  exit 1
+fi
+
+echo "Using KIND_EXPERIMENTAL_PROVIDER=${KIND_EXPERIMENTAL_PROVIDER}"
+echo "Using KIND_HELM_OVN_TIMEOUT=${KIND_HELM_OVN_TIMEOUT}"
+echo "Using BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4}"
+
+pushd "${DPU_SIM_PATH}"
+./bin/dpu-sim \
+  --config "${DPU_SIM_CONFIG}" \
+  --ovn-kubernetes-path "${OVN_KUBERNETES_PATH}" \
+  --ovnk-mode values-only
+
+install_ovnk_host
+
+./bin/dpu-sim ovnk host-access \
+  --config "${DPU_SIM_CONFIG}" \
+  --cluster "${HOST_CLUSTER}"
+./bin/dpu-sim ovnk values \
+  --config "${DPU_SIM_CONFIG}" \
+  --cluster "${DPU_CLUSTER}" \
+  --require-host-credentials
+
+install_ovnk_dpu
+wait_for_ovn
+popd

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -784,6 +784,8 @@ if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ] && [ "${DPU_MODE}" != "host" ]; th
   fi
 fi
 
+restart_dpu_sim_system_deployments_after_ovnk
+
 # IPsec pods need the signer-ca ConfigMap and signed CSRs before they can roll out.
 # The ovn-ipsec DaemonSet is created by the helm chart (tags.ovn-ipsec=true), install_ipsec
 # handles the CA creation and CSR signing (manifest apply is skipped when helm owns the DS).

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -653,8 +653,8 @@ check_dependencies
 parse_args "$@"
 set_default_params
 if [ "${DPU_MODE}" == "dpu" ] && [ "${ENABLE_ROUTE_ADVERTISEMENTS}" == true ]; then
-  if [[ -z "${FRR_K8S_REMOTE_KUBECONFIG:-}" || -z "${FRR_K8S_HOST_KUBECONFIG:-}" || -z "${FRR_K8S_REMOTE_NODE_MAP:-}" ]]; then
-    echo "DPU mode with route advertisements requires --frr-k8s-remote-kubeconfig, --frr-k8s-host-kubeconfig, and --frr-k8s-remote-node-map" >&2
+  if [[ -z "${FRR_K8S_REMOTE_KUBECONFIG:-}" || -z "${FRR_K8S_REMOTE_NODE_MAP:-}" ]]; then
+    echo "DPU mode with route advertisements requires --frr-k8s-remote-kubeconfig and --frr-k8s-remote-node-map" >&2
     exit 1
   fi
   validate_frr_k8s_remote

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -10,12 +10,24 @@ export DIR="$( cd -- "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
 
 # Source the kind-common.sh file from the same directory where this script is located
 source "${DIR}/kind-common.sh"
+source "${DIR}/kind-dpu-sim-lib.sh"
+
+OVN_HELM_EXTRA_VALUES=()
 
 set_default_params() {
   set_common_default_params
   check_ipv6
   set_cluster_cidr_ip_families
-  OVN_ENABLE_OVNKUBE_IDENTITY=${OVN_ENABLE_OVNKUBE_IDENTITY:-true}
+  DPU_MODE=${DPU_MODE:-none}
+  if [[ "${DPU_MODE}" != "none" && "${DPU_MODE}" != "host" && "${DPU_MODE}" != "dpu" ]]; then
+    echo "Invalid DPU_MODE: ${DPU_MODE}. Expected one of: none, host, dpu"
+    exit 1
+  fi
+  local ovnkube_identity_default=true
+  if [ "${DPU_MODE}" != "none" ]; then
+    ovnkube_identity_default=false
+  fi
+  OVN_ENABLE_OVNKUBE_IDENTITY=${OVN_ENABLE_OVNKUBE_IDENTITY:-${ovnkube_identity_default}}
 }
 
 usage() {
@@ -51,6 +63,11 @@ usage() {
     echo "       [ -cn  | --cluster-name ]"
     echo "       [ -mip | --metrics-ip <ip> ]"
     echo "       [ -mtu <mtu> ]"
+    echo "       [ --dpu-mode <none|host|dpu> ]"
+    echo "       [ -f | --extra-values <file> ]"
+    echo "       [ --frr-k8s-remote-kubeconfig <file> ]"
+    echo "       [ --frr-k8s-host-kubeconfig <file> ]"
+    echo "       [ --frr-k8s-remote-node-map <host=dpu[,host=dpu...]> ]"
     echo "       [ --enable-coredumps ]"
     echo "       [ -h ]"
     echo ""
@@ -129,6 +146,11 @@ usage() {
     echo "-sw  | --allow-system-writes                  Allow the script to write to /etc/hosts and other system files when needed."
     echo "-ric | --run-in-container                     Run the script from inside a docker container (adapts kubeconfig API URL)."
     echo "-kc  | --kubeconfig                           Output kubeconfig path. DEFAULT: \$HOME/\$KIND_CLUSTER_NAME.conf"
+    echo "--dpu-mode                                    Deploy OVN-Kubernetes for DPU simulator mode: none, host, or dpu. DEFAULT: none"
+    echo "-f | --extra-values                           Extra Helm values file appended after the base values file. May be repeated."
+    echo "--frr-k8s-remote-kubeconfig                   Kubeconfig used by DPU-cluster FRR-K8S pods to watch the host cluster API."
+    echo "--frr-k8s-host-kubeconfig                     Kubeconfig used by this script to write FRR-K8S resources to the host cluster API."
+    echo "--frr-k8s-remote-node-map                     Comma-separated host-node=dpu-node pairs for remote FRR-K8S node-name mapping."
     echo "-nokvipam | --opt-out-kv-ipam                 Skip installing the KubeVirt IPAM controller (requires --install-kubevirt)."
     echo ""
 
@@ -252,8 +274,6 @@ parse_args() {
                                                   ;;
             -cn | --cluster-name )                shift
                                                   KIND_CLUSTER_NAME=$1
-                                                  # Setup KUBECONFIG
-                                                  set_default_params
                                                   ;;
             -dns | --enable-dnsnameresolver )     OVN_ENABLE_DNSNAMERESOLVER=true
                                                   ;;
@@ -362,6 +382,48 @@ parse_args() {
             -kc | --kubeconfig )                  shift
                                                   KUBECONFIG=$1
                                                   ;;
+            --dpu-mode )                          shift
+                                                  DPU_MODE=$1
+                                                  if [[ "${DPU_MODE}" != "none" && "${DPU_MODE}" != "host" && "${DPU_MODE}" != "dpu" ]]; then
+                                                    echo "Invalid --dpu-mode: ${DPU_MODE}. Expected one of: none, host, dpu"
+                                                    exit 1
+                                                  fi
+                                                  if [[ "${DPU_MODE}" != "none" && -z "${OVN_ENABLE_OVNKUBE_IDENTITY:-}" ]]; then
+                                                    OVN_ENABLE_OVNKUBE_IDENTITY=false
+                                                  fi
+                                                  ;;
+            -f | --extra-values )                 shift
+                                                  if [[ -z "${1:-}" || "${1:-}" == -* ]]; then
+                                                    echo "Missing value for --extra-values" >&2
+                                                    usage
+                                                    exit 1
+                                                  fi
+                                                  OVN_HELM_EXTRA_VALUES+=("$1")
+                                                  ;;
+            --frr-k8s-remote-kubeconfig )         shift
+                                                  if [[ -z "${1:-}" || "${1:-}" == -* ]]; then
+                                                    echo "Missing value for --frr-k8s-remote-kubeconfig" >&2
+                                                    usage
+                                                    exit 1
+                                                  fi
+                                                  FRR_K8S_REMOTE_KUBECONFIG=$1
+                                                  ;;
+            --frr-k8s-host-kubeconfig )           shift
+                                                  if [[ -z "${1:-}" || "${1:-}" == -* ]]; then
+                                                    echo "Missing value for --frr-k8s-host-kubeconfig" >&2
+                                                    usage
+                                                    exit 1
+                                                  fi
+                                                  FRR_K8S_HOST_KUBECONFIG=$1
+                                                  ;;
+            --frr-k8s-remote-node-map )           shift
+                                                  if [[ -z "${1:-}" || "${1:-}" == -* ]]; then
+                                                    echo "Missing value for --frr-k8s-remote-node-map" >&2
+                                                    usage
+                                                    exit 1
+                                                  fi
+                                                  FRR_K8S_REMOTE_NODE_MAP=$1
+                                                  ;;
             -nokvipam | --opt-out-kv-ipam )       KIND_OPT_OUT_KUBEVIRT_IPAM=true
                                                   ;;
             * )                                   usage
@@ -439,6 +501,11 @@ print_params() {
      echo "KIND_INSTALL_PROMETHEUS = $KIND_INSTALL_PROMETHEUS"
      echo "KIND_ALLOW_SYSTEM_WRITES = $KIND_ALLOW_SYSTEM_WRITES"
      echo "RUN_IN_CONTAINER = $RUN_IN_CONTAINER"
+     echo "DPU_MODE = $DPU_MODE"
+     echo "OVN_HELM_EXTRA_VALUES = ${OVN_HELM_EXTRA_VALUES[*]}"
+     echo "FRR_K8S_REMOTE_KUBECONFIG = ${FRR_K8S_REMOTE_KUBECONFIG:-}"
+     echo "FRR_K8S_HOST_KUBECONFIG = ${FRR_K8S_HOST_KUBECONFIG:-}"
+     echo "FRR_K8S_REMOTE_NODE_MAP = ${FRR_K8S_REMOTE_NODE_MAP:-}"
      echo "MASTER_LOG_LEVEL = $MASTER_LOG_LEVEL"
      echo "NODE_LOG_LEVEL = $NODE_LOG_LEVEL"
      echo "OVN_LOG_LEVEL_NB = $OVN_LOG_LEVEL_NB"
@@ -463,25 +530,56 @@ helm_prereqs() {
     sudo sysctl fs.inotify.max_user_instances=512
 }
 
+helm_extra_values_args() {
+    local args=""
+    local values_file
+    for values_file in "${OVN_HELM_EXTRA_VALUES[@]}"; do
+        args+=" -f $(printf '%q' "${values_file}")"
+    done
+    printf '%s' "${args}"
+}
+
+skip_ovn_image_build_load() {
+    [ "${DPU_MODE}" != "none" ] && [ "${#OVN_HELM_EXTRA_VALUES[@]}" -gt 0 ] && [ "${OVN_IMAGE}" == "local" ]
+}
+
 create_ovn_kubernetes() {
     cd ${DIR}/../helm/ovn-kubernetes
     label_ovn_single_node_zones
     value_file="values-single-node-zone.yaml"
+    if [ "${DPU_MODE}" == "dpu" ]; then
+      value_file="values-single-node-zone-dpu.yaml"
+    fi
     echo "value_file=${value_file}"
+    local extra_values_args helm_network_args helm_image_args helm_log_args
+    extra_values_args="$(helm_extra_values_args)"
     # For multi-pod-subnet case, NET_CIDR_IPV4 is a list of CIDRs separated by comma.
     # When Helm encounters a comma within a string value in a --set argument, it attempts to parse the comma as a separator
     # for multiple values (like a list or a map), not as part of a single string value.
     set -x
     ESCAPED_NET_CIDR="${NET_CIDR//,/\\,}"
     ESCAPED_SVC_CIDR="${SVC_CIDR//,/\\,}"
+    if [ "${DPU_MODE}" == "dpu" ]; then
+      helm_network_args="--set global.mtu=${OVN_MTU}"
+      if skip_ovn_image_build_load; then
+        helm_image_args=""
+      else
+        helm_image_args="--set global.dpuImage.repository=${OVN_IMAGE%:*} --set global.dpuImage.tag=${OVN_IMAGE##*:}"
+      fi
+      helm_log_args="--set ovnkube-single-node-zone-dpu.ovnkubeNodeLogLevel=${NODE_LOG_LEVEL} --set-string ovnkube-single-node-zone-dpu.nbLogLevel=\"${OVN_LOG_LEVEL_NB}\" --set-string ovnkube-single-node-zone-dpu.sbLogLevel=\"${OVN_LOG_LEVEL_SB}\" --set-string ovnkube-single-node-zone-dpu.northdLogLevel=\"${OVN_LOG_LEVEL_NORTHD}\" --set-string ovnkube-single-node-zone-dpu.ovnControllerLogLevel=\"${OVN_LOG_LEVEL_CONTROLLER}\""
+    else
+      helm_network_args="--set k8sAPIServer=${API_URL} --set podNetwork=\"${ESCAPED_NET_CIDR}\" --set serviceNetwork=\"${ESCAPED_SVC_CIDR}\" --set mtu=${OVN_MTU}"
+      if skip_ovn_image_build_load; then
+        helm_image_args=""
+      else
+        helm_image_args="--set global.image.repository=${OVN_IMAGE%:*} --set global.image.tag=${OVN_IMAGE##*:}"
+      fi
+      helm_log_args="--set ovnkube-control-plane.logLevel=${MASTER_LOG_LEVEL} --set ovnkube-node.logLevel=${NODE_LOG_LEVEL} --set ovnkube-single-node-zone.ovnkubeNodeLogLevel=${NODE_LOG_LEVEL} --set-string ovnkube-single-node-zone.nbLogLevel=\"${OVN_LOG_LEVEL_NB}\" --set-string ovnkube-single-node-zone.sbLogLevel=\"${OVN_LOG_LEVEL_SB}\" --set-string ovnkube-single-node-zone.northdLogLevel=\"${OVN_LOG_LEVEL_NORTHD}\" --set-string ovnkube-node.ovnControllerLogLevel=\"${OVN_LOG_LEVEL_CONTROLLER}\" --set-string ovnkube-single-node-zone.ovnControllerLogLevel=\"${OVN_LOG_LEVEL_CONTROLLER}\""
+    fi
     cmd=$(cat <<EOF
-helm upgrade --install ovn-kubernetes . -f "${value_file}" \
-          --set k8sAPIServer=${API_URL} \
-          --set podNetwork="${ESCAPED_NET_CIDR}" \
-          --set serviceNetwork="${ESCAPED_SVC_CIDR}" \
-          --set mtu=${OVN_MTU} \
-          --set global.image.repository=${OVN_IMAGE%:*} \
-          --set global.image.tag=${OVN_IMAGE##*:} \
+helm upgrade --install ovn-kubernetes . -f "${value_file}" ${extra_values_args} \
+          ${helm_network_args} \
+          ${helm_image_args} \
           --set-string global.v4JoinSubnet="${JOIN_SUBNET_IPV4}" \
           --set-string global.v6JoinSubnet="${JOIN_SUBNET_IPV6}" \
           --set-string global.v4MasqueradeSubnet="${MASQUERADE_SUBNET_IPV4}" \
@@ -538,14 +636,7 @@ helm upgrade --install ovn-kubernetes . -f "${value_file}" \
           $( [ -n "${OVN_IPFIX_CACHE_ACTIVE_TIMEOUT}" ] && echo "--set global.ipfixCacheActiveTimeout=${OVN_IPFIX_CACHE_ACTIVE_TIMEOUT}" ) \
           $( [ -n "${LIBOVSDB_CLIENT_LOGFILE}" ] && echo "--set global.libovsdbClientLogFile=${LIBOVSDB_CLIENT_LOGFILE}" ) \
           --set hostNetworkNamespace=${OVN_HOST_NETWORK_NAMESPACE} \
-          --set ovnkube-control-plane.logLevel=${MASTER_LOG_LEVEL} \
-          --set ovnkube-node.logLevel=${NODE_LOG_LEVEL} \
-          --set ovnkube-single-node-zone.ovnkubeNodeLogLevel=${NODE_LOG_LEVEL} \
-          --set-string ovnkube-single-node-zone.nbLogLevel="${OVN_LOG_LEVEL_NB}" \
-          --set-string ovnkube-single-node-zone.sbLogLevel="${OVN_LOG_LEVEL_SB}" \
-          --set-string ovnkube-single-node-zone.northdLogLevel="${OVN_LOG_LEVEL_NORTHD}" \
-          --set-string ovnkube-node.ovnControllerLogLevel="${OVN_LOG_LEVEL_CONTROLLER}" \
-          --set-string ovnkube-single-node-zone.ovnControllerLogLevel="${OVN_LOG_LEVEL_CONTROLLER}"
+          ${helm_log_args}
 EOF
        )
     echo "${cmd}"
@@ -561,6 +652,13 @@ install_online_ovn_kubernetes_crds() {
 check_dependencies
 parse_args "$@"
 set_default_params
+if [ "${DPU_MODE}" == "dpu" ] && [ "${ENABLE_ROUTE_ADVERTISEMENTS}" == true ]; then
+  if [[ -z "${FRR_K8S_REMOTE_KUBECONFIG:-}" || -z "${FRR_K8S_HOST_KUBECONFIG:-}" || -z "${FRR_K8S_REMOTE_NODE_MAP:-}" ]]; then
+    echo "DPU mode with route advertisements requires --frr-k8s-remote-kubeconfig, --frr-k8s-host-kubeconfig, and --frr-k8s-remote-node-map" >&2
+    exit 1
+  fi
+  validate_frr_k8s_remote
+fi
 print_params
 helm_prereqs
 
@@ -597,13 +695,21 @@ fi
 if [ "$RUN_IN_CONTAINER" == true ]; then
   run_script_in_container
 fi
-# when using a non-default cluster name, fix up the context/cluster/user names in kubeconfig
-if [ "$KIND_CLUSTER_NAME" != "ovn" ]; then
+# when using a non-default cluster name created by this script, fix up the
+# context/cluster/user names in kubeconfig. In deploy mode the kubeconfig is
+# supplied by the caller and should be used as-is.
+if [ "$KIND_CREATE" == true ] && [ "$KIND_CLUSTER_NAME" != "ovn" ]; then
   fixup_kubeconfig_names
 fi
-build_ovn_image
+if skip_ovn_image_build_load; then
+  echo "Skipping OVN image build/load; DPU extra values are expected to provide the image"
+else
+  build_ovn_image
+fi
 detect_apiserver_url
-install_ovn_image
+if ! skip_ovn_image_build_load; then
+  install_ovn_image
+fi
 if [ "$OVN_ENABLE_DNSNAMERESOLVER" == true ]; then
     build_dnsnameresolver_images
     install_dnsnameresolver_images
@@ -617,12 +723,16 @@ if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
   if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" == true ]; then
     # Enable bgp port listening on node, required for managed mode. FRR will listen on port 179 to receive BGP updates from other nodes.
     frr_port=179
-  else
-    # external FRR is required for unmanaged mode
+  elif [ "${DPU_MODE}" != "host" ]; then
+    # external FRR is required for unmanaged mode where the FRR-K8S speakers run.
     deploy_frr_external_container
     deploy_bgp_external_server
   fi
-  install_frr_k8s $frr_port
+  if [ "${DPU_MODE}" == "host" ]; then
+    install_frr_k8s_crds
+  else
+    install_frr_k8s $frr_port
+  fi
 fi
 if [ "$KIND_REMOVE_TAINT" == true ]; then
   remove_no_schedule_taint
@@ -666,7 +776,7 @@ if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
   fi
 fi
 
-if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ]; then
+if [ "$ENABLE_ROUTE_ADVERTISEMENTS" == true ] && [ "${DPU_MODE}" != "host" ]; then
   # wait for frr-k8s to be ready
   wait_for_frr_k8s
   if [ "$ENABLE_NO_OVERLAY_MANAGED_ROUTING" != true ]; then

--- a/docs/design/dpu-host-no-overlay-routing.md
+++ b/docs/design/dpu-host-no-overlay-routing.md
@@ -1,0 +1,89 @@
+# DPU Host No-Overlay Routing
+
+This document describes the default-network host-to-pod routing path used
+when OVN-Kubernetes runs in DPU-host mode with shared gateway mode and
+`no-overlay` transport.
+
+## Problem
+
+In no-overlay mode, pod traffic between nodes is routed on the underlay.
+On a DPU deployment, host-networked pods run on the DPU host, while the
+OVN gateway router and BGP learned routes exist on the DPU.
+
+The DPU host cannot route remote pod CIDRs through `ovn-k8s-mp0`. The
+management port only reaches local node subnets. If the host keeps a broad
+cluster CIDR route through the management port, host-networked pods send
+remote pod traffic to the wrong place.
+
+At the same time, the DPU host should not learn every BGP route from the
+DPU. The routing decision should stay on the DPU, where OVN already has the
+BGP routes.
+
+## Datapath
+
+The datapath uses four pieces:
+
+1. The DPU host does not install broad default cluster CIDR routes through
+   `ovn-k8s-mp0`.
+2. The DPU host installs broad default cluster CIDR routes through the
+   shared gateway interface using the dummy next-hop address.
+3. Host nftables SNATs host-network traffic for default cluster CIDRs to
+   the host masquerade IP before the packet enters OVS.
+4. The DPU shared gateway bridge steers that already-SNATed traffic into
+   OVN. After OVN routes it back out the default-network gateway patch, a
+   higher priority bridge flow SNATs the host masquerade IP to the node
+   underlay IP and sends it out the physical interface.
+
+The first SNAT is intentionally done in host nftables, not in OpenFlow. The
+bridge only matches the already-SNATed host masquerade IP when steering the
+packet into OVN. This avoids double-SNAT in OpenFlow while still letting the
+DPU use OVN and BGP routes for the egress decision.
+
+## Forward Path
+
+For host-networked pod traffic to a remote default-network pod:
+
+1. Linux routing on the DPU host selects the shared gateway interface for
+   the default cluster CIDR.
+2. The host nftables postrouting rule SNATs the source to the host
+   masquerade IP, for example `169.254.0.2`.
+3. The DPU bridge matches:
+
+   ```text
+   in_port=<host-representor>, ip_src=<host-masquerade-ip>,
+   ip_dst=<default-cluster-cidr>
+   ```
+
+   and sends the packet to the default-network OVN patch port.
+4. OVN routes the packet using its logical router and BGP learned routes.
+5. When the packet returns to the DPU bridge from the default-network patch
+   port, the bridge matches:
+
+   ```text
+   in_port=<default-patch>, ip_src=<host-masquerade-ip>,
+   ip_dst=<default-cluster-cidr>
+   ```
+
+   and commits SNAT in the default conntrack zone to the node underlay IP.
+6. The packet leaves the physical interface toward the remote node or next
+   hop selected by OVN routing.
+
+## Return Path
+
+Return traffic enters the DPU bridge from the physical interface and follows
+the existing default conntrack-zone path. The bridge sends established
+traffic marked for OVN back to the default-network patch port, and OVN
+returns it toward the DPU host. The bridge then sends traffic destined to the
+host masquerade IP through the normal OVN-to-host dispatch path, where host
+conntrack reverses the nftables SNAT.
+
+## Scope
+
+This path is only for the default network in:
+
+- DPU-host mode
+- shared gateway mode
+- no-overlay transport
+
+It does not add host-network support for UDNs. Host-networked workloads use
+the host default network, so UDN remote pod routing is outside this path.

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -625,6 +625,85 @@ func isLocalGatewayNoOverlayUDN(netConfig *BridgeUDNConfiguration) bool {
 		config.Gateway.Mode == config.GatewayModeLocal
 }
 
+func isDPUSharedNoOverlay() bool {
+	return (config.IsModeDPU() || config.IsModeDPUHost()) &&
+		config.Gateway.Mode == config.GatewayModeShared &&
+		config.Default.Transport == types.NetworkTransportNoOverlay
+}
+
+func dpuHostNoOverlayPodCIDRFlows(defaultNetConfig *BridgeUDNConfiguration, ofPortHost string, isIPv6 bool) []string {
+	if defaultNetConfig == nil {
+		return nil
+	}
+
+	protoPrefix := protoPrefixV4
+	masqIP := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP
+	if isIPv6 {
+		protoPrefix = protoPrefixV6
+		masqIP = config.Gateway.MasqueradeIPs.V6HostMasqueradeIP
+	}
+
+	var subnets []*net.IPNet
+	for _, clusterEntry := range defaultNetConfig.Subnets {
+		subnets = append(subnets, clusterEntry.CIDR)
+	}
+
+	var flows []string
+	for _, subnet := range matchIPNetFamily(isIPv6, subnets) {
+		// Host-network traffic to no-overlay pod CIDRs is SNATed by host
+		// nftables before it enters OVS. Match the host masquerade IP so only
+		// that already-SNATed traffic is steered into OVN, avoiding double NAT
+		// in OpenFlow and preserving the offloadable path.
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=510, in_port=%s, %s, %s_src=%s, %s_dst=%s, "+
+				"actions=goto_table:2",
+				nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefix, protoPrefix,
+				masqIP, protoPrefix, subnet.String()))
+		// Return traffic comes back from OVN to the host masquerade IP. Send it
+		// through the normal OVN->host dispatch path; host conntrack reverses
+		// the nftables SNAT instead of using OpenFlow NAT here.
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=510, in_port=%s, %s, %s_src=%s, %s_dst=%s,"+
+				"actions=goto_table:3",
+				nodetypes.DefaultOpenFlowCookie, defaultNetConfig.OfPortPatch, protoPrefix,
+				protoPrefix, subnet.String(), protoPrefix, masqIP))
+	}
+	return flows
+}
+
+func dpuHostNoOverlayHostSNATEgressFlows(defaultNetConfig *BridgeUDNConfiguration, ofPortPhys string, bridgeMacAddress string, physicalIP *net.IPNet, isIPv6 bool) []string {
+	if defaultNetConfig == nil {
+		return nil
+	}
+
+	protoPrefix := protoPrefixV4
+	masqIP := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP
+	if isIPv6 {
+		protoPrefix = protoPrefixV6
+		masqIP = config.Gateway.MasqueradeIPs.V6HostMasqueradeIP
+	}
+
+	var subnets []*net.IPNet
+	for _, clusterEntry := range defaultNetConfig.Subnets {
+		subnets = append(subnets, clusterEntry.CIDR)
+	}
+
+	var flows []string
+	for _, subnet := range matchIPNetFamily(isIPv6, subnets) {
+		// After OVN routes host-network traffic back out the default-network
+		// gateway patch, SNAT the host masquerade IP to this node's underlay IP
+		// in the default conntrack zone. The reverse direction then follows the
+		// existing table 1 ct_mark=OVN path back to OVN.
+		flows = append(flows,
+			fmt.Sprintf("cookie=%s, priority=510, in_port=%s, dl_src=%s, %s, %s_src=%s, %s_dst=%s, "+
+				"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",
+				nodetypes.DefaultOpenFlowCookie, defaultNetConfig.OfPortPatch, bridgeMacAddress,
+				protoPrefix, protoPrefix, masqIP, protoPrefix, subnet.String(),
+				config.Default.ConntrackZone, physicalIP.IP, defaultNetConfig.MasqCTMark, ofPortPhys))
+	}
+	return flows
+}
+
 // getMaxFrameLength returns the maximum frame size (ignoring VLAN header) that a gateway can handle
 func getMaxFrameLength() int {
 	return config.Default.MTU + 14
@@ -752,6 +831,10 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 							physicalIP.IP,
 							netConfig.MasqCTMark, ofPortPhys))
 				}
+				if netConfig.IsDefaultNetwork() && isDPUSharedNoOverlay() {
+					dftFlows = append(dftFlows,
+						dpuHostNoOverlayHostSNATEgressFlows(netConfig, ofPortPhys, bridgeMacAddress, physicalIP, false)...)
+				}
 
 				// table0, packets coming from egressIP pods that have mark 1008 on them
 				// will be SNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
@@ -811,6 +894,11 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), %soutput:%s",
 					nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefixV4, config.Default.ConntrackZone,
 					nodetypes.CtMarkHost, modVLANID, ofPortPhys))
+			if isDPUSharedNoOverlay() {
+				defaultNetConfig := b.netConfig[types.DefaultNetworkName]
+				dftFlows = append(dftFlows,
+					dpuHostNoOverlayPodCIDRFlows(defaultNetConfig, ofPortHost, false)...)
+			}
 		}
 		if config.Gateway.Mode == config.GatewayModeLocal {
 			for _, netConfig := range b.patchedNetConfigs() {
@@ -868,6 +956,10 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 							protoPrefixV6, physicalIP.IP, config.Default.ConntrackZone,
 							physicalIP.IP,
 							netConfig.MasqCTMark, ofPortPhys))
+				}
+				if netConfig.IsDefaultNetwork() && isDPUSharedNoOverlay() {
+					dftFlows = append(dftFlows,
+						dpuHostNoOverlayHostSNATEgressFlows(netConfig, ofPortPhys, bridgeMacAddress, physicalIP, true)...)
 				}
 
 				// table0, packets coming from egressIP pods that have mark 1008 on them
@@ -928,6 +1020,11 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), %soutput:%s",
 					nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefixV6,
 					config.Default.ConntrackZone, nodetypes.CtMarkHost, modVLANID, ofPortPhys))
+			if isDPUSharedNoOverlay() {
+				defaultNetConfig := b.netConfig[types.DefaultNetworkName]
+				dftFlows = append(dftFlows,
+					dpuHostNoOverlayPodCIDRFlows(defaultNetConfig, ofPortHost, true)...)
+			}
 
 		}
 		if config.Gateway.Mode == config.GatewayModeLocal {

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
@@ -76,6 +76,76 @@ func TestSharedNoOverlayNodeIPFlowUsesNATInDefaultConntrackZone(t *testing.T) {
 	expectFlow(t, flows, expectedIPv6)
 }
 
+func TestDPUHostNoOverlayPodCIDRFlowsUseHostMasqueradeIP(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.IPv4Mode = true
+	config.IPv6Mode = true
+	config.Gateway.Mode = config.GatewayModeShared
+	config.Default.Transport = types.NetworkTransportNoOverlay
+	config.OvnKubeNode.Mode = types.NodeModeDPU
+
+	bridgeMAC := mustParseMAC(t, "62:41:d0:54:3d:64")
+	v4NodeIP := mustParseIPNet(t, "172.18.0.3/24")
+	v6NodeIP := mustParseIPNet(t, "fd00::3/64")
+
+	bridge := &BridgeConfiguration{
+		ofPortPhys: "eth0",
+		ofPortHost: nodetypes.OvsLocalPort,
+		ips:        []*net.IPNet{v4NodeIP, v6NodeIP},
+		macAddress: bridgeMAC,
+		netConfig: map[string]*BridgeUDNConfiguration{
+			types.DefaultNetworkName: {
+				OfPortPatch: "patch-breth0_ov",
+				MasqCTMark:  nodetypes.CtMarkOVN,
+				Subnets: []config.CIDRNetworkEntry{
+					{CIDR: mustParseIPNet(t, "10.244.0.0/16")},
+					{CIDR: mustParseIPNet(t, "fd10:244::/64")},
+				},
+			},
+		},
+	}
+
+	flows, err := bridge.commonFlows(nil)
+	if err != nil {
+		t.Fatalf("failed to render bridge flows: %v", err)
+	}
+
+	expectedIPv4HostToOVN := fmt.Sprintf("cookie=%s, priority=510, in_port=LOCAL, ip, ip_src=%s, "+
+		"ip_dst=10.244.0.0/16, actions=goto_table:2",
+		nodetypes.DefaultOpenFlowCookie, config.Gateway.MasqueradeIPs.V4HostMasqueradeIP)
+	expectedIPv4OVNToHost := fmt.Sprintf("cookie=%s, priority=510, in_port=patch-breth0_ov, ip, "+
+		"ip_src=10.244.0.0/16, ip_dst=%s,actions=goto_table:3",
+		nodetypes.DefaultOpenFlowCookie, config.Gateway.MasqueradeIPs.V4HostMasqueradeIP)
+	expectedIPv4OVNToPhysical := fmt.Sprintf("cookie=%s, priority=510, in_port=patch-breth0_ov, "+
+		"dl_src=%s, ip, ip_src=%s, ip_dst=10.244.0.0/16, "+
+		"actions=ct(commit, zone=%d, nat(src=172.18.0.3), exec(set_field:%s->ct_mark)), output:eth0",
+		nodetypes.DefaultOpenFlowCookie, bridgeMAC, config.Gateway.MasqueradeIPs.V4HostMasqueradeIP,
+		config.Default.ConntrackZone, nodetypes.CtMarkOVN)
+	expectedIPv6HostToOVN := fmt.Sprintf("cookie=%s, priority=510, in_port=LOCAL, ipv6, ipv6_src=%s, "+
+		"ipv6_dst=fd10:244::/64, actions=goto_table:2",
+		nodetypes.DefaultOpenFlowCookie, config.Gateway.MasqueradeIPs.V6HostMasqueradeIP)
+	expectedIPv6OVNToHost := fmt.Sprintf("cookie=%s, priority=510, in_port=patch-breth0_ov, ipv6, "+
+		"ipv6_src=fd10:244::/64, ipv6_dst=%s,actions=goto_table:3",
+		nodetypes.DefaultOpenFlowCookie, config.Gateway.MasqueradeIPs.V6HostMasqueradeIP)
+	expectedIPv6OVNToPhysical := fmt.Sprintf("cookie=%s, priority=510, in_port=patch-breth0_ov, "+
+		"dl_src=%s, ipv6, ipv6_src=%s, ipv6_dst=fd10:244::/64, "+
+		"actions=ct(commit, zone=%d, nat(src=fd00::3), exec(set_field:%s->ct_mark)), output:eth0",
+		nodetypes.DefaultOpenFlowCookie, bridgeMAC, config.Gateway.MasqueradeIPs.V6HostMasqueradeIP,
+		config.Default.ConntrackZone, nodetypes.CtMarkOVN)
+
+	expectFlow(t, flows, expectedIPv4HostToOVN)
+	expectFlow(t, flows, expectedIPv4OVNToHost)
+	expectFlow(t, flows, expectedIPv4OVNToPhysical)
+	expectFlow(t, flows, expectedIPv6HostToOVN)
+	expectFlow(t, flows, expectedIPv6OVNToHost)
+	expectFlow(t, flows, expectedIPv6OVNToPhysical)
+}
+
 func TestLocalNoOverlayServiceHairpinUsesUDNGatewayMasqueradeIP(t *testing.T) {
 	if err := config.PrepareTestConfig(); err != nil {
 		t.Fatalf("failed to prepare test config: %v", err)

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -194,6 +194,40 @@ func configureSvcRouteViaInterface(routeManager *routemanager.Controller, iface 
 	return nil
 }
 
+func shouldConfigureDPUHostNoOverlayPodCIDRRoute() bool {
+	return config.IsModeDPUHost() &&
+		config.Gateway.Mode == config.GatewayModeShared &&
+		config.Default.Transport == types.NetworkTransportNoOverlay
+}
+
+func configureDPUHostNoOverlayPodCIDRRoute(routeManager *routemanager.Controller, iface string, gwIPs []net.IP) error {
+	link, err := util.LinkSetUp(iface)
+	if err != nil {
+		return fmt.Errorf("unable to get link for %s, error: %v", iface, err)
+	}
+
+	mtu := config.Default.MTU
+	if config.Default.RoutableMTU != 0 {
+		mtu = config.Default.RoutableMTU
+	}
+
+	for _, clusterSubnet := range config.Default.ClusterSubnets {
+		subnet := clusterSubnet.CIDR
+		isV6 := utilnet.IsIPv6CIDR(subnet)
+		gwIP, err := util.MatchIPFamily(isV6, gwIPs)
+		if err != nil {
+			return fmt.Errorf("unable to find gateway IP for subnet: %v, found IPs: %v", subnet, gwIPs)
+		}
+		subnetCopy := *subnet
+		gwIPCopy := gwIP[0]
+		err = routeManager.Add(netlink.Route{LinkIndex: link.Attrs().Index, Gw: gwIPCopy, Dst: &subnetCopy, MTU: mtu})
+		if err != nil {
+			return fmt.Errorf("unable to add gateway IP route for subnet: %v, %v", subnet, err)
+		}
+	}
+	return nil
+}
+
 // getNodePrimaryIfAddrs returns the appropriate interface addresses based on the node mode
 func getNodePrimaryIfAddrs(watchFactory factory.NodeWatchFactory, nodeName string, gatewayIntf string) ([]*net.IPNet, error) {
 	switch config.OvnKubeNode.Mode {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1920,6 +1920,52 @@ var _ = Describe("Gateway unit tests", func() {
 		})
 	})
 
+	Context("configureDPUHostNoOverlayPodCIDRRoute", func() {
+		It("configures pod CIDR routes on interface without a route source", func() {
+			_, ipnet, err := net.ParseCIDR("10.244.0.0/16")
+			Expect(err).ToNot(HaveOccurred())
+			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: ipnet, HostSubnetLength: 24}}
+			gwIPs := []net.IP{net.ParseIP("169.254.0.4")}
+
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{
+				Name:  "ens1f0",
+				Index: 5,
+			}
+			expectedRoute := &netlink.Route{
+				Dst:       ipnet,
+				LinkIndex: 5,
+				Scope:     netlink.SCOPE_UNIVERSE,
+				Gw:        gwIPs[0],
+				MTU:       config.Default.MTU,
+				Table:     syscall.RT_TABLE_MAIN,
+			}
+
+			lnk.On("Attrs").Return(lnkAttr)
+			netlinkMock.On("LinkByName", lnkAttr.Name).Return(lnk, nil)
+			netlinkMock.On("LinkByIndex", lnkAttr.Index).Return(lnk, nil)
+			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
+			netlinkMock.On("RouteReplace", expectedRoute).Return(nil)
+
+			wg := &sync.WaitGroup{}
+			rm := routemanager.NewController()
+			util.SetNetLinkOpMockInst(netlinkMock)
+			stopCh := make(chan struct{})
+			wg.Add(1)
+			go func() {
+				rm.Run(stopCh, 10*time.Second)
+				wg.Done()
+			}()
+			defer func() {
+				close(stopCh)
+				wg.Wait()
+			}()
+
+			err = configureDPUHostNoOverlayPodCIDRRoute(rm, "ens1f0", gwIPs)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("getGatewayNextHops", func() {
 
 		It("Finds correct gateway interface and nexthops without configuration", func() {

--- a/go-controller/pkg/node/gateway_nftables_test.go
+++ b/go-controller/pkg/node/gateway_nftables_test.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/knftables"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 
@@ -266,6 +267,38 @@ var _ = Describe("Gateway NFTables", func() {
 					Chain: nftablesPodSubnetMasqChain,
 				}))
 			})
+		})
+	})
+
+	Describe("setupDPUHostNoOverlaySNAT", func() {
+		It("SNATs default cluster CIDR traffic to the host masquerade IP", func() {
+			nft := nodenft.SetFakeNFTablesHelper()
+			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
+				{CIDR: ovntest.MustParseIPNet("10.244.0.0/16")},
+				{CIDR: ovntest.MustParseIPNet("fd00:10:244::/48")},
+			}
+
+			Expect(setupDPUHostNoOverlaySNAT("breth0")).To(Succeed())
+			dump := nft.Dump()
+
+			Expect(dump).To(ContainSubstring("add chain inet ovn-kubernetes dpu-host-no-overlay-snat"))
+			Expect(dump).To(ContainSubstring("add rule inet ovn-kubernetes dpu-host-no-overlay-snat oifname != breth0 return"))
+			Expect(dump).To(ContainSubstring("ip daddr 10.244.0.0/16 ip saddr != 169.254.169.2 snat ip to 169.254.169.2"))
+			Expect(dump).To(ContainSubstring("ip6 daddr fd00:10:244::/48 ip6 saddr != fd69::2 snat ip6 to fd69::2"))
+		})
+
+		It("removes DPU host no-overlay SNAT rules", func() {
+			nft := nodenft.SetFakeNFTablesHelper()
+			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
+				{CIDR: ovntest.MustParseIPNet("10.244.0.0/16")},
+			}
+
+			Expect(setupDPUHostNoOverlaySNAT("breth0")).To(Succeed())
+			Expect(nft.Dump()).To(ContainSubstring("dpu-host-no-overlay-snat"))
+
+			Expect(teardownDPUHostNoOverlaySNAT()).To(Succeed())
+			Expect(nft.Dump()).NotTo(ContainSubstring("dpu-host-no-overlay-snat"))
+			Expect(teardownDPUHostNoOverlaySNAT()).To(Succeed())
 		})
 	})
 })

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -75,6 +75,10 @@ const (
 	// from accessing any of the advertised UDN networks
 	nftablesUDNBGPOutputChain = "udn-bgp-drop"
 
+	// nftablesDPUHostNoOverlaySNATChain SNATs DPU-host host-network traffic
+	// to the host masquerade IP before handing it to OVN for no-overlay pod CIDRs.
+	nftablesDPUHostNoOverlaySNATChain = "dpu-host-no-overlay-snat"
+
 	// nftablesAdvertisedUDNsSetV[4|6] is a set containing advertised UDN subnets
 	nftablesAdvertisedUDNsSetV4 = "advertised-udn-subnets-v4"
 	nftablesAdvertisedUDNsSetV6 = "advertised-udn-subnets-v6"
@@ -2231,6 +2235,18 @@ func (r *masqueradeReconciler) ensure() error {
 	if err := configureSvcRouteViaInterface(r.routeManager, gwIface, DummyNextHopIPs()); err != nil {
 		return fmt.Errorf("failed to configure service route: %w", err)
 	}
+	if shouldConfigureDPUHostNoOverlayPodCIDRRoute() {
+		if err := configureDPUHostNoOverlayPodCIDRRoute(r.routeManager, gwIface, DummyNextHopIPs()); err != nil {
+			return fmt.Errorf("failed to configure DPU host no-overlay pod CIDR route: %w", err)
+		}
+		if err := setupDPUHostNoOverlaySNAT(gwIface); err != nil {
+			return fmt.Errorf("failed to configure DPU host no-overlay SNAT: %w", err)
+		}
+	} else {
+		if err := teardownDPUHostNoOverlaySNAT(); err != nil {
+			return fmt.Errorf("failed to remove DPU host no-overlay SNAT: %w", err)
+		}
+	}
 	// 3. ARP/ND entries for masquerade IPs.
 	if err := addHostMACBindings(gwIface); err != nil {
 		return fmt.Errorf("failed to add MAC bindings: %w", err)
@@ -2238,6 +2254,81 @@ func (r *masqueradeReconciler) ensure() error {
 
 	r.lastLinkIndex = link.Attrs().Index
 	klog.Infof("Masquerade resources ensured on %s (ifindex=%d)", gwIface, r.lastLinkIndex)
+	return nil
+}
+
+func setupDPUHostNoOverlaySNAT(gwIface string) error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return err
+	}
+	tx := nft.NewTransaction()
+
+	tx.Add(&knftables.Chain{
+		Name:     nftablesDPUHostNoOverlaySNATChain,
+		Comment:  knftables.PtrTo("OVN DPU host no-overlay SNAT"),
+		Type:     knftables.PtrTo(knftables.NATType),
+		Hook:     knftables.PtrTo(knftables.PostroutingHook),
+		Priority: knftables.PtrTo(knftables.SNATPriority),
+	})
+	tx.Flush(&knftables.Chain{Name: nftablesDPUHostNoOverlaySNATChain})
+	tx.Add(&knftables.Rule{
+		Chain: nftablesDPUHostNoOverlaySNATChain,
+		Rule: knftables.Concat(
+			"oifname", "!=", gwIface,
+			"return",
+		),
+	})
+
+	for _, clusterSubnet := range config.Default.ClusterSubnets {
+		subnet := clusterSubnet.CIDR
+		if utilnet.IsIPv6CIDR(subnet) {
+			tx.Add(&knftables.Rule{
+				Chain: nftablesDPUHostNoOverlaySNATChain,
+				Rule: knftables.Concat(
+					"ip6 daddr", subnet,
+					"ip6 saddr", "!=", config.Gateway.MasqueradeIPs.V6HostMasqueradeIP,
+					"snat ip6 to", config.Gateway.MasqueradeIPs.V6HostMasqueradeIP,
+				),
+			})
+			continue
+		}
+		tx.Add(&knftables.Rule{
+			Chain: nftablesDPUHostNoOverlaySNATChain,
+			Rule: knftables.Concat(
+				"ip daddr", subnet,
+				"ip saddr", "!=", config.Gateway.MasqueradeIPs.V4HostMasqueradeIP,
+				"snat ip to", config.Gateway.MasqueradeIPs.V4HostMasqueradeIP,
+			),
+		})
+	}
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("could not update nftables rule for DPU host no-overlay SNAT: %w", err)
+	}
+	return nil
+}
+
+func teardownDPUHostNoOverlaySNAT() error {
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return err
+	}
+	tx := nft.NewTransaction()
+
+	chain := &knftables.Chain{
+		Name:     nftablesDPUHostNoOverlaySNATChain,
+		Type:     knftables.PtrTo(knftables.NATType),
+		Hook:     knftables.PtrTo(knftables.PostroutingHook),
+		Priority: knftables.PtrTo(knftables.SNATPriority),
+	}
+	tx.Add(chain)
+	tx.Flush(chain)
+	tx.Delete(chain)
+
+	if err := nft.Run(context.TODO(), tx); err != nil && !knftables.IsNotFound(err) {
+		return fmt.Errorf("could not remove nftables rule for DPU host no-overlay SNAT: %w", err)
+	}
 	return nil
 }
 

--- a/go-controller/pkg/node/managementport/port_config.go
+++ b/go-controller/pkg/node/managementport/port_config.go
@@ -131,9 +131,11 @@ func newManagementPortIPFamilyConfig(hostSubnet *net.IPNet, isIPv6 bool, netInfo
 	}
 
 	// capture all the subnets for which we need to add routes through management port
-	for _, subnet := range config.Default.ClusterSubnets {
-		if utilnet.IsIPv6CIDR(subnet.CIDR) == isIPv6 {
-			cfg.clusterSubnets = append(cfg.clusterSubnets, subnet.CIDR)
+	if managementPortRoutesDefaultClusterSubnets() {
+		for _, subnet := range config.Default.ClusterSubnets {
+			if utilnet.IsIPv6CIDR(subnet.CIDR) == isIPv6 {
+				cfg.clusterSubnets = append(cfg.clusterSubnets, subnet.CIDR)
+			}
 		}
 	}
 	// add the .3 masqueradeIP to add the route via mp0 for ETP=local case
@@ -153,4 +155,10 @@ func newManagementPortIPFamilyConfig(hostSubnet *net.IPNet, isIPv6 bool, netInfo
 	}
 
 	return cfg, nil
+}
+
+func managementPortRoutesDefaultClusterSubnets() bool {
+	return !(config.IsModeDPUHost() &&
+		config.Gateway.Mode == config.GatewayModeShared &&
+		config.Default.Transport == types.NetworkTransportNoOverlay)
 }

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -1250,6 +1250,25 @@ var _ = Describe("Management Port tests", func() {
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", "worker-node").Return(nil)
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))
+		It("does not add default cluster subnet routes through the management port for DPU host no-overlay", func() {
+			config.OvnKubeNode.Mode = types.NodeModeDPUHost
+			config.Gateway.Mode = config.GatewayModeShared
+			config.Default.Transport = types.NetworkTransportNoOverlay
+			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{
+				CIDR:             ovntest.MustParseIPNet("10.1.0.0/16"),
+				HostSubnetLength: 24,
+			}}
+
+			cfg, err := newManagementPortIPFamilyConfig(hostSubnets[0], false, netInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			var routeSubnets []string
+			for _, subnet := range cfg.clusterSubnets {
+				routeSubnets = append(routeSubnets, subnet.String())
+			}
+			Expect(routeSubnets).NotTo(ContainElement("10.1.0.0/16"))
+			Expect(routeSubnets).To(ConsistOf(fmt.Sprintf("%s/32", config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String())))
+		})
 		It("Creates managementPort by default", func() {
 			mgmtPort, err := NewManagementPortController(nil, node, hostSubnets, netdevName, rep, nil, netInfo)
 			Expect(err).NotTo(HaveOccurred())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
     - Service Traffic Policy: design/service-traffic-policy.md
     - Host To NodePort Hairpin: design/host-to-node-port-hairpin-trafficflow.md
     - ExternalIPs/LoadBalancerIngress: design/external-ip-and-loadbalancer-ingress.md
+    - DPU Host No-Overlay Routing: design/dpu-host-no-overlay-routing.md
     - Internal Subnets: design/ovn-kubernetes-subnets.md
     - Kubevirt VM Live Migration: features/live-migration.md
   - Getting Started:


### PR DESCRIPTION
Teach kind-helm.sh about DPU simulator host and DPU modes, external values files, and existing kubeconfigs so OVN-Kubernetes can be installed manually after dpu-simulator generates DPU-specific values.

Also wire the DPU-side FRR-K8S flow to use host-cluster credentials, keep unmanaged BGP resources split between the DPU and host APIs, and recover dpu-simulator-managed system add-ons after OVN-Kubernetes is ready.

Changes-Include:

  - Adds DPU simulator support to kind-helm.sh for values-only/manual Helm installs using existing host and DPU kubeconfigs.
  - Wires DPU host and DPU Helm installs to consume dpu-simulator generated values and FRR-K8S host-access artifacts.
  - Keeps unmanaged BGP resources split correctly between the host API and DPU API when running remote FRR-K8S.
  - Adds a reusable contrib/kind-dpu-sim-no-overlay.sh helper for deploying the no-overlay DPU simulator flow locally.
  - Adds a DPU simulator no-overlay CI lane that builds dpu-simulator, deploys OVN-Kubernetes through Helm, and runs traffic flow tests.
  - Extends Kind/Helm waits for DPU simulator deployments, where DPU host daemonsets can take longer to become ready.
  - Handles newer FRR-K8S manifests where the controller container was renamed from frr-k8s to controller.
  - Installs/reconciles the newer FRR-K8S CRDs/RBAC needed by remote DPU FRR-K8S controllers.
  - Peers external FRR with DPU nodes over the simulator gateway network instead of the Kind API network, so learned routes use reachable 172.30.0.0/24 next hops.
  - Rewrites the generated FRR receive config for DPU remote mode to use the external FRR gateway-network address.
  - Cleans stale external FRR/BGP containers before redeploy so dpu-simulator can remove its gateway network cleanly.

Depends on changes from dpu simulator to use this: https://github.com/ovn-kubernetes/dpu-simulator/pull/26

Tested with UDNs:
```
trozet@fedora:~/go/src/github.com/ovn-org/ovn-kubernetes/contrib$ k create -f ~/udn_namespace.yaml
namespace/udn-test created
trozet@fedora:~/go/src/github.com/ovn-org/ovn-kubernetes/contrib$ k create -f ~/cudn-dpu-sim-no-overlay.yaml
clusteruserdefinednetwork.k8s.ovn.org/l3-primary created
trozet@fedora:~/go/src/github.com/ovn-org/ovn-kubernetes/contrib$ k create -f ~/ra.yaml
routeadvertisements.k8s.ovn.org/trozet-cudn created
trozet@fedora:~/go/src/github.com/ovn-org/ovn-kubernetes/contrib$ k create -f ~/basic_udn-dpu-sim.yaml
pod/client created
trozet@fedora:~/go/src/github.com/ovn-org/ovn-kubernetes/contrib$ k create -f ~/basic2_udn-dpu-sim.yaml
pod/server created

trozet@fedora:~/go/src/github.com/ovn-org/ovn-kubernetes/contrib$ k get pod -n udn-test server -o yaml | grep ovn
    k8s.ovn.org/dpu.connection-details: '{"default":{"pfId":"0","vfId":"4","sandboxId":"07d72267206dd3ee02b5efeeaa7b1c63e412472c3e745449b4f233fc13cb608f","vfNetdevName":"eth0-4"},"udn-test/l3-primary":{"pfId":"0","vfId":"6","sandboxId":"07d72267206dd3ee02b5efeeaa7b1c63e412472c3e745449b4f233fc13cb608f","vfNetdevName":"eth0-6"}}'
    k8s.ovn.org/dpu.connection-status: '{"default":{"Status":"Ready"},"udn-test/l3-primary":{"Status":"Ready"}}'
    k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.244.2.5/24"],"mac_address":"0a:58:0a:f4:02:05","routes":[{"dest":"10.244.0.0/16","nextHop":"10.244.2.1"},{"dest":"100.64.0.0/16","nextHop":"10.244.2.1"}],"ip_address":"10.244.2.5/24","role":"infrastructure-locked"},"udn-test/l3-primary":{"ip_addresses":["10.20.1.3/24"],"mac_address":"0a:58:0a:14:01:03","gateway_ips":["10.20.1.1"],"routes":[{"dest":"10.20.0.0/16","nextHop":"10.20.1.1"},{"dest":"10.245.0.0/16","nextHop":"10.20.1.1"},{"dest":"100.65.0.0/16","nextHop":"10.20.1.1"}],"ip_address":"10.20.1.3/24","gateway_ip":"10.20.1.1","role":"primary"}}'
          "name": "default/ovn-primary",
          "name": "default/ovn-primary",
          "interface": "ovn-udn1",
trozet@fedora:~/go/src/github.com/ovn-org/ovn-kubernetes/contrib$ k exec -n udn-test -it client -- /bin/bash
utils@client:~$ ping 10.20.1.3
PING 10.20.1.3 (10.20.1.3) 56(84) bytes of data.
64 bytes from 10.20.1.3: icmp_seq=1 ttl=60 time=9.74 ms
64 bytes from 10.20.1.3: icmp_seq=2 ttl=60 time=2.18 ms
64 bytes from 10.20.1.3: icmp_seq=3 ttl=60 time=0.188 ms
^C
--- 10.20.1.3 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2003ms
rtt min/avg/max/mdev = 0.188/4.035/9.742/4.115 ms

[root@dpu-sim-dpu-worker ~]# ovn-nbctl lr-route-list  GR_cluster_udn_l3.primary_dpu-sim-host-worker
IPv4 Routes
Route Table <main>:
             10.20.1.0/24              172.30.0.253 dst-ip rtoe-GR_cluster_udn_l3.primary_dpu-sim-host-worker
            10.244.2.0/24              172.30.0.253 dst-ip rtoe-GR_cluster_udn_l3.primary_dpu-sim-host-worker
           169.254.0.0/17               169.254.0.4 dst-ip rtoe-GR_cluster_udn_l3.primary_dpu-sim-host-worker
             10.20.0.0/16                100.65.0.1 dst-ip
            172.27.0.0/16                172.30.0.4 dst-ip rtoe-GR_cluster_udn_l3.primary_dpu-sim-host-worker
                0.0.0.0/0                172.30.0.1 dst-ip rtoe-GR_cluster_udn_l3.primary_dpu-sim-host-worker
[root@dpu-sim-dpu-worker ~]# ip route show vrf l3-primary
10.20.1.0/24 nhid 75 via 172.30.0.253 dev breth1 proto bgp metric 20
10.244.2.0/24 nhid 75 via 172.30.0.253 dev breth1 proto bgp metric 20
172.27.0.0/16 nhid 67 via 172.30.0.4 dev breth1 proto bgp metric 20
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DPU support: host/dpu-specific deploy flows, no-overlay host routing, simulator orchestration and no-overlay run script, CI job for no-overlay scenarios, new CLI flags and repeatable extra Helm values, and remote FRR-K8S remote-mode deployment and receive-route handling.

* **Bug Fixes**
  * Avoid duplicate kubeconfig merges and container IP overwrites; skip Multus install when DPU mode indicates simulator provides it.

* **Documentation**
  * Added DPU Host No-Overlay Routing design doc.

* **Tests**
  * Added unit and integration tests covering DPU no-overlay flows, routing, and FRR behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->