### PR TITLE
Filter route imports across OVN networks

### DIFF
--- a/go-controller/pkg/ovn/routeimport/route_import.go
+++ b/go-controller/pkg/ovn/routeimport/route_import.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	controllerutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller"
 	nbdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -104,10 +105,10 @@ type controller struct {
 
 func (c *controller) AddNetwork(network util.NetInfo) error {
 	c.Lock()
-	defer c.Unlock()
 
 	networkID := network.GetNetworkID()
 	if c.networkIDs[networkID] != "" {
+		c.Unlock()
 		return fmt.Errorf("already tracking network %q with ID %d",
 			c.networkIDs[networkID],
 			networkID,
@@ -119,6 +120,7 @@ func (c *controller) AddNetwork(network util.NetInfo) error {
 		// this shouldn't happen as the network ID is correlated uniquely with
 		// the network name, but do the check anyway in case this is not being
 		// handled correctly
+		c.Unlock()
 		return fmt.Errorf("already tracking network name %q", name)
 	}
 
@@ -127,9 +129,16 @@ func (c *controller) AddNetwork(network util.NetInfo) error {
 	if network.IsDefault() {
 		c.tables[unix.RT_TABLE_MAIN] = networkID
 	}
+	networks := make([]string, 0, len(c.networks))
+	for name := range c.networks {
+		networks = append(networks, name)
+	}
+	c.Unlock()
 
 	c.log.V(5).Info("Started tracking network", "name", name, "id", networkID)
-	c.reconcile(name)
+	for _, name := range networks {
+		c.reconcile(name)
+	}
 
 	return nil
 }
@@ -154,12 +163,13 @@ func (c *controller) NeedsReconciliation(network util.NetInfo) bool {
 	c.RLock()
 	defer c.RUnlock()
 
-	if c.networks[network.GetNetworkName()] == nil {
+	current := c.networks[network.GetNetworkName()]
+	if current == nil {
 		return false
 	}
 
-	// TODO check if overlay mode changed
-	return false
+	return util.IsPodNetworkAdvertisedAtNode(current, c.node) != util.IsPodNetworkAdvertisedAtNode(network, c.node) ||
+		current.Transport() != network.Transport()
 }
 
 func (c *controller) ReconcileNetwork(name string) error {
@@ -248,8 +258,7 @@ func (c *controller) syncRouteUpdate(update *netlink.RouteUpdate) {
 	}
 
 	table := update.Table
-	network := c.getNetworkForTable(table)
-	if network != nil {
+	for _, network := range c.getNetworksForTable(table) {
 		c.reconcile(network.GetNetworkName())
 	}
 }
@@ -322,40 +331,46 @@ func (c *controller) syncNetwork(network string) error {
 		return nil
 	}
 
-	// get the table from the network VRF. Note we go to netlink for this as
-	// source of truth instead of using c.tables cache which is just a hint for
-	// syncRouteUpdate. This avoids implementing a more complicated logic to
-	// mantain c.tables
-	table, err := c.getRoutingTableForNetwork(network)
-	if err != nil {
-		return fmt.Errorf("failed to get VRF table from network: %w", err)
-	}
-	if table == noTable {
-		// no VRF exists yet for the network
-		return nil
-	}
-
-	// sneakily set the hint for syncRouteUpdate. Handles this sequence of events:
-	// 1. link create event
-	// 2. add Network
-	// 3. Route update event <- we wouldn't know the network of a table to add
-	//    routes to
-	c.Lock()
-	c.setTableForNetworkUnlocked(info.GetNetworkID(), table)
-	c.Unlock()
-
-	var ignoreSubnets []*net.IPNet
-	if info.Transport() != types.NetworkTransportNoOverlay {
-		// if the network is overlay mode, skip routes to the pod network
-		ignoreSubnets = make([]*net.IPNet, len(info.Subnets()))
-		for i, subnet := range info.Subnets() {
-			ignoreSubnets[i] = subnet.CIDR
+	expected := sets.New[route]()
+	if util.IsPodNetworkAdvertisedAtNode(info, c.node) {
+		// get the table from the network VRF. Note we go to netlink for this as
+		// source of truth instead of using c.tables cache which is just a hint for
+		// syncRouteUpdate. This avoids implementing a more complicated logic to
+		// mantain c.tables
+		table, err := c.getRoutingTableForNetwork(network)
+		if err != nil {
+			return fmt.Errorf("failed to get VRF table from network: %w", err)
 		}
-	}
+		if table == noTable {
+			// no VRF exists yet for the network
+			return nil
+		}
 
-	expected, err := c.getBGPRoutes(table, ignoreSubnets)
-	if err != nil {
-		return err
+		// sneakily set the hint for syncRouteUpdate. Handles this sequence of events:
+		// 1. link create event
+		// 2. add Network
+		// 3. Route update event <- we wouldn't know the network of a table to add
+		//    routes to
+		c.Lock()
+		if !isDPUMainTableFallback(info, table) {
+			c.setTableForNetworkUnlocked(info.GetNetworkID(), table)
+		}
+		c.Unlock()
+
+		var ignoreSubnets []*net.IPNet
+		if info.Transport() != types.NetworkTransportNoOverlay {
+			// if the network is overlay mode, skip routes to the pod network
+			ignoreSubnets = make([]*net.IPNet, len(info.Subnets()))
+			for i, subnet := range info.Subnets() {
+				ignoreSubnets[i] = subnet.CIDR
+			}
+		}
+		ignoreSubnets = append(ignoreSubnets, c.getOtherNetworkSubnets(info.GetNetworkName())...)
+
+		expected, err = c.getBGPRoutes(table, ignoreSubnets)
+		if err != nil {
+			return err
+		}
 	}
 
 	router := info.GetNetworkScopedGWRouterName(c.node)
@@ -433,6 +448,9 @@ func (c *controller) getBGPRoutes(table int, ignoreSubnets []*net.IPNet) (sets.S
 
 	routes := sets.New[route]()
 	for _, nlroute := range nlroutes {
+		if nlroute.Dst == nil {
+			continue
+		}
 		if util.IsContainedInAnyCIDR(nlroute.Dst, ignoreSubnets...) {
 			c.log.V(5).Info("Ignore BGP route", "table", table, "route", stringer{nlroute})
 			continue
@@ -486,6 +504,11 @@ func (c *controller) getRoutingTableForNetwork(name string) (int, error) {
 	vrf := util.GetNetworkVRFName(network)
 	link, err := c.netlink.LinkByName(vrf)
 	if c.netlink.IsLinkNotFoundError(err) {
+		if config.IsModeDPU() {
+			// DPU mode may not have a per-network VRF even when the network is
+			// advertised. FRR learns those routes in the main table instead.
+			return unix.RT_TABLE_MAIN, nil
+		}
 		// unknown link, will reconcile later if link is updated
 		return noTable, nil
 	}
@@ -502,13 +525,70 @@ func (c *controller) getRoutingTableForNetwork(name string) (int, error) {
 	return int(vrfLink.Table), nil
 }
 
-func (c *controller) getNetworkForTable(table int) util.NetInfo {
+func (c *controller) getNetworksForTable(table int) []util.NetInfo {
 	c.RLock()
 	defer c.RUnlock()
+	if table == unix.RT_TABLE_MAIN && config.IsModeDPU() {
+		// In DPU mode, advertised networks that do not have a known VRF table
+		// use the main table as the source of BGP-learned routes.
+		networks := make([]util.NetInfo, 0, len(c.networks))
+		for _, network := range c.networks {
+			if !util.IsPodNetworkAdvertisedAtNode(network, c.node) {
+				continue
+			}
+			if network.IsDefault() || !c.hasTableForNetworkUnlocked(network.GetNetworkID()) {
+				networks = append(networks, network)
+			}
+		}
+		return networks
+	}
 	if network, known := c.tables[table]; known {
-		return c.networks[c.networkIDs[network]]
+		if network := c.networks[c.networkIDs[network]]; network != nil {
+			if util.IsPodNetworkAdvertisedAtNode(network, c.node) {
+				return []util.NetInfo{network}
+			}
+		}
 	}
 	return nil
+}
+
+func (c *controller) hasTableForNetworkUnlocked(networkID int) bool {
+	for _, id := range c.tables {
+		if id == networkID {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *controller) getOtherNetworkSubnets(networkName string) []*net.IPNet {
+	c.RLock()
+	defer c.RUnlock()
+
+	var subnets []*net.IPNet
+	for name, network := range c.networks {
+		if name == networkName {
+			continue
+		}
+		subnets = append(subnets, cidrsFromNetworkEntries(network.Subnets())...)
+	}
+	return subnets
+}
+
+func cidrsFromNetworkEntries(entries []config.CIDRNetworkEntry) []*net.IPNet {
+	subnets := make([]*net.IPNet, 0, len(entries))
+	for _, entry := range entries {
+		if entry.CIDR != nil {
+			subnets = append(subnets, entry.CIDR)
+		}
+	}
+	return subnets
+}
+
+func isDPUMainTableFallback(network util.NetInfo, table int) bool {
+	return config.IsModeDPU() &&
+		!network.IsDefault() &&
+		table == unix.RT_TABLE_MAIN
 }
 
 // setTableForNetworkUnlocked needs to be called with lock

--- a/go-controller/pkg/ovn/routeimport/route_import_test.go
+++ b/go-controller/pkg/ovn/routeimport/route_import_test.go
@@ -6,6 +6,7 @@ package routeimport
 import (
 	"errors"
 	"net"
+	"sort"
 	"sync"
 	"testing"
 
@@ -38,6 +39,7 @@ func Test_controller_syncNetwork(t *testing.T) {
 	})
 
 	defaultNetwork := &util.DefaultNetInfo{}
+	defaultNetwork.SetPodNetworkAdvertisedVRFs(map[string][]string{node: []string{types.DefaultNetworkName}})
 	defaultNetworkRouter := defaultNetwork.GetNetworkScopedGWRouterName(node)
 	defaultNetworkRouterPort := types.GWRouterToExtSwitchPrefix + defaultNetworkRouter
 
@@ -58,6 +60,7 @@ func Test_controller_syncNetwork(t *testing.T) {
 	udn.On("Subnets").Return(nil)
 	udn.On("GetNetworkScopedGWRouterName", node).Return("router")
 	udn.On("Transport").Return("")
+	udn.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 
 	cudn := &multinetworkmocks.NetInfo{}
 	cudn.On("IsDefault").Return(false)
@@ -66,6 +69,7 @@ func Test_controller_syncNetwork(t *testing.T) {
 	cudn.On("Subnets").Return(nil)
 	cudn.On("GetNetworkScopedGWRouterName", node).Return("router")
 	cudn.On("Transport").Return("")
+	cudn.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 
 	// Create CUDN with subnets for overlay mode testing
 	cudnOverlay := &multinetworkmocks.NetInfo{}
@@ -83,8 +87,28 @@ func Test_controller_syncNetwork(t *testing.T) {
 	})
 	cudnOverlay.On("GetNetworkScopedGWRouterName", node).Return("cudn-overlay-router")
 	cudnOverlay.On("Transport").Return("") // Empty means overlay (geneve)
+	cudnOverlay.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 	cudnOverlayRouter := cudnOverlay.GetNetworkScopedGWRouterName(node)
 	cudnOverlayRouterPort := types.GWRouterToExtSwitchPrefix + cudnOverlayRouter
+
+	cudnUnadvertised := &multinetworkmocks.NetInfo{}
+	cudnUnadvertised.On("IsDefault").Return(false)
+	cudnUnadvertised.On("GetNetworkName").Return(types.CUDNPrefix + "cudn-unadvertised")
+	cudnUnadvertised.On("GetNetworkID").Return(6)
+	cudnUnadvertised.On("Subnets").Return([]config.CIDRNetworkEntry{
+		{
+			CIDR: &net.IPNet{
+				IP:   net.IPv4(192, 169, 0, 0),
+				Mask: net.CIDRMask(16, 32),
+			},
+			HostSubnetLength: 24,
+		},
+	})
+	cudnUnadvertised.On("GetNetworkScopedGWRouterName", node).Return("cudn-unadvertised-router")
+	cudnUnadvertised.On("Transport").Return("")
+	cudnUnadvertised.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return(nil)
+	cudnUnadvertisedRouter := cudnUnadvertised.GetNetworkScopedGWRouterName(node)
+	cudnUnadvertisedRouterPort := types.GWRouterToExtSwitchPrefix + cudnUnadvertisedRouter
 
 	// Create CUDN with subnets for no-overlay mode testing
 	cudnNoOverlay := &multinetworkmocks.NetInfo{}
@@ -102,8 +126,26 @@ func Test_controller_syncNetwork(t *testing.T) {
 	})
 	cudnNoOverlay.On("GetNetworkScopedGWRouterName", node).Return("cudn-nooverlay-router")
 	cudnNoOverlay.On("Transport").Return(types.NetworkTransportNoOverlay)
+	cudnNoOverlay.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 	cudnNoOverlayRouter := cudnNoOverlay.GetNetworkScopedGWRouterName(node)
 	cudnNoOverlayRouterPort := types.GWRouterToExtSwitchPrefix + cudnNoOverlayRouter
+
+	otherCUDNNoOverlay := &multinetworkmocks.NetInfo{}
+	otherCUDNNoOverlay.On("IsDefault").Return(false)
+	otherCUDNNoOverlay.On("GetNetworkName").Return(types.CUDNPrefix + "other-cudn-nooverlay")
+	otherCUDNNoOverlay.On("GetNetworkID").Return(5)
+	otherCUDNNoOverlay.On("Subnets").Return([]config.CIDRNetworkEntry{
+		{
+			CIDR: &net.IPNet{
+				IP:   net.IPv4(172, 16, 0, 0),
+				Mask: net.CIDRMask(16, 32),
+			},
+			HostSubnetLength: 24,
+		},
+	})
+	otherCUDNNoOverlay.On("GetNetworkScopedGWRouterName", node).Return("other-cudn-nooverlay-router")
+	otherCUDNNoOverlay.On("Transport").Return(types.NetworkTransportNoOverlay)
+	otherCUDNNoOverlay.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
 
 	type fields struct {
 		networkIDs map[int]string
@@ -121,6 +163,7 @@ func Test_controller_syncNetwork(t *testing.T) {
 		routes           []netlink.Route
 		link             netlink.Link
 		noOverlayEnabled bool
+		dpuMode          bool
 		linkErr          bool
 		routesErr        bool
 		wantErr          bool
@@ -275,6 +318,35 @@ func Test_controller_syncNetwork(t *testing.T) {
 			},
 		},
 		{
+			name:             "ignores other network routes on the default network",
+			noOverlayEnabled: true,
+			args:             args{"default"},
+			fields: fields{
+				networkIDs: map[int]string{0: "default", 4: types.CUDNPrefix + "cudn-nooverlay"},
+				networks: map[string]util.NetInfo{
+					"default":                           defaultNetwork,
+					types.CUDNPrefix + "cudn-nooverlay": cudnNoOverlay,
+				},
+			},
+			link: &netlink.Vrf{Table: unix.RT_TABLE_MAIN},
+			initial: []libovsdb.TestData{
+				&nbdb.LogicalRouter{Name: defaultNetwork.GetNetworkScopedGWRouterName(node), StaticRoutes: []string{"keep-1"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &defaultNetworkRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+			routes: []netlink.Route{
+				{Dst: ovntesting.MustParseIPNet("1.1.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
+				{Dst: ovntesting.MustParseIPNet("10.128.1.0/24"), Gw: ovntesting.MustParseIP("2.2.2.1")},
+				{Dst: ovntesting.MustParseIPNet("192.168.1.0/24"), Gw: ovntesting.MustParseIP("3.3.3.1")},
+				{Dst: ovntesting.MustParseIPNet("172.30.1.0/24"), Gw: ovntesting.MustParseIP("4.4.4.1")},
+			},
+			expected: []libovsdb.TestData{
+				&nbdb.LogicalRouter{UUID: "router", Name: defaultNetwork.GetNetworkScopedGWRouterName(node), StaticRoutes: []string{"keep-1", "add-1", "add-2"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &defaultNetworkRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "10.128.1.0/24", Nexthop: "2.2.2.1", OutputPort: &defaultNetworkRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-2", IPPrefix: "172.30.1.0/24", Nexthop: "4.4.4.1", OutputPort: &defaultNetworkRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+		},
+		{
 			name: "ignores CUDN pod subnet routes in overlay mode",
 			args: args{types.CUDNPrefix + "cudn-overlay"},
 			fields: fields{
@@ -296,11 +368,33 @@ func Test_controller_syncNetwork(t *testing.T) {
 			},
 		},
 		{
+			name: "removes imported routes when network is not advertised",
+			args: args{types.CUDNPrefix + "cudn-unadvertised"},
+			fields: fields{
+				networkIDs: map[int]string{6: types.CUDNPrefix + "cudn-unadvertised"},
+				networks:   map[string]util.NetInfo{types.CUDNPrefix + "cudn-unadvertised": cudnUnadvertised},
+			},
+			initial: []libovsdb.TestData{
+				&nbdb.LogicalRouter{Name: cudnUnadvertisedRouter, StaticRoutes: []string{"remove"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "remove", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &cudnUnadvertisedRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+			routes: []netlink.Route{
+				{Dst: ovntesting.MustParseIPNet("1.1.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
+			},
+			expected: []libovsdb.TestData{
+				&nbdb.LogicalRouter{UUID: "router", Name: cudnUnadvertisedRouter},
+			},
+		},
+		{
 			name: "adds CUDN pod subnet routes in no-overlay mode",
 			args: args{types.CUDNPrefix + "cudn-nooverlay"},
 			fields: fields{
-				networkIDs: map[int]string{4: types.CUDNPrefix + "cudn-nooverlay"},
-				networks:   map[string]util.NetInfo{types.CUDNPrefix + "cudn-nooverlay": cudnNoOverlay},
+				networkIDs: map[int]string{0: "default", 4: types.CUDNPrefix + "cudn-nooverlay", 5: types.CUDNPrefix + "other-cudn-nooverlay"},
+				networks: map[string]util.NetInfo{
+					"default":                                 defaultNetwork,
+					types.CUDNPrefix + "cudn-nooverlay":       cudnNoOverlay,
+					types.CUDNPrefix + "other-cudn-nooverlay": otherCUDNNoOverlay,
+				},
 			},
 			link: &netlink.Vrf{Table: 4},
 			initial: []libovsdb.TestData{
@@ -309,12 +403,69 @@ func Test_controller_syncNetwork(t *testing.T) {
 			},
 			routes: []netlink.Route{
 				{Dst: ovntesting.MustParseIPNet("1.1.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
+				{Dst: ovntesting.MustParseIPNet("10.128.1.0/24"), Gw: ovntesting.MustParseIP("2.2.2.1")},
 				{Dst: ovntesting.MustParseIPNet("192.168.1.0/24"), Gw: ovntesting.MustParseIP("2.2.2.1")},
+				{Dst: ovntesting.MustParseIPNet("172.16.1.0/24"), Gw: ovntesting.MustParseIP("3.3.3.1")},
+				{Dst: ovntesting.MustParseIPNet("172.30.1.0/24"), Gw: ovntesting.MustParseIP("4.4.4.1")},
 			},
 			expected: []libovsdb.TestData{
-				&nbdb.LogicalRouter{UUID: "router", Name: cudnNoOverlayRouter, StaticRoutes: []string{"keep-1", "add-1"}},
+				&nbdb.LogicalRouter{UUID: "router", Name: cudnNoOverlayRouter, StaticRoutes: []string{"keep-1", "add-1", "add-2"}},
 				&nbdb.LogicalRouterStaticRoute{UUID: "keep-1", IPPrefix: "1.1.1.0/24", Nexthop: "1.1.1.1", OutputPort: &cudnNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
 				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "192.168.1.0/24", Nexthop: "2.2.2.1", OutputPort: &cudnNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-2", IPPrefix: "172.30.1.0/24", Nexthop: "4.4.4.1", OutputPort: &cudnNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+		},
+		{
+			name:    "imports overlay CUDN external routes from the main table in DPU mode",
+			dpuMode: true,
+			args:    args{types.CUDNPrefix + "cudn-overlay"},
+			fields: fields{
+				networkIDs: map[int]string{0: "default", 3: types.CUDNPrefix + "cudn-overlay", 5: types.CUDNPrefix + "other-cudn-nooverlay"},
+				networks: map[string]util.NetInfo{
+					"default":                                 defaultNetwork,
+					types.CUDNPrefix + "cudn-overlay":         cudnOverlay,
+					types.CUDNPrefix + "other-cudn-nooverlay": otherCUDNNoOverlay,
+				},
+			},
+			initial: []libovsdb.TestData{
+				&nbdb.LogicalRouter{Name: cudnOverlayRouter},
+			},
+			routes: []netlink.Route{
+				{Dst: ovntesting.MustParseIPNet("10.128.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
+				{Dst: ovntesting.MustParseIPNet("192.168.1.0/24"), Gw: ovntesting.MustParseIP("2.2.2.1")},
+				{Dst: ovntesting.MustParseIPNet("172.16.1.0/24"), Gw: ovntesting.MustParseIP("3.3.3.1")},
+				{Dst: ovntesting.MustParseIPNet("172.30.1.0/24"), Gw: ovntesting.MustParseIP("4.4.4.1")},
+			},
+			expected: []libovsdb.TestData{
+				&nbdb.LogicalRouter{UUID: "router", Name: cudnOverlayRouter, StaticRoutes: []string{"add-1"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "172.30.1.0/24", Nexthop: "4.4.4.1", OutputPort: &cudnOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+			},
+		},
+		{
+			name:    "imports no-overlay CUDN routes from the main table in DPU mode",
+			dpuMode: true,
+			args:    args{types.CUDNPrefix + "cudn-nooverlay"},
+			fields: fields{
+				networkIDs: map[int]string{0: "default", 4: types.CUDNPrefix + "cudn-nooverlay", 5: types.CUDNPrefix + "other-cudn-nooverlay"},
+				networks: map[string]util.NetInfo{
+					"default":                                 defaultNetwork,
+					types.CUDNPrefix + "cudn-nooverlay":       cudnNoOverlay,
+					types.CUDNPrefix + "other-cudn-nooverlay": otherCUDNNoOverlay,
+				},
+			},
+			initial: []libovsdb.TestData{
+				&nbdb.LogicalRouter{Name: cudnNoOverlayRouter},
+			},
+			routes: []netlink.Route{
+				{Dst: ovntesting.MustParseIPNet("10.128.1.0/24"), Gw: ovntesting.MustParseIP("1.1.1.1")},
+				{Dst: ovntesting.MustParseIPNet("192.168.1.0/24"), Gw: ovntesting.MustParseIP("2.2.2.1")},
+				{Dst: ovntesting.MustParseIPNet("172.16.1.0/24"), Gw: ovntesting.MustParseIP("3.3.3.1")},
+				{Dst: ovntesting.MustParseIPNet("172.30.1.0/24"), Gw: ovntesting.MustParseIP("4.4.4.1")},
+			},
+			expected: []libovsdb.TestData{
+				&nbdb.LogicalRouter{UUID: "router", Name: cudnNoOverlayRouter, StaticRoutes: []string{"add-1", "add-2"}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-1", IPPrefix: "192.168.1.0/24", Nexthop: "2.2.2.1", OutputPort: &cudnNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
+				&nbdb.LogicalRouterStaticRoute{UUID: "add-2", IPPrefix: "172.30.1.0/24", Nexthop: "4.4.4.1", OutputPort: &cudnNoOverlayRouterPort, ExternalIDs: map[string]string{controllerExternalIDKey: controllerName}},
 			},
 		},
 	}
@@ -324,8 +475,10 @@ func Test_controller_syncNetwork(t *testing.T) {
 
 			// Capture and restore global config value for this subtest
 			origTransport := config.Default.Transport
+			origNodeMode := config.OvnKubeNode.Mode
 			t.Cleanup(func() {
 				config.Default.Transport = origTransport
+				config.OvnKubeNode.Mode = origNodeMode
 			})
 
 			testError := errors.New("test forced error or incorrect test arguments")
@@ -340,13 +493,19 @@ func Test_controller_syncNetwork(t *testing.T) {
 				nlmock.On("LinkByName", util.GetNetworkVRFName(network)).Return(tt.link, nil)
 			}
 
+			table := noTable
+			if tt.link != nil && tt.link.Type() == "vrf" {
+				table = int(tt.link.(*netlink.Vrf).Table)
+			}
+			if tt.dpuMode && network != nil && tt.link == nil && !tt.linkErr {
+				table = unix.RT_TABLE_MAIN
+			}
 			switch {
-			case tt.link == nil || tt.link.Type() != "vrf" || tt.routesErr:
+			case table == noTable || tt.routesErr:
 				nlmock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, testError)
 			default:
-				vrf := tt.link.(*netlink.Vrf)
 				matchFilter := func(r *netlink.Route) bool {
-					return r != nil && r.Equal(netlink.Route{Protocol: unix.RTPROT_BGP, Table: int(vrf.Table)})
+					return r != nil && r.Equal(netlink.Route{Protocol: unix.RTPROT_BGP, Table: table})
 				}
 				nlmock.On("RouteListFiltered", netlink.FAMILY_ALL, mock.MatchedBy(matchFilter), netlink.RT_FILTER_PROTOCOL|netlink.RT_FILTER_TABLE).
 					Return(tt.routes, nil)
@@ -369,6 +528,9 @@ func Test_controller_syncNetwork(t *testing.T) {
 			if tt.noOverlayEnabled {
 				config.Default.Transport = types.NetworkTransportNoOverlay
 			}
+			if tt.dpuMode {
+				config.OvnKubeNode.Mode = types.NodeModeDPU
+			}
 
 			err = c.syncNetwork(tt.args.network)
 			if tt.wantErr {
@@ -383,7 +545,30 @@ func Test_controller_syncNetwork(t *testing.T) {
 }
 
 func Test_controller_syncRouteUpdate(t *testing.T) {
+	node := "testnode"
 	defaultNetwork := &util.DefaultNetInfo{}
+	defaultNetwork.SetPodNetworkAdvertisedVRFs(map[string][]string{node: []string{types.DefaultNetworkName}})
+	cudnNoOverlay := &multinetworkmocks.NetInfo{}
+	cudnNoOverlay.On("IsDefault").Return(false)
+	cudnNoOverlay.On("GetNetworkName").Return(types.CUDNPrefix + "cudn-nooverlay")
+	cudnNoOverlay.On("GetNetworkID").Return(1)
+	cudnNoOverlay.On("Transport").Return(types.NetworkTransportNoOverlay)
+	cudnNoOverlay.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
+
+	cudnOverlay := &multinetworkmocks.NetInfo{}
+	cudnOverlay.On("IsDefault").Return(false)
+	cudnOverlay.On("GetNetworkName").Return(types.CUDNPrefix + "cudn-overlay")
+	cudnOverlay.On("GetNetworkID").Return(2)
+	cudnOverlay.On("Transport").Return("")
+	cudnOverlay.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return([]string{types.DefaultNetworkName})
+
+	cudnUnadvertised := &multinetworkmocks.NetInfo{}
+	cudnUnadvertised.On("IsDefault").Return(false)
+	cudnUnadvertised.On("GetNetworkName").Return(types.CUDNPrefix + "cudn-unadvertised")
+	cudnUnadvertised.On("GetNetworkID").Return(3)
+	cudnUnadvertised.On("Transport").Return("")
+	cudnUnadvertised.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return(nil)
+
 	type fields struct {
 		networkIDs map[int]string
 		networks   map[string]util.NetInfo
@@ -397,6 +582,7 @@ func Test_controller_syncRouteUpdate(t *testing.T) {
 		fields   fields
 		args     args
 		expected []string
+		dpuMode  bool
 	}{
 		{
 			name: "ignores route updates with protocol != BGP",
@@ -421,6 +607,22 @@ func Test_controller_syncRouteUpdate(t *testing.T) {
 			args:     args{&netlink.RouteUpdate{Route: netlink.Route{Protocol: unix.RTPROT_BGP, Table: unix.RT_TABLE_MAIN}}},
 			expected: []string{"default"},
 		},
+		{
+			name:    "processes main table route updates for DPU networks without tables",
+			dpuMode: true,
+			fields: fields{
+				networkIDs: map[int]string{0: "default", 1: types.CUDNPrefix + "cudn-nooverlay", 2: types.CUDNPrefix + "cudn-overlay", 3: types.CUDNPrefix + "cudn-unadvertised"},
+				networks: map[string]util.NetInfo{
+					"default":                              defaultNetwork,
+					types.CUDNPrefix + "cudn-nooverlay":    cudnNoOverlay,
+					types.CUDNPrefix + "cudn-overlay":      cudnOverlay,
+					types.CUDNPrefix + "cudn-unadvertised": cudnUnadvertised,
+				},
+				tables: map[int]int{unix.RT_TABLE_MAIN: 0},
+			},
+			args:     args{&netlink.RouteUpdate{Route: netlink.Route{Protocol: unix.RTPROT_BGP, Table: unix.RT_TABLE_MAIN}}},
+			expected: []string{"default", types.CUDNPrefix + "cudn-nooverlay", types.CUDNPrefix + "cudn-overlay"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -437,13 +639,18 @@ func Test_controller_syncRouteUpdate(t *testing.T) {
 			matchReconcile := func(g gomega.Gomega, expected []string) {
 				m.Lock()
 				defer m.Unlock()
-				g.Expect(reconciled).To(gomega.Equal(expected))
+				got := append([]string(nil), reconciled...)
+				want := append([]string(nil), expected...)
+				sort.Strings(got)
+				sort.Strings(want)
+				g.Expect(got).To(gomega.Equal(want))
 			}
 			r := controllerutil.NewReconciler(
 				"test",
 				&controllerutil.ReconcilerConfig{Reconcile: reconcile, Threadiness: 1, RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[string](0, 0)})
 			c := &controller{
 				log:        testr.New(t),
+				node:       node,
 				networkIDs: tt.fields.networkIDs,
 				networks:   tt.fields.networks,
 				tables:     tt.fields.tables,
@@ -451,6 +658,13 @@ func Test_controller_syncRouteUpdate(t *testing.T) {
 			}
 			err := controllerutil.Start(r)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
+			origNodeMode := config.OvnKubeNode.Mode
+			t.Cleanup(func() {
+				config.OvnKubeNode.Mode = origNodeMode
+			})
+			if tt.dpuMode {
+				config.OvnKubeNode.Mode = types.NodeModeDPU
+			}
 
 			c.syncRouteUpdate(tt.args.update)
 
@@ -458,6 +672,41 @@ func Test_controller_syncRouteUpdate(t *testing.T) {
 			g.Consistently(matchReconcile).WithArguments(tt.expected).Should(gomega.Succeed())
 		})
 	}
+}
+
+func Test_controller_NeedsReconciliation(t *testing.T) {
+	node := "testnode"
+	advertised := []string{types.DefaultNetworkName}
+
+	current := &multinetworkmocks.NetInfo{}
+	current.On("GetNetworkName").Return("network")
+	current.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return(advertised)
+	current.On("Transport").Return("")
+
+	same := &multinetworkmocks.NetInfo{}
+	same.On("GetNetworkName").Return("network")
+	same.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return(advertised)
+	same.On("Transport").Return("")
+
+	notAdvertised := &multinetworkmocks.NetInfo{}
+	notAdvertised.On("GetNetworkName").Return("network")
+	notAdvertised.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return(nil)
+	notAdvertised.On("Transport").Return("")
+
+	noOverlay := &multinetworkmocks.NetInfo{}
+	noOverlay.On("GetNetworkName").Return("network")
+	noOverlay.On("GetPodNetworkAdvertisedOnNodeVRFs", node).Return(advertised)
+	noOverlay.On("Transport").Return(types.NetworkTransportNoOverlay)
+
+	c := &controller{
+		node:     node,
+		networks: map[string]util.NetInfo{"network": current},
+	}
+
+	g := gomega.NewWithT(t)
+	g.Expect(c.NeedsReconciliation(same)).To(gomega.BeFalse())
+	g.Expect(c.NeedsReconciliation(notAdvertised)).To(gomega.BeTrue())
+	g.Expect(c.NeedsReconciliation(noOverlay)).To(gomega.BeTrue())
 }
 
 func Test_controller_syncLinkUpdate(t *testing.T) {


### PR DESCRIPTION
Route import should only import BGP routes for networks whose pod network is advertised on the local node. If a RouteAdvertisement no longer selects the network, reconcile it with an empty expected route set so stale route-import-owned static routes are removed from the network gateway router.

Keep imported routes isolated across OVN networks by filtering pod subnets that belong to other tracked networks. Overlay networks also filter their own pod subnets because Geneve handles east/west pod traffic. No-overlay networks keep their own pod subnets because those BGP routes are required for east/west routing.

In DPU mode, the advertised routes for non-default networks may be learned in the main routing table even when the network uses Geneve for east/west traffic. Fall back to the main table for advertised DPU networks that do not have a per-network VRF, and reconcile main-table BGP events for all advertised DPU networks without a known VRF table. Do not cache the main table as owned by those fallback networks so the default network and multiple CUDNs can all react to main-table route updates.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced route reconciliation to account for DPU mode and network advertisement state, improving routing consistency
  * Improved BGP route synchronization to handle multiple networks mapped to routing tables
  * Refined route filtering logic for better pod network isolation

* **Tests**
  * Expanded test coverage for DPU mode behavior and pod network advertisements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->