### PR TITLE
CUDN outboundSNAT support: implementation + nodePort traffic path fixes

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -134,6 +134,7 @@ set_common_default_params() {
   ADVERTISED_UDN_ISOLATION_MODE=${ADVERTISED_UDN_ISOLATION_MODE:-strict}
   BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4:-172.26.0.0/16}
   BGP_SERVER_NET_SUBNET_IPV6=${BGP_SERVER_NET_SUBNET_IPV6:-fc00:f853:ccd:e796::/64}
+  BGP_SERVER_HOST_PORT=${BGP_SERVER_HOST_PORT:-18080}
   OVN_OBSERV_ENABLE=${OVN_OBSERV_ENABLE:-false}
   OVN_EMPTY_LB_EVENTS=${OVN_EMPTY_LB_EVENTS:-false}
   OVN_NETWORK_QOS_ENABLE=${OVN_NETWORK_QOS_ENABLE:-false}
@@ -1306,7 +1307,7 @@ deploy_bgp_external_server() {
   $OCI_BIN network rm -f bgpnet
   $OCI_BIN network create --subnet="${BGP_SERVER_NET_SUBNET_IPV4}" ${ipv6_network} --driver bridge bgpnet
   $OCI_BIN network connect bgpnet frr
-  $OCI_BIN run  --cap-add NET_ADMIN --user 0  -d --network bgpnet  --rm  --name bgpserver -p 8080:8080  registry.k8s.io/e2e-test-images/agnhost:2.45 netexec
+  $OCI_BIN run  --cap-add NET_ADMIN --user 0  -d --network bgpnet  --rm  --name bgpserver -p "${BGP_SERVER_HOST_PORT}:8080"  registry.k8s.io/e2e-test-images/agnhost:2.45 netexec
   # let's make the bgp external server have its default route towards FRR router so that we don't need to add routes during tests back to the pods in the
   # cluster for return traffic
   local bgp_network_frr_v4 bgp_network_frr_v6 kind_network_frr_v4 kind_network_frr_v6

--- a/docs/design/service-traffic-policy.md
+++ b/docs/design/service-traffic-policy.md
@@ -477,6 +477,81 @@ cookie=0xdeff105, duration=5992.878s, table=0, n_packets=89312, n_bytes=6154654,
 
 where packet leaves the node and goes back to the external entity that initiated the connection.
 
+## User Defined Network Service Hairpin Traffic
+
+No-overlay User Defined Networks (UDNs) use the same physical bridge for service traffic, but the
+bridge must preserve enough UDN identity to send reply traffic back to the correct UDN gateway
+router patch port. The bridge flows use the UDN gateway router masquerade IP and the UDN CT mark
+for that steering.
+
+### Shared Gateway Mode, No-Overlay UDN
+
+For shared gateway mode, no-overlay UDN service traffic can hairpin from the UDN gateway router
+back to the node IP. The UDN gateway router load balancer uses `lb_force_snat_ip=router_ip`, so
+the packet can already have the node IP as source when it leaves the gateway router toward the
+physical bridge.
+
+The physical bridge still commits that packet through the default conntrack zone with
+`nat(src=<node-ip>)`. This lets conntrack detect overlapping source ports and reassign them in the
+same zone used for underlay egress, instead of bypassing NAT because the source IP already equals
+the node IP.
+
+```
+table=0, priority=99,ip,in_port="patch-breth0_<udn>",dl_src=<bridge-mac>,nw_src=<node-ip> actions=ct(commit,zone=64000,nat(src=<node-ip>),exec(set_field:<udn-ct-mark>->ct_mark)),output:<physical-port>
+table=0, priority=100,ip,in_port="patch-breth0_<udn>",dl_src=<bridge-mac>,nw_src=<udn-gr-masq-ip> actions=ct(commit,zone=64000,nat(src=<node-ip>),exec(set_field:<udn-ct-mark>->ct_mark)),output:<physical-port>
+```
+
+The priority 99 flow handles packets that were already SNATed to the node IP by the UDN gateway
+router. The priority 100 flow handles the normal UDN gateway router masquerade source. In both
+cases, the bridge commits the connection in zone 64000 and records the UDN CT mark.
+
+### Local Gateway Mode, No-Overlay UDN
+
+For local gateway mode, ingress service traffic can enter the host, get DNATed to a service, and
+then be routed back to `breth0`. Table 2 sends that packet to the UDN patch port. If the UDN gateway
+router load balancer selects a remote endpoint, `lb_force_snat_ip=router_ip` SNATs the packet to the
+node IP, and the no-overlay route can hairpin the packet back to `breth0` through the same UDN patch
+port.
+
+The existing table 0 hairpin match sends that OVN-to-host packet to table 4:
+
+```
+table=0, priority=175,ip,in_port="patch-breth0_<udn>",nw_src=<node-ip> actions=ct(table=4,zone=64001,nat)
+```
+
+Table 4 then matches on the UDN patch port and destination UDN pod CIDR, and SNATs to that UDN
+gateway router masquerade IP. The `in_port` match is what lets each no-overlay UDN use its own
+masquerade IP. The destination CIDR match keeps ordinary UDN pod traffic to node IPs, such as a
+request to a NodePort on a different node, on the default table 4 path:
+
+```
+table=4, priority=100,in_port="patch-breth0_<udn>",ip,ip_dst=<udn-pod-cidr> actions=ct(commit,zone=64002,nat(src=<udn-gr-masq-ip>),exec(set_field:<udn-ct-mark>->ct_mark),table=3)
+```
+
+After table 3 sends the packet to the host, host routing sends it back out the physical interface.
+The local gateway masquerade rules SNAT the UDN gateway router masquerade IP to the node IP for
+underlay egress. Reply traffic is restored by host conntrack back to the UDN gateway router
+masquerade IP before it returns to `breth0`.
+
+The reply path starts with a UDN-specific LOCAL flow that unSNATs in the OVN masquerade zone and
+continues to table 5:
+
+```
+table=0, priority=500,in_port=LOCAL,ip,ip_dst=<udn-gr-masq-ip> actions=ct(zone=64002,nat,table=5)
+```
+
+Table 5 finishes the service reply unNAT in the host masquerade zone and dispatches directly to the
+correct UDN patch port. This direct dispatch is important for advertised UDNs because, after the
+reply is unNATed, table 2's UDN source isolation flow would otherwise drop the packet before a
+generic dispatch flow could send it back to the UDN gateway router:
+
+```
+table=5, priority=100,ip,ct_mark=<udn-ct-mark> actions=ct(commit,zone=64001,nat,exec(set_field:<udn-ct-mark>->ct_mark)),set_field:<bridge-mac>->eth_dst,output:"patch-breth0_<udn>"
+```
+
+The IPv6 path uses equivalent flows with `ipv6`, `ipv6_dst`, and the UDN IPv6 gateway router
+masquerade IP.
+
 ## Sources
 - https://www.asykim.com/blog/deep-dive-into-kubernetes-external-traffic-policies
 

--- a/docs/okeps/okep-5259-no-overlay.md
+++ b/docs/okeps/okep-5259-no-overlay.md
@@ -915,6 +915,11 @@ priority            : 0
 type                : snat
 ```
 
+In local gateway mode, conditional SNATs on network-scoped UDN cluster routers
+use `options:ct-commit-all=true`. This keeps the NAT condition while committing
+traffic in the router SNAT zone, allowing the reverse conntrack handling needed
+by NodePort reply traffic.
+
 #### UDN Traffic Isolation
 
 Currently, for inter-UDN pod-to-pod traffic, OVN-Kubernetes supports 2 modes:

--- a/docs/okeps/okep-5259-no-overlay.md
+++ b/docs/okeps/okep-5259-no-overlay.md
@@ -761,9 +761,9 @@ SNAT behavior via:
   is not SNATed. Pod IPs must be routable on the external network.
 
 * **`outboundSNAT: Enabled`** (or `outbound-snat=enabled`): Pod egress traffic
-  to external destinations is SNATed to the node IP. This is intended for
-  deployments where pod networks are only advertised to an internal BGP fabric
-  and are not routable from external networks.
+  to external destinations is SNATed at node egress. In shared gateway mode and
+  local gateway mode using the default VRF, this exposes the node IP. In local
+  gateway VRF-Lite, Linux masquerade uses the selected VRF egress interface IP.
 
 **Important:** Regardless of this setting, pod-to-remote-pod traffic within the
 same network is never SNATed, while traffic to remote nodes, the Kubernetes API
@@ -866,6 +866,9 @@ for details).
 When `outboundSNAT` is enabled for the default network, pod egress traffic is
 forwarded to the host kernel by the ovn-cluster-router, where it is then SNATed
 to the node IP using nftables rules.
+
+For local gateway VRF-Lite CUDNs, the exposed source IP is the egress interface IP in
+the target VRF.
 
 In the following example, `10.128.0.0/24` is the pod subnet in the local node,
 `10.128.0.0/16` is the CIDR of the pod network. `outboundSNAT` is enabled for

--- a/docs/okeps/okep-5259-no-overlay.md
+++ b/docs/okeps/okep-5259-no-overlay.md
@@ -827,6 +827,19 @@ priority            : 0
 type                : snat
 ```
 
+For advertised UDNs in shared gateway mode, conditional SNATs on the UDN cluster
+router use `allowed_ext_ips` instead of `match`. This keeps the destination
+constraint on the NAT while allowing northd to render the reverse conntrack flows
+needed by NodePort reply traffic. Since `allowed_ext_ips` accepts one
+address set, each destination address set uses a separate NAT row: one for
+cluster node IPs and one for UDN service ClusterIPs.
+
+A future improvement is to restore the original conditional SNAT and set
+`options:ct-commit-all=true` on the logical router. This is postponed in shared
+gateway mode because that is the gateway mode used by offloaded deployments, and
+the option is not fully offloadable yet. As explained in the next section,
+Local gateway mode already uses `ct-commit-all`, since that scenario is not offloaded.
+
 ##### Local Gateway Mode
 
 When `outboundSNAT` is disabled, the existing BGP feature behavior is preserved:

--- a/docs/okeps/okep-5259-no-overlay.md
+++ b/docs/okeps/okep-5259-no-overlay.md
@@ -632,6 +632,23 @@ The routing table of the default VRF of node A which contains learned BGP routes
 10.128.2.0/24 nhid 25 via 172.18.0.4 dev eth0 proto bgp metric 20
 ```
 
+For layer-3 no-overlay UDNs in local gateway mode, OVN-Kubernetes installs the
+management port address with `noprefixroute` and adds explicit VRF routes through
+the UDN gateway IP. The local UDN pod subnet is routed as
+`10.128.0.0/24 via 10.128.0.1 dev ovn-k8s-mpX` instead of using a connected
+route on the management port, so underlay ingress to local UDN pods still goes
+through the OVN logical topology.
+
+For example, the relevant routes in the UDN VRF on a node with local UDN pod
+subnet `10.128.0.0/24` look like:
+
+```text
+10.128.0.0/24 via 10.128.0.1 dev ovn-k8s-mpX
+10.128.0.1 dev ovn-k8s-mpX scope link
+10.128.1.0/24 nhid 30 via 172.18.0.2 dev breth0 proto bgp metric 20
+10.128.2.0/24 nhid 25 via 172.18.0.4 dev breth0 proto bgp metric 20
+```
+
 ```mermaid
 sequenceDiagram
     participant Pod1 on Node A

--- a/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/template/net-attach-def-template.go
@@ -36,6 +36,7 @@ type SpecGetter interface {
 	GetLocalnet() *userdefinednetworkv1.LocalnetConfig
 	GetTransport() userdefinednetworkv1.TransportOption
 	GetEVPN() *userdefinednetworkv1.EVPNConfig
+	GetNoOverlay() *userdefinednetworkv1.NoOverlayConfig
 }
 
 func RenderNetAttachDefManifest(obj client.Object, targetNamespace string, opts ...RenderOption) (*netv1.NetworkAttachmentDefinition, error) {
@@ -206,6 +207,14 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter, opts *
 		netConfSpec.EVPN = renderEVPNConfig(spec, opts)
 	}
 
+	if spec.GetTransport() == userdefinednetworkv1.TransportOptionNoOverlay {
+		noOverlayCfg := spec.GetNoOverlay()
+		if noOverlayCfg != nil {
+			// Convert CRD SNATOption enum ("Enabled"/"Disabled") to internal format ("enabled"/"disabled")
+			netConfSpec.OutboundSNAT = strings.ToLower(string(noOverlayCfg.OutboundSNAT))
+		}
+	}
+
 	if netConfSpec.AllowPersistentIPs && !config.OVNKubernetesFeature.EnablePersistentIPs {
 		return nil, fmt.Errorf("allowPersistentIPs is set but persistentIPs is Disabled")
 	}
@@ -271,6 +280,9 @@ func renderCNINetworkConfig(networkName, nadName string, spec SpecGetter, opts *
 
 	if netConfSpec.Transport != "" {
 		cniNetConf["transport"] = netConfSpec.Transport
+	}
+	if netConfSpec.OutboundSNAT != "" {
+		cniNetConf["outboundSNAT"] = netConfSpec.OutboundSNAT
 	}
 	if netConfSpec.EVPN != nil {
 		cniNetConf["evpn"] = netConfSpec.EVPN

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -89,6 +89,12 @@ type NetConf struct {
 	// When omitted, the default OVN overlay transport is used.
 	Transport string `json:"transport,omitempty"`
 
+	// OutboundSNAT configures SNAT behavior for outbound traffic from pods
+	// on user-defined networks in no-overlay mode.
+	// Valid values are "enabled" and "disabled".
+	// Only valid when Transport is "no-overlay".
+	OutboundSNAT string `json:"outboundSNAT,omitempty"`
+
 	// EVPNConfig contains configuration for EVPN mode.
 	// Only valid when Transport is "evpn".
 	EVPN *EVPNConfig `json:"evpn,omitempty"`

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -140,6 +140,7 @@ func (n NetConf) MarshalJSON() ([]byte, error) {
 		AllowPersistentIPs    bool        `json:"allowPersistentIPs,omitempty"`
 		PhysicalNetworkName   string      `json:"physicalNetworkName,omitempty"`
 		Transport             string      `json:"transport,omitempty"`
+		OutboundSNAT          string      `json:"outboundSNAT,omitempty"`
 		EVPN                  *EVPNConfig `json:"evpn,omitempty"`
 		DeviceID              string      `json:"deviceID,omitempty"`
 		LogFile               string      `json:"logFile,omitempty"`
@@ -168,6 +169,7 @@ func (n NetConf) MarshalJSON() ([]byte, error) {
 		AllowPersistentIPs:    n.AllowPersistentIPs,
 		PhysicalNetworkName:   n.PhysicalNetworkName,
 		Transport:             n.Transport,
+		OutboundSNAT:          n.OutboundSNAT,
 		EVPN:                  n.EVPN,
 		DeviceID:              n.DeviceID,
 		LogFile:               n.LogFile,

--- a/go-controller/pkg/cni/types/types_test.go
+++ b/go-controller/pkg/cni/types/types_test.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNetConfMarshalJSONIncludesOutboundSNAT(t *testing.T) {
+	netConf := NetConf{
+		Transport:    "no-overlay",
+		OutboundSNAT: "enabled",
+	}
+
+	rawNetConf, err := json.Marshal(netConf)
+	if err != nil {
+		t.Fatalf("failed to marshal NetConf: %v", err)
+	}
+
+	var parsedNetConf struct {
+		Transport    string `json:"transport"`
+		OutboundSNAT string `json:"outboundSNAT"`
+	}
+	if err := json.Unmarshal(rawNetConf, &parsedNetConf); err != nil {
+		t.Fatalf("failed to unmarshal NetConf: %v", err)
+	}
+
+	if parsedNetConf.Transport != netConf.Transport {
+		t.Fatalf("expected transport %q, got %q", netConf.Transport, parsedNetConf.Transport)
+	}
+	if parsedNetConf.OutboundSNAT != netConf.OutboundSNAT {
+		t.Fatalf("expected outboundSNAT %q, got %q", netConf.OutboundSNAT, parsedNetConf.OutboundSNAT)
+	}
+}

--- a/go-controller/pkg/crd/userdefinednetwork/v1/spec.go
+++ b/go-controller/pkg/crd/userdefinednetwork/v1/spec.go
@@ -30,6 +30,11 @@ func (s *UserDefinedNetworkSpec) GetEVPN() *EVPNConfig {
 	return nil
 }
 
+func (s *UserDefinedNetworkSpec) GetNoOverlay() *NoOverlayConfig {
+	// UDN (namespace-scoped) does not support no-overlay transport
+	return nil
+}
+
 func (s *NetworkSpec) GetTopology() NetworkTopology {
 	return s.Topology
 }
@@ -52,4 +57,8 @@ func (s *NetworkSpec) GetTransport() TransportOption {
 
 func (s *NetworkSpec) GetEVPN() *EVPNConfig {
 	return s.EVPN
+}
+
+func (s *NetworkSpec) GetNoOverlay() *NoOverlayConfig {
+	return s.NoOverlay
 }

--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -1013,7 +1013,7 @@ func RemoveLoadBalancersFromLogicalRouterOps(nbClient libovsdbclient.Client, ops
 func getNATMutableFields(nat *nbdb.NAT) []interface{} {
 	return []interface{}{&nat.Type, &nat.ExternalIP, &nat.LogicalIP, &nat.LogicalPort, &nat.ExternalMAC,
 		&nat.ExternalIDs, &nat.Match, &nat.Options, &nat.ExternalPortRange, &nat.GatewayPort, &nat.Priority,
-		&nat.ExemptedExtIPs}
+		&nat.ExemptedExtIPs, &nat.AllowedExtIPs}
 }
 
 func buildNAT(
@@ -1095,6 +1095,22 @@ func BuildSNATWithExemptedExtIPs(
 	return nat
 }
 
+// BuildSNATWithAllowedExtIPs builds a logical router SNAT with allowed external IPs.
+func BuildSNATWithAllowedExtIPs(
+	externalIP *net.IP,
+	logicalIP *net.IPNet,
+	logicalPort string,
+	externalIDs map[string]string,
+	match string,
+	allowedExtIPs string,
+) *nbdb.NAT {
+	nat := BuildSNATWithMatch(externalIP, logicalIP, logicalPort, externalIDs, match)
+	if allowedExtIPs != "" {
+		nat.AllowedExtIPs = &allowedExtIPs
+	}
+	return nat
+}
+
 // BuildDNATAndSNAT builds a logical router DNAT/SNAT
 func BuildDNATAndSNAT(
 	externalIP *net.IP,
@@ -1172,6 +1188,16 @@ func isEquivalentNAT(existing *nbdb.NAT, searched *nbdb.NAT) bool {
 		if foundValue, found := existing.ExternalIDs[externalIdKey]; !found || foundValue != externalIdValue {
 			return false
 		}
+	}
+
+	if searched.AllowedExtIPs != nil &&
+		(existing.AllowedExtIPs == nil || *searched.AllowedExtIPs != *existing.AllowedExtIPs) {
+		return false
+	}
+
+	if searched.ExemptedExtIPs != nil &&
+		(existing.ExemptedExtIPs == nil || *searched.ExemptedExtIPs != *existing.ExemptedExtIPs) {
+		return false
 	}
 
 	return true

--- a/go-controller/pkg/libovsdb/ops/router_test.go
+++ b/go-controller/pkg/libovsdb/ops/router_test.go
@@ -5,6 +5,7 @@ package ops
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -92,6 +93,50 @@ func TestFindNATsUsingPredicate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildSNATWithAllowedExtIPs(t *testing.T) {
+	externalIP := net.ParseIP("169.254.0.12")
+	_, logicalIP, err := net.ParseCIDR("100.128.0.0/24")
+	if err != nil {
+		t.Fatalf("failed to parse logical IP: %v", err)
+	}
+
+	nat := BuildSNATWithAllowedExtIPs(
+		&externalIP,
+		logicalIP,
+		"rtos-blue-node",
+		map[string]string{"network": "blue"},
+		"",
+		"allowed-ext-ips-uuid",
+	)
+
+	if nat.AllowedExtIPs == nil || *nat.AllowedExtIPs != "allowed-ext-ips-uuid" {
+		t.Fatalf("expected allowed_ext_ips to be set, got %v", nat.AllowedExtIPs)
+	}
+	if nat.ExemptedExtIPs != nil {
+		t.Fatalf("expected exempted_ext_ips to be nil, got %v", nat.ExemptedExtIPs)
+	}
+}
+
+func TestEquivalentNATChecksProvidedExtIPAddressSets(t *testing.T) {
+	externalIP := net.ParseIP("169.254.0.12")
+	_, logicalIP, err := net.ParseCIDR("100.128.0.0/24")
+	if err != nil {
+		t.Fatalf("failed to parse logical IP: %v", err)
+	}
+	externalIDs := map[string]string{"network": "blue"}
+
+	existing := BuildSNATWithAllowedExtIPs(&externalIP, logicalIP, "rtos-blue-node", externalIDs, "", "node-ip-as-uuid")
+	searched := BuildSNATWithAllowedExtIPs(&externalIP, logicalIP, "rtos-blue-node", externalIDs, "", "svc-ip-as-uuid")
+	if isEquivalentNAT(existing, searched) {
+		t.Fatal("expected SNATs with different allowed_ext_ips to be distinct")
+	}
+
+	broadSearch := BuildSNATWithMatch(&externalIP, logicalIP, "rtos-blue-node", externalIDs, "")
+	if !isEquivalentNAT(existing, broadSearch) {
+		t.Fatal("expected broad SNAT search without allowed_ext_ips to still match")
 	}
 }
 

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -39,18 +39,24 @@ type BridgeUDNConfiguration struct {
 	NodeSubnets   []*net.IPNet
 	Advertised    atomic.Bool
 	ManagementIPs []*net.IPNet
+	// Transport mode for this network ("no-overlay", "evpn", or "" for default network)
+	Transport string
+	// OutboundSNAT setting for this network ("enabled", "disabled", or "")
+	OutboundSNAT string
 }
 
 func (netConfig *BridgeUDNConfiguration) ShallowCopy() *BridgeUDNConfiguration {
 	copy := &BridgeUDNConfiguration{
-		PatchPort:   netConfig.PatchPort,
-		OfPortPatch: netConfig.OfPortPatch,
-		MasqCTMark:  netConfig.MasqCTMark,
-		PktMark:     netConfig.PktMark,
-		V4MasqIPs:   netConfig.V4MasqIPs,
-		V6MasqIPs:   netConfig.V6MasqIPs,
-		Subnets:     netConfig.Subnets,
-		NodeSubnets: netConfig.NodeSubnets,
+		PatchPort:    netConfig.PatchPort,
+		OfPortPatch:  netConfig.OfPortPatch,
+		MasqCTMark:   netConfig.MasqCTMark,
+		PktMark:      netConfig.PktMark,
+		V4MasqIPs:    netConfig.V4MasqIPs,
+		V6MasqIPs:    netConfig.V6MasqIPs,
+		Subnets:      netConfig.Subnets,
+		NodeSubnets:  netConfig.NodeSubnets,
+		Transport:    netConfig.Transport,
+		OutboundSNAT: netConfig.OutboundSNAT,
 	}
 	copy.Advertised.Store(netConfig.Advertised.Load())
 	return copy
@@ -329,6 +335,8 @@ func (b *BridgeConfiguration) AddNetworkConfig(nInfo util.NetInfo, nodeSubnets, 
 			ManagementIPs: mgmtIPs,
 			Subnets:       nInfo.Subnets(),
 			NodeSubnets:   nodeSubnets,
+			Transport:     nInfo.Transport(),
+			OutboundSNAT:  nInfo.OutboundSNAT(),
 		}
 		netConfig.Advertised.Store(util.IsPodNetworkAdvertisedAtNode(nInfo, b.nodeName))
 

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -615,6 +615,22 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 		if ofPortPhys != "" {
 			for _, netConfig := range b.patchedNetConfigs() {
+				// table0, for SGW UDN no-overlay networks, handle cross-node traffic
+				// that has already been SNATed to node IP by the gateway router.
+				if !netConfig.IsDefaultNetwork() && netConfig.Transport == types.NetworkTransportNoOverlay && config.Gateway.Mode == config.GatewayModeShared {
+					// Commit to conntrack and send directly to the physical port.
+					// SNAT to the node IP may already have happened on the UDN GW
+					// router because lb_force_snat_ip=router_ip. SNAT to the same
+					// node IP again here so zone 64000 can resolve source-port collisions.
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=99, in_port=%s, dl_src=%s, %s, nw_src=%s, "+
+							"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",
+							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV4,
+							physicalIP.IP, config.Default.ConntrackZone,
+							physicalIP.IP,
+							netConfig.MasqCTMark, ofPortPhys))
+				}
+
 				// table0, packets coming from egressIP pods that have mark 1008 on them
 				// will be SNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
 				// SNATs these into egressIP prior to reaching external bridge.
@@ -716,6 +732,22 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		}
 		if ofPortPhys != "" {
 			for _, netConfig := range b.patchedNetConfigs() {
+				// table0, for SGW UDN no-overlay networks, handle cross-node traffic
+				// that has already been SNATed to node IP by the gateway router.
+				if !netConfig.IsDefaultNetwork() && netConfig.Transport == types.NetworkTransportNoOverlay && config.Gateway.Mode == config.GatewayModeShared {
+					// Commit to conntrack and send directly to the physical port.
+					// SNAT to the node IP may already have happened on the UDN GW
+					// router because lb_force_snat_ip=router_ip. SNAT to the same
+					// node IP again here so zone 64000 can resolve source-port collisions.
+					dftFlows = append(dftFlows,
+						fmt.Sprintf("cookie=%s, priority=99, in_port=%s, dl_src=%s, %s, %s_src=%s, "+
+							"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)), output:%s",
+							nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, bridgeMacAddress, protoPrefixV6,
+							protoPrefixV6, physicalIP.IP, config.Default.ConntrackZone,
+							physicalIP.IP,
+							netConfig.MasqCTMark, ofPortPhys))
+				}
+
 				// table0, packets coming from egressIP pods that have mark 1008 on them
 				// will be DNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
 				// DNATs these into egressIP prior to reaching external bridge.

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -151,6 +151,22 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 				"actions=ct(zone=%d,nat,table=5)",
 				nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefixV4, protoPrefixV4,
 				config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String(), config.Default.OVNMasqConntrackZone))
+
+		for _, netConfig := range b.patchedNetConfigs() {
+			if !isLocalGatewayNoOverlayUDN(netConfig) {
+				continue
+			}
+			// table 0, reply traffic from host back to OVN for no-overlay UDN
+			// service hairpins. Table 4 SNATs the forward direction to this
+			// UDN's gateway router masquerade IP; use the OVN masquerade CT
+			// zone to unSNAT replies and then continue reply service handling
+			// in table 5.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=500, in_port=%s, %s, %s_dst=%s,"+
+					"actions=ct(zone=%d,nat,table=5)",
+					nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefixV4, protoPrefixV4,
+					netConfig.V4MasqIPs.GatewayRouter.IP.String(), config.Default.OVNMasqConntrackZone))
+		}
 	}
 	if config.IPv6Mode {
 		if ofPortPhys != "" {
@@ -216,6 +232,22 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 				"actions=ct(zone=%d,nat,table=5)",
 				nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefixV6, protoPrefixV6,
 				config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String(), config.Default.OVNMasqConntrackZone))
+
+		for _, netConfig := range b.patchedNetConfigs() {
+			if !isLocalGatewayNoOverlayUDN(netConfig) {
+				continue
+			}
+			// table 0, reply traffic from host back to OVN for no-overlay UDN
+			// service hairpins. Table 4 SNATs the forward direction to this
+			// UDN's gateway router masquerade IP; use the OVN masquerade CT
+			// zone to unSNAT replies and then continue reply service handling
+			// in table 5.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=500, in_port=%s, %s, %s_dst=%s,"+
+					"actions=ct(zone=%d,nat,table=5)",
+					nodetypes.DefaultOpenFlowCookie, ofPortHost, protoPrefixV6, protoPrefixV6,
+					netConfig.V6MasqIPs.GatewayRouter.IP.String(), config.Default.OVNMasqConntrackZone))
+		}
 	}
 
 	var protoPrefix, masqIP, masqSubnet string
@@ -476,31 +508,121 @@ func (b *BridgeConfiguration) flowsForDefaultBridge(extraIPs []net.IP) ([]string
 	// table 4, hairpinned pkts that need to go from OVN -> Host
 	// We need to SNAT and masquerade OVN GR IP, send to table 3 for dispatch to Host
 	if config.IPv4Mode {
+		for _, netConfig := range b.patchedNetConfigs() {
+			if !isLocalGatewayNoOverlayUDN(netConfig) {
+				continue
+			}
+			// table 4, forward traffic for no-overlay UDN service hairpins
+			// from OVN to host. The UDN GR already SNATed to the node IP due to
+			// lb_force_snat_ip=router_ip; SNAT again to this UDN's gateway
+			// router masquerade IP so replies can be steered back to the same
+			// UDN. Match UDN pod CIDRs so ordinary UDN traffic to node IPs, such
+			// as NodePort requests on a different node, keeps the default table
+			// 4 behavior.
+			var udnSubnets []*net.IPNet
+			for _, clusterEntry := range netConfig.Subnets {
+				udnSubnets = append(udnSubnets, clusterEntry.CIDR)
+			}
+			for _, subnet := range matchIPNetFamily(false, udnSubnets) {
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=100, table=4, in_port=%s, %s, %s_dst=%s, "+
+						"actions=ct(commit,zone=%d,nat(src=%s),exec(set_field:%s->ct_mark),table=3)",
+						nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, protoPrefixV4, protoPrefixV4,
+						subnet.String(), config.Default.OVNMasqConntrackZone,
+						netConfig.V4MasqIPs.GatewayRouter.IP.String(), netConfig.MasqCTMark))
+			}
+		}
 		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, table=4,%s,"+
+			fmt.Sprintf("cookie=%s, priority=0, table=4,%s,"+
 				"actions=ct(commit,zone=%d,nat(src=%s),table=3)",
 				nodetypes.DefaultOpenFlowCookie, protoPrefixV4, config.Default.OVNMasqConntrackZone, config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP.String()))
 	}
 	if config.IPv6Mode {
+		for _, netConfig := range b.patchedNetConfigs() {
+			if !isLocalGatewayNoOverlayUDN(netConfig) {
+				continue
+			}
+			// table 4, forward traffic for no-overlay UDN service hairpins
+			// from OVN to host. The UDN GR already SNATed to the node IP due to
+			// lb_force_snat_ip=router_ip; SNAT again to this UDN's gateway
+			// router masquerade IP so replies can be steered back to the same
+			// UDN. Match UDN pod CIDRs so ordinary UDN traffic to node IPs, such
+			// as NodePort requests on a different node, keeps the default table
+			// 4 behavior.
+			var udnSubnets []*net.IPNet
+			for _, clusterEntry := range netConfig.Subnets {
+				udnSubnets = append(udnSubnets, clusterEntry.CIDR)
+			}
+			for _, subnet := range matchIPNetFamily(true, udnSubnets) {
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=100, table=4, in_port=%s, %s, %s_dst=%s, "+
+						"actions=ct(commit,zone=%d,nat(src=%s),exec(set_field:%s->ct_mark),table=3)",
+						nodetypes.DefaultOpenFlowCookie, netConfig.OfPortPatch, protoPrefixV6, protoPrefixV6,
+						subnet.String(), config.Default.OVNMasqConntrackZone,
+						netConfig.V6MasqIPs.GatewayRouter.IP.String(), netConfig.MasqCTMark))
+			}
+		}
 		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, table=4,%s, "+
+			fmt.Sprintf("cookie=%s, priority=0, table=4,%s, "+
 				"actions=ct(commit,zone=%d,nat(src=%s),table=3)",
 				nodetypes.DefaultOpenFlowCookie, protoPrefixV6, config.Default.OVNMasqConntrackZone, config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP.String()))
 	}
 	// table 5, Host Reply traffic to hairpinned svc, need to unDNAT, send to table 2
 	if config.IPv4Mode {
 		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, table=5, %s, "+
+			fmt.Sprintf("cookie=%s, priority=0, table=5, %s, "+
 				"actions=ct(commit,zone=%d,nat,table=2)",
 				nodetypes.DefaultOpenFlowCookie, protoPrefixV4, config.Default.HostMasqConntrackZone))
+		for _, netConfig := range b.patchedNetConfigs() {
+			if !isLocalGatewayNoOverlayUDN(netConfig) {
+				continue
+			}
+			// table 5, finish reply service unNAT for no-overlay UDN service
+			// hairpins and dispatch directly to the UDN patch port. Sending
+			// these replies through table 2 would hit the advertised-UDN source
+			// isolation drops after unNAT.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=5, %s, ct_mark=%s, "+
+					"actions=ct(commit,zone=%d,nat),"+
+					"set_field:%s->eth_dst,%soutput:%s",
+					nodetypes.DefaultOpenFlowCookie, protoPrefixV4, netConfig.MasqCTMark,
+					config.Default.HostMasqConntrackZone, bridgeMacAddress, mod_vlan_id, netConfig.OfPortPatch))
+		}
 	}
 	if config.IPv6Mode {
 		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, table=5, %s, "+
+			fmt.Sprintf("cookie=%s, priority=0, table=5, %s, "+
 				"actions=ct(commit,zone=%d,nat,table=2)",
 				nodetypes.DefaultOpenFlowCookie, protoPrefixV6, config.Default.HostMasqConntrackZone))
+		for _, netConfig := range b.patchedNetConfigs() {
+			if !isLocalGatewayNoOverlayUDN(netConfig) {
+				continue
+			}
+			// table 5, finish reply service unNAT for no-overlay UDN service
+			// hairpins and dispatch directly to the UDN patch port. Sending
+			// these replies through table 2 would hit the advertised-UDN source
+			// isolation drops after unNAT.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=5, %s, ct_mark=%s, "+
+					"actions=ct(commit,zone=%d,nat),"+
+					"set_field:%s->eth_dst,%soutput:%s",
+					nodetypes.DefaultOpenFlowCookie, protoPrefixV6, netConfig.MasqCTMark,
+					config.Default.HostMasqConntrackZone, bridgeMacAddress, mod_vlan_id, netConfig.OfPortPatch))
+		}
 	}
 	return dftFlows, nil
+}
+
+// isLocalGatewayNoOverlayUDN filters UDN-specific service hairpin flows that
+// SNAT to the UDN gateway router masquerade IP. Today those flows are only
+// needed for local gateway no-overlay UDNs, where service traffic can hairpin
+// through breth0 on the underlay. If UDNs later support underlay-routed
+// service backends in Geneve mode, such as host-networked pods, this predicate
+// should be updated to include those paths.
+func isLocalGatewayNoOverlayUDN(netConfig *BridgeUDNConfiguration) bool {
+	return !netConfig.IsDefaultNetwork() &&
+		netConfig.Transport == types.NetworkTransportNoOverlay &&
+		config.Gateway.Mode == config.GatewayModeLocal
 }
 
 // getMaxFrameLength returns the maximum frame size (ignoring VLAN header) that a gateway can handle

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package bridgeconfig
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	udngenerator "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
+	nodetypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+)
+
+func TestSharedNoOverlayNodeIPFlowUsesNATInDefaultConntrackZone(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.IPv4Mode = true
+	config.IPv6Mode = true
+	config.Gateway.Mode = config.GatewayModeShared
+
+	bridgeMAC := mustParseMAC(t, "62:41:d0:54:3d:64")
+	v4NodeIP := mustParseIPNet(t, "172.18.0.3/24")
+	v6NodeIP := mustParseIPNet(t, "fd00::3/64")
+	v4GatewayMasqIP := mustParseIPNet(t, "169.254.0.11/32")
+	v4ManagementMasqIP := mustParseIPNet(t, "169.254.0.12/32")
+	v6GatewayMasqIP := mustParseIPNet(t, "fd69::11/128")
+	v6ManagementMasqIP := mustParseIPNet(t, "fd69::12/128")
+
+	bridge := &BridgeConfiguration{
+		ofPortPhys: "eth0",
+		ofPortHost: nodetypes.OvsLocalPort,
+		ips:        []*net.IPNet{v4NodeIP, v6NodeIP},
+		macAddress: bridgeMAC,
+		netConfig: map[string]*BridgeUDNConfiguration{
+			types.DefaultNetworkName: {
+				OfPortPatch: "patch-breth0_ov",
+				MasqCTMark:  nodetypes.CtMarkOVN,
+			},
+			"bluenet": {
+				OfPortPatch: "patch-breth0_bluenet",
+				MasqCTMark:  "0x4",
+				PktMark:     "0x3",
+				Transport:   types.NetworkTransportNoOverlay,
+				V4MasqIPs: &udngenerator.MasqueradeIPs{
+					GatewayRouter:  v4GatewayMasqIP,
+					ManagementPort: v4ManagementMasqIP,
+				},
+				V6MasqIPs: &udngenerator.MasqueradeIPs{
+					GatewayRouter:  v6GatewayMasqIP,
+					ManagementPort: v6ManagementMasqIP,
+				},
+			},
+		},
+	}
+
+	flows, err := bridge.commonFlows(nil)
+	if err != nil {
+		t.Fatalf("failed to render bridge flows: %v", err)
+	}
+
+	expectedIPv4 := fmt.Sprintf("cookie=%s, priority=99, in_port=patch-breth0_bluenet, dl_src=%s, ip, nw_src=172.18.0.3, "+
+		"actions=ct(commit, zone=%d, nat(src=172.18.0.3), exec(set_field:0x4->ct_mark)), output:eth0",
+		nodetypes.DefaultOpenFlowCookie, bridgeMAC, config.Default.ConntrackZone)
+	expectedIPv6 := fmt.Sprintf("cookie=%s, priority=99, in_port=patch-breth0_bluenet, dl_src=%s, ipv6, ipv6_src=fd00::3, "+
+		"actions=ct(commit, zone=%d, nat(src=fd00::3), exec(set_field:0x4->ct_mark)), output:eth0",
+		nodetypes.DefaultOpenFlowCookie, bridgeMAC, config.Default.ConntrackZone)
+
+	expectFlow(t, flows, expectedIPv4)
+	expectFlow(t, flows, expectedIPv6)
+}
+
+func mustParseMAC(t *testing.T, value string) net.HardwareAddr {
+	t.Helper()
+	mac, err := net.ParseMAC(value)
+	if err != nil {
+		t.Fatalf("failed to parse MAC %q: %v", value, err)
+	}
+	return mac
+}
+
+func mustParseIPNet(t *testing.T, value string) *net.IPNet {
+	t.Helper()
+	ip, ipNet, err := net.ParseCIDR(value)
+	if err != nil {
+		t.Fatalf("failed to parse CIDR %q: %v", value, err)
+	}
+	ipNet.IP = ip
+	return ipNet
+}
+
+func expectFlow(t *testing.T, flows []string, expected string) {
+	t.Helper()
+	for _, flow := range flows {
+		if flow == expected {
+			return
+		}
+	}
+	t.Fatalf("expected flow not found:\n%s\n\nall flows:\n%v", expected, flows)
+}

--- a/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows_test.go
@@ -76,6 +76,88 @@ func TestSharedNoOverlayNodeIPFlowUsesNATInDefaultConntrackZone(t *testing.T) {
 	expectFlow(t, flows, expectedIPv6)
 }
 
+func TestLocalNoOverlayServiceHairpinUsesUDNGatewayMasqueradeIP(t *testing.T) {
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.IPv4Mode = true
+	config.IPv6Mode = true
+	config.Gateway.Mode = config.GatewayModeLocal
+
+	bridgeMAC := mustParseMAC(t, "62:41:d0:54:3d:64")
+	v4NodeIP := mustParseIPNet(t, "172.18.0.3/24")
+	v6NodeIP := mustParseIPNet(t, "fd00::3/64")
+	v4GatewayMasqIP := mustParseIPNet(t, "169.254.0.11/32")
+	v4ManagementMasqIP := mustParseIPNet(t, "169.254.0.12/32")
+	v6GatewayMasqIP := mustParseIPNet(t, "fd69::11/128")
+	v6ManagementMasqIP := mustParseIPNet(t, "fd69::12/128")
+
+	bridge := &BridgeConfiguration{
+		ofPortHost: nodetypes.OvsLocalPort,
+		ips:        []*net.IPNet{v4NodeIP, v6NodeIP},
+		macAddress: bridgeMAC,
+		netConfig: map[string]*BridgeUDNConfiguration{
+			types.DefaultNetworkName: {
+				OfPortPatch: "patch-breth0_ov",
+				MasqCTMark:  nodetypes.CtMarkOVN,
+			},
+			"bluenet": {
+				OfPortPatch: "patch-breth0_bluenet",
+				MasqCTMark:  "0x4",
+				PktMark:     "0x3",
+				Transport:   types.NetworkTransportNoOverlay,
+				Subnets: []config.CIDRNetworkEntry{
+					{CIDR: mustParseIPNet(t, "10.128.0.0/16")},
+					{CIDR: mustParseIPNet(t, "fd10:128::/64")},
+				},
+				V4MasqIPs: &udngenerator.MasqueradeIPs{
+					GatewayRouter:  v4GatewayMasqIP,
+					ManagementPort: v4ManagementMasqIP,
+				},
+				V6MasqIPs: &udngenerator.MasqueradeIPs{
+					GatewayRouter:  v6GatewayMasqIP,
+					ManagementPort: v6ManagementMasqIP,
+				},
+			},
+		},
+	}
+
+	flows, err := bridge.flowsForDefaultBridge(nil)
+	if err != nil {
+		t.Fatalf("failed to render bridge flows: %v", err)
+	}
+
+	expectedIPv4Hairpin := fmt.Sprintf("cookie=%s, priority=100, table=4, in_port=patch-breth0_bluenet, ip, ip_dst=10.128.0.0/16, "+
+		"actions=ct(commit,zone=%d,nat(src=169.254.0.11),exec(set_field:0x4->ct_mark),table=3)",
+		nodetypes.DefaultOpenFlowCookie, config.Default.OVNMasqConntrackZone)
+	expectedIPv4Reply := fmt.Sprintf("cookie=%s, priority=500, in_port=LOCAL, ip, ip_dst=169.254.0.11,"+
+		"actions=ct(zone=%d,nat,table=5)",
+		nodetypes.DefaultOpenFlowCookie, config.Default.OVNMasqConntrackZone)
+	expectedIPv4Table5 := fmt.Sprintf("cookie=%s, priority=100, table=5, ip, ct_mark=0x4, "+
+		"actions=ct(commit,zone=%d,nat),set_field:%s->eth_dst,output:patch-breth0_bluenet",
+		nodetypes.DefaultOpenFlowCookie, config.Default.HostMasqConntrackZone, bridgeMAC)
+
+	expectedIPv6Hairpin := fmt.Sprintf("cookie=%s, priority=100, table=4, in_port=patch-breth0_bluenet, ipv6, ipv6_dst=fd10:128::/64, "+
+		"actions=ct(commit,zone=%d,nat(src=fd69::11),exec(set_field:0x4->ct_mark),table=3)",
+		nodetypes.DefaultOpenFlowCookie, config.Default.OVNMasqConntrackZone)
+	expectedIPv6Reply := fmt.Sprintf("cookie=%s, priority=500, in_port=LOCAL, ipv6, ipv6_dst=fd69::11,"+
+		"actions=ct(zone=%d,nat,table=5)",
+		nodetypes.DefaultOpenFlowCookie, config.Default.OVNMasqConntrackZone)
+	expectedIPv6Table5 := fmt.Sprintf("cookie=%s, priority=100, table=5, ipv6, ct_mark=0x4, "+
+		"actions=ct(commit,zone=%d,nat),set_field:%s->eth_dst,output:patch-breth0_bluenet",
+		nodetypes.DefaultOpenFlowCookie, config.Default.HostMasqConntrackZone, bridgeMAC)
+
+	expectFlow(t, flows, expectedIPv4Hairpin)
+	expectFlow(t, flows, expectedIPv4Reply)
+	expectFlow(t, flows, expectedIPv4Table5)
+	expectFlow(t, flows, expectedIPv6Hairpin)
+	expectFlow(t, flows, expectedIPv6Reply)
+	expectFlow(t, flows, expectedIPv6Table5)
+}
+
 func mustParseMAC(t *testing.T, value string) net.HardwareAddr {
 	t.Helper()
 	mac, err := net.ParseMAC(value)

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -436,10 +436,28 @@ func (udng *UserDefinedNetworkGateway) addUDNManagementPortIPs(mpLink netlink.Li
 	for _, subnet := range networkLocalSubnets {
 		if config.IPv6Mode && utilnet.IsIPv6CIDR(subnet) || config.IPv4Mode && utilnet.IsIPv4CIDR(subnet) {
 			ip := udng.GetNodeManagementIP(subnet)
-			var err error
-			var exists bool
-			if exists, err = util.LinkAddrExist(mpLink, ip); err == nil && !exists {
-				err = util.LinkAddrAdd(mpLink, ip, 0, 0, 0)
+			addrFlags := 0
+			if udng.useNoPrefixRouteManagementPortIPs() {
+				// In local gateway no-overlay mode, ingress to local UDN pods
+				// must go through OVN, so prevent Linux from creating a
+				// connected route that bypasses the UDN cluster router.
+				addrFlags = unix.IFA_F_NOPREFIXROUTE
+			}
+			existingIP, err := util.LinkAddrGetIPNet(mpLink, ip.IP)
+			if err != nil {
+				return fmt.Errorf("failed to find management port IP from subnet %s on netdevice %s for network %s, err: %v",
+					subnet, mpLink.Attrs().Name, udng.GetNetworkName(), err)
+			}
+			if existingIP != nil && existingIP.String() != ip.String() {
+				err = util.LinkAddrDel(mpLink, existingIP)
+				if err != nil {
+					return fmt.Errorf("failed to delete stale management port IP %s from netdevice %s for network %s, err: %v",
+						existingIP, mpLink.Attrs().Name, udng.GetNetworkName(), err)
+				}
+				existingIP = nil
+			}
+			if existingIP == nil {
+				err = util.LinkAddrAdd(mpLink, ip, addrFlags, 0, 0)
 			}
 			if err != nil {
 				return fmt.Errorf("failed to add management port IP from subnet %s to netdevice %s for network %s, err: %v",
@@ -448,6 +466,12 @@ func (udng *UserDefinedNetworkGateway) addUDNManagementPortIPs(mpLink netlink.Li
 		}
 	}
 	return nil
+}
+
+func (udng *UserDefinedNetworkGateway) useNoPrefixRouteManagementPortIPs() bool {
+	return config.Gateway.Mode == config.GatewayModeLocal &&
+		udng.TopologyType() == types.Layer3Topology &&
+		udng.Transport() == types.NetworkTransportNoOverlay
 }
 
 // computeRoutesForUDN returns a list of routes programmed into a given UDN's VRF
@@ -516,6 +540,8 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 	//   169.254.0.3 via 100.100.1.1 dev ovn-k8s-mp1
 	// For Layer3 networks add the cluster subnet route
 	//   100.100.0.0/16 via 100.100.1.1 dev ovn-k8s-mp1
+	// Local-gateway no-overlay Layer3 uses the node-local subnet instead:
+	//   100.100.1.0/24 via 100.100.1.1 dev ovn-k8s-mp1
 	networkLocalSubnets, err := udng.getLocalSubnets()
 	if err != nil {
 		return nil, err
@@ -524,6 +550,17 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 		gwIP := udng.GetNodeGatewayIP(localSubnet)
 		if gwIP == nil {
 			return nil, fmt.Errorf("unable to find gateway IP for network %s, subnet: %s", udng.GetNetworkName(), localSubnet)
+		}
+		if udng.useNoPrefixRouteManagementPortIPs() {
+			// The management port address uses noprefixroute in local gateway
+			// no-overlay mode. Add a host route to the UDN gateway before
+			// installing routes through it.
+			retVal = append(retVal, netlink.Route{
+				LinkIndex: mpLink.Attrs().Index,
+				Dst:       util.GetIPNetFullMaskFromIP(gwIP.IP),
+				Scope:     netlink.SCOPE_LINK,
+				Table:     udng.vrfTableId,
+			})
 		}
 		etpLocalMasqueradeIP := config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP
 		if utilnet.IsIPv6CIDR(localSubnet) {
@@ -539,6 +576,15 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 			Table: udng.vrfTableId,
 		})
 		if udng.NetInfo.TopologyType() == types.Layer3Topology {
+			if udng.useNoPrefixRouteManagementPortIPs() {
+				retVal = append(retVal, netlink.Route{
+					LinkIndex: mpLink.Attrs().Index,
+					Dst:       localSubnet,
+					Gw:        gwIP.IP,
+					Table:     udng.vrfTableId,
+				})
+				continue
+			}
 			for _, clusterSubnet := range udng.Subnets() {
 				if clusterSubnet.CIDR.Contains(gwIP.IP) {
 					retVal = append(retVal, netlink.Route{

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -263,6 +263,44 @@ func getDummyOpenflowManager() *openflowManager {
 	return ofm
 }
 
+func generateNoOverlayNAD(networkName, name, namespace, topology, cidr, role, outboundSNAT string) *nadapi.NetworkAttachmentDefinition {
+	return ovntest.GenerateNADWithConfig(name, namespace, fmt.Sprintf(
+		`
+{
+        "cniVersion": "1.1.0",
+        "name": %q,
+        "type": "ovn-k8s-cni-overlay",
+        "topology": %q,
+        "subnets": %q,
+        "mtu": 1300,
+        "netAttachDefName": %q,
+        "role": %q,
+        "transport": %q,
+        "outboundSNAT": %q
+}
+`,
+		networkName,
+		topology,
+		cidr,
+		fmt.Sprintf("%s/%s", namespace, name),
+		role,
+		types.NetworkTransportNoOverlay,
+		outboundSNAT,
+	))
+}
+
+func noOverlayLayer3NetInfo(t *testing.T) util.NetInfo {
+	t.Helper()
+	nad := generateNoOverlayNAD("bluenet", "rednad", "greenamespace",
+		types.Layer3Topology, "100.128.0.0/16/24,ae70::/60/64", types.NetworkRolePrimary, types.NoOverlaySNATDisabled)
+	ovntest.AnnotateNADWithNetworkID("3", nad)
+	netInfo, err := util.ParseNADInfo(nad)
+	if err != nil {
+		t.Fatalf("failed to parse NAD: %v", err)
+	}
+	return netInfo
+}
+
 var _ = Describe("UserDefinedNetworkGateway", func() {
 	var (
 		netName               = "bluenet"
@@ -1785,6 +1823,148 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		Expect(fNPW.SyncServices(services)).NotTo(HaveOccurred(), "must sync services")
 	})
 })
+
+func prepareNoOverlayLocalGatewayTestConfig(t *testing.T) {
+	t.Helper()
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.Gateway.Mode = config.GatewayModeLocal
+	config.IPv4Mode = true
+	config.IPv6Mode = true
+	config.Kubernetes.ServiceCIDRs = ovntest.MustParseIPNets("172.16.1.0/24", "fd02::/112")
+	config.Gateway.V6MasqueradeSubnet = "fd69::/112"
+	config.Gateway.V4MasqueradeSubnet = "169.254.0.0/17"
+}
+
+func TestNoOverlayLocalGatewayUsesNoPrefixRouteManagementPortIPs(t *testing.T) {
+	prepareNoOverlayLocalGatewayTestConfig(t)
+	g := NewWithT(t)
+
+	udnGateway := &UserDefinedNetworkGateway{
+		NetInfo: noOverlayLayer3NetInfo(t),
+	}
+
+	g.Expect(udnGateway.useNoPrefixRouteManagementPortIPs()).To(BeTrue())
+
+	config.Gateway.Mode = config.GatewayModeShared
+	g.Expect(udnGateway.useNoPrefixRouteManagementPortIPs()).To(BeFalse())
+}
+
+func TestNoOverlayLocalGatewayUDNGatewayRoutesUseLocalSubnet(t *testing.T) {
+	prepareNoOverlayLocalGatewayTestConfig(t)
+	g := NewWithT(t)
+
+	udnGateway := &UserDefinedNetworkGateway{
+		NetInfo: noOverlayLayer3NetInfo(t),
+		node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker1",
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": `{"bluenet":["100.128.0.0/24", "ae70::/64"]}`,
+				},
+			},
+		},
+		gateway:          &gateway{},
+		vrfTableId:       1007,
+		gwInterfaceIndex: 11,
+	}
+	mpLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "ovn-k8s-mp3", Index: 23}}
+
+	routes, err := udnGateway.computeRoutesForUDN(mpLink)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(routes).To(HaveLen(12))
+	// routes[0]: IPv4 service CIDR route.
+	g.Expect(routes[0].Flags).To(Equal(0))
+
+	// routes[4]: IPv4 gateway host route.
+	g.Expect(*routes[4].Dst).To(Equal(*ovntest.MustParseIPNet("100.128.0.1/32")))
+	g.Expect(routes[4].Gw).To(BeNil())
+	g.Expect(routes[4].Scope).To(Equal(netlink.SCOPE_LINK))
+	g.Expect(routes[4].Flags).To(Equal(0))
+
+	// routes[5]: IPv4 ETP/local service masquerade IP route.
+	g.Expect(*routes[5].Dst).To(Equal(*ovntest.MustParseIPNet("169.254.169.3/32")))
+	g.Expect(routes[5].Gw.Equal(ovntest.MustParseIP("100.128.0.1"))).To(BeTrue())
+	g.Expect(routes[5].Flags).To(Equal(0))
+
+	// routes[6]: IPv4 node pod CIDR route.
+	g.Expect(*routes[6].Dst).To(Equal(*ovntest.MustParseIPNet("100.128.0.0/24")))
+	g.Expect(routes[6].Gw.Equal(ovntest.MustParseIP("100.128.0.1"))).To(BeTrue())
+	g.Expect(routes[6].Flags).To(Equal(0))
+
+	// routes[7]: IPv6 gateway host route.
+	g.Expect(*routes[7].Dst).To(Equal(*ovntest.MustParseIPNet("ae70::1/128")))
+	g.Expect(routes[7].Gw).To(BeNil())
+	g.Expect(routes[7].Scope).To(Equal(netlink.SCOPE_LINK))
+	g.Expect(routes[7].Flags).To(Equal(0))
+
+	// routes[8]: IPv6 ETP/local service masquerade IP route.
+	g.Expect(*routes[8].Dst).To(Equal(*ovntest.MustParseIPNet("fd69::3/128")))
+	g.Expect(routes[8].Gw.Equal(ovntest.MustParseIP("ae70::1"))).To(BeTrue())
+	g.Expect(routes[8].Flags).To(Equal(0))
+
+	// routes[9]: IPv6 node pod CIDR route.
+	g.Expect(*routes[9].Dst).To(Equal(*ovntest.MustParseIPNet("ae70::/64")))
+	g.Expect(routes[9].Gw.Equal(ovntest.MustParseIP("ae70::1"))).To(BeTrue())
+	g.Expect(routes[9].Flags).To(Equal(0))
+
+	config.Gateway.Mode = config.GatewayModeShared
+	routes, err = udnGateway.computeRoutesForUDN(mpLink)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(routes).To(HaveLen(10))
+	// routes[4]: IPv4 ETP/local service masquerade IP route.
+	g.Expect(*routes[4].Dst).To(Equal(*ovntest.MustParseIPNet("169.254.169.3/32")))
+	g.Expect(routes[4].Gw.Equal(ovntest.MustParseIP("100.128.0.1"))).To(BeTrue())
+	// routes[5]: IPv4 global pod CIDR route.
+	g.Expect(*routes[5].Dst).To(Equal(*ovntest.MustParseIPNet("100.128.0.0/16")))
+	g.Expect(routes[5].Gw.Equal(ovntest.MustParseIP("100.128.0.1"))).To(BeTrue())
+	// routes[6]: IPv6 ETP/local service masquerade IP route.
+	g.Expect(*routes[6].Dst).To(Equal(*ovntest.MustParseIPNet("fd69::3/128")))
+	g.Expect(routes[6].Gw.Equal(ovntest.MustParseIP("ae70::1"))).To(BeTrue())
+	// routes[7]: IPv6 global pod CIDR route.
+	g.Expect(*routes[7].Dst).To(Equal(*ovntest.MustParseIPNet("ae70::/60")))
+	g.Expect(routes[7].Gw.Equal(ovntest.MustParseIP("ae70::1"))).To(BeTrue())
+}
+
+func TestAdvertisedNoOverlayLocalGatewayRoutesDoNotUseConnectedSubnetPrefix(t *testing.T) {
+	prepareNoOverlayLocalGatewayTestConfig(t)
+	g := NewWithT(t)
+
+	udnGateway := &UserDefinedNetworkGateway{
+		NetInfo: noOverlayLayer3NetInfo(t),
+		node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker1",
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": `{"bluenet":["100.128.0.0/24", "ae70::/64"]}`,
+				},
+			},
+		},
+		gateway:             &gateway{},
+		vrfTableId:          1007,
+		gwInterfaceIndex:    11,
+		isNetworkAdvertised: true,
+	}
+
+	mpLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "ovn-k8s-mp3", Index: 23}}
+	routes, err := udnGateway.computeRoutesForUDN(mpLink)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(routes).To(HaveLen(12))
+	g.Expect(*routes[4].Dst).To(Equal(*ovntest.MustParseIPNet("100.128.0.1/32")))
+	g.Expect(routes[4].Gw).To(BeNil())
+	g.Expect(routes[4].Scope).To(Equal(netlink.SCOPE_LINK))
+	g.Expect(*routes[6].Dst).To(Equal(*ovntest.MustParseIPNet("100.128.0.0/24")))
+	g.Expect(routes[6].Gw.Equal(ovntest.MustParseIP("100.128.0.1"))).To(BeTrue())
+	g.Expect(*routes[7].Dst).To(Equal(*ovntest.MustParseIPNet("ae70::1/128")))
+	g.Expect(routes[7].Gw).To(BeNil())
+	g.Expect(routes[7].Scope).To(Equal(netlink.SCOPE_LINK))
+	g.Expect(*routes[9].Dst).To(Equal(*ovntest.MustParseIPNet("ae70::/64")))
+	g.Expect(routes[9].Gw.Equal(ovntest.MustParseIP("ae70::1"))).To(BeTrue())
+}
 
 func TestConstructUDNVRFIPRules(t *testing.T) {
 	if ovntest.NoRoot() {

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager.go
@@ -220,6 +220,9 @@ func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {
 	if r1.Table != r2.Table {
 		return false
 	}
+	if !areRuleFamiliesEqual(r1.Family, r2.Family) {
+		return false
+	}
 	if r1.Type != r2.Type {
 		return false
 	}
@@ -228,6 +231,10 @@ func areNetlinkRulesEqual(r1, r2 *netlink.Rule) bool {
 	}
 
 	return areIPNetsEqual(r1.Src, r2.Src) && areIPNetsEqual(r1.Dst, r2.Dst)
+}
+
+func areRuleFamiliesEqual(f1, f2 int) bool {
+	return f1 == f2 || f1 == netlink.FAMILY_ALL || f2 == netlink.FAMILY_ALL
 }
 
 func areIPNetsEqual(n1, n2 *net.IPNet) bool {

--- a/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
+++ b/go-controller/pkg/node/iprulemanager/ip_rule_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"runtime"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -18,6 +19,42 @@ import (
 
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 )
+
+func TestAreNetlinkRulesEqualChecksFamily(t *testing.T) {
+	v4Rule := netlink.NewRule()
+	v4Rule.Priority = 2000
+	v4Rule.Table = 1020
+	v4Rule.Family = netlink.FAMILY_V4
+	v4Rule.Mark = 0x1003
+
+	v6Rule := netlink.NewRule()
+	v6Rule.Priority = v4Rule.Priority
+	v6Rule.Table = v4Rule.Table
+	v6Rule.Family = netlink.FAMILY_V6
+	v6Rule.Mark = v4Rule.Mark
+
+	if areNetlinkRulesEqual(v4Rule, v6Rule) {
+		t.Fatalf("expected IPv4 and IPv6 rules with the same mark/table to be different")
+	}
+}
+
+func TestAreNetlinkRulesEqualTreatsFamilyAllAsWildcard(t *testing.T) {
+	v4Rule := netlink.NewRule()
+	v4Rule.Priority = 2000
+	v4Rule.Table = 1020
+	v4Rule.Family = netlink.FAMILY_V4
+	v4Rule.Mark = 0x1003
+
+	anyFamilyRule := netlink.NewRule()
+	anyFamilyRule.Priority = v4Rule.Priority
+	anyFamilyRule.Table = v4Rule.Table
+	anyFamilyRule.Family = netlink.FAMILY_ALL
+	anyFamilyRule.Mark = v4Rule.Mark
+
+	if !areNetlinkRulesEqual(v4Rule, anyFamilyRule) {
+		t.Fatalf("expected FAMILY_ALL to match a specific rule family")
+	}
+}
 
 // FIXME(mk) - Within GH VM, if I need to create a new NetNs. I see the following error:
 // "failed to create new network namespace: mount --make-rshared /run/user/1001/netns failed: "operation not permitted""

--- a/go-controller/pkg/node/user_defined_node_network_controller_test.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller_test.go
@@ -476,7 +476,24 @@ var _ = Describe("UserDefinedNodeNetworkController: UserDefinedPrimaryNetwork Ga
 					udnRules = append(udnRules, rule)
 				}
 			}
-			Expect(udnRules).To(HaveLen(3))
+			Expect(udnRules).To(HaveLen(4))
+			var v4PacketMarkRule, v6PacketMarkRule, v4MasqIPRule, v6MasqIPRule bool
+			for _, rule := range udnRules {
+				switch {
+				case rule.Family == netlink.FAMILY_V4 && rule.Mark != 0:
+					v4PacketMarkRule = true
+				case rule.Family == netlink.FAMILY_V6 && rule.Mark != 0:
+					v6PacketMarkRule = true
+				case rule.Family == netlink.FAMILY_V4 && rule.Dst != nil:
+					v4MasqIPRule = true
+				case rule.Family == netlink.FAMILY_V6 && rule.Dst != nil:
+					v6MasqIPRule = true
+				}
+			}
+			Expect(v4PacketMarkRule).To(BeTrue())
+			Expect(v6PacketMarkRule).To(BeTrue())
+			Expect(v4MasqIPRule).To(BeTrue())
+			Expect(v6MasqIPRule).To(BeTrue())
 
 			By("delete the network and ensure its associated VRF device is also deleted")
 			cnode := node.DeepCopy()

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -985,13 +985,40 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 			}
 		}
 
-		snat := libovsdbops.BuildSNATWithMatch(
-			&masqIP.ManagementPort.IP,
-			localPodSubnet,
-			outputPort,
-			extIDs,
-			snatMatch,
-		)
+		// For noOverlay mode with outboundSNAT enabled in local gateway mode, add exempted_ext_ips
+		// to prevent SNATing pod-to-pod traffic within the same CUDN while still SNATing pod-to-external traffic.
+		// This SNAT is on ovn_cluster_router, which is used in local gateway mode.
+		var snat *nbdb.NAT
+		if bsnc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+			bsnc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
+			config.Gateway.Mode == config.GatewayModeLocal {
+			snatMatch = ""
+			v4UUID, v6UUID, err := getNoOverlaySNATExemptionAsUUID(bsnc.addressSetFactory, bsnc.GetNetInfo(), bsnc.controllerName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
+			}
+			// Use the appropriate UUID based on IP family
+			exemptedExtIPs := v4UUID
+			if ipFamily == utilnet.IPv6 {
+				exemptedExtIPs = v6UUID
+			}
+			snat = libovsdbops.BuildSNATWithExemptedExtIPs(
+				&masqIP.ManagementPort.IP,
+				localPodSubnet,
+				outputPort,
+				extIDs,
+				snatMatch,
+				exemptedExtIPs,
+			)
+		} else {
+			snat = libovsdbops.BuildSNATWithMatch(
+				&masqIP.ManagementPort.IP,
+				localPodSubnet,
+				outputPort,
+				extIDs,
+				snatMatch,
+			)
+		}
 		snats = append(snats, snat)
 	}
 

--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -978,6 +978,32 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 			return nil, fmt.Errorf("masquerade IP cannot be empty network %s (%d): %v", bsnc.GetNetworkName(), networkID, err)
 		}
 
+		if isUDNAdvertised && config.Gateway.Mode == config.GatewayModeShared {
+			addedAllowedExtIPsSNAT := false
+			// OVN NAT.allowed_ext_ips accepts a single Address_Set, so create one
+			// SNAT per allowed destination set.
+			for _, allowedExtIPsAS := range []addressset.AddressSet{nodeIPsAS, svcIPsAS} {
+				allowedExtIPs := getAddressSetUUIDForIPFamily(ipFamily, allowedExtIPsAS)
+				if allowedExtIPs == "" {
+					continue
+				}
+				snats = append(snats, libovsdbops.BuildSNATWithAllowedExtIPs(
+					&masqIP.ManagementPort.IP,
+					localPodSubnet,
+					outputPort,
+					extIDs,
+					"",
+					allowedExtIPs,
+				))
+				addedAllowedExtIPsSNAT = true
+			}
+			if !addedAllowedExtIPsSNAT {
+				return nil, fmt.Errorf("failed to build allowed_ext_ips SNAT for advertised network %s, subnet %s: no address set UUID for IPv%s",
+					bsnc.GetNetworkName(), localPodSubnet, ipFamily)
+			}
+			continue // move to the next pod subnet
+		}
+
 		if isUDNAdvertised {
 			additionalSNATMatch := getClusterNodesDestinationBasedSNATMatch(ipFamily, nodeIPsAS, svcIPsAS)
 			if additionalSNATMatch != "" {
@@ -1023,6 +1049,17 @@ func (bsnc *BaseUserDefinedNetworkController) buildUDNEgressSNAT(localPodSubnets
 	}
 
 	return snats, nil
+}
+
+func getAddressSetUUIDForIPFamily(ipFamily utilnet.IPFamily, as addressset.AddressSet) string {
+	if as == nil {
+		return ""
+	}
+	v4UUID, v6UUID := as.GetASUUID()
+	if ipFamily == utilnet.IPv6 {
+		return v6UUID
+	}
+	return v4UUID
 }
 
 func getMasqueradeManagementIPSNATMatch(dstMac string) string {

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -5,7 +5,10 @@ package ovn
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"sync"
+	gotesting "testing"
 	"time"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -13,11 +16,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -408,3 +416,227 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 	})
 
 })
+
+func TestAdvertisedSharedGatewaySNATUsesLiveAllowedExtIPSets(t *gotesting.T) {
+	for _, outboundSNAT := range []string{types.NoOverlaySNATDisabled, types.NoOverlaySNATEnabled} {
+		t.Run(outboundSNAT, func(t *gotesting.T) {
+			bsnc, asf, localPodSubnets := newAdvertisedSNATTestController(t, outboundSNAT, config.GatewayModeShared)
+			seedAdvertisedSNATAddressSets(t, asf)
+
+			expectAdvertisedSNATUsesLiveAllowedExtIPs(t, bsnc, asf, localPodSubnets)
+		})
+	}
+}
+
+func TestAdvertisedSharedGatewaySNATFailsWithoutAllowedExtIPsForFamily(t *gotesting.T) {
+	bsnc, asf, localPodSubnets := newAdvertisedSNATTestController(t, types.NoOverlaySNATDisabled, config.GatewayModeShared)
+	config.IPv6Mode = false
+	seedAdvertisedSNATAddressSets(t, asf)
+
+	g := NewWithT(t)
+	_, err := bsnc.buildUDNEgressSNAT(localPodSubnets, "rtos-bluenet-worker1", true)
+	g.Expect(err).To(MatchError(ContainSubstring(
+		"failed to build allowed_ext_ips SNAT for advertised network bluenet, subnet ae70::/64: no address set UUID for IPv6",
+	)))
+}
+
+func TestAdvertisedLocalGatewaySNATUsesDestinationMatch(t *gotesting.T) {
+	bsnc, asf, localPodSubnets := newAdvertisedSNATTestController(t, types.NoOverlaySNATDisabled, config.GatewayModeLocal)
+	seedAdvertisedSNATAddressSets(t, asf)
+
+	expectAdvertisedSNATUsesDestinationMatch(t, bsnc, asf, localPodSubnets)
+}
+
+func newAdvertisedSNATTestController(
+	t *gotesting.T,
+	outboundSNAT string,
+	gatewayMode config.GatewayMode,
+) (*BaseUserDefinedNetworkController, *addressset.FakeAddressSetFactory, []*net.IPNet) {
+	t.Helper()
+	return newAdvertisedSNATTestControllerForTopology(
+		t,
+		types.Layer3Topology,
+		"100.128.0.0/16/24,ae70::/60/64",
+		outboundSNAT,
+		gatewayMode,
+		ovntest.MustParseIPNets("100.128.0.0/24", "ae70::/64"),
+	)
+}
+
+func newAdvertisedSNATTestControllerForTopology(
+	t *gotesting.T,
+	topology string,
+	cidrs string,
+	outboundSNAT string,
+	gatewayMode config.GatewayMode,
+	localPodSubnets []*net.IPNet,
+) (*BaseUserDefinedNetworkController, *addressset.FakeAddressSetFactory, []*net.IPNet) {
+	t.Helper()
+	RegisterTestingT(t)
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatalf("failed to prepare test config: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.IPv4Mode = true
+	config.IPv6Mode = true
+	config.Gateway.Mode = gatewayMode
+	config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16"
+	config.Gateway.V6MasqueradeSubnet = "fd69::/112"
+
+	const (
+		networkName = "bluenet"
+		nadName     = "rednad"
+		namespace   = "greenamespace"
+	)
+	nad := ovntest.GenerateNADWithConfig(nadName, namespace, fmt.Sprintf(`
+{
+        "cniVersion": "1.1.0",
+        "name": %q,
+        "type": "ovn-k8s-cni-overlay",
+        "topology": %q,
+        "subnets": %q,
+        "mtu": 1300,
+        "netAttachDefName": %q,
+        "role": %q,
+        "transport": %q,
+        "outboundSNAT": %q
+}
+`,
+		networkName,
+		topology,
+		cidrs,
+		fmt.Sprintf("%s/%s", namespace, nadName),
+		types.NetworkRolePrimary,
+		types.NetworkTransportNoOverlay,
+		outboundSNAT,
+	))
+	ovntest.AnnotateNADWithNetworkID("3", nad)
+	netInfo, err := util.ParseNADInfo(nad)
+	if err != nil {
+		t.Fatalf("failed to parse NAD: %v", err)
+	}
+
+	controllerName := getNetworkControllerName(netInfo.GetNetworkName())
+	asf := addressset.NewFakeAddressSetFactory(controllerName)
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker1",
+			Annotations: map[string]string{
+				util.OVNNodeHostCIDRs: `["192.168.126.11/24","fd00::11/64"]`,
+			},
+		},
+	}
+	clientSet := util.GetOVNClientset(&corev1.NodeList{Items: []corev1.Node{node}}).GetOVNKubeControllerClientset()
+	watchFactory, err := factory.NewOVNKubeControllerWatchFactory(clientSet)
+	if err != nil {
+		t.Fatalf("failed to create watch factory: %v", err)
+	}
+	if err := watchFactory.Start(); err != nil {
+		t.Fatalf("failed to start watch factory: %v", err)
+	}
+	t.Cleanup(watchFactory.Shutdown)
+
+	nbClient, _, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(libovsdbtest.TestSetup{})
+	if err != nil {
+		t.Fatalf("failed to create libovsdb test harness: %v", err)
+	}
+	t.Cleanup(libovsdbCleanup.Cleanup)
+	addressSetManager := addresssetmanager.NewAddressSetManager(
+		watchFactory.PodCoreInformer(),
+		watchFactory.NamespaceInformer(),
+		watchFactory.NodeCoreInformer(),
+		nbClient,
+		networkmanager.Default().Interface().GetNetworkNameForNADKey,
+	)
+	return &BaseUserDefinedNetworkController{
+			BaseNetworkController: BaseNetworkController{
+				controllerName:      controllerName,
+				ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo),
+				addressSetFactory:   asf,
+				addressSetManager:   addressSetManager,
+			},
+		},
+		asf,
+		localPodSubnets
+}
+
+func seedAdvertisedSNATAddressSets(t *gotesting.T, asf addressset.AddressSetFactory) {
+	t.Helper()
+	nodeIPsASIDs := getClusterNodeIPsAddrSetDbIDsForTest()
+	if _, err := asf.NewAddressSet(nodeIPsASIDs, []string{"192.168.126.11", "fd00::11"}); err != nil {
+		t.Fatalf("failed to create node IP address set: %v", err)
+	}
+
+	svcIPsASIDs := udnenabledsvc.GetAddressSetDBIDs()
+	if _, err := asf.NewAddressSet(svcIPsASIDs, []string{"10.96.0.10", "fd02::10"}); err != nil {
+		t.Fatalf("failed to create UDN-enabled service address set: %v", err)
+	}
+}
+
+func expectAdvertisedSNATUsesLiveAllowedExtIPs(
+	t *gotesting.T,
+	bsnc *BaseUserDefinedNetworkController,
+	asf addressset.AddressSetFactory,
+	localPodSubnets []*net.IPNet,
+) {
+	t.Helper()
+	g := NewWithT(t)
+
+	snats, err := bsnc.buildUDNEgressSNAT(localPodSubnets, "rtos-bluenet-worker1", true)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(snats).To(HaveLen(4))
+
+	nodeIPsAS, err := asf.GetAddressSet(getClusterNodeIPsAddrSetDbIDsForTest())
+	g.Expect(err).NotTo(HaveOccurred())
+	nodeIPv4ASUUID, nodeIPv6ASUUID := nodeIPsAS.GetASUUID()
+	svcIPsAS, err := asf.GetAddressSet(udnenabledsvc.GetAddressSetDBIDs())
+	g.Expect(err).NotTo(HaveOccurred())
+	svcIPv4ASUUID, svcIPv6ASUUID := svcIPsAS.GetASUUID()
+
+	actualAllowedExtIPsByLogicalIP := map[string][]string{}
+	for _, snat := range snats {
+		g.Expect(snat.Match).To(Equal(""))
+		g.Expect(snat.AllowedExtIPs).NotTo(BeNil())
+		g.Expect(snat.ExemptedExtIPs).To(BeNil())
+		actualAllowedExtIPsByLogicalIP[snat.LogicalIP] = append(
+			actualAllowedExtIPsByLogicalIP[snat.LogicalIP],
+			*snat.AllowedExtIPs,
+		)
+	}
+	g.Expect(actualAllowedExtIPsByLogicalIP["100.128.0.0/24"]).To(ConsistOf(nodeIPv4ASUUID, svcIPv4ASUUID))
+	g.Expect(actualAllowedExtIPsByLogicalIP["ae70::/64"]).To(ConsistOf(nodeIPv6ASUUID, svcIPv6ASUUID))
+}
+
+func expectAdvertisedSNATUsesDestinationMatch(
+	t *gotesting.T,
+	bsnc *BaseUserDefinedNetworkController,
+	asf addressset.AddressSetFactory,
+	localPodSubnets []*net.IPNet,
+) {
+	t.Helper()
+	g := NewWithT(t)
+
+	snats, err := bsnc.buildUDNEgressSNAT(localPodSubnets, "rtos-bluenet-worker1", true)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(snats).To(HaveLen(2))
+
+	nodeIPsAS, err := asf.GetAddressSet(getClusterNodeIPsAddrSetDbIDsForTest())
+	g.Expect(err).NotTo(HaveOccurred())
+	svcIPsAS, err := asf.GetAddressSet(udnenabledsvc.GetAddressSetDBIDs())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	dstMac := util.IPAddrToHWAddr(bsnc.GetNodeManagementIP(localPodSubnets[0]).IP)
+	dstMacMatch := getMasqueradeManagementIPSNATMatch(dstMac.String())
+	v4Match := getClusterNodesDestinationBasedSNATMatch(utilnet.IPv4, nodeIPsAS, svcIPsAS)
+	v6Match := getClusterNodesDestinationBasedSNATMatch(utilnet.IPv6, nodeIPsAS, svcIPsAS)
+
+	g.Expect(snats[0].Match).To(Equal(fmt.Sprintf("%s && %s", dstMacMatch, v4Match)))
+	g.Expect(snats[0].AllowedExtIPs).To(BeNil())
+	g.Expect(snats[0].ExemptedExtIPs).To(BeNil())
+
+	g.Expect(snats[1].Match).To(Equal(fmt.Sprintf("%s && %s", dstMacMatch, v6Match)))
+	g.Expect(snats[1].AllowedExtIPs).To(BeNil())
+	g.Expect(snats[1].ExemptedExtIPs).To(BeNil())
+}

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -893,7 +893,13 @@ func (gw *GatewayManager) updateGWRouterNAT(nodeName string, gwConfig *GatewayCo
 		if util.IsNoOverlaySNATExemptionNeeded(gw.netInfo) {
 			// Get the no-overlay SNAT exemption address set UUIDs
 			addressSetFactory := addressset.NewOvnAddressSetFactory(gw.nbClient, config.IPv4Mode, config.IPv6Mode)
-			v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(addressSetFactory, gw.netInfo, types.DefaultNetworkControllerName)
+			// Use the correct controller name: default-network-controller for default network,
+			// <networkName>-network-controller for user-defined networks
+			controllerName := types.DefaultNetworkControllerName
+			if gw.netInfo.IsUserDefinedNetwork() {
+				controllerName = getNetworkControllerName(gw.netInfo.GetNetworkName())
+			}
+			v4UUID, v6UUID, err = getNoOverlaySNATExemptionAsUUID(addressSetFactory, gw.netInfo, controllerName)
 			if err != nil {
 				return fmt.Errorf("failed to get no-overlay SNAT exemption address set UUID: %w", err)
 			}

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -1098,8 +1098,11 @@ func (oc *Layer2UserDefinedNetworkController) cleanupInterconnectSetupForRemoteN
 // externalIP = "169.254.0.12"; which is the masqueradeIP for this L2 UDN
 // so all in all we want to condionally SNAT all packets that are coming from pods hosted on this node,
 // which are leaving via UDN's mpX interface to the UDN's masqueradeIP.
-// If isUDNAdvertised is true, then we want to SNAT all packets that are coming from pods on this network
-// leaving towards nodeIPs on the cluster to masqueradeIP. If network is advertise then the SNAT looks like this:
+// If isUDNAdvertised is true, then we want to SNAT packets from pods on this network
+// leaving towards cluster node IPs and UDN-enabled service IPs to the masqueradeIP.
+// In shared gateway mode, advertised SNAT keeps NAT.match empty and uses
+// NAT.allowed_ext_ips to point directly at those address sets. Local gateway mode
+// keeps the destination address-set checks in NAT.match, for example:
 // "eth.dst == 0a:58:5d:5d:00:02 && (ip4.dst == $a712973235162149816)" "169.254.0.36" "93.93.0.0/16"
 func (oc *Layer2UserDefinedNetworkController) addOrUpdateUDNClusterSubnetEgressSNAT(localPodSubnets []*net.IPNet,
 	nodeName string, isUDNAdvertised bool) error {

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -1275,6 +1275,9 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	} else {
 		clusterRouter.Options = map[string]string{"always_learn_from_arp_request": "false"}
 	}
+	if config.Gateway.Mode == config.GatewayModeLocal {
+		clusterRouter.Options["ct-commit-all"] = "true"
+	}
 
 	expectedEntities := []libovsdbtest.TestData{
 		clusterRouter,

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -956,8 +956,11 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateRemoteNodeEvent(node *cor
 // externalIP = "169.254.0.12"; which is the masqueradeIP for this L3 UDN
 // so all in all we want to condionally SNAT all packets that are coming from pods hosted on this node,
 // which are leaving via UDN's mpX interface to the UDN's masqueradeIP.
-// If isUDNAdvertised is true, then we want to SNAT all packets that are coming from pods on this network
-// leaving towards nodeIPs on the cluster to masqueradeIP. If network is advertise then the SNAT looks like this:
+// If isUDNAdvertised is true, then we want to SNAT packets from pods on this network
+// leaving towards cluster node IPs and UDN-enabled service IPs to the masqueradeIP.
+// In shared gateway mode, advertised SNAT keeps NAT.match empty and uses
+// NAT.allowed_ext_ips to point directly at those address sets. Local gateway mode
+// keeps the destination address-set checks in NAT.match, for example:
 // "eth.dst == 0a:58:5d:5d:00:02 && (ip4.dst == $a712973235162149816)" "169.254.0.36" "93.93.0.0/24"
 func (oc *Layer3UserDefinedNetworkController) addOrUpdateUDNNodeSubnetEgressSNAT(localPodSubnets []*net.IPNet, node *corev1.Node, isUDNAdvertised bool) error {
 	outputPort := types.RouterToSwitchPrefix + oc.GetNetworkScopedName(node.Name)

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -382,8 +382,8 @@ func (oc *Layer3UserDefinedNetworkController) Stop() {
 	}
 }
 
-// Cleanup cleans up logical entities for the given network, called from net-attach-def routine
-// could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
+// Cleanup cleans up logical entities for the given network, called from the
+// net-attach-def routine or stale network cleanup.
 func (oc *Layer3UserDefinedNetworkController) Cleanup() error {
 	// cleans up related OVN logical entities
 	var ops []ovsdb.Operation
@@ -488,6 +488,11 @@ func (oc *Layer3UserDefinedNetworkController) Cleanup() error {
 	// remove load balancer groups
 	cleanupLoadBalancerGroups(oc.nbClient, oc.GetNetInfo(),
 		oc.switchLoadBalancerGroupUUID, oc.clusterLoadBalancerGroupUUID, oc.routerLoadBalancerGroupUUID)
+
+	// Cleanup noOverlay SNAT exemption address set
+	if err := cleanupNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName); err != nil {
+		klog.Warningf("Failed to cleanup noOverlay SNAT exemption address set for network %s: %v", netName, err)
+	}
 
 	return nil
 }
@@ -755,6 +760,16 @@ func (oc *Layer3UserDefinedNetworkController) init() error {
 		oc.switchLoadBalancerGroupUUID = switchLBGroupUUID
 		oc.routerLoadBalancerGroupUUID = routerLBGroupUUID
 	}
+
+	// Initialize noOverlay SNAT exemption address set when using noOverlay transport with outboundSNAT enabled
+	// This is needed for both local and shared gateway modes
+	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled {
+		if _, err := initNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName); err != nil {
+			return fmt.Errorf("failed to initialize noOverlay SNAT exemption address set for network %s: %w", oc.GetNetworkName(), err)
+		}
+	}
+
 	return nil
 }
 
@@ -823,6 +838,21 @@ func (oc *Layer3UserDefinedNetworkController) addUpdateLocalNodeEvent(node *core
 	if nSyncs.syncNode { // do this only if it is a new node add
 		errors := oc.addAllPodsOnNode(node.Name)
 		errs = append(errs, errors...)
+	}
+
+	// Sync noOverlay SNAT exemption address set BEFORE gateway initialization
+	// This must happen before the gateway creates SNAT rules that reference the address set
+	if oc.GetNetInfo().Transport() == types.NetworkTransportNoOverlay &&
+		oc.GetNetInfo().OutboundSNAT() == types.NoOverlaySNATEnabled &&
+		(nSyncs.syncNode || nSyncs.syncGw) {
+		hostAddrs, err := util.GetNodeHostAddrs(node)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to get host addresses for node %s: %w", node.Name, err))
+		} else {
+			if err := syncNoOverlaySNATExemptionAddressSet(oc.addressSetFactory, oc.GetNetInfo(), oc.controllerName, hostAddrs); err != nil {
+				errs = append(errs, fmt.Errorf("failed to sync noOverlay SNAT exemption address set: %w", err))
+			}
+		}
 	}
 
 	if util.IsNetworkSegmentationSupportEnabled() && oc.IsPrimaryNetwork() {

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -51,6 +52,8 @@ type userDefinedNetInfo struct {
 	allowPersistentIPs bool
 	ipamClaimReference string
 	hasEVPN            bool
+	transport          string // e.g., types.NetworkTransportNoOverlay
+	outboundSNAT       string // e.g., types.NoOverlaySNATEnabled
 }
 
 const (
@@ -1236,6 +1239,183 @@ var _ = Describe("Layer3 UDN Transport Mode - Interconnect", func() {
 	})
 })
 
+var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
+	var (
+		fakeOvn *FakeOVN
+	)
+
+	BeforeEach(func() {
+		Expect(config.PrepareTestConfig()).To(Succeed())
+		fakeOvn = NewFakeOVN(false)
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	// Test 1: Verify SNAT with exempted_ext_ips is created on ovn_cluster_router in LOCAL gateway mode
+	It("creates SNAT with exempted address set in local gateway mode on ovn-cluster-router", func() {
+		// Step 1: Set config.Gateway.Mode = config.GatewayModeLocal
+		By("Step 1: Setting up LOCAL gateway mode configuration")
+		config.Gateway.Mode = config.GatewayModeLocal
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+		config.Default.Zone = testICZone
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16" // Broader subnet to accommodate network ID 2
+
+		app := cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		// Step 2: Create a Layer3 CUDN with no-overlay transport and outboundSNAT enabled
+		By("Step 2: Creating Layer3 CUDN with no-overlay transport and outboundSNAT enabled")
+		cudnNetInfo := userDefinedNetInfo{
+			netName:        userDefinedNetworkName,
+			nadName:        namespacedName(ns, nadName),
+			topology:       types.Layer3Topology,
+			clustersubnets: "10.100.0.0/16",
+			hostsubnets:    "10.100.1.0/24",
+			isPrimary:      true,
+			transport:      types.NetworkTransportNoOverlay,
+			outboundSNAT:   string(types.NoOverlaySNATEnabled),
+		}
+
+		app.Action = func(*cli.Context) error {
+			// Create NAD with no-overlay transport and outboundSNAT enabled
+			netConf := cudnNetInfo.netconf()
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			n := newUDNNamespace(ns)
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, cudnNetInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			podInfo := dummyTestPod(ns, cudnNetInfo)
+
+			By("Starting fakeOvn with database setup (without node initially)")
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{Name: nodeName},
+					},
+				},
+				&corev1.NamespaceList{Items: []corev1.Namespace{*n}},
+				&corev1.NodeList{Items: []corev1.Node{}}, // Empty - will add node after watch starts
+				&corev1.PodList{Items: []corev1.Pod{*newMultiHomedPod(podInfo, cudnNetInfo)}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+			podInfo.populateLogicalSwitchCache(fakeOvn)
+
+			// Step 3: Initialize the CUDN controller
+			By("Step 3: Initializing CUDN controller")
+			fexec := util.GetExec().(*testing.FakeExec)
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --columns=_uuid list Load_Balancer_Group",
+			})
+			fullL3UDNController := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(fullL3UDNController).ToNot(BeNil())
+			Expect(fullL3UDNController.init()).To(Succeed())
+
+			userDefinedNetController, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+
+			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
+
+			// Step 4: Start watching nodes to trigger addUpdateLocalNodeEvent()
+			By("Starting node watch on L3 UDN controller")
+			Expect(fakeOvn.registerUDNNodeHandler(userDefinedNetworkName)).To(Succeed())
+
+			By("Adding node to trigger addUpdateLocalNodeEvent()")
+			// Add the node AFTER starting the watch so the watch catches the ADD event
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			By("Node created successfully")
+
+			// Wait for node processing to complete
+			By("Waiting for NAT entries to be created on ovn_cluster_router")
+			Eventually(func() error {
+				// Step 5: Query the OVN NB database to find NAT entries on the CUDN's ovn_cluster_router
+				clusterRouterName := userDefinedNetController.bnc.GetNetworkScopedClusterRouterName()
+
+				lr := &nbdb.LogicalRouter{Name: clusterRouterName}
+				lr, err = libovsdbops.GetLogicalRouter(fakeOvn.nbClient, lr)
+				if err != nil {
+					return fmt.Errorf("failed to get logical router %s: %v", clusterRouterName, err)
+				}
+
+				if len(lr.Nat) == 0 {
+					return fmt.Errorf("no NAT entries found on router %s", clusterRouterName)
+				}
+
+				// Step 6: Verify NAT entries have exempted_ext_ips set
+				foundSNATWithExemption := false
+				for _, natUUID := range lr.Nat {
+					nat := &nbdb.NAT{UUID: natUUID}
+					nat, err = libovsdbops.GetNAT(fakeOvn.nbClient, nat)
+					if err != nil {
+						continue
+					}
+
+					if nat.Type == nbdb.NATTypeSNAT && nat.ExemptedExtIPs != nil && *nat.ExemptedExtIPs != "" {
+						foundSNATWithExemption = true
+
+						// Get the address set to verify UUID and contents
+						dbIDs := libovsdbops.NewDbObjectIDs(
+							libovsdbops.AddressSetNoOverlaySNATExemption,
+							userDefinedNetController.bnc.controllerName,
+							map[libovsdbops.ExternalIDKey]string{
+								libovsdbops.ObjectNameKey: "no-overlay-snat-exemption",
+								libovsdbops.NetworkKey:    userDefinedNetworkName,
+							},
+						)
+						as, err := fakeOvn.controller.addressSetFactory.GetAddressSet(dbIDs)
+						if err != nil {
+							return fmt.Errorf("failed to get address set: %v", err)
+						}
+
+						// Verify the NAT's ExemptedExtIPs field contains the actual address set UUID
+						v4UUID, v6UUID := as.GetASUUID()
+						expectedUUID := v4UUID // For IPv4 mode
+						if config.IPv6Mode && !config.IPv4Mode {
+							expectedUUID = v6UUID
+						}
+						if *nat.ExemptedExtIPs != expectedUUID {
+							return fmt.Errorf("NAT ExemptedExtIPs (%s) does not match address set UUID (%s)",
+								*nat.ExemptedExtIPs, expectedUUID)
+						}
+
+						// Verify the address set contains both cluster subnet and node host IP
+						ipv4Addrs, ipv6Addrs := as.GetAddresses()
+						allAddrs := append(ipv4Addrs, ipv6Addrs...)
+						expectedAddrs := []string{"10.100.0.0/16", "192.168.126.202"}
+						for _, expectedAddr := range expectedAddrs {
+							if !slices.Contains(allAddrs, expectedAddr) {
+								return fmt.Errorf("address set does not contain %s, has: %v", expectedAddr, allAddrs)
+							}
+						}
+						break
+					}
+				}
+
+				if !foundSNATWithExemption {
+					return fmt.Errorf("no SNAT with ExemptedExtIPs found on router %s", clusterRouterName)
+				}
+
+				return nil
+			}).WithTimeout(5 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+
+			return nil
+		}
+
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
+
+})
+
 func newPodWithPrimaryUDN(
 	nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIPs, podMAC, namespace string,
 	primaryUDNConfig userDefinedNetInfo,
@@ -1336,6 +1516,12 @@ func (sni *userDefinedNetInfo) netconf() *ovncnitypes.NetConf {
 
 	if sni.hasEVPN {
 		netconf.Transport = types.NetworkTransportEVPN
+	}
+	if sni.transport != "" {
+		netconf.Transport = sni.transport
+	}
+	if sni.outboundSNAT != "" {
+		netconf.OutboundSNAT = sni.outboundSNAT
 	}
 
 	return netconf

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1260,8 +1260,6 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 		config.Gateway.Mode = config.GatewayModeLocal
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
-		config.OVNKubernetesFeature.EnableInterconnect = true
-		config.Default.Zone = testICZone
 		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16" // Broader subnet to accommodate network ID 2
 
 		app := cli.NewApp()
@@ -1420,8 +1418,6 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 		config.Gateway.Mode = config.GatewayModeShared
 		config.OVNKubernetesFeature.EnableMultiNetwork = true
 		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
-		config.OVNKubernetesFeature.EnableInterconnect = true
-		config.Default.Zone = testICZone
 		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16" // Broader subnet to accommodate network ID 2
 
 		app := cli.NewApp()

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1414,6 +1414,161 @@ var _ = Describe("Layer3 CUDN OutboundSNAT for no-overlay mode", func() {
 		Expect(app.Run([]string{app.Name})).To(Succeed())
 	})
 
+	// Test 2: Verify SNAT with exempted_ext_ips is created on GR_<node> in SHARED gateway mode
+	It("creates SNAT with exempted address set in shared gateway mode on gateway router", func() {
+		// Step 1: Set config.Gateway.Mode = config.GatewayModeShared
+		config.Gateway.Mode = config.GatewayModeShared
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableInterconnect = true
+		config.Default.Zone = testICZone
+		config.Gateway.V4MasqueradeSubnet = "169.254.0.0/16" // Broader subnet to accommodate network ID 2
+
+		app := cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		// Step 2: Create a Layer3 CUDN with no-overlay transport and outboundSNAT enabled
+		cudnNetInfo := userDefinedNetInfo{
+			netName:        userDefinedNetworkName,
+			nadName:        namespacedName(ns, nadName),
+			topology:       types.Layer3Topology,
+			clustersubnets: "10.100.0.0/16",
+			hostsubnets:    "10.100.1.0/24",
+			isPrimary:      true,
+			transport:      types.NetworkTransportNoOverlay,
+			outboundSNAT:   string(types.NoOverlaySNATEnabled),
+		}
+
+		app.Action = func(*cli.Context) error {
+			// Create NAD with no-overlay transport and outboundSNAT enabled
+			netConf := cudnNetInfo.netconf()
+
+			nad, err := newNetworkAttachmentDefinition(ns, nadName, *netConf)
+			Expect(err).NotTo(HaveOccurred())
+
+			n := newUDNNamespace(ns)
+			const nodeIPv4CIDR = "192.168.126.202/24"
+			testNode, err := newNodeWithUserDefinedNetworks(nodeName, nodeIPv4CIDR, cudnNetInfo)
+			Expect(err).NotTo(HaveOccurred())
+
+			podInfo := dummyTestPod(ns, cudnNetInfo)
+
+			fakeOvn.startWithDBSetup(
+				libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{Name: nodeName},
+					},
+				},
+				&corev1.NamespaceList{Items: []corev1.Namespace{*n}},
+				&corev1.NodeList{Items: []corev1.Node{}}, // Empty - will add node after watch starts
+				&corev1.PodList{Items: []corev1.Pod{*newMultiHomedPod(podInfo, cudnNetInfo)}},
+				&nadapi.NetworkAttachmentDefinitionList{Items: []nadapi.NetworkAttachmentDefinition{*nad}},
+			)
+			podInfo.populateLogicalSwitchCache(fakeOvn)
+
+			// Step 3: Initialize the CUDN controller
+			fexec := util.GetExec().(*testing.FakeExec)
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --columns=_uuid list Load_Balancer_Group",
+			})
+			fullL3UDNController := fakeOvn.fullL3UDNControllers[userDefinedNetworkName]
+			Expect(fullL3UDNController).ToNot(BeNil())
+			Expect(fullL3UDNController.init()).To(Succeed())
+
+			userDefinedNetController, ok := fakeOvn.userDefinedNetworkControllers[userDefinedNetworkName]
+			Expect(ok).To(BeTrue())
+
+			userDefinedNetController.bnc.ovnClusterLRPToJoinIfAddrs = dummyJoinIPs()
+			podInfo.populateUserDefinedNetworkLogicalSwitchCache(userDefinedNetController)
+
+			// Step 4: Create and advertise a pod on the CUDN to trigger gateway SNAT creation
+			By("Starting node watch on L3 UDN controller for shared gateway mode")
+			Expect(fakeOvn.registerUDNNodeHandler(userDefinedNetworkName)).To(Succeed())
+			Expect(userDefinedNetController.bnc.WatchPods()).To(Succeed())
+
+			By("Adding node to trigger gateway creation with SNAT+exemption")
+			// Add the node AFTER starting the watch so the watch catches the ADD event
+			_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			By("Node created, gateway should be initialized")
+
+			// Wait for pod and gateway processing to complete
+			Eventually(func() error {
+				// Step 5: Query the OVN NB database to find NAT entries on GR_<nodeName>
+				gwRouterName := userDefinedNetController.bnc.GetNetInfo().GetNetworkScopedGWRouterName(nodeName)
+				lr := &nbdb.LogicalRouter{Name: gwRouterName}
+				lr, err = libovsdbops.GetLogicalRouter(fakeOvn.nbClient, lr)
+				if err != nil {
+					return fmt.Errorf("failed to get gateway router %s: %v", gwRouterName, err)
+				}
+
+				if len(lr.Nat) == 0 {
+					return fmt.Errorf("no NAT entries found on gateway router %s", gwRouterName)
+				}
+
+				// Step 6: Verify NAT entries have exempted_ext_ips set
+				foundSNATWithExemption := false
+				for _, natUUID := range lr.Nat {
+					nat := &nbdb.NAT{UUID: natUUID}
+					nat, err = libovsdbops.GetNAT(fakeOvn.nbClient, nat)
+					if err != nil {
+						continue
+					}
+
+					if nat.Type == nbdb.NATTypeSNAT && nat.ExemptedExtIPs != nil && *nat.ExemptedExtIPs != "" {
+						foundSNATWithExemption = true
+
+						// Get the address set to verify UUID and contents
+						dbIDs := libovsdbops.NewDbObjectIDs(
+							libovsdbops.AddressSetNoOverlaySNATExemption,
+							userDefinedNetController.bnc.controllerName,
+							map[libovsdbops.ExternalIDKey]string{
+								libovsdbops.ObjectNameKey: "no-overlay-snat-exemption",
+								libovsdbops.NetworkKey:    userDefinedNetController.bnc.GetNetworkName(),
+							},
+						)
+						as, err := fakeOvn.controller.addressSetFactory.GetAddressSet(dbIDs)
+						if err != nil {
+							return fmt.Errorf("failed to get address set: %v", err)
+						}
+
+						// Verify the NAT's ExemptedExtIPs field contains the actual address set UUID
+						v4UUID, v6UUID := as.GetASUUID()
+						expectedUUID := v4UUID // For IPv4 mode
+						if config.IPv6Mode && !config.IPv4Mode {
+							expectedUUID = v6UUID
+						}
+						if *nat.ExemptedExtIPs != expectedUUID {
+							return fmt.Errorf("NAT ExemptedExtIPs (%s) does not match address set UUID (%s)",
+								*nat.ExemptedExtIPs, expectedUUID)
+						}
+
+						// Verify the address set contains both cluster subnet and node host IP
+						ipv4Addrs, ipv6Addrs := as.GetAddresses()
+						allAddrs := append(ipv4Addrs, ipv6Addrs...)
+						expectedAddrs := []string{"10.100.0.0/16", "192.168.126.202"}
+						for _, expectedAddr := range expectedAddrs {
+							if !slices.Contains(allAddrs, expectedAddr) {
+								return fmt.Errorf("address set does not contain %s, has: %v", expectedAddr, allAddrs)
+							}
+						}
+						break
+					}
+				}
+
+				if !foundSNATWithExemption {
+					return fmt.Errorf("no SNAT with ExemptedExtIPs found on gateway router %s", gwRouterName)
+				}
+
+				return nil
+			}).WithTimeout(10 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+
+			return nil
+		}
+
+		Expect(app.Run([]string{app.Name})).To(Succeed())
+	})
 })
 
 func newPodWithPrimaryUDN(

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -1979,13 +1979,18 @@ func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	clusterRouterExternalIDs := standardNonDefaultNetworkExtIDs(netInfo)
 	clusterRouterExternalIDs["k8s-cluster-router"] = "yes"
 
+	clusterRouterOptions := map[string]string{"always_learn_from_arp_request": "false"}
+	if config.Gateway.Mode == config.GatewayModeLocal {
+		clusterRouterOptions["ct-commit-all"] = "true"
+	}
+
 	clusterRouter := &nbdb.LogicalRouter{
 		Name:        clusterRouterName,
 		UUID:        clusterRouterName + "-UUID",
 		Ports:       []string{rtosLRPUUID},
 		ExternalIDs: clusterRouterExternalIDs,
 		Copp:        ptr.To(string(coppUUID)),
-		Options:     map[string]string{"always_learn_from_arp_request": "false"},
+		Options:     clusterRouterOptions,
 	}
 
 	expectedEntities := []libovsdbtest.TestData{

--- a/go-controller/pkg/ovn/no_overlay_snat_exemption.go
+++ b/go-controller/pkg/ovn/no_overlay_snat_exemption.go
@@ -85,6 +85,10 @@ func cleanupNoOverlaySNATExemptionAddressSet(
 	netInfo util.NetInfo,
 	controllerName string,
 ) error {
+	if addressSetFactory == nil {
+		return fmt.Errorf("failed to cleanup no-overlay SNAT exemption address set: address set factory is nil")
+	}
+
 	dbIDs := libovsdbops.NewDbObjectIDs(
 		libovsdbops.AddressSetNoOverlaySNATExemption,
 		controllerName,

--- a/go-controller/pkg/ovn/no_overlay_snat_exemption_unit_test.go
+++ b/go-controller/pkg/ovn/no_overlay_snat_exemption_unit_test.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ovn
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanupNoOverlaySNATExemptionAddressSetNilFactory(t *testing.T) {
+	err := cleanupNoOverlaySNATExemptionAddressSet(nil, nil, "")
+	if err == nil {
+		t.Fatalf("expected nil factory cleanup to fail")
+	}
+	if !strings.Contains(err.Error(), "address set factory is nil") {
+		t.Fatalf("expected missing address set factory error, got: %v", err)
+	}
+}

--- a/go-controller/pkg/ovn/topology/topologyfactory.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory.go
@@ -71,7 +71,6 @@ func (gtf *GatewayTopologyFactory) newClusterRouter(
 	}
 	if netInfo.IsUserDefinedNetwork() &&
 		config.Gateway.Mode == config.GatewayModeLocal &&
-		netInfo.TopologyType() == types.Layer3Topology &&
 		clusterRouterName == netInfo.GetNetworkScopedClusterRouterName() {
 		// The LGW UDN cluster router owns the conditional UDN subnet SNAT. Commit
 		// all traffic in that router's CT zone so replies do not enter the SNAT

--- a/go-controller/pkg/ovn/topology/topologyfactory.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory.go
@@ -9,6 +9,7 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -67,6 +68,15 @@ func (gtf *GatewayTopologyFactory) newClusterRouter(
 		},
 		Options: routerOptions,
 		Copp:    &coopUUID,
+	}
+	if netInfo.IsUserDefinedNetwork() &&
+		config.Gateway.Mode == config.GatewayModeLocal &&
+		netInfo.TopologyType() == types.Layer3Topology &&
+		clusterRouterName == netInfo.GetNetworkScopedClusterRouterName() {
+		// The LGW UDN cluster router owns the conditional UDN subnet SNAT. Commit
+		// all traffic in that router's CT zone so replies do not enter the SNAT
+		// zone as new flows and hit that SNAT before service reverse NAT.
+		logicalRouter.Options["ct-commit-all"] = "true"
 	}
 	if netInfo.IsUserDefinedNetwork() {
 		logicalRouter.ExternalIDs[types.NetworkExternalID] = netInfo.GetNetworkName()

--- a/go-controller/pkg/ovn/topology/topologyfactory_test.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory_test.go
@@ -102,6 +102,77 @@ var _ = Describe("Topology factory", func() {
 			)
 		})
 
+		It("sets ct-commit-all on local gateway UDN cluster routers", func() {
+			config.Gateway.Mode = config.GatewayModeLocal
+			DeferCleanup(func() {
+				Expect(config.PrepareTestConfig()).To(Succeed())
+			})
+
+			clusterRouterName := netInfo.GetNetworkScopedClusterRouterName()
+			clusterRouter, err := factory.NewClusterRouter(clusterRouterName, netInfo, coopUUID)
+			Expect(err).NotTo(HaveOccurred())
+			expectedExternalIDs := map[string]string{
+				ovntypes.NetworkExternalID:  networkName,
+				ovntypes.TopologyExternalID: ovntypes.Layer3Topology,
+				"k8s-cluster-router":        "yes",
+			}
+			expectedOptions := map[string]string{
+				"always_learn_from_arp_request": "false",
+				"ct-commit-all":                 "true",
+			}
+			Expect(clusterRouter).To(
+				WithTransform(
+					removeUUID,
+					Equal(
+						expectedClusterRouter(clusterRouterName, coopUUID, expectedOptions, expectedExternalIDs),
+					),
+				),
+			)
+		})
+
+		It("does not set ct-commit-all on shared gateway UDN cluster routers", func() {
+			config.Gateway.Mode = config.GatewayModeShared
+			DeferCleanup(func() {
+				Expect(config.PrepareTestConfig()).To(Succeed())
+			})
+			clusterRouterName := netInfo.GetNetworkScopedClusterRouterName()
+			clusterRouter, err := factory.NewClusterRouter(clusterRouterName, netInfo, coopUUID)
+			Expect(err).NotTo(HaveOccurred())
+			expectedExternalIDs := map[string]string{
+				ovntypes.NetworkExternalID:  networkName,
+				ovntypes.TopologyExternalID: ovntypes.Layer3Topology,
+				"k8s-cluster-router":        "yes",
+			}
+			expectedOptions := map[string]string{"always_learn_from_arp_request": "false"}
+			Expect(clusterRouter).To(
+				WithTransform(
+					removeUUID,
+					Equal(
+						expectedClusterRouter(clusterRouterName, coopUUID, expectedOptions, expectedExternalIDs),
+					),
+				),
+			)
+		})
+
+		It("does not set ct-commit-all on default network cluster routers", func() {
+			config.Gateway.Mode = config.GatewayModeLocal
+			DeferCleanup(func() {
+				Expect(config.PrepareTestConfig()).To(Succeed())
+			})
+
+			defaultNetInfo := &util.DefaultNetInfo{}
+			clusterRouter, err := factory.NewClusterRouter(defaultNetInfo.GetNetworkScopedClusterRouterName(), defaultNetInfo, coopUUID)
+			Expect(err).NotTo(HaveOccurred())
+			expectedExternalIDs := map[string]string{"k8s-cluster-router": "yes"}
+			expectedOptions := map[string]string{"always_learn_from_arp_request": "false"}
+			Expect(clusterRouter).To(
+				WithTransform(
+					removeUUID,
+					Equal(expectedClusterRouter(ovntypes.OVNClusterRouter, coopUUID, expectedOptions, expectedExternalIDs)),
+				),
+			)
+		})
+
 		It("creating a join switch for a layer3 primary network fails", func() {
 			clusterRouter := expectedClusterRouter(
 				routerName,

--- a/go-controller/pkg/ovn/topology/topologyfactory_test.go
+++ b/go-controller/pkg/ovn/topology/topologyfactory_test.go
@@ -130,6 +130,36 @@ var _ = Describe("Topology factory", func() {
 			)
 		})
 
+		It("sets ct-commit-all on local gateway layer2 UDN transit routers", func() {
+			config.Gateway.Mode = config.GatewayModeLocal
+			DeferCleanup(func() {
+				Expect(config.PrepareTestConfig()).To(Succeed())
+			})
+
+			layer2NetInfo, err := util.NewNetInfo(newLayer2PrimaryNetworkConf(networkName, networkSubnets))
+			Expect(err).NotTo(HaveOccurred())
+			clusterRouterName := layer2NetInfo.GetNetworkScopedClusterRouterName()
+			clusterRouter, err := factory.NewTransitRouter(clusterRouterName, layer2NetInfo, coopUUID, "42")
+			Expect(err).NotTo(HaveOccurred())
+			expectedExternalIDs := map[string]string{
+				ovntypes.NetworkExternalID:  networkName,
+				ovntypes.TopologyExternalID: ovntypes.Layer2Topology,
+				"k8s-cluster-router":        "yes",
+			}
+			expectedOptions := map[string]string{
+				libovsdbops.RequestedTnlKey: "42",
+				"ct-commit-all":             "true",
+			}
+			Expect(clusterRouter).To(
+				WithTransform(
+					removeUUID,
+					Equal(
+						expectedClusterRouter(clusterRouterName, coopUUID, expectedOptions, expectedExternalIDs),
+					),
+				),
+			)
+		})
+
 		It("does not set ct-commit-all on shared gateway UDN cluster routers", func() {
 			config.Gateway.Mode = config.GatewayModeShared
 			DeferCleanup(func() {
@@ -254,6 +284,15 @@ func newLayer3PrimaryNetworkConf(name, subnets string) *ovncnitypes.NetConf {
 	return &ovncnitypes.NetConf{
 		NetConf:  cnitypes.NetConf{Name: name},
 		Topology: ovntypes.Layer3Topology,
+		Subnets:  subnets,
+		Role:     ovntypes.NetworkRolePrimary,
+	}
+}
+
+func newLayer2PrimaryNetworkConf(name, subnets string) *ovncnitypes.NetConf {
+	return &ovncnitypes.NetConf{
+		NetConf:  cnitypes.NetConf{Name: name},
+		Topology: ovntypes.Layer2Topology,
 		Subnets:  subnets,
 		Role:     ovntypes.NetworkRolePrimary,
 	}

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -748,8 +748,9 @@ type userDefinedNetInfo struct {
 	defaultGatewayIPs   []net.IP
 	managementIPs       []net.IP
 
-	transport string
-	evpn      *ovncnitypes.EVPNConfig
+	transport    string
+	evpn         *ovncnitypes.EVPNConfig
+	outboundSNAT string
 }
 
 func (nInfo *userDefinedNetInfo) GetNetInfo() NetInfo {
@@ -887,8 +888,7 @@ func (nInfo *userDefinedNetInfo) Transport() string {
 
 // OutboundSNAT() string returns the outbound SNAT configuration for this network when using no-overlay transport.
 func (nInfo *userDefinedNetInfo) OutboundSNAT() string {
-	// TODO: implement per-network no-overlay outbound SNAT configuration
-	return ""
+	return nInfo.outboundSNAT
 }
 
 // EVPNVTEPName returns the name of the VTEP CR for EVPN
@@ -1084,6 +1084,9 @@ func (nInfo *userDefinedNetInfo) canReconcile(other NetInfo) bool {
 	if nInfo.EVPNIPVRFRouteTarget() != other.EVPNIPVRFRouteTarget() {
 		return false
 	}
+	if nInfo.OutboundSNAT() != other.OutboundSNAT() {
+		return false
+	}
 
 	lessCIDRNetworkEntry := func(a, b config.CIDRNetworkEntry) bool { return a.String() < b.String() }
 	if !cmp.Equal(nInfo.Subnets(), other.Subnets(), cmpopts.SortSlices(lessCIDRNetworkEntry)) {
@@ -1131,6 +1134,7 @@ func (nInfo *userDefinedNetInfo) copy() *userDefinedNetInfo {
 		managementIPs:         nInfo.managementIPs,
 		transport:             nInfo.transport,
 		evpn:                  nInfo.evpn,
+		outboundSNAT:          nInfo.outboundSNAT,
 	}
 	// copy mutables
 	c.mutableNetInfo.copyFrom(&nInfo.mutableNetInfo)
@@ -1155,6 +1159,7 @@ func newLayer3NetConfInfo(netconf *ovncnitypes.NetConf) (MutableNetInfo, error) 
 		mtu:            netconf.MTU,
 		transport:      netconf.Transport,
 		evpn:           netconf.EVPN,
+		outboundSNAT:   netconf.OutboundSNAT,
 		mutableNetInfo: mutableNetInfo{
 			id:      types.InvalidID,
 			nads:    sets.Set[string]{},
@@ -1571,6 +1576,18 @@ func ValidateNetConf(nadName string, netconf *ovncnitypes.NetConf) error {
 			types.NetworkTransportNoOverlay,
 			types.NetworkTransportEVPN,
 		})
+	}
+	if netconf.OutboundSNAT != "" {
+		if netconf.Transport != types.NetworkTransportNoOverlay {
+			return fmt.Errorf("outboundSNAT is only valid when transport is %q", types.NetworkTransportNoOverlay)
+		}
+		if netconf.OutboundSNAT != types.NoOverlaySNATEnabled &&
+			netconf.OutboundSNAT != types.NoOverlaySNATDisabled {
+			return fmt.Errorf("invalid outboundSNAT %q: must be one of %q", netconf.OutboundSNAT, []string{
+				types.NoOverlaySNATEnabled,
+				types.NoOverlaySNATDisabled,
+			})
+		}
 	}
 
 	if netconf.JoinSubnet != "" && netconf.Topology == types.LocalnetTopology {

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -1763,6 +1763,70 @@ func TestSubnetOverlapCheck(t *testing.T) {
 	}
 }
 
+func TestValidateNetConfOutboundSNAT(t *testing.T) {
+	tests := []struct {
+		name          string
+		transport     string
+		outboundSNAT  string
+		expectedError string
+	}{
+		{
+			name:         "empty outboundSNAT is accepted without no-overlay transport",
+			outboundSNAT: "",
+		},
+		{
+			name:         "enabled outboundSNAT is accepted with no-overlay transport",
+			transport:    ovntypes.NetworkTransportNoOverlay,
+			outboundSNAT: ovntypes.NoOverlaySNATEnabled,
+		},
+		{
+			name:         "disabled outboundSNAT is accepted with no-overlay transport",
+			transport:    ovntypes.NetworkTransportNoOverlay,
+			outboundSNAT: ovntypes.NoOverlaySNATDisabled,
+		},
+		{
+			name:          "enabled outboundSNAT is rejected without no-overlay transport",
+			outboundSNAT:  ovntypes.NoOverlaySNATEnabled,
+			expectedError: `outboundSNAT is only valid when transport is "no-overlay"`,
+		},
+		{
+			name:          "enabled outboundSNAT is rejected with EVPN transport",
+			transport:     ovntypes.NetworkTransportEVPN,
+			outboundSNAT:  ovntypes.NoOverlaySNATEnabled,
+			expectedError: `outboundSNAT is only valid when transport is "no-overlay"`,
+		},
+		{
+			name:          "invalid outboundSNAT is rejected with no-overlay transport",
+			transport:     ovntypes.NetworkTransportNoOverlay,
+			outboundSNAT:  "maybe",
+			expectedError: `invalid outboundSNAT "maybe"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			nadName := "namespace/network"
+			netconf := &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					Name: "network",
+				},
+				NADName:      nadName,
+				Topology:     ovntypes.Layer3Topology,
+				Transport:    test.transport,
+				OutboundSNAT: test.outboundSNAT,
+			}
+
+			err := ValidateNetConf(nadName, netconf)
+			if test.expectedError != "" {
+				g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(test.expectedError)))
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		})
+	}
+}
+
 func TestNewNetInfo(t *testing.T) {
 	type testConfig struct {
 		desc          string

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -865,6 +865,21 @@ func getPodAnnotationIPsForAttachmentByIndex(k8sClient clientset.Interface, podN
 	return ipnets[index].IP.String(), nil
 }
 
+func getPodAnnotationIPsForAttachmentByIPFamily(k8sClient clientset.Interface, podNamespace string, podName string, attachmentName string, family utilnet.IPFamily) (string, error) {
+	ipnets, err := getPodAnnotationIPsForAttachment(k8sClient, podNamespace, podName, attachmentName)
+	if err != nil {
+		return "", err
+	}
+	if len(ipnets) > 2 {
+		return "", fmt.Errorf("attachment for network %q with more than two IPs", attachmentName)
+	}
+	ipnet := getFirstCIDROfFamily(family, ipnets)
+	if ipnet == nil {
+		return "", fmt.Errorf("no %s IP for attachment %s on pod %s", family, attachmentName, namespacedName(podNamespace, podName))
+	}
+	return ipnet.IP.String(), nil
+}
+
 // generateIPsFromSubnets generates IP addresses from the given subnets with the specified offset
 func generateIPsFromSubnets(subnets []string, offset int) ([]string, error) {
 	var addrs []string

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1836,9 +1836,6 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in same UDN network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
-						if cudnATemplate.Spec.Network.Transport == udnv1.TransportOptionNoOverlay {
-							e2eskipper.Skipf("ETP=Cluster cross-node NodePort not supported for NoOverlay networks, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6316")
-						}
 						clientPod := podsNetA[0]
 						// The service is backed by pods in podsNetA.
 						// We want to hit the nodeport on a different node.
@@ -1881,9 +1878,6 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in different UDN network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
-						if cudnATemplate.Spec.Network.Transport == udnv1.TransportOptionNoOverlay {
-							e2eskipper.Skipf("ETP=Cluster cross-node NodePort not supported for NoOverlay networks, see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6316")
-						}
 						clientPod := podsNetA[0]
 						// The service is backed by podNetB.
 						// We want to hit the nodeport on a different node from the client.

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -754,6 +754,25 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				return condition.Reason
 			}, 30*time.Second, time.Second).Should(gomega.Equal("Accepted"))
 
+			// Check CUDN TransportAccepted condition is True after RA is created
+			if cudnTemplate.Spec.Network.Transport != "" && cudnTemplate.Spec.Network.Transport != udnv1.TransportOption("Geneve") {
+				ginkgo.By("ensure CUDN TransportAccepted condition is True")
+				gomega.Eventually(func(g gomega.Gomega) {
+					cudnObj, err := f.DynamicClient.Resource(clusterUDNGVR).Get(context.Background(), cUDN.Name, metav1.GetOptions{}, "status")
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					conditions, err := getConditions(cudnObj)
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					for _, condition := range conditions {
+						if condition.Type == "TransportAccepted" {
+							g.Expect(string(condition.Status)).To(gomega.Equal("True"))
+							g.Expect(condition.Message).To(gomega.Equal("Transport has been configured as 'no-overlay'."))
+							return
+						}
+					}
+					g.Expect(false).To(gomega.BeTrue(), "TransportAccepted condition not found in CUDN %s", cUDN.Name)
+				}, 30*time.Second, time.Second).Should(gomega.Succeed())
+			}
+
 			gomega.Expect(len(serverContainerIPs)).To(gomega.BeNumerically(">", 0))
 
 			// -----------------               ------------------                         ---------------------
@@ -876,7 +895,14 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				}
 			}
 
-			ginkgo.By("queries to the external server are not SNATed (uses podIP)")
+			expectSNAT := cudnTemplate.Spec.Network.NoOverlay != nil &&
+				cudnTemplate.Spec.Network.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+
+			if expectSNAT {
+				ginkgo.By("queries to the external server are SNATed (uses node IP) since OutboundSNAT is enabled")
+			} else {
+				ginkgo.By("queries to the external server are not SNATed (uses podIP)")
+			}
 			for _, serverContainerIP := range serverContainerIPs {
 				podIP, err := getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 0)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -896,23 +922,35 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 					framework.Poll,
 					60*time.Second)
 				framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
-				if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
-					if isIPv4Supported(f.ClientSet) && isIPv6Supported(f.ClientSet) {
-						// for dualstack we need to fetch the IP at index1
-						// if singlestack IPV6 the original podIP at index0 is the correct one
-						// FIXME: This util call assumes the first index will always be the IPv4 address
-						// and second index will always be the IPv6 address
-						// which is not always the case.
-						podIP, err = getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 1)
+
+				if expectSNAT {
+					// When OutboundSNAT is enabled, traffic to external destinations
+					// is masqueraded to the node IP. Verify the source is NOT the pod IP.
+					sourceIP := strings.Split(stdout, ":")[0]
+					if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
+						sourceIP = strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
 					}
-					// For IPv6 addresses, need to handle the brackets in the output
-					outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
-					gomega.Expect(outputIP).To(gomega.Equal(podIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					gomega.Expect(sourceIP).NotTo(gomega.Equal(podIP),
+						fmt.Sprintf("Expected SNAT for pod %s but traffic was not SNATed, output: %v", echoClientPodName, stdout))
 				} else {
-					// Original IPv4 handling
-					gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(podIP),
-						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
+						if isIPv4Supported(f.ClientSet) && isIPv6Supported(f.ClientSet) {
+							// for dualstack we need to fetch the IP at index1
+							// if singlestack IPV6 the original podIP at index0 is the correct one
+							// FIXME: This util call assumes the first index will always be the IPv4 address
+							// and second index will always be the IPv6 address
+							// which is not always the case.
+							podIP, err = getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 1)
+						}
+						// For IPv6 addresses, need to handle the brackets in the output
+						outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
+						gomega.Expect(outputIP).To(gomega.Equal(podIP),
+							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					} else {
+						// Original IPv4 handling
+						gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(podIP),
+							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
+					}
 				}
 			}
 		},
@@ -957,6 +995,106 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
 								NetworkSelector: metav1.LabelSelector{
 									MatchLabels: map[string]string{"bgp-l3": ""},
+								},
+							},
+						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
+					},
+				},
+			},
+		),
+		ginkgo.Entry("layer3 no-overlay SNAT enabled unmanaged routing", feature.NoOverlay,
+			&udnv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bgp-l3a-",
+					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+				},
+				Spec: udnv1.ClusterUserDefinedNetworkSpec{
+					Network: udnv1.NetworkSpec{
+						Topology: udnv1.NetworkTopologyLayer3,
+						Layer3: &udnv1.Layer3Config{
+							Role: "Primary",
+							Subnets: []udnv1.Layer3Subnet{{
+								CIDR:       "103.103.0.0/16",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "2014:100:200::0/60",
+								HostSubnet: 64,
+							}},
+						},
+						Transport: udnv1.TransportOptionNoOverlay,
+						NoOverlay: &udnv1.NoOverlayConfig{
+							OutboundSNAT: udnv1.SNATEnabled,
+							Routing:      udnv1.RoutingUnmanaged,
+						},
+					},
+				},
+			},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-udn-layer3-no-overlay-snat-enabled-unmanaged-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-enabled-unmanaged": ""},
+								},
+							},
+						},
+					},
+					NodeSelector:             metav1.LabelSelector{},
+					FRRConfigurationSelector: metav1.LabelSelector{},
+					Advertisements: []rav1.AdvertisementType{
+						rav1.PodNetwork,
+					},
+				},
+			},
+		),
+		ginkgo.Entry("layer3 no-overlay SNAT disabled unmanaged routing", feature.NoOverlay,
+			&udnv1.ClusterUserDefinedNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bgp-l3b-",
+					Labels:       map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
+				},
+				Spec: udnv1.ClusterUserDefinedNetworkSpec{
+					Network: udnv1.NetworkSpec{
+						Topology: udnv1.NetworkTopologyLayer3,
+						Layer3: &udnv1.Layer3Config{
+							Role: "Primary",
+							Subnets: []udnv1.Layer3Subnet{{
+								CIDR:       "103.103.0.0/16",
+								HostSubnet: 24,
+							}, {
+								CIDR:       "2014:100:200::0/60",
+								HostSubnet: 64,
+							}},
+						},
+						Transport: udnv1.TransportOptionNoOverlay,
+						NoOverlay: &udnv1.NoOverlayConfig{
+							OutboundSNAT: udnv1.SNATDisabled,
+							Routing:      udnv1.RoutingUnmanaged,
+						},
+					},
+				},
+			},
+			&rav1.RouteAdvertisements{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bgp-udn-layer3-no-overlay-snat-disabled-unmanaged-ra",
+				},
+				Spec: rav1.RouteAdvertisementsSpec{
+					NetworkSelectors: apitypes.NetworkSelectors{
+						apitypes.NetworkSelector{
+							NetworkSelectionType: apitypes.ClusterUserDefinedNetworks,
+							ClusterUserDefinedNetworkSelector: &apitypes.ClusterUserDefinedNetworkSelector{
+								NetworkSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"bgp-udn-layer3-no-overlay-snat-disabled-unmanaged": ""},
 								},
 							},
 						},
@@ -2391,10 +2529,40 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			},
 		}
 	}
+	layer3NoOverlaySNATEnabledUnmanagedSpecGen := func(udnIPv4, udnIPv6 string, _ allocators.BGPAllocation) *udnv1.NetworkSpec {
+		return &udnv1.NetworkSpec{
+			Topology: udnv1.NetworkTopologyLayer3,
+			Layer3: &udnv1.Layer3Config{
+				Role:    udnv1.NetworkRolePrimary,
+				Subnets: []udnv1.Layer3Subnet{{CIDR: udnv1.CIDR(udnIPv4)}, {CIDR: udnv1.CIDR(udnIPv6)}},
+			},
+			Transport: udnv1.TransportOptionNoOverlay,
+			NoOverlay: &udnv1.NoOverlayConfig{
+				OutboundSNAT: udnv1.SNATEnabled,
+				Routing:      udnv1.RoutingUnmanaged,
+			},
+		}
+	}
+	layer3NoOverlaySNATDisabledUnmanagedSpecGen := func(udnIPv4, udnIPv6 string, _ allocators.BGPAllocation) *udnv1.NetworkSpec {
+		return &udnv1.NetworkSpec{
+			Topology: udnv1.NetworkTopologyLayer3,
+			Layer3: &udnv1.Layer3Config{
+				Role:    udnv1.NetworkRolePrimary,
+				Subnets: []udnv1.Layer3Subnet{{CIDR: udnv1.CIDR(udnIPv4)}, {CIDR: udnv1.CIDR(udnIPv6)}},
+			},
+			Transport: udnv1.TransportOptionNoOverlay,
+			NoOverlay: &udnv1.NoOverlayConfig{
+				OutboundSNAT: udnv1.SNATDisabled,
+				Routing:      udnv1.RoutingUnmanaged,
+			},
+		}
+	}
 
 	networksToTest := []ginkgo.TableEntry{
 		ginkgo.Entry("Layer 3 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer3NetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN VRF-Lite", cudnAdvertisedVRFLite, layer2NetworkSpecGen),
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT enabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATEnabledUnmanagedSpecGen),
+		ginkgo.Entry("Layer 3 CUDN VRF-Lite no-overlay SNAT disabled unmanaged routing", feature.NoOverlay, cudnAdvertisedVRFLite, layer3NoOverlaySNATDisabledUnmanagedSpecGen),
 		ginkgo.Entry("Layer 3 CUDN EVPN IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer3IPVRFNetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFNetworkSpecGen),
 		ginkgo.Entry("Layer 2 CUDN EVPN MAC-VRF and IP-VRF shared VTEP", feature.EVPN, cudnAdvertisedEVPNUnmanagedSharedVTEP, layer2MACVRFIPVRFNetworkSpecGen),
@@ -2407,6 +2575,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
 			var testNamespace *corev1.Namespace
 			var testPod *corev1.Pod
+			var networkSpec *udnv1.NetworkSpec
 
 			getSameNode := func() string {
 				return testPod.Spec.NodeName
@@ -2429,7 +2598,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				udnIPv4, udnIPv6 := bgpAlloc.UDNSubnet, bgpAlloc.UDNSubnet6
 
-				networkSpec := networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
+				networkSpec = networkSpecGen(udnIPv4, udnIPv6, bgpAlloc)
 				switch {
 				case networkSpec.Layer3 != nil:
 					networkSpec.Layer3.Subnets = matchL3SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer3.Subnets...)
@@ -2468,7 +2637,14 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 						if !ipFamilySet.Has(family) {
 							e2eskipper.Skipf("IP family %v not supported", family)
 						}
-						ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+						expectSNAT := networkSpec.NoOverlay != nil &&
+							networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled
+
+						if expectSNAT {
+							ginkgo.By("Ensuring a request from the pod can reach the external servers (SNATed since OutboundSNAT is enabled)")
+						} else {
+							ginkgo.By("Ensuring a request from the pod can reach the external servers without being SNATed")
+						}
 						for _, externalServer := range externalServers {
 							bgpServerNetwork, err := infraprovider.Get().GetNetwork(externalServer)
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2482,17 +2658,42 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							framework.Logf("Checking request from pod reaches server %q", externalServer)
 							testPodToHostnameAndExpect(testPod, serverIP, externalServer)
 
-							testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
-								f.ClientSet,
-								testPod.Namespace,
-								testPod.Name,
-								testNetworkName,
-								family,
-							)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
-							framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
-							testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+							if expectSNAT {
+								framework.Logf("Sending request from pod to server %q is SNATed (OutboundSNAT enabled)", externalServer)
+								// When OutboundSNAT is enabled, pod-to-external traffic is masqueraded
+								// to the node IP.
+								ip, err := e2epodoutput.RunHostCmdWithRetries(
+									testPod.Namespace,
+									testPod.Name,
+									fmt.Sprintf("curl --max-time %d -g -q -s http://%s/clientip", curlMaxTime, net.JoinHostPort(serverIP, netexecPortStr)),
+									polling,
+									timeout,
+								)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								sourceIP, _, err := net.SplitHostPort(ip)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								testPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testPod.Spec.NodeName, metav1.GetOptions{})
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(testPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
+								if family == utilnet.IPv6 {
+									expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(testPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
+								}
+								gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", testPodNode.Name, family)
+								gomega.Expect(sourceIP).To(gomega.Equal(expectedNodeIPs[0]),
+									fmt.Sprintf("Expected SNAT for pod %s to use node IP %s, output: %v", testPod.Name, expectedNodeIPs[0], ip))
+							} else {
+								testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
+									f.ClientSet,
+									testPod.Namespace,
+									testPod.Name,
+									testNetworkName,
+									family,
+								)
+								gomega.Expect(err).NotTo(gomega.HaveOccurred())
+								gomega.Expect(testPodIP).ToNot(gomega.BeEmpty())
+								framework.Logf("Sending request from pod to server %q is not SNATed", externalServer)
+								testPodToClientIPAndExpect(testPod, serverIP, testPodIP)
+							}
 						}
 					},
 					ginkgo.Entry("When the network is IPv4", utilnet.IPv4),

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -903,6 +903,14 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 			} else {
 				ginkgo.By("queries to the external server are not SNATed (uses podIP)")
 			}
+			var expectedSNATSourceIPs []string
+			if expectSNAT {
+				clientPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
+				framework.ExpectNoError(err, fmt.Sprintf("Getting node %s failed: %v", clientPod.Spec.NodeName, err))
+				expectedSNATSourceIPs = e2enode.GetAddresses(clientPodNode, corev1.NodeInternalIP)
+				gomega.Expect(expectedSNATSourceIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP", clientPod.Spec.NodeName)
+				framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
+			}
 			for _, serverContainerIP := range serverContainerIPs {
 				podIP, err := getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 0)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -923,34 +931,21 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 					60*time.Second)
 				framework.ExpectNoError(err, fmt.Sprintf("Testing pod to external traffic failed: %v", err))
 
+				sourceIP, _, err := net.SplitHostPort(strings.TrimSpace(stdout))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					fmt.Sprintf("Failed to parse client address from output %q", stdout))
 				if expectSNAT {
 					// When OutboundSNAT is enabled, traffic to external destinations
 					// is masqueraded to the node IP. Verify the source is NOT the pod IP.
-					sourceIP := strings.Split(stdout, ":")[0]
-					if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
-						sourceIP = strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
-					}
-					gomega.Expect(sourceIP).NotTo(gomega.Equal(podIP),
-						fmt.Sprintf("Expected SNAT for pod %s but traffic was not SNATed, output: %v", echoClientPodName, stdout))
+					expectedSourceIP := getFirstIPStringOfFamily(utilnet.IPFamilyOfString(serverContainerIP), expectedSNATSourceIPs)
+					gomega.Expect(expectedSourceIP).NotTo(gomega.BeEmpty(),
+						"Expected node %s to have an InternalIP for the external server IP family %s",
+						clientPod.Spec.NodeName, serverContainerIP)
+					gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+						fmt.Sprintf("Expected SNAT for pod %s to use %s, output: %v", echoClientPodName, expectedSourceIP, stdout))
 				} else {
-					if isIPv6Supported(f.ClientSet) && utilnet.IsIPv6String(serverContainerIP) {
-						if isIPv4Supported(f.ClientSet) && isIPv6Supported(f.ClientSet) {
-							// for dualstack we need to fetch the IP at index1
-							// if singlestack IPV6 the original podIP at index0 is the correct one
-							// FIXME: This util call assumes the first index will always be the IPv4 address
-							// and second index will always be the IPv6 address
-							// which is not always the case.
-							podIP, err = getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 1)
-						}
-						// For IPv6 addresses, need to handle the brackets in the output
-						outputIP := strings.TrimPrefix(strings.Split(stdout, "]:")[0], "[")
-						gomega.Expect(outputIP).To(gomega.Equal(podIP),
-							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
-					} else {
-						// Original IPv4 handling
-						gomega.Expect(strings.Split(stdout, ":")[0]).To(gomega.Equal(podIP),
-							fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
-					}
+					gomega.Expect(sourceIP).To(gomega.Equal(podIP),
+						fmt.Sprintf("Testing pod %s to external traffic failed while analysing output %v", echoClientPodName, stdout))
 				}
 			}
 		},
@@ -2216,12 +2211,13 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		networkType networkType,
 		networkSpec *udnv1.NetworkSpec,
 		bgpAlloc allocators.BGPAllocation,
-	) (*corev1.Namespace, []string) {
+	) (*corev1.Namespace, []string, map[string]infraapi.NetworkInterface) {
 		ginkgo.GinkgoHelper()
 
 		framework.Logf("Configuring the infra for network %s of type %s with allocations %#v", networkName, networkType, bgpAlloc)
 
 		var servers []string
+		vrfLiteNodeInterfaces := map[string]infraapi.NetworkInterface{}
 		switch networkType {
 		case cudnAdvertisedVRFLite:
 			ginkgo.By("Running an external BGP network")
@@ -2314,6 +2310,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			for _, node := range nodeList.Items {
 				iface, err := infraprovider.Get().GetK8NodeNetworkInterface(node.Name, network)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				vrfLiteNodeInterfaces[node.Name] = iface
 				if ipFamilySet.Has(utilnet.IPv6) {
 					// prevent the IPv6 address of the interface from being removed when attaching to VRF
 					_, err = infraprovider.Get().ExecK8NodeCommand(node.Name, []string{"sysctl", "-w", "net.ipv6.conf." + iface.InfName + ".keep_addr_on_down=1"})
@@ -2324,7 +2321,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			}
 		}
 
-		return testNamespace, servers
+		return testNamespace, servers, vrfLiteNodeInterfaces
 	}
 
 	// testing helpers used throughout this testing node
@@ -2569,7 +2566,29 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		func(testedNetworkType networkType, networkSpecGen func(string, string, allocators.BGPAllocation) *udnv1.NetworkSpec) {
 			var testNamespace *corev1.Namespace
 			var testPod *corev1.Pod
+			var vrfLiteNodeInterfaces map[string]infraapi.NetworkInterface
 			var networkSpec *udnv1.NetworkSpec
+
+			expectedSNATSourceIP := func(family utilnet.IPFamily, node *corev1.Node) string {
+				ginkgo.GinkgoHelper()
+				// In LGW VRF-Lite, host nftables masquerade picks the source IP
+				// from the node's egress interface in the target VRF when no-overlay
+				// outbound SNAT is enabled.
+				if networkSpec.NoOverlay != nil && networkSpec.NoOverlay.OutboundSNAT == udnv1.SNATEnabled &&
+					testedNetworkType == cudnAdvertisedVRFLite && IsGatewayModeLocal(f.ClientSet) {
+					iface, ok := vrfLiteNodeInterfaces[node.Name]
+					gomega.Expect(ok).To(gomega.BeTrue(), "Expected VRF-Lite egress interface for node %s", node.Name)
+					expectedIP := getFirstIPStringOfFamily(family, []string{iface.IPv4, iface.IPv6})
+					gomega.Expect(expectedIP).NotTo(gomega.BeEmpty(), "Expected VRF-Lite egress interface for node %s to have an IP for %v", node.Name, family)
+					return expectedIP
+				}
+				expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv4Protocol)
+				if family == utilnet.IPv6 {
+					expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(node, corev1.NodeInternalIP, corev1.IPv6Protocol)
+				}
+				gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", node.Name, family)
+				return expectedNodeIPs[0]
+			}
 
 			getSameNode := func() string {
 				return testPod.Spec.NodeName
@@ -2600,7 +2619,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 					networkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, networkSpec.Layer2.Subnets...)
 				}
 
-				testNamespace, externalServers = configureNetworkWithInfra(
+				testNamespace, externalServers, vrfLiteNodeInterfaces = configureNetworkWithInfra(
 					f,
 					ictx,
 					testBaseName,
@@ -2624,6 +2643,10 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 							p.Spec.Containers[0].Args = []string{"netexec"}
 						},
 					)
+					var err error
+					testPod, err = f.ClientSet.CoreV1().Pods(testPod.Namespace).Get(context.Background(), testPod.Name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Expect(testPod.Spec.NodeName).NotTo(gomega.BeEmpty())
 				})
 
 				ginkgo.DescribeTable("It can reach external servers on the same network",
@@ -2668,13 +2691,9 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 								gomega.Expect(err).NotTo(gomega.HaveOccurred())
 								testPodNode, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), testPod.Spec.NodeName, metav1.GetOptions{})
 								gomega.Expect(err).NotTo(gomega.HaveOccurred())
-								expectedNodeIPs := e2enode.GetAddressesByTypeAndFamily(testPodNode, corev1.NodeInternalIP, corev1.IPv4Protocol)
-								if family == utilnet.IPv6 {
-									expectedNodeIPs = e2enode.GetAddressesByTypeAndFamily(testPodNode, corev1.NodeInternalIP, corev1.IPv6Protocol)
-								}
-								gomega.Expect(expectedNodeIPs).NotTo(gomega.BeEmpty(), "Expected node %s to have an InternalIP for %v", testPodNode.Name, family)
-								gomega.Expect(sourceIP).To(gomega.Equal(expectedNodeIPs[0]),
-									fmt.Sprintf("Expected SNAT for pod %s to use node IP %s, output: %v", testPod.Name, expectedNodeIPs[0], ip))
+								expectedSourceIP := expectedSNATSourceIP(family, testPodNode)
+								gomega.Expect(sourceIP).To(gomega.Equal(expectedSourceIP),
+									fmt.Sprintf("Expected SNAT for pod %s to use node egress IP %s, output: %v", testPod.Name, expectedSourceIP, ip))
 							} else {
 								testPodIP, err := getPodAnnotationIPsForPrimaryNetworkByIPFamily(
 									f.ClientSet,
@@ -2934,7 +2953,7 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 									otherNetworkSpec.Layer2.Subnets = matchL2SubnetsByIPFamilies(ipFamilySet, otherNetworkSpec.Layer2.Subnets...)
 								}
 
-								otherNamespace, _ = configureNetworkWithInfra(
+								otherNamespace, _, _ = configureNetworkWithInfra(
 									f,
 									ictx,
 									testBaseName,

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -28,6 +28,7 @@ import (
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
 	udnclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/clientset/versioned"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	ovnutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
@@ -2303,6 +2304,80 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 		switch networkType {
 		case cudnAdvertisedVRFLite:
 			ginkgo.By("Attaching the BGP peer network to the CUDN VRF")
+			const (
+				vrfLiteInfraTimeout = 60 * time.Second
+				vrfLiteInfraPolling = time.Second
+			)
+			waitForNodeLink := func(nodeName, linkName string) {
+				ginkgo.GinkgoHelper()
+				gomega.Eventually(func() error {
+					_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "link", "show", "dev", linkName})
+					return err
+				}).WithTimeout(vrfLiteInfraTimeout).WithPolling(vrfLiteInfraPolling).Should(
+					gomega.Succeed(),
+					"expected link %q to exist on node %q",
+					linkName,
+					nodeName,
+				)
+			}
+			waitForNodePatchPort := func(nodeName string) {
+				ginkgo.GinkgoHelper()
+				scopedNodeName := ovnutil.GetUserDefinedNetworkPrefix(types.CUDNPrefix+networkName) + nodeName
+				patchPortName := ovnutil.GetPatchPortName(deploymentconfig.Get().ExternalBridgeName(), scopedNodeName)
+				gomega.Eventually(func() error {
+					pods, err := f.ClientSet.CoreV1().Pods(deploymentconfig.Get().OVNKubernetesNamespace()).List(context.Background(), metav1.ListOptions{
+						LabelSelector: "app=ovnkube-node",
+						FieldSelector: "spec.nodeName=" + nodeName,
+					})
+					if err != nil {
+						return err
+					}
+					if len(pods.Items) == 0 {
+						return fmt.Errorf("failed to find ovnkube-node pod on node %q", nodeName)
+					}
+					command := fmt.Sprintf("ovs-vsctl --timeout=15 get Interface %s ofport", patchPortName)
+					output, err := e2epodoutput.RunHostCmd(pods.Items[0].Namespace, pods.Items[0].Name, command)
+					if err != nil {
+						return fmt.Errorf("failed to get ofport for patch port %q on node %q: %w", patchPortName, nodeName, err)
+					}
+					ofPort := strings.TrimSpace(output)
+					if ofPort == "" || ofPort == "[]" || ofPort == "-1" {
+						return fmt.Errorf("patch port %q on node %q has no valid ofport: %q", patchPortName, nodeName, ofPort)
+					}
+					return nil
+				}).WithTimeout(vrfLiteInfraTimeout).WithPolling(vrfLiteInfraPolling).Should(
+					gomega.Succeed(),
+					"expected patch port for network %q on node %q to have a valid ofport",
+					networkName,
+					nodeName,
+				)
+			}
+			attachInterfaceToVRF := func(nodeName string, iface infraapi.NetworkInterface) {
+				ginkgo.GinkgoHelper()
+				gomega.Eventually(func() error {
+					// This is idempotent when the interface is already attached to the VRF.
+					if _, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "link", "set", "dev", iface.InfName, "master", networkName}); err != nil {
+						return err
+					}
+					output, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"ip", "-o", "link", "show", "dev", iface.InfName})
+					if err != nil {
+						return err
+					}
+					fields := strings.Fields(output)
+					for idx := 0; idx < len(fields)-1; idx++ {
+						if fields[idx] == "master" && fields[idx+1] == networkName {
+							return nil
+						}
+					}
+					return fmt.Errorf("interface %q on node %q is not attached to VRF %q: %s", iface.InfName, nodeName, networkName, output)
+				}).WithTimeout(vrfLiteInfraTimeout).WithPolling(vrfLiteInfraPolling).Should(
+					gomega.Succeed(),
+					"expected interface %q on node %q to be attached to VRF %q",
+					iface.InfName,
+					nodeName,
+					networkName,
+				)
+			}
 			nodeList, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			network, err := infraprovider.Get().GetNetwork(networkName)
@@ -2310,14 +2385,16 @@ var _ = ginkgo.Describe("BGP: For BGP configured networks", feature.RouteAdverti
 			for _, node := range nodeList.Items {
 				iface, err := infraprovider.Get().GetK8NodeNetworkInterface(node.Name, network)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				vrfLiteNodeInterfaces[node.Name] = iface
+				waitForNodeLink(node.Name, iface.InfName)
+				waitForNodeLink(node.Name, networkName)
+				waitForNodePatchPort(node.Name)
 				if ipFamilySet.Has(utilnet.IPv6) {
 					// prevent the IPv6 address of the interface from being removed when attaching to VRF
 					_, err = infraprovider.Get().ExecK8NodeCommand(node.Name, []string{"sysctl", "-w", "net.ipv6.conf." + iface.InfName + ".keep_addr_on_down=1"})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
-				_, err = infraprovider.Get().ExecK8NodeCommand(node.Name, []string{"ip", "link", "set", "dev", iface.InfName, "master", networkName})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				attachInterfaceToVRF(node.Name, iface)
+				vrfLiteNodeInterfaces[node.Name] = iface
 			}
 		}
 

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1147,7 +1147,6 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 
 var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks", feature.RouteAdvertisements,
 	func(cudnATemplate, cudnBTemplate *udnv1.ClusterUserDefinedNetwork) {
-		const curlConnectionResetCode = "56"
 		const curlConnectionTimeoutCode = "28"
 
 		f := wrappedTestFramework("bgp-network-isolation")
@@ -1915,22 +1914,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
-							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
-						}
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", "", false
 					}),
 
 				ginkgo.Entry("[ETP=LOCAL] UDN pod to the same node nodeport service in different UDN network should not work",
@@ -1958,23 +1942,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
-							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
-						}
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", "", false
 					}),
 				ginkgo.Entry("[ETP=LOCAL] UDN pod to the same node nodeport service in default network should not work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
@@ -2032,23 +2000,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						out := ""
-						errBool := false
-
-						// FIXME https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5531#issuecomment-3749407414
-						// There is a new option on ovn 25.03 and further called "ct-commit-all" that can be set for each LR.
-						// This should avoid the mentioned issue.
-						if IsGatewayModeLocal(f.ClientSet) {
-							// FIXME: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5846
-							// its supposed to fail with 56 error code which is fine
-							// but due to this fwmark bug it ends up failing wtih 28 error code that's not expected.
-							out = curlConnectionTimeoutCode
-							errBool = true
-							if ipFamily == utilnet.IPv4 || (ipFamily == utilnet.IPv6 && !isIPv4Supported(f.ClientSet)) {
-								out = curlConnectionResetCode
-							}
-						}
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", out, errBool
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", "", false
 					}),
 			)
 		})

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1149,6 +1149,10 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks", feature.RouteAdvertisements,
 	func(cudnATemplate, cudnBTemplate *udnv1.ClusterUserDefinedNetwork) {
 		const curlConnectionTimeoutCode = "28"
+		const nodePortBackendLabel = "nodeport-backend"
+		const clientNodeBackend = "client-node"
+		const remoteNodeBackend = "remote-node"
+		const nodePortNodeBackend = "nodeport-node"
 
 		f := wrappedTestFramework("bgp-network-isolation")
 		f.SkipNamespaceCreation = true
@@ -1159,7 +1163,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 
 		// podNetB is in cudnB hosted on nodes[1], podNetDefault is in the default network hosted on nodes[1] - done in BeforeEach
 		var podNetB, podNetDefault *corev1.Pod
-		var svcNodePortNetA, svcNodePortNetB, svcNodePortNetDefault, svcNodePortETPLocalDefault, svcNodePortETPLocalNetA *corev1.Service
+		var svcNodePortNetA, svcNodePortNetAClientNodeBackend, svcNodePortNetARemoteNodeBackend, svcNodePortNetANodePortNodeBackend, svcNodePortNetB, svcNodePortNetDefault, svcNodePortETPLocalDefault, svcNodePortETPLocalNetA *corev1.Service
 		var cudnA, cudnB *udnv1.ClusterUserDefinedNetwork
 		var ra *rav1.RouteAdvertisements
 		var hostNetworkPort int
@@ -1270,7 +1274,10 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					p.Labels = map[string]string{"network": cudnA.Name}
 				}
 				podNetASpecs[2].Spec.NodeName = nodes.Items[1].Name
+				podNetASpecs[2].Labels[nodePortBackendLabel] = remoteNodeBackend
 				podNetASpecs[3].Spec.NodeName = nodes.Items[2].Name
+				podNetASpecs[3].Labels[nodePortBackendLabel] = nodePortNodeBackend
+				podNetASpecs[1].Labels[nodePortBackendLabel] = clientNodeBackend
 
 				podNetBSpec := e2epod.NewAgnhostPod(udnNamespaceB.Name, fmt.Sprintf("pod-1-%s-net-%s", nodes.Items[1].Name, cudnB.Name), nil, nil, []corev1.ContainerPort{{ContainerPort: 8080}}, "netexec")
 				podNetBSpec.Spec.NodeName = nodes.Items[1].Name
@@ -1297,6 +1304,19 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 				svc.Spec.Type = corev1.ServiceTypeNodePort
 				svcNodePortNetA, err = f.ClientSet.CoreV1().Services(udnNamespaceA.Name).Create(context.Background(), svc, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				createNodePortNetAService := func(name, backend string) *corev1.Service {
+					svc := e2eservice.CreateServiceSpec(name, "", false, map[string]string{"network": cudnA.Name, nodePortBackendLabel: backend})
+					svc.Spec.Ports = []corev1.ServicePort{{Port: 8080}}
+					svc.Spec.IPFamilyPolicy = &familyPolicy
+					svc.Spec.Type = corev1.ServiceTypeNodePort
+					svc, err := f.ClientSet.CoreV1().Services(udnNamespaceA.Name).Create(context.Background(), svc, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					return svc
+				}
+				svcNodePortNetAClientNodeBackend = createNodePortNetAService(fmt.Sprintf("service-%s-client-node-backend", cudnA.Name), clientNodeBackend)
+				svcNodePortNetARemoteNodeBackend = createNodePortNetAService(fmt.Sprintf("service-%s-remote-node-backend", cudnA.Name), remoteNodeBackend)
+				svcNodePortNetANodePortNodeBackend = createNodePortNetAService(fmt.Sprintf("service-%s-nodeport-node-backend", cudnA.Name), nodePortNodeBackend)
 
 				svc.Name = fmt.Sprintf("service-%s", cudnB.Name)
 				svc.Namespace = udnNamespaceB.Name
@@ -1500,6 +1520,17 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					udnNamespaceB = nil
 				}
 			})
+
+			nodePortServiceTarget := func(ipFamily utilnet.IPFamily, nodeName string, svc *corev1.Service) string {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				nodeIPv4, nodeIPv6 := getNodeAddresses(node)
+				nodeIP := nodeIPv4
+				if ipFamily == utilnet.IPv6 {
+					nodeIP = nodeIPv6
+				}
+				return net.JoinHostPort(nodeIP, fmt.Sprint(svc.Spec.Ports[0].NodePort)) + "/hostname"
+			}
 
 			ginkgo.DescribeTable("connectivity between networks",
 				func(connInfo func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool)) {
@@ -1832,23 +1863,23 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 						// Just check that the connection is successful.
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
 					}),
-				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in same UDN network should work",
+				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in same UDN network with backend on client node should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
 						clientPod := podsNetA[0]
-						// The service is backed by pods in podsNetA.
-						// We want to hit the nodeport on a different node.
-						// client is on nodes[0]. Let's hit nodeport on nodes[2].
-						node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[2].Name, metav1.GetOptions{})
-						framework.ExpectNoError(err)
-						nodeIPv4, nodeIPv6 := getNodeAddresses(node)
-						nodeIP := nodeIPv4
-						if ipFamily == utilnet.IPv6 {
-							nodeIP = nodeIPv6
-						}
-						nodePort := svcNodePortNetA.Spec.Ports[0].NodePort
-
-						// sourceIP will be joinSubnetIP for nodeports, so only using hostname endpoint
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", "", false
+						target := nodePortServiceTarget(ipFamily, nodes.Items[2].Name, svcNodePortNetAClientNodeBackend)
+						return clientPod.Name, clientPod.Namespace, target, podsNetA[1].Name, false
+					}),
+				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in same UDN network with backend on nodeport node should work",
+					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+						clientPod := podsNetA[0]
+						target := nodePortServiceTarget(ipFamily, nodes.Items[2].Name, svcNodePortNetANodePortNodeBackend)
+						return clientPod.Name, clientPod.Namespace, target, podsNetA[3].Name, false
+					}),
+				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in same UDN network with backend on a different node should work",
+					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
+						clientPod := podsNetA[0]
+						target := nodePortServiceTarget(ipFamily, nodes.Items[2].Name, svcNodePortNetARemoteNodeBackend)
+						return clientPod.Name, clientPod.Namespace, target, podsNetA[2].Name, false
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to the same node nodeport service in different UDN network should not work",
 					// FIXME: This test should work: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5419

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -1154,7 +1154,7 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 		f.SkipNamespaceCreation = true
 		var udnNamespaceA, udnNamespaceB *corev1.Namespace
 		var nodes *corev1.NodeList
-		// podsNetA has 3 pods in cudnA, two are on nodes[0] and the last one is on nodes[1] - done in BeforeEach
+		// podsNetA has 4 pods in cudnA, two on nodes[0], one on nodes[1], and one on nodes[2] - done in BeforeEach
 		var podsNetA []*corev1.Pod
 
 		// podNetB is in cudnB hosted on nodes[1], podNetDefault is in the default network hosted on nodes[1] - done in BeforeEach
@@ -1263,12 +1263,14 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					e2epod.NewAgnhostPod(udnNamespaceA.Name, fmt.Sprintf("pod-1-%s-net-%s", nodes.Items[0].Name, cudnA.Name), nil, nil, []corev1.ContainerPort{{ContainerPort: 8080}}, "netexec"),
 					e2epod.NewAgnhostPod(udnNamespaceA.Name, fmt.Sprintf("pod-2-%s-net-%s", nodes.Items[0].Name, cudnA.Name), nil, nil, []corev1.ContainerPort{{ContainerPort: 8080}}, "netexec"),
 					e2epod.NewAgnhostPod(udnNamespaceA.Name, fmt.Sprintf("pod-3-%s-net-%s", nodes.Items[1].Name, cudnA.Name), nil, nil, []corev1.ContainerPort{{ContainerPort: 8080}}, "netexec"),
+					e2epod.NewAgnhostPod(udnNamespaceA.Name, fmt.Sprintf("pod-4-%s-net-%s", nodes.Items[2].Name, cudnA.Name), nil, nil, []corev1.ContainerPort{{ContainerPort: 8080}}, "netexec"),
 				}
 				for _, p := range podNetASpecs {
 					p.Spec.NodeName = nodes.Items[0].Name
 					p.Labels = map[string]string{"network": cudnA.Name}
 				}
 				podNetASpecs[2].Spec.NodeName = nodes.Items[1].Name
+				podNetASpecs[3].Spec.NodeName = nodes.Items[2].Name
 
 				podNetBSpec := e2epod.NewAgnhostPod(udnNamespaceB.Name, fmt.Sprintf("pod-1-%s-net-%s", nodes.Items[1].Name, cudnB.Name), nil, nil, []corev1.ContainerPort{{ContainerPort: 8080}}, "netexec")
 				podNetBSpec.Spec.NodeName = nodes.Items[1].Name

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -913,7 +913,8 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 				framework.Logf("Client pod node IP addresses=%v", expectedSNATSourceIPs)
 			}
 			for _, serverContainerIP := range serverContainerIPs {
-				podIP, err := getPodAnnotationIPsForAttachmentByIndex(f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), 0)
+				podIP, err := getPodAnnotationIPsForAttachmentByIPFamily(
+					f.ClientSet, f.Namespace.Name, clientPod.Name, namespacedName(f.Namespace.Name, cUDN.Name), utilnet.IPFamilyOfString(serverContainerIP))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				framework.ExpectNoError(err, fmt.Sprintf("Getting podIPs for pod %s failed: %v", clientPod.Name, err))
 				framework.Logf("Client pod IP address=%s", podIP)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add OutboundSNAT option for user-defined no-overlay networks to control pod source IP exposure.
  * Make BGP external server host port configurable.

* **Improvements**
  * Refined SNAT generation for advertised networks with distinct shared vs local gateway behaviors.
  * Improved gateway, routing, bridge flow and conntrack handling for no-overlay local-gateway scenarios.
  * Stricter validation and compatibility checks for OutboundSNAT.

* **Tests**
  * Expanded unit and e2e tests covering OutboundSNAT, no-overlay routing, address-set behavior, and flow generation.

* **Documentation**
  * Update docs to clarify OutboundSNAT source-IP behavior and VRF-Lite notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->