### PR TITLE
Improves pkg/ovn/egressip performance

### DIFF
--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -38,6 +38,7 @@ import (
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
@@ -52,7 +53,7 @@ const (
 type InitClusterEgressPoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
 	ni util.NetInfo, clusterSubnets []*net.IPNet, controllerName, routerName string) error
 type EnsureNoRerouteNodePoliciesFunc func(client libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-	networkName, controllerName, clusterRouter string, nodeLister corelisters.NodeLister, v4, v6 bool) error
+	networkName, clusterRouter, controllerName string, clusterNodesAddressSets addressset.AddressSet, v4, v6 bool) error
 type DeleteLegacyDefaultNoRerouteNodePoliciesFunc func(nbClient libovsdbclient.Client, clusterRouter, nodeName string) error
 type CreateDefaultRouteToExternalFunc func(nbClient libovsdbclient.Client, clusterRouter, gwRouterName string, clusterSubnets []config.CIDRNetworkEntry, gatewayIPs []*net.IPNet) error
 
@@ -90,8 +91,9 @@ type Controller struct {
 
 	// An address set factory that creates address sets
 	addressSetFactory addressset.AddressSetFactory
-
-	zone string
+	// Shared address set manager that owns cluster-wide node IP address sets.
+	addressSetManager *addresssetmanager.AddressSetManager
+	zone              string
 }
 
 type svcState struct {
@@ -123,6 +125,7 @@ func NewController(
 	client kubernetes.Interface,
 	nbClient libovsdbclient.Client,
 	addressSetFactory addressset.AddressSetFactory,
+	addressSetManager *addresssetmanager.AddressSetManager,
 	initClusterEgressPolicies InitClusterEgressPoliciesFunc,
 	ensureNoRerouteNodePolicies EnsureNoRerouteNodePoliciesFunc,
 	createDefaultRouteToExternalForIC CreateDefaultRouteToExternalFunc,
@@ -140,6 +143,7 @@ func NewController(
 		client:                            client,
 		nbClient:                          nbClient,
 		addressSetFactory:                 addressSetFactory,
+		addressSetManager:                 addressSetManager,
 		initClusterEgressPolicies:         initClusterEgressPolicies,
 		ensureNoRerouteNodePolicies:       ensureNoRerouteNodePolicies,
 		createDefaultRouteToExternalForIC: createDefaultRouteToExternalForIC,

--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_node.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone_node.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -128,9 +129,19 @@ func (c *Controller) syncNode(key string) error {
 	}
 	// We ensure node no re-route policies contemplating possible node IP
 	// address changes regardless of allocated services.
+
+	// Ensure cluster node address sets (shared cluster-wide resource)
+	clusterNodeIPsAddrSetDbIDs, err := c.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressServiceBackRef)
+	if err != nil {
+		return fmt.Errorf("failed to ensure cluster node IP address set for EgressService: %w", err)
+	}
+	clusterNodesAddressSets, err := c.addressSetFactory.GetAddressSet(clusterNodeIPsAddrSetDbIDs)
+	if err != nil {
+		return fmt.Errorf("cannot ensure that addressSet %s exists %v", addresssetmanager.ClusterNodeIPsEgressServiceBackRef, err)
+	}
 	network := util.DefaultNetInfo{}
 	networkName := network.GetNetworkName()
-	err = c.ensureNoRerouteNodePolicies(c.nbClient, c.addressSetFactory, networkName, c.GetNetworkScopedClusterRouterName(), c.controllerName, c.nodeLister, config.IPv4Mode, config.IPv6Mode)
+	err = c.ensureNoRerouteNodePolicies(c.nbClient, c.addressSetFactory, networkName, c.GetNetworkScopedClusterRouterName(), c.controllerName, clusterNodesAddressSets, config.IPv4Mode, config.IPv6Mode)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -193,7 +192,7 @@ type EgressIPController struct {
 	// used as a locking mechanism to serialize egress IP processing on a per egress IP basis
 	// the order of locking should always be egressIPCache, then podAssignment, then nodeZoneState
 	egressIPCache *syncmap.SyncMap[bool]
-	// nodeUpdateMutex is used for three reasons:
+	// networkMutexes is used for three reasons:
 	// (1) to ensure safe handling of node ip address updates. VIP addresses are
 	// dynamic and might move across nodes.
 	// (2) used in ensureDefaultNoRerouteQoSRules function to ensure
@@ -201,7 +200,7 @@ type EgressIPController struct {
 	// at the same time by two different threads we end up creating duplicate
 	// QoS rules in database due to libovsdb cache race
 	// (3) to update nextHop during layer2 topology upgrade
-	nodeUpdateMutex *sync.Mutex
+	networkMutexes sync.Map
 	// podAssignment is a cache used for keeping track of which egressIP status
 	// has been set up for each pod. The key is defined by getPodKey
 	podAssignment *syncmap.SyncMap[*podAssignmentState]
@@ -249,7 +248,6 @@ func NewEIPController(
 		watchFactory:      watchFactory,
 		recorder:          recorder,
 		egressIPCache:     syncmap.NewSyncMap[bool](),
-		nodeUpdateMutex:   &sync.Mutex{},
 		podAssignment:     syncmap.NewSyncMap[*podAssignmentState](),
 		logicalPortCache:  portCache,
 		nodeZoneState:     syncmap.NewSyncMap[bool](),
@@ -272,6 +270,32 @@ func NewEIPController(
 		nadReconcilerConfig,
 	)
 	return e
+}
+
+// getNetworkMutex returns the mutex for a specific network, creating it if necessary.
+// This enables per-network locking for concurrent reconciliation of different networks.
+func (e *EgressIPController) getNetworkMutex(networkName string) *sync.Mutex {
+	// Try to load existing mutex
+	if mu, ok := e.networkMutexes.Load(networkName); ok {
+		return mu.(*sync.Mutex)
+	}
+
+	// Create new mutex
+	newMu := &sync.Mutex{}
+	actual, _ := e.networkMutexes.LoadOrStore(networkName, newMu)
+	return actual.(*sync.Mutex)
+}
+
+// lockNetwork acquires the mutex for a specific network.
+func (e *EgressIPController) lockNetwork(networkName string) {
+	mu := e.getNetworkMutex(networkName)
+	mu.Lock()
+}
+
+// unlockNetwork releases the mutex for a specific network.
+func (e *EgressIPController) unlockNetwork(networkName string) {
+	mu := e.getNetworkMutex(networkName)
+	mu.Unlock()
 }
 
 // main reconcile functions begin here
@@ -3560,34 +3584,64 @@ func createDefaultNoRerouteServicePolicies(nbClient libovsdbclient.Client, netwo
 	return nil
 }
 
+// ensureRouterPoliciesForNetwork is the optimized version of batched ops
+// It batches all operations for a single network into one transaction.
+// This method is called by l2 and l3 udn controllers on `addUpdateLocalNodeEvent`.
+// addressSetManager has its own internal locking for EnsureClusterNodeIPsAddressSet.
+// There are no overlapping resources among networks being handled by this method.
 func (e *EgressIPController) ensureRouterPoliciesForNetwork(ni util.NetInfo, node *corev1.Node) error {
-	e.nodeUpdateMutex.Lock()
-	defer e.nodeUpdateMutex.Unlock()
+	e.lockNetwork(ni.GetNetworkName())
+	defer e.unlockNetwork(ni.GetNetworkName())
+
 	subnetEntries := ni.Subnets()
 	subnets := util.GetAllClusterSubnetsFromEntries(subnetEntries)
 	if len(subnets) == 0 {
 		return nil
 	}
+
 	localNode, err := e.getALocalZoneNodeName()
 	if err != nil {
 		return err
 	}
+
 	routerName, err := getTopologyScopedRouterName(ni, localNode)
 	if err != nil {
 		return err
 	}
+
+	// Ensure cluster node address sets (shared cluster-wide resource)
 	clusterNodeIPsAddrSetDbIDs, err := e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
 	if err != nil {
 		return fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
 	}
-	if err := InitClusterEgressPolicies(e.nbClient, e.addressSetFactory, ni, subnets, e.controllerName, routerName, clusterNodeIPsAddrSetDbIDs); err != nil {
-		return fmt.Errorf("failed to initialize networks cluster logical router egress policies for the default network: %v", err)
-	}
-	err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, ni.GetNetworkName(), routerName,
-		e.controllerName, listers.NewNodeLister(e.watchFactory.NodeInformer().GetIndexer()), e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
+
+	// Build all operations without committing
+	ops := []ovsdb.Operation{}
+
+	// 1. Initialize cluster egress policies (batched)
+	// These policies are network-scoped (shared by all nodes), not per-node
+	ops, err = initClusterEgressPoliciesOps(e.nbClient, e.addressSetFactory, ni, subnets, e.controllerName, routerName, clusterNodeIPsAddrSetDbIDs, ops)
 	if err != nil {
-		return fmt.Errorf("failed to ensure no reroute node policies for network %s: %v", ni.GetNetworkName(), err)
+		return fmt.Errorf("failed to build cluster egress policies ops for network %s: %v", ni.GetNetworkName(), err)
 	}
+
+	clusterNodesAddressSets, err := e.addressSetFactory.GetAddressSet(clusterNodeIPsAddrSetDbIDs)
+	if err != nil {
+		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
+	}
+
+	// 2. Ensure default no-reroute node policies (batched)
+	ops, err = ensureDefaultNoRerouteNodePoliciesOps(e.nbClient, e.addressSetFactory, ni.GetNetworkName(), routerName,
+		e.controllerName, e.v4, e.v6, clusterNodesAddressSets, ops)
+	if err != nil {
+		return fmt.Errorf("failed to build node policies ops for network %s: %v", ni.GetNetworkName(), err)
+	}
+
+	// Commit router and node policy operations under global per-network lock
+	if _, err := libovsdbops.TransactAndCheck(e.nbClient, ops); err != nil {
+		return fmt.Errorf("failed to commit batched policy operations for network %s: %v", ni.GetNetworkName(), err)
+	}
+
 	if ni.TopologyType() == types.Layer3Topology {
 		gatewayIPs, err := udn.GetGWRouterIPs(node, ni)
 		if err != nil {
@@ -3598,14 +3652,16 @@ func (e *EgressIPController) ensureRouterPoliciesForNetwork(ni util.NetInfo, nod
 			return fmt.Errorf("failed to create route to external for network %s: %v", ni.GetNetworkName(), err)
 		}
 	}
+
 	return nil
 }
 
 // updateNodeNextHop updates the next hop IP for reroute policies on the node's logical router.
 // Only used during layer2 topology upgrade to change gwIP to the transit routerIP
 func (e *EgressIPController) updateNodeNextHop(ni util.NetInfo, node *corev1.Node) error {
-	e.nodeUpdateMutex.Lock()
-	defer e.nodeUpdateMutex.Unlock()
+	e.lockNetwork(ni.GetNetworkName())
+	defer e.unlockNetwork(ni.GetNetworkName())
+
 	transitRouterInfo, err := getTransitRouterInfo(ni, node)
 	if err != nil {
 		return err
@@ -3652,8 +3708,8 @@ func (e *EgressIPController) updateNodeNextHop(ni util.NetInfo, node *corev1.Nod
 }
 
 func (e *EgressIPController) ensureSwitchPoliciesForNode(ni util.NetInfo, nodeName string) error {
-	e.nodeUpdateMutex.Lock()
-	defer e.nodeUpdateMutex.Unlock()
+	e.lockNetwork(ni.GetNetworkName())
+	defer e.unlockNetwork(ni.GetNetworkName())
 	ops, err := e.ensureDefaultNoReRouteQosRulesForNode(ni, nodeName, nil)
 	if err != nil {
 		return fmt.Errorf("failed to ensure no reroute QoS rules for node %s and network %s: %v", nodeName, ni.GetNetworkName(), err)
@@ -3754,28 +3810,35 @@ func createDefaultReRouteQoSRuleOps(nbClient libovsdbclient.Client, addressSetFa
 }
 
 func (e *EgressIPController) ensureDefaultNoRerouteQoSRules(nodeName string) error {
-	e.nodeUpdateMutex.Lock()
-	defer e.nodeUpdateMutex.Unlock()
+	e.lockNetwork(types.DefaultNetworkName)
+	defer e.unlockNetwork(types.DefaultNetworkName)
 	defaultNetInfo := e.networkManager.GetNetwork(types.DefaultNetworkName)
 	var ops []ovsdb.Operation
 	ops, err := e.ensureDefaultNoReRouteQosRulesForNode(defaultNetInfo, nodeName, ops)
 	if err != nil {
 		return fmt.Errorf("failed to process default network: %v", err)
 	}
+	if _, err := libovsdbops.TransactAndCheck(e.nbClient, ops); err != nil {
+		return fmt.Errorf("failed to ensure default network no reroute QoS rules, err: %v", err)
+	}
+
 	if err = e.networkManager.DoWithLock(func(network util.NetInfo) error {
 		if network.GetNetworkName() == types.DefaultNetworkName {
 			return nil
 		}
-		ops, err = e.ensureDefaultNoReRouteQosRulesForNode(network, nodeName, ops)
+		e.lockNetwork(network.GetNetworkName())
+		defer e.unlockNetwork(network.GetNetworkName())
+		var networkOps []ovsdb.Operation
+		networkOps, err = e.ensureDefaultNoReRouteQosRulesForNode(network, nodeName, networkOps)
 		if err != nil {
 			return fmt.Errorf("failed to process network %s: %v", network.GetNetworkName(), err)
+		}
+		if _, err := libovsdbops.TransactAndCheck(e.nbClient, networkOps); err != nil {
+			return fmt.Errorf("failed to ensure network %s no reroute QoS rules, err: %v", network.GetNetworkName(), err)
 		}
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to ensure default no reroute QoS rules: %v", err)
-	}
-	if _, err := libovsdbops.TransactAndCheck(e.nbClient, ops); err != nil {
-		return fmt.Errorf("unable to add EgressIP QoS to switch, err: %v", err)
 	}
 	return nil
 }
@@ -3854,20 +3917,25 @@ func (e *EgressIPController) ensureDefaultNoReRouteQosRulesForNode(ni util.NetIn
 }
 
 func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
-	e.nodeUpdateMutex.Lock()
-	defer e.nodeUpdateMutex.Unlock()
-	nodeLister := listers.NewNodeLister(e.watchFactory.NodeInformer().GetIndexer())
 	clusterNodeIPsAddrSetDbIDs, err := e.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressIPBackRef)
 	if err != nil {
 		return fmt.Errorf("failed to ensure cluster node IP address set for EgressIP: %w", err)
 	}
+	clusterNodesAddressSets, err := e.addressSetFactory.GetAddressSet(clusterNodeIPsAddrSetDbIDs)
+	if err != nil {
+		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
+	}
+
 	// ensure default network is processed
+	e.lockNetwork(types.DefaultNetworkName)
+	defer e.unlockNetwork(types.DefaultNetworkName)
+
 	defaultNetInfo := e.networkManager.GetNetwork(types.DefaultNetworkName)
-	err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, defaultNetInfo.GetNetworkName(), defaultNetInfo.GetNetworkScopedClusterRouterName(),
-		e.controllerName, nodeLister, e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
+	err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, defaultNetInfo.GetNetworkName(), defaultNetInfo.GetNetworkScopedClusterRouterName(), e.controllerName, clusterNodesAddressSets, e.v4, e.v6)
 	if err != nil {
 		return fmt.Errorf("failed to ensure default no reroute policies for nodes for default network: %v", err)
 	}
+
 	if !isEgressIPForUDNSupported() {
 		return nil
 	}
@@ -3875,12 +3943,16 @@ func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
 		if network.GetNetworkName() == types.DefaultNetworkName {
 			return nil
 		}
+		e.lockNetwork(network.GetNetworkName())
+		defer e.unlockNetwork(network.GetNetworkName())
+
 		routerName, err := e.getTopologyScopedLocalZoneRouterName(network)
 		if err != nil {
 			return err
 		}
+
 		err = ensureDefaultNoRerouteNodePolicies(e.nbClient, e.addressSetFactory, network.GetNetworkName(), routerName,
-			e.controllerName, nodeLister, e.v4, e.v6, clusterNodeIPsAddrSetDbIDs)
+			e.controllerName, clusterNodesAddressSets, e.v4, e.v6)
 		if err != nil {
 			return fmt.Errorf("failed to ensure default no reroute policies for nodes for network %s: %v", network.GetNetworkName(), err)
 		}
@@ -3897,27 +3969,11 @@ func (e *EgressIPController) ensureDefaultNoRerouteNodePolicies() error {
 // sample: 101 ip4.src == $a12749576804119081385 && ip4.dst == $a11079093880111560446 allow pkt_mark=1008
 // All node addresses are listed here to decide which IP family policies are required.
 func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-	network, router, controller string, nodeLister listers.NodeLister, v4, v6 bool,
-	clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs) error {
-	nodes, err := nodeLister.List(labels.Everything())
-	if err != nil {
-		return fmt.Errorf("failed to list nodes: %v", err)
-	}
-	v4NodeAddrs, v6NodeAddrs, err := util.GetNodeAddresses(v4, v6, nodes...)
-	if err != nil {
-		return fmt.Errorf("failed to get node addresses: %v", err)
-	}
+	network, router, controller string, clusterNodesAddressSets addressset.AddressSet, v4, v6 bool) error {
+	ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS := clusterNodesAddressSets.GetASHashNames()
 
-	// all networks reference the same node IP address set
-	if clusterNodeIPsAddrSetDbIDs == nil {
-		return fmt.Errorf("cluster node IP address set DB IDs are required")
-	}
-	as, err := addressSetFactory.GetAddressSet(clusterNodeIPsAddrSetDbIDs)
-	if err != nil {
-		return fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
-	}
-
-	ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS := as.GetASHashNames()
+	var as addressset.AddressSet
+	var err error
 	// fetch the egressIP pods address-set
 	dbIDs := getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, network, controller)
 	if as, err = addressSetFactory.GetAddressSet(dbIDs); err != nil {
@@ -3934,7 +3990,7 @@ func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressS
 
 	var matchV4, matchV6 string
 	// construct the policy match
-	if len(v4NodeAddrs) > 0 {
+	if v4 {
 		// if address set hash name is empty, the address set has yet to be created
 		if ipv4EgressIPServedPodsAS == "" || ipv4EgressServiceServedPodsAS == "" || ipv4ClusterNodeIPAS == "" {
 			return types.NewSuppressedError(fmt.Errorf("address set name(s) %s not found %q %q %q", as.GetName(), ipv4EgressServiceServedPodsAS, ipv4EgressServiceServedPodsAS, ipv4ClusterNodeIPAS))
@@ -3942,7 +3998,7 @@ func ensureDefaultNoRerouteNodePolicies(nbClient libovsdbclient.Client, addressS
 		matchV4 = fmt.Sprintf(`(ip4.src == $%s || ip4.src == $%s) && ip4.dst == $%s`,
 			ipv4EgressIPServedPodsAS, ipv4EgressServiceServedPodsAS, ipv4ClusterNodeIPAS)
 	}
-	if len(v6NodeAddrs) > 0 {
+	if v6 {
 		// if address set hash name is empty, the address set has yet to be created
 		if ipv6EgressIPServedPodsAS == "" || ipv6EgressServiceServedPodsAS == "" || ipv6ClusterNodeIPAS == "" {
 			return types.NewSuppressedError(fmt.Errorf("address set hash name(s) %s not found", as.GetName()))

--- a/go-controller/pkg/ovn/egressip_ops.go
+++ b/go-controller/pkg/ovn/egressip_ops.go
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	egresssvc "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+)
+
+// initClusterEgressPoliciesOps is the ops-building version of InitClusterEgressPolicies
+// It batches all cluster-wide egress policy creation
+func initClusterEgressPoliciesOps(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory, ni util.NetInfo,
+	clusterSubnets []*net.IPNet, controllerName, routerName string, clusterNodeIPsAddrSetDbIDs *libovsdbops.DbObjectIDs, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+
+	if len(clusterSubnets) == 0 {
+		return ops, nil
+	}
+
+	var v4ClusterSubnet, v6ClusterSubnet []*net.IPNet
+	for _, subnet := range clusterSubnets {
+		if utilnet.IsIPv6CIDR(subnet) {
+			v6ClusterSubnet = append(v6ClusterSubnet, subnet)
+		} else {
+			v4ClusterSubnet = append(v4ClusterSubnet, subnet)
+		}
+	}
+
+	var v4JoinSubnet, v6JoinSubnet *net.IPNet
+	var err error
+	if len(v4ClusterSubnet) > 0 {
+		if config.Gateway.V4JoinSubnet == "" {
+			return ops, fmt.Errorf("network %s: cannot process IPv4 addresses because no IPv4 join subnet is available", ni.GetNetworkName())
+		}
+		_, v4JoinSubnet, err = net.ParseCIDR(config.Gateway.V4JoinSubnet)
+		if err != nil {
+			return ops, fmt.Errorf("network %s: failed to parse IPv4 join subnet: %v", ni.GetNetworkName(), err)
+		}
+	}
+	if len(v6ClusterSubnet) > 0 {
+		if config.Gateway.V6JoinSubnet == "" {
+			return ops, fmt.Errorf("network %s: cannot process IPv6 addresses because no IPv6 join subnet is available", ni.GetNetworkName())
+		}
+		_, v6JoinSubnet, err = net.ParseCIDR(config.Gateway.V6JoinSubnet)
+		if err != nil {
+			return ops, fmt.Errorf("network %s: failed to parse IPv6 join subnet: %v", ni.GetNetworkName(), err)
+		}
+	}
+
+	// Create pod-to-pod policies (batched)
+	ops, err = createDefaultNoReroutePodPoliciesOps(nbClient, ni.GetNetworkName(), controllerName, routerName, v4ClusterSubnet, v6ClusterSubnet, ops)
+	if err != nil {
+		return ops, fmt.Errorf("failed to create no reroute policies for pods on network %s: %v", ni.GetNetworkName(), err)
+	}
+
+	// Create pod-to-join policies (batched)
+	ops, err = createDefaultNoRerouteServicePoliciesOps(nbClient, ni.GetNetworkName(), controllerName, routerName, v4ClusterSubnet, v6ClusterSubnet,
+		v4JoinSubnet, v6JoinSubnet, ops)
+	if err != nil {
+		return ops, fmt.Errorf("failed to create no reroute policies for services on network %s: %v", ni.GetNetworkName(), err)
+	}
+
+	// Create reply traffic policy (batched)
+	ops, err = createDefaultNoRerouteReplyTrafficPolicyOps(nbClient, ni.GetNetworkName(), controllerName, routerName, ops)
+	if err != nil {
+		return ops, fmt.Errorf("failed to create no reroute reply traffic policy for network %s: %v", ni.GetNetworkName(), err)
+	}
+
+	// ensure the address-set for storing nodeIPs exists
+	// The address set with controller name 'default' is shared with all networks
+	if clusterNodeIPsAddrSetDbIDs == nil {
+		return ops, fmt.Errorf("cluster node IP address set DB IDs are required")
+	}
+	if _, err = addressSetFactory.EnsureAddressSet(clusterNodeIPsAddrSetDbIDs); err != nil {
+		return ops, fmt.Errorf("cannot ensure that addressSet %s exists %v", NodeIPAddrSetName, err)
+	}
+
+	// ensure the address-set for storing egressIP pods exists
+	dbIDs := getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, ni.GetNetworkName(), controllerName)
+	_, err = addressSetFactory.EnsureAddressSet(dbIDs)
+	if err != nil {
+		return ops, fmt.Errorf("cannot ensure that addressSet for egressIP pods %s exists for network %s: %v", EgressIPServedPodsAddrSetName, ni.GetNetworkName(), err)
+	}
+
+	// ensure the address-set for storing egressservice pod backends exists
+	dbIDs = egresssvc.GetEgressServiceAddrSetDbIDs(controllerName)
+	_, err = addressSetFactory.EnsureAddressSet(dbIDs)
+	if err != nil {
+		return ops, fmt.Errorf("cannot ensure that addressSet for egressService pods %s exists %v", egresssvc.EgressServiceServedPodsAddrSetName, err)
+	}
+
+	if !ni.IsDefault() && isEgressIPForUDNSupported() {
+		v4, v6 := len(v4ClusterSubnet) > 0, len(v6ClusterSubnet) > 0
+		ops, err = ensureDefaultNoRerouteUDNEnabledSvcPoliciesOps(nbClient, addressSetFactory, ni, controllerName, routerName, v4, v6, ops)
+		if err != nil {
+			return ops, fmt.Errorf("failed to ensure no reroute for UDN enabled services for network %s: %v", ni.GetNetworkName(), err)
+		}
+	}
+
+	return ops, nil
+}
+
+// createDefaultNoReroutePodPoliciesOps is the ops-building version of createDefaultNoReroutePodPolicies
+// It batches pod-to-pod policy creation (O(S²) policies)
+func createDefaultNoReroutePodPoliciesOps(nbClient libovsdbclient.Client, network, controller, routerName string,
+	v4ClusterSubnet, v6ClusterSubnet []*net.IPNet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+
+	// Create policies for all v4 subnet pairs
+	for _, v4Subnet1 := range v4ClusterSubnet {
+		for _, v4Subnet2 := range v4ClusterSubnet {
+			match := fmt.Sprintf("ip4.src == %s && ip4.dst == %s", v4Subnet1.String(), v4Subnet2.String())
+			dbIDs := getEgressIPLRPNoReRoutePodToPodDbIDs(IPFamilyValueV4, network, controller)
+			lrp := nbdb.LogicalRouterPolicy{
+				Priority:    types.DefaultNoRereoutePriority,
+				Action:      nbdb.LogicalRouterPolicyActionAllow,
+				Match:       match,
+				ExternalIDs: dbIDs.GetExternalIDs(),
+			}
+			// Use predicate with match filter for pod-to-pod policies (handles multiple cluster subnets)
+			p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, func(item *nbdb.LogicalRouterPolicy) bool {
+				return item.Match == match
+			})
+			var err error
+			ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, routerName, &lrp, p)
+			if err != nil {
+				return ops, fmt.Errorf("failed to create pod-to-pod policy ops for %s->%s: %v", v4Subnet1, v4Subnet2, err)
+			}
+		}
+	}
+
+	// Create policies for all v6 subnet pairs
+	for _, v6Subnet1 := range v6ClusterSubnet {
+		for _, v6Subnet2 := range v6ClusterSubnet {
+			match := fmt.Sprintf("ip6.src == %s && ip6.dst == %s", v6Subnet1.String(), v6Subnet2.String())
+			dbIDs := getEgressIPLRPNoReRoutePodToPodDbIDs(IPFamilyValueV6, network, controller)
+			lrp := nbdb.LogicalRouterPolicy{
+				Priority:    types.DefaultNoRereoutePriority,
+				Action:      nbdb.LogicalRouterPolicyActionAllow,
+				Match:       match,
+				ExternalIDs: dbIDs.GetExternalIDs(),
+			}
+			// Use predicate with match filter for pod-to-pod policies (handles multiple cluster subnets)
+			p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, func(item *nbdb.LogicalRouterPolicy) bool {
+				return item.Match == match
+			})
+			var err error
+			ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, routerName, &lrp, p)
+			if err != nil {
+				return ops, fmt.Errorf("failed to create pod-to-pod policy ops for %s->%s: %v", v6Subnet1, v6Subnet2, err)
+			}
+		}
+	}
+
+	return ops, nil
+}
+
+// createDefaultNoRerouteServicePoliciesOps is the ops-building version of createDefaultNoRerouteServicePolicies
+// It batches pod-to-join policy creation
+func createDefaultNoRerouteServicePoliciesOps(nbClient libovsdbclient.Client, network, controller, routerName string,
+	v4ClusterSubnet, v6ClusterSubnet []*net.IPNet, v4JoinSubnet, v6JoinSubnet *net.IPNet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+
+	// Create v4 pod-to-join policies
+	if v4JoinSubnet != nil {
+		for _, v4Subnet := range v4ClusterSubnet {
+			match := fmt.Sprintf("ip4.src == %s && ip4.dst == %s", v4Subnet.String(), v4JoinSubnet.String())
+			dbIDs := getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV4, network, controller)
+			lrp := nbdb.LogicalRouterPolicy{
+				Priority:    types.DefaultNoRereoutePriority,
+				Action:      nbdb.LogicalRouterPolicyActionAllow,
+				Match:       match,
+				ExternalIDs: dbIDs.GetExternalIDs(),
+			}
+			// Use predicate with match filter for pod-to-join policies (handles multiple cluster subnets)
+			p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, func(item *nbdb.LogicalRouterPolicy) bool {
+				return item.Match == match
+			})
+			var err error
+			ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, routerName, &lrp, p)
+			if err != nil {
+				return ops, fmt.Errorf("failed to create pod-to-join policy ops for %s: %v", v4Subnet, err)
+			}
+		}
+	}
+
+	// Create v6 pod-to-join policies
+	if v6JoinSubnet != nil {
+		for _, v6Subnet := range v6ClusterSubnet {
+			match := fmt.Sprintf("ip6.src == %s && ip6.dst == %s", v6Subnet.String(), v6JoinSubnet.String())
+			dbIDs := getEgressIPLRPNoReRoutePodToJoinDbIDs(IPFamilyValueV6, network, controller)
+			lrp := nbdb.LogicalRouterPolicy{
+				Priority:    types.DefaultNoRereoutePriority,
+				Action:      nbdb.LogicalRouterPolicyActionAllow,
+				Match:       match,
+				ExternalIDs: dbIDs.GetExternalIDs(),
+			}
+			// Use predicate with match filter for pod-to-join policies (handles multiple cluster subnets)
+			p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, func(item *nbdb.LogicalRouterPolicy) bool {
+				return item.Match == match
+			})
+			var err error
+			ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, routerName, &lrp, p)
+			if err != nil {
+				return ops, fmt.Errorf("failed to create pod-to-join policy ops for %s: %v", v6Subnet, err)
+			}
+		}
+	}
+
+	return ops, nil
+}
+
+// createDefaultNoRerouteReplyTrafficPolicyOps is the ops-building version of createDefaultNoRerouteReplyTrafficPolicy
+func createDefaultNoRerouteReplyTrafficPolicyOps(nbClient libovsdbclient.Client, network, controller, routerName string, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+	dbIDs := getEgressIPLRPNoReRouteDbIDs(types.DefaultNoRereoutePriority, ReplyTrafficNoReroute, IPFamilyValue, network, controller)
+	lrp := nbdb.LogicalRouterPolicy{
+		Priority:    types.DefaultNoRereoutePriority,
+		Action:      nbdb.LogicalRouterPolicyActionAllow,
+		Match:       fmt.Sprintf("pkt.mark == %d", types.EgressIPReplyTrafficConnectionMark),
+		ExternalIDs: dbIDs.GetExternalIDs(),
+	}
+	// Use predicate generator based on dbIDs to match the original implementation
+	p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, nil)
+	return libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, routerName, &lrp, p)
+}
+
+// ensureDefaultNoRerouteUDNEnabledSvcPoliciesOps is the ops-building version of ensureDefaultNoRerouteUDNEnabledSvcPolicies
+func ensureDefaultNoRerouteUDNEnabledSvcPoliciesOps(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
+	ni util.NetInfo, controller, routerName string, v4, v6 bool, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+
+	var err error
+	var as addressset.AddressSet
+	// fetch the egressIP pods address-set
+	dbIDs := getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, ni.GetNetworkName(), controller)
+	if as, err = addressSetFactory.EnsureAddressSet(dbIDs); err != nil {
+		return ops, fmt.Errorf("cannot ensure that addressSet %s exists %v", EgressIPServedPodsAddrSetName, err)
+	}
+	ipv4EgressIPServedPodsAS, ipv6EgressIPServedPodsAS := as.GetASHashNames()
+
+	// fetch the egressService pods address-set
+	dbIDs = egresssvc.GetEgressServiceAddrSetDbIDs(controller)
+	if as, err = addressSetFactory.EnsureAddressSet(dbIDs); err != nil {
+		return ops, fmt.Errorf("cannot ensure that addressSet %s exists %v", egresssvc.EgressServiceServedPodsAddrSetName, err)
+	}
+	ipv4EgressServiceServedPodsAS, ipv6EgressServiceServedPodsAS := as.GetASHashNames()
+
+	dbIDs = udnenabledsvc.GetAddressSetDBIDs()
+	var ipv4UDNEnabledSvcAS, ipv6UDNEnabledSvcAS string
+	// address set maybe not created immediately
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(_ context.Context) (done bool, err error) {
+		as, err := addressSetFactory.GetAddressSet(dbIDs)
+		if err != nil {
+			klog.V(5).Infof("Failed to get UDN enabled service address set, retrying: %v", err)
+			return false, nil
+		}
+		ipv4UDNEnabledSvcAS, ipv6UDNEnabledSvcAS = as.GetASHashNames()
+		if ipv4UDNEnabledSvcAS == "" && ipv6UDNEnabledSvcAS == "" {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return ops, fmt.Errorf("failed to retrieve UDN enabled service address set from NB DB: %v", err)
+	}
+	// if address set hash name is empty, the address set has yet to be created
+	if (v4 && ipv4UDNEnabledSvcAS == "") || (v6 && ipv6UDNEnabledSvcAS == "") {
+		return ops, types.NewSuppressedError(fmt.Errorf("failed to retrieve UDN enabled service address set"))
+	}
+
+	var matchV4, matchV6 string
+	// construct the policy match
+	if v4 {
+		if ipv4EgressIPServedPodsAS == "" || ipv4EgressServiceServedPodsAS == "" || ipv4UDNEnabledSvcAS == "" {
+			return ops, fmt.Errorf("address set hash name(s) not found")
+		}
+		matchV4 = fmt.Sprintf(`(ip4.src == $%s || ip4.src == $%s) && ip4.dst == $%s`,
+			ipv4EgressIPServedPodsAS, ipv4EgressServiceServedPodsAS, ipv4UDNEnabledSvcAS)
+	}
+	if v6 {
+		if ipv6EgressIPServedPodsAS == "" || ipv6EgressServiceServedPodsAS == "" || ipv6UDNEnabledSvcAS == "" {
+			return ops, fmt.Errorf("address set hash name(s) not found")
+		}
+		matchV6 = fmt.Sprintf(`(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s`,
+			ipv6EgressIPServedPodsAS, ipv6EgressServiceServedPodsAS, ipv6UDNEnabledSvcAS)
+	}
+
+	// Create policy for v4
+	if matchV4 != "" {
+		dbIDs := getEgressIPLRPNoReRouteDbIDs(types.DefaultNoRereoutePriority, NoReRouteUDNPodToCDNSvc, IPFamilyValueV4, ni.GetNetworkName(), controller)
+		lrp := nbdb.LogicalRouterPolicy{
+			Priority:    types.DefaultNoRereoutePriority,
+			Action:      nbdb.LogicalRouterPolicyActionAllow,
+			Match:       matchV4,
+			ExternalIDs: dbIDs.GetExternalIDs(),
+		}
+		p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, nil)
+		ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, routerName, &lrp, p)
+		if err != nil {
+			return ops, err
+		}
+	}
+
+	// Create policy for v6
+	if matchV6 != "" {
+		dbIDs := getEgressIPLRPNoReRouteDbIDs(types.DefaultNoRereoutePriority, NoReRouteUDNPodToCDNSvc, IPFamilyValueV6, ni.GetNetworkName(), controller)
+		lrp := nbdb.LogicalRouterPolicy{
+			Priority:    types.DefaultNoRereoutePriority,
+			Action:      nbdb.LogicalRouterPolicyActionAllow,
+			Match:       matchV6,
+			ExternalIDs: dbIDs.GetExternalIDs(),
+		}
+		p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, nil)
+		ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, routerName, &lrp, p)
+		if err != nil {
+			return ops, err
+		}
+	}
+
+	return ops, nil
+}
+
+// ensureDefaultNoRerouteNodePoliciesOps builds ovsdb operations for node policies
+// without committing. It follows the accumulator pattern: accepts an existing
+// ops slice, appends new operations, and returns the extended slice for batching.
+func ensureDefaultNoRerouteNodePoliciesOps(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory, network, router, controller string, v4, v6 bool, clusterNodesAddressSets addressset.AddressSet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+	ipv4ClusterNodeIPAS, ipv6ClusterNodeIPAS := clusterNodesAddressSets.GetASHashNames()
+
+	var as addressset.AddressSet
+	var err error
+	// fetch the egressIP pods address-set
+	dbIDs := getEgressIPAddrSetDbIDs(EgressIPServedPodsAddrSetName, network, controller)
+	if as, err = addressSetFactory.EnsureAddressSet(dbIDs); err != nil {
+		return ops, fmt.Errorf("cannot ensure that addressSet %s exists %v", EgressIPServedPodsAddrSetName, err)
+	}
+	ipv4EgressIPServedPodsAS, ipv6EgressIPServedPodsAS := as.GetASHashNames()
+
+	// fetch the egressService pods address-set
+	dbIDs = egresssvc.GetEgressServiceAddrSetDbIDs(controller)
+	if as, err = addressSetFactory.EnsureAddressSet(dbIDs); err != nil {
+		return ops, fmt.Errorf("cannot ensure that addressSet %s exists %v", egresssvc.EgressServiceServedPodsAddrSetName, err)
+	}
+	ipv4EgressServiceServedPodsAS, ipv6EgressServiceServedPodsAS := as.GetASHashNames()
+
+	var matchV4, matchV6 string
+	// construct the policy match
+	if v4 {
+		if ipv4EgressIPServedPodsAS == "" || ipv4EgressServiceServedPodsAS == "" || ipv4ClusterNodeIPAS == "" {
+			return ops, types.NewSuppressedError(fmt.Errorf("address set hash name(s) not found %q %q %q", ipv4EgressIPServedPodsAS, ipv4EgressServiceServedPodsAS, ipv4ClusterNodeIPAS))
+		}
+		matchV4 = fmt.Sprintf(`(ip4.src == $%s || ip4.src == $%s) && ip4.dst == $%s`,
+			ipv4EgressIPServedPodsAS, ipv4EgressServiceServedPodsAS, ipv4ClusterNodeIPAS)
+	}
+	if v6 {
+		if ipv6EgressIPServedPodsAS == "" || ipv6EgressServiceServedPodsAS == "" || ipv6ClusterNodeIPAS == "" {
+			return ops, types.NewSuppressedError(fmt.Errorf("address set hash name(s) not found"))
+		}
+		matchV6 = fmt.Sprintf(`(ip6.src == $%s || ip6.src == $%s) && ip6.dst == $%s`,
+			ipv6EgressIPServedPodsAS, ipv6EgressServiceServedPodsAS, ipv6ClusterNodeIPAS)
+	}
+
+	// Create global allow policy for node traffic (batched)
+	if matchV4 != "" {
+		dbIDs := getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV4, network, controller)
+		lrp := nbdb.LogicalRouterPolicy{
+			Priority:    types.DefaultNoRereoutePriority,
+			Action:      nbdb.LogicalRouterPolicyActionAllow,
+			Match:       matchV4,
+			Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
+			ExternalIDs: dbIDs.GetExternalIDs(),
+		}
+		p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, nil)
+		ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, router, &lrp, p)
+		if err != nil {
+			return ops, err
+		}
+	}
+
+	if matchV6 != "" {
+		dbIDs := getEgressIPLRPNoReRoutePodToNodeDbIDs(IPFamilyValueV6, network, controller)
+		lrp := nbdb.LogicalRouterPolicy{
+			Priority:    types.DefaultNoRereoutePriority,
+			Action:      nbdb.LogicalRouterPolicyActionAllow,
+			Match:       matchV6,
+			Options:     map[string]string{"pkt_mark": types.EgressIPNodeConnectionMark},
+			ExternalIDs: dbIDs.GetExternalIDs(),
+		}
+		p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, nil)
+		ops, err = libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient, ops, router, &lrp, p)
+		if err != nil {
+			return ops, err
+		}
+	}
+
+	return ops, nil
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	listers "k8s.io/client-go/listers/core/v1"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
 
@@ -368,7 +367,7 @@ func (oc *DefaultNetworkController) InitEgressServiceZoneController() (*egresssv
 	initClusterEgressPolicies := func(_ libovsdbclient.Client, _ addressset.AddressSetFactory, _ util.NetInfo, _ []*net.IPNet, _, _ string) error {
 		return nil
 	}
-	ensureNodeNoReroutePolicies := func(_ libovsdbclient.Client, _ addressset.AddressSetFactory, _, _, _ string, _ listers.NodeLister, _, _ bool) error {
+	ensureNodeNoReroutePolicies := func(_ libovsdbclient.Client, _ addressset.AddressSetFactory, _, _, _ string, _ addressset.AddressSet, _, _ bool) error {
 		return nil
 	}
 	// used only when IC=true
@@ -386,18 +385,14 @@ func (oc *DefaultNetworkController) InitEgressServiceZoneController() (*egresssv
 			return InitClusterEgressPolicies(nbClient, addressSetFactory, ni, clusterSubnets, controllerName, routerName, clusterNodeIPsAddrSetDbIDs)
 		}
 		ensureNodeNoReroutePolicies = func(nbClient libovsdbclient.Client, addressSetFactory addressset.AddressSetFactory,
-			network, router, controller string, nodeLister listers.NodeLister, v4, v6 bool) error {
-			clusterNodeIPsAddrSetDbIDs, err := oc.addressSetManager.EnsureClusterNodeIPsAddressSet(addresssetmanager.ClusterNodeIPsEgressServiceBackRef)
-			if err != nil {
-				return fmt.Errorf("failed to ensure cluster node IP address set for EgressService: %w", err)
-			}
-			return ensureDefaultNoRerouteNodePolicies(nbClient, addressSetFactory, network, router, controller, nodeLister, v4, v6, clusterNodeIPsAddrSetDbIDs)
+			network, router, controller string, clusterNodesAddressSets addressset.AddressSet, v4, v6 bool) error {
+			return ensureDefaultNoRerouteNodePolicies(nbClient, addressSetFactory, network, router, controller, clusterNodesAddressSets, v4, v6)
 		}
 		createDefaultNodeRouteToExternal = libovsdbutil.CreateDefaultRouteToExternal
 	}
 
 	return egresssvc_zone.NewController(oc.GetNetInfo(), ovntypes.DefaultNetworkControllerName, oc.client, oc.nbClient, oc.addressSetFactory,
-		initClusterEgressPolicies, ensureNodeNoReroutePolicies,
+		oc.addressSetManager, initClusterEgressPolicies, ensureNodeNoReroutePolicies,
 		createDefaultNodeRouteToExternal,
 		oc.stopChan, oc.watchFactory.EgressServiceInformer(), oc.watchFactory.ServiceCoreInformer(),
 		oc.watchFactory.EndpointSliceCoreInformer(),


### PR DESCRIPTION
Rewrites `ensureRouterPoliciesForNetwork` method to perform operations in batch with libovsdb. The goal is to avoid many DB operations in series, simplify many writes to a single one, dependencies are handled properly (e.g., ensure address sets, and get predicates).

Improves `ensureDefaultNoRerouteNodePolicies` method, node lister is moved to an outside function, so the operation of listing all nodes address and setting them is not repeated for all networks in a single reconcile loop, this is an idempotent operation.

Notice, the `Ops` methods used in `ensureRouterPoliciesForNetwork` can be used in other methods too, so they can have their operations batched. For example, `initClusterEgressPolicies` could use `initClusterEgressPoliciesOps` for all its networks and run a single `TransactAndCheck` DB operation. For example, the method `ensureDefaultNoRerouteQoSRules` already does that.

The global mutex for node is not needed, as it is used in methods that reconcile content on a per network basis.
Performance can be improved to set this lock only on a per-network basis.
See analysis below of call flow of the changed usage of global mutex:

ensureDefaultNoRerouteNodePolicies ->
being used by default_network_controller.go
- DeleteResource method: when case of EgressNodeType
- AddResource method: in case of EgressNodeType if shouldSyncReroute
- UpdateResource method: in case of EgressNodeType if syncEIPNodeRerouteFailed or node host CIDR annotations changed

ensureRouterPoliciesForNetwork ->
called in l2_udn_controller and l3_udn_controller
- Both inside their respective `addUpdateLocalNodeEvent` in case of a primary network only

updateNodeNextHop -> called once by l2_udn_controller
- In the method addRouterSetupForRemoteNodeGR:
- The updateNodeNextHop added ops to libovsdb have a predicate restraining it to only the network Name it is being called with

ensureSwitchPoliciesForNode -> same as ensureRouterPoliciesForNetwork

ensureDefaultNoRerouteQoSRules ->
being used by default_network_cotnroller.go inside addResource and updateResource methods in case obj is EgressNodeType.

ensureDefaultNoRerouteNodePolicies ->
being used by default_network_cotnroller.go inside addResource and updateResource methods in case obj is EgressNodeType.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced reconciliation contention for egress IP by switching from a single global lock to per-network locking.
  * Batched router and node policy work to reduce the number of OVN transactions, and reused precomputed cluster node address-set data across “no reroute” policy generation.

* **Bug Fixes / Reliability**
  * Improved consistency of “no reroute” policy inputs by sourcing cluster node IP matching from shared address sets.
  * Added more resilient handling for cases where required address-set hashes are not yet available, suppressing premature errors to prevent disruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->