### PR TITLE
UDN Performance Metrics

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -2042,9 +2042,16 @@ ovn-cluster-manager() {
   }
   echo "ovn_cluster_manager_ssl_opts=${ovn_cluster_manager_ssl_opts}"
 
+  ovnkube_metrics_scale_enable_flag=
+  if [[ ${ovnkube_metrics_scale_enable} == "true" ]]; then
+    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale"
+  fi
+  echo "ovnkube_metrics_scale_enable_flag: ${ovnkube_metrics_scale_enable_flag}"
+
   rm -f ${OVN_RUNDIR}/ovnkube-cluster-manager.pid
 
   echo "=============== ovn-cluster-manager ========== control plane node only"
+
   /usr/bin/ovnkube --init-cluster-manager ${K8S_NODE} \
     ${anp_enabled_flag} \
     ${egressfirewall_enabled_flag} \
@@ -2079,6 +2086,7 @@ ovn-cluster-manager() {
     ${dynamic_udn_grace_period} \
     ${ovn_enable_dnsnameresolver_flag} \
     ${ovn_allow_icmp_netpol_flag} \
+    ${ovnkube_metrics_scale_enable_flag} \
     --gateway-mode=${ovn_gateway_mode} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --host-network-namespace ${ovn_host_network_namespace} \

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -6,6 +6,7 @@ package node
 import (
 	"fmt"
 	"net"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -410,7 +411,9 @@ func (na *NodeAllocator) syncNodeNetworkAnnotations(node *corev1.Node) error {
 
 	// Also update the node annotation if the networkID doesn't match
 	if len(updatedSubnetsMap) > 0 || networkID != types.NoNetworkID || newTunnelID != types.NoTunnelID {
+		updateStart := time.Now()
 		err = na.updateNodeNetworkAnnotationsWithRetry(node.Name, updatedSubnetsMap, networkID, newTunnelID)
+
 		if err != nil {
 			if errR := na.clusterSubnetAllocator.ReleaseNetworks(node.Name, allocatedSubnets...); errR != nil {
 				klog.Warningf("Error releasing node %s subnets: %v", node.Name, errR)
@@ -420,6 +423,11 @@ func (na *NodeAllocator) syncNodeNetworkAnnotations(node *corev1.Node) error {
 				klog.Infof("Releasing node %s tunnelID for network %s since annotation update failed", node.Name, networkName)
 			}
 			return err
+		}
+
+		if na.netInfo.IsUserDefinedNetwork() && config.Metrics.EnableScaleMetrics {
+			updateDuration := time.Since(updateStart)
+			metrics.RecordUDNUpdateNodeAnnotationDuration(networkName, updateDuration.Seconds())
 		}
 	}
 

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller.go
@@ -792,6 +792,12 @@ func (c *Controller) syncUserDefinedNetwork(udn *userdefinednetworkv1.UserDefine
 			klog.Infof("Finalizer removed from UserDefinedNetworks [%s/%s]", udn.Namespace, udn.Name)
 			metrics.DecrementUDNCount(role, topology)
 			metrics.DeleteDynamicUDNNodeCount(util.GenerateUDNNetworkName(udn.Namespace, udn.Name))
+
+			if config.Metrics.EnableScaleMetrics {
+				// Clean up UDN metric time series to prevent cardinality explosion
+				networkName := util.GenerateUDNNetworkName(udn.Namespace, udn.Name)
+				metrics.CleanupUDNMetrics(networkName)
+			}
 		}
 
 		return nil, nil

--- a/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
+++ b/go-controller/pkg/clustermanager/userdefinednetwork/controller_helper.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -20,13 +21,32 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/clustermanager/userdefinednetwork/template"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	userdefinednetworkv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utiludn "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/udn"
 )
 
-func (c *Controller) updateNAD(obj client.Object, namespace string) (*netv1.NetworkAttachmentDefinition, error) {
+func (c *Controller) updateNAD(obj client.Object, namespace string) (_ *netv1.NetworkAttachmentDefinition, err error) {
+	start := time.Now()
+	defer func() {
+		if err != nil || !config.Metrics.EnableScaleMetrics {
+			return
+		}
+		duration := time.Since(start)
+		// Record workflow phase metric for NAD sync
+		// Use network-scoped name to avoid collisions between same-name UDNs in different namespaces
+		networkName := obj.GetName()
+		switch o := obj.(type) {
+		case *userdefinednetworkv1.UserDefinedNetwork:
+			networkName = util.GenerateUDNNetworkName(o.Namespace, o.Name)
+		case *userdefinednetworkv1.ClusterUserDefinedNetwork:
+			networkName = util.GenerateCUDNNetworkName(o.Name)
+		}
+		metrics.RecordUDNNADSyncDuration(networkName, duration.Seconds())
+	}()
 	if utiludn.IsPrimaryNetwork(template.GetSpec(obj)) {
 		// check if required UDN label is on namespace
 		ns, err := c.namespaceInformer.Lister().Get(namespace)

--- a/go-controller/pkg/metrics/cluster_manager.go
+++ b/go-controller/pkg/metrics/cluster_manager.go
@@ -160,6 +160,24 @@ var metricVTEPCondition = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		"Use the 'condition' and 'status' labels to select.",
 }, []string{"name", "condition", "status"})
 
+// These metrics are being emitted per-network to provide granular data for performance testing
+// If performance issues arise due to cardinality, these metrics should be aggregated
+var metricUDNUpdateNodeAnnotationDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemClusterManager,
+	Name:      "udn_update_node_annotation_duration_seconds",
+	Help:      "Time spent updating node annotations during UDN network allocation.",
+	Buckets:   prometheus.ExponentialBuckets(.01, 2, 13), // 10ms to ~40s
+}, []string{"name"})
+
+var metricUDNNADSyncDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemClusterManager,
+	Name:      "udn_nad_sync_duration_seconds",
+	Help:      "Time spent syncing NetworkAttachmentDefinitions during UDN reconciliation.",
+	Buckets:   prometheus.ExponentialBuckets(.005, 2, 14), // 5ms to ~40s
+}, []string{"name"})
+
 // RegisterClusterManagerBase registers ovnkube cluster manager base metrics with the Prometheus registry.
 // This function should only be called once.
 func RegisterClusterManagerBase() {
@@ -203,6 +221,11 @@ func RegisterClusterManagerFunctional() {
 		prometheus.MustRegister(metricUDNCount)
 		prometheus.MustRegister(metricCUDNCount)
 		prometheus.MustRegister(metricCUDNCondition)
+		if config.Metrics.EnableScaleMetrics {
+			prometheus.MustRegister(metricUDNUpdateNodeAnnotationDuration)
+			prometheus.MustRegister(metricUDNNADSyncDuration)
+			registerWorkqueueMetrics(types.MetricOvnkubeNamespace, types.MetricOvnkubeSubsystemClusterManager)
+		}
 		if config.OVNKubernetesFeature.EnableDynamicUDNAllocation {
 			prometheus.MustRegister(metricUDNNodesRendered)
 		}
@@ -333,4 +356,21 @@ func boolFloat64(b bool) float64 {
 		return 1
 	}
 	return 0
+}
+
+// RecordUDNUpdateNodeAnnotationDuration records duration of updating node annotations during UDN allocation
+func RecordUDNUpdateNodeAnnotationDuration(name string, duration float64) {
+	metricUDNUpdateNodeAnnotationDuration.WithLabelValues(name).Observe(duration)
+}
+
+// RecordUDNNADSyncDuration records duration of syncing NADs during UDN reconciliation
+func RecordUDNNADSyncDuration(name string, duration float64) {
+	metricUDNNADSyncDuration.WithLabelValues(name).Observe(duration)
+}
+
+// CleanupUDNMetrics removes all metric time series associated with a deleted UDN to prevent
+// unbounded cardinality growth. Should be called when a UDN or CUDN is fully deleted.
+func CleanupUDNMetrics(networkName string) {
+	metricUDNUpdateNodeAnnotationDuration.DeleteLabelValues(networkName)
+	metricUDNNADSyncDuration.DeleteLabelValues(networkName)
 }

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -13,6 +13,7 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -100,6 +101,14 @@ var metricOVNControllerSBDBConnection = prometheus.NewGauge(prometheus.GaugeOpts
 	Name:      "southbound_database_connected",
 	Help:      "Specifies if OVN controller is connected to OVN southbound database (1) or not (0)",
 })
+
+var metricUDNNBDBProgrammedDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemController,
+	Name:      "udn_nbdb_programmed_duration_seconds",
+	Help:      "NBDB programming duration for UDN network initialization, aggregated by topology",
+	Buckets:   prometheus.ExponentialBuckets(.001, 2, 18), // 1ms to ~131s
+}, []string{"topology"})
 
 var (
 	ovnControllerVersion       string
@@ -386,6 +395,9 @@ func RegisterOvnControllerMetrics(ovsDBClient libovsdbclient.Client, ovnRegistry
 
 	// ovn-controller metrics
 	ovnRegistry.MustRegister(metricOVNControllerSBDBConnection)
+	if config.Metrics.EnableScaleMetrics {
+		ovnRegistry.MustRegister(metricUDNNBDBProgrammedDuration)
+	}
 	ovnRegistry.MustRegister(prometheus.NewCounterFunc(
 		prometheus.CounterOpts{
 			Namespace: types.MetricOvnNamespace,
@@ -445,4 +457,9 @@ func RegisterOvnControllerMetrics(ovsDBClient libovsdbclient.Client, ovnRegistry
 	// Register the ovn-controller coverage/show metrics
 	componentStopwatchShowMetricsMap[ovnController] = ovnControllerStopwatchShowMetricsMap
 	registerStopwatchShowMetrics(ovnRegistry, ovnController, types.MetricOvnNamespace, types.MetricOvnSubsystemController)
+}
+
+// RecordUDNNBDBProgrammedDuration records the NBDB programming duration for UDN network initialization.
+func RecordUDNNBDBProgrammedDuration(topology string, duration float64) {
+	metricUDNNBDBProgrammedDuration.WithLabelValues(topology).Observe(duration)
 }

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -50,6 +50,12 @@ var _ = Describe("MetricServer", func() {
 				t.opts.EnableOVNControllerMetrics = tc.enableOVNController
 				t.opts.EnableOVNNorthdMetrics = tc.enableOVNNorthd
 
+				savedEnableScaleMetrics := config.Metrics.EnableScaleMetrics
+				config.Metrics.EnableScaleMetrics = tc.enableScaleMetrics
+				DeferCleanup(func() {
+					config.Metrics.EnableScaleMetrics = savedEnableScaleMetrics
+				})
+
 				// Mock the exec runner for RunOvsVswitchdAppCtl calls
 				mockCmd := new(mock_k8s_io_utils_exec.Cmd)
 				mockExecRunner := new(mocks.ExecRunner)
@@ -429,6 +435,7 @@ type metricsTestCase struct {
 	enableOVNDB         bool
 	enableOVNController bool
 	enableOVNNorthd     bool
+	enableScaleMetrics  bool
 	mockRunCommands     []ovntest.TestifyMockHelper
 	expectedMetrics     []string
 }
@@ -605,6 +612,7 @@ var (
 
 	OVNControllerMetricsTestCase = metricsTestCase{
 		enableOVNController: true,
+		enableScaleMetrics:  true,
 		mockRunCommands: []ovntest.TestifyMockHelper{
 			// ovs-ofctl -t 5 dump-aggregate br-int
 			{

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -449,7 +449,16 @@ func (oc *Layer2UserDefinedNetworkController) Cleanup() error {
 	return nil
 }
 
-func (oc *Layer2UserDefinedNetworkController) init() error {
+func (oc *Layer2UserDefinedNetworkController) init() (err error) {
+	start := time.Now()
+	defer func() {
+		if err == nil && config.Metrics.EnableScaleMetrics {
+			duration := time.Since(start)
+			metrics.RecordUDNNBDBProgrammedDuration(oc.TopologyType(), duration.Seconds())
+			klog.Infof("Recorded NBDB programmed duration for network %s: %v", oc.GetNetworkName(), duration)
+		}
+	}()
+
 	// Create default Control Plane Protection (COPP) entry for routers
 	defaultCOPPUUID, err := EnsureDefaultCOPP(oc.nbClient)
 	if err != nil {

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -715,7 +715,16 @@ func (oc *Layer3UserDefinedNetworkController) SyncNodes(nodes []*corev1.Node) er
 	return oc.syncNodes(nodesToInterfaces(nodes))
 }
 
-func (oc *Layer3UserDefinedNetworkController) init() error {
+func (oc *Layer3UserDefinedNetworkController) init() (err error) {
+	start := time.Now()
+	defer func() {
+		if err == nil && config.Metrics.EnableScaleMetrics {
+			duration := time.Since(start)
+			metrics.RecordUDNNBDBProgrammedDuration(oc.TopologyType(), duration.Seconds())
+			klog.Infof("Recorded NBDB programmed duration for network %s: %v", oc.GetNetworkName(), duration)
+		}
+	}()
+
 	if err := oc.gatherJoinSwitchIPs(); err != nil {
 		return fmt.Errorf("failed to gather join switch IPs for network %s: %v", oc.GetNetworkName(), err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Adds three new UDN-related performance metrics - 

- udn_update_node_annotation_duration_seconds{network_name} - Tracks the total time spent updating node annotations. 

- udn_workflow_phase_duration_seconds{network_name, phase} - Tracks duration of two UDN phases, queue_wait and nad_sync. queue_wait is only emitted once.  

- udn_nbdb_programmed_duration_seconds - Aggregate of time taken for UDN to be reflected in NBDB.

Primarily used for gathering granular performance data during the ongoing UDN perf/scale effort. These are gated behind the EnableScaleMetrics feature gate. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Observability**
  * Added timing metrics for NBDB programming, overall reconciliation, per-node allocation phases, and NAD sync; workflow-phase durations for first-time readiness and async node-allocation are recorded, capped, and non-positive values skipped. First-reconcile metrics are emitted only once per network instance.
* **Chores**
  * In-memory tracking and removal of network-specific metrics on deletion to prevent metric cardinality growth.
* **Tests**
  * Metrics tests extended to cover the scale-metrics flag and new histograms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->