### PR TITLE
Create UDN VRFs in DPU mode

### DIFF
--- a/go-controller/pkg/controllermanager/node_controller_manager.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager.go
@@ -227,7 +227,6 @@ func (ncm *NodeControllerManager) CleanupStaleNetworks(validNetworks ...util.Net
 		errs = append(errs, err)
 	}
 
-	// in DPU mode, vrfManager would be nil
 	if ncm.vrfManager != nil {
 		validVRFDevices := make(sets.Set[string])
 		for _, network := range validNetworks {
@@ -299,8 +298,14 @@ func NewNodeControllerManager(ovnClient *util.OVNClientset, wf factory.NodeWatch
 		}
 	}
 
-	if util.IsNetworkSegmentationSupportEnabled() && config.OvnKubeNode.Mode != ovntypes.NodeModeDPU {
+	if util.IsNetworkSegmentationSupportEnabled() {
+		// DPU-host mode uses the VRF manager for management-port VRFs,
+		// IP rules, and host kernel traffic. DPU mode only needs the VRF
+		// device as the table anchor for reflecting FRR-learned BGP
+		// routes into OVN. Full mode uses one VRF manager for both.
 		ncm.vrfManager = vrfmanager.NewController(ncm.routeManager)
+	}
+	if util.IsNetworkSegmentationSupportEnabled() && config.OvnKubeNode.Mode != ovntypes.NodeModeDPU {
 		ncm.ruleManager = iprulemanager.NewController(config.IPv4Mode, config.IPv6Mode)
 	}
 

--- a/go-controller/pkg/controllermanager/node_controller_manager_test.go
+++ b/go-controller/pkg/controllermanager/node_controller_manager_test.go
@@ -275,6 +275,38 @@ var _ = Describe("Healthcheck tests", func() {
 
 	})
 
+	Describe("NewNodeControllerManager", func() {
+		It("creates a VRF manager in DPU mode", func() {
+			Expect(config.PrepareTestConfig()).To(Succeed())
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+			config.OvnKubeNode.Mode = types.NodeModeDPU
+
+			factoryMock := factoryMocks.NodeWatchFactory{}
+			factoryMock.On("UserDefinedNetworkInformer").Return(nil)
+			factoryMock.On("ClusterUserDefinedNetworkInformer").Return(nil)
+			factoryMock.On("NamespaceInformer").Return(nil)
+			nadListerMock := &nadlistermocks.NetworkAttachmentDefinitionLister{}
+			nadInformerMock := &nadinformermocks.NetworkAttachmentDefinitionInformer{}
+			nadInformerMock.On("Lister").Return(nadListerMock)
+			nadInformerMock.On("Informer").Return(nil)
+			factoryMock.On("NADInformer").Return(nadInformerMock)
+			nodeInformerMock := &coreinformermocks.NodeInformer{}
+			nodeListerMock := &corelistermocks.NodeLister{}
+			nodeInformerMock.On("Lister").Return(nodeListerMock)
+			factoryMock.On("NodeCoreInformer").Return(nodeInformerMock)
+			fakeClient := &util.OVNClientset{
+				KubeClient: fake.NewSimpleClientset(),
+			}
+
+			ncm, err := NewNodeControllerManager(fakeClient, &factoryMock, "worker1",
+				&sync.WaitGroup{}, nil, routemanager.NewController(), nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ncm.vrfManager).NotTo(BeNil())
+			Expect(ncm.ruleManager).To(BeNil())
+		})
+	})
+
 	Context("verify cleanup of deleted networks", func() {
 		var (
 			staleNetID uint = 1000

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -47,6 +47,10 @@ const (
 	// UDNMasqueradeIPRulePriority the priority of the ip routing rules created for masquerade IP address
 	// allocated for every user defined network.
 	UDNMasqueradeIPRulePriority = 2000
+	// dpuUDNVRFRouteTableIDStart is a distinct table range for UDN VRFs
+	// created on DPUs. DPU mode has no host management interface to derive a
+	// table from, so this avoids colliding with link-index based tables.
+	dpuUDNVRFRouteTableIDStart = 100000
 )
 
 // UserDefinedNetworkGateway contains information
@@ -264,6 +268,11 @@ func (udng *UserDefinedNetworkGateway) AddNetwork() error {
 			return fmt.Errorf("could not add VRF %s routes for network %s, err: %v", vrfDeviceName, udng.GetNetworkName(), err)
 		}
 	}
+	if config.IsModeDPU() {
+		if err = udng.ensureDPUVRF(); err != nil {
+			return err
+		}
+	}
 
 	udng.updateAdvertisementStatus()
 
@@ -342,16 +351,16 @@ func (udng *UserDefinedNetworkGateway) GetNetworkRuleMetadata() string {
 // DelNetwork has returned succesfully.
 func (udng *UserDefinedNetworkGateway) DelNetwork() error {
 	var errs []error
+	vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
 	if config.IsModeDPUHost() || config.IsModeFull() {
-		vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
 		// delete the iprules for this network
 		if err := udng.ruleManager.DeleteWithMetadata(udng.GetNetworkRuleMetadata()); err != nil {
 			errs = append(errs, fmt.Errorf("unable to delete iprules for network %s, err: %v", udng.GetNetworkName(), err))
 		}
-		// delete the VRF device for this network
-		if err := udng.vrfManager.DeleteVRF(vrfDeviceName); err != nil {
-			errs = append(errs, fmt.Errorf("unable to delete VRF device %s for network %s, err: %v", vrfDeviceName, udng.GetNetworkName(), err))
-		}
+	}
+	// delete the VRF device for this network
+	if err := udng.vrfManager.DeleteVRF(vrfDeviceName); err != nil {
+		errs = append(errs, fmt.Errorf("unable to delete VRF device %s for network %s, err: %v", vrfDeviceName, udng.GetNetworkName(), err))
 	}
 	if config.IsModeDPU() || config.IsModeFull() {
 		// delete the openflows for this network
@@ -803,6 +812,21 @@ func (udng *UserDefinedNetworkGateway) doReconcile() error {
 		if err := udng.updateAdvertisedUDNIsolationRules(); err != nil {
 			return fmt.Errorf("error while updating advertised UDN isolation rules for network %s: %w", udng.GetNetworkName(), err)
 		}
+	}
+	return nil
+}
+
+func dpuUDNVRFRouteTableID(networkID int) int {
+	return dpuUDNVRFRouteTableIDStart + networkID
+}
+
+func (udng *UserDefinedNetworkGateway) ensureDPUVRF() error {
+	vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
+	vrfTableID := dpuUDNVRFRouteTableID(udng.GetNetworkID())
+	udng.vrfTableId = vrfTableID
+	if err := udng.vrfManager.AddVRF(vrfDeviceName, "", uint32(vrfTableID), nil); err != nil {
+		return fmt.Errorf("could not add DPU VRF %d for network %s, err: %v",
+			vrfTableID, udng.GetNetworkName(), err)
 	}
 	return nil
 }

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1625,6 +1625,39 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 	})
 
+	ovntest.OnSupportedPlatformsIt("should create a route import VRF in DPU mode", func() {
+		config.OvnKubeNode.Mode = types.NodeModeDPU
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+		}
+		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16/24", types.NetworkRolePrimary)
+		ovntest.AnnotateNADWithNetworkID(netID, nad)
+		netInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			ofm := getDummyOpenflowManager()
+			udnGateway, err := NewUserDefinedNetworkGateway(netInfo, node, nil, nil, vrf, nil, &gateway{openflowManager: ofm})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(udnGateway.ensureDPUVRF()).To(Succeed())
+
+			vrfLink, err := util.GetNetLinkOps().LinkByName(util.GetNetworkVRFName(netInfo))
+			Expect(err).NotTo(HaveOccurred())
+			vrfDevice, ok := vrfLink.(*netlink.Vrf)
+			Expect(ok).To(BeTrue())
+			Expect(vrfDevice.Table).To(Equal(uint32(dpuUDNVRFRouteTableID(netInfo.GetNetworkID()))))
+			Expect(vrfLink.Attrs().MasterIndex).To(Equal(0))
+			Expect(udnGateway.vrfTableId).To(Equal(dpuUDNVRFRouteTableID(netInfo.GetNetworkID())))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+
 	ovntest.OnSupportedPlatformsIt("should have default route when network is advertised on default VRF", func() {
 		config.Gateway.Interface = "eth0"
 		config.IPv4Mode = true


### PR DESCRIPTION
Route import discovers the table to mirror by looking up the per-network VRF. DPU mode programs the UDN datapath on the DPU, but did not create that VRF, so advertised CUDNs had no table for BGP routes to land in and the existing import logic had nothing to read.

Create a DPU-only UDN VRF with no enslaved management interface. Use a DPU-specific table range because there is no host management port index to derive the table from. Wire DPU mode to create and run the VRF manager while keeping the IP rule manager limited to full and DPU-host modes.

Leave the DPU-host IP rules and management-port routes unchanged, and delete the VRF with the network.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VRF support for User Defined Networks in DPU deployments, with dedicated route-table IDs to avoid conflicts

* **Improvements**
  * VRF initialization now occurs consistently when network segmentation is enabled (including DPU mode)
  * More robust VRF lifecycle handling during network creation and deletion; rule handling remains unchanged

* **Tests**
  * Added tests validating VRF creation, route-table assignment, and segmentation behavior in DPU mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->