### PR TITLE
e2e: always resolve agnhost image via DeploymentConfig

### DIFF
--- a/test/e2e/deploymentconfig/configs/kind/kind.go
+++ b/test/e2e/deploymentconfig/configs/kind/kind.go
@@ -4,8 +4,9 @@
 package kind
 
 import (
+	"k8s.io/kubernetes/test/utils/image"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig/api"
-	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
 )
 
@@ -35,5 +36,5 @@ func (k kind) PrimaryInterfaceName() string {
 }
 
 func (k kind) GetAgnHostContainerImage() string {
-	return images.AgnHost()
+	return image.GetE2EImage(image.Agnhost)
 }

--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -6,7 +6,7 @@ package images
 import (
 	"os"
 
-	"k8s.io/kubernetes/test/utils/image"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 )
 
 var (
@@ -16,7 +16,6 @@ var (
 	// New test images should ideally be sourced from the upstream k8s.io/kubernetes/test/utils/image package.
 	// Failing to find an image from upstream k8s, please get community approval because downstream consumers must
 	// pre-approve new images.
-	agnHost = image.GetE2EImage(image.Agnhost)
 	// FIXME: iperf3 image should not be retrieved from a users repo and should not have latest tag
 	iperf3                = "quay.io/sronanrh/iperf:latest"
 	netshoot              = "ghcr.io/nicolaka/netshoot:v0.13"
@@ -24,14 +23,13 @@ var (
 	metallbLBService      = "quay.io/itssurya/dev-images:metallb-lbservice"
 	udpServerSrcIPPrinter = "quay.io/itssurya/dev-images:udp-server-srcip-printer"
 	frr                   = "quay.io/frrouting/frr:10.5.3"
-
+	
+	agnHostOverride = ""
 	extraImages []string
 )
 
 func init() {
-	if agnHostOverride := os.Getenv("AGNHOST_IMAGE"); agnHostOverride != "" {
-		agnHost = agnHostOverride
-	}
+	agnHostOverride = os.Getenv("AGNHOST_IMAGE")
 	if iperf3Override := os.Getenv("IPERF3_IMAGE"); iperf3Override != "" {
 		iperf3 = iperf3Override
 	}
@@ -53,7 +51,10 @@ func init() {
 }
 
 func AgnHost() string {
-	return agnHost
+	if agnHostOverride != "" {
+		return agnHostOverride
+	}
+	return deploymentconfig.Get().GetAgnHostContainerImage()
 }
 
 func IPerf3() string {
@@ -90,6 +91,7 @@ func Add(imgs ...string) {
 // Required returns the deduplicated set of images needed for the current
 // test run. agnhost is always included because it is used by most e2e tests.
 func Required() []string {
+	agnHost := AgnHost()
 	seen := map[string]struct{}{
 		agnHost: {},
 	}


### PR DESCRIPTION
Instead of tests individually resolving where they get the agnhost image from, have that coordinated from the images e2e package. This also honors the upstream specific override. Other images shoudl follow the same approach in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how Agnhost container images are sourced, aligning some test deployment configs with Kubernetes E2E image utilities
  * Added an AGNHOST_IMAGE environment override to allow custom Agnhost images for tests
  * Simplified image resolution logic and reduced internal dependency usage to improve test infrastructure maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->