### PR TITLE
fix(evpn): re-program PERMANENT neighbors after kubevirt live migration

### DIFF
--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -483,6 +483,17 @@ func IsPodAllowedForMigration(pod *corev1.Pod, netInfo util.NetInfo) bool {
 			netInfo.TopologyType() == ovntypes.LocalnetTopology)
 }
 
+// LiveMigrationStatusChanged returns true if the live migration status
+// changed between the old and new pod. This is a lightweight check suitable
+// for use in informer event filters to detect when a migration completes.
+func LiveMigrationStatusChanged(oldPod, newPod *corev1.Pod) bool {
+	if oldPod == nil || newPod == nil {
+		return false
+	}
+	return oldPod.Annotations[kubevirtv1.MigrationTargetReadyTimestamp] !=
+		newPod.Annotations[kubevirtv1.MigrationTargetReadyTimestamp]
+}
+
 func isTargetPodReady(targetPod *corev1.Pod) bool {
 	if targetPod == nil {
 		return false

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 
 	"github.com/vishvananda/netlink"
-	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,11 +37,12 @@ type neighEntries struct {
 // podNeedsUpdate returns true for local pods when the annotation changed, the pod completed, or was deleted.
 // For non-local pods, it returns true when the kubevirt migration target ready timestamp changes,
 // so that reconcilePod can remove the local source pod's entries.
+// For local pods, it also returns true on migration status changes so that
+// reconcilePod re-programs PERMANENT neighbor entries that may have been
+// overwritten by zebra's extern_learn during EVPN MAC mobility.
 func (c *Controller) podNeedsUpdate(oldObj, newObj *corev1.Pod) bool {
-	if oldObj != nil && newObj != nil &&
-		oldObj.Spec.NodeName != c.nodeName && newObj.Spec.NodeName != c.nodeName {
-		return oldObj.Annotations[kubevirtv1.MigrationTargetReadyTimestamp] !=
-			newObj.Annotations[kubevirtv1.MigrationTargetReadyTimestamp]
+	if kubevirt.LiveMigrationStatusChanged(oldObj, newObj) {
+		return true
 	}
 
 	var oldAnnot, newAnnot string
@@ -186,9 +186,7 @@ func (c *Controller) ensurePodNeighbors(entries *neighEntries) error {
 	klog.V(5).Infof("Configured FDB %s vlan %d on %s", entries.mac, entries.macvrfVID, entries.ovsPortName)
 	for _, ip := range entries.ips {
 		if err := util.LinkNeighAdd(svi, ip, entries.mac); err != nil {
-			if !errors.Is(err, syscall.EEXIST) {
-				return fmt.Errorf("failed to add neighbor %s on %s: %w", ip, entries.sviName, err)
-			}
+			return fmt.Errorf("failed to add neighbor %s on %s: %w", ip, entries.sviName, err)
 		}
 		klog.V(5).Infof("Configured neighbor %s lladdr %s on %s", ip, entries.mac, entries.sviName)
 	}

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
@@ -82,7 +82,7 @@ var _ = Describe("EVPN pod controller", func() {
 
 			nlMock.On("LinkByName", sviName).Return(sviLink, nil)
 			nlMock.On("LinkByName", ovsPortName).Return(ovsPortLink, nil)
-			nlMock.On("NeighAdd", mock.Anything).Return(nil)
+			nlMock.On("NeighSet", mock.Anything).Return(nil)
 
 			mac, _ := net.ParseMAC("0a:58:0a:00:00:05")
 			podAnnotation := `{"test-ns/test-nad":{"ip_addresses":["10.0.0.5/24"],"mac_address":"0a:58:0a:00:00:05","ip_address":"10.0.0.5/24"}}`
@@ -99,12 +99,12 @@ var _ = Describe("EVPN pod controller", func() {
 			Expect(ctrl.reconcilePod("test-ns/test-pod")).To(Succeed())
 
 			By("verifying FDB entry was added on OVS port")
-			nlMock.AssertCalled(GinkgoT(), "NeighAdd", mock.MatchedBy(func(n *netlink.Neigh) bool {
+			nlMock.AssertCalled(GinkgoT(), "NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
 				return n.LinkIndex == 20 && n.HardwareAddr.String() == mac.String() && n.Vlan == 100
 			}))
 
 			By("verifying neighbor entry was added on SVI")
-			nlMock.AssertCalled(GinkgoT(), "NeighAdd", mock.MatchedBy(func(n *netlink.Neigh) bool {
+			nlMock.AssertCalled(GinkgoT(), "NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
 				return n.LinkIndex == 10 && n.IP.Equal(net.ParseIP("10.0.0.5"))
 			}))
 
@@ -240,7 +240,7 @@ var _ = Describe("EVPN pod controller", func() {
 			ctrl.podLister = newFakePodLister(pod)
 
 			Expect(ctrl.reconcilePod("test-ns/test-pod")).To(Succeed())
-			nlMock.AssertNotCalled(GinkgoT(), "NeighAdd", mock.Anything)
+			nlMock.AssertNotCalled(GinkgoT(), "NeighSet", mock.Anything)
 
 			By("verifying no cache entry was created")
 			_, exists := ctrl.podNeighbors["test-ns/test-pod"]
@@ -263,7 +263,7 @@ var _ = Describe("EVPN pod controller", func() {
 			ctrl.podLister = newFakePodLister(pod)
 
 			Expect(ctrl.reconcilePod("test-ns/test-pod")).To(Succeed())
-			nlMock.AssertNotCalled(GinkgoT(), "NeighAdd", mock.Anything)
+			nlMock.AssertNotCalled(GinkgoT(), "NeighSet", mock.Anything)
 		})
 
 		It("cleans up entries when pod completes", func() {
@@ -342,7 +342,7 @@ var _ = Describe("EVPN pod controller", func() {
 			ctrl.podLister = newFakePodLister(pod)
 
 			Expect(ctrl.reconcilePod("test-ns/remote-pod")).To(Succeed())
-			nlMock.AssertNotCalled(GinkgoT(), "NeighAdd", mock.Anything)
+			nlMock.AssertNotCalled(GinkgoT(), "NeighSet", mock.Anything)
 		})
 	})
 })

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
@@ -82,6 +82,7 @@ var _ = Describe("EVPN pod controller", func() {
 
 			nlMock.On("LinkByName", sviName).Return(sviLink, nil)
 			nlMock.On("LinkByName", ovsPortName).Return(ovsPortLink, nil)
+			nlMock.On("NeighAdd", mock.Anything).Return(nil)
 			nlMock.On("NeighSet", mock.Anything).Return(nil)
 
 			mac, _ := net.ParseMAC("0a:58:0a:00:00:05")
@@ -99,7 +100,7 @@ var _ = Describe("EVPN pod controller", func() {
 			Expect(ctrl.reconcilePod("test-ns/test-pod")).To(Succeed())
 
 			By("verifying FDB entry was added on OVS port")
-			nlMock.AssertCalled(GinkgoT(), "NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+			nlMock.AssertCalled(GinkgoT(), "NeighAdd", mock.MatchedBy(func(n *netlink.Neigh) bool {
 				return n.LinkIndex == 20 && n.HardwareAddr.String() == mac.String() && n.Vlan == 100
 			}))
 

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -851,6 +851,24 @@ func (_m *NetLinkOps) NeighAdd(neigh *netlink.Neigh) error {
 	return r0
 }
 
+// NeighSet provides a mock function with given fields: neigh
+func (_m *NetLinkOps) NeighSet(neigh *netlink.Neigh) error {
+	ret := _m.Called(neigh)
+
+	if len(ret) == 0 {
+		panic("no return value specified for NeighSet")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*netlink.Neigh) error); ok {
+		r0 = rf(neigh)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NeighDel provides a mock function with given fields: neigh
 func (_m *NetLinkOps) NeighDel(neigh *netlink.Neigh) error {
 	ret := _m.Called(neigh)

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -58,6 +58,7 @@ type NetLinkOps interface {
 	RuleListFiltered(family int, filter *netlink.Rule, filterMask uint64) ([]netlink.Rule, error)
 	RuleAdd(rule *netlink.Rule) error
 	NeighAdd(neigh *netlink.Neigh) error
+	NeighSet(neigh *netlink.Neigh) error
 	NeighDel(neigh *netlink.Neigh) error
 	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
 	ConntrackDeleteFilters(table netlink.ConntrackTableType, family netlink.InetFamily, filters ...netlink.CustomConntrackFilter) (uint, error)
@@ -240,6 +241,10 @@ func (defaultNetLinkOps) RuleAdd(rule *netlink.Rule) error {
 
 func (defaultNetLinkOps) NeighAdd(neigh *netlink.Neigh) error {
 	return netlink.NeighAdd(neigh)
+}
+
+func (defaultNetLinkOps) NeighSet(neigh *netlink.Neigh) error {
+	return netlink.NeighSet(neigh)
 }
 
 func (defaultNetLinkOps) NeighDel(neigh *netlink.Neigh) error {
@@ -658,7 +663,9 @@ func LinkNeighDel(link netlink.Link, neighIP net.IP) error {
 	return nil
 }
 
-// LinkNeighAdd adds MAC/IP bindings for the given link
+// LinkNeighAdd adds or replaces MAC/IP bindings for the given link.
+// It uses NeighSet (NLM_F_CREATE|NLM_F_REPLACE) so that existing entries
+// (e.g. extern_learn from EVPN) are replaced with the desired state.
 func LinkNeighAdd(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAddr) error {
 	neigh := &netlink.Neigh{
 		LinkIndex:    link.Attrs().Index,
@@ -667,9 +674,9 @@ func LinkNeighAdd(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAddr) 
 		IP:           neighIP,
 		HardwareAddr: neighMAC,
 	}
-	err := netLinkOps.NeighAdd(neigh)
+	err := netLinkOps.NeighSet(neigh)
 	if err != nil {
-		return fmt.Errorf("failed to add neighbour entry %+v: %w", neigh, err)
+		return fmt.Errorf("failed to set neighbour entry %+v: %w", neigh, err)
 	}
 	return nil
 }

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -838,7 +838,7 @@ func TestLinkNeighAdd(t *testing.T) {
 			inputLink: mockLink,
 			errExp:    true,
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "NeighAdd", OnCallMethodArgType: []string{"*netlink.Neigh"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "NeighSet", OnCallMethodArgType: []string{"*netlink.Neigh"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},
@@ -848,7 +848,7 @@ func TestLinkNeighAdd(t *testing.T) {
 			desc:      "test code path where adding neighbor returns success",
 			inputLink: mockLink,
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "NeighAdd", OnCallMethodArgType: []string{"*netlink.Neigh"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "NeighSet", OnCallMethodArgType: []string{"*netlink.Neigh"}, RetArgList: []interface{}{nil}},
 			},
 			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},


### PR DESCRIPTION
## 📑 Description

Fix EVPN PERMANENT neighbor entries being lost after kubevirt live
migration, causing Type-5 /32 host routes to disappear and north/south
traffic to black-hole via ECMP.

Fixes #6420

## Additional Information for reviewers

Two commits:

1. **NeighSet instead of NeighAdd**: `LinkNeighAdd` used `NeighAdd`
   which silently fails with EEXIST when zebra has already placed an
   `extern_learn` entry. `NeighSet` replaces any existing entry.

   Safe for all existing callers:
   - **EVPN pod controller**: needs replace to overwrite `extern_learn`
     with PERMANENT (the fix)
   - **Management port**: programs gateway neighbor at startup,
     idempotent with `Set`
   - **Gateway bridge**: already had a manual `NeighDel` + `NeighAdd`
     workaround for stale entries — `NeighSet` makes that unnecessary.
     A follow-up PR can simplify this code path.

2. **Trigger reconcilePod on target node after migration**: The
   `MigrationTargetReadyTimestamp` check in `podNeedsUpdate` was
   guarded by a node locality check that excluded the target node
   (where the pod is local). Source and uninvolved nodes already
   triggered on this annotation change. This fix removes the guard
   so the target node also re-programs PERMANENT neighbors after
   migration completes and zebra has settled.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [X] My code requires tests
- [X] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

The e2e test `ingress routed over evpn` should stop flaking (~60%
failure rate on master since introduction in #6193).

The focused test has been run 15 times locally with this fix — all
passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KubeVirt live migration status detection added.

* **Bug Fixes**
  * Network neighbor operation failures are now reported instead of ignored.
  * Neighbor programming now uses add-or-replace semantics for improved reliability.

* **Tests**
  * Network neighbor tests updated to reflect the new neighbor programming behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->