### PR TITLE
 Website fully responsive across all screen sizes - Mobile, Standard Laptop & Desktop, Tablet, and Ultra-wide screens

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -212,7 +212,11 @@
   font-size: clamp(0.875rem, 0.825rem + 0.25vw, 1.125rem);
   position: relative;
   left: clamp(-1.375rem, -1.5vw, -0.5rem);
-  top: clamp(2px, 0.4vw, 4px);
+}
+
+.md-header__button.md-logo {
+  position: relative;
+  top: -2px;
 }
 
 [dir="ltr"] .md-source__icon + .md-source__repository {
@@ -317,6 +321,7 @@ a.md-tabs__link {
 
 .md-main__inner {
   grid-template-columns: minmax(min(10rem, 15vw), 12.5rem) 1fr minmax(min(10rem, 15vw), 12.5rem);
+  margin-top: 1rem;
 }
 
 [dir="ltr"] .md-sidebar--primary:not([hidden]) ~ .md-content > .md-content__inner {
@@ -525,6 +530,13 @@ a.md-tabs__link {
   }
 }
 
+img[alt="ovn-kubernetes-logo"] {
+  width: clamp(240px, 20vw, 300px);
+  display: block;
+  margin-inline: auto;
+}
+
+/* Responsive Breakpoint for Mobile, Tablet, and Small Screens */
 @media screen and (max-width: 59.9em) {
   :root {
     --md-header-height: 3rem;
@@ -545,43 +557,58 @@ a.md-tabs__link {
 
   /* Primary Sidebar (The Drawer) */
   .md-sidebar--primary {
-    position: fixed;
-    top: -25px;
-    left: 0;
-    width: 280px !important; /* Standard mobile drawer width */
-    height: 100vh;
-    z-index: 100;
-    transform: translateX(-100%); /* Start completely hidden */
-    transition: transform var(--ok-med);
-    visibility: visible !important;
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 280px !important;
+    height: 100vh !important;
+    z-index: 100 !important;
+    transform: translateX(-100%) !important;
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
     display: block !important;
-    background: var(--ok-sidebar-bg);
+    background: var(--md-default-bg-color) !important;
+    overflow: visible !important;
   }
 
-  /* Slide in when the drawer toggle is checked */
-  /* NOTE: This project's build renders data-md-toggle="__drawer" (non-standard). 
-  The standard mkdocs-material value is usually "drawer". 
-  If upgrading mkdocs-material in the future, verify the rendered attribute 
-  value in browser DevTools to ensure the mobile drawer continues to function.
-*/
-html [data-md-toggle="__drawer"]:checked ~ .md-container .md-sidebar--primary {
+  [data-md-toggle="drawer"]:checked ~ .md-container .md-sidebar--primary {
     transform: translateX(0) !important;
     visibility: visible !important;
+    pointer-events: auto !important;
     display: block !important;
-    box-shadow: 10px 0 30px rgba(0, 0, 0, 0.2);
-}
+    box-shadow: var(--md-shadow-z3), 10px 0 30px rgba(0, 0, 0, 0.2) !important;
+  }
 
-  /* Sidebar Scroll Container Reset */
+  /* Scrollwrap: fill entire drawer, allow scrolling */
   .md-sidebar--primary .md-sidebar__scrollwrap {
-    position: relative !important;
-    width: 100% !important;
-    height: 100% !important;
-    max-height: none !important;
+    position: absolute !important;
+    top: 0 !important;
+    bottom: 0 !important;
     left: 0 !important;
+    right: 0 !important;
+    width: auto !important;
+    height: auto !important;
+    max-height: none !important;
+    margin: 0 !important;
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
     border: none !important;
-    border-radius: 0 !important; /* Remove desktop curves in drawer mode */
-    padding-top: 1rem;
-    background: transparent !important; /* Let parent background handle it */
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    transform: none !important;
+    scroll-snap-type: none !important;
+  }
+
+  .md-sidebar--primary .md-sidebar__scrollwrap:hover {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+
+  .md-sidebar--primary .md-sidebar__inner {
+    margin: 0 !important;
+    padding: 0 !important;
   }
 
   /* Content Area - Crucial Reset */
@@ -592,53 +619,107 @@ html [data-md-toggle="__drawer"]:checked ~ .md-container .md-sidebar--primary {
     width: 100% !important;
     max-width: 100vw;
     transform: none !important;
-    text-align: left; /* Optional: justifying text on tiny screens can look messy */
+    text-align: left; 
   }
 
   /* Reset grid columns to stack */
   .md-main__inner {
     display: block !important;
+    margin-top: 0.5rem;
   }
 
   /* Cleanup */
   .md-sidebar--secondary {
-    display: none; /* Hide Table of Contents on mobile to save space */
+    display: none;
   }
 
   /* Fix for the logo/title alignment in mobile header */
   .md-header .md-ellipsis {
     left: 0; 
-    top: 0;
+    top: 0.1rem;
   }
-  .md-nav--primary .md-nav__title[for=__drawer] {
-    height: 63.5px;
-    background-color: var(--md-primary-fg-color);
-    color: var(--md-primary-bg-color);
-    font-weight: 700;
-    border-radius: 0 !important;
+  /* Drawer title bar */
+  .md-nav--primary .md-nav__title {
+    animation: none !important;
+    font-size: 0.8rem !important;
+    font-weight: 800 !important;
+    color: var(--md-accent-fg-color, var(--md-primary-fg-color)) !important;
+    border-radius: var(--ok-radius-sm) !important;
+    padding: 0.6rem 0.8rem !important;
+    height: 3rem !important;
+    cursor: pointer !important;
+    position: relative !important;
+    white-space: nowrap !important;
+    line-height: 1.5 !important;
+    display: flex !important;
+    align-items: center !important;
+    gap: 0.4rem !important;
+    transition: transform var(--ok-fast), box-shadow var(--ok-fast), background-color var(--ok-fast) !important;
+  }
 
-}
-.md-nav__title .md-nav__button.md-logo img, .md-nav__title .md-nav__button.md-logo svg {
-  fill: currentcolor;
-  display: block;
-  height: 1.7rem;
-  max-width: 100%;
-  object-fit: contain;
-  width: auto;
-  position: relative;
-  left: 3em;
-  top: 0.5em;
-}
-.md-sidebar--primary .md-nav__title {
-  animation: none !important;
-  font-size: clamp(1rem, 0.9rem + 0.35vw, 1.2rem);
-  font-weight: 800;
-  color: var(--md-accent-fg-color, var(--md-primary-fg-color));
-  border-radius: var(--ok-radius-sm);
-  padding: 20px;
-  transition: transform var(--ok-fast), box-shadow var(--ok-fast), background-color var(--ok-fast);
-  height: 63.5px;
-}
+  .md-nav--primary .md-nav__title .md-nav__icon {
+    position: static !important;
+    flex-shrink: 0 !important;
+    transform: none !important;
+  }
+
+  .md-nav--primary .md-nav__title[for=__drawer] {
+    height: 3rem !important;
+    background-color: var(--md-primary-fg-color) !important;
+    color: var(--md-primary-bg-color) !important;
+    font-weight: 700 !important;
+    border-radius: 0 !important;
+    padding: 0.4rem 0.8rem !important;
+  }
+
+  .md-nav--primary .md-nav__title .md-logo {
+    display: block !important;
+    position: absolute !important;
+    left: 0.2rem !important;
+    top: 0.1rem !important;
+    margin: 0 !important;
+    padding: 0.2rem !important;
+    right: auto !important;
+  }
+
+  .md-nav__title .md-nav__button.md-logo img,
+  .md-nav__title .md-nav__button.md-logo svg {
+    fill: currentcolor;
+    display: block;
+    height: 1.4rem;
+    max-width: 100%;
+    object-fit: contain;
+    width: auto;
+    position: relative;
+    left: 7rem;
+    top: 0.5rem;
+  }
+
+  .md-nav--primary .md-nav__item,
+  .md-nav--primary .md-nav__title {
+    font-size: 0.8rem !important;
+    line-height: 1.5 !important;
+  }
+
+  .md-nav--primary .md-nav__link {
+    margin-top: 0 !important;
+    padding: 0.6rem 0.8rem !important;
+  }
+
+  .md-nav--primary .md-nav__link.md-nav__container {
+    padding: 0.6rem 0.8rem !important;
+    font-size: 0.8rem !important;
+    line-height: 1.5 !important;
+    display: flex !important;
+    align-items: center !important;
+  }
+
+  .md-nav--primary .md-nav__link.md-nav__container > .md-nav__link {
+    padding: 0 !important;
+    font-size: inherit !important;
+    line-height: inherit !important;
+  }
+
 body:has(#__drawer:checked) {
   overflow: hidden !important;
   overscroll-behavior: contain;
@@ -646,17 +727,446 @@ body:has(#__drawer:checked) {
 }
 }
 
-img[alt="ovn-kubernetes-logo"] {
-  width: clamp(240px, 20vw, 300px);
-}
-img {
-  display: block;
-  float: none;
-  margin-left: auto;
-  margin-right: auto;
-}
+/* Responsive Breakpoint for Large Screens */
 @media screen and (min-width: 123.0625em) {
 .md-typeset h1 {
   font-size: 1.5rem;
 }
+}
+
+/* Responsive Breakpoint for Mid-Screen and Medium Tablet */
+@media screen and (min-width: 59.875em) and (max-width: 86.25em) {
+  :root {
+    --md-header-height: 3rem;
+  }
+
+  .md-header {
+    height: auto !important;
+    min-height: var(--md-header-height);
+    z-index: 10;
+  }
+
+  /* Force hamburger visible — theme hides it at >=76.25em */
+  .md-header__button[for="__drawer"] {
+    display: block !important;
+    cursor: pointer;
+    z-index: 11;
+  }
+
+  /* Hide logo button that theme only shows at >=76.25em */
+  .md-header__button.md-logo {
+    display: none !important;
+  }
+
+  /* Override theme's height:0 on sidebars at >=76.25em */
+  .md-sidebar {
+    height: auto !important;
+  }
+
+  /* Primary sidebar */
+  .md-sidebar--primary {
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 280px !important;
+    height: 100vh !important;
+    max-width: none !important;
+    min-width: 0 !important;
+    z-index: 100 !important;
+    transform: translateX(-100%) !important;
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s !important;
+    visibility: visible !important;
+    display: block !important;
+    background: var(--md-default-bg-color) !important;
+    overflow: visible !important;
+  }
+
+  .md-sidebar--primary[hidden] {
+    display: block !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
+    transform: translateX(-100%) !important;
+  }
+
+  /* Slide drawer in when checkbox is toggled */
+  [data-md-toggle="drawer"]:checked ~ .md-container .md-sidebar--primary,
+  [data-md-toggle="drawer"]:checked ~ .md-container .md-sidebar--primary[hidden] {
+    transform: translateX(0) !important;
+    visibility: visible !important;
+    pointer-events: auto !important;
+    display: block !important;
+    box-shadow: var(--md-shadow-z3), 10px 0 30px rgba(0, 0, 0, 0.2) !important;
+  }
+
+  /* Overlay backdrop when drawer is open */
+  .md-overlay {
+    background-color: rgba(0, 0, 0, 0.54) !important;
+    height: 0;
+    opacity: 0;
+    position: fixed !important;
+    top: 0;
+    transition: width 0ms 0.25s, height 0ms 0.25s, opacity 0.25s !important;
+    width: 0;
+    z-index: 90 !important;
+  }
+
+  [data-md-toggle="drawer"]:checked ~ .md-overlay {
+    height: 100% !important;
+    opacity: 1 !important;
+    transition: width 0ms, height 0ms, opacity 0.25s !important;
+    width: 100% !important;
+  }
+
+  /* Scrollwrap: fill entire drawer, allow scrolling */
+  .md-sidebar--primary .md-sidebar__scrollwrap {
+    position: absolute !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    width: auto !important;
+    height: auto !important;
+    max-height: none !important;
+    margin: 0 !important;
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    transform: none !important;
+    scroll-snap-type: none !important;
+  }
+
+  .md-sidebar--primary .md-sidebar__scrollwrap:hover {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+
+  .md-sidebar--primary .md-sidebar__inner {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  .md-nav--primary,
+  .md-nav--primary .md-nav {
+    background-color: var(--md-default-bg-color) !important;
+    display: flex !important;
+    flex-direction: column !important;
+    height: 100% !important;
+    left: 0 !important;
+    position: absolute !important;
+    right: 0 !important;
+    top: 0 !important;
+    z-index: 1 !important;
+  }
+
+  /* Undo the theme's desktop accordion on .md-nav at >=76.25em */
+  .md-nav--primary .md-nav {
+    margin-bottom: 0 !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  .md-nav--primary .md-nav__list {
+    flex: 1 !important;
+    overflow-y: auto !important;
+  }
+
+  .md-nav--primary .md-nav__title ~ .md-nav__list {
+    background-color: var(--md-default-bg-color) !important;
+    box-shadow: 0 0.05rem 0 var(--md-default-fg-color--lightest) inset !important;
+    overflow-y: auto !important;
+    scroll-snap-type: y mandatory !important;
+    touch-action: pan-y !important;
+  }
+
+  .md-nav--primary .md-nav__item,
+  .md-nav--primary .md-nav__title {
+    font-size: 0.8rem !important;
+    line-height: 1.5 !important;
+  }
+
+  .md-nav--primary .md-nav__item {
+    border-top: 0.05rem solid var(--md-default-fg-color--lightest) !important;
+  }
+
+  .md-nav--primary .md-nav__link {
+    margin-top: 0 !important;
+    padding: 0.6rem 0.8rem !important;
+  }
+
+  /* Drawer title bar */
+  .md-nav--primary .md-nav__title {
+    animation: none !important;
+    font-size: 0.8rem !important;
+    font-weight: 800 !important;
+    color: var(--md-accent-fg-color, var(--md-primary-fg-color)) !important;
+    border-radius: var(--ok-radius-sm) !important;
+    padding: 0.6rem 0.8rem !important;
+    height: 3rem !important;
+    cursor: pointer !important;
+    position: relative !important;
+    white-space: nowrap !important;
+    line-height: 1.5 !important;
+    display: flex !important;
+    align-items: center !important;
+    gap: 0.4rem !important;
+    transition: transform var(--ok-fast), box-shadow var(--ok-fast), background-color var(--ok-fast) !important;
+  }
+
+  .md-nav--primary .md-nav__title[for=__drawer] {
+    height: 3rem !important;
+    background-color: var(--md-primary-fg-color) !important;
+    color: var(--md-primary-bg-color) !important;
+    font-weight: 700 !important;
+    border-radius: 0 !important;
+    padding: 0.4rem 0.8rem !important;
+  }
+
+  .md-nav--primary .md-nav__title .md-logo {
+    display: block !important;
+    position: absolute !important;
+    left: 0.2rem !important;
+    top: 0.1rem !important;
+    margin: 0 !important;
+    padding: 0.2rem !important;
+    right: auto !important;
+  }
+
+  .md-nav__title .md-nav__button.md-logo img,
+  .md-nav__title .md-nav__button.md-logo svg {
+    fill: currentcolor;
+    display: block;
+    height: 1.4rem;
+    max-width: 100%;
+    object-fit: contain;
+    width: auto;
+    position: relative;
+    left: 7rem;
+    top: 0.5rem;
+  }
+
+  /* Container link */
+  .md-nav--primary .md-nav__link.md-nav__container {
+    padding: 0.6rem 0.8rem !important;
+    font-size: 0.8rem !important;
+    line-height: 1.5 !important;
+    display: flex !important;
+    align-items: center !important;
+  }
+
+  .md-nav--primary .md-nav__link.md-nav__container > .md-nav__link {
+    padding: 0 !important;
+    font-size: inherit !important;
+    line-height: inherit !important;
+  }
+
+  /* Forward arrow on nav links that have sub-panels */
+  .md-nav--primary .md-nav__link .md-nav__icon {
+    flex-shrink: 0 !important;
+    font-size: 1.2rem !important;
+    height: 1.2rem !important;
+    width: 1.2rem !important;
+  }
+
+  .md-nav--primary .md-nav__link .md-nav__icon:after {
+    background-color: currentcolor !important;
+    content: "" !important;
+    display: block !important;
+    height: 100% !important;
+    mask-image: var(--md-nav-icon--next) !important;
+    -webkit-mask-image: var(--md-nav-icon--next) !important;
+    mask-position: center !important;
+    -webkit-mask-position: center !important;
+    mask-repeat: no-repeat !important;
+    -webkit-mask-repeat: no-repeat !important;
+    mask-size: contain !important;
+    -webkit-mask-size: contain !important;
+    width: 100% !important;
+    transform: none !important;
+  }
+
+  /* Content area — full-width, no sidebar offsets */
+  [dir="ltr"] .md-content > .md-content__inner,
+  [dir="ltr"] .md-sidebar--primary:not([hidden]) ~ .md-content > .md-content__inner {
+    margin: 0 !important;
+    padding: 1rem;
+    width: 100% !important;
+    max-width: 100vw;
+    transform: none !important;
+    text-align: left;
+  }
+
+  /* Stack layout to single column */
+  .md-main__inner {
+    display: block !important;
+    margin-top: 0.5rem;
+  }
+
+  /* Hide the standalone TOC sidebar (right column) */
+  .md-sidebar--secondary {
+    display: none !important;
+  }
+
+  .md-nav--primary .md-nav__link[for=__toc] {
+    display: flex !important;
+  }
+
+  .md-nav--primary .md-nav__link[for=__toc] .md-icon:after {
+    content: "" !important;
+    background-color: currentcolor !important;
+    display: block !important;
+    height: 100% !important;
+    width: 100% !important;
+    mask-image: var(--md-toc-icon) !important;
+    -webkit-mask-image: var(--md-toc-icon) !important;
+    mask-position: center !important;
+    -webkit-mask-position: center !important;
+    mask-repeat: no-repeat !important;
+    -webkit-mask-repeat: no-repeat !important;
+    mask-size: contain !important;
+    -webkit-mask-size: contain !important;
+  }
+
+  .md-nav--primary .md-nav__link[for=__toc] + .md-nav__link {
+    display: none !important;
+  }
+
+  .md-nav--primary .md-nav__link[for=__toc] ~ .md-nav {
+    display: flex !important;
+  }
+
+  .md-nav__toggle ~ .md-nav {
+    display: flex !important;
+    flex-direction: column !important;
+    opacity: 0 !important;
+    transform: translateX(100%) !important;
+    transition: transform 0.25s cubic-bezier(0.8, 0, 0.6, 1),
+                opacity 125ms 50ms !important;
+    grid-template-rows: none !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    height: 100% !important;
+    z-index: 1 !important;
+  }
+
+  .md-nav__toggle:checked ~ .md-nav {
+    opacity: 1 !important;
+    transform: translateX(0) !important;
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 125ms 125ms !important;
+    visibility: visible !important;
+    pointer-events: auto !important;
+  }
+
+  .md-nav__toggle:checked ~ .md-nav > .md-nav__list {
+    backface-visibility: hidden !important;
+  }
+
+  .md-nav--primary .md-nav__title .md-nav__icon {
+    display: block !important;
+    height: 1.2rem !important;
+    margin: 0 !important;
+    position: static !important;
+    flex-shrink: 0 !important;
+    transform: none !important;
+    width: 1.2rem !important;
+  }
+
+  .md-nav--primary .md-nav__title .md-nav__icon:after {
+    background-color: currentcolor !important;
+    content: "" !important;
+    display: block !important;
+    height: 100% !important;
+    mask-image: var(--md-nav-icon--prev) !important;
+    -webkit-mask-image: var(--md-nav-icon--prev) !important;
+    mask-position: center !important;
+    -webkit-mask-position: center !important;
+    mask-repeat: no-repeat !important;
+    -webkit-mask-repeat: no-repeat !important;
+    mask-size: contain !important;
+    -webkit-mask-size: contain !important;
+    width: 100% !important;
+  }
+
+  /* Secondary nav (TOC) inside the drawer */
+  .md-nav--primary .md-nav--secondary .md-nav {
+    background-color: initial !important;
+    position: static !important;
+  }
+
+  [dir="ltr"] .md-nav--primary .md-nav--secondary .md-nav .md-nav__link {
+    padding-left: 1.4rem !important;
+  }
+
+  [dir="ltr"] .md-nav--primary .md-nav--secondary .md-nav .md-nav .md-nav__link {
+    padding-left: 2rem !important;
+  }
+
+  .md-nav--secondary .md-nav__title {
+    background: var(--md-default-bg-color) !important;
+    box-shadow: 0 0 0.4rem 0.4rem var(--md-default-bg-color) !important;
+    position: sticky !important;
+    top: 0 !important;
+    z-index: 1 !important;
+    display: flex !important;
+    align-items: center !important;
+    gap: 0.4rem !important;
+    height: 3rem !important;
+    padding: 0.6rem 0.8rem !important;
+    white-space: nowrap !important;
+    line-height: 1.5 !important;
+  }
+
+  .md-nav--secondary .md-nav__title .md-nav__icon {
+    display: block !important;
+    height: 1.2rem !important;
+    width: 1.2rem !important;
+    margin: 0 !important;
+    position: static !important;
+    flex-shrink: 0 !important;
+    transform: none !important;
+  }
+
+  .md-nav--secondary .md-nav__title .md-nav__icon:after {
+    background-color: currentcolor !important;
+    content: "" !important;
+    display: block !important;
+    height: 100% !important;
+    mask-image: var(--md-nav-icon--prev) !important;
+    -webkit-mask-image: var(--md-nav-icon--prev) !important;
+    mask-position: center !important;
+    -webkit-mask-position: center !important;
+    mask-repeat: no-repeat !important;
+    -webkit-mask-repeat: no-repeat !important;
+    mask-size: contain !important;
+    -webkit-mask-size: contain !important;
+    width: 100% !important;
+  }
+
+  [dir="ltr"] .md-nav--secondary .md-nav__list {
+    padding-left: 0.6rem !important;
+  }
+
+  .md-nav--secondary .md-nav__list {
+    padding-bottom: 0.4rem !important;
+  }
+
+  /* Header logo/title alignment reset */
+  .md-header .md-ellipsis {
+    left: 0;
+    top: 0.1rem;
+  }
+
+  /* Lock body scroll when drawer is open */
+  body:has(#__drawer:checked) {
+    overflow: hidden !important;
+    overscroll-behavior: contain;
+    height: 100dvh;
+  }
 }


### PR DESCRIPTION
This PR makes the OVN-Kubernetes documentation site fully responsive by adding and refining CSS breakpoints so the layout adapts cleanly from small mobile screens through tablets, standard laptops/desktops, and ultra-wide monitors. The hamburger drawer, navigation hierarchy, table of contents, sidebar panels, and header are now consistent and usable at every viewport width.

## Summary

- **Mobile & Small Screens (`≤ 59.9em / 958px`):** Reworked the hamburger drawer to use a full-height panel with proper scrolling, consistent 3rem title bar, and correct `data-md-toggle="drawer"` selector. Navigation items, container links, and label links now share uniform sizing and padding.

<img width="1038" height="949" alt="Screenshot From 2026-05-22 16-14-59" src="https://github.com/user-attachments/assets/9fa5b1c4-81ba-4fc7-ae48-d49a1b08427c" />

https://github.com/user-attachments/assets/10d6fa1f-df85-4d79-b3da-290cbd7d4273

- **Mid-Screen & Medium Tablet (`59.875em – 86.25em / 958px – 1380px`):** Added a new responsive breakpoint that forces the mobile-style hamburger drawer layout at widths where mkdocs-material normally switches to desktop mode (≥76.25em). Overrides the theme's desktop sidebar, accordion nav, and hidden hamburger to provide a consistent drawer experience with slide-in sub-panels, TOC integration via 3-line icon, back arrows, and overlay backdrop.

<img width="1044" height="937" alt="Screenshot From 2026-05-22 16-14-25" src="https://github.com/user-attachments/assets/6b4da336-472d-489a-ba9c-56cc924b2983" />

https://github.com/user-attachments/assets/d93f5b23-362f-4f28-bf6f-7e692b4062eb

<img width="1347" height="934" alt="Screenshot From 2026-05-22 16-13-32" src="https://github.com/user-attachments/assets/3cfafa4f-3614-44fb-8a4e-66d5c3288ce7" />

https://github.com/user-attachments/assets/5066435e-f99f-41eb-9403-50e7dc4269dd

- **Standard Laptop & Desktop (`> 86.25em / 1380px`):** Default mkdocs-material desktop layout with both primary (left navigation) and secondary (table of contents) sidebars visible in a three-column grid. Frosted-glass card sidebars, hover micro-interactions, and fluid typography scale cleanly across typical laptop and monitor widths.

<img width="1894" height="995" alt="Screenshot From 2026-05-22 16-13-04" src="https://github.com/user-attachments/assets/6e7d8d4c-619c-42bc-83fb-dcc9638bee4d" />

- **Ultra-Wide & Extra-Large Screens (`≥ 123.0625em / 1969px`):** Caps heading font size to prevent oversized text on very wide displays.

<img width="1470" height="377" alt="Screenshot From 2026-05-12 12-21-09" src="https://github.com/user-attachments/assets/50967faf-e775-413d-93a8-5163f7a81317" />

## Test plan
- Resize browser from 320px to 2000px+ and verify layout transitions are smooth at each breakpoint

https://github.com/user-attachments/assets/62b48b1e-cccb-45da-8afe-09d34b6f9013










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Mobile navigation drawer rebuilt as a fixed full-height off-canvas that slides in, with body scroll locked while open.
  * Mobile layout simplified to a single-column flow; secondary sidebar hidden.
  * Header ellipsis positioning and header/logo/title/nav sizing/alignment refined for mobile and tablet breakpoints.
  * Removed global image-centering; added targeted logo/image sizing and responsive adjustments for tablet/large screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->