### PR TITLE
e2e: remove temporary multihoming NAD sync sleeps

### DIFF
--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -2338,10 +2338,6 @@ ip a add %[4]s/24 dev %[2]s
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			By("sitting on our hands for a couple secs we give the controller time to sync all NADs before provisioning policies and pods")
-			// TODO: this is temporary. We hope to eventually sync pods & multi-net policies on NAD C/U/D ops
-			time.Sleep(3 * time.Second)
-
 			podConfig := podConfiguration{
 				attachments: []nadapi.NetworkSelectionElement{
 					{Name: secondaryNetworkName},
@@ -2417,9 +2413,6 @@ ip a add %[4]s/24 dev %[2]s
 					metav1.CreateOptions{},
 				)
 				Expect(err).NotTo(HaveOccurred())
-
-				By("waiting for controller to sync the NAD")
-				time.Sleep(5 * time.Second)
 
 				By("creating a pod with multiple attachments to the same secondary NAD")
 				// Specify the same NAD name multiple times to test GetIndexedNADKey functionality
@@ -2769,10 +2762,6 @@ func createNads(f *framework.Framework, nadClient nadclient.K8sCniCncfIoV1Interf
 			return err
 		}
 	}
-
-	By("sitting on our hands for a couple secs we give the controller time to sync all NADs before provisioning policies and pods")
-	// TODO: this is temporary. We hope to eventually sync pods & multi-net policies on NAD C/U/D ops
-	time.Sleep(3 * time.Second)
 
 	return nil
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

Some multihoming tests were using fixed sleeps after creating network attachment definitions to give controllers time to catch up before creating pods or applying policies. These waits were added as temporary buffers and now just slow the suite down.

This cleanup assumes the original production-side race is already addressed by PR #5705 (https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5705, "Fixes NAD Controller syncAll for networkID upgrade from node->NAD") and/or later by commit 5b01e17b18b7 ("Refactor NADController notifying into level driven reconciler").

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

Originally part of https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5910 but now just sleeps removed.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed hard-coded delays from end-to-end tests to speed up execution and reduce flakiness, while preserving existing test logic and assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->