### PR TITLE
chore: skip cicd tests for doc changes

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     branches: [ master, release-* ]
     paths-ignore:
+      - 'docs/**'
       - '**/*.md'
       - 'mkdocs.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   push:
     branches:
       - master

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches: [ master ]
     paths-ignore:
+      - 'docs/**'
       - '**/*.md'
       - 'mkdocs.yml'
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,11 @@ on:
     branches: [ master,release-* ]
     # Only run jobs if at least one non-doc file is changed
     paths-ignore:
+      - 'docs/**'
       - '**/*.md'
       - 'mkdocs.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   schedule:
     - cron: '0 */12 * * *'
   workflow_dispatch:


### PR DESCRIPTION
## 📑 Description

Skip CI/CD test jobs if the changes are documentation-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to skip running for documentation-only and template-only changes across multiple pipelines. Builds and tests will be bypassed when only docs, markdown/site config, or repository template files are modified, reducing unnecessary pipeline runs and improving efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->