### PR TITLE
helm: add ksmHonorLabels to make alert label selectors configurable

### DIFF
--- a/helm/ovn-kubernetes/templates/ovnkube-alerts.yaml
+++ b/helm/ovn-kubernetes/templates/ovnkube-alerts.yaml
@@ -3,6 +3,14 @@
 {{- end }}
 
 {{ if .Values.monitoring.enablePrometheusRule }}
+
+{{- $nsLabel := "namespace" -}}
+{{- $podLabel := "pod" -}}
+{{- if and (hasKey .Values.monitoring "ksmHonorLabels") (not .Values.monitoring.ksmHonorLabels) -}}
+{{- $nsLabel = "exported_namespace" -}}
+{{- $podLabel = "exported_pod" -}}
+{{- end }}
+
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -41,19 +49,19 @@ spec:
 
     - alert: OvnKubePodRestarts
       expr: |
-        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", container=~"ovnkube.*"}[15m]) * 60 * 5 > 0
+        rate(kube_pod_container_status_restarts_total{ {{ $nsLabel }}="ovn-kubernetes", container=~"ovnkube.*"}[15m]) * 60 * 5 > 0
       for: 30m
       labels:
        severity: critical
       annotations:
        description: |
-         {{`Pod ovn-kubernetes/ {{ $labels.pod }} {{ $labels.container}} is restarting 
-         {{ printf "%.2f" $value }} times / 5 minutes.`}}        
+         {{`Pod ovn-kubernetes/ {{ $labels.`}}{{ $podLabel }}{{` }} {{ $labels.container}} is restarting
+         {{ printf "%.2f" $value }} times / 5 minutes.`}}
                 
     - alert: K8sNodeWithoutOvnKubeAgentRunning
       expr: |
         kube_node_info unless on(node)
-        (kube_pod_info{namespace="ovn-kubernetes", pod=~"ovnkube-node.*"}) > 0
+        (kube_pod_info{ {{ $nsLabel }}="ovn-kubernetes", {{ $podLabel }}=~"ovnkube-node.*"}) > 0
       for: 10m
       labels:
        severity: warning
@@ -217,35 +225,35 @@ spec:
 
     - alert: OvnNBDBContainerRestarts
       expr: |
-        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", container="nb-ovsdb"}[15m]) * 60 * 5 > 0
+        rate(kube_pod_container_status_restarts_total{ {{ $nsLabel }}="ovn-kubernetes", container="nb-ovsdb"}[15m]) * 60 * 5 > 0
       for: 30m
       labels:
        severity: critical
       annotations:
        description: |
-         {{`Pod ovn-kubernetes/ {{ $labels.pod }} nbdb container is 
+         {{`Pod ovn-kubernetes/ {{ $labels.`}}{{ $podLabel }}{{` }} nbdb container is
          restarting {{ printf "%.2f" $value }} times / 5 minutes`}}
 
     - alert: OvnSBDBContainerRestarts
       expr: |
-        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", container="sb-ovsdb"}[15m]) * 60 * 5 > 0
+        rate(kube_pod_container_status_restarts_total{ {{ $nsLabel }}="ovn-kubernetes", container="sb-ovsdb"}[15m]) * 60 * 5 > 0
       for: 30m
       labels:
        severity: critical
       annotations:
        description: |
-         {{`Pod ovn-kubernetes/ {{ $labels.pod }} sbdb container is 
+         {{`Pod ovn-kubernetes/ {{ $labels.`}}{{ $podLabel }}{{` }} sbdb container is
          restarting {{ printf "%.2f" $value }} times / 5 minutes.`}}
 
     - alert: OvnNorthdContainerRestarts
       expr: |
-        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", container="ovn-northd"}[15m]) * 60 * 5 > 0
+        rate(kube_pod_container_status_restarts_total{ {{ $nsLabel }}="ovn-kubernetes", container="ovn-northd"}[15m]) * 60 * 5 > 0
       for: 30m
       labels:
        severity: critical
       annotations:
        description: |
-         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-northd container is 
+         {{`Pod ovn-kubernetes/ {{ $labels.`}}{{ $podLabel }}{{` }} ovn-northd container is
          restarting {{ printf "%.2f" $value }} times / 5 minutes`}}
 
     - alert: OvnNorthdNotActive
@@ -285,14 +293,14 @@ spec:
 
     - alert: OvnControllerContainerRestarts
       expr: |
-        rate(kube_pod_container_status_restarts_total{namespace="ovn-kubernetes", 
+        rate(kube_pod_container_status_restarts_total{ {{ $nsLabel }}="ovn-kubernetes",
         container="ovn-controller"}[15m]) * 60 * 5 > 0
       for: 30m
       labels:
        severity: critical
       annotations:
        description: |
-         {{`Pod ovn-kubernetes/ {{ $labels.pod }} ovn-controller container 
+         {{`Pod ovn-kubernetes/ {{ $labels.`}}{{ $podLabel }}{{` }} ovn-controller container
          is restarting {{ printf "%.2f" $value }} times / 5 minutes`}}
 
     - alert: OvnControllerTxnError

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -186,3 +186,8 @@ monitoring:
   # in defining that.
   commonServiceMonitorSelectorLabels:
     release: kube-prometheus-stack
+  # -- whether kube-state-metrics is scraped with honorLabels: true. When false,
+  # the alert rules use exported_namespace/exported_pod label names to match
+  # against kube-state-metrics' relabeled series.
+  # @default -- true
+  ksmHonorLabels: true

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -189,3 +189,8 @@ monitoring:
   enableServiceMonitor: false
   # -- deploy PrometheusRules for specific metric collection using the Prometheus Operator
   enablePrometheusRule: false
+  # -- whether kube-state-metrics is scraped with honorLabels: true. When false,
+  # the alert rules use exported_namespace/exported_pod label names to match
+  # against kube-state-metrics' relabeled series.
+  # @default -- true
+  ksmHonorLabels: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

When kube-state-metrics is scraped without `honorLabels: true`, the metrics own `namespace` and `pod` labels are renamed to `exported_namespace` and `exported_pod`. The six alert rules that query `kube_*` metrics hardcoded `namespace=` and `pod=` selectors, so they never matched, causing false positives and missed alerts.

Add `monitoring.ksmHonorLabels` (default: true) to all values files. When set to false, the PrometheusRule template switches those six expressions and their annotations to use `exported_namespace` and `exported_pod` instead.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6364

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed monitoring alerts to correctly handle different kube-state-metrics label configurations.
  * Improved alert rule compatibility when kube-state-metrics uses alternative label naming conventions.

* **Configuration**
  * Added new `monitoring.ksmHonorLabels` setting to control kube-state-metrics label behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->