### PR TITLE
helm,ovnkube.sh: derive --gateway-nexthop from a host interface

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -165,6 +165,39 @@ ovn_gateway_mode=${OVN_GATEWAY_MODE:-"shared"}
 ovn_gateway_opts=${OVN_GATEWAY_OPTS:-""}
 ovn_gateway_router_subnet=${OVN_GATEWAY_ROUTER_SUBNET:-""}
 
+# OVN_GATEWAY_NEXTHOP_INTERFACE - if set and --gateway-nexthop is not already
+# in OVN_GATEWAY_OPTS, derive the next-hop(s) from the routes attached to
+# this host interface (first IPv4 `via` and first IPv6 `via`, comma-joined
+# for dual-stack). Lets racks each have their own gateway IP without a
+# cluster-wide static --gateway-nexthop. Works even when the interface has
+# no default route on it (e.g. an OVN-dedicated VLAN with only a /11 route
+# via the rack router); v4-only and v6-only deployments are supported.
+ovn_gateway_nexthop_interface=${OVN_GATEWAY_NEXTHOP_INTERFACE:-}
+if [[ -n "${ovn_gateway_nexthop_interface}" ]]; then
+    if [[ "${ovn_gateway_opts}" == *--gateway-nexthop* ]]; then
+        echo "OVN_GATEWAY_NEXTHOP_INTERFACE=${ovn_gateway_nexthop_interface} ignored: --gateway-nexthop already set in OVN_GATEWAY_OPTS"
+    else
+        nh_v4=$(ip -4 route show dev "${ovn_gateway_nexthop_interface}" 2>/dev/null \
+                | awk '{for(i=1;i<NF;i++) if($i=="via"){print $(i+1); exit}}')
+        nh_v6=$(ip -6 route show dev "${ovn_gateway_nexthop_interface}" 2>/dev/null \
+                | awk '{for(i=1;i<NF;i++) if($i=="via"){print $(i+1); exit}}')
+        nexthops=""
+        if [[ -n "${nh_v4}" && -n "${nh_v6}" ]]; then
+            nexthops="${nh_v4},${nh_v6}"
+        elif [[ -n "${nh_v4}" ]]; then
+            nexthops="${nh_v4}"
+        elif [[ -n "${nh_v6}" ]]; then
+            nexthops="${nh_v6}"
+        fi
+        if [[ -n "${nexthops}" ]]; then
+            ovn_gateway_opts="${ovn_gateway_opts} --gateway-nexthop=${nexthops}"
+            echo "Derived --gateway-nexthop=${nexthops} from interface ${ovn_gateway_nexthop_interface}"
+        else
+            echo "WARN: interface ${ovn_gateway_nexthop_interface} has no 'via' route; --gateway-nexthop not appended (ovnkube-node will attempt netlink auto-detect)"
+        fi
+    fi
+fi
+
 net_cidr=${OVN_NET_CIDR:-10.128.0.0/14/23}
 svc_cidr=${OVN_SVC_CIDR:-172.30.0.0/16}
 mtu=${OVN_MTU:-1400}

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -190,6 +190,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_GATEWAY_NEXTHOP_INTERFACE
+          value: {{ default "" .Values.global.gatewayNexthopInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -192,6 +192,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_GATEWAY_NEXTHOP_INTERFACE
+          value: {{ default "" .Values.global.gatewayNexthopInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node/templates/ovnkube-node.yaml
@@ -192,6 +192,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_GATEWAY_NEXTHOP_INTERFACE
+          value: {{ default "" .Values.global.gatewayNexthopInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -347,6 +347,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_GATEWAY_NEXTHOP_INTERFACE
+          value: {{ default "" .Values.global.gatewayNexthopInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -409,6 +409,8 @@ spec:
           value: {{ default "" .Values.global.disableForwarding | quote }}
         - name: OVN_ENCAP_PORT
           value: {{ default 6081 .Values.global.encapPort | quote }}
+        - name: OVN_GATEWAY_NEXTHOP_INTERFACE
+          value: {{ default "" .Values.global.gatewayNexthopInterface | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
         - name: OVN_NETFLOW_TARGETS

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -23,6 +23,14 @@ global:
   gatewayMode: shared
   # -- Optional extra gateway options
   gatewayOpts: ""
+  # -- Host interface from which to derive --gateway-nexthop per node. If set,
+  # ovnkube.sh resolves the first IPv4 `via` route and first IPv6 `via` route
+  # on that interface and appends them comma-joined to --gateway-nexthop.
+  # Useful for multi-rack clusters where each rack's gateway IP is different
+  # so a static cluster-wide --gateway-nexthop in gatewayOpts won't fit.
+  # Leave empty to defer to gatewayOpts or to ovnkube-node's auto-detection.
+  # Skipped when --gateway-nexthop is already present in gatewayOpts.
+  gatewayNexthopInterface: ""
   # -- Use simulated DPU operations instead of SR-IOV/switchdev hardware (for Kind/VM-based DPU simulation)
   simulateDpu: false
   # -- The DPU-side representor interface for the host's uplink (PF). Required for simulated environments where switchdev metadata is unavailable.

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -29,6 +29,14 @@ global:
   gatewayMode: shared
   # -- Optional extra gateway options
   gatewayOpts: ""
+  # -- Host interface from which to derive --gateway-nexthop per node. If set,
+  # ovnkube.sh resolves the first IPv4 `via` route and first IPv6 `via` route
+  # on that interface and appends them comma-joined to --gateway-nexthop.
+  # Useful for multi-rack clusters where each rack's gateway IP is different
+  # so a static cluster-wide --gateway-nexthop in gatewayOpts won't fit.
+  # Leave empty to defer to gatewayOpts or to ovnkube-node's auto-detection.
+  # Skipped when --gateway-nexthop is already present in gatewayOpts.
+  gatewayNexthopInterface: ""
   # -- Use simulated DPU operations instead of SR-IOV/switchdev hardware (for Kind/VM-based DPU simulation)
   simulateDpu: false
   # -- The DPU-side representor interface for the host's uplink (PF). Required for simulated environments where switchdev metadata is unavailable.


### PR DESCRIPTION
## Summary

`--gateway-nexthop` today is either a single cluster-wide value (set via `global.gatewayOpts: \"... --gateway-nexthop=X.Y.Z.W\"`) or auto-detected by ovnkube-node from the host's default route. Neither works for **multi-rack clusters** where:

- Each rack's upstream router lives at a different IP, so a static cluster-wide value forces all nodes to share one nexthop.
- The dedicated egress VLAN (e.g. `ovn-ext`) deliberately lacks a default route — only a CIDR-scoped one like \`10.128.0.0/11 via <rack-router>\` — so ovnkube-node's netlink fallback on `--gateway-interface=ovn-ext` finds nothing and logs *\"No default route identified. Egress features may not function correctly!\"* (gateway_init.go:111).

This PR adds a values-driven, per-node lookup so a single `global.gatewayNexthopInterface` setting works cluster-wide.

## Changes

- **`dist/images/ovnkube.sh`** — when `OVN_GATEWAY_NEXTHOP_INTERFACE` is set and `--gateway-nexthop` is not already in `OVN_GATEWAY_OPTS`, parse the first IPv4 `via` route and first IPv6 `via` route on that host interface (\`ip -o addr show dev <iface>\`). Dual-stack joined with a comma, matching the binary parser at `pkg/node/gateway_init.go:47` which splits `Gateway.NextHop` on `,` and accepts one v4 and/or one v6 entry. Falls back silently with a warning when the interface has no `via` route, leaving ovnkube-node's netlink auto-detect in place.

- **helm templates** — thread `global.gatewayNexthopInterface` through `OVN_GATEWAY_NEXTHOP_INTERFACE` on every daemonset that runs ovnkube-node: `ovnkube-node`, `ovnkube-node-dpu`, `ovnkube-node-dpu-host`, `ovnkube-single-node-zone`, `ovnkube-single-node-zone-dpu`.

- **`helm/values-single-node-zone{,-dpu}.yaml`** — document the new value with empty default. Existing deployments are unaffected.

## Motivating example

Three-rack cluster, each rack's nodes have an `ovn-ext` VLAN with:

| Rack | ovn-ext IP/prefix | ovn-ext route |
|---|---|---|
| 1 | 10.128.0.231/20 | \`10.128.0.0/11 via 10.128.0.1\` |
| 2 | 10.128.16.245/20 | \`10.128.0.0/11 via 10.128.16.1\` |
| 3 | 10.128.32.30/20 | \`10.128.0.0/11 via 10.128.32.1\` |

Without this change, ops either had to template-render the chart per-rack with hardcoded `--gateway-nexthop`, or write per-node annotations. With `global.gatewayNexthopInterface: ovn-ext`, each node's `ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings` references the right rack-local nexthop with a single helm value.

Verified in production on a 3-control-plane / 3-rack OVN-Kubernetes deployment.

## Test plan

- [ ] `helm template` with `global.gatewayNexthopInterface` unset → `OVN_GATEWAY_NEXTHOP_INTERFACE` renders as empty quoted string, ovnkube.sh path is a no-op, downstream behaviour unchanged
- [ ] `helm template` with `global.gatewayNexthopInterface=ovn-ext` → `OVN_GATEWAY_NEXTHOP_INTERFACE: \"ovn-ext\"` shows up in all 5 affected daemonsets
- [ ] On a node where ovn-ext only has v4 `via` route: \`kubectl exec ds/ovnkube-node -- grep 'Derived --gateway-nexthop'\` in container logs shows the rack-local v4
- [ ] On a dual-stack node: the derived nexthop is \`v4,v6\` comma-joined
- [ ] If the user already sets `--gateway-nexthop` in `global.gatewayOpts`, the new path logs an *ignored* message and does not override
- [ ] If the named interface has no `via` route, log shows the WARN and ovnkube-node's netlink fallback takes over (no startup failure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `gatewayNexthopInterface` configuration option for network interface selection in OVN Kubernetes deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->