### PR TITLE
node: translate gw port to OVS bridge in masqueradeReconciler.ensure

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2196,6 +2196,19 @@ func (r *masqueradeReconciler) ensure() error {
 	if gwIface == "" || gwIface == types.DeriveFromMgmtPort {
 		return nil
 	}
+	// If gwIface is an OVS port (which is what happens after OVS takes
+	// over a physical interface like ovn-ext -- the host IP migrates to
+	// the bridge), translate to the bridge name. Otherwise both paths in
+	// this reconciler deadlock: the slow path's
+	// GetNetworkInterfaceIPAddresses(<port>) fails because the port has
+	// no IPv4, the fast path's lastLinkIndex is only set on slow-path
+	// success, and link.Attrs().Index then never matches the slave port.
+	// Mirrors the same translation done in initGatewayPreStart.
+	if config.IsModeDPU() || config.IsModeFull() {
+		if bridgeName, _, err := util.RunOVSVsctl("port-to-br", gwIface); err == nil && bridgeName != "" {
+			gwIface = bridgeName
+		}
+	}
 	if !r.mu.TryLock() {
 		return nil
 	}


### PR DESCRIPTION
## Summary

In local gateway mode (or any setup where OVS takes over the user-configured `--gateway-interface`), the masquerade reconciler enters a permanent error loop on every link / address event:

```
failed to find IPv4 address on interface ovn-ext
```

The cluster keeps working because the masquerade IP and routes were already set on the bridge during the initial gateway-init path, but the reconciler is stuck and won't recover those resources if they ever disappear.

## Root cause — double dead-lock in `masqueradeReconciler.ensure()`

Once OVS has taken over `ovn-ext` (or whichever interface the operator passed to `--gateway-interface`), the host IPv4 migrates from the physical netdev to the OVS internal bridge port (e.g. `brovn-ext` in local mode, `br-ex` in shared mode). The physical `ovn-ext` has no v4 address any more, only the bridge does. The reconciler however still references `config.Gateway.Interface` directly:

```go
gwIface := config.Gateway.Interface
...
link, err := util.GetNetLinkOps().LinkByName(gwIface)            // ovn-ext (port) -- exists
if link.Attrs().Index == r.lastLinkIndex && masqueradeIPConfigured(link) {
    return nil                                                    // unreachable, see below
}
ifAddrs, err := nodeutil.GetNetworkInterfaceIPAddresses(gwIface) // FAILS: no v4 on slave port
```

- **Slow path** fails before `r.lastLinkIndex` is updated.
- **Fast path** needs `link.Attrs().Index == r.lastLinkIndex`, but `lastLinkIndex` is only seeded at the **end** of a successful slow path. It never gets seeded → fast path is unreachable → every event re-enters slow path → re-fails.

## Fix

Mirror the `port-to-br` translation that `initGatewayPreStart` already performs at `gateway_init.go:84-90`: when running in Full or DPU mode and `gwIface` resolves as an OVS port, switch to the bridge name. Subsequent `LinkByName`, `GetNetworkInterfaceIPAddresses`, and `masqueradeIPConfigured` checks then operate on the netdev that actually carries the host IP. Both paths converge and the log goes quiet.

## Test plan

- [ ] `helm install ... --set global.gatewayMode=local --set 'global.gatewayOpts=--gateway-interface=<phys-iface>'` on a node, then `kubectl delete pod -n ovn-kubernetes -l app=ovnkube-node` — confirm new pod's log no longer contains \`"failed to find IPv4 address on interface <phys-iface>"\` repeating
- [ ] Same in shared mode (`br-ex` naming) on a cluster where `--gateway-interface` is a real NIC, not auto-detected
- [ ] `masqueradeIPConfigured` fast path now succeeds on second `ensure()` call (verify with klog `lastSuccessful=<bridge_ifindex>`)
- [ ] If `port-to-br` returns error (e.g. interface really isn't an OVS port — auto-detect case), the existing behaviour is preserved (the translation block falls through silently)

Verified on a 3-rack production cluster running local gateway mode with `--gateway-interface=ovn-ext` (bridge `brovn-ext`). Before the fix, killing an ovnkube-node pod produced the warning approximately once per second until the new pod stabilised; after the fix the reconciler's fast path succeeds and the log is quiet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a deadlock issue that could occur during network interface transitions when the system assumes control of physical interfaces. The enhancement prevents configuration mismatches and ensures reliable network operations across all deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->