### PR TITLE
node/util: translate OVS port to bridge in GetNetworkInterfaceIPAddresses

### DIFF
--- a/go-controller/pkg/node/util/util.go
+++ b/go-controller/pkg/node/util/util.go
@@ -15,7 +15,23 @@ import (
 )
 
 // GetNetworkInterfaceIPAddresses returns the IP addresses for the network interface 'iface'.
+//
+// If iface turns out to be an OVS port on a bridge -- which is what happens
+// once OVS has taken over a physical gateway interface in shared/local mode
+// (the host IP migrates from the slave port to the bridge's internal port) --
+// translate to the bridge name first. Every caller of this function wants
+// "the IPs the host has on this gateway path", which after takeover live on
+// the bridge, not on the slave port. Doing the translation here covers all
+// callers at once and matches the translation that initGatewayPreStart
+// already does for `config.Gateway.Interface` in gateway_init.go:84-90.
+//
+// `port-to-br` returns an error when iface is not an OVS port (e.g. a plain
+// Linux netdev like the kubernetes node interface), in which case we keep
+// the original iface -- preserving the historical behaviour.
 func GetNetworkInterfaceIPAddresses(iface string) ([]*net.IPNet, error) {
+	if bridgeName, _, err := pkgutil.RunOVSVsctl("port-to-br", iface); err == nil && bridgeName != "" {
+		iface = bridgeName
+	}
 	allIPs, err := pkgutil.GetFilteredInterfaceV4V6IPs(iface)
 	if err != nil {
 		return nil, fmt.Errorf("could not find IP addresses: %v", err)


### PR DESCRIPTION
## Summary

(Replaces #6455 which was closed — that fix only patched one of six callers.)

`GetNetworkInterfaceIPAddresses(iface)` has **six callers** across `gateway_init.go`, `gateway_shared_intf.go`, and `bridgeconfig/bridgeconfig.go`. All six pass `config.Gateway.Interface` (or a variant thereof) — the operator-configured gateway interface name like `ovn-ext`. After OVS takes over that interface in shared / local gateway mode, the host's IPv4 / IPv6 migrate from the slave port to the bridge's internal port (e.g. `brovn-ext` in local mode, `br-ex` in shared mode). The slave port is left with no addresses, so every one of these six callers eventually fails with:

```
failed to find IPv4 address on interface ovn-ext
```

## Impact

The most visible site is `gateway_init.go:424`, which runs during `DefaultNodeNetworkController` initialization when `config.Gateway.Interface != kubeIntf` (typical multi-VLAN setup where the K8s API VLAN and the OVN gateway VLAN are different). On every ovnkube-node pod restart in such a deployment the controller fails to start and crash-loops with:

```
failed to init default node network controller: ... failed to find IPv4 address on interface ovn-ext
```

The other five sites (`gateway_init.go:226`, `gateway_init.go:407`, `gateway_shared_intf.go:2219`, `bridgeconfig.go:222`, `bridgeconfig.go:272`) hit the same mismatch in less catastrophic ways — log spam, reconciler dead-locks, masquerade resource non-recovery. #6455 fixed `gateway_shared_intf.go:2219` specifically by translating at the call site; auditing the other five spots prompted this broader fix.

## Fix

Every caller wants \"the IPs the host has on this gateway path.\" After OVS takeover those IPs are on the bridge's internal port. Translate once inside `GetNetworkInterfaceIPAddresses` so all six callers benefit, with no further per-site patching:

```go
func GetNetworkInterfaceIPAddresses(iface string) ([]*net.IPNet, error) {
    if bridgeName, _, err := pkgutil.RunOVSVsctl(\"port-to-br\", iface); err == nil && bridgeName != \"\" {
        iface = bridgeName
    }
    allIPs, err := pkgutil.GetFilteredInterfaceV4V6IPs(iface)
    ...
}
```

When `iface` is not an OVS port (e.g. the plain kubernetes node interface in DPU-host mode), `port-to-br` returns a non-nil error and the original `iface` is preserved — keeping the historical behaviour for the legitimate non-OVS callers.

## Relation to #6455

#6455 patched `masqueradeReconciler.ensure()` specifically. With *only* this central fix (no narrow patch), the reconciler's slow path succeeds and the log spam stops — but the fast path (`link.Attrs().Index == r.lastLinkIndex && masqueradeIPConfigured(link)`) still operates on the slave port's link object, so it falls through to the slow path on every link / address event. The two fixes are complementary; if a maintainer prefers the narrow approach they can resurrect #6455, but the central fix is strictly required for the init-time crash at `gateway_init.go:424`.

## Test plan

- [ ] Multi-VLAN cluster, `config.Gateway.Interface=<phys-iface>` ≠ `kubeIntf`, local gateway mode: pod can start (no `DefaultNodeNetworkController` init failure)
- [ ] `kubectl delete pod -n ovn-kubernetes -l app=ovnkube-node` repeats clean (no \"failed to find IPv4 address on interface ...\" log loop)
- [ ] Shared gateway mode with `br-ex` naming behaves the same
- [ ] DPU-host mode where `kubeIntf` is a plain Linux netdev (not an OVS port) — `port-to-br` returns error, original iface preserved, no regression
- [ ] Unit test: pass a fake netdev that is not an OVS port → translation no-ops → existing behaviour

Production-validated on a 3-rack local-gateway cluster (`--gateway-interface=ovn-ext`, bridge `brovn-ext`) running together with the narrow translation from #6455. Both `DefaultNodeNetworkController` init and `masqueradeReconciler.ensure()` reach the bridge cleanly; previously-crashlooping ovnkube-node pods now stabilise within a single restart cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network interface IP address detection for OpenVSwitch bridge configurations. IP addresses are now correctly resolved when interfaces are mapped to OVS ports, with automatic fallback to the original behavior if detection fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->