### PR TITLE
cni: drop transient=true marker from pod veth on br-int

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -566,10 +566,14 @@ func ConfigureOVS(ctx context.Context, namespace, podName, podIfName, hostIfaceN
 		}
 	}
 
-	// Add the new sandbox's OVS port, tag the port as transient so stale
-	// pod ports are scrubbed on hard reboot
+	// Add the new sandbox's OVS port. Do NOT tag the port as transient:
+	// in containerized OVS, ovs-server restarts on every helm upgrade /
+	// ovs-node container restart, and --delete-transient-ports would
+	// silently scrub the live pod veth row from conf.db. No reconciler
+	// re-adds it, so every non-hostNetwork pod on the node would lose
+	// connectivity until kubectl delete pod forces a fresh CNI ADD.
 	ovsArgs := []string{
-		"--may-exist", "add-port", "br-int", hostIfaceName, "other_config:transient=true",
+		"--may-exist", "add-port", "br-int", hostIfaceName,
 		"--", "set", "interface", hostIfaceName,
 		fmt.Sprintf("external_ids:attached_mac=%s", ifInfo.MAC),
 		fmt.Sprintf("external_ids:iface-id=%s", ifaceID),

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -1501,7 +1501,7 @@ func TestConfigureOVS(t *testing.T) {
 			// ovs-vsctl add port to br-int
 			ovsAddPortCmd := fmt.Sprintf(
 				"ovs-vsctl --timeout=30 --may-exist "+
-					"add-port br-int %s other_config:transient=true "+
+					"add-port br-int %s "+
 					"-- set interface %s external_ids:attached_mac=%s "+
 					"external_ids:iface-id=%s external_ids:iface-id-ver=%s "+
 					"external_ids:sandbox=%s ",

--- a/go-controller/pkg/node/base_node_network_controller_dpu_test.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu_test.go
@@ -40,7 +40,7 @@ func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID, podUID string)
 	if ip != "" {
 		ipAddrExtID = fmt.Sprintf("external_ids:ip_addresses=%s ", ip)
 	}
-	return fmt.Sprintf("ovs-vsctl --timeout=30 --may-exist add-port br-int %s other_config:transient=true "+
+	return fmt.Sprintf("ovs-vsctl --timeout=30 --may-exist add-port br-int %s "+
 		"-- set interface %s external_ids:attached_mac=%s external_ids:iface-id=%s external_ids:iface-id-ver=%s "+
 		"%sexternal_ids:sandbox=%s external_ids:vf-netdev-name=%s "+
 		"-- --if-exists remove interface %s external_ids k8s.ovn.org/network "+


### PR DESCRIPTION
## 📑 Description

`pkg/cni/helper_linux.go` was tagging every pod veth OVS port with `other_config:transient=true`, paired with `dist/images/ovnkube.sh` starting ovs-server with `--delete-transient-ports`. **In containerized deployments this combination is a time bomb**: every ovs-node container restart silently scrubs all live pod veth rows from conf.db.

### Reproduction

```
1. Cluster running normally, ovs-vsctl find Interface external_ids:sandbox!=""
   returns rows for every non-hostNetwork pod on the node.
2. helm upgrade ovn-kubernetes  (or any other reason ovs-node container restarts:
   image pull, OOM, eviction, manual restart, etc.)
3. ovs-server starts with --delete-transient-ports → scrubs every row marked
   transient=true → kernel veths are torn down as a side effect.
4. CNI plugin is not re-invoked (CNI ADD only runs at sandbox creation, not
   container restart). Pods stay in Running state with no host-side veth in
   br-int. All non-hostNetwork pod connectivity is dead.
5. Only `kubectl delete pod` (forcing a fresh sandbox → CNI ADD) recovers.
```

Observed in production after a routine helm upgrade: coredns mass-death; `ovs-vswitchd.log` showed each pod veth port being added at CNI ADD time then deleted later during the ovs-server restart triggered by the rollout.

### Root cause

The original `transient=true` was intended to scrub stale pod ports on **hard node reboot**, where conf.db on hostPath could survive but kernel netdevs would be gone. In containerized OVS, ovs-server restart != node reboot, so the marker fires on every container restart and falsely treats live rows as stale.

### Fix

Drop the `transient=true` marker on the pod-veth path in `helper_linux.go`.

`NodeControllerManager.checkForStaleOVSPodInterfaces` (controllermanager/node_controller_manager.go:517, scheduled every 60s at line 380) already provides the original "scrub stale rows" guarantee, using the **K8s pod list as source of truth** (compares `external_ids:iface-id-ver` against current pod UIDs on this node). This is strictly safer than `--delete-transient-ports` which doesn't distinguish between stale and live rows.

Other `transient=true` sites are **not affected** by this change:
- `pkg/util/nicstobridge.go:241` — host uplink (eth0 → breth0)
- `pkg/node/bridgeconfig/bridgeconfig.go:188` — DPU host gateway representor

Both target one-shot host infrastructure with separate reconciler coverage.

### Side effects

Stale conf.db rows can still appear if CNI DEL fails to run (cri-o crash, force pod delete with `--grace-period=0`, etc.). These are now reaped by the existing `checkForStaleOVSPodInterfaces` sweep within ~60s. Cosmetic ovs-vswitchd warnings (`could not open network device`) may appear briefly until the sweep runs; no functional impact on other pods.

## ✅ Checks

- [x] Unit test `helper_linux_test.go` updated for VF representor path
- [x] DPU test helper `base_node_network_controller_dpu_test.go` updated
- [ ] My code requires changes to the documentation — no
- [x] All the tests have passed in the CI

## How to verify it

Production-validated on a 3-rack multi-VLAN cluster:

- Before the fix: every `helm upgrade ovn-kubernetes` killed all non-hostNetwork pods on each node, required manual `kubectl delete pod -l <selector>` recovery per workload.
- After the fix: ovs-node container restarts (helm upgrade, image pull, OOM) no longer affect pod connectivity. New pods are correctly attached to br-int, existing pods survive the OVS restart, and `checkForStaleOVSPodInterfaces` keeps conf.db clean on its 60s schedule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Improved pod network reliability during system maintenance and service restarts. Removed configuration that could cause pod network interfaces to be lost when containers or Open vSwitch services restart, ensuring more stable and persistent pod-to-pod and external network connectivity. Enhances overall system resilience during infrastructure updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->