### PR TITLE
util: assume pod network advertisement for certain transports

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -291,6 +291,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		hostSubnets := ovntest.MustParseIPNets(nodeSubnet)
 		rm := routemanager.NewController()
 		netInfo := &multinetworkmocks.NetInfo{}
+		netInfo.On("Transport").Return("")
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return(nil)
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))
@@ -1260,6 +1261,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		hostSubnets := ovntest.MustParseIPNets(nodeSubnet)
 		rm := routemanager.NewController()
 		netInfo := &multinetworkmocks.NetInfo{}
+		netInfo.On("Transport").Return("")
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return(nil)
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))

--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"slices"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -983,7 +982,6 @@ func (udng *UserDefinedNetworkGateway) deleteAdvertisedUDNIsolationRules() error
 }
 
 func (udng *UserDefinedNetworkGateway) updateAdvertisementStatus() {
-	vrfs := udng.GetPodNetworkAdvertisedOnNodeVRFs(udng.node.Name)
-	udng.isNetworkAdvertised = len(vrfs) > 0
-	udng.isNetworkAdvertisedToDefaultVRF = slices.Contains(vrfs, types.DefaultNetworkName)
+	udng.isNetworkAdvertised = util.IsPodNetworkAdvertisedAtNode(udng.NetInfo, udng.node.Name)
+	udng.isNetworkAdvertisedToDefaultVRF = util.IsPodNetworkAdvertisedAtNodeDefaultVRF(udng.NetInfo, udng.node.Name)
 }

--- a/go-controller/pkg/node/managementport/port_dpu_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux_test.go
@@ -407,6 +407,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			config.Default.MTU = 1400
 			netInfoMock := &multinetworkmocks.NetInfo{}
 			netInfoMock.On("IsPrimaryNetwork").Return(false)
+			netInfoMock.On("Transport").Return("")
 			netInfoMock.On("GetPodNetworkAdvertisedOnNodeVRFs", mock.Anything).Return(nil)
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},
@@ -434,6 +435,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
 			netInfoMock := &multinetworkmocks.NetInfo{}
 			netInfoMock.On("IsPrimaryNetwork").Return(false)
+			netInfoMock.On("Transport").Return("")
 			netInfoMock.On("GetPodNetworkAdvertisedOnNodeVRFs", mock.Anything).Return(nil)
 			cfg := &managementPortConfig{
 				hostSubnets: []*net.IPNet{ipnet},

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -274,6 +274,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 		KubeClient: fakeClient,
 	}
 
+	netInfo.On("Transport").Return("")
 	if isRoutingAdvertised {
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return([]string{"vrf"})
 	} else {
@@ -375,6 +376,7 @@ func testManagementPortDPU(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.
 		KubeClient: fakeClient,
 	}
 
+	netInfo.On("Transport").Return("")
 	netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return(nil)
 
 	_, err = config.InitConfig(ctx, fexec, nil)
@@ -490,6 +492,7 @@ func testManagementPortDPUHost(ctx *cli.Context, fexec *ovntest.FakeExec, testNS
 		netInfo.On("GetNodeManagementIP", nodeSubnetCIDRs[i]).Return(util.GetNodeManagementIfAddr(nodeSubnetCIDRs[i]))
 	}
 
+	netInfo.On("Transport").Return("")
 	netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", nodeName).Return(nil)
 
 	_, err = config.InitConfig(ctx, fexec, nil)
@@ -832,6 +835,7 @@ var _ = Describe("Management Port tests", func() {
 				netInfo := &multinetworkmocks.NetInfo{}
 				nodeNet := ovntest.MustParseIPNet("10.1.1.0/24")
 
+				netInfo.On("Transport").Return("")
 				netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", "").Return(nil)
 				netInfo.On("GetNodeGatewayIP", nodeNet).Return(util.GetNodeGatewayIfAddr(nodeNet))
 				netInfo.On("GetNodeManagementIP", nodeNet).Return(util.GetNodeManagementIfAddr(nodeNet))
@@ -1242,6 +1246,7 @@ var _ = Describe("Management Port tests", func() {
 		hostSubnets := []*net.IPNet{ovntest.MustParseIPNet("10.1.1.0/24")}
 		netdevName, rep := "ens1f0v0", "ens1f0_0"
 		netInfo := &multinetworkmocks.NetInfo{}
+		netInfo.On("Transport").Return("")
 		netInfo.On("GetPodNetworkAdvertisedOnNodeVRFs", "worker-node").Return(nil)
 		netInfo.On("GetNodeGatewayIP", hostSubnets[0]).Return(util.GetNodeGatewayIfAddr(hostSubnets[0]))
 		netInfo.On("GetNodeManagementIP", hostSubnets[0]).Return(util.GetNodeManagementIfAddr(hostSubnets[0]))

--- a/go-controller/pkg/node/user_defined_node_network_controller.go
+++ b/go-controller/pkg/node/user_defined_node_network_controller.go
@@ -134,9 +134,13 @@ func (nc *UserDefinedNodeNetworkController) Cleanup() error {
 func (nc *UserDefinedNodeNetworkController) HandleNetworkRefChange(_ string, _ bool) {}
 
 func (nc *UserDefinedNodeNetworkController) shouldReconcileNetworkChange(old, new util.NetInfo) bool {
-	wasUDNNetworkAdvertisedAtNode := util.IsPodNetworkAdvertisedAtNode(old, nc.name)
-	isUDNNetworkAdvertisedAtNode := util.IsPodNetworkAdvertisedAtNode(new, nc.name)
-	return wasUDNNetworkAdvertisedAtNode != isUDNNetworkAdvertisedAtNode
+	switch {
+	case util.IsPodNetworkAdvertisedAtNode(old, nc.name) != util.IsPodNetworkAdvertisedAtNode(new, nc.name):
+		return true
+	case util.IsPodNetworkAdvertisedAtNodeDefaultVRF(old, nc.name) != util.IsPodNetworkAdvertisedAtNodeDefaultVRF(new, nc.name):
+		return true
+	}
+	return false
 }
 
 // Reconcile function reconciles three entities based on whether UDN network is advertised

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -33,6 +33,7 @@ import (
 	testnm "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -77,7 +78,8 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN(true)
+		useFakeAddressSets := false
+		fakeOvn = NewFakeOVN(useFakeAddressSets)
 		initialDB = libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{},
 		}
@@ -121,6 +123,19 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 					extraObjects = append(extraObjects, remotePod)
 				}
 
+				var expectedNBData []libovsdbtest.TestData
+				if netInfo.hasEVPN {
+					// emulate address sets handled by other controllers, needed for EVPN SNATs
+					nodeIPsAS4, _ := buildEgressIPNodeAddressSets(nil)
+					udnEnnabledSvcAS4, _ := buildUDNEnabledSvcAddressSets(nil)
+					initialDB.NBData = append(
+						initialDB.NBData,
+						nodeIPsAS4,
+						udnEnnabledSvcAS4,
+					)
+					expectedNBData = append(expectedNBData, nodeIPsAS4, udnEnnabledSvcAS4)
+				}
+
 				Expect(setupFakeOvnForLayer2Topology(fakeOvn, initialDB, netInfo, nodes, podInfo, pod, extraObjects...)).To(Succeed())
 				defer fakeOvn.networkManager.Stop()
 
@@ -134,14 +149,11 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 					expectationOptions = append(expectationOptions, withClusterPortGroup())
 				}
 				By("asserting the OVN entities provisioned in the NBDB are the expected ones")
-				Eventually(fakeOvn.nbClient).Should(
-					libovsdbtest.HaveData(
-						newUserDefinedNetworkExpectationMachine(
-							fakeOvn,
-							[]testPod{podInfo},
-							expectationOptions...,
-						).expectedLogicalSwitchesAndPorts(nodeName)...))
-
+				expectedNBData = append(
+					expectedNBData,
+					newUserDefinedNetworkExpectationMachine(fakeOvn, []testPod{podInfo}, expectationOptions...).expectedLogicalSwitchesAndPorts(nodeName)...,
+				)
+				Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedNBData))
 				return nil
 			}
 
@@ -1232,6 +1244,11 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	masqSNAT := newNATEntry(masqSNATUUID1, "169.254.169.14", nodeSubnet.String(), standardNonDefaultNetworkExtIDs(netInfo), "")
 	masqSNAT.Match = getMasqueradeManagementIPSNATMatch(util.IPAddrToHWAddr(managementPortIP(nodeSubnet)).String())
 	masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("trtos-%s", netInfo.GetNetworkScopedName(ovntypes.OVNLayer2Switch)))
+	if netInfo.Transport() == ovntypes.NetworkTransportEVPN {
+		nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkControllerName))
+		udnEnabledSvcV4ASHashName, _ := addressset.GetHashNamesForAS(udnenabledsvc.GetAddressSetDBIDs())
+		masqSNAT.Match += fmt.Sprintf(" && (ip4.dst == $%s || ip4.dst == $%s)", nodeIPV4ASHashName, udnEnabledSvcV4ASHashName)
+	}
 	gwChassisName := fmt.Sprintf("%s-%s", rtosLRPName, gwConfig.ChassisID)
 	gatewayChassisUUID := gwChassisName + "-UUID"
 	lrsrNextHop := trInfo.gatewayRouterNets[0].IP.String()

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -29,6 +29,8 @@ import (
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
+	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	zoneic "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -82,7 +84,8 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN(true)
+		useFakeAddressSets := false
+		fakeOvn = NewFakeOVN(useFakeAddressSets)
 		initialDB = libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalSwitch{
@@ -143,6 +146,19 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 					Expect(err).NotTo(HaveOccurred())
 					testNode2.Annotations["k8s.ovn.org/zone-name"] = "blah"
 					nodes = append(nodes, *testNode2)
+				}
+
+				var expectedNBData []libovsdbtest.TestData
+				if netInfo.hasEVPN {
+					// emulate address sets handled by other controllers, needed for EVPN SNATs
+					nodeIPsAS4, _ := buildEgressIPNodeAddressSets(nil)
+					udnEnabledSvcAS4, _ := buildUDNEnabledSvcAddressSets(nil)
+					initialDB.NBData = append(
+						initialDB.NBData,
+						nodeIPsAS4,
+						udnEnabledSvcAS4,
+					)
+					expectedNBData = append(expectedNBData, nodeIPsAS4, udnEnabledSvcAS4)
 				}
 
 				fakeOvn.startWithDBSetup(
@@ -250,15 +266,13 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 					defaultNetExpectations = append(defaultNetExpectations, ingressPG)
 					defaultNetExpectations = append(defaultNetExpectations, defaultDenyExpectedData...)
 				}
-				Eventually(fakeOvn.nbClient).WithTimeout(5 * time.Second).Should(
-					libovsdbtest.HaveData(
-						append(
-							defaultNetExpectations,
-							newUserDefinedNetworkExpectationMachine(
-								fakeOvn,
-								[]testPod{podInfo},
-								expectationOptions...,
-							).expectedLogicalSwitchesAndPorts(nodeName)...)))
+				By("asserting the OVN entities provisioned in the NBDB are the expected ones")
+				expectedNBData = append(expectedNBData, defaultNetExpectations...)
+				expectedNBData = append(
+					expectedNBData,
+					newUserDefinedNetworkExpectationMachine(fakeOvn, []testPod{podInfo}, expectationOptions...).expectedLogicalSwitchesAndPorts(nodeName)...,
+				)
+				Eventually(fakeOvn.nbClient).WithTimeout(5 * time.Second).Should(libovsdbtest.HaveData(expectedNBData))
 
 				return nil
 			}
@@ -1527,8 +1541,13 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 		expectedGRStaticRoute(staticRoute2, ipv4DefaultRoute, nextHopIP, nil, &staticRouteOutputPort, netInfo),
 		expectedGRStaticRoute(staticRoute3, masqSubnet, nextHopMasqIP, nil, &staticRouteOutputPort, netInfo),
 	}
+	var udnSubnetMasqMatch string
+	if netInfo.Transport() == types.NetworkTransportEVPN {
+		nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+		udnSubnetMasqMatch = fmt.Sprintf("ip4.dst == $%s", nodeIPV4ASHashName)
+	}
 	expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
-	expectedEntities = append(expectedEntities, newNATEntry(nat2, dummyMasqueradeIP().IP.String(), netInfo.Subnets()[0].CIDR.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
+	expectedEntities = append(expectedEntities, newNATEntry(nat2, dummyMasqueradeIP().IP.String(), netInfo.Subnets()[0].CIDR.String(), standardNonDefaultNetworkExtIDs(netInfo), udnSubnetMasqMatch))
 	return expectedEntities
 }
 
@@ -1651,8 +1670,13 @@ func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		rtojLRPUUID := rtojLRPName + "-UUID"
 		nodeIP := gwConfig.IPAddresses[0].IP.String()
 		masqSNAT := newNATEntry(masqSNATUUID1, "169.254.169.14", nodeSubnet.String(), standardNonDefaultNetworkExtIDs(netInfo), "")
-		masqSNAT.Match = getMasqueradeManagementIPSNATMatch(util.IPAddrToHWAddr(managementPortIP(nodeSubnet)).String())
 		masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("rtos-%s_%s", netInfo.GetNetworkName(), nodeName))
+		masqSNAT.Match = getMasqueradeManagementIPSNATMatch(util.IPAddrToHWAddr(managementPortIP(nodeSubnet)).String())
+		if hasEVPN {
+			nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+			udnEnabledSvcV4ASHashName, _ := addressset.GetHashNamesForAS(udnenabledsvc.GetAddressSetDBIDs())
+			masqSNAT.Match += fmt.Sprintf(" && (ip4.dst == $%s || ip4.dst == $%s)", nodeIPV4ASHashName, udnEnabledSvcV4ASHashName)
+		}
 		expectedEntities = append(expectedEntities,
 			&nbdb.LogicalRouterPort{
 				UUID:        rtojLRPUUID,

--- a/go-controller/pkg/ovn/multihoming_test.go
+++ b/go-controller/pkg/ovn/multihoming_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -583,4 +585,10 @@ type podAnnotation struct {
 type podRoute struct {
 	Dest    string `json:"dest"`
 	NextHop string `json:"nextHop"`
+}
+
+// buildUDNEnabledSvcAddressSets returns an UDN enabled services address set
+func buildUDNEnabledSvcAddressSets(ips []string) (*nbdb.AddressSet, *nbdb.AddressSet) {
+	dbIDs := udnenabledsvc.GetAddressSetDBIDs()
+	return addressset.GetTestDbAddrSets(dbIDs, ips)
 }

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -1938,8 +1938,29 @@ func AllowsPersistentIPs(netInfo NetInfo) bool {
 	}
 }
 
+// IsPodNetworkAdvertisedAtNode returns true if the pod network is advertised at
+// the given node. For networks with NoOverlay or EVPN transport this always
+// returns true as those networks should always be advertised.
 func IsPodNetworkAdvertisedAtNode(netInfo NetInfo, node string) bool {
-	return len(netInfo.GetPodNetworkAdvertisedOnNodeVRFs(node)) > 0
+	switch netInfo.Transport() {
+	case types.NetworkTransportNoOverlay, types.NetworkTransportEVPN:
+		return true
+	default:
+		return len(netInfo.GetPodNetworkAdvertisedOnNodeVRFs(node)) > 0
+	}
+}
+
+// IsPodNetworkAdvertisedAtNodeDefaultVRF returns true if the pod network is
+// advertised at the given node in the default VRF. For networks with EVPN
+// transport this always returns false as those networks should not be
+// advertised in the default VRF.
+func IsPodNetworkAdvertisedAtNodeDefaultVRF(netInfo NetInfo, node string) bool {
+	switch netInfo.Transport() {
+	case types.NetworkTransportEVPN:
+		return false
+	default:
+		return slices.Contains(netInfo.GetPodNetworkAdvertisedOnNodeVRFs(node), types.DefaultNetworkName)
+	}
 }
 
 func GetNetworkVRFName(netInfo NetInfo) string {


### PR DESCRIPTION
IsPodNetworkAdvertisedAtNode now assumes networks with NoOverlay or EVPN transport are always advertised, rather than relying solely on RouteAdvertisements VRF configuration. Introduce
IsPodNetworkAdvertisedAtNodeDefaultVRF which assumes EVPN transport is never advertised in the default VRF. This prevents races where networks behave as not advertised until RouteAdvertisement information is realized. Refactor gateway_udn to use these helpers.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how pod network advertisement status is determined for gateway nodes, including explicit handling for specific transport modes and the default network context.
  * Removed an unnecessary dependency to simplify the implementation.
* **Tests**
  * Updated unit tests and mock expectations to align with the revised advertisement checks and transport behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->