### PR TITLE
fix(evpn): gate neighbor programming on migration domain readiness

### DIFF
--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
@@ -185,9 +185,7 @@ func (c *Controller) ensurePodNeighbors(entries *neighEntries) error {
 		return fmt.Errorf("failed to get OVS port %s: %w", entries.ovsPortName, err)
 	}
 	if err := util.LinkFDBSet(ovsPort, entries.mac, entries.macvrfVID); err != nil {
-		if !errors.Is(err, syscall.EEXIST) {
-			return fmt.Errorf("failed to add FDB entry for %s on %s: %w", entries.mac, entries.ovsPortName, err)
-		}
+		return fmt.Errorf("failed to set FDB entry for %s on %s: %w", entries.mac, entries.ovsPortName, err)
 	}
 	klog.V(5).Infof("Configured FDB %s vlan %d on %s", entries.mac, entries.macvrfVID, entries.ovsPortName)
 	for _, ip := range entries.ips {

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
@@ -64,28 +64,32 @@ func (c *Controller) podNeedsUpdate(oldObj, newObj *corev1.Pod) bool {
 	return oldAnnot != newAnnot
 }
 
-// handleLiveMigrationTargetReady is called when a non-local kubevirt migration target pod
-// becomes ready. It finds the local source pod and removes its neighbor/FDB entries so
-// FRR withdraws the Type-2 routes from this node.
-func (c *Controller) handleLiveMigrationTargetReady(targetPod *corev1.Pod) error {
-	migrationStatus, err := kubevirt.DiscoverLiveMigrationStatus(c.podLister, targetPod)
-	if err != nil {
-		return fmt.Errorf("failed to discover live migration status: %w", err)
+// shouldDeleteNeighbors returns true when a pod's neighbor/FDB entries should be removed.
+// This happens when the pod has completed, or when this node is the migration source
+// and the target domain is ready (so FRR withdraws the Type-2 routes from this node).
+func (c *Controller) shouldDeleteNeighbors(migrationStatus *kubevirt.LiveMigrationStatus, pod *corev1.Pod) bool {
+	if util.PodCompleted(pod) {
+		return true
 	}
 	if migrationStatus == nil || !migrationStatus.IsTargetDomainReady() {
-		return nil
+		return false
 	}
-	if migrationStatus.SourcePod.Spec.NodeName != c.nodeName {
-		return nil
-	}
+	return migrationStatus.SourcePod.Spec.NodeName == c.nodeName
+}
 
-	key, err := cache.MetaNamespaceKeyFunc(migrationStatus.SourcePod)
-	if err != nil {
-		return err
+// shouldEnsureNeighbors returns true when a pod's PERMANENT neighbor entries should be
+// programmed. For non-kubevirt pods (migrationStatus==nil) it always returns true.
+// During live migration, it returns true only on the target node after the target
+// domain is ready, ensuring neighbors are programmed after the source has withdrawn
+// its routes and zebra's extern_learn entries are gone.
+func (c *Controller) shouldEnsureNeighbors(migrationStatus *kubevirt.LiveMigrationStatus) bool {
+	if migrationStatus == nil {
+		return true
 	}
-	klog.Infof("Live migration target %s/%s ready, removing entries for local source pod %s",
-		targetPod.Namespace, targetPod.Name, key)
-	return c.deletePodNeighbors(key)
+	if !migrationStatus.IsTargetDomainReady() {
+		return false
+	}
+	return migrationStatus.TargetPod.Spec.NodeName == c.nodeName
 }
 
 func (c *Controller) reconcilePod(key string) error {
@@ -102,13 +106,12 @@ func (c *Controller) reconcilePod(key string) error {
 		return err
 	}
 
-	if pod.Spec.NodeName != c.nodeName {
-		// Non-local pod: this is a kubevirt migration target whose ready timestamp changed.
-		// Find the local source pod and remove its entries so FRR withdraws the Type-2 routes.
-		return c.handleLiveMigrationTargetReady(pod)
+	migrationStatus, err := kubevirt.DiscoverLiveMigrationStatus(c.podLister, pod)
+	if err != nil {
+		return fmt.Errorf("failed to discover live migration status: %w", err)
 	}
 
-	if util.PodCompleted(pod) {
+	if c.shouldDeleteNeighbors(migrationStatus, pod) {
 		return c.deletePodNeighbors(key)
 	}
 
@@ -119,7 +122,7 @@ func (c *Controller) reconcilePod(key string) error {
 	c.podNeighLock.Lock()
 	existing, hasExisting := c.podNeighbors[key]
 	c.podNeighLock.Unlock()
-	if hasExisting && existing.uid == pod.UID {
+	if hasExisting && existing.uid == pod.UID && c.shouldEnsureNeighbors(migrationStatus) {
 		return c.ensurePodNeighbors(existing)
 	}
 
@@ -155,8 +158,11 @@ func (c *Controller) reconcilePod(key string) error {
 	for _, ipNet := range podAnnotation.IPs {
 		entries.ips = append(entries.ips, ipNet.IP)
 	}
-	if err := c.ensurePodNeighbors(entries); err != nil {
-		return err
+
+	if c.shouldEnsureNeighbors(migrationStatus) {
+		if err := c.ensurePodNeighbors(entries); err != nil {
+			return err
+		}
 	}
 
 	c.podNeighLock.Lock()

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
@@ -191,7 +191,7 @@ func (c *Controller) ensurePodNeighbors(entries *neighEntries) error {
 	}
 	klog.V(5).Infof("Configured FDB %s vlan %d on %s", entries.mac, entries.macvrfVID, entries.ovsPortName)
 	for _, ip := range entries.ips {
-		if err := util.LinkNeighAdd(svi, ip, entries.mac); err != nil {
+		if err := util.LinkNeighSet(svi, ip, entries.mac); err != nil {
 			return fmt.Errorf("failed to add neighbor %s on %s: %w", ip, entries.sviName, err)
 		}
 		klog.V(5).Infof("Configured neighbor %s lladdr %s on %s", ip, entries.mac, entries.sviName)

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller.go
@@ -184,7 +184,7 @@ func (c *Controller) ensurePodNeighbors(entries *neighEntries) error {
 	if err != nil {
 		return fmt.Errorf("failed to get OVS port %s: %w", entries.ovsPortName, err)
 	}
-	if err := util.LinkFDBAdd(ovsPort, entries.mac, entries.macvrfVID); err != nil {
+	if err := util.LinkFDBSet(ovsPort, entries.mac, entries.macvrfVID); err != nil {
 		if !errors.Is(err, syscall.EEXIST) {
 			return fmt.Errorf("failed to add FDB entry for %s on %s: %w", entries.mac, entries.ovsPortName, err)
 		}

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"net"
 	"syscall"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -343,6 +345,149 @@ var _ = Describe("EVPN pod controller", func() {
 
 			Expect(ctrl.reconcilePod("test-ns/remote-pod")).To(Succeed())
 			nlMock.AssertNotCalled(GinkgoT(), "NeighSet", mock.Anything)
+		})
+
+		Context("during live migration", func() {
+			const (
+				vmName        = "test-vm"
+				sourceNode    = "source-node"
+				podAnnotation = `{"test-ns/test-nad":{"ip_addresses":["10.0.0.5/24"],"mac_address":"0a:58:0a:00:00:05","ip_address":"10.0.0.5/24"}}`
+			)
+
+			var (
+				netInfo     *multinetworkmocks.NetInfo
+				sviLink     netlink.Link
+				ovsPortLink netlink.Link
+			)
+
+			// newVirtLauncherPod builds a kubevirt virt-launcher pod with the
+			// labels and annotations needed to be recognized by
+			// DiscoverLiveMigrationStatus and the EVPN pod controller.
+			newVirtLauncherPod := func(name, nodeName string, creationOffset time.Duration, targetReady bool) *corev1.Pod {
+				annotations := map[string]string{
+					kubevirtv1.DomainAnnotation: vmName,
+					types.OvnPodAnnotationName:  podAnnotation,
+				}
+				if targetReady {
+					annotations[kubevirtv1.MigrationTargetReadyTimestamp] = "2024-01-01T00:00:00Z"
+				}
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              name,
+						Namespace:         "test-ns",
+						UID:               k8stypes.UID(name + "-uid"),
+						Annotations:       annotations,
+						Labels:            map[string]string{kubevirtv1.AppLabel: "virt-launcher", kubevirtv1.VirtualMachineNameLabel: vmName},
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(creationOffset)},
+					},
+					Spec:   corev1.PodSpec{NodeName: nodeName},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				}
+			}
+
+			BeforeEach(func() {
+				netInfo = &multinetworkmocks.NetInfo{}
+				netInfo.On("EVPNVTEPName").Return("vtep1")
+				netInfo.On("EVPNMACVRFVID").Return(100)
+				netInfo.On("EVPNMACVRFVNI").Return(int32(10100))
+				netInfo.On("GetNetworkName").Return("mynet")
+				netInfo.On("GetNetworkID").Return(5)
+				netInfo.On("IsPrimaryNetwork").Return(true)
+				const nadKey = "test-ns/test-nad"
+				fakeNM.NADNetworks = map[string]util.NetInfo{nadKey: netInfo}
+				fakeNM.PrimaryNetworks = map[string]util.NetInfo{"test-ns": netInfo}
+
+				sviName := GetEVPNL2SVIName(netInfo)
+				ovsPortName := GetEVPNOVSPortName(netInfo)
+				sviLink = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: sviName, Index: 10}}
+				ovsPortLink = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ovsPortName, Index: 20}}
+
+				nlMock.On("LinkByName", sviName).Return(sviLink, nil)
+				nlMock.On("LinkByName", ovsPortName).Return(ovsPortLink, nil)
+			})
+
+			It("does NOT program neighbors on target node before domain is ready", func() {
+				sourcePod := newVirtLauncherPod("virt-launcher-source", sourceNode, -time.Minute, false)
+				targetPod := newVirtLauncherPod("virt-launcher-target", nodeName, 0, false)
+				ctrl.podLister = newFakePodLister(sourcePod, targetPod)
+
+				Expect(ctrl.reconcilePod("test-ns/virt-launcher-target")).To(Succeed())
+
+				nlMock.AssertNotCalled(GinkgoT(), "NeighSet", mock.Anything)
+
+				By("verifying cache entry was created but neighbors were not programmed")
+				ctrl.podNeighLock.Lock()
+				_, exists := ctrl.podNeighbors["test-ns/virt-launcher-target"]
+				ctrl.podNeighLock.Unlock()
+				Expect(exists).To(BeTrue(), "cache entry should exist even though neighbors were deferred")
+			})
+
+			It("programs neighbors on target node after domain is ready", func() {
+				sourcePod := newVirtLauncherPod("virt-launcher-source", sourceNode, -time.Minute, false)
+				targetPod := newVirtLauncherPod("virt-launcher-target", nodeName, 0, true)
+				ctrl.podLister = newFakePodLister(sourcePod, targetPod)
+
+				nlMock.On("NeighSet", mock.Anything).Return(nil)
+
+				Expect(ctrl.reconcilePod("test-ns/virt-launcher-target")).To(Succeed())
+
+				mac, _ := net.ParseMAC("0a:58:0a:00:00:05")
+
+				By("verifying FDB entry was added on OVS port")
+				nlMock.AssertCalled(GinkgoT(), "NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.LinkIndex == ovsPortLink.Attrs().Index &&
+						n.HardwareAddr.String() == mac.String() &&
+						n.Vlan == 100
+				}))
+
+				By("verifying neighbor entry was added on SVI")
+				nlMock.AssertCalled(GinkgoT(), "NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.LinkIndex == sviLink.Attrs().Index &&
+						n.IP.Equal(net.ParseIP("10.0.0.5"))
+				}))
+			})
+
+			It("deletes neighbors on source node after target domain is ready", func() {
+				mac, _ := net.ParseMAC("0a:58:0a:00:00:05")
+				sourceKey := "test-ns/virt-launcher-source"
+
+				// Controller runs on source node for this test.
+				ctrl.nodeName = sourceNode
+
+				// Pre-seed cache as if source pod was previously reconciled.
+				ctrl.podNeighbors[sourceKey] = &neighEntries{
+					uid:         "virt-launcher-source-uid",
+					sviName:     GetEVPNL2SVIName(netInfo),
+					ovsPortName: GetEVPNOVSPortName(netInfo),
+					macvrfVID:   100,
+					ips:         []net.IP{net.ParseIP("10.0.0.5")},
+					mac:         mac,
+				}
+
+				sourcePod := newVirtLauncherPod("virt-launcher-source", sourceNode, -time.Minute, false)
+				targetPod := newVirtLauncherPod("virt-launcher-target", nodeName, 0, true)
+				ctrl.podLister = newFakePodLister(sourcePod, targetPod)
+
+				nlMock.On("NeighDel", mock.Anything).Return(nil)
+
+				Expect(ctrl.reconcilePod(sourceKey)).To(Succeed())
+
+				By("verifying FDB entry was deleted from OVS port")
+				nlMock.AssertCalled(GinkgoT(), "NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.LinkIndex == ovsPortLink.Attrs().Index &&
+						n.HardwareAddr.String() == mac.String()
+				}))
+
+				By("verifying neighbor entry was deleted from SVI")
+				nlMock.AssertCalled(GinkgoT(), "NeighDel", mock.MatchedBy(func(n *netlink.Neigh) bool {
+					return n.LinkIndex == sviLink.Attrs().Index &&
+						n.IP.Equal(net.ParseIP("10.0.0.5"))
+				}))
+
+				By("verifying cache was cleared")
+				_, exists := ctrl.podNeighbors[sourceKey]
+				Expect(exists).To(BeFalse())
+			})
 		})
 	})
 })

--- a/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_pod_controller_test.go
@@ -82,7 +82,6 @@ var _ = Describe("EVPN pod controller", func() {
 
 			nlMock.On("LinkByName", sviName).Return(sviLink, nil)
 			nlMock.On("LinkByName", ovsPortName).Return(ovsPortLink, nil)
-			nlMock.On("NeighAdd", mock.Anything).Return(nil)
 			nlMock.On("NeighSet", mock.Anything).Return(nil)
 
 			mac, _ := net.ParseMAC("0a:58:0a:00:00:05")
@@ -100,7 +99,7 @@ var _ = Describe("EVPN pod controller", func() {
 			Expect(ctrl.reconcilePod("test-ns/test-pod")).To(Succeed())
 
 			By("verifying FDB entry was added on OVS port")
-			nlMock.AssertCalled(GinkgoT(), "NeighAdd", mock.MatchedBy(func(n *netlink.Neigh) bool {
+			nlMock.AssertCalled(GinkgoT(), "NeighSet", mock.MatchedBy(func(n *netlink.Neigh) bool {
 				return n.LinkIndex == 20 && n.HardwareAddr.String() == mac.String() && n.Vlan == 100
 			}))
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2361,7 +2361,7 @@ func addHostMACBindings(bridgeName string) error {
 				klog.Warningf("Failed to remove IP neighbor entry for ip %s, on iface %s: %v",
 					ip, bridgeName, err)
 			}
-			if err = util.LinkNeighAdd(link, net.ParseIP(ip), dummyNextHopMAC); err != nil {
+			if err = util.LinkNeighSet(link, net.ParseIP(ip), dummyNextHopMAC); err != nil {
 				return fmt.Errorf("failed to configure neighbor: %s, on iface %s: %v",
 					ip, bridgeName, err)
 			}

--- a/go-controller/pkg/node/managementport/port_linux.go
+++ b/go-controller/pkg/node/managementport/port_linux.go
@@ -302,7 +302,7 @@ func setupManagementPortIPFamilyConfig(link netlink.Link, mpcfg *managementPortC
 				klog.Warningf("Could not remove remove stale IP neighbor entry for IP %s, on iface %s: %v", cfg.gwIP.String(), types.K8sMgmtIntfName, err)
 			}
 		}
-		err = util.LinkNeighAdd(link, cfg.gwIP, mpcfg.gwMAC)
+		err = util.LinkNeighSet(link, cfg.gwIP, mpcfg.gwMAC)
 	}
 	if err != nil {
 		return err

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -618,8 +618,10 @@ func LinkRouteGetByDstAndGw(link netlink.Link, gwIP net.IP, subnet *net.IPNet) (
 	return route, err
 }
 
-// LinkFDBAdd adds a static FDB entry on the bridge that owns the given port.
-func LinkFDBAdd(port netlink.Link, mac net.HardwareAddr, vlan int) error {
+// LinkFDBSet adds or replaces a static FDB entry on the bridge that owns the given port.
+// It uses NeighSet (NLM_F_CREATE|NLM_F_REPLACE) so it succeeds whether
+// the entry is new or already exists.
+func LinkFDBSet(port netlink.Link, mac net.HardwareAddr, vlan int) error {
 	neigh := &netlink.Neigh{
 		LinkIndex:    port.Attrs().Index,
 		Family:       syscall.AF_BRIDGE,
@@ -628,8 +630,8 @@ func LinkFDBAdd(port netlink.Link, mac net.HardwareAddr, vlan int) error {
 		Vlan:         vlan,
 		HardwareAddr: mac,
 	}
-	if err := netLinkOps.NeighAdd(neigh); err != nil {
-		return fmt.Errorf("failed to add FDB entry %s vlan %d on %s: %w", mac, vlan, port.Attrs().Name, err)
+	if err := netLinkOps.NeighSet(neigh); err != nil {
+		return fmt.Errorf("failed to set FDB entry %s vlan %d on %s: %w", mac, vlan, port.Attrs().Name, err)
 	}
 	return nil
 }

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -663,10 +663,10 @@ func LinkNeighDel(link netlink.Link, neighIP net.IP) error {
 	return nil
 }
 
-// LinkNeighAdd adds or replaces MAC/IP bindings for the given link.
-// It uses NeighSet (NLM_F_CREATE|NLM_F_REPLACE) so that existing entries
-// (e.g. extern_learn from EVPN) are replaced with the desired state.
-func LinkNeighAdd(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAddr) error {
+// LinkNeighSet adds or replaces MAC/IP bindings for the given link.
+// It uses NeighSet (NLM_F_CREATE|NLM_F_REPLACE) so it succeeds whether
+// the entry is new or already exists (e.g. zebra's extern_learn).
+func LinkNeighSet(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAddr) error {
 	neigh := &netlink.Neigh{
 		LinkIndex:    link.Attrs().Index,
 		Family:       getFamily(neighIP),

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -818,7 +818,7 @@ func TestLinkRouteExists(t *testing.T) {
 	}
 }
 
-func TestLinkNeighAdd(t *testing.T) {
+func TestLinkNeighSet(t *testing.T) {
 	mockNetLinkOps := new(mocks.NetLinkOps)
 	mockLink := new(netlink_mocks.Link)
 	// below is defined in net_linux.go
@@ -861,7 +861,7 @@ func TestLinkNeighAdd(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
 			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
-			err := LinkNeighAdd(tc.inputLink, tc.inputNeigIP, tc.inputMacAddr)
+			err := LinkNeighSet(tc.inputLink, tc.inputNeigIP, tc.inputMacAddr)
 			t.Log(err)
 			if tc.errExp {
 				require.Error(t, err)

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -2331,6 +2331,17 @@ ip route add %[3]s via %[4]s
 				test:     liveMigrateFailed,
 				topology: udnv1.NetworkTopologyLocalnet,
 			}),
+			Entry(nil, testData{
+				resource: virtualMachineWithUDN,
+				test:     liveMigrateFailed,
+				topology: udnv1.NetworkTopologyLayer2,
+				role:     udnv1.NetworkRolePrimary,
+				ingress:  "routed",
+				evpn: &udnv1.EVPNConfig{
+					MACVRF: &udnv1.VRFConfig{},
+					IPVRF:  &udnv1.VRFConfig{},
+				},
+			}),
 		)
 	})
 	Context("with kubevirt VM using layer2 UDPN", Ordered, func() {


### PR DESCRIPTION
## 📑 Description

During kubevirt live migration, PERMANENT neighbor entries were programmed
before the target domain was ready, that's wrong since traffic should not be steered there yet.
This change wait for live migration target domain to be ready to create the neighbors entries
at target node.

It also address sone pending comments from original PR related to use Set also on FDB table and also 
rename their functions since now they use Set instead of Add netlink operation.

## Additional Information for reviewers
This is a follow up as commented at https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6442#discussion_r3302149418

There is a follow up issue created so ovnk do remove the mac mobility created remote neighbors:
- https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6526

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

The e2e test are passing allright + changess on unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVPN live-migration handling: neighbor/FDB entries are now deferred, removed, or re-applied to ensure they appear on the correct node and in the right order.
  * FDB is programmed before permanent neighbor entries to avoid races.
  * Neighbor/FDB updates use replace/set semantics for reliable create-or-update behavior.

* **Tests**
  * Unit tests updated to validate set-based neighbor/FDB behavior.
  * Added e2e coverage for routed EVPN during live-migration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->