### PR TITLE
Optimize addressManager sync

### DIFF
--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -181,15 +181,15 @@ func (c *Controller) syncLink(link netlink.Link) error {
 		}
 	}
 	linkName := link.Attrs().Name
-	// get all addresses associated with the link depending on which IP families we support
-	foundAddresses, err := util.GetFilteredInterfaceAddrs(link, c.ipv4Enabled, c.ipv6Enabled)
-	if err != nil {
-		return fmt.Errorf("failed to get address from link %q: %w", linkName, err)
-	}
 	wantedAddresses, found := c.store[linkName]
 	// we don't manage this link therefore we don't need to add any addresses
 	if !found {
 		return nil
+	}
+	// get all addresses associated with the link depending on which IP families we support
+	foundAddresses, err := util.GetFilteredInterfaceAddrs(link, c.ipv4Enabled, c.ipv6Enabled)
+	if err != nil {
+		return fmt.Errorf("failed to get address from link %q: %w", linkName, err)
 	}
 	// add addresses we want that are not found on the link
 	for _, addressWanted := range wantedAddresses {

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -550,18 +550,11 @@ func (c *addressManager) sync() {
 	var addrs []netlink.Addr
 
 	if c.useNetlink {
-		links, err := netlink.LinkList()
+		var err error
+		addrs, err = util.GetNetLinkOps().AddrList(nil, getSupportedIPFamily())
 		if err != nil {
-			klog.Errorf("Failed sync due to being unable to list links: %v", err)
+			klog.Errorf("Failed to sync node addresses: unable to list all interface addresses: %v", err)
 			return
-		}
-		for _, link := range links {
-			foundAddrs, err := util.GetNetLinkOps().AddrList(link, getSupportedIPFamily())
-			if err != nil {
-				klog.Errorf("Failed sync due to being unable to list addresses for %q: %v", link.Attrs().Name, err)
-				return
-			}
-			addrs = append(addrs, foundAddrs...)
 		}
 	}
 


### PR DESCRIPTION
`addressManager.sync()` called `AddrList` on every interface on the node, including pod veth pairs which can become a problem at scale. List all addresses in one `addrs, err = netlink.AddrList(nil, getSupportedIPFamily())` call  instead. 
`linkmanager.syncLink()` called `GetFilteredInterfaceAddrs` before checking whether the link is in the managed store, issuing a needless `AddrList` for every unmanaged link event. Move the call after the skip. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip address-filtering work for unmanaged network links to avoid unnecessary processing and related errors.
  * Improve node address collection on Linux to fail fast on address-listing errors, reducing spurious failures.

* **Tests**
  * Non-functional whitespace-only update in a Node IP Handler test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->