### PR TITLE
Add IPsec tunnel IKE Child SA state metric

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -663,6 +663,13 @@ jobs:
         export OVN_IMAGE="ovn-daemonset-fedora:pr"
         make -C test install-kind
 
+    - name: Install prom2json binary
+      if: env.ENABLE_IPSEC == 'true'
+      run: |
+        set -x
+        go install github.com/prometheus/prom2json/cmd/prom2json@latest
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
     - name: traffic-flow-tests setup
       timeout-minutes: 5
       if: env.TRAFFIC_FLOW_TESTS != ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -469,6 +469,7 @@ jobs:
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "shard-conformance", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
+          - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones","ipsec":"enable-ipsec"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "dns-name-resolver": "enable-dns-name-resolver"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv6",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
@@ -503,7 +504,7 @@ jobs:
           - {"target": "serial", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
     needs: [ build-pr ]
     env:
-      JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}"
+      JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}-${{ matrix.ic }}${{ matrix.ipsec != '' && format('-{0}', matrix.ipsec) || '' }}"
       OVN_HYBRID_OVERLAY_ENABLE: ${{ matrix.target == 'control-plane' && (matrix.ipfamily == 'ipv4' || matrix.ipfamily == 'dualstack' ) }}
       OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' || startsWith(matrix.target, 'network-segmentation') || startsWith(matrix.target, 'bgp') }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' || startsWith(matrix.target, 'bgp') }}"
@@ -537,6 +538,7 @@ jobs:
       ENABLE_NO_OVERLAY: "${{ matrix.no-overlay != '' }}"
       ENABLE_NO_OVERLAY_OUTBOUND_SNAT: "${{ matrix.no-overlay == 'snat-enabled' || matrix.no-overlay == 'managed' }}"
       ENABLE_NO_OVERLAY_MANAGED_ROUTING: "${{ matrix.no-overlay == 'managed' }}"
+      ENABLE_IPSEC: "${{ matrix.ipsec == 'enable-ipsec' }}"
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1075,6 +1075,12 @@ ovnkube-controller() {
   fi
   echo "egressqos_enabled_flag=${egressqos_enabled_flag}"
 
+  ipsec_enabled_flag=
+  if [[ ${ENABLE_IPSEC} == "true" ]]; then
+	  ipsec_enabled_flag="--enable-ipsec"
+  fi
+  echo "ipsec_enabled_flag=${ipsec_enabled_flag}"
+
   multi_network_enabled_flag=
   if [[ ${ovn_multi_network_enable} == "true" ]]; then
 	  multi_network_enabled_flag="--enable-multi-network --enable-multi-networkpolicy"
@@ -1262,6 +1268,7 @@ ovnkube-controller() {
     ${dynamic_udn_allocation_flag} \
     ${dynamic_udn_grace_period} \
     ${ovn_allow_icmp_netpol_flag} \
+    ${ipsec_enabled_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --gateway-mode=${ovn_gateway_mode} \
     --host-network-namespace ${ovn_host_network_namespace} \
@@ -1415,6 +1422,12 @@ ovnkube-controller-with-node() {
 	  egressqos_enabled_flag="--enable-egress-qos"
   fi
   echo "egressqos_enabled_flag=${egressqos_enabled_flag}"
+
+  ipsec_enabled_flag=
+  if [[ ${ENABLE_IPSEC} == "true" ]]; then
+	  ipsec_enabled_flag="--enable-ipsec"
+  fi
+  echo "ipsec_enabled_flag=${ipsec_enabled_flag}"
 
   multi_network_enabled_flag=
   if [[ ${ovn_multi_network_enable} == "true" ]]; then
@@ -1795,6 +1808,7 @@ ovnkube-controller-with-node() {
     ${ovn_disable_requestedchassis_flag} \
     ${cluster_access_opts} \
     ${ovn_allow_icmp_netpol_flag} \
+    ${ipsec_enabled_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --export-ovs-metrics \
     --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
@@ -1871,6 +1885,11 @@ ovn-cluster-manager() {
 	  egressqos_enabled_flag="--enable-egress-qos"
   fi
   echo "egressqos_enabled_flag=${egressqos_enabled_flag}"
+
+  ipsec_enabled_flag=
+  if [[ ${ENABLE_IPSEC} == "true" ]]; then
+	  ipsec_enabled_flag="--enable-ipsec"
+  fi
 
   hybrid_overlay_flags=
   if [[ ${ovn_hybrid_overlay_enable} == "true" ]]; then
@@ -2079,6 +2098,7 @@ ovn-cluster-manager() {
     ${dynamic_udn_grace_period} \
     ${ovn_enable_dnsnameresolver_flag} \
     ${ovn_allow_icmp_netpol_flag} \
+    ${ipsec_enabled_flag} \
     --gateway-mode=${ovn_gateway_mode} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --host-network-namespace ${ovn_host_network_namespace} \
@@ -2427,6 +2447,12 @@ ovn-node() {
   fi
   echo "dynamic_udn_grace_period=${dynamic_udn_grace_period}"
 
+  ipsec_enabled_flag=
+  if [[ ${ENABLE_IPSEC} == "true" ]]; then
+	  ipsec_enabled_flag="--enable-ipsec"
+  fi
+
+
   # NB client cert material is only consumed by the Egress IP gRPC
   # health-check channel (see pkg/ovn/healthcheck/egressip_healthcheck.go).
   # The OVN NB/SB DB connections themselves are unix-socket only.
@@ -2489,6 +2515,7 @@ ovn-node() {
         ${dynamic_udn_allocation_flag} \
         ${dynamic_udn_grace_period} \
         ${network_qos_enabled_flag} \
+        ${ipsec_enabled_flag} \
         --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
         --export-ovs-metrics \
         --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -547,9 +547,6 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 				return
 			}
 
-			// register ovnkube node specific prometheus metrics exported by the node
-			metrics.RegisterNodeMetrics(ctx.Done())
-
 			// OVS is not running on dpu-host nodes
 			if config.IsModeDPU() || config.IsModeFull() {
 				ovsClient, err = libovsdb.NewOVSClient(ctx.Done())
@@ -557,6 +554,13 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 					nodeErr = fmt.Errorf("failed to initialize libovsdb vswitchd client: %w", err)
 					return
 				}
+			}
+
+			// register ovnkube node specific prometheus metrics exported by the node
+			err = metrics.RegisterNodeMetrics(ctx.Done(), wg, ovsClient)
+			if err != nil {
+				nodeErr = fmt.Errorf("failed to register node metrics %w", err)
+				return
 			}
 
 			nodeControllerManager, err := controllermanager.NewNodeControllerManager(

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/vishvananda/netlink v1.3.2-0.20260320193013-72a8cd7e0a73
+	github.com/vishvananda/netns v0.0.5
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.48.0
 	golang.org/x/sync v0.19.0
@@ -132,7 +133,6 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -84,6 +84,7 @@ function testrun {
 # These packages requires root for network namespace manipulation in unit tests
 root_pkgs=(
     "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controllermanager"
+    "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics"
     "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node"
     "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/egressip"
     "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iptables"

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -507,6 +507,7 @@ type OVNKubernetesFeatureConfig struct {
 	// UDNDeletionGracePeriod specified in number of seconds to wait before garbage collecting a UDN. Applies
 	// only when Dynamic UDN Allocation is enabled.
 	UDNDeletionGracePeriod time.Duration `gcfg:"udn-deletion-grace-period"`
+	EnableIPsec            bool          `gcfg:"enable-ipsec"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -1322,6 +1323,12 @@ var OVNK8sFeatureFlags = []cli.Flag{
 			"feature is used.",
 		Destination: &cliConfig.OVNKubernetesFeature.UDNDeletionGracePeriod,
 		Value:       OVNKubernetesFeature.UDNDeletionGracePeriod,
+	},
+	&cli.BoolFlag{
+		Name:        "enable-ipsec",
+		Usage:       "Configure IPsec Encryption for ovn-kubernetes managed pod to pod traffic.",
+		Destination: &cliConfig.OVNKubernetesFeature.EnableIPsec,
+		Value:       OVNKubernetesFeature.EnableIPsec,
 	},
 }
 

--- a/go-controller/pkg/metrics/ipsec.go
+++ b/go-controller/pkg/metrics/ipsec.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
+)
+
+type ovsAppctlClient func(timeout int, args ...string) (string, string, error)
+
+// IPsecStatus represents the output of 'ovs-appctl -t ovs-monitor-ipsec ipsec/status'
+// The outer map keys are connection names (e.g., "ovn-194484-0")
+// The inner map keys are tunnel names (e.g., "ovn-194484-0-in-1", "ovn-194484-0-out-1")
+// The values are tunnel status strings containing ESP information
+type IPsecStatus map[string]map[string]string
+
+// areAllIPsecTunnelsEstablished checks if all expected IPsec tunnels (based on geneve interfaces)
+// have established Child SAs by querying ovs-monitor-ipsec daemon.
+// 1. Retrieve geneve interfaces from OVS DB.
+// 2. Query 'ovs-appctl -t ovs-monitor-ipsec ipsec/status' to get tunnel status.
+// 3. Parse the JSON output to extract tunnel names.
+// 4. Return true when all expected tunnels (-in-1 and -out-1 for each geneve interface) are found.
+func areAllIPsecTunnelsEstablished(ovsDBClient libovsdbclient.Client, ovsAppctl ovsAppctlClient) (bool, error) {
+	// Get geneve interfaces from OVS DB
+	geneveInterfaces, err := getGeneveInterfaces(ovsDBClient)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve geneve interfaces: %v", err)
+	}
+	if len(geneveInterfaces) == 0 {
+		return false, fmt.Errorf("no geneve interfaces found")
+	}
+
+	// Each geneve interface has -in-1 and -out-1 tunnels.
+	expectedTunnels := sets.New[string]()
+	for _, geneveTunnel := range geneveInterfaces {
+		expectedTunnels.Insert(fmt.Sprintf("%s-in-1", geneveTunnel))
+		expectedTunnels.Insert(fmt.Sprintf("%s-out-1", geneveTunnel))
+	}
+
+	// Query ovs-monitor-ipsec for tunnel status
+	stdout, stderr, err := ovsAppctl(5, "-t", "ovs-monitor-ipsec", "ipsec/status")
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve ipsec status, stderr: %v, err: %v", stderr, err)
+	}
+	if stdout == "" {
+		return false, fmt.Errorf("no IPsec tunnels found")
+	}
+
+	// The output is in Python dict format with single quotes, convert to JSON
+	// First, escape any double quotes inside the string values
+	jsonOutput := strings.ReplaceAll(stdout, "\"", "\\\"")
+	// Then replace single quotes with double quotes to get valid JSON
+	jsonOutput = strings.ReplaceAll(jsonOutput, "'", "\"")
+
+	// Parse the JSON output
+	var status IPsecStatus
+	if err := json.Unmarshal([]byte(jsonOutput), &status); err != nil {
+		return false, fmt.Errorf("failed to parse ipsec status output: %v", err)
+	}
+
+	// Extract all tunnel names from the nested map structure
+	foundTunnels := sets.New[string]()
+	for _, tunnels := range status {
+		for tunnelName := range tunnels {
+			if expectedTunnels.Has(tunnelName) {
+				foundTunnels.Insert(tunnelName)
+			}
+		}
+	}
+
+	// Check if all expected tunnels were found
+	return foundTunnels.Len() == expectedTunnels.Len(), nil
+}
+
+func getGeneveInterfaces(ovsDBClient libovsdbclient.Client) ([]string, error) {
+	interfaces, err := ovsops.FindInterfacesWithPredicate(ovsDBClient, func(intf *vswitchd.Interface) bool {
+		return intf.Type == "geneve"
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve Geneve interfaces: %v", err)
+	}
+
+	var infNames []string
+	for _, intf := range interfaces {
+		infNames = append(infNames, intf.Name)
+	}
+	return infNames, nil
+}

--- a/go-controller/pkg/metrics/ipsec_test.go
+++ b/go-controller/pkg/metrics/ipsec_test.go
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics/mocks"
+	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
+)
+
+type fakeOVSAppctlClient struct {
+	output clientOutput
+	mutex  sync.Mutex
+}
+
+func NewFakeOVSAppctlClient(data clientOutput) fakeOVSAppctlClient {
+	return fakeOVSAppctlClient{output: data}
+}
+
+func (c *fakeOVSAppctlClient) FakeCall(_ int, _ ...string) (string, string, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.output.stdout, c.output.stderr, c.output.err
+}
+
+func (c *fakeOVSAppctlClient) ChangeOutput(newOutput clientOutput) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.output = newOutput
+}
+
+// buildIPsecOutput generates IPsec tunnel status output in JSON format for the given tunnel names.
+// For each tunnel name, it generates entries for both inbound (-in-1) and outbound (-out-1) tunnels.
+// The output format matches 'ovs-appctl -t ovs-monitor-ipsec ipsec/status' command output.
+func buildIPsecOutput(tunnelNames ...string) string {
+	var output strings.Builder
+	connectionID := 10
+
+	output.WriteString("{")
+	for i, tunnelName := range tunnelNames {
+		if i > 0 {
+			output.WriteString(", ")
+		}
+
+		connectionID++
+		inConnID := connectionID
+		connectionID++
+		outConnID := connectionID
+
+		// Format: {'tunnel-name': {'tunnel-name-in-1': 'esp info', 'tunnel-name-out-1': 'esp info'}}
+		fmt.Fprintf(&output, "'%s': {'%s-in-1': '#%d: \"%s-in-1\" esp.e591db0c@192.168.111.21 esp.88eb5d94@192.168.111.24 Traffic: ESPin=5MB ESPout=0B ESPmax=2^63B ', '%s-out-1': '#%d: \"%s-out-1\" esp.c16822ce@192.168.111.21 esp.e2b67192@192.168.111.24 Traffic: ESPin=0B ESPout=8MB ESPmax=2^63B '}",
+			tunnelName, tunnelName, inConnID, tunnelName, tunnelName, outConnID, tunnelName)
+	}
+	output.WriteString("}")
+
+	return output.String()
+}
+
+// buildOVSTestData creates the OVS DB test data structure with geneve tunnel interfaces.
+func buildOVSTestData(tunnelNames ...string) []libovsdbtest.TestData {
+	var data []libovsdbtest.TestData
+	var portUUIDs []string
+
+	// Create interfaces and ports for each tunnel
+	for _, tunnelName := range tunnelNames {
+		intfUUID := buildUUID()
+		portUUID := buildUUID()
+
+		data = append(data,
+			&vswitchd.Interface{
+				UUID: intfUUID,
+				Name: tunnelName,
+				Type: "geneve",
+			},
+			&vswitchd.Port{
+				UUID:       portUUID,
+				Name:       tunnelName,
+				Interfaces: []string{intfUUID},
+			},
+		)
+		portUUIDs = append(portUUIDs, portUUID)
+	}
+
+	// Create br-int bridge with all ports
+	brUUID := buildUUID()
+	data = append(data, &vswitchd.Bridge{
+		UUID:  brUUID,
+		Name:  "br-int",
+		Ports: portUUIDs,
+	})
+
+	// Create OpenvSwitch object
+	data = append(data, &vswitchd.OpenvSwitch{
+		UUID:    buildUUID(),
+		Bridges: []string{brUUID},
+	})
+
+	return data
+}
+
+var _ = ginkgo.Describe("IPsec metrics", func() {
+	var (
+		geneveTunnelName1                    = "ovn-8ebfff-0"
+		geneveTunnelName2                    = "ovn-e9845d-0"
+		stopChan                             chan struct{}
+		wg                                   *sync.WaitGroup
+		mockIPsecTunnelIKEChildSAStateMetric *mocks.GaugeMock
+		ovsClient                            libovsdbclient.Client
+		libovsdbCtx                          *libovsdbtest.Context
+		ovsAppctlClient                      fakeOVSAppctlClient
+	)
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		stopChan = make(chan struct{})
+		wg = &sync.WaitGroup{}
+		prevMetric := metricIPsecTunnelIKEChildSAState
+		ginkgo.DeferCleanup(func() {
+			metricIPsecTunnelIKEChildSAState = prevMetric
+		})
+		mockIPsecTunnelIKEChildSAStateMetric = mocks.NewGaugeMock()
+		metricIPsecTunnelIKEChildSAState = mockIPsecTunnelIKEChildSAStateMetric
+
+		// Create libovsdb test harness with geneve tunnel interfaces
+		ovsClient, libovsdbCtx, err = libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+			OVSData: buildOVSTestData(geneveTunnelName1, geneveTunnelName2),
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create libovsdb test harness")
+		ginkgo.DeferCleanup(libovsdbCtx.Cleanup)
+
+		ovsAppctlClient = NewFakeOVSAppctlClient(clientOutput{})
+		err = MonitorIPsecTunnelsState(stopChan, wg, ovsClient, ovsAppctlClient.FakeCall)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "monitor ipsec tunnel state should not fail")
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("clean up resources for the test")
+		close(stopChan)
+		wg.Wait()
+		// Clean up ip xfrm state entry after every test.
+		err := netlink.XfrmStateDel(getBaseState())
+		if err != nil && !errors.Is(err, syscall.ENOENT) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "should not return an error for ip xfrm state entry cleanup")
+		}
+	})
+
+	ginkgo.Context("Tunnel state", func() {
+		ovntest.OnSupportedPlatformsIt("when geneve tunnels are present with IKE Child SAs established", func() {
+			ginkgo.By("Emulate IKE Child SAs establishment for existing Geneve tunnels")
+			ovsAppctlClient.ChangeOutput(clientOutput{
+				stdout: buildIPsecOutput(geneveTunnelName1, geneveTunnelName2),
+			})
+			ginkgo.By("Trigger ip xfrm state event")
+			err := netlink.XfrmStateAdd(getBaseState())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "should not return an error ip xfrm state entry add operation")
+			ginkgo.By("Check IKE Child SA metric is in established state")
+			gomega.Eventually(func() int {
+				return int(mockIPsecTunnelIKEChildSAStateMetric.GetValue())
+			}).WithTimeout(10 * time.Second).Should(gomega.Equal(1))
+		})
+		ovntest.OnSupportedPlatformsIt("when geneve tunnels are present with IKE Child SAs not established for a tunnel", func() {
+			ginkgo.By("Emulate IKE Child SA establishment failure for one of the existing Geneve tunnels")
+			// Only tunnel2 is fully established; tunnel1 is missing all IPsec SAs
+			ovsAppctlClient.ChangeOutput(clientOutput{
+				stdout: buildIPsecOutput(geneveTunnelName2),
+			})
+			ginkgo.By("Trigger ip xfrm state event")
+			err := netlink.XfrmStateAdd(getBaseState())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "should not return an error ip xfrm state entry add operation")
+			ginkgo.By("Check IKE Child SA metric is not in established state")
+			gomega.Eventually(func() int {
+				return int(mockIPsecTunnelIKEChildSAStateMetric.GetValue())
+			}).WithTimeout(10 * time.Second).Should(gomega.Equal(0))
+		})
+
+		ovntest.OnSupportedPlatformsIt("check IKE Child SA establishment when IPsec tunnels change", func() {
+			// Test no IPsec tunnel metrics when no IPsec tunnels are established.
+			ginkgo.By("Emulate scenario with no IPsec tunnels established")
+			ovsAppctlClient.ChangeOutput(clientOutput{}) // Empty output = no tunnels
+			ginkgo.By("Trigger ip xfrm state event")
+			state := getBaseState()
+			err := netlink.XfrmStateAdd(state)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "should not return an error ip xfrm state entry add operation")
+			ginkgo.By("Check IKE Child SA metric is not in established state")
+			gomega.Consistently(func() int {
+				return int(mockIPsecTunnelIKEChildSAStateMetric.GetValue())
+			}).WithTimeout(5 * time.Second).Should(gomega.Equal(0))
+			// Test corresponding IPsec tunnel metrics when only one tunnel is established.
+			ginkgo.By("Emulate IPsec tunnel established for only one Geneve tunnel")
+			ovsAppctlClient.ChangeOutput(clientOutput{
+				stdout: buildIPsecOutput(geneveTunnelName1),
+			})
+			ginkgo.By("Trigger ip xfrm state event")
+			err = netlink.XfrmStateDel(state)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "should not return an error ip xfrm state entry delete operation")
+			ginkgo.By("Check IKE Child SA metric is not in established state")
+			gomega.Consistently(func() int {
+				return int(mockIPsecTunnelIKEChildSAStateMetric.GetValue())
+			}).WithTimeout(5 * time.Second).Should(gomega.Equal(0))
+			// Test corresponding IPsec tunnel metrics when all tunnels are established.
+			ginkgo.By("Emulate IPsec tunnels established for all Geneve tunnels")
+			ovsAppctlClient.ChangeOutput(clientOutput{
+				stdout: buildIPsecOutput(geneveTunnelName1, geneveTunnelName2),
+			})
+			ginkgo.By("Trigger ip xfrm state event")
+			err = netlink.XfrmStateAdd(state)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "should not return an error ip xfrm state entry add operation")
+			ginkgo.By("Check IKE Child SA metric is in established state")
+			gomega.Eventually(func() int {
+				return int(mockIPsecTunnelIKEChildSAStateMetric.GetValue())
+			}).WithTimeout(10 * time.Second).Should(gomega.Equal(1))
+		})
+	})
+})
+
+func getBaseState() *netlink.XfrmState {
+	return &netlink.XfrmState{
+		// Force 4 byte notation for the IPv4 addresses
+		Src:   net.ParseIP("127.0.0.1").To4(),
+		Dst:   net.ParseIP("127.0.0.2").To4(),
+		Proto: netlink.XFRM_PROTO_ESP,
+		Mode:  netlink.XFRM_MODE_TUNNEL,
+		Spi:   1,
+		Auth: &netlink.XfrmStateAlgo{
+			Name: "hmac(sha256)",
+			Key:  []byte("abcdefghijklmnopqrstuvwzyzABCDEF"),
+		},
+		Crypt: &netlink.XfrmStateAlgo{
+			Name: "cbc(aes)",
+			Key:  []byte("abcdefghijklmnopqrstuvwzyzABCDEF"),
+		},
+		Mark: &netlink.XfrmMark{
+			Value: 0x12340000,
+			Mask:  0xffff0000,
+		},
+	}
+}

--- a/go-controller/pkg/metrics/mocks/gauge.go
+++ b/go-controller/pkg/metrics/mocks/gauge.go
@@ -4,6 +4,7 @@
 package mocks
 
 import (
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,56 +13,71 @@ import (
 
 type GaugeMock struct {
 	value float64
+	mutex sync.Mutex
 }
 
 func NewGaugeMock() *GaugeMock {
 	return &GaugeMock{}
 }
 
-func (GaugeMock) Desc() *prometheus.Desc {
+func (h *GaugeMock) Desc() *prometheus.Desc {
 	panic("unimplemented")
 }
 
-func (GaugeMock) Write(*io_prometheus_client.Metric) error {
+func (h *GaugeMock) Write(*io_prometheus_client.Metric) error {
 	panic("unimplemented")
 }
 
-func (GaugeMock) Describe(chan<- *prometheus.Desc) {
-	panic("unimplemented")
+func (h *GaugeMock) Describe(chan<- *prometheus.Desc) {
 }
 
-func (GaugeMock) Collect(chan<- prometheus.Metric) {
-	panic("unimplemented")
+func (h *GaugeMock) Collect(chan<- prometheus.Metric) {
 }
 
 func (h *GaugeMock) Observe(value float64) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
 	h.value = value
 }
 
 func (gm *GaugeMock) Set(value float64) {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value = value
 }
 
 func (gm *GaugeMock) Inc() {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value++
 }
 
 func (gm *GaugeMock) Dec() {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value--
 }
 
 func (gm *GaugeMock) Add(value float64) {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value += value
 }
 
 func (gm *GaugeMock) Sub(value float64) {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value -= value
 }
 
 func (gm *GaugeMock) SetToCurrentTime() {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	gm.value = float64(time.Now().UnixMilli())
 }
 
 func (gm *GaugeMock) GetValue() float64 {
+	gm.mutex.Lock()
+	defer gm.mutex.Unlock()
 	return gm.value
 }

--- a/go-controller/pkg/metrics/node.go
+++ b/go-controller/pkg/metrics/node.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
 // MetricCNIRequestDuration is a prometheus metric that tracks the duration
@@ -52,7 +55,7 @@ var metricOvnKubeNodeLogFileSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var registerNodeMetricsOnce sync.Once
 
-func RegisterNodeMetrics(stopChan <-chan struct{}) {
+func RegisterNodeMetrics(stopChan <-chan struct{}, wg *sync.WaitGroup, ovsDBClient libovsdbclient.Client) error {
 	registerNodeMetricsOnce.Do(func() {
 		// ovnkube-node metrics
 		prometheus.MustRegister(MetricCNIRequestDuration)
@@ -85,4 +88,8 @@ func RegisterNodeMetrics(stopChan <-chan struct{}) {
 		prometheus.MustRegister(metricOvnKubeNodeLogFileSize)
 		go ovnKubeLogFileSizeMetricsUpdater(metricOvnKubeNodeLogFileSize, stopChan)
 	})
+	if config.OVNKubernetesFeature.EnableIPsec {
+		return MonitorIPsecTunnelsState(stopChan, wg, ovsDBClient, util.RunOVSAppctlWithTimeout)
+	}
+	return nil
 }

--- a/go-controller/pkg/metrics/ovnkube_controller.go
+++ b/go-controller/pkg/metrics/ovnkube_controller.go
@@ -9,9 +9,14 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
+	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
 
 	corev1 "k8s.io/api/core/v1"
 	kapimtypes "k8s.io/apimachinery/pkg/types"
@@ -247,6 +252,13 @@ var metricIPsecEnabled = prometheus.NewGauge(prometheus.GaugeOpts{
 	Subsystem: types.MetricOvnkubeSubsystemController,
 	Name:      "ipsec_enabled",
 	Help:      "Specifies whether IPSec is enabled for this cluster(1) or not enabled for this cluster(0)",
+})
+
+var metricIPsecTunnelIKEChildSAState = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: types.MetricOvnkubeNamespace,
+	Subsystem: types.MetricOvnkubeSubsystemController,
+	Name:      "ipsec_tunnel_ike_child_sa_state",
+	Help:      "Specifies whether IPSec Child SAs are established for the Geneve tunnels(1) or not(0)",
 })
 
 var metricEgressRoutingViaHost = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -610,6 +622,168 @@ func ipsecMetricHandler(table string, model model.Model) {
 		metricIPsecEnabled.Set(1)
 	} else {
 		metricIPsecEnabled.Set(0)
+	}
+}
+
+// subscribeFn defines the function signature for subscribing to xfrm events.
+type xfrmSubscribeFn func() (bool, chan []syscall.NetlinkMessage, *nl.NetlinkSocket, error)
+
+// MonitorIPsecTunnelsState will register a metric for the ipsec tunnel ike child sa establishment status.
+// It will then subscribe to xfrm netlink events and update the metric with ike child sa establishment up
+// or down status.
+func MonitorIPsecTunnelsState(stopChan <-chan struct{}, wg *sync.WaitGroup, ovsDBClient libovsdbclient.Client, ovsAppctl ovsAppctlClient) error {
+	if ovsDBClient == nil {
+		klog.Warningf("ovsDBClient is not set, can not retrieve IPsec tunnel ike child sa establishment metric")
+		return nil
+	}
+	if err := prometheus.Register(metricIPsecTunnelIKEChildSAState); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			return err
+		}
+	}
+	subscribe := func() (bool, chan []syscall.NetlinkMessage, *nl.NetlinkSocket, error) {
+		groups, err := getXfrmMcastGroups([]nl.XfrmMsgType{nl.XFRM_MSG_NEWSA, nl.XFRM_MSG_DELSA, nl.XFRM_MSG_UPDSA,
+			nl.XFRM_MSG_NEWPOLICY, nl.XFRM_MSG_DELPOLICY, nl.XFRM_MSG_UPDPOLICY})
+		if err != nil {
+			return false, nil, nil, fmt.Errorf("error creating XFRM groups: %v", err)
+		}
+		sock, err := nl.SubscribeAt(netns.None(), netns.None(), unix.NETLINK_XFRM, groups...)
+		if err != nil {
+			return false, nil, nil, fmt.Errorf("error subscribing XFRM events: %v", err)
+		}
+		// Buffered channel to prevent deadlock: allows reader to send one final
+		// message during shutdown even if main handler has already exited.
+		msgCh := make(chan []syscall.NetlinkMessage, 1)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer close(msgCh)
+			for {
+				msgs, from, err := sock.Receive()
+				if err != nil {
+					klog.Infof("XFRM reader exiting: %v", err)
+					return
+				}
+				if from.Pid != nl.PidKernel {
+					klog.Warningf("Unexpected XFRM sender pid %d (expected %d)", from.Pid, nl.PidKernel)
+					continue
+				}
+				select {
+				case msgCh <- msgs:
+				case <-stopChan:
+					return
+				}
+			}
+		}()
+		// Initial reconciliation
+		updateIPsecTunnelStateMetric(ovsDBClient, ovsAppctl)
+		return true, msgCh, sock, nil
+	}
+
+	return runInternalIPsec(stopChan, wg, ovsDBClient, ovsAppctl, subscribe)
+}
+
+// reconcile period for xfrm event handler, this would kick in for every 60 seconds if
+// there is no explicit xfrm events. when xfrm event occurs, reconcile period is
+// automatically extended by another 60 seconds.
+var xfrmHandlerReconcilePeriod = 60 * time.Second
+
+// runInternalIPsec runs the main monitoring loop with subscription handling.
+func runInternalIPsec(stopChan <-chan struct{}, wg *sync.WaitGroup,
+	ovsDBClient libovsdbclient.Client, ovsAppctl ovsAppctlClient, subscribe xfrmSubscribeFn) error {
+	// Get the current network namespace handle
+	currentNs, err := ns.GetCurrentNS()
+	if err != nil {
+		return fmt.Errorf("error retrieving current net namespace, err: %v", err)
+	}
+	subscribed, xfrmCh, sock, err := subscribe()
+	if err != nil {
+		return err
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err = currentNs.Do(func(_ ns.NetNS) error {
+			xfrmSyncTimer := time.NewTicker(xfrmHandlerReconcilePeriod)
+			defer xfrmSyncTimer.Stop()
+			for {
+				select {
+				case msgs, ok := <-xfrmCh:
+					xfrmSyncTimer.Reset(xfrmHandlerReconcilePeriod)
+					if !ok {
+						// Channel closed (i.e. netlink socket reader is exited)
+						// Check if shutdown is requested.
+						select {
+						case <-stopChan:
+							return nil
+						default:
+							if subscribed, xfrmCh, sock, err = subscribe(); err != nil {
+								klog.Errorf("Error during XFRM re-subscribe due to channel closing: %v", err)
+							}
+						}
+						continue
+					}
+					if len(msgs) > 0 {
+						updateIPsecTunnelStateMetric(ovsDBClient, ovsAppctl)
+					}
+				case <-xfrmSyncTimer.C:
+					updateIPsecTunnelStateMetric(ovsDBClient, ovsAppctl)
+					if !subscribed {
+						if subscribed, xfrmCh, sock, err = subscribe(); err != nil {
+							klog.Errorf("Error during XFRM events re-subscribe: %v", err)
+						}
+					}
+				case <-stopChan:
+					// Trigger xfrm netlink socket reader exit.
+					if sock != nil {
+						sock.Close()
+					}
+					return nil
+				}
+			}
+		})
+		if err != nil {
+			klog.Errorf("Failed to run XFRM event handler goroutine, err: %v", err)
+		}
+	}()
+	return nil
+}
+
+func getXfrmMcastGroups(types []nl.XfrmMsgType) ([]uint, error) {
+	groups := make([]uint, 0)
+	if len(types) == 0 {
+		return nil, fmt.Errorf("no xfrm msg type specified")
+	}
+	for _, t := range types {
+		var group uint
+		switch t {
+		case nl.XFRM_MSG_ACQUIRE:
+			group = nl.XFRMNLGRP_ACQUIRE
+		case nl.XFRM_MSG_EXPIRE:
+			group = nl.XFRMNLGRP_EXPIRE
+		case nl.XFRM_MSG_NEWSA, nl.XFRM_MSG_DELSA, nl.XFRM_MSG_UPDSA:
+			group = nl.XFRMNLGRP_SA
+		case nl.XFRM_MSG_NEWPOLICY, nl.XFRM_MSG_DELPOLICY, nl.XFRM_MSG_UPDPOLICY:
+			group = nl.XFRMNLGRP_POLICY
+		default:
+			return nil, fmt.Errorf("unsupported xfrm group: %x", t)
+		}
+		groups = append(groups, group)
+	}
+	return groups, nil
+}
+
+func updateIPsecTunnelStateMetric(ovsDBClient libovsdbclient.Client, ovsAppctl ovsAppctlClient) {
+	ipsecEstablished, err := areAllIPsecTunnelsEstablished(ovsDBClient, ovsAppctl)
+	if err != nil {
+		klog.Errorf("Error in checking IPsec tunnel states, err: %v", err)
+		metricIPsecTunnelIKEChildSAState.Set(0)
+		return
+	}
+	if ipsecEstablished {
+		metricIPsecTunnelIKEChildSAState.Set(1)
+	} else {
+		metricIPsecTunnelIKEChildSAState.Set(0)
 	}
 }
 

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
@@ -39,6 +39,9 @@ spec:
       serviceAccountName: ovnkube-node
       hostNetwork: true
       dnsPolicy: Default
+      {{- if eq (hasKey .Values.global "unprivilegedMode" | ternary .Values.global.unprivilegedMode false) false }}
+      hostPID: true
+      {{- end }}
       priorityClassName: "system-node-critical"
       initContainers:
       - name: ovn-keys

--- a/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
+++ b/helm/ovn-kubernetes/charts/ovn-ipsec/templates/daemonset.yaml
@@ -206,6 +206,16 @@ spec:
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
 
+          # On ovn-ipsec pod restart, the old pluto PID file may remain even though the
+          # process is gone. This prevents the new pluto daemon from starting, with the
+          # error: "/run/pluto/pluto.pid already exists".
+          # If the file exists but no pluto process is running, remove the stale PID file
+          # before starting a new pluto process.
+          if [ -f /var/run/pluto/pluto.pid ] && ! pgrep -F /var/run/pluto/pluto.pid > /dev/null 2>&1; then
+            echo "Removing stale pluto.pid"
+            rm -f /var/run/pluto/pluto.pid
+          fi
+
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
           # Check kernel modules only for libreswan version <= 5.2. The _stackmanager binary is
           # removed from 5.3 onwards, so this check is not needed on later versions.

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -349,6 +349,8 @@ spec:
           value: {{ default 6081 .Values.global.encapPort | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
+        - name: ENABLE_IPSEC
+          value: {{ hasKey .Values.global "enableIpsec" | ternary .Values.global.enableIpsec false | quote }}
         - name: OVN_NETFLOW_TARGETS
           value: {{ default "" .Values.global.netFlowTargets | quote }}
         - name: OVN_SFLOW_TARGETS

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -411,6 +411,8 @@ spec:
           value: {{ default 6081 .Values.global.encapPort | quote }}
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: {{ default "" .Values.global.disablePacketMtuCheck | quote }}
+        - name: ENABLE_IPSEC
+          value: {{ hasKey .Values.global "enableIpsec" | ternary .Values.global.enableIpsec false | quote }}
         - name: OVN_NETFLOW_TARGETS
           value: {{ default "" .Values.global.netFlowTargets | quote }}
         - name: OVN_SFLOW_TARGETS

--- a/test/e2e/feature/features.go
+++ b/test/e2e/feature/features.go
@@ -23,6 +23,7 @@ var (
 	DisablePacketMTUCheck = New("DisablePacketMTUCheck")
 	VirtualMachineSupport = New("VirtualMachineSupport")
 	Interconnect          = New("Interconnect")
+	IPsec                 = New("IPsec")
 	Multicast             = New("Multicast")
 	MultiHoming           = New("MultiHoming")
 	NodeIPMACMigration    = New("NodeIPMACMigration")

--- a/test/e2e/ipsec.go
+++ b/test/e2e/ipsec.go
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+)
+
+var _ = ginkgo.Describe("IPsec", feature.IPsec, func() {
+
+	f := wrappedTestFramework("ipsec")
+	var nodes *v1.NodeList
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		if !isIPsecEnabled() {
+			ginkgo.Skip("Test requires IPsec enabled cluster. but IPsec is not enabled in this cluster.")
+		}
+		nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 2)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			e2eskipper.Skipf(
+				"Test requires >= 2 Ready nodes, but there are only %v nodes",
+				len(nodes.Items))
+		}
+
+	})
+	ginkgo.Context("Metrics", func() {
+		// Validate IPsec metrics can be retrieved in IPsec enabled cluster
+		// Verify two kinds of metrics were collected
+		// "ovnkube_controller_ipsec_enabled 1" is the IPsec legacy metric
+		// "ovnkube_controller_ipsec_tunnel_ike_child_sa_state 1" is the new one added,
+		// 1 reflect tunnel established, 0 reflecting tunnel not established.
+		// Note: IPsec connection state is held in the kernel (ip xfrm state and policy), not in the
+		// pluto daemon itself. Killing pluto doesn't immediately affect existing tunnels as the kernel
+		// maintains them. Other nodes only detect issues during rekey or new connection attempts
+		// (infrequent operations). This test verifies that killing the pluto daemon and restarting
+		//  ovn-ipsec pod does not disrupt tunnel state, and the metric remains set to 1 throughout.
+		ginkgo.It("IKE Child SA State which reflects the down and up state of the IPsec tunnel", func() {
+			ipsecMetricName := "ovnkube_controller_ipsec_enabled"
+			ipsecTunnelMetricName := "ovnkube_controller_ipsec_tunnel_ike_child_sa_state"
+			node1 := nodes.Items[0]
+
+			ovnKubernetesNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+			ovnPods, err := f.ClientSet.CoreV1().Pods(ovnKubernetesNamespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "name=ovnkube-node",
+			})
+			if err != nil {
+				framework.Failf("failed to list OVN pods: %v", err)
+			}
+
+			for _, ovnPod := range ovnPods.Items {
+				ginkgo.By(fmt.Sprintf("Verify IPsec enabled metric from ovn pod %s", ovnPod.Name))
+				ipsecMetricValue := getMetricValue(f, ovnPod.Name, ovnKubernetesNamespace, ipsecMetricName)
+				gomega.Expect(ipsecMetricValue).Should(gomega.Equal("1"))
+
+				ginkgo.By(fmt.Sprintf("Verify IPsec tunnel metrics reflecting up from ovn pod %s", ovnPod.Name))
+				ipsecTunnelMetricValue := getMetricValue(f, ovnPod.Name, ovnKubernetesNamespace, ipsecTunnelMetricName)
+				gomega.Expect(ipsecTunnelMetricValue).Should(gomega.Equal("1"))
+			}
+
+			ipsecContainer := "ovn-ipsec"
+			ginkgo.By(fmt.Sprintf("Kill pluto process in IPsec pod which was deployed on node %s", node1.Name))
+			ipsecPod, err := f.ClientSet.CoreV1().Pods(ovnKubernetesNamespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "app=ovn-ipsec",
+				FieldSelector: "spec.nodeName=" + node1.Name,
+			})
+			if err != nil {
+				framework.Failf("could not get ipsec pods: %v", err)
+			}
+			if len(ipsecPod.Items) == 0 {
+				framework.Failf("no ovn-ipsec pods found on node %s", node1.Name)
+			}
+
+			_, err = e2ekubectl.RunKubectl(ovnKubernetesNamespace, "exec", ipsecPod.Items[0].Name, "--container", ipsecContainer, "--",
+				"bash", "-c", "sudo pkill pluto")
+			framework.ExpectNoError(err, "killing pluto process failed")
+			err = f.ClientSet.CoreV1().Pods(ovnKubernetesNamespace).Delete(context.TODO(), ipsecPod.Items[0].Name, metav1.DeleteOptions{})
+			if err != nil {
+				framework.Failf("failed to delete pod %s: %v", ipsecPod.Items[0].Name, err)
+			}
+			ginkgo.By(fmt.Sprintf("Wait the recreated ipsec pod to be ready on node %s", node1.Name))
+			gomega.Eventually(func() bool {
+				ginkgo.By(fmt.Sprintf("Get the new ipsec pod on node %s", node1.Name))
+				ipsecPod, err := f.ClientSet.CoreV1().Pods(ovnKubernetesNamespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: "app=ovn-ipsec",
+					FieldSelector: "spec.nodeName=" + node1.Name,
+				})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						return false // Pod not yet recreated, keep polling
+					}
+					framework.Logf("Unexpected error getting ipsec pod: %v", err)
+					return false
+				}
+				if len(ipsecPod.Items) == 0 {
+					return false
+				}
+
+				framework.Logf("Wait pluto process back in ipsec pod %s", ipsecPod.Items[0].Name)
+				output, _ := e2ekubectl.RunKubectl(ovnKubernetesNamespace, "exec", ipsecPod.Items[0].Name, "--container", ipsecContainer, "--",
+					"bash", "-c", "sudo ps -ef | grep pluto | grep -v ovs-monitor-ipsec")
+				return strings.Contains(output, " /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf")
+			}, 90*time.Second, 2*time.Second).Should(gomega.BeTrue())
+
+			ginkgo.By("Verify IPsec metrics reflecting the up tunnel from all ovn pods")
+			//Wait a few seconds for tunnels setting up.
+			gomega.Eventually(func() bool {
+				for _, ovnPod := range ovnPods.Items {
+					ipsecTunnelMetricValue := getMetricValue(f, ovnPod.Name, ovnKubernetesNamespace, ipsecTunnelMetricName)
+					if ipsecTunnelMetricValue != "1" {
+						return false
+					}
+				}
+				return true
+			}, 20*time.Second, 5*time.Second).Should(gomega.BeTrue())
+		})
+
+	})
+
+})
+
+// Get metric value by prom2json tool which is for name:value pair,not for labels matching.
+func getMetricValue(f *framework.Framework, podName, podNamespace, metricName string) string {
+	ginkgo.GinkgoHelper()
+
+	pod, err := f.ClientSet.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		framework.Failf("failed to get pod %s in namespace %s: %v", podName, podNamespace, err)
+	}
+
+	podIP := pod.Status.PodIP
+	if podIP == "" {
+		framework.Failf("no pod IP available for pod %s", podName)
+	}
+
+	metricURL := fmt.Sprintf("http://%s/metrics", net.JoinHostPort(podIP, "9410"))
+
+	// Run prom2json directly from the host where tests are running
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "prom2json", metricURL)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			framework.Failf("prom2json timed out for %s", metricURL)
+		}
+		framework.Failf("prom2json failed: %v, output: %s, pod: %s/%s", err, string(output), podNamespace, podName)
+	}
+
+	// Parse prom2json output to extract the specific metric value
+	type promMetric struct {
+		Name    string `json:"name"`
+		Metrics []struct {
+			Value string `json:"value"`
+		} `json:"metrics"`
+	}
+
+	var metrics []promMetric
+	if err := json.Unmarshal(output, &metrics); err != nil {
+		framework.Failf("failed to parse prom2json output: %v", err)
+	}
+
+	// Find the metric by name and extract its value
+	for _, m := range metrics {
+		if m.Name == metricName {
+			if len(m.Metrics) == 0 {
+				framework.Failf("no metric value found for %s from pod %s/%s", metricName, podNamespace, podName)
+			}
+			metric := m.Metrics[0].Value
+			framework.Logf("The value of %s is %s from pod %s/%s", metricName, metric, podNamespace, podName)
+			return metric
+		}
+	}
+
+	framework.Failf("metric %s not found in prom2json output from pod %s/%s", metricName, podNamespace, podName)
+	return ""
+}

--- a/test/e2e/pod.go
+++ b/test/e2e/pod.go
@@ -367,7 +367,15 @@ var _ = ginkgo.Describe("Pod to pod TCP with low MTU", func() {
 						cmd)
 					framework.ExpectNoError(err, "Checking ip route cache output failed")
 					framework.Logf(" ip route output in client pod: %s", stdout)
-					gomega.Expect(stdout).To(gomega.MatchRegexp("mtu 1342"))
+
+					// MTU calculation: node MTU (1400) - Geneve overhead (58 bytes) - IPsec ESP overhead (34 bytes if enabled)
+					// Without IPsec: 1400 - 58 = 1342
+					// With IPsec: 1400 - 58 - 34 = 1308
+					expectedMTU := 1342
+					if isIPsecEnabled() {
+						expectedMTU = 1308
+					}
+					gomega.Expect(stdout).To(gomega.MatchRegexp(fmt.Sprintf("mtu %d", expectedMTU)))
 				}
 			})
 		})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1455,6 +1455,11 @@ func isPreConfiguredUdnAddressesEnabled() bool {
 	return val == "true"
 }
 
+func isIPsecEnabled() bool {
+	val, present := os.LookupEnv("ENABLE_IPSEC")
+	return present && val == "true"
+}
+
 func getNodeContainerName() string {
 	return "ovnkube-controller"
 }


### PR DESCRIPTION
This PR adds the `ovnkube_controller_ipsec_tunnel_ike_child_sa_state` metric to reflect the IKE Child SA establishment state for all OVN-managed IPsec tunnels.

The metric is set to `1` when all configured tunnels have established IKE Child SAs; otherwise, it is set to `0`. The implementation listens for xfrm netlink events related to xfrm state and policy changes.

To determine the tunnel state, `ovnkube-controller` needs access to the Libreswan pluto daemon so it can execute the `ipsec showstates` command. To enable this, the commit updates the `ovn-ipsec` pod to run with `hostPID` enabled and mounts the host `/var/run/pluto` directory to share the pluto PID file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--enable-ipsec` flag to control IPsec encryption for managed pod-to-pod traffic.
  * Added IPsec tunnel discovery and new Prometheus metrics reporting IKE Child SA state (including Geneve in/out tunnel readiness).
* **Bug Fixes**
  * Improved node metrics initialization to capture and handle registration errors.
* **Tests**
  * Added/expanded unit tests for IPsec metrics parsing and monitoring.
  * Added end-to-end coverage that validates metric transitions when an IPsec tunnel is disrupted.
* **Chores**
  * Updated Helm charts and CI/E2E workflow shards to enable IPsec mounts/runtime and run IPsec-specific lanes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->