### PR TITLE
Add CLI flags for configuring TLS to ovnkube-identity

### DIFF
--- a/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
+++ b/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
@@ -34,6 +34,7 @@ import (
 	identitywebhook "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/cmd/ovnkube-identity/webhook"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovnwebhook"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/tls"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
@@ -308,6 +309,11 @@ func main() {
 }
 
 func runWebhook(ctx context.Context, restCfg *rest.Config) error {
+	applyTLSOptions, err := tls.NewApplyConfigOptions(cliCfg.minTLSVersion, cliCfg.tlsCipherSuites.Value())
+	if err != nil {
+		return err
+	}
+
 	return identitywebhook.Run(ctx, restCfg, identitywebhook.Config{
 		EnableHybridOverlay:     cliCfg.enableHybridOverlay,
 		ExtraAllowedUsers:       cliCfg.extraAllowedUsers.Value(),
@@ -316,6 +322,7 @@ func runWebhook(ctx context.Context, restCfg *rest.Config) error {
 		CertDir:                 cliCfg.certDir,
 		Host:                    cliCfg.host,
 		Port:                    cliCfg.port,
+		ApplyTLSOptions:         applyTLSOptions,
 	})
 }
 

--- a/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
+++ b/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go
@@ -56,6 +56,8 @@ type config struct {
 	csrAcceptanceConditions    []csrapprover.CSRAcceptanceCondition
 	podAdmissionConditionFile  string
 	podAdmissionConditions     []ovnwebhook.PodAdmissionConditionOption
+	minTLSVersion              string
+	tlsCipherSuites            cli.StringSlice
 }
 
 var cliCfg config
@@ -260,6 +262,16 @@ func main() {
 			Name:        "pod-admission-conditions",
 			Usage:       "Configure additional pod validate admission conditions",
 			Destination: &cliCfg.podAdmissionConditionFile,
+		},
+		&cli.StringFlag{
+			Name:        "tls-min-version",
+			Usage:       "Minimum TLS version supported by the webhook server",
+			Destination: &cliCfg.minTLSVersion,
+		},
+		&cli.StringSliceFlag{
+			Name:        "tls-cipher-suites",
+			Usage:       "Comma-separated list of cipher suites for the webhook server",
+			Destination: &cliCfg.tlsCipherSuites,
 		},
 	}
 	ctx := context.Background()

--- a/go-controller/cmd/ovnkube-identity/webhook/webhook.go
+++ b/go-controller/cmd/ovnkube-identity/webhook/webhook.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/csrapprover"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovnwebhook"
+	ovntls "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/tls"
 )
 
 var logger = klog.NewKlogr()
@@ -42,6 +43,7 @@ type Config struct {
 	CertDir                 string
 	Host                    string
 	Port                    int
+	ApplyTLSOptions         ovntls.ApplyConfigOptions
 
 	// This field is a constructor used for creating clients and is intended for testing.
 	NewKubernetesClient func(*rest.Config) (kubernetes.Interface, error)
@@ -111,18 +113,19 @@ func Run(ctx context.Context, restCfg *rest.Config, config Config) error {
 	}
 	webhookMux.Handle("/pod", podHandler)
 
-	cfg := &tls.Config{
-		NextProtos: []string{"h2"},
-		MinVersion: tls.VersionTLS12,
-	}
-
 	certPath := filepath.Join(config.CertDir, "tls.crt")
 	keyPath := filepath.Join(config.CertDir, "tls.key")
 	certWatcher, err := certwatcher.New(certPath, keyPath)
 	if err != nil {
 		return fmt.Errorf("failed to setup certwatcher: %v", err)
 	}
-	cfg.GetCertificate = certWatcher.GetCertificate
+
+	cfg := &tls.Config{
+		NextProtos:     []string{"h2"},
+		GetCertificate: certWatcher.GetCertificate,
+	}
+
+	config.ApplyTLSOptions(cfg)
 
 	go func() {
 		if err := certWatcher.Start(ctx); err != nil {

--- a/go-controller/cmd/ovnkube-identity/webhook/webhook_test.go
+++ b/go-controller/cmd/ovnkube-identity/webhook/webhook_test.go
@@ -138,6 +138,60 @@ var _ = Describe("Run", func() {
 				"Server should be using new certificate after rotation")
 		}).Within(3 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
 	})
+
+	Context("with applied TLS config options", func() {
+		BeforeEach(func() {
+			config.ApplyTLSOptions = func(tlsConfig *tls.Config) {
+				tlsConfig.MinVersion = tls.VersionTLS12
+				tlsConfig.CipherSuites = []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				}
+			}
+		})
+
+		Specify("the HTTP server should offer the applied TLS options", func() {
+			Eventually(func(g Gomega) {
+				conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", config.Host, config.Port), &tls.Config{
+					InsecureSkipVerify: true,
+					MaxVersion:         tls.VersionTLS12, // Force TLS 1.2 to test minimum version
+					NextProtos:         []string{"h2"},   // Request HTTP/2 via ALPN
+				})
+
+				g.Expect(err).NotTo(HaveOccurred())
+				defer conn.Close()
+
+				err = conn.Handshake()
+				g.Expect(err).NotTo(HaveOccurred())
+
+				state := conn.ConnectionState()
+
+				// For Intermediate profile with MaxVersion TLS 1.2, should negotiate exactly TLS 1.2
+				g.Expect(int(state.Version)).To(Equal(tls.VersionTLS12))
+				g.Expect(state.CipherSuite).To(Equal(tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256))
+				g.Expect(state.NegotiatedProtocol).To(Equal("h2"))
+			}).Within(5 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+		})
+
+		Specify("the HTTP server should reject TLS versions below the minimum", func() {
+			Eventually(func(g Gomega) {
+				// Attempt to connect with TLS 1.1 (below the server's minimum of TLS 1.2)
+				conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", config.Host, config.Port), &tls.Config{
+					InsecureSkipVerify: true,
+					MinVersion:         tls.VersionTLS10,
+					MaxVersion:         tls.VersionTLS11, // Restrict client to TLS 1.1 or below
+				})
+
+				if err == nil {
+					err = conn.Handshake()
+					conn.Close()
+				}
+
+				// The connection or handshake should fail because the server requires TLS 1.2+
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("protocol version"))
+			}).Within(5 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+		})
+	})
 })
 
 func newWebhookConfig(port int) webhook.Config {
@@ -160,9 +214,10 @@ func newWebhookConfig(port int) webhook.Config {
 	Expect(os.WriteFile(keyPath, keyPEM, 0600)).To(Succeed())
 
 	return webhook.Config{
-		CertDir: tempDir,
-		Host:    "localhost",
-		Port:    port,
+		CertDir:         tempDir,
+		Host:            "localhost",
+		Port:            port,
+		ApplyTLSOptions: func(*tls.Config) {},
 		NewKubernetesClient: func(_ *rest.Config) (kubernetes.Interface, error) {
 			return k8sfake.NewClientset(), nil
 		},

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -61,6 +61,7 @@ require (
 	k8s.io/apimachinery v0.35.1
 	k8s.io/apiserver v0.35.1
 	k8s.io/client-go v0.35.1
+	k8s.io/component-base v0.35.1
 	k8s.io/component-helpers v0.35.1
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubelet v0.35.1
@@ -152,7 +153,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
-	k8s.io/component-base v0.35.1 // indirect
 	k8s.io/controller-manager v0.35.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260304202019-5b3e3fdb0acf // indirect
 	kubevirt.io/containerized-data-importer-api v1.55.0 // indirect

--- a/go-controller/pkg/tls/tls.go
+++ b/go-controller/pkg/tls/tls.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tls
+
+import (
+	"crypto/tls"
+
+	cliflag "k8s.io/component-base/cli/flag"
+)
+
+type ApplyConfigOptions func(*tls.Config)
+
+func NewApplyConfigOptions(minVersion string, cipherSuites []string) (ApplyConfigOptions, error) {
+	minVersionID, err := cliflag.TLSVersion(minVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	cipherSuiteIDs, err := cliflag.TLSCipherSuites(cipherSuites)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(cfg *tls.Config) {
+		cfg.CipherSuites = cipherSuiteIDs
+		cfg.MinVersion = minVersionID
+	}, nil
+}

--- a/go-controller/pkg/tls/tls_suite_test.go
+++ b/go-controller/pkg/tls/tls_suite_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tls_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTLS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Suite")
+}

--- a/go-controller/pkg/tls/tls_test.go
+++ b/go-controller/pkg/tls/tls_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tls_test
+
+import (
+	"crypto/tls"
+
+	ovntls "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewApplyConfigOptions", func() {
+	assertApplySuccess := func(minVersion string, ciperSuites []string) *tls.Config {
+		applyOpts, err := ovntls.NewApplyConfigOptions(minVersion, ciperSuites)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(applyOpts).ToNot(BeNil())
+
+		cfg := &tls.Config{}
+		applyOpts(cfg)
+
+		return cfg
+	}
+
+	Context("with valid inputs", func() {
+		It("should correctly apply the settings", func() {
+			cfg := assertApplySuccess("VersionTLS12", []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+			})
+			Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+			Expect(cfg.CipherSuites).To(ConsistOf(tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384))
+		})
+	})
+
+	Context("with empty cipher suites list", func() {
+		It("should apply an empty cipher suites list", func() {
+			cfg := assertApplySuccess("VersionTLS13", []string{})
+			Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+			Expect(cfg.CipherSuites).To(BeEmpty())
+		})
+	})
+
+	Context("with nil cipher suites list", func() {
+		It("should apply an empty cipher suites list", func() {
+			cfg := assertApplySuccess("VersionTLS11", nil)
+			Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS11)))
+			Expect(cfg.CipherSuites).To(BeEmpty())
+		})
+	})
+
+	Context("with empty min version", func() {
+		It("should apply the default min version", func() {
+			cfg := assertApplySuccess("", []string{})
+			Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		})
+	})
+
+	DescribeTableSubtree("with invalid",
+		func(minVersion string, ciperSuites []string) {
+			It("should return an error", func() {
+				applyOpts, err := ovntls.NewApplyConfigOptions(minVersion, ciperSuites)
+				Expect(err).To(HaveOccurred())
+				Expect(applyOpts).To(BeNil())
+			})
+		},
+		Entry("TLS version string", "InvalidTLSVersion", []string{}),
+		Entry("cipher suite name", "VersionTLS12", []string{
+			"TLS_AES_128_GCM_SHA256",
+			"InvalidCipherSuite",
+			"TLS_AES_256_GCM_SHA384"}),
+	)
+})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

Added optional CLI flags `--tls-min-version` and `--tls-cipher-suites` that will be used to configure TLS parameters for the webhook.

Also added a `tls.ApplyConfigOptionsFor` function that will be used to parse the CLI flags and apply to a `tls.Config`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI adds --tls-min-version and --tls-cipher-suites; webhook TLS now honors those settings.

* **Tests**
  * Added unit and suite tests covering TLS option parsing, validation, application, and handshake behavior.

* **Chores**
  * Introduced TLS utility helpers to parse/apply TLS options and updated module declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->