### PR TITLE
Use node name as zone name; drop kubectl lookup in ovnkube.sh

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -832,60 +832,16 @@ function memory_trim_on_compaction_supported {
   fi
 }
 
+# zone name equals node name in the IC mode
 function get_node_zone() {
-  createKubeconfig=false
-  # DPU might have K8S_TOKEN/K8S_TOKENFILE and K8S_CACERT/K8S_CACERT_DATA provided to access DPU host (K8S_NODE here)
-  # which is in a different cluster. So we might need to create kubeconfig accordingly.
-  if [[ ${ovnkube_node_mode} == "dpu" ]]; then
-    if [[ -n ${K8S_TOKEN} ]] || [[ -n ${K8S_TOKEN_FILE} ]] || [[ -n ${K8S_CACERT_DATA} ]] || [[ -n ${K8S_CACERT} ]]; then
-      createKubeconfig=true
-    fi
+  if [[ -z "${K8S_NODE}" ]]; then
+    echo "Missing k8s node name. Exiting..."
+    exit 1
   fi
-
-  if [[ ${createKubeconfig} == "false" ]]; then
-    zone=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${k8s_cacert} \
-       get node ${K8S_NODE} -o=jsonpath={'.metadata.labels.k8s\.ovn\.org/zone-name'})
-  else
-    local dpuhost_k8s_apiserver=${K8S_APISERVER}
-    local dpuhost_k8s_token=${K8S_TOKEN}
-    local dpuhost_ca_config=""
-    if [[ -n ${K8S_TOKEN_FILE} ]]; then
-      dpuhost_k8s_token=$(cat ${K8S_TOKEN_FILE})
-    fi
-    if [[ -n ${K8S_CACERT_DATA} ]]; then
-      dpuhost_ca_config="certificate-authority-data: ${K8S_CACERT_DATA}"
-    elif [[ -n ${K8S_CACERT} ]]; then
-      dpuhost_ca_config="certificate-authority: ${K8S_CACERT}"
-    fi
-    zone=$(kubectl --kubeconfig=<(cat <<EOF
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: ${dpuhost_k8s_apiserver}
-    ${dpuhost_ca_config}
-  name: dpuhost-cluster
-contexts:
-- context:
-    cluster: dpuhost-cluster
-    user: dpu-user
-  name: dpuhost-context
-current-context: dpuhost-context
-users:
-- name: dpu-user
-  user:
-    token: ${dpuhost_k8s_token}
-EOF
-) get node ${K8S_NODE} -o=jsonpath={'.metadata.labels.k8s\.ovn\.org/zone-name'})
-
-  fi
-  if [ -z "$zone" ]; then
-    zone="${K8S_NODE}"
-  fi
-  echo "$zone"
+  echo "${K8S_NODE}"
 }
 
-# v1.0.0 - run nb_ovsdb in a separate container listening only on
+# v1.3.0 - run nb_ovsdb in a separate container listening only on
 # unix sockets
 local-nb-ovsdb() {
   trap 'ovsdb_cleanup nb' TERM
@@ -924,7 +880,7 @@ local-nb-ovsdb() {
   echo "=============== run nb-ovsdb (unix sockets only) ========== terminated"
 }
 
-# v1.0.0 - run sb_ovsdb in a separate container listening only on
+# v1.3.0 - run sb_ovsdb in a separate container listening only on
 # unix sockets
 local-sb-ovsdb() {
   trap 'ovsdb_cleanup sb' TERM


### PR DESCRIPTION
Under interconnect, each node is its own zone and the zone name matches the node name. Otherwise, ovnkube-controller-with-node would fail with "timed out waiting for the node zone to match the OVN Southbound db zone" error.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
