### PR TITLE
UT: fix EVPN UDN expected node IP address set

### DIFF
--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go
@@ -126,7 +126,8 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 2 network", func() {
 				var expectedNBData []libovsdbtest.TestData
 				if netInfo.hasEVPN {
 					// emulate address sets handled by other controllers, needed for EVPN SNATs
-					nodeIPsAS4, _ := buildEgressIPNodeAddressSets(nil)
+					nodeIPsAS4, _, err := buildClusterNodeIPsAddressSetsForNodes(nodes)
+					Expect(err).NotTo(HaveOccurred())
 					udnEnnabledSvcAS4, _ := buildUDNEnabledSvcAddressSets(nil)
 					initialDB.NBData = append(
 						initialDB.NBData,
@@ -1245,7 +1246,7 @@ func expectedLayer2EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 	masqSNAT.Match = getMasqueradeManagementIPSNATMatch(util.IPAddrToHWAddr(managementPortIP(nodeSubnet)).String())
 	masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("trtos-%s", netInfo.GetNetworkScopedName(ovntypes.OVNLayer2Switch)))
 	if netInfo.Transport() == ovntypes.NetworkTransportEVPN {
-		nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkControllerName))
+		nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getClusterNodeIPsAddrSetDbIDsForTest())
 		udnEnabledSvcV4ASHashName, _ := addressset.GetHashNamesForAS(udnenabledsvc.GetAddressSetDBIDs())
 		masqSNAT.Match += fmt.Sprintf(" && (ip4.dst == $%s || ip4.dst == $%s)", nodeIPV4ASHashName, udnEnabledSvcV4ASHashName)
 	}

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -151,7 +151,8 @@ var _ = Describe("OVN Multi-Homed pod operations for layer 3 network", func() {
 				var expectedNBData []libovsdbtest.TestData
 				if netInfo.hasEVPN {
 					// emulate address sets handled by other controllers, needed for EVPN SNATs
-					nodeIPsAS4, _ := buildEgressIPNodeAddressSets(nil)
+					nodeIPsAS4, _, err := buildClusterNodeIPsAddressSetsForNodes(nodes)
+					Expect(err).NotTo(HaveOccurred())
 					udnEnabledSvcAS4, _ := buildUDNEnabledSvcAddressSets(nil)
 					initialDB.NBData = append(
 						initialDB.NBData,
@@ -1403,6 +1404,20 @@ func (sni *userDefinedNetInfo) String() string {
 	return fmt.Sprintf("%q: %q", sni.netName, sni.hostsubnets)
 }
 
+func buildClusterNodeIPsAddressSetsForNodes(nodes []corev1.Node) (*nbdb.AddressSet, *nbdb.AddressSet, error) {
+	nodePtrs := make([]*corev1.Node, 0, len(nodes))
+	for i := range nodes {
+		nodePtrs = append(nodePtrs, &nodes[i])
+	}
+	v4NodeAddrs, v6NodeAddrs, err := util.GetNodeAddresses(config.IPv4Mode, config.IPv6Mode, nodePtrs...)
+	if err != nil {
+		return nil, nil, err
+	}
+	nodeAddrs := append(v4NodeAddrs, v6NodeAddrs...)
+	nodeIPsAS4, nodeIPsAS6 := buildEgressIPNodeAddressSets(util.StringSlice(nodeAddrs))
+	return nodeIPsAS4, nodeIPsAS6, nil
+}
+
 func newNodeWithUserDefinedNetworks(nodeName string, nodeIPv4CIDR string, netInfos ...userDefinedNetInfo) (*corev1.Node, error) {
 	var nodeSubnetInfo []string
 	for _, info := range netInfos {
@@ -1543,7 +1558,7 @@ func expectedGWRouterPlusNATAndStaticRoutes(
 	}
 	var udnSubnetMasqMatch string
 	if netInfo.Transport() == types.NetworkTransportEVPN {
-		nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+		nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getClusterNodeIPsAddrSetDbIDsForTest())
 		udnSubnetMasqMatch = fmt.Sprintf("ip4.dst == $%s", nodeIPV4ASHashName)
 	}
 	expectedEntities = append(expectedEntities, newNATEntry(nat1, dummyMasqueradeIP().IP.String(), gwRouterJoinIPAddress().IP.String(), standardNonDefaultNetworkExtIDs(netInfo), ""))
@@ -1673,7 +1688,7 @@ func expectedLayer3EgressEntities(netInfo util.NetInfo, gwConfig util.L3GatewayC
 		masqSNAT.LogicalPort = ptr.To(fmt.Sprintf("rtos-%s_%s", netInfo.GetNetworkName(), nodeName))
 		masqSNAT.Match = getMasqueradeManagementIPSNATMatch(util.IPAddrToHWAddr(managementPortIP(nodeSubnet)).String())
 		if hasEVPN {
-			nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getEgressIPAddrSetDbIDs(NodeIPAddrSetName, types.DefaultNetworkName, types.DefaultNetworkControllerName))
+			nodeIPV4ASHashName, _ := addressset.GetHashNamesForAS(getClusterNodeIPsAddrSetDbIDsForTest())
 			udnEnabledSvcV4ASHashName, _ := addressset.GetHashNamesForAS(udnenabledsvc.GetAddressSetDBIDs())
 			masqSNAT.Match += fmt.Sprintf(" && (ip4.dst == $%s || ip4.dst == $%s)", nodeIPV4ASHashName, udnEnabledSvcV4ASHashName)
 		}


### PR DESCRIPTION
Update the layer2 and layer3 EVPN CUDN test fixtures to match the shared ClusterNodeIPs address set now used by route advertisement SNATs.

The expected node-ips address set is now populated from the fake test nodes, and EVPN SNAT matches derive the address-set hash from the shared ClusterNodeIPs DB IDs instead of the old EgressIP DB IDs.

Fixes: #6476



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated EVPN-related test validation to use cluster node IP address sets for more accurate test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ovn-kubernetes/ovn-kubernetes/pull/6477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->