### PR TITLE
Decreasing log level for three obj_retry messages

### DIFF
--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -359,7 +359,7 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 			initObj = entry.oldObj
 		}
 
-		klog.Infof("%s: retry object setup: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
+		klog.V(5).Infof("%s: retry object setup: %s %s (attempt %d, backoff %s)", r.name, r.ResourceHandler.ObjType, objKey, entry.failedAttempts, entry.backoff)
 
 		if entry.newObj != nil {
 			// get the latest version of the object from the informer;
@@ -423,7 +423,7 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 
 			// create new object if needed
 			if entry.newObj != nil {
-				klog.Infof("%s: adding new object: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
+				klog.V(5).Infof("%s: adding new object: %s %s", r.name, r.ResourceHandler.ObjType, objKey)
 				if !r.ResourceHandler.IsResourceScheduled(entry.newObj) {
 					// unscheduled resources (pods) will be retried again later we do not track these as failures, and should not retry.
 					// we should avoid queuing objects to the retry handler that are not scheduled. Thus treat this as an error.
@@ -795,7 +795,7 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					// See: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/3318#issuecomment-1349804450
 					if _, loaded := r.terminatedObjects.LoadAndDelete(key); loaded {
 						// object was already terminated
-						klog.Infof("%s: ignoring delete event for resource in terminal state %s %s",
+						klog.V(5).Infof("%s: ignoring delete event for resource in terminal state %s %s",
 							r.name, r.ResourceHandler.ObjType, key)
 						return
 					}


### PR DESCRIPTION

## 📑 Description
These three lines make up 55% of all log content.

Fixes #

## Additional Information for reviewers

Increasing log level for three noisy obj_retry logging statements

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
Ran end-to-end tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced standard log verbosity for retry and deletion handling by moving several info-level messages to verbose mode to declutter primary logs.
  * Verbose logs now include failed-attempt counts and current backoff durations for improved diagnostics when verbose logging is enabled.
  * No public API or exported-entity changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->