### PR TITLE
DPU-host: skip LoadDeviceInfoFromDP for primary UDN

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -419,12 +420,17 @@ func (s *Server) getPrimaryUDNPodRequest(originalPodRequest *PodRequest) (*PodRe
 				pod.Namespace, pod.Name, resourceName, err)
 		}
 		primaryPodRequest.CNIConf.DeviceID = deviceID
+		// Load device info if the device plugin wrote it. The file may not
+		// exist (e.g. when the device plugin has no NAD discovery configured),
+		// in which case GetNetdevNameFromDeviceId falls back to sysfs.
 		deviceInfo, err := nadutils.LoadDeviceInfoFromDP(resourceName, deviceID)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return nil, fmt.Errorf("failed to load primary UDN's device info for pod %s/%s resource %s deviceID %s: %w",
 				pod.Namespace, pod.Name, resourceName, deviceID, err)
 		}
-		primaryPodRequest.deviceInfo = *deviceInfo
+		if deviceInfo != nil {
+			primaryPodRequest.deviceInfo = *deviceInfo
+		}
 	}
 	if err = updateDeviceInfo(primaryPodRequest); err != nil {
 		return nil, err


### PR DESCRIPTION
In DPU-host mode the SR-IOV device plugin does not generate devinfo files under /var/run/k8s.cni.cncf.io/devinfo/dp/. Skip the LoadDeviceInfoFromDP call for primary UDN interfaces when running in DPU-host mode, since the netdev name can still be resolved from sysfs via GetNetdevNameFromDeviceId.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device-info handling for DPU-host (SR-IOV) setups: missing device-plugin info files are now treated as non-fatal, allowing fallback resolution and preventing request failures; device information is only applied when actually available, improving robustness across modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->