### PR TITLE
Customizes workqueue prometheus metrics

### DIFF
--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -391,6 +391,9 @@ func (cm *ControllerManager) initDefaultNetworkController(observManager *observa
 func (cm *ControllerManager) Start(ctx context.Context) error {
 	klog.Info("Starting the ovnkube controller")
 
+	// Configure metrics early so workqueue provider is set before any workqueues are created
+	cm.configureMetrics(cm.stopChan)
+
 	// Make sure that the ovnkube-controller zone matches with the Northbound db zone.
 	// Wait for 300s before giving up
 	maxTimeout := 300 * time.Second
@@ -453,8 +456,6 @@ func (cm *ControllerManager) Start(ctx context.Context) error {
 	if err = cm.setTopologyType(); err != nil {
 		return fmt.Errorf("failed to set layer2 topology type: %w", err)
 	}
-
-	cm.configureMetrics(cm.stopChan)
 
 	cm.configureSvcTemplateSupport()
 

--- a/go-controller/pkg/metrics/node.go
+++ b/go-controller/pkg/metrics/node.go
@@ -76,7 +76,6 @@ func RegisterNodeMetrics(stopChan <-chan struct{}) {
 			},
 			func() float64 { return 1 },
 		))
-		registerWorkqueueMetrics(types.MetricOvnkubeNamespace, types.MetricOvnkubeSubsystemNode)
 		if err := prometheus.Register(MetricResourceRetryFailuresCount); err != nil {
 			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
 				panic(err)

--- a/go-controller/pkg/metrics/ovnkube_controller.go
+++ b/go-controller/pkg/metrics/ovnkube_controller.go
@@ -374,7 +374,9 @@ func RegisterOVNKubeControllerPerformance(nbClient libovsdbclient.Client) {
 	prometheus.MustRegister(MetricRequeueServiceCount)
 	prometheus.MustRegister(MetricSyncServiceCount)
 	prometheus.MustRegister(MetricSyncServiceLatency)
-	registerWorkqueueMetrics(types.MetricOvnkubeNamespace, types.MetricOvnkubeSubsystemController)
+	if config.Metrics.EnableScaleMetrics {
+		registerWorkqueueMetrics(types.MetricOvnkubeNamespace, types.MetricOvnkubeSubsystemController)
+	}
 	prometheus.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace: types.MetricOvnNamespace,

--- a/go-controller/pkg/metrics/workqueue.go
+++ b/go-controller/pkg/metrics/workqueue.go
@@ -54,13 +54,13 @@ var (
 	latency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    QueueLatencyKey,
 		Help:    "How long in seconds an item stays in workqueue before being requested.",
-		Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
+		Buckets: prometheus.ExponentialBuckets(10e-3, 10, 6),
 	}, []string{"name"})
 
 	workDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    WorkDurationKey,
 		Help:    "How long in seconds processing an item from workqueue takes.",
-		Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
+		Buckets: prometheus.ExponentialBuckets(10e-3, 10, 6),
 	}, []string{"name"})
 
 	unfinished = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -88,10 +88,6 @@ var (
 )
 
 type prometheusMetricsProvider struct {
-}
-
-func init() {
-	workqueue.SetProvider(prometheusMetricsProvider{})
 }
 
 func (prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
@@ -123,6 +119,8 @@ func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.Counter
 }
 
 func registerWorkqueueMetrics(namespace, subsystem string) {
+	workqueue.SetProvider(prometheusMetricsProvider{})
+
 	registry := prometheus.WrapRegistererWithPrefix(
 		fmt.Sprintf("%s_%s_workqueue_", namespace, subsystem),
 		prometheus.DefaultRegisterer,


### PR DESCRIPTION
- removes register workqueue metrics from kube node, since it always runs with controller, and controller already registers the workqueue metrics by default.

- reduces the amount of buckets in workqueue histograms, as the previous settings is unrealistic and only generates uneeded metric series.

- sets workqueue metrics to be registered only when EnableScaleMetrics flag is set given that they are not relevant in all setups. It avoids registering Prometheus collectors when metrics are disabled; It's simpler and follows the same pattern used elsewhere in the codebase (see [ovnkube_controller.go:397-407]); Workqueue metrics are typically all-or-nothing — you either want to monitor workqueue behavior or you don't.


Critical findings based on perf/scale tests:
1.    ovnkube_node_ and ovnkube_controller_` are prometheus metrics prefixes that report duplicate metrics related to workqueue, because both controllers register the workqueue metrics (i.e., by calling registerWorkqueueMetrics`, this was seen in a simple kind cluster with ovn-k8s. Previously node and controller were not executed always together. 

2.    The prometheus histogram bucket configuration of the metrics are misconfigured: ExponentialBuckets(10e-9, 10, 10) = [10ns, 100ns, 1μs, 10μs, 100μs, 1ms, 10ms, 100ms, 1s, 10s]. These values are unrealistic for a k8s workqueue. This leads to series explosion. 

3.    The number of workqueues per L2 or L3 UDN is 5. There are shared workqueues for the l2/l3 controllers too. But in general, with 5 workqueues per UDN. And in a single workqueue there are 29 metric series (2*12 (each histogram) + 3 gauges +2 counters). In total, 145 metric series per UDN. The workqueues are instantiated in network_qos_controller.go when the feature EnableNetworkQoS is set. Interesting, among all the queues, there are no distinction on per-UDN basis, the names of the queues are static, so their metrics are reported in an aggregated manner (probably overlapping).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Chores / Monitoring**
  * Register controller workqueue performance metrics only when scale metrics are enabled.
  * Updated Prometheus workqueue duration histograms for finer-grained timing.
  * Adjusted workqueue metrics activation so the provider registers when workqueue metrics are explicitly set.
  * Improved node metrics visibility by adding node resource retry failure counting, while retaining node logfile size metrics updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->