### PR TITLE
area-maintainers: introduce virtualization area with merge github action

### DIFF
--- a/.github/scripts/area-merge.js
+++ b/.github/scripts/area-merge.js
@@ -1,0 +1,338 @@
+// Area Maintainer Merge Bot
+//
+// Parses CODEOWNERS to determine area maintainer authorization, then verifies
+// file scope and CI status before merging PRs via /area-maintainer-approved.
+//
+// Called from .github/workflows/area-merge.yml via actions/github-script.
+
+const fs = require('fs');
+
+module.exports = async ({ github, context, core }) => {
+  // --- Determine which PRs to process and who triggered ---
+  let pullNumbers = [];
+  let commenter = null;
+
+  if (context.eventName === 'issue_comment') {
+    pullNumbers.push(context.payload.issue.number);
+    commenter = context.payload.comment.user.login.toLowerCase();
+  } else if (context.eventName === 'check_suite') {
+    const suite = context.payload.check_suite;
+    for (const pr of (suite.pull_requests || [])) {
+      pullNumbers.push(pr.number);
+    }
+  }
+
+  if (pullNumbers.length === 0) {
+    core.info('No pull requests to process');
+    return;
+  }
+
+  // --- Parse CODEOWNERS ---
+  // Extracts two things:
+  //   1. Pattern rules: which users are listed on each file pattern line (for review assignment)
+  //   2. Area maintainers: parsed from section header comments matching
+  //      "Area Maintainer: @user1 @user2" — only these users can trigger merges
+  const codeownersContent = fs.readFileSync('CODEOWNERS', 'utf8');
+  const rules = [];
+  let currentAreaMaintainers = [];
+
+  for (const line of codeownersContent.split('\n')) {
+    const trimmed = line.trim();
+
+    // Parse area maintainer(s) from section header comments
+    // Format: # ... (Area Maintainer: @user1 @user2)
+    const maintainerMatch = trimmed.match(/Area Maintainer[s]?:\s*((?:@[\w-]+[\s,]*)+)/i);
+    if (maintainerMatch) {
+      currentAreaMaintainers = maintainerMatch[1]
+        .match(/@[\w-]+/g)
+        .map(u => u.replace('@', '').toLowerCase());
+      continue;
+    }
+
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 2) continue;
+    const pattern = parts[0];
+    if (pattern === '*') continue;
+    const owners = parts.slice(1).map(o => o.replace('@', '').toLowerCase());
+    rules.push({ pattern, owners, areaMaintainers: [...currentAreaMaintainers] });
+  }
+
+  function matchPattern(pattern, filePath) {
+    const normalizedFile = '/' + filePath;
+    if (pattern.endsWith('/')) {
+      return normalizedFile.startsWith(pattern) ||
+             normalizedFile === pattern.slice(0, -1);
+    }
+    return normalizedFile === pattern;
+  }
+
+  // Last matching rule wins, mirroring CODEOWNERS precedence.
+  function findAreaMaintainers(filePath) {
+    let maintainers = null;
+    for (const rule of rules) {
+      if (matchPattern(rule.pattern, filePath)) {
+        maintainers = rule.areaMaintainers;
+      }
+    }
+    return maintainers;
+  }
+
+  async function fetchAllComments(prNumber) {
+    const allComments = [];
+    let page = 1;
+    while (true) {
+      const { data: comments } = await github.rest.issues.listComments({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        per_page: 100,
+        page: page,
+      });
+      if (comments.length === 0) break;
+      allComments.push(...comments);
+      if (comments.length < 100) break;
+      page++;
+    }
+    return allComments;
+  }
+
+  // --- Process each PR ---
+  for (const prNumber of pullNumbers) {
+    core.info(`Processing PR #${prNumber}`);
+
+    const { data: pr } = await github.rest.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: prNumber,
+    });
+
+    if (pr.state !== 'open') {
+      core.info(`PR #${prNumber} is ${pr.state}, skipping`);
+      continue;
+    }
+
+    // Prevent PR authors from merging their own PRs
+    const prAuthor = pr.user.login.toLowerCase();
+    if (commenter && commenter === prAuthor) {
+      core.info(`PR #${prNumber} author ${prAuthor} cannot approve their own PR`);
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `@${commenter} you cannot use \`/area-maintainer-approved\` on your own PR. ` +
+          `Another area maintainer or a repo maintainer must approve and merge it.`,
+      });
+      continue;
+    }
+
+    // For check_suite retries, find who previously ran /area-maintainer-approved
+    let requester = commenter;
+    let allComments = null;
+    if (!requester) {
+      allComments = await fetchAllComments(prNumber);
+      const mergeComment = [...allComments]
+        .reverse()
+        .find(c => c.body.includes('/area-maintainer-approved') &&
+                   c.user.login !== 'github-actions[bot]' &&
+                   c.user.login.toLowerCase() !== prAuthor);
+      if (mergeComment) {
+        requester = mergeComment.user.login.toLowerCase();
+      }
+    }
+
+    if (!requester) {
+      core.info(`No /area-maintainer-approved request found for PR #${prNumber}, skipping`);
+      continue;
+    }
+
+    // For check_suite, verify the bot posted a "waiting" comment for the current head SHA.
+    // If new commits were pushed after approval, the SHA won't match and we skip
+    // to prevent merging code the area maintainer never reviewed.
+    if (context.eventName === 'check_suite') {
+      if (!allComments) allComments = await fetchAllComments(prNumber);
+      const waitingMarker = `<!-- area-merge-sha:${pr.head.sha} -->`;
+      const isWaiting = allComments.some(c =>
+        c.user.login === 'github-actions[bot]' &&
+        c.body.includes(waitingMarker)
+      );
+      if (!isWaiting) {
+        core.info(`PR #${prNumber} has no waiting marker for current SHA ${pr.head.sha}, skipping`);
+        continue;
+      }
+    }
+
+    core.info(`/area-maintainer-approved requested by: ${requester}`);
+
+    // Get changed files (paginate for large PRs)
+    const changedFiles = [];
+    let page = 1;
+    while (true) {
+      const { data: files } = await github.rest.pulls.listFiles({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: prNumber,
+        per_page: 100,
+        page: page,
+      });
+      if (files.length === 0) break;
+      changedFiles.push(...files.map(f => f.filename));
+      if (files.length < 100) break;
+      page++;
+    }
+
+    core.info(`Changed files (${changedFiles.length}): ${changedFiles.join(', ')}`);
+
+    // Check authorization: requester must be an area maintainer for ALL changed files
+    const unauthorizedFiles = [];
+    for (const file of changedFiles) {
+      const maintainers = findAreaMaintainers(file);
+      if (!maintainers || !maintainers.includes(requester)) {
+        unauthorizedFiles.push(file);
+      }
+    }
+
+    if (unauthorizedFiles.length > 0) {
+      core.info(`Unauthorized files: ${unauthorizedFiles.join(', ')}`);
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `@${requester} cannot merge this PR via \`/area-maintainer-approved\`.\n\n` +
+          `You are not listed as an Area Maintainer for the following files in \`CODEOWNERS\`:\n` +
+          unauthorizedFiles.map(f => `- \`${f}\``).join('\n') +
+          `\n\nOnly area maintainers (listed in the \`Area Maintainer:\` section header in CODEOWNERS) can trigger merges. ` +
+          `A repo maintainer from \`ovn-kubernetes-committers\` is required to merge this PR.`,
+      });
+      continue;
+    }
+
+    // Check CI status
+    const ref = pr.head.sha;
+
+    const allCheckRuns = [];
+    let checkPage = 1;
+    while (true) {
+      const { data } = await github.rest.checks.listForRef({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: ref,
+        per_page: 100,
+        page: checkPage,
+      });
+      allCheckRuns.push(...data.check_runs);
+      if (allCheckRuns.length >= data.total_count) break;
+      checkPage++;
+    }
+
+    const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: ref,
+    });
+
+    const pendingChecks = [];
+    const failedChecks = [];
+
+    for (const run of allCheckRuns) {
+      if (run.name === 'area-merge') continue;
+      if (run.status !== 'completed') {
+        pendingChecks.push(run.name);
+      } else if (run.conclusion !== 'success' && run.conclusion !== 'neutral' && run.conclusion !== 'skipped') {
+        failedChecks.push(run.name);
+      }
+    }
+
+    // Gate on the aggregate state first — it covers ALL commit statuses
+    // regardless of pagination, so we never miss a failure or pending status.
+    // Then iterate the (possibly partial) statuses array for detailed names.
+    if (combinedStatus.state === 'failure') {
+      for (const status of combinedStatus.statuses) {
+        if (status.state === 'failure' || status.state === 'error') {
+          failedChecks.push(status.context);
+        }
+      }
+      if (failedChecks.length === 0) {
+        failedChecks.push('(commit status failure — details may be on a later page)');
+      }
+    } else if (combinedStatus.state === 'pending') {
+      for (const status of combinedStatus.statuses) {
+        if (status.state === 'pending') {
+          pendingChecks.push(status.context);
+        } else if (status.state === 'failure' || status.state === 'error') {
+          failedChecks.push(status.context);
+        }
+      }
+      if (pendingChecks.length === 0 && failedChecks.length === 0) {
+        pendingChecks.push('(commit status pending — details may be on a later page)');
+      }
+    }
+
+    if (failedChecks.length > 0) {
+      core.info(`Failed checks: ${failedChecks.join(', ')}`);
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `Cannot merge via \`/area-maintainer-approved\`: the following CI checks have failed:\n` +
+          failedChecks.map(c => `- \`${c}\``).join('\n') +
+          `\n\nPlease fix the failures and run \`/area-maintainer-approved\` again.`,
+      });
+      continue;
+    }
+
+    if (pendingChecks.length > 0) {
+      core.info(`Pending checks: ${pendingChecks.join(', ')}`);
+
+      const shaMarker = `<!-- area-merge-sha:${ref} -->`;
+      if (!allComments) allComments = await fetchAllComments(prNumber);
+      const alreadyWaiting = allComments.some(c =>
+        c.user.login === 'github-actions[bot]' &&
+        c.body.includes(shaMarker)
+      );
+      if (!alreadyWaiting) {
+        await github.rest.issues.createComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: prNumber,
+          body: `${shaMarker}\nArea maintainer @${requester} has approved this PR via \`/area-maintainer-approved\`. ` +
+            `Waiting on CI checks to complete — will merge automatically when all checks pass.\n\n` +
+            `Pending checks:\n` +
+            pendingChecks.map(c => `- \`${c}\``).join('\n'),
+        });
+      }
+      continue;
+    }
+
+    // All checks passed, authorized — merge!
+    core.info(`All checks passed. Merging PR #${prNumber}`);
+    try {
+      await github.rest.pulls.merge({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: prNumber,
+        sha: ref,
+        merge_method: 'merge',
+        commit_title: `Merge pull request #${prNumber} (/area-maintainer-approved by @${requester})`,
+      });
+
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `PR merged by area maintainer @${requester} via \`/area-maintainer-approved\`.`,
+      });
+
+      core.info(`Successfully merged PR #${prNumber}`);
+    } catch (e) {
+      core.setFailed(`Failed to merge PR #${prNumber}: ${e.message}`);
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `Failed to merge this PR: \`${e.message}\`\n\n` +
+          `A repo maintainer may need to merge manually.`,
+      });
+    }
+  }
+};

--- a/.github/workflows/area-merge.yml
+++ b/.github/workflows/area-merge.yml
@@ -1,0 +1,38 @@
+name: "Area Maintainer Merge"
+
+on:
+  issue_comment:
+    types: [created]
+  check_suite:
+    types: [completed]
+
+jobs:
+  area-merge:
+    if: >
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/area-maintainer-approved')) ||
+      github.event_name == 'check_suite'
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch (for CODEOWNERS and scripts)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            CODEOWNERS
+            .github/scripts/area-merge.js
+          persist-credentials: false
+
+      - name: Area maintainer merge check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const script = require('./.github/scripts/area-merge.js');
+            await script({ github, context, core });

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,51 @@
+# CODEOWNERS - Area Maintainers for ovn-kubernetes
+#
+# Each line is a file pattern followed by one or more owners (GitHub usernames
+# or team slugs). When a PR modifies files matching a pattern, GitHub will
+# automatically request reviews from the listed owners.
+#
+# Order matters: the LAST matching pattern takes precedence.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# To add a new area:
+#   1. Add a section below with the file patterns and area maintainer(s)
+#   2. Optionally create a GitHub team in the ovn-kubernetes org
+#   3. Use individual @usernames or @org/team-slug
+
+# ============================================================================
+# Default: catch-all for anything not matched below
+# ============================================================================
 * @ovn-kubernetes/ovn-kubernetes-members
+
+# ============================================================================
+# Virtualization (Area Maintainer: @maiqueb)
+# ============================================================================
+# E2E tests
+/test/e2e/kubevirt.go @maiqueb @qinqon @ormergi
+/test/e2e/kubevirt/ @maiqueb @qinqon @ormergi
+/test/e2e/multihoming.go @maiqueb @qinqon @ormergi
+/test/e2e/multihoming_utils.go @maiqueb @qinqon @ormergi
+/test/e2e/multihoming_external_router_utils.go @maiqueb @qinqon @ormergi
+/test/e2e/network_segmentation_localnet.go @maiqueb @qinqon @ormergi
+/test/e2e/localnet-underlay.go @maiqueb @qinqon @ormergi
+/test/e2e/network_segmentation_preconfigured_layer2.go @maiqueb @qinqon @ormergi
+/test/e2e/testscenario/cudn/valid-scenarios-localnet.go @maiqueb @qinqon @ormergi
+/test/e2e/testscenario/cudn/invalid-scenarios-localnet-vlan.go @maiqueb @qinqon @ormergi
+/test/e2e/testscenario/cudn/invalid-scenarios-localnet-subnets.go @maiqueb @qinqon @ormergi
+/test/e2e/testscenario/cudn/invalid-scenarios-localnet-role.go @maiqueb @qinqon @ormergi
+/test/e2e/testscenario/cudn/invalid-scenarios-localnet-phynetname.go @maiqueb @qinqon @ormergi
+/test/e2e/testscenario/cudn/invalid-scenarios-localnet-mtu.go @maiqueb @qinqon @ormergi
+# Unit tests
+/go-controller/pkg/ovn/kubevirt_test.go @maiqueb @qinqon @ormergi
+/go-controller/pkg/ovn/multihoming_test.go @maiqueb @qinqon @ormergi
+/go-controller/pkg/ovn/multipolicy_test.go @maiqueb @qinqon @ormergi
+/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go @maiqueb @qinqon @ormergi
+/go-controller/pkg/util/multi_network_test.go @maiqueb @qinqon @ormergi
+# Production code
+/go-controller/pkg/kubevirt/ @maiqueb @qinqon @ormergi
+/go-controller/pkg/util/arp.go @maiqueb @qinqon @ormergi
+/go-controller/pkg/util/ndp/ @maiqueb @qinqon @ormergi
+# Docs
+/docs/features/live-migration.md @maiqueb @qinqon @ormergi
+/docs/features/multiple-networks/multi-homing.md @maiqueb @qinqon @ormergi
+/docs/features/multiple-networks/multi-network-policies.md @maiqueb @qinqon @ormergi

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,6 +11,9 @@ This governance explains how the project is run.
 - [Members](#members)
   - [Becoming a Member](#becoming-a-member)
   - [Removing a Member](#removing-a-member)
+- [Area Maintainers](#area-maintainers)
+  - [Becoming an Area Maintainer](#becoming-an-area-maintainer)
+  - [Removing an Area Maintainer](#removing-an-area-maintainer)
 - [Meetings](#meetings)
 - [Code of Conduct](#code-of-conduct)
 - [Security Response Team](#security-response-team)
@@ -58,6 +61,13 @@ the project succeed.
 
 The collective team of all Maintainers is known as the Maintainer Council, which
 is the governing body for the project.
+
+Maintainers have purview over all areas and Area Maintainers. They create and
+dissolve areas, appoint and remove Area Maintainers, approve changes to an
+area's file scope in `CODEOWNERS`, and may override or merge any PR regardless
+of area boundaries. Area Maintainers operate under the authority delegated by
+the Maintainers and are expected to escalate cross-area concerns or contentious
+decisions to them.
 
 ### Becoming a Maintainer
 
@@ -136,6 +146,80 @@ maintainers.
 Members who are consistently unresponsive to assigned PR reviews may be
 contacted by Maintainers to discuss their availability and commitment. If the
 pattern of non-responsiveness continues, the Member may be removed.
+
+## Area Maintainers
+
+Area Maintainers are trusted contributors who own a specific area of the
+codebase (e.g. KubeVirt, Egress IP, Services). They have the authority to review,
+approve, and merge pull requests that **exclusively** touch files within their
+area, as defined in `CODEOWNERS`. Area Maintainers are not full Maintainers —
+they cannot merge PRs that touch files outside their designated area.
+
+Area Maintainers are automatically requested as reviewers by GitHub when a PR
+modifies files matching their `CODEOWNERS` patterns. They can merge qualifying
+PRs by commenting `/area-maintainer-approved` on the PR, which triggers the
+merge bot (`.github/workflows/area-merge.yml`) to verify file scope and CI
+status before merging.
+
+### Area Maintainer Responsibilities
+
+- **Area health and ownership:** Take ownership of the overall health of the
+  area. Maintain high code quality standards, ensure technical debt is managed,
+  foster innovation without rushing changes that compromise stability, and
+  promptly bring up stuck PRs for review at community meetings.
+- **PR approval:** Review and approve pull requests within their area.
+  Ensure contributions meet quality standards and are well-tested. Area
+  Maintainers must not approve or merge their own pull requests — another
+  area maintainer, reviewer, or repo maintainer must review and approve them.
+- **Design proposals:** Own, review, and drive OKEPs (OVN-Kubernetes Enhancement
+  Proposals) related to their area.
+- **Documentation:** Ensure documentation for the area is accurate and
+  up to date.
+- **CI health:** Monitor CI for their area and address failures and flakes
+  promptly without needing to be pinged.
+- **Upstream engagement:** Attend OVN-Kubernetes upstream meetings and represent
+  the area's interests, especially for cross-area collaborations.
+- **Community support:** Help other contributors working in the area with
+  reviews, guidance, and mentoring.
+- **Communication:** Keep the Maintainers informed of important changes,
+  design decisions, and roadmap items happening in the area.
+- **Scope management:** If the area's file list in `CODEOWNERS` needs
+  expansion or contraction, file a request to the Maintainers, who have the
+  final say on the area's scope.
+
+### Becoming an Area Maintainer
+
+Area Maintainers are typically individuals who are already fulfilling the
+responsibilities listed above — the role formalizes what they are already doing.
+To become an Area Maintainer you need to demonstrate the following:
+
+- commitment to the specific area:
+  - participate in discussions, contributions, code and documentation reviews
+    related to the area for 3 months or more,
+  - perform reviews for 5 non-trivial pull requests in the area,
+  - contribute 10 non-trivial pull requests to the area and have them merged,
+- demonstrated ownership of area health: maintaining code quality, addressing
+  CI failures, keeping documentation current, and driving improvements without
+  compromising stability,
+- deep understanding of the area's code, design, and interactions with the
+  rest of the project,
+- ability to write quality code and/or documentation,
+- ability to collaborate with the team.
+
+A new Area Maintainer must be proposed by an existing Maintainer by sending a
+message to the [developer mailing list](https://groups.google.com/g/ovn-kubernetes).
+The appointment requires approval from a simple majority of the Maintainers.
+Once approved, the new Area Maintainer's GitHub username is added to the
+relevant entries in `CODEOWNERS`.
+
+### Removing an Area Maintainer
+
+Area Maintainers may resign at any time.
+
+Area Maintainers may also be removed after being inactive in their area for a
+period of 6 months or more, for failure to fulfill their responsibilities, or
+for violating the Code of Conduct. An Area Maintainer may be removed at any
+time by a simple majority vote of the Maintainers.
 
 ## Meetings
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -35,10 +35,13 @@ Be trustworthy. During a review, your actions both build and help maintain the t
 
 ## Process
 
-* Reviewers are automatically assigned via the load-balancing algorithm using contributors from the ovn-kubernetes/ovn-kubernetes-members team.
-* Reviewers may opt out of reviewing of any PR or the reviewing process altogether by contacting committers or setting their github profile status as "busy" and removing themselves from any currently assigned PR.
+* **Reviewers for area-owned files** are automatically assigned when a PR touches files listed in `CODEOWNERS`. GitHub requests reviews from the owners listed on the matching pattern lines (area maintainers and reviewers alike). Merge authority is determined separately by the merge bot based on the `Area Maintainer:` header in `CODEOWNERS`.
+* If no area-specific pattern matches, reviewers are assigned via the load-balancing algorithm using contributors from the ovn-kubernetes/ovn-kubernetes-members team (configured in `CODEOWNERS`).
+* Area maintainers are appointed by the repo Maintainers (see [Area Maintainers](./GOVERNANCE.md#area-maintainers) in the governance docs).
+* **Area maintainer merge:** Area maintainers can merge PRs that **only** touch files within their area by commenting `/area-maintainer-approved` on the PR. The merge bot (`.github/workflows/area-merge.yml`) verifies that all changed files are within the commenter's area in `CODEOWNERS` and that all CI checks pass before merging. If CI is still running, the bot waits and merges automatically when checks go green. Area maintainers cannot use `/area-maintainer-approved` on their own PRs — the bot will reject the attempt; another area maintainer or repo maintainer must approve and merge instead. PRs touching files outside the area maintainer's scope require a committer from `ovn-kubernetes-committers` to merge.
+* Reviewers may opt out of reviewing of any PR or the reviewing process altogether by contacting committers or setting their GitHub profile status as "busy" and removing themselves from any currently assigned PR.
 * Reviewers should wait for automated checks to pass before reviewing
-* At least 1 approved review is required from a maintainer before a pull request can be merged
+* At least 1 approved review is required from a maintainer before a pull request can be merged. **Exception:** PRs that exclusively touch files within a single area (as defined in `CODEOWNERS`) may be merged by the designated area maintainer via `/area-maintainer-approved` without a full maintainer approval.
 * All CI checks must pass
 * If a PR is stuck for some reason it is down to the reviewer to determine the best course of action:
   * PRs may be closed if they are no longer relevant

--- a/docs/developer-guide/areas.md
+++ b/docs/developer-guide/areas.md
@@ -1,0 +1,55 @@
+# Project Areas
+
+ovn-kubernetes organises its codebase into **areas** — focused domains that are
+owned by designated **Area Maintainers**. Each area has a clear scope of files
+defined in [`CODEOWNERS`](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CODEOWNERS)
+and a set of maintainers and reviewers responsible for its health.
+
+For the full governance details — roles, responsibilities, appointment and
+removal process — see [Area Maintainers](../governance/GOVERNANCE.md#area-maintainers)
+in the governance docs.
+
+## How Areas Work
+
+* Every area is declared as a section in `CODEOWNERS` with a header comment
+  identifying the Area Maintainer(s):
+  ```
+  # Virtualization (Area Maintainer: @user)
+  ```
+* GitHub automatically assigns reviewers from the listed owners when a PR
+  touches files matching the area's patterns.
+* Area Maintainers can merge PRs that **exclusively** touch files within their
+  area by commenting `/area-maintainer-approved` on the PR. The merge bot
+  (`.github/workflows/area-merge.yml`) verifies file scope, CI status, and
+  authorization before merging.
+* PRs that touch files across multiple areas require a repo Maintainer to merge.
+
+## Current Areas
+
+### Virtualization
+
+| | |
+|---|---|
+| **Scope** | KubeVirt integration, live migration, multi-homing, localnet |
+| **Area Maintainer** | [@maiqueb](https://github.com/maiqueb) |
+| **Reviewers** | [@qinqon](https://github.com/qinqon), [@ormergi](https://github.com/ormergi) |
+
+**Files:**
+
+| Category | Paths |
+|---|---|
+| E2E tests | `/test/e2e/kubevirt.go`, `/test/e2e/kubevirt/`, `/test/e2e/multihoming.go`, `/test/e2e/multihoming_utils.go`, `/test/e2e/multihoming_external_router_utils.go`, `/test/e2e/network_segmentation_localnet.go`, `/test/e2e/localnet-underlay.go`, `/test/e2e/network_segmentation_preconfigured_layer2.go`, `/test/e2e/testscenario/cudn/valid-scenarios-localnet.go`, `/test/e2e/testscenario/cudn/invalid-scenarios-localnet-*.go` |
+| Unit tests | `/go-controller/pkg/ovn/kubevirt_test.go`, `/go-controller/pkg/ovn/multihoming_test.go`, `/go-controller/pkg/ovn/multipolicy_test.go`, `/go-controller/pkg/ovn/layer2_user_defined_network_controller_test.go`, `/go-controller/pkg/util/multi_network_test.go` |
+| Production code | `/go-controller/pkg/kubevirt/`, `/go-controller/pkg/util/arp.go`, `/go-controller/pkg/util/ndp/` |
+| Docs | `/docs/features/live-migration.md`, `/docs/features/multiple-networks/multi-homing.md`, `/docs/features/multiple-networks/multi-network-policies.md` |
+
+## Adding a New Area
+
+1. Open a PR proposing the new area — the PR must be approved by the repo
+   Maintainers (see [Governance](../governance/GOVERNANCE.md#area-maintainers)).
+2. Add a new section to `CODEOWNERS` with the file patterns and the proposed
+   Area Maintainer in the section header comment.
+3. Add an entry to this document describing the area's scope, maintainer(s),
+   and reviewers.
+4. Once merged, the Area Maintainer can begin using `/area-maintainer-approved`
+   to merge qualifying PRs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - Contributing Guide: governance/CONTRIBUTING.md
       - Governance: governance/GOVERNANCE.md
       - Reviewing Guide: governance/REVIEWING.md
+      - Project Areas: developer-guide/areas.md
       - Coding Guide: developer-guide/developer.md
       - OVN-Kubernetes Container Images: developer-guide/image-build.md
       - Documentation Guide: developer-guide/documentation.md


### PR DESCRIPTION
Introduce the Area Maintainer role as a way to scale code review and merge authority without granting full repo maintainer access. This PR also introduces the concept or Area for the first time - just borrowing it from other bigger projects like Kubernetes and Kubevirt.

This is the first area (kubevirt) as a guinea pig for the model:
- CODEOWNERS: defines file patterns for the kubevirt area with @maiqueb as area maintainer and @qinqon, @ormergi as reviewers. GitHub's round-robin algorithm picks one reviewer per PR.
- area-merge.yml: GitHub Actions workflow that lets area maintainers merge PRs by commenting /area-maintainer-approved. The bot parses the "Area Maintainer:" header in CODEOWNERS to determine who can trigger merges (only @maiqueb), verifies all changed files are within scope, checks CI status, and merges via API.
- GOVERNANCE.md: adds Area Maintainer role definition, appointment process (requires Maintainer majority vote), and removal policy.
- REVIEWING.md: documents area maintainer review assignment and the command-based merge flow.


Tested this in my own fork:

https://github.com/tssurya/ovn-kubernetes/pull/2
https://github.com/tssurya/ovn-kubernetes/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added SIGs track to governance and updated reviewing guidance to reflect SIG-based ownership and merge rules.
* **New Features**
  * Introduced an automated "SIG Merge" workflow: SIG Leads may trigger merges via /sig-approve; CI gating, waiting notices, success and denial comments are posted.
* **Chores**
  * Updated CODEOWNERS to add a SIG for virtualization and assign ownership for related test and KubeVirt areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->