### PR TITLE
Perf(networkmanager): Increase networkReconciler Threadiness for parallel UDN startup

### DIFF
--- a/go-controller/pkg/networkmanager/network_controller.go
+++ b/go-controller/pkg/networkmanager/network_controller.go
@@ -30,6 +30,14 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
+const (
+	// defaultNetworkReconcilerThreadiness defines the number of worker goroutines
+	// for processing network reconciliation events. Value of 5 provides good
+	// parallelism for bulk UDN creation while controlling resource consumption.
+	// Aligns with Kubernetes controller-manager conventions and UDN service controller.
+	defaultNetworkReconcilerThreadiness = 5
+)
+
 func newNetworkController(name, zone, node string, cm ControllerManager, wf watchFactory) *networkController {
 	nc := &networkController{
 		name:                   fmt.Sprintf("[%s network controller]", name),
@@ -48,7 +56,7 @@ func newNetworkController(name, zone, node string, cm ControllerManager, wf watc
 	networkConfig := &controller.ReconcilerConfig{
 		RateLimiter: workqueue.DefaultTypedControllerRateLimiter[string](),
 		Reconcile:   nc.syncNetwork,
-		Threadiness: 1,
+		Threadiness: defaultNetworkReconcilerThreadiness,
 		MaxAttempts: controller.InfiniteAttempts,
 	}
 	nc.networkReconciler = controller.NewReconciler(

--- a/go-controller/pkg/networkmanager/network_controller_test.go
+++ b/go-controller/pkg/networkmanager/network_controller_test.go
@@ -6,7 +6,9 @@ package networkmanager
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/onsi/gomega"
@@ -452,4 +454,188 @@ func TestNetworkControllerStopsNetworkOnStartFailure(t *testing.T) {
 	expectedNetworkKey := testNetworkKey(netInfo)
 	g.Expect(tcm.started).To(gomega.Equal([]string{expectedNetworkKey}))
 	g.Expect(tcm.stopped).To(gomega.Equal([]string{expectedNetworkKey}))
+}
+
+// TestNetworkController_ConcurrentReconciliation validates that the networkReconciler
+// can safely handle concurrent network additions and deletions without data races.
+func TestNetworkController_ConcurrentReconciliation(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	fakeClient := util.GetOVNClientset().GetOVNKubeControllerClientset()
+	wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClient)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	tcm := &testControllerManager{
+		controllers: map[string]NetworkController{},
+		defaultNetwork: &testNetworkController{
+			ReconcilableNetInfo: &util.DefaultNetInfo{},
+		},
+	}
+	nm := newNetworkController("test", "", "", tcm, wf)
+
+	err = wf.Start()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer wf.Shutdown()
+
+	g.Expect(nm.Start()).To(gomega.Succeed())
+	defer nm.Stop()
+
+	const numNetworks = 20
+	const numIterations = 3
+
+	for iteration := 0; iteration < numIterations; iteration++ {
+		t.Logf("Iteration %d/%d: Testing concurrent add/delete of %d networks", iteration+1, numIterations, numNetworks)
+
+		// Phase 1: Concurrent network additions
+		var addWg sync.WaitGroup
+		for i := 0; i < numNetworks; i++ {
+			addWg.Add(1)
+			go func(idx int) {
+				defer addWg.Done()
+
+				// Create a test network
+				networkName := fmt.Sprintf("test-net-%d-%d", iteration, idx)
+				netConf := &ovncnitypes.NetConf{
+					NetConf: cnitypes.NetConf{
+						Name: networkName,
+						Type: "ovn-k8s-cni-overlay",
+					},
+					Topology: "layer2",
+					Role:     "secondary",
+					MTU:      1400,
+				}
+
+				netInfo, err := util.NewNetInfo(netConf)
+				if err != nil {
+					t.Errorf("Failed to create NetInfo for %s: %v", networkName, err)
+					return
+				}
+
+				mutableNetInfo := util.NewMutableNetInfo(netInfo)
+				nm.EnsureNetwork(mutableNetInfo)
+			}(i)
+		}
+		addWg.Wait()
+
+		// getAllNetworks() returns only secondary networks, not the default network
+		g.Eventually(nm.getAllNetworks, 5*time.Second, 100*time.Millisecond).
+			Should(gomega.HaveLen(numNetworks))
+
+		// Phase 2: Concurrent network deletions
+		var delWg sync.WaitGroup
+		for i := 0; i < numNetworks; i++ {
+			delWg.Add(1)
+			go func(idx int) {
+				defer delWg.Done()
+				networkName := fmt.Sprintf("test-net-%d-%d", iteration, idx)
+				nm.DeleteNetwork(networkName)
+			}(i)
+		}
+		delWg.Wait()
+
+		g.Eventually(nm.getAllNetworks).WithTimeout(5*time.Second).
+			WithPolling(100*time.Millisecond).Should(gomega.BeEmpty(),
+			"all test networks should be deleted")
+	}
+}
+
+// TestNetworkController_ConcurrentReconciliationMixed validates concurrent operations
+// with mixed add, update, and delete operations happening simultaneously.
+func TestNetworkController_ConcurrentReconciliationMixed(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	fakeClient := util.GetOVNClientset().GetOVNKubeControllerClientset()
+	wf, err := factory.NewOVNKubeControllerWatchFactory(fakeClient)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	tcm := &testControllerManager{
+		controllers: map[string]NetworkController{},
+		defaultNetwork: &testNetworkController{
+			ReconcilableNetInfo: &util.DefaultNetInfo{},
+		},
+	}
+	nm := newNetworkController("test", "", "", tcm, wf)
+
+	err = wf.Start()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer wf.Shutdown()
+
+	g.Expect(nm.Start()).To(gomega.Succeed())
+	defer nm.Stop()
+
+	const numOperations = 30
+	const numUniqueNetworks = 10
+	var wg sync.WaitGroup
+
+	for i := 0; i < numOperations; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			networkName := fmt.Sprintf("mixed-net-%d", idx%numUniqueNetworks)
+			netConf := &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					Name: networkName,
+					Type: "ovn-k8s-cni-overlay",
+				},
+				Topology: "layer2",
+				Role:     "secondary",
+				MTU:      1400,
+			}
+
+			netInfo, err := util.NewNetInfo(netConf)
+			if err != nil {
+				t.Errorf("Failed to create NetInfo: %v", err)
+				return
+			}
+
+			mutableNetInfo := util.NewMutableNetInfo(netInfo)
+
+			// Randomly add or delete
+			if idx%3 == 0 {
+				nm.DeleteNetwork(networkName)
+			} else {
+				nm.EnsureNetwork(mutableNetInfo)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Ensure all networks exist to reach a deterministic final state
+	for i := 0; i < numUniqueNetworks; i++ {
+		networkName := fmt.Sprintf("mixed-net-%d", i)
+		netConf := &ovncnitypes.NetConf{
+			NetConf: cnitypes.NetConf{
+				Name: networkName,
+				Type: "ovn-k8s-cni-overlay",
+			},
+			Topology: "layer2",
+			Role:     "secondary",
+			MTU:      1400,
+		}
+
+		netInfo, err := util.NewNetInfo(netConf)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		mutableNetInfo := util.NewMutableNetInfo(netInfo)
+		nm.EnsureNetwork(mutableNetInfo)
+	}
+
+	// Verify all networks exist (deterministic final state)
+	g.Eventually(func(g gomega.Gomega) {
+		networks := nm.getAllNetworks()
+		// getAllNetworks() returns secondary networks only
+		g.Expect(networks).To(gomega.HaveLen(numUniqueNetworks),
+			"Expected %d networks after mixed operations, got %d", numUniqueNetworks, len(networks))
+
+		// Verify each network can be retrieved
+		for _, network := range networks {
+			retrieved := nm.getNetwork(network.GetNetworkName())
+			g.Expect(retrieved).ToNot(gomega.BeNil())
+		}
+	}).Should(gomega.Succeed())
 }


### PR DESCRIPTION
The `networkReconciler` workqueue was configured with `Threadiness: 1`, causing all `syncNetwork` calls to execute serially. Since each network controller's `Start()` method blocks on patch port readiness (~2s), bulk UDN creation experienced linear time accumulation.

This change increases `Threadiness` to `5` via the constant `defaultNetworkReconcilerThreadiness`, enabling parallel reconciliation of independent network controllers. This aligns with:

- Kubernetes controller-manager conventions (most controllers use 5 workers)
- Existing UDN service controller configuration (`layer2_user_defined_network_controller.go:71`)
- Parent epic CORENET-5658 (UDN scalability)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

This PR increases the `networkReconciler` workqueue `Threadiness` from `1` to `5`, enabling parallel processing of network controller initialization for User-Defined Networks (UDNs).

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the parallel worker capacity for network reconciliation to improve throughput and responsiveness during bursts of network events.
* **Tests**
  * Added concurrency-focused tests that validate eventual consistency when multiple secondary networks are added, listed, and deleted in parallel.
  * Added coverage to verify controller startup and reconciliation are truly parallel (based on timing and overlap), not effectively serial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->