### PR TITLE
Bump OVN to ovn-25.09.2-82.

### DIFF
--- a/contrib/kind-common
+++ b/contrib/kind-common
@@ -574,6 +574,12 @@ install_dnsnameresolver_operator() {
     -e 's/^\(.*--dns-name-resolver-namespace=\).*/\1ovn-kubernetes/' \
     -e 's/^\(.*--coredns-port=\).*/\153/' config/default/manager_auth_proxy_patch.yaml
 
+  # gcr.io Container Registry shutdown issue
+  # See https://github.com/kubernetes-sigs/kubebuilder/discussions/3907#discussioncomment-11477582 for more details.
+  # REVERT ME: when coredns team fixes image in upstream, we can revert this patch.
+  sed -i 's|gcr.io/kubebuilder/kube-rbac-proxy|registry.k8s.io/kubebuilder/kube-rbac-proxy|g' \
+    config/default/manager_auth_proxy_patch.yaml
+
   make install CONTROLLER_TOOLS_VERSION=v0.19.0
   make deploy IMG=${DNSNAMERESOLVER_OPERATOR} CONTROLLER_TOOLS_VERSION=v0.19.0
   popd
@@ -827,6 +833,18 @@ install_ffr_k8s() {
   clone_frr
 
   # apply frr-k8s
+  # The all-in-one manifest is only consumed here (deploy_frr_external_container
+  # uses CRDs and the demo scripts, not this manifest), so the fix lives here
+  # rather than in clone_frr. This covers both kind.sh and kind-helm.sh since
+  # both call install_frr_k8s.
+  #
+  # gcr.io/kubebuilder/kube-rbac-proxy is unavailable after Google's Container
+  # Registry shutdown (https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation).
+  # Upstream bug: https://github.com/metallb/metallb/issues/2619
+  # Use the same image from the Kubernetes community registry instead.
+  # REVERT ME: when https://github.com/metallb/metallb/issues/2619 is fixed
+  sed -i 's|gcr.io/kubebuilder/kube-rbac-proxy|registry.k8s.io/kubebuilder/kube-rbac-proxy|g' \
+    "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml
   kubectl apply -f "${FRR_TMP_DIR}"/frr-k8s/config/all-in-one/frr-k8s.yaml
   kubectl wait -n frr-k8s-system deployment frr-k8s-webhook-server --for condition=Available --timeout 2m
   kubectl rollout status -n frr-k8s-system daemonset frr-k8s-daemon --timeout 2m

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -95,7 +95,7 @@ RUN git log -n 1
 # Stage to download OVN RPMs from koji #
 ########################################
 FROM quay.io/fedora/fedora:42 AS kojidownloader
-ARG ovnver=ovn-25.09.2-2.fc42
+ARG ovnver=ovn-25.09.2-82.fc42
 
 USER root
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
The previous version used on the release-1.2 branch, ovn-25.09.2-2.fc42, is not available anymore.  Therefore we use now the equivalent version to what's used on release-1.3.

This picks up the following relevant OVN changes:
  7982264e0c pinctrl: Process packets even when the lock is taken.
  1252ba3854 northd: Do not forward unknown ether type to router ports.
  e97f7caf40 northd: Commit ECMP symmetric egress traffic earlier.
  04eac21d10 controller: Prevent crash when SB_Global is empty.
  1959012412 lflow: Add missing match on eth.src for ND port security.
  55494c15d5 northd: Do not send ICMP packet too big for multicast traffic.
  4d3bc6a7e9 lflow: Enable default drop for ND NS in with port security enabled.
  33dfbceab4 northd: Improvements of ICMP TTL exceeded behavior.
  c157eb5399 physical: Fix remote chassis flood ingress flows for multiple encaps.
  0d16ab09df controller: Add missing nw_ttl field to match against legit NAs.
  3f7ada652a pinctrl: Avoid unaligned access to dhcpv6 options.
  9ee7c8bc23 northd: Do not assign requested tunnel key to the derived CR port.
  75fff00bca northd: Delete learned route with CR without chassis.
  6da9f1fc75 en-datapath-sync: Avoid unnecessary datapath recomputes.
  59abbd20f7 controller: CT zone allocation for DGP LSPs enabled ACL.


## Additional Information for reviewers
Only the OVN version was changed to the latest Fedora 25.09.z version.
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
CI should be green.