### PR TITLE
inconsistent managementPortRepresentor state#3216

### DIFF
--- a/go-controller/pkg/node/managementport/port_dpu_linux.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux.go
@@ -92,7 +92,7 @@ func (mp *managementPortRepresentor) checkRepresentorPortHealth() error {
 		// Get management port representor by name
 		link, err := util.GetNetLinkOps().LinkByName(mp.repDevName)
 		if err != nil {
-			return fmt.Errorf("failed to get link device %s: %w", mp.repDevName, err)
+			klog.Fatalf("Can't find neither renamed management port %s nor original representor device %s: %v, inconsistent state, crashing to recover with fresh start", mp.ifName, mp.repDevName, err)
 		}
 		err = bringupManagementPortLink(types.DefaultNetworkName, link, nil, mp.ifName, config.Default.MTU)
 		if err != nil {

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -746,6 +746,7 @@ var _ = Describe("Management Port tests", func() {
 
 				// Return error here, so we know that function didn't returned earlier
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
+				netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
 				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
 			})
@@ -760,9 +761,26 @@ var _ = Describe("Management Port tests", func() {
 					"ovs-vsctl --timeout=15 --if-exists del-port br-int " + mgmtPortName,
 				})
 				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
+				netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
 
 				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("Succeeds when representor link is already removed", func() {
+				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
+					Output: "," + mgmtPortName,
+				})
+				execMock.AddFakeCmdsNoOutputNoError([]string{
+					"ovs-vsctl --timeout=15 --if-exists get Interface " + mgmtPortName + " external-ids:ovn-orig-mgmt-port-rep-name",
+					"ovs-vsctl --timeout=15 --if-exists del-port br-int " + mgmtPortName,
+				})
+				netlinkOpsMock.On("LinkByName", mgmtPortName).Return(nil, netlinkMockErr)
+				netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+
+				err := syncMgmtPortInterface(ovsClient, mgmtPortName, false)
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("Fails to set representor link down", func() {

--- a/go-controller/pkg/node/managementport/utils_linux.go
+++ b/go-controller/pkg/node/managementport/utils_linux.go
@@ -200,7 +200,13 @@ func DeleteManagementPortRepInterface(network, repDevice, savedName string) erro
 
 	link, err := util.GetNetLinkOps().LinkByName(repDevice)
 	if err != nil {
-		return fmt.Errorf("failed to lookup management port representor interface %s for network %s: %v", repDevice, network, err)
+		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			return fmt.Errorf("failed to lookup management port representor interface %s for network %s: %v", repDevice, network, err)
+		}
+
+		klog.V(5).Infof("Management port representor interface %s is already removed for network %s", repDevice, network)
+
+		return nil
 	}
 
 	err = TearDownManagementPortLink(network, link, savedName)


### PR DESCRIPTION
See commit message or #6495 for more info about the issue

# Solution

When `LinkByName(repDevName)` fails, we know the ovn-k controller is in an
inconsistent state which indicates we should probably crash to cause a
container restart and hopefully a clean state.

We could also instead theoretically record a more stable identifier of the
device (e.g. PCI address) instead of a name and try to find it by that, but
that would be more complex and possibly insufficient as it indicates that
more things are probably anyway in an inconsistent state as well, so
crashing is probably the best option anyway, even though it feels like a
bit more like a hacky solution.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6495

## Additional Information for reviewers

After the crash, to prevent another crash, I've also modified
`DeleteManagementPortRepInterface` to not try to delete things that already
don't exist, by using a simple `IsLinkNotFoundError` condition.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

To verify it I would have to build an ARM version, load it in my DPU and ensure
that the issue does not reproduce. I'm still in the process of doing that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * On Linux, management-port representor inconsistencies now trigger an immediate fail-fast restart when critical devices are missing after reboot.
  * Deleting a management-port representor treats “already removed” cases as non-fatal and proceeds without error.

* **Tests**
  * Strengthened tests for representor lookup, removal, and failure paths to assert correct non-fatal and fail-fast behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->