### PR TITLE
ovspinning: skip OVS PMD threads if any

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1187,7 +1187,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 				klog.V(4).Infof("Error closing PodResourcesAPI client: %v", err)
 			}
 		}()
-		ovspinning.Run(ctx, stopCh, podResClient)
+		ovspinning.Run(ctx, stopCh, podResClient, nc.ovsClient)
 	}(nc.stopChan)
 
 	klog.Infof("Default node network controller initialized and ready.")

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux.go
@@ -29,6 +29,8 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
+const PmdPrefix string = "pmd"
+
 // These variables are meant to be used in unit tests
 var tickDuration time.Duration = 1 * time.Second
 var getOvsVSwitchdPIDFn func() (string, error) = util.GetOvsVSwitchdPID
@@ -179,7 +181,7 @@ func setOvsVSwitchdCPUAffinity(set *cpuset.CPUSet) error {
 	}
 
 	klog.V(5).Infof("Managing ovs-vswitchd[%s] daemon CPU affinity", ovsVSwitchdPID)
-	return setProcessCPUAffinity(ovsVSwitchdPID, set)
+	return setProcessCPUAffinity(ovsVSwitchdPID, set, true)
 }
 
 func setOvsDBServerCPUAffinity(set *cpuset.CPUSet) error {
@@ -190,7 +192,7 @@ func setOvsDBServerCPUAffinity(set *cpuset.CPUSet) error {
 	}
 
 	klog.V(5).Infof("Managing ovsdb-server[%s] daemon CPU affinity", ovsDBserverPID)
-	return setProcessCPUAffinity(ovsDBserverPID, set)
+	return setProcessCPUAffinity(ovsDBserverPID, set, false)
 }
 
 // setProcessCPUAffinity sets the CPU affinity of a target process and all its threads
@@ -205,6 +207,7 @@ func setOvsDBServerCPUAffinity(set *cpuset.CPUSet) error {
 // Parameters:
 //   - targetPIDStr: string representation of the target process ID
 //   - set: pointer to the desired CPU set; if empty, current process affinity is used
+//   - skipPmds: whether to try to skip PMD threads from affinity setting or not
 //
 // Returns:
 //   - error: any error encountered during PID conversion, affinity retrieval, or setting
@@ -212,7 +215,7 @@ func setOvsDBServerCPUAffinity(set *cpuset.CPUSet) error {
 // The function skips setting affinity if the target process already has the desired
 // CPU affinity. Individual thread affinity setting failures are logged as warnings
 // but don't stop the overall operation.
-func setProcessCPUAffinity(targetPIDStr string, set *cpuset.CPUSet) error {
+func setProcessCPUAffinity(targetPIDStr string, set *cpuset.CPUSet, skipPmds bool) error {
 
 	targetPID, err := strconv.Atoi(targetPIDStr)
 	if err != nil {
@@ -247,6 +250,9 @@ func setProcessCPUAffinity(targetPIDStr string, set *cpuset.CPUSet) error {
 
 	klog.Infof("Setting CPU affinity of PID(%d) (ntasks=%d) to %s, was %s", targetPID, len(taskIDs), printCPUSet(desiredProcessCPUs), printCPUSet(targetProcessCPUs))
 	for _, taskID := range taskIDs {
+		if skipPmds && isPmdThread(taskID) {
+			continue
+		}
 		err = unix.SchedSetaffinity(taskID, &desiredProcessCPUs)
 		if err != nil {
 			// The task may have been stopped, don't break the loop and continue setting CPU affinity on other tasks.
@@ -301,6 +307,15 @@ func printCPUSet(cpus unix.CPUSet) string {
 		result.WriteString(",")
 	}
 	return strings.TrimRight(result.String(), ",")
+}
+
+func isPmdThread(tid int) bool {
+	threadName, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", tid))
+	if err != nil {
+		klog.Errorf("Unable to get name of task ID %d", tid)
+		return false
+	}
+	return strings.HasPrefix(string(threadName), PmdPrefix)
 }
 
 // getThreadsOfProcess returns the list of thread IDs of the given process

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -136,7 +137,16 @@ func Run(ctx context.Context, stopCh <-chan struct{}, podResCli podresourcesapi.
 			}
 			// add reservedSystemCPUs as well, because PodResourcesAPI does not count for them.
 			cpus = cpus.Union(reservedCPUs)
-			err = setOvsVSwitchdCPUAffinity(&cpus, ovsClient)
+
+			// When DPDK is enabled, remove the CPUs dedicated to PMD threads from the
+			// affinity set so that non-PMD OVS threads don't compete with them.
+			pmdCPUs, enabled := getPmdCPUs(ovsClient)
+			if enabled && !pmdCPUs.IsEmpty() {
+				cpus = cpus.Difference(pmdCPUs)
+				klog.V(5).Infof("Excluding PMD CPUs %s from ovs-vswitchd affinity", pmdCPUs)
+			}
+
+			err = setOvsVSwitchdCPUAffinity(&cpus, enabled)
 			if err != nil {
 				klog.Warningf("Error while aligning ovs-vswitchd CPUs to current process: %v", err)
 			}
@@ -176,14 +186,12 @@ func isFileNotEmpty(filename string) (bool, error) {
 	return f.Size() > 0, nil
 }
 
-func setOvsVSwitchdCPUAffinity(set *cpuset.CPUSet, ovsClient libovsdbclient.Client) error {
+func setOvsVSwitchdCPUAffinity(set *cpuset.CPUSet, dpdkEnabled bool) error {
 
 	ovsVSwitchdPID, err := getOvsVSwitchdPIDFn()
 	if err != nil {
 		return fmt.Errorf("can't retrieve ovs-vswitchd PID: %w", err)
 	}
-
-	dpdkEnabled := isDPDKEnabled(ovsClient)
 
 	klog.V(5).Infof("Managing ovs-vswitchd[%s] daemon CPU affinity (dpdk=%v)", ovsVSwitchdPID, dpdkEnabled)
 	return setProcessCPUAffinity(ovsVSwitchdPID, set, dpdkEnabled)
@@ -492,16 +500,50 @@ func getAllocatableCPUs(ctx context.Context, podResCli podresourcesapi.PodResour
 	return cpuset.New(convertInt64ToInt(allocatableResp.CpuIds)...), nil
 }
 
-// isDPDKEnabled checks the libovsdb cache for the dpdk_initialized column
-// in the Open_vSwitch table.
-func isDPDKEnabled(ovsClient libovsdbclient.Client) bool {
-	if ovsClient == nil {
-		return false
-	}
+// getPmdCPUs returns the PMD CPU set and whether DPDK is enabled.
+func getPmdCPUs(ovsClient libovsdbclient.Client) (cpuset.CPUSet, bool) {
 	ovs, err := ovsops.GetOpenvSwitch(ovsClient)
 	if err != nil {
-		klog.V(5).Infof("Cannot read Open_vSwitch table: %v", err)
-		return false
+		klog.V(5).Infof("Cannot read Open_vSwitch table for pmd-cpu-mask: %v", err)
+		return cpuset.New(), false
 	}
-	return ovs.DpdkInitialized
+	if !ovs.DpdkInitialized {
+		return cpuset.New(), false
+	}
+
+	mask, ok := ovs.OtherConfig["pmd-cpu-mask"]
+	if !ok || mask == "" {
+		return cpuset.New(), true
+	}
+
+	pmdCPUs, err := parsePmdCpuMask(mask)
+	if err != nil {
+		klog.Warningf("Failed to parse pmd-cpu-mask %q: %v", mask, err)
+		return cpuset.New(), true
+	}
+	return pmdCPUs, true
+}
+
+// parsePmdCpuMask parses a hex bitmask string (e.g. "0xc", "C", "0x0006")
+// into a cpuset.CPUSet.
+func parsePmdCpuMask(mask string) (cpuset.CPUSet, error) {
+	mask = strings.TrimSpace(mask)
+	mask = strings.TrimPrefix(mask, "0x")
+	mask = strings.TrimPrefix(mask, "0X")
+	if mask == "" {
+		return cpuset.New(), nil
+	}
+
+	v := new(big.Int)
+	if _, ok := v.SetString(mask, 16); !ok {
+		return cpuset.New(), fmt.Errorf("invalid hex mask: %q", mask)
+	}
+
+	var positions []int
+	for i := 0; i < v.BitLen(); i++ {
+		if v.Bit(i) == 1 {
+			positions = append(positions, i)
+		}
+	}
+	return cpuset.New(positions...), nil
 }

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux.go
@@ -26,6 +26,9 @@ import (
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/utils/cpuset"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -42,7 +45,7 @@ var kubeletConfigFilePath = "/host/etc/kubernetes/kubelet.conf"
 // masks to that of the current process.
 // This feature is enabled by the presence of a non-empty file in the path `/etc/openvswitch/enable_dynamic_cpu_affinity`
 // we're passing the podResCli from the caller, so we could support unit-tests
-func Run(ctx context.Context, stopCh <-chan struct{}, podResCli podresourcesapi.PodResourcesListerClient) {
+func Run(ctx context.Context, stopCh <-chan struct{}, podResCli podresourcesapi.PodResourcesListerClient, ovsClient libovsdbclient.Client) {
 
 	// The file must be present at startup to enable the feature
 	isFeatureEnabled, err := isFileNotEmpty(featureEnablerFile)
@@ -133,7 +136,7 @@ func Run(ctx context.Context, stopCh <-chan struct{}, podResCli podresourcesapi.
 			}
 			// add reservedSystemCPUs as well, because PodResourcesAPI does not count for them.
 			cpus = cpus.Union(reservedCPUs)
-			err = setOvsVSwitchdCPUAffinity(&cpus)
+			err = setOvsVSwitchdCPUAffinity(&cpus, ovsClient)
 			if err != nil {
 				klog.Warningf("Error while aligning ovs-vswitchd CPUs to current process: %v", err)
 			}
@@ -173,15 +176,17 @@ func isFileNotEmpty(filename string) (bool, error) {
 	return f.Size() > 0, nil
 }
 
-func setOvsVSwitchdCPUAffinity(set *cpuset.CPUSet) error {
+func setOvsVSwitchdCPUAffinity(set *cpuset.CPUSet, ovsClient libovsdbclient.Client) error {
 
 	ovsVSwitchdPID, err := getOvsVSwitchdPIDFn()
 	if err != nil {
 		return fmt.Errorf("can't retrieve ovs-vswitchd PID: %w", err)
 	}
 
-	klog.V(5).Infof("Managing ovs-vswitchd[%s] daemon CPU affinity", ovsVSwitchdPID)
-	return setProcessCPUAffinity(ovsVSwitchdPID, set, true)
+	dpdkEnabled := isDPDKEnabled(ovsClient)
+
+	klog.V(5).Infof("Managing ovs-vswitchd[%s] daemon CPU affinity (dpdk=%v)", ovsVSwitchdPID, dpdkEnabled)
+	return setProcessCPUAffinity(ovsVSwitchdPID, set, dpdkEnabled)
 }
 
 func setOvsDBServerCPUAffinity(set *cpuset.CPUSet) error {
@@ -485,4 +490,18 @@ func getAllocatableCPUs(ctx context.Context, podResCli podresourcesapi.PodResour
 		return cpuset.CPUSet{}, fmt.Errorf("GetAllocatableResources failed: %w", err)
 	}
 	return cpuset.New(convertInt64ToInt(allocatableResp.CpuIds)...), nil
+}
+
+// isDPDKEnabled checks the libovsdb cache for the dpdk_initialized column
+// in the Open_vSwitch table.
+func isDPDKEnabled(ovsClient libovsdbclient.Client) bool {
+	if ovsClient == nil {
+		return false
+	}
+	ovs, err := ovsops.GetOpenvSwitch(ovsClient)
+	if err != nil {
+		klog.V(5).Infof("Cannot read Open_vSwitch table: %v", err)
+		return false
+	}
+	return ovs.DpdkInitialized
 }

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -109,7 +109,7 @@ func TestAlignCPUAffinity(t *testing.T) {
 					&kubeletpodresourcesv1.AllocatableResourcesResponse{CpuIds: tc.allocatableCPUs}, nil)
 				mockClient.On("List", mock.Anything, mock.Anything).Return(
 					buildListPodResourcesResponse(tc.usedCPUs), nil)
-				Run(context.Background(), stopCh, mockClient)
+				Run(context.Background(), stopCh, mockClient, nil)
 			}()
 
 			expectedUnixCPUSet := convertCPUSet(&expectedCPUs)

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -26,7 +26,9 @@ import (
 	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/utils/cpuset"
 
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/kubelet/pkg/apis/podresources/v1"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
 
 func TestAlignCPUAffinity(t *testing.T) {
@@ -93,6 +95,14 @@ func TestAlignCPUAffinity(t *testing.T) {
 			defer mockFeatureEnableFile(t, "1")()
 			defer mockKubeletConfigFile(t, cpuset.New(tc.reservedCPUs...))()
 
+			ovsClient, ovsTestCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs"},
+				},
+			})
+			require.NoError(t, err)
+			defer ovsTestCtx.Cleanup()
+
 			var wg sync.WaitGroup
 			stopCh := make(chan struct{})
 			defer func() {
@@ -109,7 +119,7 @@ func TestAlignCPUAffinity(t *testing.T) {
 					&kubeletpodresourcesv1.AllocatableResourcesResponse{CpuIds: tc.allocatableCPUs}, nil)
 				mockClient.On("List", mock.Anything, mock.Anything).Return(
 					buildListPodResourcesResponse(tc.usedCPUs), nil)
-				Run(context.Background(), stopCh, mockClient, nil)
+				Run(context.Background(), stopCh, mockClient, ovsClient)
 			}()
 
 			expectedUnixCPUSet := convertCPUSet(&expectedCPUs)
@@ -123,7 +133,6 @@ func TestAlignCPUAffinity(t *testing.T) {
 				expectedCPUs, err = convertUnixCPUSetToK8sCPUSet(pidSelfCPUs)
 				assert.NoError(t, err)
 				expectedUnixCPUSet = pidSelfCPUs
-
 			}
 			klog.Infof("Test CPU Affinity %s", expectedCPUs)
 
@@ -131,7 +140,7 @@ func TestAlignCPUAffinity(t *testing.T) {
 			assertPIDHasSchedAffinity(t, ovsDBPid, expectedUnixCPUSet)
 
 			// Disable the feature by making the enabler file empty
-			err := os.WriteFile(featureEnablerFile, []byte(""), 0)
+			err = os.WriteFile(featureEnablerFile, []byte(""), 0)
 			require.NoError(t, err)
 
 			// wait for the ovspinning loop to stabilize and stop running
@@ -519,5 +528,118 @@ func buildListPodResourcesResponse(usedCPUs [][]int64) *kubeletpodresourcesv1.Li
 
 	return &kubeletpodresourcesv1.ListPodResourcesResponse{
 		PodResources: podResources,
+	}
+}
+
+func TestGetPmdCPUs(t *testing.T) {
+	tests := []struct {
+		name            string
+		ovsData         []libovsdbtest.TestData
+		expectedCPUs    cpuset.CPUSet
+		expectedEnabled bool
+	}{
+		{
+			name:            "empty OVS table returns empty set, not enabled",
+			ovsData:         []libovsdbtest.TestData{},
+			expectedCPUs:    cpuset.New(),
+			expectedEnabled: false,
+		},
+		{
+			name: "dpdk not initialized returns empty set, not enabled",
+			ovsData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", DpdkInitialized: false,
+					OtherConfig: map[string]string{"pmd-cpu-mask": "0xc"}},
+			},
+			expectedCPUs:    cpuset.New(),
+			expectedEnabled: false,
+		},
+		{
+			name: "dpdk initialized, no pmd-cpu-mask: enabled but empty CPUs",
+			ovsData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", DpdkInitialized: true,
+					OtherConfig: map[string]string{}},
+			},
+			expectedCPUs:    cpuset.New(),
+			expectedEnabled: true,
+		},
+		{
+			name: "dpdk initialized, empty pmd-cpu-mask: enabled but empty CPUs",
+			ovsData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", DpdkInitialized: true,
+					OtherConfig: map[string]string{"pmd-cpu-mask": ""}},
+			},
+			expectedCPUs:    cpuset.New(),
+			expectedEnabled: true,
+		},
+		{
+			name: "dpdk initialized, valid mask 0xc: enabled, CPUs 2 and 3",
+			ovsData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", DpdkInitialized: true,
+					OtherConfig: map[string]string{"pmd-cpu-mask": "0xc"}},
+			},
+			expectedCPUs:    cpuset.New(2, 3),
+			expectedEnabled: true,
+		},
+		{
+			name: "dpdk initialized, invalid mask: enabled but empty CPUs",
+			ovsData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", DpdkInitialized: true,
+					OtherConfig: map[string]string{"pmd-cpu-mask": "xyz"}},
+			},
+			expectedCPUs:    cpuset.New(),
+			expectedEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ovsClient, testCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+				OVSData: tt.ovsData,
+			})
+			require.NoError(t, err)
+			defer testCtx.Cleanup()
+
+			cpus, enabled := getPmdCPUs(ovsClient)
+			assert.Equal(t, tt.expectedCPUs, cpus)
+			assert.Equal(t, tt.expectedEnabled, enabled)
+		})
+	}
+}
+
+func TestParsePmdCpuMask(t *testing.T) {
+	tests := []struct {
+		name        string
+		mask        string
+		expected    []int
+		expectError bool
+	}{
+		{name: "hex with 0x prefix", mask: "0xc", expected: []int{2, 3}},
+		{name: "hex with 0X prefix", mask: "0XC", expected: []int{2, 3}},
+		{name: "bare hex lowercase", mask: "c", expected: []int{2, 3}},
+		{name: "bare hex uppercase", mask: "C", expected: []int{2, 3}},
+		{name: "single bit", mask: "0x1", expected: []int{0}},
+		{name: "multiple bits", mask: "0x6", expected: []int{1, 2}},
+		{name: "all low byte", mask: "0xff", expected: []int{0, 1, 2, 3, 4, 5, 6, 7}},
+		{name: "zero", mask: "0x0", expected: []int{}},
+		{name: "leading zeros", mask: "0x0000000000000006", expected: []int{1, 2}},
+		{name: "empty string", mask: "", expected: []int{}},
+		{name: "whitespace only", mask: "  ", expected: []int{}},
+		{name: "with whitespace", mask: " 0xc ", expected: []int{2, 3}},
+		{name: "invalid", mask: "xyz", expectError: true},
+		{name: "CPU 64 only", mask: "0x10000000000000000", expected: []int{64}},
+		{name: "CPUs spanning 64-bit boundary", mask: "0x10000000000000003", expected: []int{0, 1, 64}},
+		{name: "CPU 128 only", mask: "0x100000000000000000000000000000000", expected: []int{128}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parsePmdCpuMask(tt.mask)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, cpuset.New(tt.expected...), result)
+		})
 	}
 }

--- a/go-controller/pkg/node/ovspinning/ovspinning_noop.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_noop.go
@@ -9,11 +9,12 @@ package ovspinning
 import (
 	"context"
 
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"k8s.io/klog/v2"
 
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
-func Run(_ context.Context, _ <-chan struct{}, _ podresourcesapi.PodResourcesListerClient) {
+func Run(_ context.Context, _ <-chan struct{}, _ podresourcesapi.PodResourcesListerClient, _ libovsdbclient.Client) {
 	klog.Infof("OVS CPU pinning is supported on linux platform only")
 }


### PR DESCRIPTION
In case OVS-DPDK is enabled in the same ovs-vswitchd daemon ovn-k8s manages, new PMD (Poll-Mode-Driver) threads will be created. These threads must be carefully pinned to maximize performance so `ovspinning` should skip them.