### PR TITLE
agents: Add AGENTS.md project context for AI coding/review agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# AGENTS.md — OVN-Kubernetes
+
+Project context for AI coding agents. See [agents.md](https://agents.md/) for the open standard.
+
+## Project Overview
+
+OVN-Kubernetes is a network plugin written according to CNI Spec that provides
+networking for Kubernetes clusters with Open Virtual Network (OVN) and
+Open vSwitch (OVS) at its core.
+
+| Feature | Description |
+|---------|-------------|
+| Pod Networking | Pod-to-pod connectivity via OVN logical switches and routers |
+| IPAM | IP address management for pods and networks |
+| Services | Kubernetes Services implemented as OVN load balancers |
+| Endpoint Slices | Scalable endpoint tracking for services |
+| NetworkPolicy | Kubernetes NetworkPolicy enforcement via OVN ACLs |
+| AdminNetworkPolicy | Cluster-scoped network policy (ANP/BANP) |
+| EgressIP | Source IP control for egress traffic |
+| EgressFirewall | Egress traffic filtering rules |
+| EgressService | Egress traffic routing through services |
+| EgressQoS | QoS marking on egress traffic |
+| Multi-Egress Gateway | Egress traffic via multiple gateway nodes |
+| User Defined Networks | Multi-network support, network segmentation (UDN) |
+| Cluster Network Connect | Connecting isolated User Defined Networks together for controlled inter-UDN connectivity |
+| Multi-Homing | Pods attached to multiple networks |
+| DPU/SmartNIC Offload | Hardware acceleration via OVS offload |
+| Multicast | IGMP snooping and relay via OVN |
+| NetworkQoS | DSCP marking and traffic shaping |
+| BGP | Route advertisements and peering |
+| EVPN | Ethernet VPN integration |
+| No-Overlay | Direct pod routing using BGP-learned routes, without encapsulation |
+| KubeVirt | VM live migration and persistent IPs support |
+| Hybrid Overlay | Mixed Windows/Linux clusters via VXLAN |
+
+## Repository Layout
+
+```text
+go-controller/ # Main Go codebase — feature implementations, component code, ovnkube binaries, CRDs, libovsdb models, observability library, hybrid-overlay
+test/e2e/      # End-to-end Ginkgo tests covering all features (network policy, egress, UDN, KubeVirt, BGP, etc.)
+dist/          # Container images (Dockerfiles) and deployment YAML manifests
+helm/          # Helm charts for deploying ovn-kubernetes
+docs/          # mkdocs source for ovn-kubernetes.io — OKEPs, feature docs, design docs, developer, installation guides
+contrib/       # Kind cluster scripts, local deployment helpers (kind.sh), and development tooling
+LICENSES/      # License and third-party package licensing information
+```
+
+## Build and Test
+
+```bash
+cd go-controller/
+make build          # Build ovnkube binaries
+make lint           # Format and lint Go code (required before PR)
+make test           # Run unit tests
+```
+
+E2E tests run via CI on Kind clusters. See `test/e2e/` for Ginkgo test suites.
+To run E2E locally, first set up a Kind cluster using `contrib/kind.sh`, then run the tests.
+See `docs/developer-guide/local_testing_guide.md` for more details.
+
+## Key Conventions
+
+See `CONTRIBUTING.md` for full details:
+- [Commit message guidelines](CONTRIBUTING.md#commit-message-guidelines)
+- [Pull request checklist](CONTRIBUTING.md#pull-request-checklist)
+- [Sign your commits (DCO)](CONTRIBUTING.md#sign-your-commits)
+- [AI guidelines](CONTRIBUTING.md#ai-guidelines)
+
+## OKEPs (Enhancement Proposals)
+
+New features require an OKEP in `docs/okeps/`. See `docs/okeps/okep-4368-template.md` for the
+template. OKEPs must have an associated GitHub issue, cover all template sections and update
+`mkdocs.yml`.
+
+## Architecture Notes
+
+The OVN-Kubernetes plugin watches the Kubernetes API. It acts on the generated Kubernetes
+cluster events by creating and configuring the corresponding OVN logical constructs in the
+OVN database for those events. OVN (which is an abstraction on top of Open vSwitch) converts
+these logical constructs into logical flows in its database and programs the OpenFlow flows
+on the node, which enables networking on a Kubernetes cluster.
+
+See [Architecture](docs/design/architecture.md) for component details (ovnkube-control-plane,
+ovnkube-node, ovs-node pods and their containers).
+
+### Gateway Modes
+
+OVN-Kubernetes supports two gateway modes that affect how traffic enters and
+leaves the cluster:
+- **Local gateway (lgw)** — Traffic leaving the pod to go outside the cluster leaves the OVN stack
+  and enters the host networking stack via the management port (mp-X) and then based on routes on
+  the host, it either leaves via breth0/primary node NIC or via other interfaces on the host. This
+  mode uses nftables to implement a lot of the service traffic and since traffic leaves the OVN/OVS
+  datapath, it is not hardware offloadable.
+- **Shared gateway (sgw)** — Traffic leaving the pod to go outside the cluster stays within the
+  OVN/OVS datapath. It goes from the pod through the OVN logical switch, to the Gateway Router
+  (GR), and out via the OVS bridge (breth0) directly. This mode is hardware offloadable to DPUs/SmartNICs.
+
+To determine which mode a cluster is using, check the `k8s.ovn.org/l3-gateway-config`
+annotation on any node — the `mode` field will be `"local"` or `"shared"`.
+Shared gateway is the default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,9 @@ The best way to reach us with a question when contributing is to ask on:
 
 ## Pull Request Lifecycle
 
-1. When you open a PR a maintainer will automatically be assigned for review
+1. When you open a PR a reviewer will automatically be assigned. This need not be a maintainer.
 2. Make sure that your PR is passing CI - if you need help with failing checks please feel free to ask!
-3. Once it is passing all CI checks, a maintainer will review your PR and you may be asked to make changes.
-4. When you have received at least one approval from a maintainer, that maintainer will merge your PR.
+3. Once the assigned reviewer approves (+1), a maintainer (see `MAINTAINERS.md` for the current list) will review and merge your PR. You may be asked to make additional changes by maintainer post reviewer's approval.
 
 In some cases, other changes may conflict with your PR. If this happens, you will get notified by a comment in the issue that your PR requires a rebase, and the `needs-rebase` label will be applied. Once a rebase has been performed, this label will be automatically removed.
 
@@ -196,6 +195,8 @@ make test
 * All modular changes must be accompanied by new unit tests if they don't exist already.
 
 * All functional changes and new features must be accompanied by extensive end-to-end test coverage
+
+* Documentation updates are required when user-facing behavior changes
 
 ## AI Guidelines
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -21,6 +21,10 @@ which is super lightweight and running only on the control plane nodes in your c
         * Allocates transit subnet IP to each node
         * Consolidates zone statuses across all nodes for features like EgressFirewall
         and EgressQoS
+* ovnkube-identity pod
+    * Runs only on control-plane nodes
+    * Provides certificate-based identity for node authentication
+    * Ensures requests from ovnkube-node pods are authenticated and authorized
 
 The data plane includes the `ovnkube-node` and `ovs-node` pods in the `ovn-kubernetes`
 namespace running on all your nodes in the cluster making this architecture localized


### PR DESCRIPTION
Add a root-level AGENTS.md following the open standard
https://agents.md/ to provide project
context to AI coding agents. This file is auto-detected by
CodeRabbit, Cursor, Claude Code (CLAUDE.md symlink), Codex,
Copilot, Gemini CLI etc

Covers: repo layout, build commands, commit format, PR
requirements, AI usage policy, OKEP process, and architecture
notes.

Refs: https://agents.md/, https://www.aihero.dev/a-complete-guide-to-agents-md

Some examples from other projects for reference:

1. https://github.com/kubernetes/kubernetes/blob/master/AGENTS.md
2.  https://github.com/kubernetes-sigs/kubebuilder/pull/5273
3. https://github.com/openshift/hypershift/blob/main/AGENTS.md
4. https://github.com/openshift/cluster-ingress-operator/blob/master/AGENTS.md