### PR TITLE
e2e: require stable ETP=local nodeport responses

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1219,7 +1219,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 	endpointsSelector := map[string]string{"servicebackend": "true"}
 
 	var endPoints []*v1.Pod
-	var nodesHostnames sets.String
+	var nodesHostnames sets.Set[string]
 	var maxTries int
 	var nodes *v1.NodeList
 	var newNodeAddresses []string
@@ -1235,7 +1235,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 
 		ginkgo.BeforeEach(func() {
 			endPoints = make([]*v1.Pod, 0)
-			nodesHostnames = sets.NewString()
+			nodesHostnames = sets.New[string]()
 
 			var err error
 			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
@@ -1315,7 +1315,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 							continue
 						}
 
-						responses := sets.NewString()
+						responses := sets.New[string]()
 						valid := false
 						nodePort := nodeTCPPort
 						if protocol == "udp" {
@@ -1463,7 +1463,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 							for _, protocol := range []string{"http", "udp"} {
 								port := protocolPorts[protocol]
 								ginkgo.By(fmt.Sprintf("Hitting nodeport %s/%d on %s with IP %s and reaching all the endpoints ", protocol, port, nodeName, address))
-								responses := sets.NewString()
+								responses := sets.New[string]()
 								valid := false
 								for i := 0; i < maxTries; i++ {
 									epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, address, port, "hostname")
@@ -1639,7 +1639,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 
 		ginkgo.BeforeEach(func() {
 			endPoints = make([]*v1.Pod, 0)
-			nodesHostnames = sets.NewString()
+			nodesHostnames = sets.New[string]()
 
 			var err error
 			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
@@ -1740,7 +1740,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 
 			for _, protocol := range []string{"http", "udp"} {
 				for _, externalAddress := range newNodeAddresses {
-					responses := sets.NewString()
+					responses := sets.New[string]()
 					valid := false
 					externalPort := int32(clusterHTTPPort)
 					if protocol == "udp" {
@@ -1782,7 +1782,7 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 	f := wrappedTestFramework("nodeport-ingress-test")
 	hostNetEndpointsSelector := map[string]string{"hostNetservicebackend": "true"}
 	var endPoints []*v1.Pod
-	var nodesHostnames sets.String
+	var nodesHostnames sets.Set[string]
 	var nodes *v1.NodeList
 	var providerCtx infraapi.Context
 	var isDualStack bool
@@ -1804,7 +1804,7 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 
 		ginkgo.BeforeEach(func() {
 			endPoints = make([]*v1.Pod, 0)
-			nodesHostnames = sets.NewString()
+			nodesHostnames = sets.New[string]()
 
 			var err error
 			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -53,6 +53,10 @@ const (
 	redirectPort         = "13337"
 	defaultPodInterface  = "eth0"
 	udnPodInterface      = "ovn-udn1"
+
+	localNodePortConvergenceTimeout      = 10 * time.Second
+	localNodePortConvergencePollInterval = 1 * time.Second
+	localNodePortStableProbeCount        = 3
 )
 
 // setupHostRedirectPod
@@ -515,6 +519,60 @@ func IsGatewayModeLocal(cs kubernetes.Interface) bool {
 	l3Config, err := util.ParseNodeL3GatewayAnnotation(node)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "must get node l3 gateway annotation")
 	return l3Config.Mode == config.GatewayModeLocal
+}
+
+// validateStableLocalEndpointViaExternalContainer probes a NodePort until several consecutive
+// hostname/client-IP response pairs match the expected local endpoint. currentResponses is
+// returned for failure diagnostics only; transient non-local responses do not affect success
+// after the service converges.
+func validateStableLocalEndpointViaExternalContainer(externalContainer infraapi.ExternalContainer, protocol, nodeAddress string, nodePort int32, expectedResponses sets.Set[string]) (sets.Set[string], error) {
+	ginkgo.GinkgoHelper()
+	var currentResponses sets.Set[string]
+	consecutiveMatches := 0
+	var lastErr error
+
+	err := wait.PollUntilContextTimeout(context.Background(), localNodePortConvergencePollInterval, localNodePortConvergenceTimeout, true, func(context.Context) (bool, error) {
+		// hostname and clientip are two separate requests; the consecutive-match
+		// requirement below absorbs any transient mismatch between them.
+		epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress, nodePort, "hostname")
+		rawClientIP := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress, nodePort, "clientip")
+		currentResponses = sets.New[string]()
+
+		matched := false
+		switch {
+		case epHostname == "" || rawClientIP == "":
+			lastErr = fmt.Errorf("empty response hostname=%q clientIP=%q", epHostname, rawClientIP)
+		default:
+			epClientIP, _, err := net.SplitHostPort(rawClientIP)
+			if err != nil {
+				lastErr = fmt.Errorf("failed to parse client ip %q: %w", rawClientIP, err)
+				break
+			}
+			currentResponses.Insert(epHostname, epClientIP)
+			if matched = currentResponses.Equal(expectedResponses); !matched {
+				lastErr = fmt.Errorf("observed responses %v, expected %v", currentResponses, expectedResponses)
+			}
+		}
+
+		if !matched {
+			consecutiveMatches = 0
+			return false, nil
+		}
+		consecutiveMatches++
+		if consecutiveMatches == localNodePortStableProbeCount {
+			return true, nil
+		}
+		lastErr = fmt.Errorf("observed expected responses %v for %d/%d consecutive probes", currentResponses, consecutiveMatches, localNodePortStableProbeCount)
+		return false, nil
+	})
+
+	if err != nil {
+		if lastErr != nil {
+			return currentResponses, fmt.Errorf("timed out waiting for stable local nodeport responses: %w", lastErr)
+		}
+		return currentResponses, err
+	}
+	return currentResponses, nil
 }
 
 // restartOVNKubeNodePod restarts the ovnkube-node pod from namespace, running on nodeName
@@ -1463,9 +1521,8 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 							continue
 						}
 
-						responses := sets.NewString()
 						// Fill expected responses, it should hit the nodeLocal endpoints and not SNAT packet IP
-						expectedResponses := sets.NewString()
+						expectedResponses := sets.New[string]()
 
 						if utilnet.IsIPv6String(nodeAddress.Address) {
 							expectedResponses.Insert(node.Name+"-ep", externalContainer.GetIPv6())
@@ -1473,33 +1530,16 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 							expectedResponses.Insert(node.Name+"-ep", externalContainer.GetIPv4())
 						}
 
-						valid := false
 						nodePort := nodeTCPPort
 						if protocol == "udp" {
 							nodePort = nodeUDPPort
 						}
 
 						ginkgo.By("Hitting the nodeport on " + node.Name + " and trying to reach only the local endpoint with protocol " + protocol)
-
-						for i := 0; i < maxTries; i++ {
-							epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "hostname")
-							epClientIP := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "clientip")
-							if epHostname == "" || epClientIP == "" {
-								continue
-							}
-							epClientIP, _, err = net.SplitHostPort(epClientIP)
-							if err != nil {
-								continue
-							}
-							responses.Insert(epHostname, epClientIP)
-
-							if responses.Equal(expectedResponses) {
-								framework.Logf("Validated local endpoint on node %s with address %s, and packet src IP %s", node.Name, nodeAddress.Address, epClientIP)
-								valid = true
-								break
-							}
-						}
-						gomega.Expect(valid).To(gomega.Equal(true), fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Actual Responses=%v", node.Name, expectedResponses, responses))
+						currentResponses, err := validateStableLocalEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, expectedResponses)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+							fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Current Responses=%v", node.Name, expectedResponses, currentResponses))
+						framework.Logf("Validated stable local endpoint responses for node %s with address %s", node.Name, nodeAddress.Address)
 					}
 				}
 			}
@@ -1743,7 +1783,6 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 	hostNetEndpointsSelector := map[string]string{"hostNetservicebackend": "true"}
 	var endPoints []*v1.Pod
 	var nodesHostnames sets.String
-	maxTries := 0
 	var nodes *v1.NodeList
 	var providerCtx infraapi.Context
 	var isDualStack bool
@@ -1798,9 +1837,6 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 				framework.ExpectNoError(err)
 				endPoints = append(endPoints, hostNetPod)
 				nodesHostnames.Insert(hostNetPod.Name)
-
-				// this is arbitrary and mutuated from k8s network e2e tests. We aim to hit all the endpoints at least once
-				maxTries = len(endPoints)*len(endPoints) + 30
 			}
 
 			ginkgo.By("Creating an external container to send the traffic from")
@@ -1846,9 +1882,8 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 							continue
 						}
 
-						responses := sets.NewString()
 						// Fill expected responses, it should hit the nodeLocal endpoints and not SNAT packet IP
-						expectedResponses := sets.NewString()
+						expectedResponses := sets.New[string]()
 
 						if utilnet.IsIPv6String(nodeAddress.Address) {
 							expectedResponses.Insert(node.Name, externalContainer.GetIPv6())
@@ -1856,33 +1891,16 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 							expectedResponses.Insert(node.Name, externalContainer.GetIPv4())
 						}
 
-						valid := false
 						nodePort := nodeTCPPort
 						if protocol == "udp" {
 							nodePort = nodeUDPPort
 						}
 
 						ginkgo.By("Hitting the nodeport on " + node.Name + " and trying to reach only the local endpoint with protocol " + protocol)
-						for i := 0; i < maxTries; i++ {
-							epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "hostname")
-							epClientIP := pokeEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, "clientip")
-							if epHostname == "" || epClientIP == "" {
-								continue
-							}
-							epClientIP, _, err = net.SplitHostPort(epClientIP)
-							if err != nil {
-								continue
-							}
-							responses.Insert(epHostname, epClientIP)
-
-							if responses.Equal(expectedResponses) {
-								framework.Logf("Validated local endpoint on node %s with address %s, and packet src IP %s ", node.Name, nodeAddress.Address, epClientIP)
-								valid = true
-								break
-							}
-						}
-						gomega.Expect(valid).To(gomega.Equal(true),
-							fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Actual Responses=%v", node.Name, expectedResponses, responses))
+						currentResponses, err := validateStableLocalEndpointViaExternalContainer(externalContainer, protocol, nodeAddress.Address, nodePort, expectedResponses)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+							fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Current Responses=%v", node.Name, expectedResponses, currentResponses))
+						framework.Logf("Validated stable local endpoint responses for node %s with address %s", node.Name, nodeAddress.Address)
 					}
 				}
 			}

--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -647,7 +647,7 @@ spec:
 				ginkgo.By("Selecting additional IP addresses for serverNode on which source pod lives (networking routing to secondaryIP address on other nodes is harder to achieve)")
 				// add new secondary IP from node subnet to the node where the source pod lives on,
 				// if the cluster is v6 add an ipv6 address
-				toCurlSecondaryNodeIPAddresses := sets.NewString()
+				toCurlSecondaryNodeIPAddresses := sets.New[string]()
 				// node2ndaryIPs holds the nodeName as the key and the value is
 				// a map with ipFamily(v4 or v6) as the key and the secondaryIP as the value
 				node2ndaryIPs := make(map[string]map[int]string)
@@ -699,7 +699,7 @@ spec:
 				}
 
 				ginkgo.By("Should NOT be able to reach each secondary hostIP via node selector")
-				for _, address := range toCurlSecondaryNodeIPAddresses.List() {
+				for _, address := range sets.List(toCurlSecondaryNodeIPAddresses) {
 					if !IsIPv6Cluster(f.ClientSet) && utilnet.IsIPv6String(address) || IsIPv6Cluster(f.ClientSet) && !utilnet.IsIPv6String(address) {
 						continue
 					}
@@ -739,7 +739,7 @@ spec:
 				}
 
 				ginkgo.By("Should be able to reach secondary hostIP via node selector")
-				for _, address := range toCurlSecondaryNodeIPAddresses.List() {
+				for _, address := range sets.List(toCurlSecondaryNodeIPAddresses) {
 					if !IsIPv6Cluster(f.ClientSet) && utilnet.IsIPv6String(address) || IsIPv6Cluster(f.ClientSet) && !utilnet.IsIPv6String(address) {
 						continue
 					}

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -1638,7 +1638,7 @@ spec:
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.Expect(stdout).To(gomega.Equal(fmt.Sprintf("adminpolicybasedexternalroute.k8s.ovn.org/%s created\n", policyName)))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gwIPs := sets.NewString(gateways...).List()
+	gwIPs := sets.List(sets.New(gateways...))
 	gomega.Eventually(func() string {
 		lastMsg, err := e2ekubectl.RunKubectl("", "get", "apbexternalroute", policyName, "-ojsonpath={.status.messages[-1:]}")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1659,7 +1659,7 @@ func checkAPBExternalRouteStatus(policyName string) {
 
 func createAPBExternalRouteCRWithStaticHop(policyName, namespaceName string, bfd bool, gateways ...string) {
 	createAPBExternalRouteCRWithStaticHopAndStatus(policyName, namespaceName, bfd, "Success", gateways...)
-	gwIPs := sets.NewString(gateways...).List()
+	gwIPs := sets.List(sets.New(gateways...))
 	gomega.Eventually(func() string {
 		lastMsg, err := e2ekubectl.RunKubectl("", "get", "apbexternalroute", policyName, "-ojsonpath={.status.messages[-1:]}")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -980,7 +980,7 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 		ginkgo.It("should listen on each host addresses", func() {
 			endPoints := make([]*v1.Pod, 0)
 			endpointsSelector := map[string]string{"servicebackend": "true"}
-			nodesHostnames := sets.NewString()
+			nodesHostnames := sets.New[string]()
 			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
 			framework.ExpectNoError(err)
 
@@ -1024,7 +1024,7 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 
 			ginkgo.By("Selecting additional IP addresses for each node")
 			// add new secondary IP from node subnet to all nodes, if the cluster is v6 add an ipv6 address
-			toCurlAddresses := sets.NewString()
+			toCurlAddresses := sets.New[string]()
 			primaryIPv4Subnet, ipv6, err := primaryProviderNetwork.IPv4IPv6Subnets()
 			framework.ExpectNoError(err, "must get primary provider network subnets")
 			primaryNetworkSubnet := primaryIPv4Subnet
@@ -1142,7 +1142,7 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 						toCurlPort = int32(udpNodePort)
 					}
 
-					for _, address := range toCurlAddresses.List() {
+					for _, address := range sets.List(toCurlAddresses) {
 						if !isIPv6Cluster && utilnet.IsIPv6String(address) {
 							continue
 						}
@@ -1162,7 +1162,7 @@ var _ = ginkgo.Describe("Services", feature.Service, func() {
 		ginkgo.It("should work on secondary node interfaces for ETP=local and ETP=cluster when backend pods are also served by EgressIP", func() {
 			endPoints := make([]*v1.Pod, 0)
 			endpointsSelector := map[string]string{"servicebackend": "true"}
-			nodesHostnames := sets.NewString()
+			nodesHostnames := sets.New[string]()
 			isIPv6Cluster := IsIPv6Cluster(f.ClientSet)
 
 			nodes, err = e2enode.GetBoundedReadySchedulableNodes(context.TODO(), f.ClientSet, 3)
@@ -1301,7 +1301,7 @@ spec:
 			}
 			_, secondarySubnet, err := net.ParseCIDR(secondarySubnetStr)
 			framework.ExpectNoError(err, "must parse secondary subnet %q", secondarySubnetStr)
-			toCurlAddressesSecondary := sets.NewString()
+			toCurlAddressesSecondary := sets.New[string]()
 			for i, node := range nodes.Items {
 				addrAnnotation, ok := node.Annotations["k8s.ovn.org/host-cidrs"]
 				gomega.Expect(ok).To(gomega.BeTrue())
@@ -1405,7 +1405,7 @@ spec:
 				"a network that is a secondary host network and verify that the src IP is the expected egressIP %s, failed: %v",
 				egressPod.Namespace, egressPod.Name, egressIP, err)
 
-			externalSvcClientIPs := sets.NewString(serverExternalContainerIP)
+			externalSvcClientIPs := sets.New(serverExternalContainerIP)
 			for _, serviceSpec := range []*v1.Service{etpLocalSvc, etpClusterSvc} {
 				tcpNodePort, udpNodePort := nodePortsFromService(serviceSpec)
 
@@ -1414,7 +1414,7 @@ spec:
 					if protocol == "udp" {
 						toCurlPort = int32(udpNodePort)
 					}
-					for _, address := range toCurlAddressesSecondary.List() {
+					for _, address := range sets.List(toCurlAddressesSecondary) {
 						if !isIPv6Cluster && utilnet.IsIPv6String(address) {
 							continue
 						}
@@ -2192,8 +2192,8 @@ spec:
 				Namespace: namespace,
 			},
 			Spec: v1.ServiceSpec{
-				Selector: labels,
-				Type:     v1.ServiceTypeNodePort,
+				Selector:              labels,
+				Type:                  v1.ServiceTypeNodePort,
 				IPFamilyPolicy:        ptr.To(v1.IPFamilyPolicyPreferDualStack),
 				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 				Ports: []v1.ServicePort{
@@ -2366,8 +2366,8 @@ spec:
 				Namespace: namespace,
 			},
 			Spec: v1.ServiceSpec{
-				Selector: labels,
-				Type:     v1.ServiceTypeNodePort,
+				Selector:              labels,
+				Type:                  v1.ServiceTypeNodePort,
 				IPFamilyPolicy:        ptr.To(v1.IPFamilyPolicyPreferDualStack),
 				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 				Ports: []v1.ServicePort{

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -379,8 +379,8 @@ func pokeEndpointViaNode(nodeName, protocol, targetHost string, localPort, targe
 
 // wrapper logic around pokeEndpoint
 // contact the ExternalIP service until each endpoint returns its hostname and return true, or false otherwise
-func pokeExternalIpService(externalContainer infraapi.ExternalContainer, protocol, externalAddress string, externalPort int32, maxTries int, nodesHostnames sets.String) bool {
-	responses := sets.NewString()
+func pokeExternalIpService(externalContainer infraapi.ExternalContainer, protocol, externalAddress string, externalPort int32, maxTries int, nodesHostnames sets.Set[string]) bool {
+	responses := sets.New[string]()
 
 	for i := 0; i < maxTries; i++ {
 		epHostname := pokeEndpointViaExternalContainer(externalContainer, protocol, externalAddress, externalPort, "hostname")


### PR DESCRIPTION
The no-overlay CI lane failed (https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/26942442261/job/79488477055?pr=6498 ) because the ETP=Local NodePort test saw a transient non-local host-network endpoint while the service datapath was still converging:

`Expected Responses=map[172.18.0.6:{} ovn-control-plane:{}], Actual Responses=map[172.18.0.6:{} ovn-control-plane:{} ovn-worker:{}]`

Despite the retry loop, the test accumulated every hostname/client-IP response in the same set used for validation. Once a transient non-local endpoint was inserted, the expected response set could never match, even if later probes reached the correct local endpoint.

So the e2e test would only succeed if the first attempt succeeded, despite the retry loop. Accepting the first expected response is too weak because it could be one lucky hit during convergence.

Validate each current hostname/client-IP response pair against the expected local endpoint and require three consecutive expected pairs before passing.

Assisted-by: Codex
Signed-off-by: Riccardo Ravaioli <rravaioli@nvidia.com> 


Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6502 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a polling-based stability check for NodePort responses under externalTrafficPolicy=local, replacing single-try matches and improving diagnostic output on failure.
  * Modernized test collections to use typed generic set utilities for iteration and comparison.
  * Updated egress and external-gateway tests for consistent set handling and more reliable assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->