### PR TITLE
fix: Use default GOTOOLCHAIN=auto when generating license files

### DIFF
--- a/go-controller/hack/update-third-party-licenses.sh
+++ b/go-controller/hack/update-third-party-licenses.sh
@@ -202,7 +202,7 @@ collect_module_downloads() {
                     cp go.sum "${tmp_sumfile}"
                 fi
 
-                GOTOOLCHAIN=local GOWORK=off GOFLAGS=-mod=mod \
+                GOWORK=off GOFLAGS=-mod=mod \
                     go mod download -modfile="$(basename "${tmp_modfile}")" -json all || true
             )
         done \

--- a/go-controller/hack/update-third-party-licenses.sh
+++ b/go-controller/hack/update-third-party-licenses.sh
@@ -268,6 +268,11 @@ generate_license_tree() {
         exit 1
     fi
 
+    if [[ ${#package_dirs[@]} -eq 0 ]]; then
+        echo "no third-party module source directories were collected; refusing to overwrite ${LICENSES_DIR}" >&2
+        exit 1
+    fi
+
     for package_key in "${!package_dirs[@]}"; do
         package_path=${package_key%@*}
         resolved_version=${package_key##*@}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

This allows to run `make third-party-licenses` when required go version is not
installed. If that's the case, the target will download the necessary versions.

- **fix: Use default GOTOOLCHAIN=auto when generating license files**
- **fix: fail license generation on module download errors**

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

```
 nix shell github:NixOS/nixpkgs/release-25.05#go_1_23 --command go version
go version go1.23.12 darwin/arm64

 nix shell github:NixOS/nixpkgs/release-25.05#go_1_23 --command make  third-party-licenses -C go-controller/
make: Entering directory '/Users/ihrachyshka/src/ovn-kubernetes/go-controller'
go: downloading go1.25.1 (darwin/arm64)
go: downloading go1.25.0 (darwin/arm64)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the license generation script to validate that third-party modules were collected before proceeding, preventing unintended overwrites of the licenses directory when no modules are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->