### PR TITLE
Fix using docker for dpu-sim CI lane

### DIFF
--- a/.github/workflows/kind-dpu-offload.yml
+++ b/.github/workflows/kind-dpu-offload.yml
@@ -24,6 +24,7 @@ concurrency:
 env:
   DPU_SIM_REF: main
   OVN_KUBERNETES_PATH: ${{ github.workspace }}/ovn-kubernetes
+  KIND_EXPERIMENTAL_PROVIDER: docker
 
 jobs:
   kind-dpu-offload:


### PR DESCRIPTION
The CI lane was setting up docker, but then executing dpu-sim with podman. We need to use docker anyway in anticipation of landing https://github.com/ovn-kubernetes/dpu-simulator/pull/26



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-visible changes in this release. This update contains infrastructure and internal configuration adjustments only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->