### PR TITLE
CI: wait for service reachability after dual-stack conversion

### DIFF
--- a/contrib/kind-dual-stack-conversion.sh
+++ b/contrib/kind-dual-stack-conversion.sh
@@ -46,6 +46,26 @@ convert_cni() {
   echo "Updated CNI"
 }
 
+curl_service_from_node() {
+  local node=$1
+  local target=$2
+  local attempts=${3:-6}
+  local interval=${4:-2}
+  local timeout=${5:-5}
+
+  for i in $(seq 1 "${attempts}"); do
+    if docker exec "${node}" curl --max-time "${timeout}" --silent --show-error --fail "${target}" >/dev/null; then
+      echo "Validated ${target} from node ${node} after ${i} attempt(s)"
+      return 0
+    fi
+    if [ "${i}" -eq "${attempts}" ]; then
+      return 1
+    fi
+    echo "Waiting for ${target} to be reachable from node ${node} (${i}/${attempts})"
+    sleep "${interval}"
+  done
+}
+
 convert_k8s_control_plane(){
   # Kubeadm installs apiserver and controller-manager as static pods
   # one the configuration has changed kubelet restart them
@@ -288,11 +308,11 @@ IPS=()
 CLUSTER_IPV4=$(kubectl get services my-service-v4 -o jsonpath='{.spec.clusterIPs[0]}')
 IPS+=("${CLUSTER_IPV4}:8081")
 CLUSTER_IPV6=$(kubectl get services my-service-v6 -o jsonpath='{.spec.clusterIPs[0]}')
-IPS+=("\[${CLUSTER_IPV6}\]:8080")
+IPS+=("[${CLUSTER_IPV6}]:8080")
 
 for n in $NODES; do
-  for ip in ${IPS[@]}; do
-    docker exec $n curl --connect-timeout 5 $ip
+  for ip in "${IPS[@]}"; do
+    curl_service_from_node "${n}" "${ip}"
   done
 done
 


### PR DESCRIPTION
The dual-stack conversion setup validates service reachability immediately after restarting OVN-Kubernetes and recreating pods. In a failed CI job (https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/26942442261/job/79488476191?pr=6498), the IPv4 service curl succeeded, but the first IPv6 service curl timed out within its single 5-second connect window.

```
++ kubectl get services my-service-v4 -o 'jsonpath={.spec.clusterIPs[0]}'
+ CLUSTER_IPV4=10.96.19.207
+ IPS+=("${CLUSTER_IPV4}:8081")
++ kubectl get services my-service-v6 -o 'jsonpath={.spec.clusterIPs[0]}'
+ CLUSTER_IPV6=fd00:10:96::39b5
+ IPS+=("\[${CLUSTER_IPV6}\]:8080")
+ for n in $NODES
+ for ip in ${IPS[@]}
+ docker exec ovn-control-plane curl --connect-timeout 5 10.96.19.207:8081
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
100   191  100   191    0     0  44542      0 --:--:-- --:--:-- --:--:-- 47750
<html>
<head>
<title>It works! Apache httpd</title>
</head>
<body>
<p>It works!</p>
</body>
</html>
+ for ip in ${IPS[@]}
+ docker exec ovn-control-plane curl --connect-timeout 5 '\[fd00:10:96::39b5\]:8080'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
curl: (28) Failed to connect to fd00:10:96::39b5 port 8080 after 5001 ms: Timeout was reached
```

The log only proves that the IPv6 service was not reachable immediately after the setup readiness checks completed. The exact failed-attempt artifacts show that OVNK had transient IPv6 setup errors during conversion, but the OVN DB later had the IPv6 service VIP and backends before the curl ran. So the failure does not prove whether IPv6 service connectivity would have converged shortly afterward or whether the cluster had a persistent IPv6 connectivity problem.

Add a bounded retry around the post-conversion service curl checks, so transient post-conversion service/datapath convergence does not fail the setup step, while still failing if IPv4 or IPv6 service connectivity never becomes available.

Addresses https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6508 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced dual-stack service connectivity verification with automatic retry logic for improved reliability during network testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->