### PR TITLE
[FYI] prevent duplicate logical_router_static_route

### DIFF
--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -665,9 +665,7 @@ func (zic *ZoneInterconnectHandler) addRemoteNodeStaticRoutes(node *corev1.Node,
 		// external-ids, skip types.NetworkExternalID check in the predicate function to replace existing static route
 		// with correct external-ids on an upgrade scenario.
 		p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
-			return lrsr.IPPrefix == prefix &&
-				lrsr.Nexthop == nexthop &&
-				lrsr.ExternalIDs["ic-node"] == node.Name
+			return lrsr.IPPrefix == prefix
 		}
 		var err error
 		ops, err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicateOps(zic.nbClient, ops, zic.networkClusterRouterName, &logicalRouterStaticRoute, p)


### PR DESCRIPTION
On some OpenShift platforms I notice logical_router_static_route from previous deleted nodes are sometimes leaked and never cleaned, leading to traffic loss between nodes.

    ovn-nbctl lr-route-list ovn_cluster_router | grep ecmp
               10.224.67.0/24              100.88.10.33 dst-ip ecmp
               10.224.67.0/24              100.88.3.148 dst-ip ecmp
              10.224.192.0/24               100.88.1.94 dst-ip ecmp
              10.224.192.0/24              100.88.4.222 dst-ip ecmp

Proposal here to make sure no 2 routes with same prefix are created. Tested against a kind cluster in this fashion, where we simulate the addition of a node while a prior route already exists:

    k exec -ti -n ovn-kubernetes ovnkube-node-btx87 -c nb-ovsdb -- bash
    [root@ovn-worker ~]# ovn-nbctl lr-route-list ovn_cluster_router
    IPv4 Routes
    Route Table <main>:
                   100.64.0.2                100.88.0.2 dst-ip
                   100.64.0.3                100.88.0.3 dst-ip
                   100.64.0.4                100.64.0.4 dst-ip
                10.244.0.0/24                100.88.0.2 dst-ip
                10.244.1.0/24                100.88.0.3 dst-ip
                10.244.2.0/24                100.64.0.4 src-ip
                10.244.0.0/16                100.64.0.4 src-ip
    [root@ovn-worker ~]# ovn-nbctl  lr-route-del ovn_cluster_router   10.244.0.0/24                100.88.0.2
    [root@ovn-worker ~]# ovn-nbctl  lr-route-add ovn_cluster_router   10.244.0.0/24                1.2.3.4
    [root@ovn-worker ~]# ovn-nbctl lr-route-list ovn_cluster_router
    IPv4 Routes
    Route Table <main>:
                   100.64.0.2                100.88.0.2 dst-ip
                   100.64.0.3                100.88.0.3 dst-ip
                   100.64.0.4                100.64.0.4 dst-ip
                10.244.0.0/24                   1.2.3.4 dst-ip
                10.244.1.0/24                100.88.0.3 dst-ip
                10.244.2.0/24                100.64.0.4 src-ip
                10.244.0.0/16                100.64.0.4 src-ip

    k exec -ti -n ovn-kubernetes       ovnkube-node-btx87  -c ovnkube-controller -- bash
    pkill -f "bash /root/ovnkube.sh ovnkube-controller-with-node"

after restart check there is no duplicate:

    [root@ovn-worker ~]# ovn-nbctl lr-route-list ovn_cluster_router
    IPv4 Routes
    Route Table <main>:
                   100.64.0.2                100.88.0.2 dst-ip
                   100.64.0.3                100.88.0.3 dst-ip
                   100.64.0.4                100.64.0.4 dst-ip
                10.244.0.0/24                100.88.0.2 dst-ip
                10.244.1.0/24                100.88.0.3 dst-ip
                10.244.2.0/24                100.64.0.4 src-ip
                10.244.0.0/16                100.64.0.4 src-ip

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static route replacement logic in zone interconnect routing to enhance consistency handling during system upgrades and operational updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->