### PR TITLE
Sync reconcile pod-selector address sets at creation time

### DIFF
--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -330,8 +330,10 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 	}
 	addrSetKey = getInternalKey(podSelector, namespaceSelector, nodeSelector, namespace, controllerName, legacyNetpolMode)
 
+	var found bool
 	err = m.addressSets.DoWithLock(addrSetKey, func(key string) error {
-		psAddrSet, found := m.addressSets.Load(key)
+		var psAddrSet *podSelectorAddressSet
+		psAddrSet, found = m.addressSets.Load(key)
 		if !found {
 			addrSetDbIDs := GetPodSelectorAddrSetDbIDs(podSelector, namespaceSelector, nodeSelector, namespace, controllerName, legacyNetpolMode)
 			ipv4Mode, ipv6Mode := netInfo.IPMode()
@@ -343,6 +345,8 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 				addrSet, err = m.addressSetFactoryV6.EnsureAddressSet(addrSetDbIDs)
 			case ipv4Mode && ipv6Mode:
 				addrSet, err = m.addressSetFactoryDualstack.EnsureAddressSet(addrSetDbIDs)
+			default:
+				return fmt.Errorf("neither IPv4 nor IPv6 mode is enabled")
 			}
 			// if the first step of creating address set fails, return error since there is nothing to cleanup
 			if err != nil {
@@ -365,14 +369,26 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 				},
 			}
 			m.addressSets.LoadOrStore(key, psAddrSet)
-			// this only puts key to the queue, no lock
-			m.addressSetReconciler.Reconcile(key)
 		}
 		// psAddrSet is successfully init-ed
 		psAddrSet.backRefs[backRef] = true
 		psAddrSetHashV4, psAddrSetHashV6 = psAddrSet.addressSet.GetASHashNames()
 		return nil
 	})
+	if err != nil {
+		return
+	}
+	if !found {
+		// Populate a newly created address set before returning hashes to the caller.
+		// Until reconcile runs, the NB object is empty while ACLs may already reference it
+		// (e.g. on DB ID change or first ensure). This is a one-time sync on creation;
+		// existing sets are kept up to date by the async reconciler on pod/namespace/node events.
+		if reconcileErr := m.reconcileAddressSet(addrSetKey); reconcileErr != nil {
+			klog.Errorf("Failed to reconcile address set %s on ensure: %v", addrSetKey, reconcileErr)
+			// this only puts key to the queue, no lock
+			m.addressSetReconciler.Reconcile(addrSetKey)
+		}
+	}
 	return
 }
 

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -197,6 +197,24 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Consistently(addressSetManager.nbClient, 100*time.Millisecond, 20*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{}))
 	})
 
+	ginkgo.It("populates address set synchronously on first ensure", func() {
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		podIP := "10.128.1.3"
+		peer := knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{},
+		}
+		pod := testing.NewPod(namespace1.Name, "pod1", nodeName, podIP)
+		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*pod})
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(
+			peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dbIDs := GetPodSelectorAddrSetDbIDs(peer.PodSelector, peer.NamespaceSelector, nil, namespace1.Name, controllerName, false)
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{podIP})
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+	})
+
 	ginkgo.It("reconciles the registered cluster node IP address set on node events", func() {
 		node1 := corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -881,7 +899,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		restartedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{node2MgmtIP})
-		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{restartedAS}))
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{restartedAS}))
 	})
 	ginkgo.It("updates IPs for existing nodes when the host network traffic namespace is created", func() {
 		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"


### PR DESCRIPTION
When EnsureAddressSet creates a new in-memory entry for a new DB ID, it returns hashes before async reconcile populates the NB address set. ACLs wired during that window can reference an empty set. Populate from the informer cache synchronously before registration.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address sets are now populated synchronously when created, improving initialization reliability.
  * Invalid configurations that are neither IPv4-only nor IPv6-only are now rejected with an error.

* **Tests**
  * Tests updated to verify synchronous address-set population and to use deterministic assertions for address-set state validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->