### PR TITLE
Improve/fix config.Gateway.DisableForwarding

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -40,9 +40,9 @@ provides the `disable-forwarding` config/command-line option to do this:
 
   - If `disable-forwarding` is `false`:
 
-      - OVN-Kubernetes sets the default policy of the ip6tables `FORWARD` chain to
-        `ACCEPT`. (This normally has no effect since that's the normal default policy
-        anyway.)
+      - OVN-Kubernetes does not take any action other than resetting the default policy of
+        the `FORWARD` chain back to `ACCEPT` if it appears that OVN-Kubernetes itself had
+        previously set it to `DROP`.
 
 For consistency, OVN-Kubernetes also applies the effect of `disable-forwarding` to IPv4 as
 well, even though it is not necessary.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -14,19 +14,25 @@ OVN-Kubernetes configures packet forwarding as follows:
     the OVN-Kubernetes management port and bridge interfaces, allowing IPv4 packets to be
     forwarded to and from those interfaces specifically.
 
-  - If IPv6 is enabled, it sets the `net.ipv6.conf.all.forwarding` sysctl to `1`, enabling
-    IPv6 packets to be forwarded to and from _all_ interfaces. (Until recently, the kernel
-    did not support enabling IPv6 forwarding only on specific interfaces.)
+  - If IPv6 is enabled, and you are using a sufficiently new kernel (6.17+), it sets the
+    `net.ipv6.conf.[IFNAME].force_forwarding` sysctl to `1` on the OVN-Kubernetes
+    management port and bridge interfaces, allowing IPv6 packets to be forwarded to and
+    from those interfaces specifically.
 
-The result is that for IPv4, packet forwarding is only enabled on OVN-Kubernetes's own
-interfaces (unless the administrator set `net.ipv4.ip_forward` themselves to enable global
-IPv4 forwarding), but for IPv6, packet forwarding is enabled on _all_ interfaces.
+The result is that packet forwarding is only enabled on OVN-Kubernetes's own interfaces
+(unless the administrator set `net.ipv4.ip_forward` and/or `net.ipv6.conf.all.forwarding`
+themselves to enable global forwarding)
 
-The [IP sysctl documentation] suggests that if you only want IPv6 forwarding on specific
-interfaces, you should use iptables rules to block it on other interfaces. OVN-Kubernetes
-provides the `disable-forwarding` config/command-line option to do this:
+Older (pre-6.17) kernels did not support per-interface IPv6 forwarding, so if you are
+running on an older host with IPv6 enabled, OVN-Kubernetes has to set
+`net.ipv6.conf.all.forwarding` to `1`, enabling IPv6 packets to be forwarded to and from
+_all_ interfaces. The [IP sysctl documentation] recommends that if you only want IPv6
+forwarding on specific interfaces in this case, you should use iptables rules to block it
+on other interfaces. OVN-Kubernetes provides the `disable-forwarding` config/command-line
+option to do this:
 
-  - If `disable-forwarding` is `true` (and IPv6 is enabled):
+  - If `disable-forwarding` is `true` (and IPv6 is enabled, and the kernel does not
+    support per-interface IPv6 forwarding):
 
       - OVN-Kubernetes sets the default policy of the ip6tables `FORWARD` chain to
         `DROP`, blocking the effect of the global forwarding sysctls.
@@ -38,13 +44,15 @@ provides the `disable-forwarding` config/command-line option to do this:
       - This fixes IPv6 forwarding to work effectively the same as IPv4 forwarding: it is
         only allowed on OVN-Kubernetes's own interfaces.
 
-  - If `disable-forwarding` is `false` (or the cluster is single-stack IPv4):
+  - In all other cases (`disable-forwarding` is `false`, or the cluster is single-stack
+    IPv4, or the kernel supports per-interface IPv6 forwarding):
 
       - OVN-Kubernetes does not take any action other than resetting the default policy of
         the `FORWARD` chain back to `ACCEPT` if it appears that OVN-Kubernetes itself had
         previously set it to `DROP`.
 
-Note that setting `disable-forwarding` has no effect on IPv4 traffic.
+Note that setting `disable-forwarding` has no effect on IPv4 traffic, and has no effect on
+nodes with newer kernels.
 
 Note that this is always done via iptables, not nftables, to better preserve compatibility
 with other components. If ovn-kubernetes were to create its own `hook forward; policy

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -26,7 +26,7 @@ The [IP sysctl documentation] suggests that if you only want IPv6 forwarding on 
 interfaces, you should use iptables rules to block it on other interfaces. OVN-Kubernetes
 provides the `disable-forwarding` config/command-line option to do this:
 
-  - If `disable-forwarding` is `true`:
+  - If `disable-forwarding` is `true` (and IPv6 is enabled):
 
       - OVN-Kubernetes sets the default policy of the ip6tables `FORWARD` chain to
         `DROP`, blocking the effect of the global forwarding sysctls.
@@ -38,14 +38,13 @@ provides the `disable-forwarding` config/command-line option to do this:
       - This fixes IPv6 forwarding to work effectively the same as IPv4 forwarding: it is
         only allowed on OVN-Kubernetes's own interfaces.
 
-  - If `disable-forwarding` is `false`:
+  - If `disable-forwarding` is `false` (or the cluster is single-stack IPv4):
 
       - OVN-Kubernetes does not take any action other than resetting the default policy of
         the `FORWARD` chain back to `ACCEPT` if it appears that OVN-Kubernetes itself had
         previously set it to `DROP`.
 
-For consistency, OVN-Kubernetes also applies the effect of `disable-forwarding` to IPv4 as
-well, even though it is not necessary.
+Note that setting `disable-forwarding` has no effect on IPv4 traffic.
 
 Note that this is always done via iptables, not nftables, to better preserve compatibility
 with other components. If ovn-kubernetes were to create its own `hook forward; policy

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -8,120 +8,52 @@ Let us look at the supported configuration variables by OVN-Kubernetes
 
 ### Disable Forwarding Config
 
-OVN-Kubernetes allows to enable or disable IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex).
-By default forwarding is enabled and this allows host to forward traffic across OVN-Kubernetes managed interfaces.
-If forwarding is disabled then Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by cluster nodes.
+OVN-Kubernetes configures packet forwarding as follows:
 
-IP forwarding is implemented at cluster node level by modifying both iptables `FORWARD` chain and IP forwarding `sysctl` parameters. 
+  - If IPv4 is enabled, it sets the `net.ipv4.conf.[IFNAME].forwarding` sysctl to `1` on
+    the OVN-Kubernetes management port and bridge interfaces, allowing IPv4 packets to be
+    forwarded to and from those interfaces specifically.
 
-#### IPv4
+  - If IPv6 is enabled, it sets the `net.ipv6.conf.all.forwarding` sysctl to `1`, enabling
+    IPv6 packets to be forwarded to and from _all_ interfaces. (Until recently, the kernel
+    did not support enabling IPv6 forwarding only on specific interfaces.)
 
-If forwarding is enabled(default) and it is desired to allow forwarding for traffic on unmanaged ovn-kubernetes interfaces, then system administrators need to set the following sysctl parameters on the desired interfaces or globally.
-OVN-Kubernetes already sets sysctl forwarding for interfaces it manages, such as the ovn-k8s-mp0 interface and the shared gateway bridge interface. An operator can be built to manage forwarding sysctl parameters based on forwarding mode.
-No extra iptables rules are added by OVN-Kubernetes to FORWARD chain while using this IP forwarding mode.
+The result is that for IPv4, packet forwarding is only enabled on OVN-Kubernetes's own
+interfaces (unless the administrator set `net.ipv4.ip_forward` themselves to enable global
+IPv4 forwarding), but for IPv6, packet forwarding is enabled on _all_ interfaces.
 
-```
-net.ipv4.ip_forward=1
-```
-IP forwarding can be disabled either by setting `disable-forwarding` command line option to `true` while starting ovnkube or by setting `disable-forwarding` to `true` in config file. If forwarding is disabled the default policy for the [FORWARD iptables chain is set as DROP](#forwarding-rules) and system administrators can add use-case specific ACCEPT rules.
+The [IP sysctl documentation] suggests that if you only want IPv6 forwarding on specific
+interfaces, you should use iptables rules to block it on other interfaces. OVN-Kubernetes
+provides the `disable-forwarding` config/command-line option to do this:
 
-When IP forwarding is disabled, following sysctl parameters are modified by OVN-Kubernetes to allow forwarding Kubernetes related traffic on OVN-Kubernetes managed bridge interfaces and management port interface.
+  - If `disable-forwarding` is `true`:
 
-```
-net.ipv4.conf.br-ex.forwarding=1
-net.ipv4.conf.ovn-k8s-mp0.forwarding = 1
-```
+      - OVN-Kubernetes sets the default policy of the ip6tables `FORWARD` chain to
+        `DROP`, blocking the effect of the global forwarding sysctls.
 
-#### IPv6
+      - To ensure that OVN-Kubernetes's own IPv6 traffic is still forwarded, it adds
+        specific `ACCEPT` rules to the `FORWARD` chain to allow forwarding traffic to
+        or from IPv6 Pod and Service networks, and to or from the IPv6 "masquerade IP".
 
-IP forwarding works differently for IPv6:
-```
-/proc/sys/net/ipv6/* Variables:
+      - This fixes IPv6 forwarding to work effectively the same as IPv4 forwarding: it is
+        only allowed on OVN-Kubernetes's own interfaces.
 
-conf/all/forwarding - BOOLEAN
-  Enable global IPv6 forwarding between all interfaces.
-  IPv4 and IPv6 work differently here; e.g. netfilter must be used
-  to control which interfaces may forward packets and which not.
+  - If `disable-forwarding` is `false`:
 
-...
+      - OVN-Kubernetes sets the default policy of the ip6tables `FORWARD` chain to
+        `ACCEPT`. (This normally has no effect since that's the normal default policy
+        anyway.)
 
-conf/interface/*:
+For consistency, OVN-Kubernetes also applies the effect of `disable-forwarding` to IPv4 as
+well, even though it is not necessary.
 
-forwarding - INTEGER
-	Configure interface-specific Host/Router behaviour.
+Note that this is always done via iptables, not nftables, to better preserve compatibility
+with other components. If ovn-kubernetes were to create its own `hook forward; policy
+drop` table in nftables, there would be no way for other components to add `accept` rules
+that would override it. But if all components use the iptables `FORWARD` chain, then they
+can all coordinate on accept/drop there.
 
-	Note: It is recommended to have the same setting on all
-	interfaces; mixed router/host scenarios are rather uncommon.
-
-	Possible values are:
-		0 Forwarding disabled
-		1 Forwarding enabled
-
-	FALSE (0):
-
-	By default, Host behaviour is assumed.  This means:
-
-	1. IsRouter flag is not set in Neighbour Advertisements.
-	2. If accept_ra is TRUE (default), transmit Router
-	   Solicitations.
-	3. If accept_ra is TRUE (default), accept Router
-	   Advertisements (and do autoconfiguration).
-	4. If accept_redirects is TRUE (default), accept Redirects.
-
-	TRUE (1):
-
-	If local forwarding is enabled, Router behaviour is assumed.
-	This means exactly the reverse from the above:
-
-	1. IsRouter flag is set in Neighbour Advertisements.
-	2. Router Solicitations are not sent unless accept_ra is 2.
-	3. Router Advertisements are ignored unless accept_ra is 2.
-	4. Redirects are ignored.
-
-	Default: 0 (disabled) if global forwarding is disabled (default),
-		 otherwise 1 (enabled).
-```
-https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
-
-It is not possible to configure the IPv6 forwarding per interface by setting the 
-`net.ipv6.conf.IFNAME.forwarding` sysctl (it just configures the interface-specific Host/Router 
-behaviour). \
-Instead, the opposite approach is required where the global forwarding is always enabled and 
-the traffic is restricted through iptables.
-
-#### Forwarding rules
-
-When the `disable-forwarding` parameter is configured specific iptables rules are added to
-the FORWARD chain to forward clusterNetwork and serviceNetwork traffic to their intended destinations.
-Additionally, the default policy for the FORWARD chain is set as `DROP`. Otherwise, the policy
-defaults to `ACCEPT` and no custom rules are added. This behavior is the same for both IPv6 and IPv4
-networks:
-
-```
-# In IPv4 with disable-forwarding=true the FORWARD policy is set to DROP
-Chain FORWARD (policy DROP 0 packets, 0 bytes)
- pkts bytes target     prot opt in     out     source               destination         
-    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            169.254.169.1       
-    0     0 ACCEPT     0    --  *      *       169.254.169.1        0.0.0.0/0           
-    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            10.96.0.0/16        
-    0     0 ACCEPT     0    --  *      *       10.96.0.0/16         0.0.0.0/0           
-    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            10.244.0.0/16       
-    0     0 ACCEPT     0    --  *      *       10.244.0.0/16        0.0.0.0/0           
-    0     0 ACCEPT     0    --  ovn-k8s-mp0 *       0.0.0.0/0            0.0.0.0/0           
-    0     0 ACCEPT     0    --  *      ovn-k8s-mp0  0.0.0.0/0            0.0.0.0/0
-    
-# In IPv6 with disable-forwarding=true the FORWARD policy is set to DROP
-Chain FORWARD (policy DROP 0 packets, 0 bytes)
- pkts bytes target     prot opt in     out     source               destination         
-    0     0 ACCEPT     0    --  *      *       ::/0                 fd69::1             
-    0     0 ACCEPT     0    --  *      *       fd69::1              ::/0                
-    0     0 ACCEPT     0    --  *      *       ::/0                 fd00:10:96::/112    
-    0     0 ACCEPT     0    --  *      *       fd00:10:96::/112     ::/0                
-    0     0 ACCEPT     0    --  *      *       ::/0                 fd00:10:244::/48    
-    0     0 ACCEPT     0    --  *      *       fd00:10:244::/48     ::/0                
-    0     0 ACCEPT     0    --  ovn-k8s-mp0 *       ::/0                 ::/0                
-    0     0 ACCEPT     0    --  *      ovn-k8s-mp0  ::/0                 ::/0          
-```
+[IP sysctl documentation]: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
 
 ### VLAN Config
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -615,7 +615,7 @@ type GatewayConfig struct {
 	RouterSubnet string `gcfg:"router-subnet"`
 	// SingeNode indicates the cluster has only one node
 	SingleNode bool `gcfg:"single-node"`
-	// DisableForwarding controls if forwarding is blocked on non-OVNK controlled interfaces
+	// DisableForwarding controls if IPv6 forwarding is blocked on non-OVNK controlled interfaces
 	DisableForwarding bool `gcfg:"disable-forwarding"`
 	// AllowNoUplink (disabled by default) controls if the external gateway bridge without an uplink port is allowed in local gateway mode.
 	AllowNoUplink bool `gcfg:"allow-no-uplink"`
@@ -1678,7 +1678,7 @@ var OVNGatewayFlags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		Name:        "disable-forwarding",
-		Usage:       "Disable forwarding except on OVNK controlled interfaces.",
+		Usage:       "Disable IPv6 forwarding except on OVNK controlled interfaces.",
 		Destination: &cliConfig.Gateway.DisableForwarding,
 	},
 	&cli.StringFlag{

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -615,7 +615,7 @@ type GatewayConfig struct {
 	RouterSubnet string `gcfg:"router-subnet"`
 	// SingeNode indicates the cluster has only one node
 	SingleNode bool `gcfg:"single-node"`
-	// DisableForwarding controls if IPv6 forwarding is blocked on non-OVNK controlled interfaces
+	// DisableForwarding controls if IPv6 forwarding is blocked on non-OVNK controlled interfaces when using older kernels
 	DisableForwarding bool `gcfg:"disable-forwarding"`
 	// AllowNoUplink (disabled by default) controls if the external gateway bridge without an uplink port is allowed in local gateway mode.
 	AllowNoUplink bool `gcfg:"allow-no-uplink"`
@@ -1677,8 +1677,9 @@ var OVNGatewayFlags = []cli.Flag{
 		Destination: &cliConfig.Gateway.DisableSNATMultipleGWs,
 	},
 	&cli.BoolFlag{
-		Name:        "disable-forwarding",
-		Usage:       "Disable IPv6 forwarding except on OVNK controlled interfaces.",
+		Name: "disable-forwarding",
+		Usage: "Disable IPv6 forwarding except on OVNK controlled interfaces when using " +
+			"an older kernel that doesn't allow per-interface IPv6 forwarding.",
 		Destination: &cliConfig.Gateway.DisableForwarding,
 	},
 	&cli.StringFlag{

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -615,7 +615,7 @@ type GatewayConfig struct {
 	RouterSubnet string `gcfg:"router-subnet"`
 	// SingeNode indicates the cluster has only one node
 	SingleNode bool `gcfg:"single-node"`
-	// DisableForwarding (enabled by default) controls if forwarding is allowed on OVNK controlled interfaces
+	// DisableForwarding controls if forwarding is blocked on non-OVNK controlled interfaces
 	DisableForwarding bool `gcfg:"disable-forwarding"`
 	// AllowNoUplink (disabled by default) controls if the external gateway bridge without an uplink port is allowed in local gateway mode.
 	AllowNoUplink bool `gcfg:"allow-no-uplink"`
@@ -1678,7 +1678,7 @@ var OVNGatewayFlags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		Name:        "disable-forwarding",
-		Usage:       "Disable forwarding on OVNK controlled interfaces.",
+		Usage:       "Disable forwarding except on OVNK controlled interfaces.",
 		Destination: &cliConfig.Gateway.DisableForwarding,
 	},
 	&cli.StringFlag{

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -597,12 +597,9 @@ func getIntfName(gatewayIntf string) (string, error) {
 // bridgedGatewayNodeSetup enables forwarding on bridge interface, sets up the physical network name mappings for the bridge,
 // and returns an ifaceID created from the bridge name and the node name
 func bridgedGatewayNodeSetup(ovsClient libovsdbclient.Client, nodeName, bridgeName, physicalNetworkName string) (string, error) {
-	// IPv6 forwarding is enabled globally
-	if config.IPv4Mode {
-		err := util.SetForwardingModeForInterface(bridgeName)
-		if err != nil {
-			return "", err
-		}
+	err := util.SetForwardingModeForInterface(bridgeName)
+	if err != nil {
+		return "", err
 	}
 
 	// ovn-bridge-mappings maps a physical network name to a local ovs bridge

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1591,10 +1591,10 @@ func DummyMasqueradeIPs() []net.IP {
 	return nextHops
 }
 
-// configureGlobalForwarding configures the global forwarding settings. It sets the
-// FORWARD policy to DROP if config.Gateway.DisableForwarding is set (or sets it back to
-// ACCEPT if it had previously set it DROP and DisableForwarding is now unset) for all
-// enabled IP families. For IPv6 it additionally always enables global forwarding.
+// configureGlobalForwarding configures the global forwarding settings for IPv6. It
+// enables global forwarding, and sets the ip6tables FORWARD policy to DROP if
+// config.Gateway.DisableForwarding is set (or sets it back to ACCEPT if it had previously
+// set it DROP and DisableForwarding is now unset).
 //
 // This function assumes that other forwarding setup will also be performed. Specifically,
 // for IPv4, you must call util.SetForwardingModeForInterface() to enable per-interface
@@ -1620,7 +1620,7 @@ func configureGlobalForwarding() error {
 		}
 
 		desiredPolicy := ""
-		if nodeutil.NeedIPTablesForwardingRules() {
+		if nodeutil.NeedIPTablesForwardingRules(proto) {
 			desiredPolicy = "DROP"
 		} else {
 			// If there's evidence that we previously configured

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
 
 	corev1 "k8s.io/api/core/v1"
@@ -48,6 +49,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/podresourcesapi"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	nodetypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/types"
+	nodeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
@@ -1589,10 +1591,10 @@ func DummyMasqueradeIPs() []net.IP {
 	return nextHops
 }
 
-// configureGlobalForwarding configures the global forwarding settings.
-// It sets the FORWARD policy to DROP/ACCEPT based on the config.Gateway.DisableForwarding
-// value, for all enabled IP families. For IPv6 it additionally always enables global
-// forwarding.
+// configureGlobalForwarding configures the global forwarding settings. It sets the
+// FORWARD policy to DROP if config.Gateway.DisableForwarding is set (or sets it back to
+// ACCEPT if it had previously set it DROP and DisableForwarding is now unset) for all
+// enabled IP families. For IPv6 it additionally always enables global forwarding.
 //
 // This function assumes that other forwarding setup will also be performed. Specifically,
 // for IPv4, you must call util.SetForwardingModeForInterface() to enable per-interface
@@ -1617,15 +1619,34 @@ func configureGlobalForwarding() error {
 			return fmt.Errorf("failed to get the iptables helper: %w", err)
 		}
 
-		target := "ACCEPT"
-		if config.Gateway.DisableForwarding {
-			target = "DROP"
-
+		desiredPolicy := ""
+		if nodeutil.NeedIPTablesForwardingRules() {
+			desiredPolicy = "DROP"
+		} else {
+			// If there's evidence that we previously configured
+			// DisableForwarding, then change the policy back to ACCEPT now.
+			// (Note that the rules we look for here will be deleted later
+			// by the gateway setup.)
+			masqueradeIP := config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP
+			if proto == iptables.ProtocolIPv6 {
+				masqueradeIP = config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP
+			}
+			forwardRules := getMasqueradeIpTablesForwardRules(masqueradeIP, proto)
+			if len(forwardRules) != 0 {
+				rule := forwardRules[0]
+				if ruleExists, _ := ipt.Exists(rule.Table, rule.Chain, rule.Args...); ruleExists {
+					desiredPolicy = "ACCEPT"
+				}
+			}
 		}
-		if err := ipt.ChangePolicy("filter", "FORWARD", target); err != nil {
-			return fmt.Errorf("failed to change the forward policy to %q: %w", target, err)
+
+		if desiredPolicy != "" {
+			if err := ipt.ChangePolicy("filter", "FORWARD", desiredPolicy); err != nil {
+				return fmt.Errorf("failed to change the forward policy to %q: %w", desiredPolicy, err)
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1590,20 +1590,20 @@ func DummyMasqueradeIPs() []net.IP {
 }
 
 // configureGlobalForwarding configures the global forwarding settings.
-// It sets the FORWARD policy to DROP/ACCEPT based on the config.Gateway.DisableForwarding value for all enabled IP families.
-// For IPv6 it additionally always enables the global forwarding.
+// It sets the FORWARD policy to DROP/ACCEPT based on the config.Gateway.DisableForwarding
+// value, for all enabled IP families. For IPv6 it additionally always enables global
+// forwarding.
+//
+// This function assumes that other forwarding setup will also be performed. Specifically,
+// for IPv4, you must call util.SetForwardingModeForInterface() to enable per-interface
+// forwarding on the interfaces that need it (the bridge and management port interfaces).
+// And if config.Gateway.DisableForwarding is set, you must call
+// initExternalBridgeServiceForwardingRules() to create netfilter rules to forward the
+// traffic that OVN-Kubernetes needs, and block other traffic from being forwarded.
 func configureGlobalForwarding() error {
-	// Global forwarding works differently for IPv6:
-	//   conf/all/forwarding - BOOLEAN
-	//    Enable global IPv6 forwarding between all interfaces.
-	//	  IPv4 and IPv6 work differently here; e.g. netfilter must be used
-	//	  to control which interfaces may forward packets and which not.
-	// https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
-	//
-	// It is not possible to configure the IPv6 forwarding per interface by
-	// setting the net.ipv6.conf.<ifname>.forwarding sysctl. Instead,
-	// the opposite approach is required where the global forwarding
-	// is enabled and an iptables rule is added to restrict it by default.
+	// It is not possible to configure IPv6 forwarding per interface by
+	// setting the net.ipv6.conf.<ifname>.forwarding sysctl, so we always
+	// enable global forwarding.
 	if config.IPv6Mode {
 		if err := ip.EnableIP6Forward(); err != nil {
 			return fmt.Errorf("could not set the correct global forwarding value for ipv6:  %w", err)

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1591,22 +1591,20 @@ func DummyMasqueradeIPs() []net.IP {
 	return nextHops
 }
 
-// configureGlobalForwarding configures the global forwarding settings for IPv6. It
-// enables global forwarding, and sets the ip6tables FORWARD policy to DROP if
-// config.Gateway.DisableForwarding is set (or sets it back to ACCEPT if it had previously
-// set it DROP and DisableForwarding is now unset).
+// configureGlobalForwarding configures the global forwarding settings for IPv6 when
+// per-interface forwarding is not available. It enables global forwarding, and sets the
+// ip6tables FORWARD policy to DROP if config.Gateway.DisableForwarding is set (or sets it
+// back to ACCEPT if it had previously set it DROP and DisableForwarding is now unset).
 //
 // This function assumes that other forwarding setup will also be performed. Specifically,
-// for IPv4, you must call util.SetForwardingModeForInterface() to enable per-interface
+// you must call util.SetForwardingModeForInterface() to enable per-interface
 // forwarding on the interfaces that need it (the bridge and management port interfaces).
 // And if config.Gateway.DisableForwarding is set, you must call
 // initExternalBridgeServiceForwardingRules() to create netfilter rules to forward the
 // traffic that OVN-Kubernetes needs, and block other traffic from being forwarded.
 func configureGlobalForwarding() error {
-	// It is not possible to configure IPv6 forwarding per interface by
-	// setting the net.ipv6.conf.<ifname>.forwarding sysctl, so we always
-	// enable global forwarding.
-	if config.IPv6Mode {
+	if config.IPv6Mode && !util.SupportsIPv6InterfaceForwarding() {
+		// Enable global forwarding since per-interface forwarding isn't available.
 		if err := ip.EnableIP6Forward(); err != nil {
 			return fmt.Errorf("could not set the correct global forwarding value for ipv6:  %w", err)
 		}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1439,18 +1439,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 				"OVN-KUBE-ETP": []string{},
 				"OVN-KUBE-ITP": []string{},
 			},
-			"filter": {
-				"FORWARD": []string{
-					"-d 169.254.169.1 -j ACCEPT",
-					"-s 169.254.169.1 -j ACCEPT",
-					"-d 172.16.1.0/24 -j ACCEPT",
-					"-s 172.16.1.0/24 -j ACCEPT",
-					"-d 10.1.0.0/16 -j ACCEPT",
-					"-s 10.1.0.0/16 -j ACCEPT",
-					"-i ovn-k8s-mp0 -j ACCEPT",
-					"-o ovn-k8s-mp0 -j ACCEPT",
-				},
-			},
+			"filter": {},
 			"mangle": {
 				"OUTPUT": []string{
 					"-j OVN-KUBE-ITP",
@@ -1459,10 +1448,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			},
 		}
 		f4 := iptV4.(*util.FakeIPTables)
-		err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
-			Table: "filter",
-			Chain: "FORWARD",
-		}: "DROP"})
+		err = f4.MatchState(expectedTables, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedTables = map[string]util.FakeTable{

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	nodeipt "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iptables"
+	nodeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
@@ -352,19 +353,19 @@ func getMasqueradeIpTablesNATRules(masqueradeIP net.IP, protocol iptables.Protoc
 	}
 }
 
-// initExternalBridgeForwardingRules sets up iptables rules for br-* interface svc traffic forwarding
+// initExternalBridgeForwardingRules adds or removes iptables rules for br-* interface svc
+// traffic forwarding:
 // -A FORWARD -s 10.96.0.0/16 -j ACCEPT
 // -A FORWARD -d 10.96.0.0/16 -j ACCEPT
 // -A FORWARD -s 169.254.169.1 -j ACCEPT
 // -A FORWARD -d 169.254.169.1 -j ACCEPT
 func initExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
-	return insertIptRules(getGatewayForwardRules(cidrs))
-}
-
-// delExternalBridgeServiceForwardingRules removes iptables rules which might
-// have been added to disable forwarding
-func delExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
-	return deleteIptRules(getGatewayForwardRules(cidrs))
+	rules := getGatewayForwardRules(cidrs)
+	if nodeutil.NeedIPTablesForwardingRules() {
+		return insertIptRules(rules)
+	} else {
+		return deleteIptRules(rules)
+	}
 }
 
 func getLocalGatewayFilterRules(ifname string, protocol iptables.Protocol) []nodeipt.Rule {
@@ -395,7 +396,7 @@ func getLocalGatewayFilterRules(ifname string, protocol iptables.Protocol) []nod
 func initLocalGatewayIPTFilterRules(ifname string) error {
 	for _, protocol := range clusterIPTablesProtocols() {
 		rules := getLocalGatewayFilterRules(ifname, protocol)
-		if config.Gateway.DisableForwarding {
+		if nodeutil.NeedIPTablesForwardingRules() {
 			// Insert (rather than append) the filter table rules because they
 			// need to be evaluated BEFORE the DROP rules we have for
 			// forwarding. DO NOT change the ordering; especially important

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -267,16 +267,13 @@ func getExternalIPTRules(svcPort corev1.ServicePort, externalIP, dstIP string, s
 	}
 }
 
-func getGatewayForwardRules(cidrs []*net.IPNet) []nodeipt.Rule {
-	var returnRules []nodeipt.Rule
-	protocols := make(map[iptables.Protocol]struct{})
+func getGatewayForwardRules(cidrs []*net.IPNet) map[iptables.Protocol][]nodeipt.Rule {
+	returnRules := map[iptables.Protocol][]nodeipt.Rule{}
 
 	// Add rules for all CIDRs.
 	for _, cidr := range cidrs {
 		protocol := getIPTablesProtocol(cidr.IP.String())
-		protocols[protocol] = struct{}{}
-
-		returnRules = append(returnRules, []nodeipt.Rule{
+		returnRules[protocol] = append(returnRules[protocol], []nodeipt.Rule{
 			{
 				Table: "filter",
 				Chain: "FORWARD",
@@ -299,12 +296,12 @@ func getGatewayForwardRules(cidrs []*net.IPNet) []nodeipt.Rule {
 	}
 
 	// Add rules for MasqueraIPs.
-	for protocol := range protocols {
+	for protocol := range returnRules {
 		masqueradeIP := config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP
 		if protocol == iptables.ProtocolIPv6 {
 			masqueradeIP = config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP
 		}
-		returnRules = append(returnRules, getMasqueradeIpTablesForwardRules(masqueradeIP, protocol)...)
+		returnRules[protocol] = append(returnRules[protocol], getMasqueradeIpTablesForwardRules(masqueradeIP, protocol)...)
 	}
 
 	return returnRules
@@ -360,12 +357,19 @@ func getMasqueradeIpTablesNATRules(masqueradeIP net.IP, protocol iptables.Protoc
 // -A FORWARD -s 169.254.169.1 -j ACCEPT
 // -A FORWARD -d 169.254.169.1 -j ACCEPT
 func initExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
-	rules := getGatewayForwardRules(cidrs)
-	if nodeutil.NeedIPTablesForwardingRules() {
-		return insertIptRules(rules)
-	} else {
-		return deleteIptRules(rules)
+	allRules := getGatewayForwardRules(cidrs)
+	for protocol, rules := range allRules {
+		var err error
+		if nodeutil.NeedIPTablesForwardingRules(protocol) {
+			err = insertIptRules(rules)
+		} else {
+			err = deleteIptRules(rules)
+		}
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func getLocalGatewayFilterRules(ifname string, protocol iptables.Protocol) []nodeipt.Rule {
@@ -396,7 +400,7 @@ func getLocalGatewayFilterRules(ifname string, protocol iptables.Protocol) []nod
 func initLocalGatewayIPTFilterRules(ifname string) error {
 	for _, protocol := range clusterIPTablesProtocols() {
 		rules := getLocalGatewayFilterRules(ifname, protocol)
-		if nodeutil.NeedIPTablesForwardingRules() {
+		if nodeutil.NeedIPTablesForwardingRules(protocol) {
 			// Insert (rather than append) the filter table rules because they
 			// need to be evaluated BEFORE the DROP rules we have for
 			// forwarding. DO NOT change the ordering; especially important

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -3678,6 +3678,8 @@ var _ = Describe("Node Operations", func() {
 			config.IPv4Mode = true
 			config.IPv6Mode = true
 
+			util.SetSupportsIPv6InterfaceForwarding(false)
+
 			By("setting DisableForwarding = true, and confirming that configureGlobalForwarding() sets the IPv6 policy to DROP")
 			config.Gateway.DisableForwarding = true
 			err = configureGlobalForwarding()
@@ -3730,6 +3732,17 @@ var _ = Describe("Node Operations", func() {
 			err = f6.MatchState(expectedTablesV6, expectedPolicyAccept)
 			Expect(err).NotTo(HaveOccurred())
 
+			By("setting DisableForwarding = true with SupportsIPv6InterfaceForwarding() also true, and confirming that configureGlobalForwarding() does not change the policy")
+			config.Gateway.DisableForwarding = true
+			util.SetSupportsIPv6InterfaceForwarding(true)
+			defer util.SetSupportsIPv6InterfaceForwarding(false)
+			err = configureGlobalForwarding()
+			Expect(err).NotTo(HaveOccurred())
+			err = f4.MatchState(expectedTablesV4, expectedPolicyAccept)
+			Expect(err).NotTo(HaveOccurred())
+			err = f6.MatchState(expectedTablesV6, expectedPolicyAccept)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("deleting the OVN-K DisableForwarding rules and manually setting the policy back to DROP")
 			err = nodeipt.DelRules(rules)
 			Expect(err).NotTo(HaveOccurred())
@@ -3738,8 +3751,11 @@ var _ = Describe("Node Operations", func() {
 			err = iptV6.ChangePolicy("filter", "FORWARD", "DROP")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("re-running configureGlobalForwarding() and confirming that it doesn't change the policy")
-			configureGlobalForwarding()
+			By("setting DisableForwarding = false, and confirming that configureGlobalForwarding() doesn't change the policy")
+			config.Gateway.DisableForwarding = false
+			util.SetSupportsIPv6InterfaceForwarding(false)
+			err = configureGlobalForwarding()
+			Expect(err).NotTo(HaveOccurred())
 			err = f4.MatchState(expectedTablesEmpty, expectedPolicyDrop)
 			Expect(err).NotTo(HaveOccurred())
 			err = f6.MatchState(expectedTablesEmpty, expectedPolicyDrop)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/coreos/go-iptables/iptables"
 	"github.com/stretchr/testify/mock"
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
@@ -27,6 +28,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
+	nodeipt "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/iptables"
 	nodenft "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/nftables"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
@@ -85,14 +87,8 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset)
 		subnets = append(subnets, subnet.CIDR)
 	}
 	subnets = append(subnets, config.Kubernetes.ServiceCIDRs...)
-	if config.Gateway.DisableForwarding {
-		if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
-			return fmt.Errorf("failed to add accept rules in forwarding table for bridge %s: err %v", linkName, err)
-		}
-	} else {
-		if err := delExternalBridgeServiceForwardingRules(subnets); err != nil {
-			return fmt.Errorf("failed to delete accept rules in forwarding table for bridge %s: err %v", linkName, err)
-		}
+	if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
+		return fmt.Errorf("failed to configure iptables forwarding rules for bridge %s: err %v", linkName, err)
 	}
 
 	// set up a controller to handle events on services to mock the nodeportwatcher bits
@@ -3690,13 +3686,60 @@ var _ = Describe("Node Operations", func() {
 			err = f6.MatchState(expectedTablesEmpty, expectedPolicyDrop)
 			Expect(err).NotTo(HaveOccurred())
 
+			By("manually creating some of the rules OVN-K would create when DisableForwarding is true")
+			var rules []nodeipt.Rule
+			rules = append(rules, getMasqueradeIpTablesForwardRules(config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP, iptables.ProtocolIPv4)...)
+			rules = append(rules, getMasqueradeIpTablesForwardRules(config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP, iptables.ProtocolIPv6)...)
+			err = nodeipt.AddRules(rules, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedTablesV4 := map[string]util.FakeTable{
+				"filter": {
+					"FORWARD": []string{
+						"-d 169.254.169.1 -j ACCEPT",
+						"-s 169.254.169.1 -j ACCEPT",
+					},
+				},
+				"nat":    {},
+				"mangle": {},
+			}
+			err = f4.MatchState(expectedTablesV4, expectedPolicyDrop)
+			Expect(err).NotTo(HaveOccurred())
+			expectedTablesV6 := map[string]util.FakeTable{
+				"filter": {
+					"FORWARD": []string{
+						"-d fd69::1 -j ACCEPT",
+						"-s fd69::1 -j ACCEPT",
+					},
+				},
+				"nat":    {},
+				"mangle": {},
+			}
+			err = f6.MatchState(expectedTablesV6, expectedPolicyDrop)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("setting DisableForwarding = false, and confirming that configureGlobalForwarding() sets the policy to ACCEPT")
 			config.Gateway.DisableForwarding = false
 			err = configureGlobalForwarding()
 			Expect(err).NotTo(HaveOccurred())
-			err = f4.MatchState(expectedTablesEmpty, expectedPolicyAccept)
+			err = f4.MatchState(expectedTablesV4, expectedPolicyAccept)
 			Expect(err).NotTo(HaveOccurred())
-			err = f6.MatchState(expectedTablesEmpty, expectedPolicyAccept)
+			err = f6.MatchState(expectedTablesV6, expectedPolicyAccept)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("deleting the OVN-K DisableForwarding rules and manually setting the policy back to DROP")
+			err = nodeipt.DelRules(rules)
+			Expect(err).NotTo(HaveOccurred())
+			err = iptV4.ChangePolicy("filter", "FORWARD", "DROP")
+			Expect(err).NotTo(HaveOccurred())
+			err = iptV6.ChangePolicy("filter", "FORWARD", "DROP")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("re-running configureGlobalForwarding() and confirming that it doesn't change the policy")
+			configureGlobalForwarding()
+			err = f4.MatchState(expectedTablesEmpty, expectedPolicyDrop)
+			Expect(err).NotTo(HaveOccurred())
+			err = f6.MatchState(expectedTablesEmpty, expectedPolicyDrop)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -3545,8 +3545,12 @@ var _ = Describe("Node Operations", func() {
 	Context("disable-forwarding", func() {
 		It("adds or removes iptables rules upon change in forwarding mode", func() {
 			app.Action = func(*cli.Context) error {
-				config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: ovntest.MustParseIPNet("10.1.0.0/16"), HostSubnetLength: 24}}
-				config.Kubernetes.ServiceCIDRs = ovntest.MustParseIPNets("172.16.1.0/24")
+				config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
+					{CIDR: ovntest.MustParseIPNet("fd00:10:1::/48"), HostSubnetLength: 64},
+				}
+				config.Kubernetes.ServiceCIDRs = ovntest.MustParseIPNets("fd00:172:16::/108")
+				config.IPv4Mode = false
+				config.IPv6Mode = true
 				config.Gateway.DisableForwarding = true
 
 				stopChan := make(chan struct{})
@@ -3561,6 +3565,8 @@ var _ = Describe("Node Operations", func() {
 
 				fNPW.watchFactory = wf
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
+				Expect(configureGlobalForwarding()).To(Succeed())
+
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
 						"PREROUTING": []string{
@@ -3580,12 +3586,12 @@ var _ = Describe("Node Operations", func() {
 					},
 					"filter": {
 						"FORWARD": []string{
-							"-d 169.254.169.1 -j ACCEPT",
-							"-s 169.254.169.1 -j ACCEPT",
-							"-d 172.16.1.0/24 -j ACCEPT",
-							"-s 172.16.1.0/24 -j ACCEPT",
-							"-d 10.1.0.0/16 -j ACCEPT",
-							"-s 10.1.0.0/16 -j ACCEPT",
+							"-d fd69::1 -j ACCEPT",
+							"-s fd69::1 -j ACCEPT",
+							"-d fd00:172:16::/108 -j ACCEPT",
+							"-s fd00:172:16::/108 -j ACCEPT",
+							"-d fd00:10:1::/48 -j ACCEPT",
+							"-s fd00:10:1::/48 -j ACCEPT",
 						},
 					},
 					"mangle": {
@@ -3595,21 +3601,11 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ITP": []string{},
 					},
 				}
-
-				Expect(configureGlobalForwarding()).To(Succeed())
-				f4 := iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables, map[util.FakePolicyKey]string{{
 					Table: "filter",
 					Chain: "FORWARD",
 				}: "DROP"})
-				Expect(err).NotTo(HaveOccurred())
-				expectedTables = map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Enable forwarding and test deletion of iptables rules from FORWARD chain
@@ -3617,6 +3613,7 @@ var _ = Describe("Node Operations", func() {
 				fNPW.watchFactory = wf
 				Expect(configureGlobalForwarding()).To(Succeed())
 				Expect(startNodePortWatcher(fNPW, fakeClient)).To(Succeed())
+
 				expectedTables = map[string]util.FakeTable{
 					"nat": {
 						"PREROUTING": []string{
@@ -3645,25 +3642,62 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 
-				f4 = iptV4.(*util.FakeIPTables)
-				err = f4.MatchState(expectedTables, map[util.FakePolicyKey]string{{
+				f6 = iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables, map[util.FakePolicyKey]string{{
 					Table: "filter",
 					Chain: "FORWARD",
 				}: "ACCEPT"})
-				Expect(err).NotTo(HaveOccurred())
-				expectedTables = map[string]util.FakeTable{
-					"nat":    {},
-					"filter": {},
-					"mangle": {},
-				}
-				f6 = iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables, nil)
 				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
 		})
-	})
 
+		It("updates the default FORWARD policy correctly according to the config", func() {
+			expectedTablesEmpty := map[string]util.FakeTable{
+				"filter": {
+					"FORWARD": []string{},
+				},
+				"nat":    {},
+				"mangle": {},
+			}
+
+			expectedPolicyDrop := map[util.FakePolicyKey]string{{
+				Table: "filter",
+				Chain: "FORWARD",
+			}: "DROP"}
+			expectedPolicyAccept := map[util.FakePolicyKey]string{{
+				Table: "filter",
+				Chain: "FORWARD",
+			}: "ACCEPT"}
+
+			err := iptV4.NewChain("filter", "FORWARD")
+			Expect(err).NotTo(HaveOccurred())
+			err = iptV6.NewChain("filter", "FORWARD")
+			Expect(err).NotTo(HaveOccurred())
+			f4 := iptV4.(*util.FakeIPTables)
+			f6 := iptV6.(*util.FakeIPTables)
+			config.IPv4Mode = true
+			config.IPv6Mode = true
+
+			By("setting DisableForwarding = true, and confirming that configureGlobalForwarding() sets the policy to DROP")
+			config.Gateway.DisableForwarding = true
+			err = configureGlobalForwarding()
+			Expect(err).NotTo(HaveOccurred())
+			err = f4.MatchState(expectedTablesEmpty, expectedPolicyDrop)
+			Expect(err).NotTo(HaveOccurred())
+			err = f6.MatchState(expectedTablesEmpty, expectedPolicyDrop)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("setting DisableForwarding = false, and confirming that configureGlobalForwarding() sets the policy to ACCEPT")
+			config.Gateway.DisableForwarding = false
+			err = configureGlobalForwarding()
+			Expect(err).NotTo(HaveOccurred())
+			err = f4.MatchState(expectedTablesEmpty, expectedPolicyAccept)
+			Expect(err).NotTo(HaveOccurred())
+			err = f6.MatchState(expectedTablesEmpty, expectedPolicyAccept)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 })

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -3667,6 +3667,7 @@ var _ = Describe("Node Operations", func() {
 				Table: "filter",
 				Chain: "FORWARD",
 			}: "ACCEPT"}
+			expectedPolicyNotSet := map[util.FakePolicyKey]string{}
 
 			err := iptV4.NewChain("filter", "FORWARD")
 			Expect(err).NotTo(HaveOccurred())
@@ -3677,20 +3678,22 @@ var _ = Describe("Node Operations", func() {
 			config.IPv4Mode = true
 			config.IPv6Mode = true
 
-			By("setting DisableForwarding = true, and confirming that configureGlobalForwarding() sets the policy to DROP")
+			By("setting DisableForwarding = true, and confirming that configureGlobalForwarding() sets the IPv6 policy to DROP")
 			config.Gateway.DisableForwarding = true
 			err = configureGlobalForwarding()
 			Expect(err).NotTo(HaveOccurred())
-			err = f4.MatchState(expectedTablesEmpty, expectedPolicyDrop)
+			err = f4.MatchState(expectedTablesEmpty, expectedPolicyNotSet)
 			Expect(err).NotTo(HaveOccurred())
 			err = f6.MatchState(expectedTablesEmpty, expectedPolicyDrop)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("manually creating some of the rules OVN-K would create when DisableForwarding is true")
+			By("manually creating some of the rules OVN-K would create when DisableForwarding is true, and setting the IPv4 policy to DROP")
 			var rules []nodeipt.Rule
 			rules = append(rules, getMasqueradeIpTablesForwardRules(config.Gateway.MasqueradeIPs.V4OVNMasqueradeIP, iptables.ProtocolIPv4)...)
 			rules = append(rules, getMasqueradeIpTablesForwardRules(config.Gateway.MasqueradeIPs.V6OVNMasqueradeIP, iptables.ProtocolIPv6)...)
 			err = nodeipt.AddRules(rules, false)
+			Expect(err).NotTo(HaveOccurred())
+			err = iptV4.ChangePolicy("filter", "FORWARD", "DROP")
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedTablesV4 := map[string]util.FakeTable{
@@ -3718,7 +3721,7 @@ var _ = Describe("Node Operations", func() {
 			err = f6.MatchState(expectedTablesV6, expectedPolicyDrop)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("setting DisableForwarding = false, and confirming that configureGlobalForwarding() sets the policy to ACCEPT")
+			By("setting DisableForwarding = false, and confirming that configureGlobalForwarding() sets the policy to ACCEPT for both IPv4 and IPv6")
 			config.Gateway.DisableForwarding = false
 			err = configureGlobalForwarding()
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1910,14 +1910,8 @@ func newNodePortWatcher(
 			subnets = append(subnets, subnet.CIDR)
 		}
 		subnets = append(subnets, config.Kubernetes.ServiceCIDRs...)
-		if config.Gateway.DisableForwarding {
-			if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
-				return nil, fmt.Errorf("failed to add accept rules in forwarding table for bridge %s: err %v", gwBridge.GetGatewayIface(), err)
-			}
-		} else {
-			if err := delExternalBridgeServiceForwardingRules(subnets); err != nil {
-				return nil, fmt.Errorf("failed to delete accept rules in forwarding table for bridge %s: err %v", gwBridge.GetGatewayIface(), err)
-			}
+		if err := initExternalBridgeServiceForwardingRules(subnets); err != nil {
+			return nil, fmt.Errorf("failed to configure iptables forwarding rules for bridge %s: err %v", gwBridge.GetGatewayIface(), err)
 		}
 	}
 

--- a/go-controller/pkg/node/managementport/port_dpu_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_dpu_linux_test.go
@@ -423,6 +423,11 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(linkMock, nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
 
+			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
+				Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
+			})
+
 			err = mgmtPort.doReconcile()
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -455,6 +460,11 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			mockDeviceIDToNetdev(deviceID, types.K8sMgmtIntfName)
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(linkMock, nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
+
+			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
+				Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
+			})
 
 			err = mgmtPort.doReconcile()
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/managementport/port_linux.go
+++ b/go-controller/pkg/node/managementport/port_linux.go
@@ -308,19 +308,6 @@ func setupManagementPortIPFamilyConfig(link netlink.Link, mpcfg *managementPortC
 		return err
 	}
 
-	protocol := iptables.ProtocolIPv4
-	if mpcfg.ipv6 != nil && cfg == mpcfg.ipv6 {
-		protocol = iptables.ProtocolIPv6
-	}
-
-	// IPv6 forwarding is enabled globally
-	if protocol == iptables.ProtocolIPv4 {
-		err := util.SetForwardingModeForInterface(types.K8sMgmtIntfName)
-		if err != nil {
-			klog.Warning(err)
-		}
-	}
-
 	return nil
 }
 
@@ -332,6 +319,10 @@ func setupManagementPortConfig(link netlink.Link, cfg *managementPortConfig, rou
 	}
 	if cfg.ipv6 != nil && err == nil {
 		err = setupManagementPortIPFamilyConfig(link, cfg, cfg.ipv6, routeManager)
+	}
+
+	if err == nil {
+		err = util.SetForwardingModeForInterface(types.K8sMgmtIntfName)
 	}
 
 	return err

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -234,7 +234,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	})
 	var isRoutingAdvertised bool
 	for _, cfg := range configs {
-		// We do not enable per-interface forwarding for IPv6
+		// We do not enable per-interface forwarding for IPv6 for this test suite
 		if cfg.family == netlink.FAMILY_V4 {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",

--- a/go-controller/pkg/node/managementport/port_suite_test.go
+++ b/go-controller/pkg/node/managementport/port_suite_test.go
@@ -17,5 +17,6 @@ func TestAdder(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	util.SetFakeIPTablesHelpers()
 	nodenft.SetFakeNFTablesHelper()
+	util.SetSupportsIPv6InterfaceForwarding(false)
 	ginkgo.RunSpecs(t, "Management Port Suite")
 }

--- a/go-controller/pkg/node/managementport/port_udn_linux.go
+++ b/go-controller/pkg/node/managementport/port_udn_linux.go
@@ -299,12 +299,9 @@ func (mp *udnManagementPortOVS) create() error {
 	klog.V(3).Infof("Setup management port link %s for network %s succeeded", mp.ifName, mp.GetNetworkName())
 
 	// STEP3
-	// IPv6 forwarding is enabled globally
-	if ipv4, _ := mp.IPMode(); ipv4 {
-		err = util.SetForwardingModeForInterface(mp.ifName)
-		if err != nil {
-			return err
-		}
+	err = util.SetForwardingModeForInterface(mp.ifName)
+	if err != nil {
+		return err
 	}
 
 	// add loose mode for rp filter on management port
@@ -364,11 +361,9 @@ func (mp *udnManagementPortNetdev) create() error {
 		return fmt.Errorf("bring up management port %s for network %s failed: %v", mp.ifName, mp.GetNetworkName(), err)
 	}
 
-	if ipv4, _ := mp.IPMode(); ipv4 {
-		err = util.SetForwardingModeForInterface(mp.ifName)
-		if err != nil {
-			return err
-		}
+	err = util.SetForwardingModeForInterface(mp.ifName)
+	if err != nil {
+		return err
 	}
 
 	// add loose mode for rp filter on management port

--- a/go-controller/pkg/node/node_suite_test.go
+++ b/go-controller/pkg/node/node_suite_test.go
@@ -29,5 +29,6 @@ func TestNodeSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
 	util.SetFakeIPTablesHelpers()
 	nodenft.SetFakeNFTablesHelper()
+	util.SetSupportsIPv6InterfaceForwarding(false)
 	RunSpecs(t, "Node Suite")
 }

--- a/go-controller/pkg/node/util/util.go
+++ b/go-controller/pkg/node/util/util.go
@@ -125,5 +125,5 @@ func GenerateICMPFragmentationFlow(ipAddr, outputPort, inPort, cookie string, pr
 // NeedIPTablesForwardingRules determines whether iptables forwarding rules are needed to
 // work around DisableForwarding.
 func NeedIPTablesForwardingRules(proto iptables.Protocol) bool {
-	return config.Gateway.DisableForwarding && proto == iptables.ProtocolIPv6
+	return config.Gateway.DisableForwarding && proto == iptables.ProtocolIPv6 && !pkgutil.SupportsIPv6InterfaceForwarding()
 }

--- a/go-controller/pkg/node/util/util.go
+++ b/go-controller/pkg/node/util/util.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/coreos/go-iptables/iptables"
+
 	net2 "k8s.io/utils/net"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -122,6 +124,6 @@ func GenerateICMPFragmentationFlow(ipAddr, outputPort, inPort, cookie string, pr
 
 // NeedIPTablesForwardingRules determines whether iptables forwarding rules are needed to
 // work around DisableForwarding.
-func NeedIPTablesForwardingRules() bool {
-	return config.Gateway.DisableForwarding
+func NeedIPTablesForwardingRules(proto iptables.Protocol) bool {
+	return config.Gateway.DisableForwarding && proto == iptables.ProtocolIPv6
 }

--- a/go-controller/pkg/node/util/util.go
+++ b/go-controller/pkg/node/util/util.go
@@ -119,3 +119,9 @@ func GenerateICMPFragmentationFlow(ipAddr, outputPort, inPort, cookie string, pr
 		cookie, priority, inPort, icmpMatch, nwDst, ipAddr, icmpType, icmpCode, action)
 	return icmpFragmentationFlow
 }
+
+// NeedIPTablesForwardingRules determines whether iptables forwarding rules are needed to
+// work around DisableForwarding.
+func NeedIPTablesForwardingRules() bool {
+	return config.Gateway.DisableForwarding
+}

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -12,8 +12,11 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os/exec"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -1012,6 +1015,31 @@ func ipAddrExistsAtInterface(ipAddr net.IP, iface net.Interface) (bool, error) {
 	return false, nil
 }
 
+var supportsIPv6InterfaceForwarding atomic.Bool
+var checkSupportsIPv6InterfaceForwarding sync.Once
+
+// SupportsIPv6InterfaceForwarding checks whether the kernel supports per-interface IPv6
+// forwarding, as opposed to only global IPv6 forwarding.
+func SupportsIPv6InterfaceForwarding() bool {
+	checkSupportsIPv6InterfaceForwarding.Do(func() {
+		// We avoid using RunSysctl here because we don't want unit tests to have
+		// to deal with figuring out exactly when this function is going to be
+		// called so they can fake it out with fExec.
+		_, err := exec.Command("sysctl", "net.ipv6.conf.lo.force_forwarding").CombinedOutput()
+		supportsIPv6InterfaceForwarding.Store(err == nil)
+	})
+	return supportsIPv6InterfaceForwarding.Load()
+}
+
+// SetSupportsIPv6InterfaceForwarding overrides the value returned by
+// SupportsIPv6InterfaceForwarding(), for testing purposes.
+func SetSupportsIPv6InterfaceForwarding(val bool) {
+	// Make sure the Once has run, so it doesn't override us later.
+	_ = SupportsIPv6InterfaceForwarding()
+
+	supportsIPv6InterfaceForwarding.Store(val)
+}
+
 // The sysctl fs interface uses slash as the path separator and allows interface names to
 // contain dots. But the CLI uses dots as the separator and expects interface names to
 // have been rewritten to use slashes instead.
@@ -1021,11 +1049,21 @@ func sysctlIfName(ifName string) string {
 
 // SetForwardingModeForInterface updates the forwarding options for the specified interface
 func SetForwardingModeForInterface(ifName string) error {
-	setVal := fmt.Sprintf("net.ipv4.conf.%s.forwarding = 1", sysctlIfName(ifName))
-	stdout, stderr, err := RunSysctl("-w", setVal)
-	if err != nil || stdout != setVal {
-		return fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
-			ifName, stdout, stderr, err)
+	if config.IPv4Mode {
+		setVal := fmt.Sprintf("net.ipv4.conf.%s.forwarding = 1", sysctlIfName(ifName))
+		stdout, stderr, err := RunSysctl("-w", setVal)
+		if err != nil || stdout != setVal {
+			return fmt.Errorf("could not set the correct IPv4 forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
+				ifName, stdout, stderr, err)
+		}
+	}
+	if config.IPv6Mode && SupportsIPv6InterfaceForwarding() {
+		setVal := fmt.Sprintf("net.ipv6.conf.%s.force_forwarding = 1", sysctlIfName(ifName))
+		stdout, stderr, err := RunSysctl("-w", setVal)
+		if err != nil || stdout != setVal {
+			return fmt.Errorf("could not set the correct IPv6 forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
+				ifName, stdout, stderr, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The current state of IP forwarding / iptables `FORWARD` chain in ovn-kubernetes is weird and ugly because until very recently, the kernel didn't let you do what we want to do for IPv6. This PR makes us use per-interface IPv6 forwarding if we can, and then gets rid of the iptables policy hacking in the cases where it isn't needed and makes things worse. 

The current state of forwarding is:

```
OVN-Kubernetes configures packet forwarding as follows:

  - If IPv4 is enabled, it sets the `net.ipv4.conf.[IFNAME].forwarding` sysctl to `1` on
    the OVN-Kubernetes management port and bridge interfaces, allowing IPv4 packets to be
    forwarded to and from those interfaces specifically.

  - If IPv6 is enabled, it sets the `net.ipv6.conf.all.forwarding` sysctl to `1`, enabling
    IPv6 packets to be forwarded to and from _all_ interfaces. (Until recently, the kernel
    did not support enabling IPv6 forwarding only on specific interfaces.)

The result is that for IPv4, packet forwarding is only enabled on OVN-Kubernetes's own
interfaces (unless the administrator set `net.ipv4.ip_forward` themselves to enable global
IPv4 forwarding), but for IPv6, packet forwarding is enabled on _all_ interfaces.

The [IP sysctl documentation] suggests that if you only want IPv6 forwarding on specific
interfaces, you should use netfilter rules to block it on other interfaces. OVN-Kubernetes
provides the `disable-forwarding` config/command-line option to do this:

  - If `disable-forwarding` is `true`:

      - OVN-Kubernetes sets the default policy of the ip6tables `FORWARD` chain in to
        `DROP`, blocking the effect of the global forwarding sysctls.

      - To ensure that OVN-Kubernetes's own IPv6 traffic is still forwarded, it adds
        specific `ACCEPT` rules to the `FORWARD` chain to allowing forwarding traffic to
        or from IPv6 Pod and Service networks, and to or from the IPv6 "masquerade IP".

      - This fixes IPv6 forwarding to work effectively the same as IPv4 forwarding: it is
        only allowed on OVN-Kubernetes's own interfaces.

  - If `disable-forwarding` is `false`:

      - OVN-Kubernetes sets the default policy of the ip6tables `FORWARD` chain to
        `ACCEPT`. (This normally has no effect since that's the normal default policy
        anyway.)

For consistency, OVN-Kubernetes also applies the effect of `disable-forwarding` to IPv4 as
well, even though it is not necessary.

[IP sysctl documentation]: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
```

This PR changes it so that (1) we use per-interface IPv6 forwarding if we can, just like we do with IPv4, (2) `disable-forwarding: true` means "if we have to enable global IPv6 forwarding, then try to mitigate the effects of it" and nothing else. So:

1. `disable-forwarding: false` (the default) no longer implies "forcibly set the iptables FORWARD chain policy to ACCEPT". It just means "_don't disable_ any forwarding", not "_do enable_ extra forwarding that might previously have been disabled".
2. `disable-forwarding: true` no longer disables IPv4 forwarding, because that is almost certainly not what the admin wants; if forwarding is possible on interfaces other than OVN-K's, it's because _something explicitly enabled forwarding on those interfaces_, so OVN-K should not be blocking it. ([OCPBUGS-77458](https://redhat.atlassian.net/browse/OCPBUGS-77458))
3. For the same reason, `disable-forwarding: true` no longer disables IPv6 forwarding if you have a kernel that supports per-interface IPv6 forwarding, because in that case, we are not enabling any excess forwarding, so there's nothing that needs disabling.

(This means that `disable-forwarding: false` and `disable-fowarding: true` are now both no-ops on kernel 6.17+, and some day we can just drop that option/code.)

(RHEL 10 should be getting a backport of the relevant fix soon. It's unclear if RHEL 9 will get it or not.)

Fixes #6392 
cc @kyrtapz