### PR TITLE
[WIP] Prevent Pod Backoff Accumulation during UDN Controller Startup

### DIFF
--- a/go-controller/pkg/clustermanager/pod/allocator.go
+++ b/go-controller/pkg/clustermanager/pod/allocator.go
@@ -116,9 +116,6 @@ func (a *PodAllocator) Init() error {
 func (a *PodAllocator) getActiveNetworkForPod(pod *corev1.Pod) (util.NetInfo, error) {
 	activeNetwork, err := a.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
 	if err != nil {
-		if util.IsInvalidPrimaryNetworkError(err) {
-			a.recordPodErrorEvent(pod, err)
-		}
 		return nil, err
 	}
 	// Cluster manager pod allocation should always have an active network
@@ -202,6 +199,11 @@ func (a *PodAllocator) reconcile(old, new *corev1.Pod, releaseFromAllocator bool
 		if a.netInfo.IsPrimaryNetwork() {
 			activeNetwork, err = a.getActiveNetworkForPod(pod)
 			if err != nil {
+				if util.IsInvalidPrimaryNetworkError(err) {
+					klog.V(5).Infof("Skipping pod %s/%s on network %s: primary network not ready yet for namespace",
+						pod.Namespace, pod.Name, a.netInfo.GetNetworkName())
+					return nil
+				}
 				return fmt.Errorf("failed looking for an active network: %w", err)
 			}
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
When UDNs and Pods are being created at the same time, the default network controller sees the pod and . This quickly maxes out the backoff mechanism, so by the time the UDNs are ready, the pods have already accumulated max backoff. 

This fix prevents backoff from accumulating by throwing the InvalidPrimaryNetworkError and skipping the step where the pod is put into a backoff loop. 

An alternative approach may be to have the UDN controller reset the backoff of the default network, but that may lead to some crossed wires where the UDN controller would have control over the default network controller. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
