### PR TITLE
Adding missing labels for UDN workloads

### DIFF
--- a/contrib/perf/workloads/udn-density-l2-pods-netpol.yml
+++ b/contrib/perf/workloads/udn-density-l2-pods-netpol.yml
@@ -36,7 +36,13 @@ jobs:
     churnConfig:
       percent: 10
       cycles: 10
-      mode: objects
+      mode: namespaces 
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
     objects:
 
       - objectTemplate: workloads/templates/udn-density/udn_l2.yml

--- a/contrib/perf/workloads/udn-density-l3-pods-netpol.yml
+++ b/contrib/perf/workloads/udn-density-l3-pods-netpol.yml
@@ -36,7 +36,13 @@ jobs:
     churnConfig:
       percent: 10
       cycles: 10
-      mode: objects
+      mode: namespaces 
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      k8s.ovn.org/primary-user-defined-network: ""
     objects:
 
       - objectTemplate: workloads/templates/udn-density/udn_l3.yml


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
We are missing the proper ns labels for the UDN workloads

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched select performance workloads to run at the namespace scope instead of object scope.
  * Updated namespace label configuration for affected workloads: disabled OpenShift SCC pod-security label synchronization.
  * Set Kubernetes pod-security enforce/audit/warn to "privileged" and cleared the primary user-defined network label for those namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->