### PR TITLE
dpulease: guard Ready() against nil receiver

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -864,7 +864,11 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 		if !ok {
 			return fmt.Errorf("cannot get kubeclient for starting CNI server")
 		}
-		cniServer, err = cni.NewCNIServer(nc.watchFactory, kclient.KClient, nc.networkManager, nc.ovsClient, nc.dpuNodeLeaseManager)
+		var dpuHealth cni.DPUStatusProvider
+		if nc.dpuNodeLeaseManager != nil {
+			dpuHealth = nc.dpuNodeLeaseManager
+		}
+		cniServer, err = cni.NewCNIServer(nc.watchFactory, kclient.KClient, nc.networkManager, nc.ovsClient, dpuHealth)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- When `DPUNodeLeaseRenewInterval` is set to 0 the lease manager is not created, but the CNI server still receives a nil `*Manager` wrapped in the `DPUHealth` interface
- The interface value is non-nil (Go's nil interface vs nil pointer distinction), so `checkDPUHealth` calls `Ready()` on a nil receiver, panicking on the RWMutex
- Add a nil receiver guard so `Ready()` returns healthy when the manager was never initialized

## Root Cause
Classic Go nil-interface-vs-nil-pointer issue. `nc.dpuNodeLeaseManager` is `nil` (`*dpulease.Manager`), but when assigned to the `DPUHealth` interface parameter in `NewCNIServer(...)`, Go wraps the nil pointer in a non-nil interface value. The existing `if s.dpuHealth == nil` check in `checkDPUHealth` doesn't catch this case.

## Test plan
- [x] Verified with `GOOS=linux go build`
- [ ] Unit test for `Ready()` with nil receiver
- [ ] Deploy with `--dpu-node-lease-renew-interval=0` and verify pods can be created without panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DPU health status provider initialization to properly handle scenarios where certain components may be unavailable, preventing potential runtime issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->