### PR TITLE
Single OVSDB transaction for node add/cleanup, plus stale IC route removal on node add

### DIFF
--- a/go-controller/pkg/libovsdb/ops/router.go
+++ b/go-controller/pkg/libovsdb/ops/router.go
@@ -226,9 +226,9 @@ func CreateOrUpdateLogicalRouterPortOps(nbClient libovsdbclient.Client, ops []ov
 	return ops, err
 }
 
-// DeleteLogicalRouterPorts deletes the provided logical router ports and
-// removes them from the provided logical router
-func DeleteLogicalRouterPorts(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter, lrps ...*nbdb.LogicalRouterPort) error {
+// DeleteLogicalRouterPortsOps deletes the provided logical router ports, removes
+// them from the provided logical router and returns the corresponding ops
+func DeleteLogicalRouterPortsOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, router *nbdb.LogicalRouter, lrps ...*nbdb.LogicalRouterPort) ([]ovsdb.Operation, error) {
 	originalPorts := router.Ports
 	router.Ports = make([]string, 0, len(lrps))
 	opModels := make([]operationModel, 0, len(lrps)+1)
@@ -255,8 +255,20 @@ func DeleteLogicalRouterPorts(nbClient libovsdbclient.Client, router *nbdb.Logic
 	opModels = append(opModels, opModel)
 
 	m := newModelClient(nbClient)
-	err := m.Delete(opModels...)
+	ops, err := m.DeleteOps(ops, opModels...)
 	router.Ports = originalPorts
+	return ops, err
+}
+
+// DeleteLogicalRouterPorts deletes the provided logical router ports and
+// removes them from the provided logical router
+func DeleteLogicalRouterPorts(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter, lrps ...*nbdb.LogicalRouterPort) error {
+	ops, err := DeleteLogicalRouterPortsOps(nbClient, nil, router, lrps...)
+	if err != nil {
+		return err
+	}
+
+	_, err = TransactAndCheck(nbClient, ops)
 	return err
 }
 

--- a/go-controller/pkg/libovsdb/ops/router_test.go
+++ b/go-controller/pkg/libovsdb/ops/router_test.go
@@ -450,3 +450,150 @@ func TestDeleteLogicalRouterStaticRoutes(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteLogicalRouterPortsOps(t *testing.T) {
+	fakeLRP1 := &nbdb.LogicalRouterPort{
+		UUID:     buildNamedUUID(),
+		Name:     "lrp1",
+		MAC:      "00:00:00:00:00:01",
+		Networks: []string{"192.168.1.1/24"},
+	}
+	fakeLRP2 := &nbdb.LogicalRouterPort{
+		UUID:     buildNamedUUID(),
+		Name:     "lrp2",
+		MAC:      "00:00:00:00:00:02",
+		Networks: []string{"192.168.2.1/24"},
+	}
+	fakeLRP3 := &nbdb.LogicalRouterPort{
+		UUID:     buildNamedUUID(),
+		Name:     "lrp3",
+		MAC:      "00:00:00:00:00:03",
+		Networks: []string{"192.168.3.1/24"},
+	}
+
+	initialNbdb := libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			fakeLRP1,
+			fakeLRP2,
+			fakeLRP3,
+			&nbdb.LogicalRouter{
+				Name:  "rtr1",
+				UUID:  buildNamedUUID(),
+				Ports: []string{fakeLRP1.UUID, fakeLRP2.UUID, fakeLRP3.UUID},
+			},
+		},
+	}
+
+	expectedNbdb := libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			fakeLRP3,
+			&nbdb.LogicalRouter{
+				Name:  "rtr1",
+				UUID:  buildNamedUUID(),
+				Ports: []string{fakeLRP3.UUID},
+			},
+		},
+	}
+
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(initialNbdb, nil)
+	if err != nil {
+		t.Fatalf("failed to set up test harness: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+
+	router := &nbdb.LogicalRouter{Name: "rtr1"}
+	ops, err := DeleteLogicalRouterPortsOps(nbClient, nil,
+		router,
+		&nbdb.LogicalRouterPort{Name: "lrp1"},
+		&nbdb.LogicalRouterPort{Name: "lrp2"},
+	)
+	if err != nil {
+		t.Fatal(fmt.Errorf("DeleteLogicalRouterPortsOps() error = %v", err))
+	}
+
+	_, err = TransactAndCheck(nbClient, ops)
+	if err != nil {
+		t.Fatal(fmt.Errorf("TransactAndCheck() error = %v", err))
+	}
+
+	matcher := libovsdbtest.HaveData(expectedNbdb.NBData)
+	success, err := matcher.Match(nbClient)
+
+	if !success {
+		t.Fatal(fmt.Errorf("expected NBDB didn't match actual, err: %v", matcher.FailureMessage(nbClient)))
+	}
+	if err != nil {
+		t.Fatal(fmt.Errorf("matcher encountered error: %v", err))
+	}
+}
+
+func TestDeleteLogicalRouterPorts(t *testing.T) {
+	fakeLRP1 := &nbdb.LogicalRouterPort{
+		UUID:     buildNamedUUID(),
+		Name:     "lrp1",
+		MAC:      "00:00:00:00:00:01",
+		Networks: []string{"192.168.1.1/24"},
+	}
+	fakeLRP2 := &nbdb.LogicalRouterPort{
+		UUID:     buildNamedUUID(),
+		Name:     "lrp2",
+		MAC:      "00:00:00:00:00:02",
+		Networks: []string{"192.168.2.1/24"},
+	}
+	fakeLRP3 := &nbdb.LogicalRouterPort{
+		UUID:     buildNamedUUID(),
+		Name:     "lrp3",
+		MAC:      "00:00:00:00:00:03",
+		Networks: []string{"192.168.3.1/24"},
+	}
+
+	initialNbdb := libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			fakeLRP1,
+			fakeLRP2,
+			fakeLRP3,
+			&nbdb.LogicalRouter{
+				Name:  "rtr1",
+				UUID:  buildNamedUUID(),
+				Ports: []string{fakeLRP1.UUID, fakeLRP2.UUID, fakeLRP3.UUID},
+			},
+		},
+	}
+
+	expectedNbdb := libovsdbtest.TestSetup{
+		NBData: []libovsdbtest.TestData{
+			fakeLRP3,
+			&nbdb.LogicalRouter{
+				Name:  "rtr1",
+				UUID:  buildNamedUUID(),
+				Ports: []string{fakeLRP3.UUID},
+			},
+		},
+	}
+
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(initialNbdb, nil)
+	if err != nil {
+		t.Fatalf("failed to set up test harness: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+
+	router := &nbdb.LogicalRouter{Name: "rtr1"}
+	err = DeleteLogicalRouterPorts(nbClient,
+		router,
+		&nbdb.LogicalRouterPort{Name: "lrp1"},
+		&nbdb.LogicalRouterPort{Name: "lrp2"},
+	)
+	if err != nil {
+		t.Fatal(fmt.Errorf("DeleteLogicalRouterPorts() error = %v", err))
+	}
+
+	matcher := libovsdbtest.HaveData(expectedNbdb.NBData)
+	success, err := matcher.Match(nbClient)
+
+	if !success {
+		t.Fatal(fmt.Errorf("expected NBDB didn't match actual, err: %v", matcher.FailureMessage(nbClient)))
+	}
+	if err != nil {
+		t.Fatal(fmt.Errorf("matcher encountered error: %v", err))
+	}
+}

--- a/go-controller/pkg/libovsdb/ops/switch.go
+++ b/go-controller/pkg/libovsdb/ops/switch.go
@@ -394,6 +394,13 @@ func createOrUpdateLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.L
 	return err
 }
 
+// CreateOrUpdateLogicalSwitchPortsOnSwitchOps creates or updates the provided
+// logical switch ports and adds them to the provided logical switch and
+// returns the corresponding ops
+func CreateOrUpdateLogicalSwitchPortsOnSwitchOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, sw *nbdb.LogicalSwitch, lsps ...*nbdb.LogicalSwitchPort) ([]ovsdb.Operation, error) {
+	return createOrUpdateLogicalSwitchPortsOps(nbClient, ops, sw, false, true, nil, lsps...)
+}
+
 // CreateOrUpdateLogicalSwitchPortsOnSwitchWithCustomFieldsOps creates or updates the provided
 // logical switch ports, adds them to the provided logical switch and returns
 // the corresponding ops

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -465,8 +465,7 @@ func (zic *ZoneInterconnectHandler) addTransitSwitchConfig(sw *nbdb.LogicalSwitc
 //     to the node logical switch port in the transit switch
 //   - remove any stale static routes in the ovn_cluster_router for the node
 //
-// All nbdb operations (LRP add, LSP add, stale route deletes) are committed in
-// a single OVSDB transaction.
+// All nbdb operations are committed in a single OVSDB transaction.
 func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.Node, nodeID int) error {
 	nodeTransitSwitchPortIPs, err := util.ParseNodeTransitSwitchPortAddrs(node)
 	if err != nil || len(nodeTransitSwitchPortIPs) == 0 {
@@ -517,7 +516,7 @@ func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.No
 
 	// Its possible that node is moved from a remote zone to the local zone. Build ops to delete the
 	// remote zone routes for this node as it's no longer needed.
-	ops, err = zic.deleteLocalNodeStaticRoutes(ops, node, nodeTransitSwitchPortIPs)
+	ops, err = zic.deleteLocalNodeStaticRoutes(ops, node)
 	if err != nil {
 		return err
 	}
@@ -533,10 +532,10 @@ func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.No
 //     Eg. if the node name is ovn-worker and the network is default, the name would be - tstor.ovn-worker
 //     if the node name is ovn-worker and the network name is blue, the logical port name would be - blue.tstor.ovn-worker
 //   - binds the remote port to the node remote chassis in SBDB
+//   - removes any IC static routes that conflict with this node's routes
 //   - adds static routes for the remote node via the remote port ip in the ovn_cluster_router
 //
-// All nbdb operations (LSP add, static routes add, leftover LRP cleanup) are
-// committed in a single OVSDB transaction.
+// All nbdb operations are committed in a single OVSDB transaction.
 func (zic *ZoneInterconnectHandler) createRemoteZoneNodeResources(node *corev1.Node, nodeID int, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs []*net.IPNet) error {
 	transitRouterPortMac := util.IPAddrToHWAddr(nodeTransitSwitchPortIPs[0].IP)
 	var transitRouterPortNetworks []string
@@ -733,64 +732,21 @@ func (zic *ZoneInterconnectHandler) addRemoteNodeStaticRoutes(ops []ovsdb.Operat
 	return ops, nil
 }
 
-// deleteLocalNodeStaticRoutes builds ops to delete the static routes added by
-// the function addRemoteNodeStaticRoutes.
-func (zic *ZoneInterconnectHandler) deleteLocalNodeStaticRoutes(ops []ovsdb.Operation, node *corev1.Node, nodeTransitSwitchPortIPs []*net.IPNet) ([]ovsdb.Operation, error) {
-	// skip types.NetworkExternalID check in the predicate function as this static route may be deleted
-	// before types.NetworkExternalID external-ids is set correctly during upgrade.
-	deleteRouteOps := func(prefix, nexthop string) error {
-		p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
-			return lrsr.IPPrefix == prefix &&
-				lrsr.Nexthop == nexthop &&
-				lrsr.ExternalIDs["ic-node"] == node.Name
-		}
-		var err error
-		ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(zic.nbClient, ops, zic.networkClusterRouterName, p)
-		if err != nil {
-			return fmt.Errorf("failed to build ops to delete static route: %w", err)
-		}
-		return nil
+// deleteLocalNodeStaticRoutes builds ops to delete all IC static routes owned
+// by the given node from the cluster router. Called on the local-add path so
+// that a node moving from a remote zone to the local zone has its previous
+// remote IC routes cleaned up.
+func (zic *ZoneInterconnectHandler) deleteLocalNodeStaticRoutes(ops []ovsdb.Operation, node *corev1.Node) ([]ovsdb.Operation, error) {
+	// Match on ic-node only, so any IC static route tagged with this node
+	// gets removed regardless of prefix/nexthop drift from current annotations.
+	p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
+		return lrsr.ExternalIDs["ic-node"] == node.Name
 	}
-
-	nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(node, zic.GetNetworkName())
+	var err error
+	ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(zic.nbClient, ops, zic.networkClusterRouterName, p)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse node %s subnets annotation %w", node.Name, err)
+		return nil, fmt.Errorf("failed to build ops to delete static routes for node %s: %w", node.Name, err)
 	}
-
-	nodeSubnetStaticRoutes := zic.getStaticRoutes(nodeSubnets, nodeTransitSwitchPortIPs, false)
-	for _, staticRoute := range nodeSubnetStaticRoutes {
-		if err := deleteRouteOps(staticRoute.prefix, staticRoute.nexthop); err != nil {
-			return nil, fmt.Errorf("error deleting static route %s - %s from the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
-		}
-	}
-
-	if zic.IsUserDefinedNetwork() {
-		// UDN cluster router doesn't connect to a join switch
-		// or to a Gateway router.
-		return ops, nil
-	}
-
-	// Clear the routes connecting to the GW Router for the default network
-	nodeGRPIPs, err := udn.GetGWRouterIPs(node, zic.GetNetInfo())
-	if err != nil {
-		if util.IsAnnotationNotSetError(err) {
-			// FIXME(tssurya): This is present for backwards compatibility
-			// Remove me a few months from now
-			var err1 error
-			nodeGRPIPs, err1 = util.ParseNodeGatewayRouterLRPAddrs(node)
-			if err1 != nil {
-				return nil, fmt.Errorf("failed to parse node %s Gateway router LRP Addrs annotation %w", node.Name, err1)
-			}
-		}
-	}
-
-	nodenodeGRPIPStaticRoutes := zic.getStaticRoutes(nodeGRPIPs, nodeTransitSwitchPortIPs, true)
-	for _, staticRoute := range nodenodeGRPIPStaticRoutes {
-		if err := deleteRouteOps(staticRoute.prefix, staticRoute.nexthop); err != nil {
-			return nil, fmt.Errorf("error deleting static route %s - %s from the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
-		}
-	}
-
 	return ops, nil
 }
 

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -294,6 +294,9 @@ func (zic *ZoneInterconnectHandler) DeleteNode(node *corev1.Node) error {
 }
 
 // CleanupStaleNodes cleans up the interconnect resources for stale nodes.
+// It identifies stale nodes by inspecting the transit switch ports (or, if
+// the transit switch is missing, by inspecting cluster router ports and
+// IC-tagged static routes) and deletes the corresponding ports.
 func (zic *ZoneInterconnectHandler) CleanupStaleNodes(objs []interface{}) error {
 	// Build set of current node names
 	foundNodeNames := sets.New[string]()
@@ -461,6 +464,9 @@ func (zic *ZoneInterconnectHandler) addTransitSwitchConfig(sw *nbdb.LogicalSwitc
 //   - creates a logical router port in the ovn_cluster_router with the name - <network_name>.rtots-<node_name> and connects
 //     to the node logical switch port in the transit switch
 //   - remove any stale static routes in the ovn_cluster_router for the node
+//
+// All nbdb operations (LRP add, LSP add, stale route deletes) are committed in
+// a single OVSDB transaction.
 func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.Node, nodeID int) error {
 	nodeTransitSwitchPortIPs, err := util.ParseNodeTransitSwitchPortAddrs(node)
 	if err != nil || len(nodeTransitSwitchPortIPs) == 0 {
@@ -487,7 +493,10 @@ func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.No
 		Name: zic.networkClusterRouterName,
 	}
 
-	if err := libovsdbops.CreateOrUpdateLogicalRouterPort(zic.nbClient, &logicalRouter, &logicalRouterPort, nil); err != nil {
+	var ops []ovsdb.Operation
+
+	ops, err = libovsdbops.CreateOrUpdateLogicalRouterPortOps(zic.nbClient, ops, &logicalRouter, &logicalRouterPort, nil)
+	if err != nil {
 		return fmt.Errorf("failed to create/update cluster router %s to add transit switch port %s for the node %s: %w", zic.networkClusterRouterName, logicalRouterPortName, node.Name, err)
 	}
 
@@ -500,15 +509,23 @@ func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.No
 	externalIDs := map[string]string{
 		"node": node.Name,
 	}
-	err = zic.addNodeLogicalSwitchPort(zic.networkTransitSwitchName, zic.GetNetworkScopedName(types.TransitSwitchToRouterPrefix+node.Name),
+	ops, err = zic.addNodeLogicalSwitchPort(ops, zic.networkTransitSwitchName, zic.GetNetworkScopedName(types.TransitSwitchToRouterPrefix+node.Name),
 		lportTypeRouter, []string{lportTypeRouterAddr}, lspOptions, externalIDs)
 	if err != nil {
 		return err
 	}
 
-	// Its possible that node is moved from a remote zone to the local zone. Check and delete the remote zone routes
-	// for this node as it's no longer needed.
-	return zic.deleteLocalNodeStaticRoutes(node, nodeTransitSwitchPortIPs)
+	// Its possible that node is moved from a remote zone to the local zone. Build ops to delete the
+	// remote zone routes for this node as it's no longer needed.
+	ops, err = zic.deleteLocalNodeStaticRoutes(ops, node, nodeTransitSwitchPortIPs)
+	if err != nil {
+		return err
+	}
+
+	if _, err := libovsdbops.TransactAndCheck(zic.nbClient, ops); err != nil {
+		return fmt.Errorf("failed to create interconnect resources for local zone node %s: %w", node.Name, err)
+	}
+	return nil
 }
 
 // createRemoteZoneNodeResources creates the remote zone node resources
@@ -517,6 +534,9 @@ func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.No
 //     if the node name is ovn-worker and the network name is blue, the logical port name would be - blue.tstor.ovn-worker
 //   - binds the remote port to the node remote chassis in SBDB
 //   - adds static routes for the remote node via the remote port ip in the ovn_cluster_router
+//
+// All nbdb operations (LSP add, static routes add, leftover LRP cleanup) are
+// committed in a single OVSDB transaction.
 func (zic *ZoneInterconnectHandler) createRemoteZoneNodeResources(node *corev1.Node, nodeID int, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs []*net.IPNet) error {
 	transitRouterPortMac := util.IPAddrToHWAddr(nodeTransitSwitchPortIPs[0].IP)
 	var transitRouterPortNetworks []string
@@ -547,21 +567,34 @@ func (zic *ZoneInterconnectHandler) createRemoteZoneNodeResources(node *corev1.N
 		"node": node.Name,
 	}
 
+	var ops []ovsdb.Operation
+
 	remotePortName := zic.GetNetworkScopedName(types.TransitSwitchToRouterPrefix + node.Name)
-	if err := zic.addNodeLogicalSwitchPort(zic.networkTransitSwitchName, remotePortName, lportTypeRemote, []string{remotePortAddr}, lspOptions, externalIDs); err != nil {
+	ops, err = zic.addNodeLogicalSwitchPort(ops, zic.networkTransitSwitchName, remotePortName, lportTypeRemote, []string{remotePortAddr}, lspOptions, externalIDs)
+	if err != nil {
 		return err
 	}
 
-	if err := zic.addRemoteNodeStaticRoutes(node, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs); err != nil {
+	ops, err = zic.addRemoteNodeStaticRoutes(ops, node, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs)
+	if err != nil {
 		return err
 	}
 
-	// Cleanup the logical router port connecting to the transit switch for the remote node (if present)
-	// Cleanup would be required when a local zone node moves to a remote zone.
-	return zic.cleanupNodeClusterRouterPort(node.Name)
+	// Build ops to cleanup the logical router port connecting to the transit switch
+	// for the remote node (if present). Cleanup would be required when a local zone
+	// node moves to a remote zone.
+	ops, err = zic.cleanupNodeClusterRouterPort(ops, node.Name)
+	if err != nil {
+		return err
+	}
+
+	if _, err := libovsdbops.TransactAndCheck(zic.nbClient, ops); err != nil {
+		return fmt.Errorf("failed to create interconnect resources for remote zone node %s: %w", node.Name, err)
+	}
+	return nil
 }
 
-func (zic *ZoneInterconnectHandler) addNodeLogicalSwitchPort(logicalSwitchName, portName, portType string, addresses []string, options, externalIDs map[string]string) error {
+func (zic *ZoneInterconnectHandler) addNodeLogicalSwitchPort(ops []ovsdb.Operation, logicalSwitchName, portName, portType string, addresses []string, options, externalIDs map[string]string) ([]ovsdb.Operation, error) {
 	logicalSwitch := nbdb.LogicalSwitch{
 		Name: logicalSwitchName,
 	}
@@ -573,86 +606,92 @@ func (zic *ZoneInterconnectHandler) addNodeLogicalSwitchPort(logicalSwitchName, 
 		Addresses:   addresses,
 		ExternalIDs: externalIDs,
 	}
-	if err := libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitch(zic.nbClient, &logicalSwitch, &logicalSwitchPort); err != nil {
-		return fmt.Errorf("failed to add logical port %s to switch %s, error: %w", portName, logicalSwitch.Name, err)
+	ops, err := libovsdbops.CreateOrUpdateLogicalSwitchPortsOnSwitchOps(zic.nbClient, ops, &logicalSwitch, &logicalSwitchPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build ops to add logical port %s to switch %s, error: %w", portName, logicalSwitch.Name, err)
 	}
-	return nil
+	return ops, nil
 }
 
-// cleanupNode cleansup the local zone node or remote zone node resources
 func (zic *ZoneInterconnectHandler) cleanupNode(nodeName string) error {
 	klog.Infof("Cleaning up interconnect resources for the node %s for the network %s", nodeName, zic.GetNetworkName())
 
-	// Cleanup the logical router port in the cluster router for the node
-	// if it exists.
-	if err := zic.cleanupNodeClusterRouterPort(nodeName); err != nil {
+	var ops []ovsdb.Operation
+	var err error
+
+	// Build ops to delete the logical router port in the cluster router for
+	// the node if it exists.
+	ops, err = zic.cleanupNodeClusterRouterPort(ops, nodeName)
+	if err != nil {
 		return err
 	}
 
-	// Cleanup the logical switch port in the transit switch for the node
-	// if it exists.
-	if err := zic.cleanupNodeTransitSwitchPort(nodeName); err != nil {
+	// Build ops to delete the logical switch port in the transit switch for
+	// the node if it exists.
+	ops, err = zic.cleanupNodeTransitSwitchPort(ops, nodeName)
+	if err != nil {
 		return err
 	}
 
-	// Delete any static routes in the cluster router for this node.
+	// Build ops to delete any static routes in the cluster router for this node.
 	// skip types.NetworkExternalID check in the predicate function as this static route may be deleted
 	// before types.NetworkExternalID external-ids is set correctly during upgrade.
 	p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
 		return lrsr.ExternalIDs["ic-node"] == nodeName
 	}
-	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(zic.nbClient, zic.networkClusterRouterName, p); err != nil {
-		return fmt.Errorf("failed to cleanup static routes for the node %s: %w", nodeName, err)
+	ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(zic.nbClient, ops, zic.networkClusterRouterName, p)
+	if err != nil {
+		return fmt.Errorf("failed to build ops to cleanup static routes for the node %s: %w", nodeName, err)
+	}
+
+	// Commit all three deletes atomically.
+	if _, err = libovsdbops.TransactAndCheck(zic.nbClient, ops); err != nil {
+		return fmt.Errorf("failed to cleanup interconnect resources for the node %s: %w", nodeName, err)
 	}
 
 	return nil
 }
 
-func (zic *ZoneInterconnectHandler) cleanupNodeClusterRouterPort(nodeName string) error {
-	lrp := nbdb.LogicalRouterPort{
+func (zic *ZoneInterconnectHandler) cleanupNodeClusterRouterPort(ops []ovsdb.Operation, nodeName string) ([]ovsdb.Operation, error) {
+	logicalRouterPort := &nbdb.LogicalRouterPort{
 		Name: zic.GetNetworkScopedName(types.RouterToTransitSwitchPrefix + nodeName),
 	}
-	logicalRouterPort, err := libovsdbops.GetLogicalRouterPort(zic.nbClient, &lrp)
-	if err != nil {
-		// logical router port doesn't exist. So nothing to cleanup.
-		return nil
-	}
-
-	logicalRouter := nbdb.LogicalRouter{
+	logicalRouter := &nbdb.LogicalRouter{
 		Name: zic.networkClusterRouterName,
 	}
 
-	if err := libovsdbops.DeleteLogicalRouterPorts(zic.nbClient, &logicalRouter, logicalRouterPort); err != nil {
-		return fmt.Errorf("failed to delete logical router port %s from router %s for the node %s, error: %w", logicalRouterPort.Name, zic.networkClusterRouterName, nodeName, err)
+	ops, err := libovsdbops.DeleteLogicalRouterPortsOps(zic.nbClient, ops, logicalRouter, logicalRouterPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build ops to delete logical router port %s from router %s for the node %s, error: %w", logicalRouterPort.Name, zic.networkClusterRouterName, nodeName, err)
 	}
 
-	return nil
+	return ops, nil
 }
 
-func (zic *ZoneInterconnectHandler) cleanupNodeTransitSwitchPort(nodeName string) error {
-	logicalSwitch := &nbdb.LogicalSwitch{
-		Name: zic.networkTransitSwitchName,
-	}
+func (zic *ZoneInterconnectHandler) cleanupNodeTransitSwitchPort(ops []ovsdb.Operation, nodeName string) ([]ovsdb.Operation, error) {
 	logicalSwitchPort := &nbdb.LogicalSwitchPort{
 		Name: zic.GetNetworkScopedName(types.TransitSwitchToRouterPrefix + nodeName),
 	}
-
-	if err := libovsdbops.DeleteLogicalSwitchPorts(zic.nbClient, logicalSwitch, logicalSwitchPort); err != nil {
-		return fmt.Errorf("failed to delete logical switch port %s from transit switch %s for the node %s, error: %w", logicalSwitchPort.Name, zic.networkTransitSwitchName, nodeName, err)
+	logicalSwitch := &nbdb.LogicalSwitch{
+		Name: zic.networkTransitSwitchName,
 	}
-	return nil
+
+	ops, err := libovsdbops.DeleteLogicalSwitchPortsOps(zic.nbClient, ops, logicalSwitch, logicalSwitchPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build ops to delete logical switch port %s from transit switch %s for the node %s, error: %w", logicalSwitchPort.Name, zic.networkTransitSwitchName, nodeName, err)
+	}
+	return ops, nil
 }
 
-// addRemoteNodeStaticRoutes adds static routes in ovn_cluster_router to reach the remote node via the
-// remote node transit switch port.
+// addRemoteNodeStaticRoutes builds ops to add static routes in ovn_cluster_router
+// to reach the remote node via the remote node transit switch port.
 // Eg. if node ovn-worker2 is a remote node
 // ovn-worker2 - { node_subnet = 10.244.0.0/24,  node id = 2,  transit switch port ip = 100.88.0.2/16,  join ip connecting to GR_ovn-worker = 100.64.0.2/16}
 // Then the below static routes are added
 // ip4.dst == 10.244.0.0/24 , nexthop = 100.88.0.2
 // ip4.dst == 100.64.0.2/16 , nexthop = 100.88.0.2  (only for default primary network)
-func (zic *ZoneInterconnectHandler) addRemoteNodeStaticRoutes(node *corev1.Node, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs []*net.IPNet) error {
-	ops := make([]ovsdb.Operation, 0, 2)
-	addRoute := func(prefix, nexthop string) error {
+func (zic *ZoneInterconnectHandler) addRemoteNodeStaticRoutes(ops []ovsdb.Operation, node *corev1.Node, nodeTransitSwitchPortIPs, nodeSubnets, nodeGRPIPs []*net.IPNet) ([]ovsdb.Operation, error) {
+	addRouteOps := func(prefix, nexthop string) error {
 		logicalRouterStaticRoute := nbdb.LogicalRouterStaticRoute{
 			ExternalIDs: map[string]string{
 				"ic-node":               node.Name,
@@ -677,57 +716,58 @@ func (zic *ZoneInterconnectHandler) addRemoteNodeStaticRoutes(node *corev1.Node,
 
 	nodeSubnetStaticRoutes := zic.getStaticRoutes(nodeSubnets, nodeTransitSwitchPortIPs, false)
 	for _, staticRoute := range nodeSubnetStaticRoutes {
-		if err := addRoute(staticRoute.prefix, staticRoute.nexthop); err != nil {
-			return fmt.Errorf("error adding static route %s - %s to the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
+		if err := addRouteOps(staticRoute.prefix, staticRoute.nexthop); err != nil {
+			return nil, fmt.Errorf("error adding static route %s - %s to the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
 		}
 	}
 
 	if len(nodeGRPIPs) > 0 {
 		nodeGRPIPStaticRoutes := zic.getStaticRoutes(nodeGRPIPs, nodeTransitSwitchPortIPs, true)
 		for _, staticRoute := range nodeGRPIPStaticRoutes {
-			if err := addRoute(staticRoute.prefix, staticRoute.nexthop); err != nil {
-				return fmt.Errorf("error adding static route %s - %s to the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
+			if err := addRouteOps(staticRoute.prefix, staticRoute.nexthop); err != nil {
+				return nil, fmt.Errorf("error adding static route %s - %s to the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
 			}
 		}
 	}
 
-	_, err := libovsdbops.TransactAndCheck(zic.nbClient, ops)
-	return err
+	return ops, nil
 }
 
-// deleteLocalNodeStaticRoutes deletes the static routes added by the function addRemoteNodeStaticRoutes
-func (zic *ZoneInterconnectHandler) deleteLocalNodeStaticRoutes(node *corev1.Node, nodeTransitSwitchPortIPs []*net.IPNet) error {
+// deleteLocalNodeStaticRoutes builds ops to delete the static routes added by
+// the function addRemoteNodeStaticRoutes.
+func (zic *ZoneInterconnectHandler) deleteLocalNodeStaticRoutes(ops []ovsdb.Operation, node *corev1.Node, nodeTransitSwitchPortIPs []*net.IPNet) ([]ovsdb.Operation, error) {
 	// skip types.NetworkExternalID check in the predicate function as this static route may be deleted
 	// before types.NetworkExternalID external-ids is set correctly during upgrade.
-	deleteRoute := func(prefix, nexthop string) error {
+	deleteRouteOps := func(prefix, nexthop string) error {
 		p := func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
 			return lrsr.IPPrefix == prefix &&
 				lrsr.Nexthop == nexthop &&
 				lrsr.ExternalIDs["ic-node"] == node.Name
 		}
-		if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(zic.nbClient, zic.networkClusterRouterName, p); err != nil {
-			return fmt.Errorf("failed to delete static route: %w", err)
+		var err error
+		ops, err = libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicateOps(zic.nbClient, ops, zic.networkClusterRouterName, p)
+		if err != nil {
+			return fmt.Errorf("failed to build ops to delete static route: %w", err)
 		}
 		return nil
 	}
 
 	nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(node, zic.GetNetworkName())
 	if err != nil {
-		return fmt.Errorf("failed to parse node %s subnets annotation %w", node.Name, err)
+		return nil, fmt.Errorf("failed to parse node %s subnets annotation %w", node.Name, err)
 	}
 
 	nodeSubnetStaticRoutes := zic.getStaticRoutes(nodeSubnets, nodeTransitSwitchPortIPs, false)
 	for _, staticRoute := range nodeSubnetStaticRoutes {
-		// Possible optimization: Add all the routes in one transaction
-		if err := deleteRoute(staticRoute.prefix, staticRoute.nexthop); err != nil {
-			return fmt.Errorf("error deleting static route %s - %s from the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
+		if err := deleteRouteOps(staticRoute.prefix, staticRoute.nexthop); err != nil {
+			return nil, fmt.Errorf("error deleting static route %s - %s from the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
 		}
 	}
 
 	if zic.IsUserDefinedNetwork() {
 		// UDN cluster router doesn't connect to a join switch
 		// or to a Gateway router.
-		return nil
+		return ops, nil
 	}
 
 	// Clear the routes connecting to the GW Router for the default network
@@ -739,20 +779,19 @@ func (zic *ZoneInterconnectHandler) deleteLocalNodeStaticRoutes(node *corev1.Nod
 			var err1 error
 			nodeGRPIPs, err1 = util.ParseNodeGatewayRouterLRPAddrs(node)
 			if err1 != nil {
-				return fmt.Errorf("failed to parse node %s Gateway router LRP Addrs annotation %w", node.Name, err1)
+				return nil, fmt.Errorf("failed to parse node %s Gateway router LRP Addrs annotation %w", node.Name, err1)
 			}
 		}
 	}
 
 	nodenodeGRPIPStaticRoutes := zic.getStaticRoutes(nodeGRPIPs, nodeTransitSwitchPortIPs, true)
 	for _, staticRoute := range nodenodeGRPIPStaticRoutes {
-		// Possible optimization: Add all the routes in one transaction
-		if err := deleteRoute(staticRoute.prefix, staticRoute.nexthop); err != nil {
-			return fmt.Errorf("error deleting static route %s - %s from the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
+		if err := deleteRouteOps(staticRoute.prefix, staticRoute.nexthop); err != nil {
+			return nil, fmt.Errorf("error deleting static route %s - %s from the router %s : %w", staticRoute.prefix, staticRoute.nexthop, zic.networkClusterRouterName, err)
 		}
 	}
 
-	return nil
+	return ops, nil
 }
 
 // interconnectStaticRoute represents a static route

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
@@ -579,6 +579,365 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("AddRemoteZoneNode cleans up conflicting routes from previously-deleted nodes before adding the node", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Set up 3 healthy nodes - all transit ports + legitimate routes present
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Inject a stale route attributed to a deleted node "oldNode4" whose
+				// prefix matches one of node3's prefixes but with a different
+				// nexthop. This represents the customer bug: a previously-deleted
+				// node left behind a route on a subnet that's now being recycled to
+				// node3, and the dead nexthop would cause ECMP collision.
+				staleConflictingRoute := nbdb.LogicalRouterStaticRoute{
+					IPPrefix: "10.244.4.0/24", // matches one of node3's subnet prefixes
+					Nexthop:  "100.88.0.99",   // dead transit IP belonging to oldNode4
+					ExternalIDs: map[string]string{
+						"ic-node":             "oldNode4",
+						"k8s.ovn.org/network": types.DefaultNetworkName,
+					},
+				}
+				staleConflictingRoutePredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.IPPrefix == staleConflictingRoute.IPPrefix &&
+						route.Nexthop == staleConflictingRoute.Nexthop &&
+						route.ExternalIDs != nil &&
+						route.ExternalIDs["ic-node"] == "oldNode4"
+				}
+				ops, err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(libovsdbOvnNBClient, nil, types.OVNClusterRouter, &staleConflictingRoute, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = libovsdbops.TransactAndCheck(libovsdbOvnNBClient, ops)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Sanity: stale route exists before cleanup
+				clusterRouter, err := libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				staleRoutesBefore, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, staleConflictingRoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(staleRoutesBefore).To(gomega.HaveLen(1), "stale conflicting route should exist before cleanup")
+
+				// Re-add node3. The per-node cleanup must detect the stale route from
+				// oldNode4 on a prefix that belongs to node3 and remove it before
+				// node3's new routes are added. This prevents ECMP collision.
+				err = zoneICHandler.AddRemoteZoneNode(&testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Stale conflicting route should be gone
+				clusterRouter, err = libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				staleRoutesAfter, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, staleConflictingRoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(staleRoutesAfter).To(gomega.BeEmpty(), "stale conflicting route from oldNode4 should have been removed")
+
+				// Verify only ONE route exists for the recycled prefix - no ECMP
+				prefixPredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.IPPrefix == "10.244.4.0/24"
+				}
+				routesForPrefix, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, prefixPredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(routesForPrefix).To(gomega.HaveLen(1), "only node3's route should exist for the recycled prefix - no ECMP collision")
+				gomega.Expect(routesForPrefix[0].ExternalIDs["ic-node"]).To(gomega.Equal(testNode3.Name), "the remaining route should belong to node3")
+
+				// All 3 nodes' resources otherwise intact
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("AddRemoteZoneNode removes route with wrong nexthop pairing while keeping legitimate routes", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Set up 3 healthy nodes - all transit ports + legitimate routes present
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Inject a bogus route tagged ic-node=node3 but with the WRONG nexthop
+				// (node1's transit IP instead of node3's). The (prefix, nexthop) pair
+				// is invalid for node3.
+				bogusRoute := nbdb.LogicalRouterStaticRoute{
+					IPPrefix: "10.244.4.0/24",
+					Nexthop:  "100.88.0.2", // node1's transit IP - WRONG for node3
+					ExternalIDs: map[string]string{
+						"ic-node":             testNode3.Name,
+						"k8s.ovn.org/network": types.DefaultNetworkName,
+					},
+				}
+				bogusRoutePredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.IPPrefix == bogusRoute.IPPrefix &&
+						route.Nexthop == bogusRoute.Nexthop &&
+						route.ExternalIDs != nil &&
+						route.ExternalIDs["ic-node"] == testNode3.Name
+				}
+				ops, err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(libovsdbOvnNBClient, nil, types.OVNClusterRouter, &bogusRoute, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = libovsdbops.TransactAndCheck(libovsdbOvnNBClient, ops)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Sanity: 2 legitimate node3 routes + 1 bogus = 3 routes tagged ic-node=node3
+				clusterRouter, err := libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				node3RoutePredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.ExternalIDs != nil && route.ExternalIDs["ic-node"] == testNode3.Name
+				}
+				routesBefore, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, node3RoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(routesBefore).To(gomega.HaveLen(3), "expected 2 legitimate + 1 bogus route tagged for node3 before cleanup")
+
+				// Re-add node3 - the per-node cleanup on the create path must detect
+				// and remove the bogus route whose (prefix, nexthop) pair is not in
+				// node3's valid set.
+				err = zoneICHandler.AddRemoteZoneNode(&testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Bogus route should be gone
+				clusterRouter, err = libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				bogusRoutes, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, bogusRoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(bogusRoutes).To(gomega.BeEmpty(), "the bogus wrong-nexthop route for node3 should have been removed")
+
+				// Both legitimate node3 routes must still be there
+				routesAfter, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, node3RoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(routesAfter).To(gomega.HaveLen(2), "node3's two legitimate routes should still exist")
+
+				// All 3 nodes' resources otherwise intact
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("AddLocalZoneNode removes all IC routes for the node regardless of prefix or nexthop drift", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Set up 3 healthy nodes. node1, node2 local; node3 remote. node3 gets IC routes.
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Inject two extra routes tagged with node3, each with drift from node3's
+				// current annotations:
+				//   - route A: stale prefix (10.244.99.0/24), correct nexthop (node3's live transit IP)
+				//   - route B: current prefix (10.244.4.0/24), stale nexthop (100.88.0.99)
+				// Neither would be caught by the old strict (prefix, nexthop, ic-node) predicate.
+				staleByPrefix := nbdb.LogicalRouterStaticRoute{
+					IPPrefix: "10.244.99.0/24", // subnet not assigned to any node
+					Nexthop:  "100.88.0.4",     // node3's live transit IP
+					ExternalIDs: map[string]string{
+						"ic-node":             testNode3.Name,
+						"k8s.ovn.org/network": types.DefaultNetworkName,
+					},
+				}
+				staleByNexthop := nbdb.LogicalRouterStaticRoute{
+					IPPrefix: "10.244.4.0/24", // matches node3's subnet
+					Nexthop:  "100.88.0.99",   // stale transit IP
+					ExternalIDs: map[string]string{
+						"ic-node":             testNode3.Name,
+						"k8s.ovn.org/network": types.DefaultNetworkName,
+					},
+				}
+				ops, err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(libovsdbOvnNBClient, nil, types.OVNClusterRouter, &staleByPrefix, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				ops, err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(libovsdbOvnNBClient, ops, types.OVNClusterRouter, &staleByNexthop, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = libovsdbops.TransactAndCheck(libovsdbOvnNBClient, ops)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Sanity: 2 legitimate node3 routes + 2 drifted routes = 4 routes tagged ic-node=node3
+				clusterRouter, err := libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				node3RoutePredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.ExternalIDs != nil && route.ExternalIDs["ic-node"] == testNode3.Name
+				}
+				routesBefore, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, node3RoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(routesBefore).To(gomega.HaveLen(4), "expected 2 legitimate + 2 drifted routes tagged for node3 before migration")
+
+				// Migrate node3 from remote to local. deleteLocalNodeStaticRoutes fires with
+				// the loose predicate (ic-node == node.Name only), removing ALL routes
+				// tagged with node3 - drifted ones included.
+				testNode3.Annotations[ovnNodeZoneNameAnnotation] = "global"
+				err = zoneICHandler.AddLocalZoneNode(&testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// All routes tagged ic-node=node3 should be gone. Node3 is now local; its IC
+				// routes have been removed and not re-added (local nodes don't have IC routes
+				// to themselves).
+				clusterRouter, err = libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				routesAfter, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, node3RoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(routesAfter).To(gomega.BeEmpty(), "all IC routes tagged with node3 should have been removed on local-add")
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("AddLocalZoneNode cleans up this node's own stale routes when moving from remote to local", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: initialNBDB,
+					SBData: initialSBDB,
+				}
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+				libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = createTransitSwitchPortBindings(libovsdbOvnSBClient, types.DefaultNetworkName, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				zoneICHandler := NewZoneInterconnectHandler(&util.DefaultNetInfo{}, libovsdbOvnNBClient, libovsdbOvnSBClient, nil)
+				err = zoneICHandler.createOrUpdateTransitSwitch(0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Set up 3 nodes: node1, node2 local; node3 remote. node3's IC routes get created.
+				err = invokeICHandlerAddNodeFunction("global", zoneICHandler, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = checkInterconnectResources("global", types.DefaultNetworkName, libovsdbOvnNBClient, testNodesRouteInfo, &testNode1, &testNode2, &testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Sanity: node3 has its remote-node IC routes tagged with ic-node=node3
+				clusterRouter, err := libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				node3RoutePredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.ExternalIDs != nil && route.ExternalIDs["ic-node"] == testNode3.Name
+				}
+				routesBefore, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, node3RoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(routesBefore).ToNot(gomega.BeEmpty(), "node3's remote-node IC routes should exist before migration")
+
+				// Capture node1/node2's routes as baseline for later comparison
+				node1And2RoutePredicate := func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.ExternalIDs != nil &&
+						(route.ExternalIDs["ic-node"] == testNode1.Name || route.ExternalIDs["ic-node"] == testNode2.Name)
+				}
+				node1And2RoutesBefore, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, node1And2RoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Migrate node3 from remote zone "foo" to local zone "global".
+				// AddLocalZoneNode calls deleteLocalNodeStaticRoutes with the loose predicate,
+				// which removes all IC routes tagged with node3. Node3 is now local so no
+				// re-adds happen for it.
+				testNode3.Annotations[ovnNodeZoneNameAnnotation] = "global"
+				err = zoneICHandler.AddLocalZoneNode(&testNode3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// All of node3's IC routes should be gone
+				clusterRouter, err = libovsdbops.GetLogicalRouter(libovsdbOvnNBClient, &nbdb.LogicalRouter{Name: types.OVNClusterRouter})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				node3RoutesAfter, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, node3RoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(node3RoutesAfter).To(gomega.BeEmpty(), "all IC routes tagged with node3 should be gone after remote to local migration")
+
+				// node1's and node2's routes must be untouched
+				node1And2RoutesAfter, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(libovsdbOvnNBClient, clusterRouter, node1And2RoutePredicate)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(node1And2RoutesAfter).To(gomega.HaveLen(len(node1And2RoutesBefore)), "node1's and node2's routes should be untouched by node3's migration")
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"-init-cluster-manager",
+				"-zone-join-switch-subnets=" + joinSubnetCIDR,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 		ginkgo.It("CleanupStaleNodes with nil should cleanup all transit switch ports for no-overlay migration", func() {
 			app.Action = func(ctx *cli.Context) error {
 				dbSetup := libovsdbtest.TestSetup{
@@ -1141,9 +1500,6 @@ var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 				r := newOVNClusterRouter(types.DefaultNetworkName)
 				err = libovsdbops.CreateOrUpdateLogicalRouter(libovsdbOvnNBClient, r)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				err = zoneICHandler.AddLocalZoneNode(&testNode4)
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("failed to parse node node4 subnets annotation")))
 
 				// Set node subnet annotation
 				testNode4.Annotations[ovnNodeSubnetsAnnotation] = "{\"default\":[\"10.244.5.0/24\"]}"


### PR DESCRIPTION
## What this PR does

Two changes to the zone interconnect handler:

1. Batch all nbdb operations per node lifecycle event into a single OVSDB transaction, so each event is atomic

2. Simplify the delete predicate in `deleteLocalNodeStaticRoutes` to match on the `ic-node` label only.

## Commits

- [`3f6bbe6`](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6519/commits/3f6bbe64a742f324a2995f0494cfba017c0b48f3) — Use single OVSDB transaction for zone interconnect node create and delete paths.
- [`8a105f3`](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6519/commits/8a105f34c17475dd6e75de885c3e6a8af56d93e8) — Simplify `deleteLocalNodeStaticRoutes` to match on ic-node only.

## Tests

- Existing 19 `pkg/ovn/zone_interconnect` specs unchanged and passing.
- 4 new specs added:
  - Conflicting routes from previously-deleted nodes cleaned up on remote-add
  - Wrong-nexthop pairing removed while legitimate routes preserved
  - Drift scenarios (stale prefix, stale nexthop) cleaned up on local-add
  - Remote to local zone transition cleanup
- Independence check: commit 1 alone builds and passes all 19 pre-existing specs.