### PR TITLE
e2e: configure framework TestContext to verify service accounts

### DIFF
--- a/test/e2e/testcontext.go
+++ b/test/e2e/testcontext.go
@@ -66,6 +66,9 @@ func ProcessTestContextAndSetupLogging() {
 		t.Provider = "skeleton"
 	}
 
+	// verify service accounts are created for namespaces before tests run
+	t.VerifyServiceAccount = true
+
 	var err error
 	t.CloudConfig.Provider, err = framework.SetupProviderConfig(t.Provider)
 	if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test verification by adding a pre-test validation step for service account setup before provider initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->