### PR TITLE
Stop allocating L2 node tunnel IDs when transit router is used

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -230,6 +230,9 @@ func NewClusterManager(
 // Start the cluster manager.
 func (cm *ClusterManager) Start(ctx context.Context) error {
 	klog.Info("Starting the cluster manager")
+	if err := cm.setTopologyType(); err != nil {
+		return fmt.Errorf("failed to set layer2 topology type: %w", err)
+	}
 
 	// Start and sync the watch factory to begin listening for events
 	if err := cm.wf.Start(); err != nil {
@@ -381,6 +384,29 @@ func (cm *ClusterManager) CleanupStaleNetworks(validNetworks ...util.NetInfo) er
 func (cm *ClusterManager) Reconcile(name string, old, new util.NetInfo) error {
 	if cm.raController != nil {
 		cm.raController.ReconcileNetwork(name, old, new)
+	}
+	return nil
+}
+
+// setTopologyType verifies if all nodes have the annotation Layer2UsesTransitRouter
+// and set it in config.Layer2UsesTransitRouter flag.
+// This way, cluster manager does not annotate nodes with tunnel IDs.
+func (cm *ClusterManager) setTopologyType() error {
+	if !config.Layer2UsesTransitRouter {
+		nodes, err := cm.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to get nodes from informer while setting topology type for layer2: %w", err)
+		}
+		// set it to true and check if all the nodes already have annotation
+		config.Layer2UsesTransitRouter = true
+		for _, node := range nodes.Items {
+			if !util.UDNLayer2NodeUsesTransitRouter(&node) {
+				// if at least one node doesn't have the annotation, consider none of them have Layer2UsesTransitRouter
+				config.Layer2UsesTransitRouter = false
+				return nil
+			}
+		}
+		klog.Infof("Switching to transit router for layer2 networks")
 	}
 	return nil
 }

--- a/go-controller/pkg/clustermanager/clustermanager_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_test.go
@@ -1752,6 +1752,109 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 		})
 	})
 
+	ginkgo.Context("Layer2 topology type detection", func() {
+		type topoTestEntry struct {
+			nodeAnnotations []map[string]string
+			expectedTransit bool
+		}
+
+		ginkgo.DescribeTable("sets Layer2UsesTransitRouter on Start",
+			func(entry topoTestEntry) {
+				app.Action = func(ctx *cli.Context) error {
+					var nodes []corev1.Node
+					for i, ann := range entry.nodeAnnotations {
+						nodes = append(nodes, corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:        fmt.Sprintf("node%d", i+1),
+								Annotations: ann,
+							},
+						})
+					}
+
+					kubeFakeClient := fake.NewSimpleClientset(&corev1.NodeList{Items: nodes})
+					fakeClient := &util.OVNClusterManagerClientset{
+						KubeClient: kubeFakeClient,
+					}
+
+					_, err := config.InitConfig(ctx, nil, nil)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					config.Layer2UsesTransitRouter = false
+
+					f, err = factory.NewClusterManagerWatchFactory(fakeClient)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					c, cancel := context.WithCancel(ctx.Context)
+					defer cancel()
+					clusterManager, err := NewClusterManager(fakeClient, f, "identity", nil)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					err = clusterManager.Start(c)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					defer clusterManager.Stop()
+
+					gomega.Expect(config.Layer2UsesTransitRouter).To(
+						gomega.Equal(entry.expectedTransit),
+						"Layer2UsesTransitRouter mismatch",
+					)
+
+					return nil
+				}
+				gomega.Expect(app.Run([]string{
+					app.Name,
+					"-cluster-subnets=" + clusterCIDR,
+				})).To(gomega.Succeed())
+			},
+			ginkgo.Entry("all nodes use transit router",
+				topoTestEntry{
+					nodeAnnotations: []map[string]string{
+						{util.Layer2TopologyVersion: util.TransitRouterTopoVersion},
+						{util.Layer2TopologyVersion: util.TransitRouterTopoVersion},
+					},
+					expectedTransit: true,
+				},
+			),
+			ginkgo.Entry("no nodes use transit router",
+				topoTestEntry{
+					nodeAnnotations: []map[string]string{
+						{},
+						{},
+					},
+					expectedTransit: false,
+				},
+			),
+			ginkgo.Entry("mixed: one node uses transit router, one does not",
+				topoTestEntry{
+					nodeAnnotations: []map[string]string{
+						{util.Layer2TopologyVersion: util.TransitRouterTopoVersion},
+						{},
+					},
+					expectedTransit: false,
+				},
+			),
+			ginkgo.Entry("single node uses transit router",
+				topoTestEntry{
+					nodeAnnotations: []map[string]string{
+						{util.Layer2TopologyVersion: util.TransitRouterTopoVersion},
+					},
+					expectedTransit: true,
+				},
+			),
+			ginkgo.Entry("single node without transit router",
+				topoTestEntry{
+					nodeAnnotations: []map[string]string{
+						{},
+					},
+					expectedTransit: false,
+				},
+			),
+			ginkgo.Entry("no nodes in cluster",
+				topoTestEntry{
+					nodeAnnotations: []map[string]string{},
+					expectedTransit: true,
+				},
+			),
+		)
+	})
+
 	ginkgo.Context("EVPN VTEP and UDN integration", func() {
 		ginkgo.It("should freeze NADs when VTEP goes into CIDROverlap after a second VTEP is created", func() {
 			app.Action = func(ctx *cli.Context) error {

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -42,6 +42,12 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
+const (
+	// reserve tunnel key = 1 for transitRouterToSwitch port
+	// matches same variable in transit_router.go
+	transitRouterToSwitchTunnelKey = 1
+)
+
 type NetworkStatusReporter func(networkName string, fieldManager string, condition *metav1.Condition, events ...*util.EventDetails) error
 
 // networkClusterController is the cluster controller for the networks. An
@@ -406,7 +412,7 @@ func (ncc *networkClusterController) init() error {
 		if err = ncc.tunnelIDAllocator.ReserveID("zero", types.NoTunnelID); err != nil {
 			return err
 		}
-		if util.IsNetworkSegmentationSupportEnabled() && ncc.IsPrimaryNetwork() {
+		if util.IsNetworkSegmentationSupportEnabled() && ncc.IsPrimaryNetwork() && !config.Layer2UsesTransitRouter {
 			// if the network is a primary L2 UDN network, then we need to reserve
 			// the IDs used by each node in this network's pod allocator
 			nodes, err := ncc.watchFactory.GetNodes()
@@ -429,6 +435,13 @@ func (ncc *networkClusterController) init() error {
 						return fmt.Errorf("unable to reserve id for network %s, node %s: %w", ncc.GetNetworkName(), node.Name, err)
 					}
 				}
+			}
+		}
+		// With transit router, no node tunnel IDs are allocated, but we must
+		// still reserve ID 1 so pod IDs don't collide with tunnel key on the switch-to-transit-router LSP.
+		if config.Layer2UsesTransitRouter {
+			if err := ncc.tunnelIDAllocator.ReserveID("reserved-transit-switch-key", transitRouterToSwitchTunnelKey); err != nil {
+				return err
 			}
 		}
 	}
@@ -700,7 +713,8 @@ func (ncc *networkClusterController) shouldReconcileNode(
 	return ncc.relevantNodeAnnotationsChanged(oldState, newState)
 }
 
-func (ncc *networkClusterController) relevantNodeAnnotationsChanged(oldState, newState *sharednode.NodeAnnotationState) bool {
+func (ncc *networkClusterController) relevantNodeAnnotationsChanged(
+	oldState, newState *sharednode.NodeAnnotationState) bool {
 	if ncc.nodeAllocator.HasNodeSubnetAllocation() &&
 		sharednode.NodeSubnetAnnotationChangedForNetworkWithState(oldState, newState, ncc.GetNetworkName()) {
 		return true

--- a/go-controller/pkg/clustermanager/network_cluster_controller_node_test.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller_node_test.go
@@ -25,6 +25,7 @@ func TestShouldReconcileNodeIgnoresOtherNetworkTunnelIDChanges(t *testing.T) {
 	}
 	config.OVNKubernetesFeature.EnableMultiNetwork = true
 	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.Layer2UsesTransitRouter = false
 
 	netInfo := mustClusterManagerNetInfo(t, &ovncnitypes.NetConf{
 		NetConf:  cnitypes.NetConf{Name: "blue", Type: "ovn-k8s-cni-overlay"},
@@ -35,19 +36,67 @@ func TestShouldReconcileNodeIgnoresOtherNetworkTunnelIDChanges(t *testing.T) {
 	ncc := &networkClusterController{ReconcilableNetInfo: util.NewReconcilableNetInfo(netInfo)}
 	ncc.nodeAllocator = cmnode.NewNodeAllocator(1, netInfo, nil, nil, nil)
 
+	// If both (oldNode or newNode) have TransitRouterTopoVersion it should not reconcile
 	oldNode := testNodeWithAnnotations("node1", map[string]string{
 		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"9"}`,
 	})
 	newNode := testNodeWithAnnotations("node1", map[string]string{
-		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"10"}`,
+		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"8","red":"10"}`,
 	})
 
 	cache := sharednode.NewNodeAnnotationCache()
 	oldState := cache.UpdateNodeAnnotationState(oldNode, false)
 	newState := cache.UpdateNodeAnnotationState(newNode, true)
 
+	if !ncc.shouldReconcileNode(oldNode, newNode, oldState, newState, false, false) {
+		t.Fatal("expected changed network tunnel ID to trigger reconciliation")
+	}
+
+	// If both (oldNode or newNode) have not TransitRouterTopoVersion it should not reconcile
+	// if there are no changes in tunnel ID
+	oldNode = testNodeWithAnnotations("node1", map[string]string{
+		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"9"}`,
+	})
+	newNode = testNodeWithAnnotations("node1", map[string]string{
+		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"10"}`,
+	})
+
+	oldState = cache.UpdateNodeAnnotationState(oldNode, false)
+	newState = cache.UpdateNodeAnnotationState(newNode, true)
+
 	if ncc.shouldReconcileNode(oldNode, newNode, oldState, newState, false, false) {
 		t.Fatal("expected unchanged network tunnel ID to avoid reconciliation")
+	}
+
+	// No reconciliation should happen if tunnel ID changes or not.
+	config.Layer2UsesTransitRouter = true
+
+	oldNode = testNodeWithAnnotations("node1", map[string]string{
+		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"9"}`,
+	})
+	newNode = testNodeWithAnnotations("node1", map[string]string{
+		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"8","red":"10"}`,
+	})
+
+	oldState = cache.UpdateNodeAnnotationState(oldNode, false)
+	newState = cache.UpdateNodeAnnotationState(newNode, true)
+
+	if ncc.shouldReconcileNode(oldNode, newNode, oldState, newState, false, false) {
+		t.Fatal("expected changed network tunnel ID to not trigger reconciliation when Layer2UsesTransitRouter is true")
+	}
+
+	oldNode = testNodeWithAnnotations("node1", map[string]string{
+		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"9"}`,
+	})
+	newNode = testNodeWithAnnotations("node1", map[string]string{
+		types.UDNLayer2NodeGRLRPTunnelIDAnnotation: `{"blue":"7","red":"10"}`,
+	})
+
+	oldState = cache.UpdateNodeAnnotationState(oldNode, false)
+	newState = cache.UpdateNodeAnnotationState(newNode, true)
+
+	if ncc.shouldReconcileNode(oldNode, newNode, oldState, newState, false, false) {
+		t.Fatal("expected unchanged network tunnel ID to not trigger reconciliation when Layer2UsesTransitRouter is true")
 	}
 }
 
@@ -84,6 +133,7 @@ func TestShouldReconcileNodeWhenNetworkSpecificTunnelIDChanges(t *testing.T) {
 	}
 	config.OVNKubernetesFeature.EnableMultiNetwork = true
 	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.Layer2UsesTransitRouter = false // Needed, so it reconciles UDNLayer2NodeGRLRPTunnelIDAnnotation
 
 	netInfo := mustClusterManagerNetInfo(t, &ovncnitypes.NetConf{
 		NetConf:  cnitypes.NetConf{Name: "blue", Type: "ovn-k8s-cni-overlay"},

--- a/go-controller/pkg/clustermanager/network_cluster_controller_test.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller_test.go
@@ -17,6 +17,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -481,6 +482,155 @@ func TestReconcileNodeMarksNodeSyncFailedOnCleanupError(t *testing.T) {
 	g.Expect(failed).To(gomega.BeTrue())
 	_, parseErr := util.ParseNetworkIDAnnotation(node, networkName)
 	g.Expect(parseErr).To(gomega.HaveOccurred())
+}
+
+func TestInitReserveTransitTunnelKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		transitRouter  bool
+		nodeTunnelIDs  map[string]int // node name -> tunnel ID annotation
+		wantAllocMinID int            // verify AllocateID returns >= this value
+	}{
+		// Transit router ON: only the transit-router-to-switch key (ID 1) is
+		// reserved. Node tunnel IDs are not consumed by the allocator.
+		{
+			name:           "transit router: no nodes, transit key reserved",
+			transitRouter:  true,
+			nodeTunnelIDs:  nil,
+			wantAllocMinID: 2,
+		},
+		{
+			name:          "transit router: node IDs are not consumed by allocator",
+			transitRouter: true,
+			nodeTunnelIDs: map[string]int{
+				"node1": 10,
+				"node2": 11,
+			},
+			wantAllocMinID: 2,
+		},
+		// Transit router OFF: no transit key reservation.
+		// Node tunnel IDs are consumed by the allocator.
+		{
+			name:           "no transit router: no nodes, no transit key reserved",
+			transitRouter:  false,
+			nodeTunnelIDs:  nil,
+			wantAllocMinID: 1,
+		},
+		{
+			name:          "no transit router: node IDs consumed by allocator",
+			transitRouter: false,
+			nodeTunnelIDs: map[string]int{
+				"node1": 10,
+				"node2": 11,
+			},
+			wantAllocMinID: 1,
+		},
+		{
+			name:          "no transit router: node with ID 1 consumed by allocator",
+			transitRouter: false,
+			nodeTunnelIDs: map[string]int{
+				"node1": 1,
+			},
+			wantAllocMinID: 2,
+		},
+		{
+			name:          "no transit router: node without annotation",
+			transitRouter: false,
+			nodeTunnelIDs: map[string]int{
+				"node1": types.InvalidID,
+			},
+			wantAllocMinID: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			err := config.PrepareTestConfig()
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+			config.Layer2UsesTransitRouter = tt.transitRouter
+
+			const networkName = "l2-primary-test"
+			netConf := &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					Name: networkName,
+					Type: "ovn-k8s-cni-overlay",
+				},
+				Topology: types.Layer2Topology,
+				Role:     types.NetworkRolePrimary,
+			}
+			netInfo, err := util.NewNetInfo(netConf)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+
+			var nodes []corev1.Node
+			for nodeName, tunnelID := range tt.nodeTunnelIDs {
+				node := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        nodeName,
+						Annotations: map[string]string{},
+					},
+				}
+				if tunnelID != types.InvalidID {
+					node.Annotations, err = util.UpdateUDNLayer2NodeGRLRPTunnelIDs(node.Annotations, networkName, tunnelID)
+					g.Expect(err).ToNot(gomega.HaveOccurred())
+				}
+				nodes = append(nodes, node)
+			}
+
+			runtimeObjs := make([]runtime.Object, len(nodes))
+			for i := range nodes {
+				runtimeObjs[i] = &nodes[i]
+			}
+			fakeClient := util.GetOVNClientset(runtimeObjs...).GetClusterManagerClientset()
+
+			wf, err := factory.NewClusterManagerWatchFactory(fakeClient)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(wf.Start()).To(gomega.Succeed())
+			defer wf.Shutdown()
+
+			nm := &networkmanager.FakeNetworkManager{}
+			nodeController := nodecontroller.NewController(wf, "clustermanager-node", nm)
+			g.Expect(nodeController.Start()).To(gomega.Succeed())
+			defer nodeController.Stop()
+
+			ncc := newNetworkClusterController(
+				netInfo,
+				fakeClient,
+				wf,
+				nil,
+				nm,
+				nil,
+				nodeController,
+			)
+
+			err = ncc.init()
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(ncc.tunnelIDAllocator).ToNot(gomega.BeNil())
+
+			// Verify transit-router-to-switch key reservation depends on mode.
+			// Reserve-then-release to probe without affecting subsequent allocation.
+			transitKeyErr := ncc.tunnelIDAllocator.ReserveID("transit-key-probe", transitRouterToSwitchTunnelKey)
+			if transitKeyErr == nil {
+				ncc.tunnelIDAllocator.ReleaseID("transit-key-probe")
+			}
+			if tt.transitRouter {
+				g.Expect(transitKeyErr).To(gomega.HaveOccurred(),
+					"transit key (ID %d) should be reserved when transit router is enabled", transitRouterToSwitchTunnelKey)
+			}
+
+			// Verify the next allocated ID reflects the reservation state:
+			// transit router ON reserves ID 1 so pods start at 2;
+			// transit router OFF has no reservation so pods start at 1
+			// (unless a node consumed low IDs).
+			nextID, allocErr := ncc.tunnelIDAllocator.AllocateID("test-pod")
+			g.Expect(allocErr).ToNot(gomega.HaveOccurred())
+			g.Expect(nextID).To(gomega.BeNumerically(">=", tt.wantAllocMinID),
+				"allocated ID should be >= %d", tt.wantAllocMinID)
+		})
+	}
 }
 
 func getUDNNodesRenderedMetric(t *testing.T, networkName string) float64 {

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -378,8 +378,10 @@ func (na *NodeAllocator) syncNodeNetworkAnnotations(node *corev1.Node) error {
 			updatedSubnetsMap[networkName] = validExistingSubnets
 		}
 	}
+	// TunnelID annotation is set in node only if Layer2UsesTransitRouter is disabled.
+	// Given that tunnelID only is used by `createGWRouterPeerSwitchPort`.
 	newTunnelID := types.NoTunnelID
-	if util.IsNetworkSegmentationSupportEnabled() && na.netInfo.IsPrimaryNetwork() && util.DoesNetworkRequireTunnelIDs(na.netInfo) {
+	if na.HasNodeTunnelIDAllocation() {
 		existingTunnelID, err := util.ParseUDNLayer2NodeGRLRPTunnelIDs(node, networkName)
 		if err != nil && !util.IsAnnotationNotSetError(err) {
 			return fmt.Errorf("failed to fetch tunnelID annotation from the node %s for network %s, err: %v",
@@ -731,7 +733,8 @@ func (na *NodeAllocator) HasNodeSubnetAllocation() bool {
 func (na *NodeAllocator) HasNodeTunnelIDAllocation() bool {
 	return util.IsNetworkSegmentationSupportEnabled() &&
 		na.netInfo.IsPrimaryNetwork() &&
-		util.DoesNetworkRequireTunnelIDs(na.netInfo)
+		util.DoesNetworkRequireTunnelIDs(na.netInfo) &&
+		!config.Layer2UsesTransitRouter
 }
 
 func (na *NodeAllocator) markAllocatedNetworksForUnmanagedHONode(node *corev1.Node) error {

--- a/go-controller/pkg/clustermanager/node/node_allocator_test.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator_test.go
@@ -728,11 +728,18 @@ func TestController_CleanupNodeRemovesUDNAnnotations(t *testing.T) {
 }
 
 func TestController_CleanupNodeReleasesTunnelIDs(t *testing.T) {
+	origLayerUsesTransitRouter := config.Layer2UsesTransitRouter
+	t.Cleanup(func() {
+		config.Layer2UsesTransitRouter = origLayerUsesTransitRouter
+	})
+
 	if err := config.PrepareTestConfig(); err != nil {
 		t.Fatal(err)
 	}
 	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
 	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	// Start with legacy topology (no transit router)
+	config.Layer2UsesTransitRouter = false
 
 	netConf := &ovncnitypes.NetConf{
 		NetConf: cnitypes.NetConf{
@@ -754,6 +761,7 @@ func TestController_CleanupNodeReleasesTunnelIDs(t *testing.T) {
 			Annotations: map[string]string{},
 		},
 	}
+	// Node does NOT have transit router annotation (legacy topology)
 	node.Annotations, err = util.UpdateUDNLayer2NodeGRLRPTunnelIDs(node.Annotations, networkName, 42)
 	if err != nil {
 		t.Fatal(err)
@@ -773,6 +781,11 @@ func TestController_CleanupNodeReleasesTunnelIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Verify HasNodeTunnelIDAllocation returns true in legacy mode
+	if !na.HasNodeTunnelIDAllocation() {
+		t.Fatal("HasNodeTunnelIDAllocation should return true in legacy topology")
+	}
+
 	if err := na.CleanupNode(node.Name, node); err != nil {
 		t.Fatalf("CleanupNode failed: %v", err)
 	}
@@ -786,5 +799,221 @@ func TestController_CleanupNodeReleasesTunnelIDs(t *testing.T) {
 	}
 	if gotID := na.idAllocator.GetID(networkName + "_" + node.Name); gotID != types.InvalidID {
 		t.Fatalf("expected tunnel ID to be released, got %d", gotID)
+	}
+}
+
+// TestCleanupNode_TransitRouterMigration verifies that tunnel ID annotations
+// are cleaned up when a node transitions to transit router topology.
+func TestCleanupNode_TransitRouterMigration(t *testing.T) {
+	origLayerUsesTransitRouter := config.Layer2UsesTransitRouter
+	t.Cleanup(func() {
+		config.Layer2UsesTransitRouter = origLayerUsesTransitRouter
+	})
+
+	if err := config.PrepareTestConfig(); err != nil {
+		t.Fatal(err)
+	}
+	config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	// Simulate transit router mode
+	config.Layer2UsesTransitRouter = true
+
+	netConf := &ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "udn-l2-migration",
+			Type: "ovn-k8s-cni-overlay",
+		},
+		Topology: types.Layer2Topology,
+		Role:     types.NetworkRolePrimary,
+	}
+	netInfo, err := util.NewNetInfo(netConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	networkName := netInfo.GetNetworkName()
+
+	// Node has stale tunnel ID annotation from legacy topology
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node1",
+			Annotations: map[string]string{},
+		},
+	}
+	// Node now uses transit router
+	node.Annotations[util.Layer2TopologyVersion] = util.TransitRouterTopoVersion
+	// But still has legacy tunnel ID annotation
+	node.Annotations, err = util.UpdateUDNLayer2NodeGRLRPTunnelIDs(node.Annotations, networkName, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fakeClient := fake.NewClientset(node)
+	kube := &kube.Kube{KClient: fakeClient}
+
+	idAlloc := id.NewIDAllocator("tunnel-ids", 1024)
+	// Simulate that the ID was allocated in legacy mode
+	if err := idAlloc.ReserveID(networkName+"_"+node.Name, 42); err != nil {
+		t.Fatal(err)
+	}
+
+	na := &NodeAllocator{
+		nodeLister:             newFakeNodeLister([]*corev1.Node{node}),
+		kube:                   kube,
+		netInfo:                netInfo,
+		clusterSubnetAllocator: NewSubnetAllocator(),
+		idAllocator:            idAlloc,
+	}
+
+	// Verify HasNodeTunnelIDAllocation returns false in transit router mode
+	if na.HasNodeTunnelIDAllocation() {
+		t.Fatal("HasNodeTunnelIDAllocation should return false in transit router mode")
+	}
+
+	// CleanupNode should remove the stale tunnel ID annotation
+	if err := na.CleanupNode(node.Name, node); err != nil {
+		t.Fatalf("CleanupNode failed: %v", err)
+	}
+
+	// Verify annotation was removed
+	updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := util.ParseUDNLayer2NodeGRLRPTunnelIDs(updatedNode, networkName); !util.IsAnnotationNotSetError(err) {
+		t.Fatalf("expected tunnel ID annotation to be removed after migration to transit router, got: %v", err)
+	}
+
+	// Verify allocator state was released
+	if gotID := na.idAllocator.GetID(networkName + "_" + node.Name); gotID != types.InvalidID {
+		t.Fatalf("expected tunnel ID to be released from allocator, got %d", gotID)
+	}
+}
+
+// TestSyncNodeNetworkAnnotations_TunnelID verifies that tunnel ID allocation
+// is correctly skipped or performed based on the Layer2UsesTransitRouter configuration.
+func TestSyncNodeNetworkAnnotations_TunnelID(t *testing.T) {
+	tests := []struct {
+		name            string
+		transitRouter   bool
+		wantAnnotation  bool
+		wantAllocatorID bool
+	}{
+		{
+			name:            "skip tunnel ID when transit router is used",
+			transitRouter:   true,
+			wantAnnotation:  false,
+			wantAllocatorID: false,
+		},
+		{
+			name:            "allocate tunnel ID when transit router is not used",
+			transitRouter:   false,
+			wantAnnotation:  true,
+			wantAllocatorID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origLayerUsesTransitRouter := config.Layer2UsesTransitRouter
+			t.Cleanup(func() {
+				config.Layer2UsesTransitRouter = origLayerUsesTransitRouter
+			})
+
+			if err := config.PrepareTestConfig(); err != nil {
+				t.Fatal(err)
+			}
+			config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+			config.OVNKubernetesFeature.EnableMultiNetwork = true
+			config.Layer2UsesTransitRouter = false
+
+			netConf := &ovncnitypes.NetConf{
+				NetConf: cnitypes.NetConf{
+					Name: "udn-l2",
+					Type: "ovn-k8s-cni-overlay",
+				},
+				Topology: types.Layer2Topology,
+				Role:     types.NetworkRolePrimary,
+				Subnets:  "10.1.0.0/16",
+			}
+			netInfo, err := util.NewNetInfo(netConf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			networkName := netInfo.GetNetworkName()
+
+			node1 := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "node1",
+					Annotations: map[string]string{},
+				},
+			}
+
+			fakeClient := fake.NewClientset(node1)
+			kube := &kube.Kube{KClient: fakeClient}
+
+			idAlloc := id.NewIDAllocator("tunnel-ids", 1024)
+			// Reserve ID 0 as it's not usable (types.NoTunnelID)
+			if err := idAlloc.ReserveID("zero", types.NoTunnelID); err != nil {
+				t.Fatal(err)
+			}
+
+			na := &NodeAllocator{
+				nodeLister:             newFakeNodeLister([]*corev1.Node{node1}),
+				kube:                   kube,
+				netInfo:                netInfo,
+				networkID:              1,
+				clusterSubnetAllocator: NewSubnetAllocator(),
+				idAllocator:            idAlloc,
+			}
+
+			// Set the topology mode directly (setTopologyType is now in ClusterManager)
+			config.Layer2UsesTransitRouter = tt.transitRouter
+
+			// Verify HasNodeTunnelIDAllocation returns the expected value
+			expectedHasTunnelID := !tt.transitRouter
+			if na.HasNodeTunnelIDAllocation() != expectedHasTunnelID {
+				t.Fatalf("HasNodeTunnelIDAllocation()=%v, want %v", na.HasNodeTunnelIDAllocation(), expectedHasTunnelID)
+			}
+
+			// Sync node annotations
+			if err := na.syncNodeNetworkAnnotations(node1); err != nil {
+				t.Fatalf("syncNodeNetworkAnnotations failed: %v", err)
+			}
+
+			// Verify tunnel ID annotation
+			updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), node1.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			tunnelID, err := util.ParseUDNLayer2NodeGRLRPTunnelIDs(updatedNode, networkName)
+			if tt.wantAnnotation {
+				if err != nil {
+					t.Fatalf("tunnel ID annotation should be set, got error: %v", err)
+				}
+				if tunnelID == types.InvalidID {
+					t.Fatal("tunnel ID should have a valid value")
+				}
+			} else {
+				if !util.IsAnnotationNotSetError(err) {
+					t.Fatalf("tunnel ID annotation should not be set, got: %v (error: %v)", updatedNode.Annotations, err)
+				}
+			}
+
+			// Verify allocator state
+			allocatorID := na.idAllocator.GetID(networkName + "_" + node1.Name)
+			if tt.wantAllocatorID {
+				if allocatorID == types.InvalidID {
+					t.Fatal("tunnel ID should be allocated in the allocator")
+				}
+				if tt.wantAnnotation && allocatorID != tunnelID {
+					t.Fatalf("allocated tunnel ID mismatch: allocator has %d, annotation has %d", allocatorID, tunnelID)
+				}
+			} else {
+				if allocatorID != types.InvalidID {
+					t.Fatalf("tunnel ID should not be allocated in the allocator, got %d", allocatorID)
+				}
+			}
+		})
 	}
 }

--- a/test/e2e/network_segmentation_node_annotations.go
+++ b/test/e2e/network_segmentation_node_annotations.go
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ovnkubeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+var _ = Describe("Network Segmentation: Node Annotations", feature.NetworkSegmentation, func() {
+	f := wrappedTestFramework("network-segmentation-node-annotations")
+	f.SkipNamespaceCreation = true
+
+	var (
+		cs clientset.Interface
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+
+		var err error
+		namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
+			"e2e-framework":           f.BaseName,
+			RequiredUDNNamespaceLabel: "",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		f.Namespace = namespace
+	})
+
+	Context("Tunnel ID Annotations", func() {
+		// NOTE: These tests validate the behavior based on the Layer2UsesTransitRouter configuration.
+		// The configuration is determined by the k8s.ovn.org/layer2-topology-version annotation on nodes.
+		// Version "2.0" indicates transit router topology (Layer2UsesTransitRouter=true).
+		// Missing or other values indicate legacy topology (Layer2UsesTransitRouter=false).
+
+		// Serial() is required because this test modifies cluster-wide state (node annotations)
+		// that controls Layer2UsesTransitRouter and affects ovnkube-control-plane behavior.
+		It("should clean up tunnel ID annotations when UDN is deleted with transit router topology", Serial, func() {
+			// This test verifies that tunnel ID annotations are cleaned up when a UDN is deleted
+			// in transit router topology. The test simulates a migration scenario by:
+			// 1. Creating an L2 primary network
+			// 2. Ensuring all nodes have transit router topology annotation
+			// 3. Manually injecting tunnel ID annotations on nodes (simulating legacy state)
+			// 4. Deleting the UDN
+			// 5. Verifying that tunnel ID annotations are cleaned up during UDN deletion
+			testUdnName := "node-annotation-l2-tunnel-id-cleanup"
+
+			By("ensuring all nodes have transit router topology annotation")
+			nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(nodeList.Items)).To(BeNumerically(">", 0), "should have at least one node")
+
+			for i := range nodeList.Items {
+				node := &nodeList.Items[i]
+				if node.Annotations[ovnkubeutil.Layer2TopologyVersion] != ovnkubeutil.TransitRouterTopoVersion {
+					node.Annotations[ovnkubeutil.Layer2TopologyVersion] = ovnkubeutil.TransitRouterTopoVersion
+					_, err = cs.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred(), "failed to set transit router topology on node %s", node.Name)
+					framework.Logf("Set transit router topology on node %s", node.Name)
+				} else {
+					framework.Logf("Node %s already has transit router topology", node.Name)
+				}
+			}
+
+			By("creating an L2 primary network")
+			netConfig := &networkAttachmentConfigParams{
+				name:      testUdnName,
+				namespace: f.Namespace.Name,
+				topology:  "layer2",
+				cidr:      joinStrings("10.129.0.0/16", "2014:100:200::0/60"),
+				role:      "primary",
+			}
+			udnManifest := generateUserDefinedNetworkManifest(netConfig, f.ClientSet)
+			cleanup, err := createManifest(f.Namespace.Name, udnManifest)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for network to be ready")
+			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, f.Namespace.Name, testUdnName), 30*time.Second, time.Second).Should(Succeed())
+
+			By("verifying no tunnel ID annotations are allocated in transit router topology")
+
+			nodeList, err = e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+			Expect(err).NotTo(HaveOccurred())
+			for i := range nodeList.Items {
+				node := &nodeList.Items[i]
+				node, err = cs.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err := ovnkubeutil.ParseUDNLayer2NodeGRLRPTunnelIDs(node, f.Namespace.Name+"_"+testUdnName)
+				Expect(ovnkubeutil.IsAnnotationNotSetError(err)).To(BeTrue(),
+					"node %s should NOT have tunnel ID annotation with transit router topology", node.Name)
+				framework.Logf("Node %s correctly has no tunnel ID annotation (transit router)", node.Name)
+			}
+
+			By("manually injecting tunnel ID annotations on nodes (simulating legacy migration scenario)")
+			networkKey := f.Namespace.Name + "_" + testUdnName
+			injectedTunnelIDs := make(map[string]int)
+			nodeList, err = e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+			Expect(err).NotTo(HaveOccurred())
+
+			for i := range nodeList.Items {
+				node := &nodeList.Items[i]
+				// Inject a unique tunnel ID for each node (starting from 100 to avoid conflicts)
+				tunnelID := 10 + i
+				injectedTunnelIDs[node.Name] = tunnelID
+
+				node.Annotations, err = ovnkubeutil.UpdateUDNLayer2NodeGRLRPTunnelIDs(node.Annotations, networkKey, tunnelID)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = cs.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred(), "failed to inject tunnel ID on node %s", node.Name)
+				framework.Logf("Injected tunnel ID %s: %d on node %s (simulating legacy state)", networkKey, tunnelID, node.Name)
+			}
+
+			By("verifying injected tunnel ID annotations are present")
+			nodeList, err = e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+			Expect(err).NotTo(HaveOccurred())
+			for i := range nodeList.Items {
+				node := &nodeList.Items[i]
+				node, err = cs.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				tunnelID, err := ovnkubeutil.ParseUDNLayer2NodeGRLRPTunnelIDs(node, networkKey)
+				Expect(err).NotTo(HaveOccurred(), "should be able to parse injected tunnel ID on node %s", node.Name)
+				Expect(tunnelID).To(Equal(injectedTunnelIDs[node.Name]), "injected tunnel ID should match on node %s", node.Name)
+				framework.Logf("Verified injected tunnel ID %d on node %s", tunnelID, node.Name)
+			}
+
+			By("deleting the UDN")
+			err = f.DynamicClient.Resource(udnGVR).Namespace(f.Namespace.Name).Delete(context.TODO(), testUdnName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to delete UDN %s", testUdnName)
+			framework.Logf("Initiated deletion of UDN %s", testUdnName)
+
+			// Clean up the temporary manifest files
+			cleanup()
+
+			By("verifying UDN is completely deleted")
+			Eventually(func() error {
+				_, err := f.DynamicClient.Resource(udnGVR).Namespace(f.Namespace.Name).Get(context.TODO(), testUdnName, metav1.GetOptions{})
+				if err != nil {
+					// Expected: UDN should not be found
+					framework.Logf("UDN %s successfully deleted", testUdnName)
+					return nil
+				}
+				return fmt.Errorf("UDN %s still exists, waiting for deletion", testUdnName)
+			}, 120*time.Second, time.Second).Should(Succeed(), "UDN should be completely deleted")
+
+			By("verifying tunnel ID annotations are cleaned up after UDN deletion")
+			Eventually(func() error {
+				nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+				if err != nil {
+					return err
+				}
+
+				for i := range nodeList.Items {
+					node := &nodeList.Items[i]
+					// Refresh node to get latest annotations
+					node, err = cs.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+					if err != nil {
+						return fmt.Errorf("failed to get node %s: %v", node.Name, err)
+					}
+
+					_, err := ovnkubeutil.ParseUDNLayer2NodeGRLRPTunnelIDs(node, networkKey)
+					if err != nil {
+						if ovnkubeutil.IsAnnotationNotSetError(err) {
+							// Expected: annotation should be removed
+							framework.Logf("Node %s tunnel ID annotation correctly cleaned up", node.Name)
+							continue
+						}
+						return fmt.Errorf("failed to parse tunnel ID for node %s: %v", node.Name, err)
+					}
+
+					// If we still have a tunnel ID, cleanup hasn't happened yet
+					return fmt.Errorf("node %s still has tunnel ID annotation, waiting for cleanup", node.Name)
+				}
+
+				return nil
+			}, 60*time.Second, 2*time.Second).Should(Succeed(), "all tunnel ID annotations should be cleaned up after UDN deletion")
+		})
+
+		It("should have all nodes with transit router settings Layer2TopologyVersion set to 2.0", func() {
+			By("checking current Layer2 topology mode on nodes")
+			nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(nodeList.Items)).To(BeNumerically(">", 0), "should have at least one node")
+
+			// Determine if cluster is using transit router topology
+			nodesUsingTransitRouter := make(map[string]bool)
+			for i := range nodeList.Items {
+				node := &nodeList.Items[i]
+				usesTransitRouter := ovnkubeutil.UDNLayer2NodeUsesTransitRouter(node)
+				nodesUsingTransitRouter[node.Name] = usesTransitRouter
+				framework.Logf("Node %s uses transit router: %v (annotation: %s)",
+					node.Name, usesTransitRouter, node.Annotations[ovnkubeutil.Layer2TopologyVersion])
+			}
+			// Check if ALL nodes are using transit router
+			allNodesUseTransitRouter := true
+			for _, usesTransitRouter := range nodesUsingTransitRouter {
+				if !usesTransitRouter {
+					allNodesUseTransitRouter = false
+					break
+				}
+			}
+			Expect(allNodesUseTransitRouter).To(BeTrue(), "all nodes should have TransitRouter enabled")
+		})
+
+		It("should NOT allocate tunnel ID annotations for L3 networks", func() {
+			testUdnName := "node-annotation-not-l3-tunnel-id"
+			By("creating an L3 network")
+			netConfig := &networkAttachmentConfigParams{
+				name:      testUdnName,
+				namespace: f.Namespace.Name,
+				topology:  "layer3",
+				cidr:      joinStrings("103.103.0.0/16", "2014:100:200::0/60"),
+				role:      "primary",
+			}
+			udnManifest := generateUserDefinedNetworkManifest(netConfig, f.ClientSet)
+			cleanup, err := createManifest(f.Namespace.Name, udnManifest)
+			defer cleanup()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for network to be ready")
+			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, f.Namespace.Name, testUdnName), 30*time.Second, time.Second).Should(Succeed())
+
+			By("verifying tunnel ID annotations are NOT allocated on nodes")
+			nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+			Expect(err).NotTo(HaveOccurred())
+
+			for i := range nodeList.Items {
+				node := &nodeList.Items[i]
+				// Refresh node to get latest annotations
+				node, err = cs.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err := ovnkubeutil.ParseUDNLayer2NodeGRLRPTunnelIDs(node, f.Namespace.Name+"_"+testUdnName)
+				Expect(ovnkubeutil.IsAnnotationNotSetError(err)).To(BeTrue(),
+					"node %s should NOT have tunnel ID annotation for L3 network", node.Name)
+			}
+		})
+
+		It("should NOT allocate tunnel ID annotations for secondary L2 networks", func() {
+			testUdnName := "node-annotation-not-l2-tunnel-id"
+			By("creating a secondary L2 network")
+			netConfig := &networkAttachmentConfigParams{
+				name:      testUdnName,
+				namespace: f.Namespace.Name,
+				topology:  "layer2",
+				cidr:      joinStrings("10.130.0.0/16", "2014:100:200::0/60"),
+				role:      "secondary",
+			}
+			udnManifest := generateUserDefinedNetworkManifest(netConfig, f.ClientSet)
+			cleanup, err := createManifest(f.Namespace.Name, udnManifest)
+			defer cleanup()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for network to be ready")
+			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, f.Namespace.Name, testUdnName), 30*time.Second, time.Second).Should(Succeed())
+
+			By("verifying tunnel ID annotations are NOT allocated on nodes")
+			nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+			Expect(err).NotTo(HaveOccurred())
+
+			for i := range nodeList.Items {
+				node := &nodeList.Items[i]
+				// Refresh node to get latest annotations
+				node, err = cs.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err := ovnkubeutil.ParseUDNLayer2NodeGRLRPTunnelIDs(node, f.Namespace.Name+"_"+testUdnName)
+				Expect(ovnkubeutil.IsAnnotationNotSetError(err)).To(BeTrue(),
+					"node %s should NOT have tunnel ID annotation for secondary L2 network", node.Name)
+			}
+		})
+	})
+})


### PR DESCRIPTION
Stop allocating L2 node tunnel IDs when transit router is used

Makes sure tunnelID annotation is not done by cluster-manager
when Layer2UsesTransitRouter is enabled.
This avoids node reconciliation cycles.

Primary Usage: The tunnel ID annotation UDNLayer2NodeGRLRPTunnelIDAnnotation
is primarily used by createGWRouterPeerSwitchPort() when
Layer2UsesTransitRouter is disabled.
   
Adds 4 table driven tests to validate changes when transit router
is enabled/disabled for nodes in create/delete of L2/L3 UDNs.

Adds integration tests to validate create/delete of L2/L3 UDNs
and evaluate creation of UDNLayer2NodeGRLRPTunnelIDAnnotation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation and node annotation handling now respect Layer 2 transit-router mode: GRL-RP tunnel ID annotations are skipped when transit-router is enabled, and tunnel IDs are preserved correctly across topology transitions.
  * Tunnel ID changes now trigger reconciliation only when relevant to nodes that require tunnel IDs.

* **Tests**
  * Added unit tests for tunnel ID allocation/reconciliation decisions across Layer2 vs Layer3, primary vs secondary, transit-router presence, and topology transitions.
  * Added an end-to-end “Network Segmentation: Node Annotations” suite validating tunnel ID correctness/uniqueness and ensuring tunnel IDs are not set for non-L2 cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->