### PR TITLE
Fix primary UDN race condition in CNI server

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -333,6 +333,17 @@ func (s *Server) handleCNIRequest(r *http.Request) (result []byte, err error) {
 		}
 		if primaryPodRequest != nil {
 			klog.V(4).Infof("Pod %s/%s primaryUDN podRequest %v", primaryPodRequest.PodNamespace, primaryPodRequest.PodName, primaryPodRequest)
+
+			// Wait for the OVN controller to create the primary UDN annotation before proceeding.
+			// This prevents a race condition where the CNI tries to configure the OVS port
+			// before the logical port has been created by the OVN controller.
+			_, _, _, err = GetPodWithAnnotations(primaryPodRequest.ctx, s.clientSet,
+				primaryPodRequest.PodNamespace, primaryPodRequest.PodName,
+				primaryPodRequest.nadKey, isOvnReady)
+			if err != nil {
+				return nil, fmt.Errorf("failed to wait for primary UDN pod annotation: %v", err)
+			}
+
 			primaryResponse, err := primaryPodRequest.cmdAdd(s.kubeAuth, s.clientSet, s.ovsClient)
 			if err != nil {
 				return nil, fmt.Errorf("failed to add primary UDN pod request: %v", err)


### PR DESCRIPTION
## Summary
Fix a race condition introduced in #6362 (commit 1826e9971) that causes primary UDN pods to fail with "timed out waiting for OVS port binding (ovn-installed)" errors.

## The Problem
When #6362 refactored primary UDN handling to create separate pod requests at the CNI server level, it removed the critical annotation waiting logic. This creates a race condition:

1. Default network CNI Add completes
2. CNI server creates `primaryPodRequest` for UDN interface
3. `primaryPodRequest.cmdAdd()` is called immediately
4. CNI tries to wait for `external-ids:ovn-installed=true` on OVS port
5. **Race**: OVN controller hasn't created the logical port yet (annotation not ready)
6. CNI times out after 2 minutes
7. Pod creation fails

## Root Cause
The original code in `udn/primary_network.go` had `WaitForPrimaryAnnotationFn()` which ensured the OVN controller created the logical port before the CNI configured OVS. When refactored into `cniserver.go`, this waiting logic was not preserved.

## The Fix
Add `GetPodWithAnnotations(isOvnReady)` before calling `cmdAdd()` to wait for the OVN controller to finish creating the logical port.

## Impact
- **Detected in**: OpenShift downstream CI (64 NetworkSegmentation tests failing)
- **Why not detected upstream**: Race is timing-dependent - may not manifest in faster CI environments
- **Risk**: Low - restores original behavior with minimal code change

## Testing
- Should be verified with NetworkSegmentation e2e tests
- Specifically tests involving primary UDN pod creation
