### PR TITLE
e2e: fix UDN subnet overlap with downstream service CIDR

### DIFF
--- a/test/e2e/allocators/subnet_spec.go
+++ b/test/e2e/allocators/subnet_spec.go
@@ -131,6 +131,7 @@ func (s subnetSpec) usable() int {
 	return s.total() - s.excluded.Len()
 }
 
+// nthFree returns the index of the n-th non-excluded subnet (1-indexed).
 func (s subnetSpec) nthFree(n int) int {
 	count := 0
 	for i := range s.total() {

--- a/test/e2e/allocators/udn.go
+++ b/test/e2e/allocators/udn.go
@@ -12,16 +12,40 @@ var (
 	udnV4, udnV6 subnetSpec
 )
 
-// AllocateUDNSubnets always allocates the same fixed UDN IPv4 and IPv6 subnet
-// within the dedicated UDN subnet broader range. Used when overlaps across UDNs
-// are not a concern but still prevents overlaps with other subnets.
-func AllocateUDNSubnets() (ipv4, ipv6 string) {
+func initSubnetSpecs() {
 	udnOnce.Do(func() {
 		udnV4 = newSubnetSpec(udnSubnets, nil)
 		udnV6 = newSubnetSpec(udnSubnets6, nil)
 	})
+}
 
-	udnV4Idx := udnV4.nthFree(1)
-	udnV6Idx := udnV6.nthFree(1)
-	return udnV4.cidr(udnV4Idx), udnV6.cidr(udnV6Idx)
+// GetFirstUDNSubnets always allocates the first UDN IPv4 and IPv6 subnet
+// within the dedicated UDN subnet broader range. Used when overlaps across UDNs
+// are not a concern but still prevents overlaps with other subnets.
+func GetFirstUDNSubnets() (ipv4, ipv6 string) {
+	subnets4, subnets6 := GetNthFirstUDNSubnets(1)
+	return subnets4[0], subnets6[0]
+}
+
+// GetNthFirstUDNSubnets returns the first n UDN IPv4 and IPv6 subnets within
+// the dedicated UDN subnet broader range. Used when overlaps across UDNs are
+// not a concern but still prevents overlaps with other subnets.
+func GetNthFirstUDNSubnets(n int) (ipv4, ipv6 []string) {
+	if n < 1 {
+		panic("GetNthFirstUDNSubnets: n must be >= 1")
+	}
+	initSubnetSpecs()
+	if n > udnV4.usable() || n > udnV6.usable() {
+		panic("GetNthFirstUDNSubnets: not enough free subnets available")
+	}
+
+	ipv4 = make([]string, 0, n)
+	ipv6 = make([]string, 0, n)
+	for i := 1; i < n+1; i++ {
+		udnV4Idx := udnV4.nthFree(i)
+		udnV6Idx := udnV6.nthFree(i)
+		ipv4 = append(ipv4, udnV4.cidr(udnV4Idx))
+		ipv6 = append(ipv6, udnV6.cidr(udnV6Idx))
+	}
+	return ipv4, ipv6
 }

--- a/test/e2e/egress_firewall.go
+++ b/test/e2e/egress_firewall.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/images"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider"
@@ -152,18 +153,20 @@ func egressFirewallPolicyValidationTests(useUDN bool, udnTopology string) {
 				f.Namespace = namespace
 				framework.ExpectNoError(err)
 
-				userDefinedNetworkIPv4Subnets := []string{"172.31.0.0/16"}
-				userDefinedNetworkIPv6Subnets := []string{"2014:100:200::0/60"}
+				userDefinedNetworkIPv4Subnets, userDefinedNetworkIPv6Subnets := allocators.GetNthFirstUDNSubnets(1)
+				cidr := joinStrings(joinStrings(userDefinedNetworkIPv4Subnets...), joinStrings(userDefinedNetworkIPv6Subnets...))
 				if udnTopology == "layer3" {
-					userDefinedNetworkIPv4Subnets = []string{"172.31.0.0/23/24", "172.30.0.0/16/24"}
-					userDefinedNetworkIPv6Subnets = []string{"2014:100:200::0/63/64", "2014:100:100::0/48/64"}
+					// For Layer 3, use multiple CIDRs per IP family. The first
+					// CIDR is just big enough to allocate hostSubnets for the
+					// first two nodes, remaining nodes will be allocated
+					// hostSubnets from the second CIDR
+					cidr = primaryLayer3MultiCIDRs()
 				}
-				userDefinedNetworkSubnets := append(append([]string{}, userDefinedNetworkIPv4Subnets...), userDefinedNetworkIPv6Subnets...)
 
 				nadCfg := networkAttachmentConfigParams{
 					name:     "tenant-red",
 					topology: udnTopology,
-					cidr:     joinStrings(userDefinedNetworkSubnets...),
+					cidr:     cidr,
 					role:     "primary",
 				}
 

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -29,6 +29,7 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/ip"
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/allocators"
 )
 
 func netCIDR(netCIDR string, netPrefixLengthPerNode int) string {
@@ -43,18 +44,34 @@ func primaryLayer3MultiCIDRs() string {
 	return joinStrings(primaryLayer3MultiIPv4CIDRs(), primaryLayer3MultiIPv6CIDRs())
 }
 
+// primaryLayer3IPv4CIDRs returns two IPv4 CIDRs for a primary network in layer3
+// topology. The first CIDR is resized to a /23 to force an overflow to the
+// second CIDR for a third and subsequent nodes hostSubnet.
+func primaryLayer3IPv4CIDRs() (string, string) {
+	subnets4, _ := allocators.GetNthFirstUDNSubnets(2)
+	subnets4[0] = firstSubnetOf(subnets4[0], 23) + "/24"
+	subnets4[1] = subnets4[1] + "/24"
+	return subnets4[0], subnets4[1]
+}
+
+// primaryLayer3IPv6CIDRs returns two IPv6 CIDRs for a primary network in layer3
+// topology. The first CIDR is resized to a /63 to force an overflow to the
+// second CIDR for a third and subsequent nodes hostSubnet.
+func primaryLayer3IPv6CIDRs() (string, string) {
+	_, subnets6 := allocators.GetNthFirstUDNSubnets(2)
+	subnets6[0] = firstSubnetOf(subnets6[0], 63) + "/64"
+	subnets6[1] = subnets6[1] + "/64"
+	return subnets6[0], subnets6[1]
+}
+
 func primaryLayer3MultiIPv4CIDRs() string {
-	return joinStrings(
-		"172.31.0.0/23/24",
-		"172.30.0.0/16/24",
-	)
+	subnet1, subnet2 := primaryLayer3IPv4CIDRs()
+	return joinStrings(subnet1, subnet2)
 }
 
 func primaryLayer3MultiIPv6CIDRs() string {
-	return joinStrings(
-		"2014:100:200::0/63/64",
-		"2014:100:100::0/48/64",
-	)
+	subnet1, subnet2 := primaryLayer3IPv6CIDRs()
+	return joinStrings(subnet1, subnet2)
 }
 
 func filterCIDRsAndJoin(cs clientset.Interface, cidrs string) string {

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -79,13 +79,6 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 		customL2IPv6InfraCIDR               = "2014:100:200::/122"
 		userDefinedNetworkName              = "hogwarts"
 		nadName                             = "gryffindor"
-
-		// The first subnet can support 2 nodes; when the cluster has more than 2 nodes,
-		// both subnets will be utilized.
-		userDefinedNetworkIPv4Subnet1 = "172.31.0.0/23/24"
-		userDefinedNetworkIPv4Subnet2 = "172.30.0.0/16/24"
-		userDefinedNetworkIPv6Subnet1 = "2014:100:200::0/63/64"
-		userDefinedNetworkIPv6Subnet2 = "2014:100:100::0/48/64"
 	)
 
 	BeforeEach(func() {
@@ -1103,12 +1096,11 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						&networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr: joinStrings(
-								// the 1st set of CIDR can only allocate subnet for 2 nodes
-								userDefinedNetworkIPv4Subnet1, userDefinedNetworkIPv4Subnet2,
-								// the 2nd set of CIDR can allocate subnet for remaining nodes
-								userDefinedNetworkIPv6Subnet1, userDefinedNetworkIPv6Subnet2,
-							),
+							// Use multiple CIDRs per IP family. The first CIDR
+							// is just big enough to allocate hostSubnets for
+							// the first two nodes, remaining nodes will be
+							// allocated hostSubnets from the second CIDR
+							cidr: primaryLayer3MultiCIDRs(),
 							role: "primary",
 						},
 					),
@@ -1151,7 +1143,13 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						e2eskipper.Skipf("need at least 3 ready schedulable nodes to run this test")
 					}
 
-					By("creating the intial network with one CIDR")
+					// Use multiple CIDRs per IP family. The first CIDR is just
+					// big enough to allocate hostSubnets for the first two
+					// nodes, remaining nodes will be allocated hostSubnets from
+					// the second CIDR
+					userDefinedNetworkIPv4Subnet1, userDefinedNetworkIPv4Subnet2 := primaryLayer3IPv4CIDRs()
+					userDefinedNetworkIPv6Subnet1, userDefinedNetworkIPv6Subnet2 := primaryLayer3IPv6CIDRs()
+					By("creating the initial network with one CIDR")
 					netConfig := &networkAttachmentConfigParams{
 						name:      randomNetworkMetaName(),
 						namespace: f.Namespace.Name,

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2016,3 +2016,17 @@ func waitForNodeReadyState(f *framework.Framework, nodeName string, timeout time
 		return false
 	}, timeout, 10*time.Second).Should(gomega.BeTrue(), expectationMessage)
 }
+
+// firstSubnetOf returns the first subnet of a given size within the provided
+// subnet
+func firstSubnetOf(subnet string, subnetSize int) string {
+	_, ipNet, err := net.ParseCIDR(subnet)
+	if err != nil {
+		panic(fmt.Sprintf("firstSubnetOf: invalid subnet %q: %v", subnet, err))
+	}
+	ones, bits := ipNet.Mask.Size()
+	if subnetSize < ones || subnetSize > bits {
+		panic(fmt.Sprintf("firstSubnetOf: requested size /%d is not between min /%d and max /%d for %s", subnetSize, ones, bits, subnet))
+	}
+	return fmt.Sprintf("%s/%d", ipNet.IP, subnetSize)
+}


### PR DESCRIPTION
PR #5433 introduced hardcoded UDN subnets that overlap with the downstream service CIDR. Replace these with subnets sourced from the allocators package which takes care to prevent such overlaps.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced hardcoded test subnets with dynamic UDN subnet allocation helpers for more flexible IPv4/IPv6 subnet selection.
  * Primary layer‑3 and multihoming CIDR generators now derive values from the allocator and handle resizing/overflow scenarios.
  * Added a CIDR parsing/validation helper and a clarifying comment for subnet indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->