### PR TITLE
Fix UDN controller startup timeout during pod sync

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_user_defined.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined.go
@@ -14,6 +14,7 @@ import (
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -520,6 +521,21 @@ func (bsnc *BaseUserDefinedNetworkController) syncPodsForUserDefinedNetwork(pods
 		if bsnc.IsPrimaryNetwork() {
 			activeNetwork, err = bsnc.networkManager.GetActiveNetworkForNamespace(pod.Namespace)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					// namespace deleted after pod listing - safe to skip
+					klog.Infof("%s network controller pod sync: pod %s/%s namespace deleted, skipping",
+						bsnc.GetNetworkName(), pod.Namespace, pod.Name)
+					continue
+				}
+				if util.IsInvalidPrimaryNetworkError(err) {
+					// If network manager isn't aware of the primary network for this pod's namespace,
+					// it can't possibly be already wired to our network unless someone is directly messing
+					// with the NADs owned by a CUDN, as network manager syncs all NADs at startup.
+					// Skip during initial sync to avoid blocking startup.
+					klog.V(5).Infof("%s network controller pod sync: pod %s/%s namespace network not ready, skipping",
+						bsnc.GetNetworkName(), pod.Namespace, pod.Name)
+					continue
+				}
 				return fmt.Errorf("failed to find the active network for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 			}
 			if activeNetwork == nil || activeNetwork.IsDefault() {

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -415,6 +415,54 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should not fail to sync pods if namespace has primary UDN label but NAD not ready", func() {
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+		fakeOVN := NewFakeOVN(false)
+		// Create namespace with primary UDN label but no NAD
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-namespace",
+				Labels: map[string]string{
+					types.RequiredUDNNamespaceLabel: "",
+				},
+			},
+		}
+		fakeOVN.start(
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker1",
+					Annotations: map[string]string{
+						"k8s.ovn.org/network-ids": `{"other": "3"}`,
+					},
+				},
+			},
+			namespace,
+		)
+		Expect(fakeOVN.NewUserDefinedNetworkController(nad)).To(Succeed())
+		controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
+		Expect(ok).To(BeTrue())
+		// inject a real networkManager so GetActiveNetworkForNamespace will get called
+		nadController, err := networkmanager.NewForZone("dummyZone", nil, fakeOVN.watcher)
+		Expect(err).NotTo(HaveOccurred())
+		controller.bnc.networkManager = nadController.Interface()
+
+		// Pod in namespace with primary UDN label but no NAD causes InvalidPrimaryNetworkError
+		podInLabeledNamespace := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-pod",
+			},
+		}
+
+		var initialPodList []interface{}
+		initialPodList = append(initialPodList, podInLabeledNamespace)
+
+		// Should skip pod without error when GetActiveNetworkForNamespace returns InvalidPrimaryNetworkError
+		err = controller.bnc.syncPodsForUserDefinedNetwork(initialPodList)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 })
 
 func TestAdvertisedSharedGatewaySNATUsesLiveAllowedExtIPSets(t *gotesting.T) {


### PR DESCRIPTION
During controller initialization, syncPodsForUserDefinedNetwork() calls GetActiveNetworkForNamespace() which can fail when a namespace is deleted (NotFound) or has the primary UDN label but no NAD yet (InvalidPrimaryNetworkError).

Without error handling, these failures cause the factory retry loop to spin for 60 seconds until context deadline expires, blocking controller startup and preventing pods from getting their logical ports created.

Add error handling to skip these pods during initial sync. Normal event-driven processing will handle them once their namespaces are ready.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod synchronization now skips pods when a namespace is missing or when primary-network information isn’t yet available, avoiding failures during initial sync.

* **Tests**
  * Added a test to ensure synchronization succeeds for namespaces labeled for a primary network that isn’t yet ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->