### PR TITLE
node: fix DPU/DPUHost gateway reconciliation on IP change

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -986,6 +986,10 @@ func (c *Controller) repairNode() error {
 	}
 	parsedNodeEIPConfig, err := c.getNodeEgressIPConfig()
 	if err != nil {
+		if ovnconfig.OvnKubeNode.Mode == types.NodeModeDPUHost && util.IsAnnotationNotSetError(err) {
+			klog.Infof("DPUHost mode: %s annotation not yet set by DPU, deferring egress IP repair", util.OvnNodeIfAddr)
+			return nil
+		}
 		return fmt.Errorf("failed to get node egress IP config: %v", err)
 	}
 	for _, egressIP := range egressIPs {

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -986,10 +986,6 @@ func (c *Controller) repairNode() error {
 	}
 	parsedNodeEIPConfig, err := c.getNodeEgressIPConfig()
 	if err != nil {
-		if ovnconfig.OvnKubeNode.Mode == types.NodeModeDPUHost && util.IsAnnotationNotSetError(err) {
-			klog.Infof("DPUHost mode: %s annotation not yet set by DPU, deferring egress IP repair", util.OvnNodeIfAddr)
-			return nil
-		}
 		return fmt.Errorf("failed to get node egress IP config: %v", err)
 	}
 	for _, egressIP := range egressIPs {

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -29,6 +29,7 @@ import (
 	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops/ovs"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/bridgeconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/managementport"
+	nodeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -213,7 +214,6 @@ func (c *addressManager) runInternal(stopChan <-chan struct{}, subscribe subscri
 				if c.gatewayIfIndex != 0 && a.LinkIndex == c.gatewayIfIndex {
 					c.reconcileMasqueradeResources()
 				}
-				continue
 			}
 			addrChanged := false
 			if a.NewAddr {
@@ -320,19 +320,59 @@ func (c *addressManager) handleNodePrimaryAddrChange() {
 	}
 }
 
-// updateNodeAddressAnnotations updates all relevant annotations for the node including
-// k8s.ovn.org/host-cidrs, k8s.ovn.org/node-primary-ifaddr, k8s.ovn.org/l3-gateway-config.
+// updateNodeAddressAnnotations updates the node address annotations. In DPUHost mode
+// the host has no gateway bridge and node-primary-ifaddr / l3-gateway-config are owned
+// by the DPU, so only host-cidrs is maintained; in all other modes the full set
+// (k8s.ovn.org/host-cidrs, k8s.ovn.org/node-primary-ifaddr, k8s.ovn.org/l3-gateway-config)
+// is updated.
 func (c *addressManager) updateNodeAddressAnnotations() error {
-	var err error
+	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+		return c.updateDPUHostAddressAnnotations()
+	}
+	return c.updateGatewayAddressAnnotations()
+}
+
+// updateDPUHostAddressAnnotations refreshes the host-owned annotations in DPUHost mode:
+// k8s.ovn.org/host-cidrs and k8s.ovn.org/primary-dpu-host-addr. The latter tracks the
+// gateway interface addresses; node-primary-ifaddr and l3-gateway-config are derived
+// from it by the DPU.
+func (c *addressManager) updateDPUHostAddressAnnotations() error {
+	if err := c.updateHostCIDRs(); err != nil {
+		return err
+	}
+
+	ifAddrs, err := nodeutil.GetNetworkInterfaceIPAddresses(config.Gateway.Interface)
+	if err != nil {
+		return err
+	}
+	if err := util.SetNodePrimaryDPUHostAddr(c.nodeAnnotator, ifAddrs); err != nil {
+		return err
+	}
+
+	return c.nodeAnnotator.Run()
+}
+
+// updateGatewayAddressAnnotations updates k8s.ovn.org/host-cidrs,
+// k8s.ovn.org/node-primary-ifaddr and k8s.ovn.org/l3-gateway-config from the gateway
+// bridge addresses.
+func (c *addressManager) updateGatewayAddressAnnotations() error {
 	var ifAddrs []*net.IPNet
 
-	// Get node information
 	node, err := c.watchFactory.GetNode(c.nodeName)
 	if err != nil {
 		return err
 	}
 
-	if c.useNetlink {
+	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		// On the DPU, br-dpu has no IP of its own (the address lives on the host and is
+		// conveyed through the primary-dpu-host-addr annotation), so the bridge netlink
+		// path below would fail. Derive the addresses from the annotation, as done at
+		// gateway init.
+		ifAddrs, err = getNodePrimaryIfAddrs(c.watchFactory, c.nodeName, "")
+		if err != nil {
+			return err
+		}
+	} else if c.useNetlink {
 		// get updated interface IP addresses for the gateway bridge
 		ifAddrs, err = c.gatewayBridge.UpdateInterfaceIPAddresses(node)
 		if err != nil {
@@ -358,17 +398,12 @@ func (c *addressManager) updateNodeAddressAnnotations() error {
 		return err
 	}
 	gatewayCfg.IPAddresses = ifAddrs
-	err = util.SetL3GatewayConfig(c.nodeAnnotator, gatewayCfg)
-	if err != nil {
+	if err = util.SetL3GatewayConfig(c.nodeAnnotator, gatewayCfg); err != nil {
 		return err
 	}
 
 	// push all updates to the node
-	err = c.nodeAnnotator.Run()
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.nodeAnnotator.Run()
 }
 
 func (c *addressManager) updateHostCIDRs() error {
@@ -468,9 +503,13 @@ func (c *addressManager) isValidNodeIP(addr net.IP, linkIndex int) bool {
 		return false
 	}
 	// check CDN management port
-	mgmtPortAddress, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6(addr), c.mgmtPort.GetAddresses())
-	if mgmtPortAddress != nil && addr.Equal(mgmtPortAddress.IP) {
-		return false
+	// mgmtPort is nil in DPUHost mode (the address manager is constructed without one),
+	// so guard against a nil dereference before consulting it.
+	if c.mgmtPort != nil {
+		mgmtPortAddress, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6(addr), c.mgmtPort.GetAddresses())
+		if mgmtPortAddress != nil && addr.Equal(mgmtPortAddress.IP) {
+			return false
+		}
 	}
 
 	if util.IsNetworkSegmentationSupportEnabled() {
@@ -487,7 +526,10 @@ func (c *addressManager) isValidNodeIP(addr net.IP, linkIndex int) bool {
 	if util.IsAddressReservedForInternalUse(addr) {
 		return false
 	}
-	if config.OVNKubernetesFeature.EnableEgressIP {
+	// Egress IP exclusions don't apply in DPUHost mode, and the address manager there
+	// has no gateway bridge (c.gatewayBridge is nil), so skip this block to avoid a nil
+	// dereference below.
+	if config.OVNKubernetesFeature.EnableEgressIP && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
 		// EIP assigned to the primary interface which selects pods with a role primary user defined network must be excluded.
 		if util.IsNetworkSegmentationSupportEnabled() && config.Gateway.Mode != config.GatewayModeDisabled {
 			// Two methods to lookup EIPs assigned to the gateway bridge. Fast path from a shared cache or slow path from node annotations.
@@ -540,10 +582,6 @@ func (c *addressManager) refreshGatewayIfIndex() {
 
 func (c *addressManager) sync() {
 	if config.IsModeDPU() {
-		return
-	}
-	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
-		c.reconcileMasqueradeResources()
 		return
 	}
 

--- a/go-controller/pkg/node/obj_retry_node.go
+++ b/go-controller/pkg/node/obj_retry_node.go
@@ -266,6 +266,20 @@ func (h *nodeEventHandler) UpdateResource(oldObj, newObj interface{}, _ bool) er
 					}
 				}
 			}
+
+			// On the DPU, the host (DPUHost) publishes its primary interface address via the
+			// primary-dpu-host-addr annotation. When it changes we must rebuild
+			// node-primary-ifaddr and l3-gateway-config from it: only the DPU holds the
+			// OVS/OVN state (chassis, bridge, MAC, ofport) required to author l3-gateway-config,
+			// so the host cannot do it. We piggyback on this existing local-node watch rather
+			// than registering a separate node informer handler.
+			if config.OvnKubeNode.Mode == types.NodeModeDPU && util.NodePrimaryDPUHostAddrAnnotationChanged(oldNode, newNode) {
+				if gw, ok := h.nc.Gateway.(*gateway); ok && gw.nodeIPManager != nil {
+					if err := gw.nodeIPManager.updateGatewayAddressAnnotations(); err != nil {
+						return fmt.Errorf("failed to update gateway annotations after primary-dpu-host-addr change for node %s: %w", newNode.Name, err)
+					}
+				}
+			}
 			return nil
 		}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6469

node: reconcile DPU/DPUHost gateway annotations on IP change
    
    On DPU-Host nodes the IP-related node annotations were written once at
    startup and never refreshed, leaving stale addresses when a host
    interface IP changed.
    
    - DPUHost: the address manager now updates k8s.ovn.org/host-cidrs and
      k8s.ovn.org/primary-dpu-host-addr at runtime (guarding the nil mgmtPort
      and gatewayBridge that don't exist in this mode).
    - DPU: on a primary-dpu-host-addr change it rebuilds
      k8s.ovn.org/node-primary-ifaddr and k8s.ovn.org/l3-gateway-config,
      reusing the existing local-node watch instead of adding a new informer
      handler.
      
     node: fix DPUHost controller crash when node-primary-ifaddr is not yet set
    
    On DPU host startup the EgressIP controller's repairNode() requires the
    node-primary-ifaddr annotation, which is set by the DPU after it reads
    primary-dpu-host-addr. When the DPU hasn't processed this yet, repairNode
    fails after a 10s timeout and the error is treated as fatal, stopping the
    entire node network controller manager and killing the Node IP manager.
    After that, no IP change detection or annotation updates happen.
    
    Skip the repair in DPUHost mode when the annotation is not yet available;
    there is no stale egress IP state to clean before the DPU has initialized.