### PR TITLE
Add ovnkube TLS configuration CLI args to configure the metrics server TLS

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
@@ -53,9 +53,10 @@ var OvsExporterCommand = cli.Command{
 			BindAddress:      bindAddress,
 			EnableOVSMetrics: true,
 			OnFatalError:     cancel,
+			OVSDBClient:      ovsClient,
 		}
 
-		_ = metrics.StartOVNMetricsServer(opts, ovsClient, innerCtx.Done(), wg)
+		_ = metrics.StartMetricsServer(opts, innerCtx.Done(), wg)
 
 		// run until cancelled (by OS signal or fatal error)
 		<-innerCtx.Done()

--- a/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
@@ -55,7 +55,7 @@ var OvsExporterCommand = cli.Command{
 			OnFatalError:     cancel,
 		}
 
-		_ = metrics.StartOVNMetricsServer(opts, ovsClient, nil, innerCtx.Done(), wg)
+		_ = metrics.StartOVNMetricsServer(opts, ovsClient, innerCtx.Done(), wg)
 
 		// run until cancelled (by OS signal or fatal error)
 		<-innerCtx.Done()

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -327,8 +327,10 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 			KeyFile:     config.Metrics.NodeServerPrivKey,
 			EnablePprof: config.Metrics.EnablePprof,
 			// Use default registry so existing metric registrations keep working.
-			Registerer: prometheus.DefaultRegisterer,
+			Registerer:      prometheus.DefaultRegisterer,
+			ApplyTLSOptions: config.TLS.ApplyOptions,
 		}
+
 		metrics.StartMetricsServer(opts, ctx.Done(), ovnKubeStartWg)
 	}
 
@@ -616,6 +618,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 				EnableOVNNorthdMetrics:     true,
 				EnableOVNDBMetrics:         true,
 				OVSDBClient:                ovsClient,
+				ApplyTLSOptions:            config.TLS.ApplyOptions,
 			}
 
 			if combineMetricsEndpoints(runMode) {

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -615,7 +615,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 				opts.EnablePprof = config.Metrics.EnablePprof
 			}
 
-			metrics.StartOVNMetricsServer(opts, ovsClient, ovnClientset.KubeClient, ctx.Done(), wg)
+			metrics.StartOVNMetricsServer(opts, ovsClient, ctx.Done(), wg)
 		}
 	}
 

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -83,6 +83,7 @@ func getFlagsByCategory() map[string][]cli.Flag {
 	m["Monitoring Options"] = config.MonitoringFlags
 	m["IPFIX Flow Tracing Options"] = config.IPFIXFlags
 	m["Metrics Options"] = config.MetricsFlags
+	m["TLS Options"] = config.TLSFlags
 	m["Hybrid Overlay Options"] = config.HybridOverlayFlags
 
 	return m

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -320,8 +320,15 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	eventRecorder := util.EventRecorder(ovnClientset.KubeClient)
 
 	if config.Metrics.BindAddress != "" && !combineMetricsEndpoints(runMode) {
-		metrics.StartMetricsServer(config.Metrics.BindAddress, config.Metrics.EnablePprof,
-			config.Metrics.NodeServerCert, config.Metrics.NodeServerPrivKey, ctx.Done(), ovnKubeStartWg)
+		opts := metrics.MetricServerOptions{
+			BindAddress: config.Metrics.BindAddress,
+			CertFile:    config.Metrics.NodeServerCert,
+			KeyFile:     config.Metrics.NodeServerPrivKey,
+			EnablePprof: config.Metrics.EnablePprof,
+			// Use default registry so existing metric registrations keep working.
+			Registerer: prometheus.DefaultRegisterer,
+		}
+		metrics.StartMetricsServer(opts, ctx.Done(), ovnKubeStartWg)
 	}
 
 	// In IC mode, only cluster manager runs leader election. Node and
@@ -607,6 +614,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 				EnableOVNControllerMetrics: true,
 				EnableOVNNorthdMetrics:     true,
 				EnableOVNDBMetrics:         true,
+				OVSDBClient:                ovsClient,
 			}
 
 			if combineMetricsEndpoints(runMode) {
@@ -615,7 +623,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 				opts.EnablePprof = config.Metrics.EnablePprof
 			}
 
-			metrics.StartOVNMetricsServer(opts, ovsClient, ctx.Done(), wg)
+			metrics.StartMetricsServer(opts, ctx.Done(), wg)
 		}
 	}
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -30,6 +30,7 @@ import (
 	kexec "k8s.io/utils/exec"
 	utilnet "k8s.io/utils/net"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/tls"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
 
@@ -158,6 +159,9 @@ var (
 
 	// Metrics holds Prometheus metrics-related parameters.
 	Metrics MetricsConfig
+
+	// TLS holds TLS-related configuration parameters.
+	TLS TLSConfig
 
 	// OVNKubernetesFeature config holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
 	OVNKubernetesFeature = OVNKubernetesFeatureConfig{
@@ -473,6 +477,30 @@ type MetricsConfig struct {
 	EnableScaleMetrics   bool `gcfg:"enable-scale-metrics"`
 }
 
+// TLSConfig holds TLS-related configuration parameters.
+type TLSConfig struct {
+	MinVersion   string `gcfg:"tls-min-version"`
+	CipherSuites string `gcfg:"tls-cipher-suites"`
+
+	// ApplyOptions is the parsed and validated TLS configuration function
+	// that can be applied to tls.Config. This is populated during config
+	// initialization and should not be set via config file or CLI.
+	ApplyOptions tls.ApplyConfigOptions
+}
+
+// ParseCipherSuites parses the comma-separated CipherSuites string into a slice.
+// Trims whitespace and filters out empty strings.
+func (c *TLSConfig) ParseCipherSuites() []string {
+	suites := strings.Split(c.CipherSuites, ",")
+	result := make([]string, 0, len(suites))
+	for _, suite := range suites {
+		if trimmed := strings.TrimSpace(suite); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
 // OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
 type OVNKubernetesFeatureConfig struct {
 	// Admin Network Policy feature is enabled
@@ -703,6 +731,7 @@ type config struct {
 	OVNKubernetesFeature OVNKubernetesFeatureConfig
 	Kubernetes           KubernetesConfig
 	Metrics              MetricsConfig
+	TLS                  TLSConfig
 	OvnNorth             OvnAuthConfig
 	OvnSouth             OvnAuthConfig
 	Gateway              GatewayConfig
@@ -724,6 +753,7 @@ var (
 	savedOVNKubernetesFeature OVNKubernetesFeatureConfig
 	savedKubernetes           KubernetesConfig
 	savedMetrics              MetricsConfig
+	savedTLS                  TLSConfig
 	savedOvnNorth             OvnAuthConfig
 	savedOvnSouth             OvnAuthConfig
 	savedGateway              GatewayConfig
@@ -755,6 +785,7 @@ func init() {
 	savedOVNKubernetesFeature = OVNKubernetesFeature
 	savedKubernetes = Kubernetes
 	savedMetrics = Metrics
+	savedTLS = TLS
 	savedOvnNorth = OvnNorth
 	savedOvnSouth = OvnSouth
 	savedGateway = Gateway
@@ -788,6 +819,7 @@ func PrepareTestConfig() error {
 	OVNKubernetesFeature = savedOVNKubernetesFeature
 	Kubernetes = savedKubernetes
 	Metrics = savedMetrics
+	TLS = savedTLS
 	OvnNorth = savedOvnNorth
 	OvnSouth = savedOvnSouth
 	Gateway = savedGateway
@@ -1499,6 +1531,20 @@ var MetricsFlags = []cli.Flag{
 	},
 }
 
+// TLSFlags capture TLS-related options
+var TLSFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:        "tls-min-version",
+		Usage:       "Minimum TLS version supported",
+		Destination: &cliConfig.TLS.MinVersion,
+	},
+	&cli.StringFlag{
+		Name:        "tls-cipher-suites",
+		Usage:       "Comma-separated list of cipher suites (TLS 1.0-1.2 only; ignored for TLS 1.3)",
+		Destination: &cliConfig.TLS.CipherSuites,
+	},
+}
+
 // OvnNBFlags capture OVN northbound database options. The cert/key flags
 // below are no longer used for OVN DB connection (which is unix-socket only)
 // but their values are still consumed by the Egress IP gRPC health-check
@@ -1821,6 +1867,7 @@ func GetFlags(customFlags []cli.Flag) []cli.Flag {
 	flags = append(flags, OVNK8sFeatureFlags...)
 	flags = append(flags, K8sFlags...)
 	flags = append(flags, MetricsFlags...)
+	flags = append(flags, TLSFlags...)
 	flags = append(flags, OvnNBFlags...)
 	flags = append(flags, OvnSBFlags...)
 	flags = append(flags, OVNGatewayFlags...)
@@ -2094,6 +2141,27 @@ func buildMetricsConfig(cli, file *config) error {
 	// And CLI overrides over config file, Kubernetes, and default values
 	if err := overrideFields(&Metrics, &cli.Metrics, &savedMetrics); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func buildTLSConfig(cli, file *config) error {
+	// Copy config file values over default values
+	if err := overrideFields(&TLS, &file.TLS, &savedTLS); err != nil {
+		return err
+	}
+
+	// And CLI overrides over config file and default values
+	if err := overrideFields(&TLS, &cli.TLS, &savedTLS); err != nil {
+		return err
+	}
+
+	// Parse and validate the TLS config, storing the result
+	var err error
+	TLS.ApplyOptions, err = tls.NewApplyConfigOptions(TLS.MinVersion, TLS.ParseCipherSuites())
+	if err != nil {
+		return fmt.Errorf("invalid TLS configuration: %v", err)
 	}
 
 	return nil
@@ -2704,6 +2772,10 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 	// Metrics must be built after Kubernetes to ensure metrics options override
 	// legacy Kubernetes metrics options
 	if err = buildMetricsConfig(&cliConfig, &cfg); err != nil {
+		return "", err
+	}
+
+	if err = buildTLSConfig(&cliConfig, &cfg); err != nil {
 		return "", err
 	}
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -170,6 +170,10 @@ node-server-cert=/path/to/node-metrics.crt
 enable-config-duration=true
 enable-scale-metrics=true
 
+[tls]
+tls-min-version=VersionTLS12
+tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+
 [logging]
 loglevel=5
 logfile=/var/log/ovnkube.log
@@ -330,6 +334,8 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.DNSServiceName).To(gomega.Equal("kube-dns"))
 			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal(""))
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal(""))
+			gomega.Expect(TLS.MinVersion).To(gomega.Equal(""))
+			gomega.Expect(TLS.ParseCipherSuites()).To(gomega.BeEmpty())
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.128.0.0/14"), 23},
 			}))
@@ -523,6 +529,12 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.BeTrue())
 			gomega.Expect(Metrics.EnableScaleMetrics).To(gomega.BeTrue())
 
+			gomega.Expect(TLS.MinVersion).To(gomega.Equal("VersionTLS12"))
+			gomega.Expect(TLS.ParseCipherSuites()).To(gomega.Equal([]string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			}))
+
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal("/path/to/nb-client-private.key"))
 			gomega.Expect(OvnNorth.Cert).To(gomega.Equal("/path/to/nb-client.crt"))
 			gomega.Expect(OvnNorth.CACert).To(gomega.Equal("/path/to/nb-client-ca.crt"))
@@ -639,6 +651,12 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.BeTrue())
 			gomega.Expect(Metrics.EnableScaleMetrics).To(gomega.BeTrue())
 
+			gomega.Expect(TLS.MinVersion).To(gomega.Equal("VersionTLS13"))
+			gomega.Expect(TLS.ParseCipherSuites()).To(gomega.Equal([]string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+			}))
+
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal("/client/privkey"))
 			gomega.Expect(OvnNorth.Cert).To(gomega.Equal("/client/cert"))
 			gomega.Expect(OvnNorth.CACert).To(gomega.Equal("/client/cacert"))
@@ -731,6 +749,8 @@ var _ = Describe("Config Operations", func() {
 			"-metrics-enable-pprof=false",
 			"-ofctrl-wait-before-clear=5000",
 			"-metrics-enable-config-duration=true",
+			"-tls-min-version=VersionTLS13",
+			"-tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384",
 			"-egressip-reachability-total-timeout=5",
 			"-egressip-node-healthcheck-port=4321",
 			"-enable-multi-network=true",

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -19,8 +19,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
-
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
@@ -431,40 +429,22 @@ func writePlainText(statusCode int, text string, w http.ResponseWriter) {
 	fmt.Fprintln(w, text)
 }
 
-// StartMetricsServer runs the prometheus listener so that OVN K8s metrics can be collected.
-// It now reuses the unified MetricServer implementation so it can share plumbing with the
-// OVN/OVS metrics server. TLS and pprof behaviour remain unchanged.
-func StartMetricsServer(bindAddress string, enablePprof bool, certFile string, keyFile string,
-	stopChan <-chan struct{}, wg *sync.WaitGroup) {
-	opts := MetricServerOptions{
-		BindAddress: bindAddress,
-		CertFile:    certFile,
-		KeyFile:     keyFile,
-		EnablePprof: enablePprof,
-		// Use default registry so existing metric registrations keep working.
-		Registerer: prometheus.DefaultRegisterer,
-	}
+// StartMetricsServer runs the prometheus listener so that metrics can be collected.
+// It registers metrics based on the enabled flags in MetricServerOptions and returns
+// the MetricServer instance to allow dynamic metric registration via Enable* methods.
+func StartMetricsServer(opts MetricServerOptions, stopChan <-chan struct{}, wg *sync.WaitGroup) *MetricServer {
+	klog.Infof("Starting Metrics Server on address: %s", opts.BindAddress)
+	metricsServer := NewMetricServer(opts)
 
-	server := NewMetricServer(opts, nil)
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		server.Run(stopChan)
-	}()
-}
-
-// StartOVNMetricsServer runs the prometheus listener so that OVN metrics can be collected
-func StartOVNMetricsServer(opts MetricServerOptions, ovsClient libovsdbclient.Client, stopChan <-chan struct{}, wg *sync.WaitGroup) *MetricServer {
-
-	klog.Infof("Create OVN Metrics Server on address: %s", opts.BindAddress)
-	metricsServer := NewMetricServer(opts, ovsClient)
+	// Register metrics based on the enabled flags in opts.
+	// This is safe to call unconditionally as registerMetrics only registers
+	// metrics for which the corresponding Enable* flag is true.
 	metricsServer.registerMetrics()
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		klog.Infof("OVN Metrics Server starts to run ...")
+		klog.Infof("Metrics Server starts to run ...")
 		metricsServer.Run(stopChan)
 	}()
 

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
@@ -446,7 +445,7 @@ func StartMetricsServer(bindAddress string, enablePprof bool, certFile string, k
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	server := NewMetricServer(opts, nil, nil)
+	server := NewMetricServer(opts, nil)
 
 	wg.Add(1)
 	go func() {
@@ -456,13 +455,10 @@ func StartMetricsServer(bindAddress string, enablePprof bool, certFile string, k
 }
 
 // StartOVNMetricsServer runs the prometheus listener so that OVN metrics can be collected
-func StartOVNMetricsServer(opts MetricServerOptions,
-	ovsClient libovsdbclient.Client,
-	kubeClient kubernetes.Interface,
-	stopChan <-chan struct{}, wg *sync.WaitGroup) *MetricServer {
+func StartOVNMetricsServer(opts MetricServerOptions, ovsClient libovsdbclient.Client, stopChan <-chan struct{}, wg *sync.WaitGroup) *MetricServer {
 
 	klog.Infof("Create OVN Metrics Server on address: %s", opts.BindAddress)
-	metricsServer := NewMetricServer(opts, ovsClient, kubeClient)
+	metricsServer := NewMetricServer(opts, ovsClient)
 	metricsServer.registerMetrics()
 
 	wg.Add(1)

--- a/go-controller/pkg/metrics/server.go
+++ b/go-controller/pkg/metrics/server.go
@@ -40,6 +40,8 @@ type MetricServerOptions struct {
 	EnableOVNNorthdMetrics     bool
 	EnablePprof                bool
 
+	OVSDBClient libovsdbclient.Client
+
 	// OnFatalError is called when an unrecoverable error occurs (e.g., failed to bind to address).
 	// If set, it allows the caller to trigger a graceful shutdown.
 	OnFatalError func()
@@ -56,8 +58,6 @@ type MetricServer struct {
 	// Configuration
 	opts MetricServerOptions
 
-	ovsDBClient libovsdbclient.Client
-
 	ovsDbProperties []*util.OvsDbProperties
 
 	// HTTP server
@@ -69,16 +69,15 @@ type MetricServer struct {
 }
 
 // NewMetricServer creates a new MetricServer instance
-func NewMetricServer(opts MetricServerOptions, ovsDBClient libovsdbclient.Client) *MetricServer {
+func NewMetricServer(opts MetricServerOptions) *MetricServer {
 	registerer := opts.Registerer
 	if registerer == nil {
 		registerer = prometheus.NewRegistry()
 	}
 
 	server := &MetricServer{
-		opts:        opts,
-		ovsDBClient: ovsDBClient,
-		registerer:  registerer,
+		opts:       opts,
+		registerer: registerer,
 	}
 
 	server.mux = http.NewServeMux()
@@ -112,7 +111,7 @@ func NewMetricServer(opts MetricServerOptions, ovsDBClient libovsdbclient.Client
 func (s *MetricServer) registerMetrics() {
 	if s.opts.EnableOVSMetrics {
 		klog.Infof("MetricServer registers OVS metrics")
-		registerOvsMetrics(s.ovsDBClient, s.registerer)
+		registerOvsMetrics(s.opts.OVSDBClient, s.registerer)
 	}
 	if s.opts.EnableOVNDBMetrics {
 		klog.Infof("MetricServer registers OVN DB metrics")
@@ -120,7 +119,7 @@ func (s *MetricServer) registerMetrics() {
 	}
 	if s.opts.EnableOVNControllerMetrics {
 		klog.Infof("MetricServer registers OVN Controller metrics")
-		RegisterOvnControllerMetrics(s.ovsDBClient, s.registerer)
+		RegisterOvnControllerMetrics(s.opts.OVSDBClient, s.registerer)
 	}
 	if s.opts.EnableOVNNorthdMetrics {
 		klog.Infof("MetricServer registers OVN Northd metrics")
@@ -131,16 +130,16 @@ func (s *MetricServer) registerMetrics() {
 // updateOvsMetrics updates the OVS metrics
 func (s *MetricServer) updateOvsMetrics() {
 	ovsDatapathMetricsUpdate()
-	if err := updateOvsBridgeMetrics(s.ovsDBClient, util.RunOVSOfctl); err != nil {
+	if err := updateOvsBridgeMetrics(s.opts.OVSDBClient, util.RunOVSOfctl); err != nil {
 		klog.Errorf("Updating ovs bridge metrics failed: %s", err.Error())
 	}
-	if err := updateOvsInterfaceMetrics(s.ovsDBClient); err != nil {
+	if err := updateOvsInterfaceMetrics(s.opts.OVSDBClient); err != nil {
 		klog.Errorf("Updating ovs interface metrics failed: %s", err.Error())
 	}
 	if err := setOvsMemoryMetrics(util.RunOvsVswitchdAppCtl); err != nil {
 		klog.Errorf("Updating ovs memory metrics failed: %s", err.Error())
 	}
-	if err := setOvsHwOffloadMetrics(s.ovsDBClient); err != nil {
+	if err := setOvsHwOffloadMetrics(s.opts.OVSDBClient); err != nil {
 		klog.Errorf("Updating ovs hardware offload metrics failed: %s", err.Error())
 	}
 	coverageShowMetricsUpdate(ovsVswitchd)
@@ -148,7 +147,7 @@ func (s *MetricServer) updateOvsMetrics() {
 
 // updateOvnControllerMetrics updates the OVN Controller metrics
 func (s *MetricServer) updateOvnControllerMetrics() {
-	if err := setOvnControllerConfigurationMetrics(s.ovsDBClient); err != nil {
+	if err := setOvnControllerConfigurationMetrics(s.opts.OVSDBClient); err != nil {
 		klog.Errorf("Setting ovn controller config metrics failed: %s", err.Error())
 	}
 

--- a/go-controller/pkg/metrics/server.go
+++ b/go-controller/pkg/metrics/server.go
@@ -17,7 +17,6 @@ import (
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
@@ -48,11 +47,6 @@ type MetricServerOptions struct {
 	// Prometheus plumbing
 	Registerer prometheus.Registerer
 
-	// Kubernetes integration
-	K8sClient   kubernetes.Interface
-	K8sNodeName string
-	OVSDBClient libovsdbclient.Client
-
 	dbIsClustered  bool
 	dbFoundViaPath bool
 }
@@ -63,7 +57,6 @@ type MetricServer struct {
 	opts MetricServerOptions
 
 	ovsDBClient libovsdbclient.Client
-	kubeClient  kubernetes.Interface
 
 	ovsDbProperties []*util.OvsDbProperties
 
@@ -76,7 +69,7 @@ type MetricServer struct {
 }
 
 // NewMetricServer creates a new MetricServer instance
-func NewMetricServer(opts MetricServerOptions, ovsDBClient libovsdbclient.Client, kubeClient kubernetes.Interface) *MetricServer {
+func NewMetricServer(opts MetricServerOptions, ovsDBClient libovsdbclient.Client) *MetricServer {
 	registerer := opts.Registerer
 	if registerer == nil {
 		registerer = prometheus.NewRegistry()
@@ -86,7 +79,6 @@ func NewMetricServer(opts MetricServerOptions, ovsDBClient libovsdbclient.Client
 		opts:        opts,
 		ovsDBClient: ovsDBClient,
 		registerer:  registerer,
-		kubeClient:  kubeClient,
 	}
 
 	server.mux = http.NewServeMux()

--- a/go-controller/pkg/metrics/server.go
+++ b/go-controller/pkg/metrics/server.go
@@ -21,6 +21,7 @@ import (
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
+	ovntls "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/tls"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -30,8 +31,9 @@ type MetricServerOptions struct {
 	BindAddress string
 
 	// TLS configuration
-	CertFile string
-	KeyFile  string
+	CertFile        string
+	KeyFile         string
+	ApplyTLSOptions ovntls.ApplyConfigOptions
 
 	// Feature flags
 	EnableOVSMetrics           bool
@@ -221,6 +223,11 @@ func (s *MetricServer) Run(stopChan <-chan struct{}) {
 					return &cert, nil
 				},
 			}
+
+			if s.opts.ApplyTLSOptions != nil {
+				s.opts.ApplyTLSOptions(s.server.TLSConfig)
+			}
+
 			listenAndServe = func() error { return s.server.ListenAndServeTLS("", "") }
 		}
 

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -21,9 +21,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
-
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
@@ -47,9 +44,8 @@ func TestNewMetricServerRunAndShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var ovsDBClient libovsdbclient.Client
-	var kubeClient kubernetes.Interface = fake.NewSimpleClientset()
 
-	server := NewMetricServer(opts, ovsDBClient, kubeClient)
+	server := NewMetricServer(opts, ovsDBClient)
 	require.NotNil(t, server, "Server should not be nil")
 	require.NotNil(t, server.mux, "Server mux should not be nil")
 	require.NotNil(t, server.registerer, "Server registerer should not be nil")
@@ -108,9 +104,8 @@ func TestNewMetricServerRunAndFailOnFatalError(t *testing.T) {
 	}
 
 	var ovsDBClient libovsdbclient.Client
-	var kubeClient kubernetes.Interface = fake.NewSimpleClientset()
 
-	server := NewMetricServer(opts, ovsDBClient, kubeClient)
+	server := NewMetricServer(opts, ovsDBClient)
 	require.NotNil(t, server, "Server should not be nil")
 	require.NotNil(t, server.mux, "Server mux should not be nil")
 	require.NotNil(t, server.registerer, "Server registerer should not be nil")
@@ -869,8 +864,7 @@ func TestHandleMetrics(t *testing.T) {
 			}()
 
 			// Create server with OVS client
-			var kubeClient kubernetes.Interface = fake.NewSimpleClientset()
-			server := NewMetricServer(opts, ovsDBClient, kubeClient)
+			server := NewMetricServer(opts, ovsDBClient)
 			server.registerMetrics()
 
 			// Iterate server registry to list all registered metric names.

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -6,10 +6,12 @@ package metrics
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -166,6 +168,95 @@ var _ = Describe("MetricServer", func() {
 			Eventually(onFatalInvoked).Within(5 * time.Second).Should(BeClosed())
 		})
 	})
+
+	When("TLS is enabled", func() {
+		BeforeEach(func() {
+			// Create temporary cert and key files
+			var err error
+			t.opts.CertFile, t.opts.KeyFile, err = ovntest.CreateTestCertificateFiles()
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				_ = os.Remove(t.opts.CertFile)
+				_ = os.Remove(t.opts.KeyFile)
+			})
+		})
+
+		Context("with no applied TLS config options", func() {
+			It("should default to TLS 1.2", func() {
+				t.testTLSHandshake(tls.VersionTLS12, nil, func(g Gomega, state tls.ConnectionState, err error) {
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(state.Version).To(BeNumerically("==", tls.VersionTLS12))
+				})
+			})
+
+			It("should reject TLS 1.1 and earlier", func() {
+				t.testTLSHandshake(tls.VersionTLS11, nil, func(g Gomega, _ tls.ConnectionState, err error) {
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err.Error()).To(Or(
+						ContainSubstring("protocol version"),
+						ContainSubstring("handshake failure"),
+						ContainSubstring("tls: no supported versions"),
+					))
+				})
+			})
+		})
+
+		Context("with applied TLS ciphers", func() {
+			BeforeEach(func() {
+				t.opts.ApplyTLSOptions = func(tlsConfig *tls.Config) {
+					tlsConfig.MinVersion = tls.VersionTLS12
+					// Configure server to explicitly NOT accept ChaCha20-Poly1305
+					// Only accept AES-based cipher suites
+					tlsConfig.CipherSuites = []uint16{
+						tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // Required for HTTP/2
+					}
+				}
+			})
+
+			It("should accept allowed cipher suites", func() {
+				// Client offers an AES cipher suite that the server explicitly allows
+				t.testTLSHandshake(tls.VersionTLS12, []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				}, func(g Gomega, state tls.ConnectionState, err error) {
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(state.CipherSuite).To(Equal(tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256))
+				})
+			})
+
+			It("should reject disallowed cipher suites", func() {
+				// Client offers ONLY ChaCha20-Poly1305, which server explicitly excludes so handshake should fail.
+				t.testTLSHandshake(tls.VersionTLS12, []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+				}, func(g Gomega, _ tls.ConnectionState, err error) {
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err.Error()).To(ContainSubstring("handshake failure"))
+				})
+			})
+		})
+
+		Context("with applied TLS minimum version", func() {
+			BeforeEach(func() {
+				t.opts.ApplyTLSOptions = func(tlsConfig *tls.Config) {
+					tlsConfig.MinVersion = tls.VersionTLS13
+				}
+			})
+
+			It("should reject versions below the minimum", func() {
+				for clientVersion := tls.VersionTLS11; clientVersion <= tls.VersionTLS12; clientVersion++ {
+					t.testTLSHandshake(clientVersion, nil, func(g Gomega, _ tls.ConnectionState, err error) {
+						g.Expect(err).To(HaveOccurred())
+						g.Expect(err.Error()).To(Or(
+							ContainSubstring("protocol version"),
+							ContainSubstring("handshake failure"),
+							ContainSubstring("tls: no supported versions"),
+						))
+					})
+				}
+			})
+		})
+	})
 })
 
 type metricsTestDriver struct {
@@ -273,6 +364,28 @@ func newMetricsTestDriver() *metricsTestDriver {
 	})
 
 	return t
+}
+
+func (t *metricsTestDriver) testTLSHandshake(clientVersion int, clientCipherSuites []uint16, verify func(Gomega, tls.ConnectionState, error)) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         uint16(clientVersion),
+		MaxVersion:         uint16(clientVersion),
+		CipherSuites:       clientCipherSuites,
+	}
+
+	Eventually(func(g Gomega) {
+		conn, err := tls.Dial("tcp", t.opts.BindAddress, tlsConfig)
+		if err != nil {
+			verify(g, tls.ConnectionState{}, err)
+			return
+		}
+		defer conn.Close()
+
+		state := conn.ConnectionState()
+		g.Expect(state.HandshakeComplete).To(BeTrue())
+		verify(g, state, err)
+	}).Within(5 * time.Second).Should(Succeed())
 }
 
 func setupAppFs() {

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -7,11 +7,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -19,7 +18,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
@@ -28,118 +26,264 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestNewMetricServerRunAndShutdown(t *testing.T) {
-	opts := MetricServerOptions{
-		BindAddress:                "127.0.0.1:0", // Use random port for testing
-		EnableOVSMetrics:           false,
-		EnableOVNDBMetrics:         false,
-		EnableOVNControllerMetrics: false,
-		EnableOVNNorthdMetrics:     false,
-	}
+var _ = BeforeSuite(func() {
+	// Register OVN-Kube controller base metrics into the default registry once for all tests
+	RegisterOVNKubeControllerBase()
+})
 
-	ctx, cancel := context.WithCancel(context.Background())
+var _ = Describe("MetricServer", func() {
+	t := newMetricsTestDriver()
 
-	server := NewMetricServer(opts)
-	require.NotNil(t, server, "Server should not be nil")
-	require.NotNil(t, server.mux, "Server mux should not be nil")
-	require.NotNil(t, server.registerer, "Server registerer should not be nil")
+	DescribeTableSubtree("",
+		func(desc string, tc metricsTestCase, registerer prometheus.Registerer) {
+			BeforeEach(func() {
+				t.opts.Registerer = registerer
+				t.opts.EnableOVSMetrics = tc.enableOVS
+				t.opts.EnableOVNDBMetrics = tc.enableOVNDB
+				t.opts.EnableOVNControllerMetrics = tc.enableOVNController
+				t.opts.EnableOVNNorthdMetrics = tc.enableOVNNorthd
 
-	// Start server in background
-	serverDone := make(chan struct{})
-	go func() {
-		t.Log("Server starting...")
-		server.Run(ctx.Done())
-		close(serverDone)
-	}()
+				// Mock the exec runner for RunOvsVswitchdAppCtl calls
+				mockCmd := new(mock_k8s_io_utils_exec.Cmd)
+				mockExecRunner := new(mocks.ExecRunner)
+				util.RunCmdExecRunner = mockExecRunner
+				ovntest.ProcessMockFnList(&mockExecRunner.Mock, tc.mockRunCommands)
 
-	// Give server time to start
-	time.Sleep(1 * time.Second)
+				mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
+				mockKexecIface.Mock.On("Command", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Maybe().Return(mockCmd)
+				mockKexecIface.Mock.On("Command", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Maybe().Return(mockCmd)
+				mockKexecIface.Mock.On("Command", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+					mock.Anything).Maybe().Return(mockCmd)
+				_ = util.SetSpecificExec(mockKexecIface)
 
-	// Test graceful shutdown
-	t.Log("Initiating graceful shutdown by cancelling context")
-	shutdownStart := time.Now()
-	cancel()
+				DeferCleanup(func() {
+					// Reset exec interface to avoid test pollution
+					util.ResetRunner()
+				})
+			})
 
-	// Wait for server to stop with timeout
-	select {
-	case <-serverDone:
-		shutdownDuration := time.Since(shutdownStart)
-		t.Logf("Server stopped gracefully in %v", shutdownDuration)
+			It(fmt.Sprintf("should handle %s metrics", desc), func() {
+				var response string
 
-		// Validate shutdown was reasonably fast (should be under 6 seconds, allowing for 5s grace period)
-		if shutdownDuration > 6*time.Second {
-			t.Errorf("Shutdown took too long: %v (expected < 6s)", shutdownDuration)
+				Eventually(func(g Gomega) {
+					// Make actual HTTP request to the /metrics endpoint
+					metricsURL := fmt.Sprintf("http://%s/metrics", t.opts.BindAddress)
+					resp, err := http.Get(metricsURL)
+					g.Expect(err).NotTo(HaveOccurred())
+					defer resp.Body.Close()
+
+					g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+					body, err := io.ReadAll(resp.Body)
+					g.Expect(err).NotTo(HaveOccurred())
+
+					response = string(body)
+					g.Expect(response).NotTo(BeEmpty())
+				}).Within(5 * time.Second).Should(Succeed())
+
+				gotMetrics := []string{}
+				for _, line := range strings.Split(response, "\n") {
+					if strings.HasPrefix(line, "# TYPE ") {
+						m := strings.Split(line, " ")[2]
+						gotMetrics = append(gotMetrics, m)
+					}
+				}
+
+				diff := cmp.Diff(gotMetrics, tc.expectedMetrics, cmpopts.SortSlices(func(x, y string) bool {
+					return x < y
+				}))
+				Expect(diff).To(BeEmpty(), "metrics mismatch (-got +want):\n%s", diff)
+			})
+		},
+
+		Entry("", "OVS", OVSMetricsTestCase, nil),
+		Entry("", "OVN DB", OVNDBMetricsTestCase, nil),
+		Entry("", "OVN Controller", OVNControllerMetricsTestCase, nil),
+		Entry("", "OVN Northd", OVNNorthdMetricsTestCase, nil),
+		Entry("", "default registry", DefaultMetricsTestCase, prometheus.DefaultRegisterer),
+	)
+
+	When("EnablePprof", func() {
+		BeforeEach(func() {
+			t.opts.EnablePprof = true
+		})
+
+		It("should serve pprof endpoints", func() {
+			baseURL := fmt.Sprintf("http://%s", t.opts.BindAddress)
+
+			// Test the pprof index endpoint
+			Eventually(func(g Gomega) {
+				resp, err := http.Get(baseURL + "/debug/pprof/")
+				g.Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			}).Within(5 * time.Second).Should(Succeed())
+
+			// Test the log level endpoint
+			Eventually(func(g Gomega) {
+				req, err := http.NewRequest("PUT", baseURL+"/debug/flags/v", strings.NewReader("2"))
+				g.Expect(err).NotTo(HaveOccurred())
+
+				resp, err := http.DefaultClient.Do(req)
+				g.Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				body, err := io.ReadAll(resp.Body)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(body)).To(ContainSubstring("successfully set klog.logging.verbosity to 2"))
+			}).Within(5 * time.Second).Should(Succeed())
+		})
+	})
+
+	Context("", func() {
+		var onFatalInvoked <-chan struct{}
+
+		BeforeEach(func() {
+			t.opts.BindAddress = "127.0.0.5:9410"
+
+			// Occupy the port first so that the metrics server will fail with "address already in use"
+			listener, err := net.Listen("tcp", t.opts.BindAddress)
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(listener.Close)
+
+			var ctx context.Context
+
+			ctx, t.opts.OnFatalError = context.WithCancel(context.Background())
+			onFatalInvoked = ctx.Done()
+		})
+
+		It("should call OnFatalError when failing to bind", func() {
+			// Wait for OnFatalError to be called (context cancelled) or timeout
+			Eventually(onFatalInvoked).Within(5 * time.Second).Should(BeClosed())
+		})
+	})
+})
+
+type metricsTestDriver struct {
+	libovsdbCleanup *libovsdbtest.Context
+	opts            MetricServerOptions
+}
+
+func newMetricsTestDriver() *metricsTestDriver {
+	t := &metricsTestDriver{}
+
+	BeforeEach(func() {
+		// disable Process metrics collector to avoid the test flakiness
+		savedUnprivileged := config.UnprivilegedMode
+		config.UnprivilegedMode = true
+
+		savedRunner := util.RunCmdExecRunner
+
+		t.opts = MetricServerOptions{
+			BindAddress: fmt.Sprintf("127.0.0.1:%d", getFreePort()),
 		}
 
-	case <-time.After(10 * time.Second):
-		t.Fatal("Server did not shut down within timeout period (10s)")
-	}
+		setupAppFs()
 
-	t.Logf("TestNewMetricServer completed successfully")
+		// common OVS DB setup
+		ovsVersion := "2.17.0"
+
+		intf1 := vswitchd.Interface{Name: "porta", UUID: buildUUID()}
+		port1 := vswitchd.Port{Name: "porta", UUID: buildUUID()}
+		br1 := vswitchd.Bridge{Name: "br-int", UUID: buildUUID()}
+
+		testDB := []libovsdbtest.TestData{
+			&vswitchd.Interface{
+				UUID: intf1.UUID,
+				Name: intf1.Name,
+				Statistics: map[string]int{
+					"rx_packets": 1000,
+					"tx_packets": 800,
+					"rx_bytes":   100000,
+					"tx_bytes":   80000,
+				},
+			},
+			&vswitchd.Port{UUID: port1.UUID, Name: port1.Name, Interfaces: []string{intf1.UUID}},
+			&vswitchd.Bridge{UUID: br1.UUID, Name: br1.Name, Ports: []string{port1.UUID}},
+			&vswitchd.OpenvSwitch{
+				UUID:       buildUUID(),
+				OVSVersion: &ovsVersion,
+				Bridges:    []string{br1.UUID},
+				ExternalIDs: map[string]string{
+					"ovn-bridge-remote-probe-interval": "100",
+					"ovn-remote-probe-interval":        "200",
+					"ovn-monitor-all":                  "false",
+					"ovn-encap-ip":                     "192.168.1.1",
+					"ovn-encap-type":                   "geneve",
+					"ovn-remote":                       "unix:/var/run/ovn/ovnsb_db.sock",
+					"ovn-k8s-node-port":                "false",
+					"ovn-bridge-mappings":              "physnet:breth0",
+				},
+			},
+		}
+
+		// Setup OVS test harness
+		dbSetup := libovsdbtest.TestSetup{
+			OVSData: testDB,
+		}
+
+		var err error
+		t.opts.OVSDBClient, t.libovsdbCleanup, err = libovsdbtest.NewOVSTestHarness(dbSetup)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set a sample metric value to ensure the metric is initialized
+		MetricOVNKubeControllerSyncDuration.WithLabelValues("pods").Set(0)
+
+		DeferCleanup(func() {
+			config.UnprivilegedMode = savedUnprivileged
+			util.RunCmdExecRunner = savedRunner
+
+			if t.libovsdbCleanup != nil {
+				t.libovsdbCleanup.Cleanup()
+			}
+		})
+	})
+
+	JustBeforeEach(func() {
+		server := NewMetricServer(t.opts)
+		server.registerMetrics()
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		serverDone := make(chan struct{})
+		go func() {
+			server.Run(ctx.Done())
+			close(serverDone)
+		}()
+
+		DeferCleanup(func() {
+			shutdownStart := time.Now()
+			cancel()
+
+			// Wait for server to stop with timeout
+			Eventually(serverDone, 10*time.Second).Should(BeClosed())
+
+			// Validate shutdown was reasonably fast (should be under 6 seconds, allowing for 5s grace period)
+			Expect(time.Since(shutdownStart)).To(BeNumerically("<", 6*time.Second))
+		})
+	})
+
+	return t
 }
 
-func TestNewMetricServerRunAndFailOnFatalError(t *testing.T) {
-	// Occupy the port first so that the metrics server will fail with "address already in use"
-	addr := "127.0.0.5:9410"
-	listener, err := net.Listen("tcp", addr)
-	require.NoError(t, err, "Failed to listen on %s", addr)
-	defer listener.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	opts := MetricServerOptions{
-		BindAddress:                addr,
-		OnFatalError:               cancel,
-		EnableOVSMetrics:           false,
-		EnableOVNDBMetrics:         false,
-		EnableOVNControllerMetrics: false,
-		EnableOVNNorthdMetrics:     false,
-	}
-
-	server := NewMetricServer(opts)
-	require.NotNil(t, server, "Server should not be nil")
-	require.NotNil(t, server.mux, "Server mux should not be nil")
-	require.NotNil(t, server.registerer, "Server registerer should not be nil")
-
-	// Start server in background
-	serverDone := make(chan struct{})
-	go func() {
-		t.Log("Server starting...")
-		server.Run(ctx.Done())
-		close(serverDone)
-	}()
-
-	// Wait for OnFatalError to be called (context cancelled) or timeout
-	select {
-	case <-ctx.Done():
-		t.Log("OnFatalError was called as expected (context cancelled)")
-	case <-time.After(5 * time.Second):
-		t.Fatal("OnFatalError was not called within timeout - server should have failed to bind")
-	}
-
-	// Wait for server goroutine to finish
-	select {
-	case <-serverDone:
-		t.Log("Server stopped as expected")
-	case <-time.After(5 * time.Second):
-		t.Fatal("Server did not stop within timeout after OnFatalError was called")
-	}
-}
-
-func setupAppFs(t *testing.T) {
-	t.Helper()
+func setupAppFs() {
 	prevFS := util.AppFs
 	util.AppFs = afero.NewMemMapFs()
-	t.Cleanup(func() {
+	DeferCleanup(func() {
 		util.AppFs = prevFS
 	})
 
-	if err := util.AppFs.MkdirAll("/var/run/openvswitch/", 0o755); err != nil {
-		t.Fatalf("failed to AppFs.MkdirAlle: %v", err)
-	}
+	err := util.AppFs.MkdirAll("/var/run/openvswitch/", 0o755)
+	Expect(err).NotTo(HaveOccurred())
 
 	files := []ovntest.AferoFileMockHelper{
 		{FileName: "/var/run/openvswitch/ovs-vswitchd.pid", Permissions: 0o755, Content: []byte("101")},
@@ -152,13 +296,496 @@ func setupAppFs(t *testing.T) {
 	}
 
 	for _, file := range files {
-		if err := afero.WriteFile(util.AppFs, file.FileName, file.Content, file.Permissions); err != nil {
-			t.Fatalf("failed to afero.WriteFile: %v", err)
-		}
+		err := afero.WriteFile(util.AppFs, file.FileName, file.Content, file.Permissions)
+		Expect(err).NotTo(HaveOccurred())
 	}
 }
 
+func getFreePort() int {
+	listener, err := net.Listen("tcp", "localhost:0")
+	Expect(err).NotTo(HaveOccurred())
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	return port
+}
+
+type metricsTestCase struct {
+	enableOVS           bool
+	enableOVNDB         bool
+	enableOVNController bool
+	enableOVNNorthd     bool
+	mockRunCommands     []ovntest.TestifyMockHelper
+	expectedMetrics     []string
+}
+
 var (
+	OVSMetricsTestCase = metricsTestCase{
+		enableOVS: true,
+		mockRunCommands: []ovntest.TestifyMockHelper{
+			// dpctl/dump-dps
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dpctl/dump-dps"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("system@ovs-system")), bytes.NewBuffer([]byte("")), nil},
+			},
+			// dpctl/show
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dpctl/show", "system@ovs-system"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(dpctlShowOutput)), bytes.NewBuffer([]byte("")), nil},
+			},
+			// memory/show
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "memory/show"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovsMemoryShowOutput)), bytes.NewBuffer([]byte("")), nil},
+			},
+			// coverage/show
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "coverage/show"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(coverageShowOutput)), bytes.NewBuffer([]byte("")), nil},
+			},
+			// ovs-ofctl dump-aggregate br-int
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dump-aggregate", "br-int"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovsOfctlDumpAggregateOutput)), bytes.NewBuffer([]byte("")), nil},
+			},
+		},
+		expectedMetrics: []string{
+			"ovs_build_info",
+			"ovs_vswitchd_bridge_flows_total",
+			"ovs_vswitchd_bridge_ports_total",
+			"ovs_vswitchd_bridge_reconfigure",
+			"ovs_vswitchd_bridge_total",
+			"ovs_vswitchd_bridge",
+			"ovs_vswitchd_dp_flows_lookup_hit",
+			"ovs_vswitchd_dp_flows_lookup_lost",
+			"ovs_vswitchd_dp_flows_lookup_missed",
+			"ovs_vswitchd_dp_flows_total",
+			"ovs_vswitchd_dp_if_total",
+			"ovs_vswitchd_dp_masks_hit_ratio",
+			"ovs_vswitchd_dp_masks_hit",
+			"ovs_vswitchd_dp_masks_total",
+			"ovs_vswitchd_dp_packets_total",
+			"ovs_vswitchd_dp_total",
+			"ovs_vswitchd_dp",
+			"ovs_vswitchd_dpif_execute",
+			"ovs_vswitchd_dpif_flow_del",
+			"ovs_vswitchd_dpif_flow_flush",
+			"ovs_vswitchd_dpif_flow_get",
+			"ovs_vswitchd_dpif_flow_put",
+			"ovs_vswitchd_dpif_port_add",
+			"ovs_vswitchd_dpif_port_del",
+			"ovs_vswitchd_handlers_total",
+			"ovs_vswitchd_hw_offload",
+			"ovs_vswitchd_interface_collisions_total",
+			"ovs_vswitchd_interface_resets_total",
+			"ovs_vswitchd_interface_rx_dropped_total",
+			"ovs_vswitchd_interface_rx_errors_total",
+			"ovs_vswitchd_interface_tx_dropped_total",
+			"ovs_vswitchd_interface_tx_errors_total",
+			"ovs_vswitchd_interface_up_wait_seconds_total",
+			"ovs_vswitchd_interfaces_total",
+			"ovs_vswitchd_netlink_overflow",
+			"ovs_vswitchd_netlink_received",
+			"ovs_vswitchd_netlink_recv_jumbo",
+			"ovs_vswitchd_netlink_sent",
+			"ovs_vswitchd_ofproto_dpif_expired",
+			"ovs_vswitchd_ofproto_flush",
+			"ovs_vswitchd_ofproto_packet_out",
+			"ovs_vswitchd_ofproto_recv_openflow",
+			"ovs_vswitchd_ofproto_reinit_ports",
+			"ovs_vswitchd_packet_in_drop",
+			"ovs_vswitchd_packet_in",
+			"ovs_vswitchd_pstream_open",
+			"ovs_vswitchd_rconn_discarded",
+			"ovs_vswitchd_rconn_overflow",
+			"ovs_vswitchd_rconn_queued",
+			"ovs_vswitchd_rconn_sent",
+			"ovs_vswitchd_revalidators_total",
+			"ovs_vswitchd_stream_open",
+			"ovs_vswitchd_tc_policy",
+			"ovs_vswitchd_txn_aborted",
+			"ovs_vswitchd_txn_error",
+			"ovs_vswitchd_txn_incomplete",
+			"ovs_vswitchd_txn_success",
+			"ovs_vswitchd_txn_try_again",
+			"ovs_vswitchd_txn_unchanged",
+			"ovs_vswitchd_txn_uncommitted",
+			"ovs_vswitchd_upcall_flow_limit_hit",
+			"ovs_vswitchd_upcall_flow_limit_kill",
+			"ovs_vswitchd_vconn_open",
+			"ovs_vswitchd_vconn_received",
+			"ovs_vswitchd_vconn_sent",
+			"ovs_vswitchd_xlate_actions_oversize",
+			"ovs_vswitchd_xlate_actions_too_many_output",
+			"ovs_vswitchd_xlate_actions",
+			"promhttp_metric_handler_requests_in_flight",
+			"promhttp_metric_handler_requests_total",
+		},
+	}
+
+	OVNDBMetricsTestCase = metricsTestCase{
+		enableOVNDB: true,
+		mockRunCommands: []ovntest.TestifyMockHelper{
+			// ovs-appctl version
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "version"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("ovsdb-server (Open vSwitch) 3.5.0")), bytes.NewBuffer([]byte("")), nil},
+			},
+			// ovsdb-client  get-schema-version unix:/var/run/openvswitch/ovnnb_db.sock OVN_Northbound
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "get-schema-version", mock.AnythingOfType("string"), "OVN_Northbound"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("7.11.0")), bytes.NewBuffer([]byte("")), nil},
+			},
+			// ovsdb-client  get-schema-version unix:/var/run/openvswitch/ovnnb_db.sock OVN_Southbound
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "get-schema-version", mock.AnythingOfType("string"), "OVN_Southbound"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("20.41.0")), bytes.NewBuffer([]byte("")), nil},
+			},
+			// ovs-appctl  -t /var/run/openvswitch/ovnnb_db.ctl cluster/status OVN_Northbound
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), mock.AnythingOfType("string"), "cluster/status", "OVN_Northbound"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte(`"cluster/status" is not a valid command`)), fmt.Errorf("server returned an error")},
+			},
+			// ovs-appctl  -t /var/run/openvswitch/ovnnb_db.ctl memory/show
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), mock.AnythingOfType("string"), "memory/show"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovnDBMemoryShowOutput)), bytes.NewBuffer([]byte("")), nil},
+			},
+			// ovs-appctl  -t /var/run/openvswitch/ovnsb_db.ctl memory/show
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), mock.AnythingOfType("string"), "memory/show"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovnDBMemoryShowOutput)), bytes.NewBuffer([]byte("")), nil},
+			},
+		},
+		expectedMetrics: []string{
+			"ovn_db_build_info",
+			"ovn_db_db_size_bytes",
+			"ovn_db_jsonrpc_server_sessions",
+			"ovn_db_ovsdb_monitors",
+			"promhttp_metric_handler_requests_in_flight",
+			"promhttp_metric_handler_requests_total",
+		},
+	}
+
+	OVNControllerMetricsTestCase = metricsTestCase{
+		enableOVNController: true,
+		mockRunCommands: []ovntest.TestifyMockHelper{
+			// ovs-ofctl -t 5 dump-aggregate br-int
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dump-aggregate", "br-int"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovnControllerDumpAggregateOutput)), bytes.NewBuffer([]byte("")), nil},
+				CallTimes:  2,
+			},
+			// ovs-appctl -t /var/run/openvswitch/ovn-controller.113.ctl coverage/show
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "coverage/show"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovnControllercoverageShowOutput)), bytes.NewBuffer([]byte("")), nil},
+			},
+			// ovs-appctl -t  /var/run/openvswitch/ovn-controller.113.ctl version
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "version"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovnControllerVersionOutput)), bytes.NewBuffer([]byte("")), nil},
+			},
+			// ovs-appctl -t  /var/run/openvswitch/ovn-controller.113.ctl connection-status
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "connection-status"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
+			},
+		},
+		expectedMetrics: []string{
+			"ovn_controller_bfd_run_95th_percentile",
+			"ovn_controller_bfd_run_long_term_avg",
+			"ovn_controller_bfd_run_maximum",
+			"ovn_controller_bfd_run_minimum",
+			"ovn_controller_bfd_run_short_term_avg",
+			"ovn_controller_bfd_run_total_samples",
+			"ovn_controller_bridge_mappings",
+			"ovn_controller_build_info",
+			"ovn_controller_ct_zone_commit_95th_percentile",
+			"ovn_controller_ct_zone_commit_long_term_avg",
+			"ovn_controller_ct_zone_commit_maximum",
+			"ovn_controller_ct_zone_commit_minimum",
+			"ovn_controller_ct_zone_commit_short_term_avg",
+			"ovn_controller_ct_zone_commit_total_samples",
+			"ovn_controller_encap_ip",
+			"ovn_controller_encap_type",
+			"ovn_controller_flow_generation_95th_percentile",
+			"ovn_controller_flow_generation_long_term_avg",
+			"ovn_controller_flow_generation_maximum",
+			"ovn_controller_flow_generation_minimum",
+			"ovn_controller_flow_generation_short_term_avg",
+			"ovn_controller_flow_generation_total_samples",
+			"ovn_controller_flow_installation_95th_percentile",
+			"ovn_controller_flow_installation_long_term_avg",
+			"ovn_controller_flow_installation_maximum",
+			"ovn_controller_flow_installation_minimum",
+			"ovn_controller_flow_installation_short_term_avg",
+			"ovn_controller_flow_installation_total_samples",
+			"ovn_controller_if_status_mgr_run_95th_percentile",
+			"ovn_controller_if_status_mgr_run_long_term_avg",
+			"ovn_controller_if_status_mgr_run_maximum",
+			"ovn_controller_if_status_mgr_run_minimum",
+			"ovn_controller_if_status_mgr_run_short_term_avg",
+			"ovn_controller_if_status_mgr_run_total_samples",
+			"ovn_controller_if_status_mgr_update_95th_percentile",
+			"ovn_controller_if_status_mgr_update_long_term_avg",
+			"ovn_controller_if_status_mgr_update_maximum",
+			"ovn_controller_if_status_mgr_update_minimum",
+			"ovn_controller_if_status_mgr_update_short_term_avg",
+			"ovn_controller_if_status_mgr_update_total_samples",
+			"ovn_controller_integration_bridge_geneve_ports",
+			"ovn_controller_integration_bridge_openflow_total",
+			"ovn_controller_integration_bridge_patch_ports",
+			"ovn_controller_lflow_run",
+			"ovn_controller_monitor_all",
+			"ovn_controller_netlink_overflow",
+			"ovn_controller_netlink_received",
+			"ovn_controller_netlink_recv_jumbo",
+			"ovn_controller_netlink_sent",
+			"ovn_controller_ofctrl_seqno_run_95th_percentile",
+			"ovn_controller_ofctrl_seqno_run_long_term_avg",
+			"ovn_controller_ofctrl_seqno_run_maximum",
+			"ovn_controller_ofctrl_seqno_run_minimum",
+			"ovn_controller_ofctrl_seqno_run_short_term_avg",
+			"ovn_controller_ofctrl_seqno_run_total_samples",
+			"ovn_controller_openflow_probe_interval_seconds",
+			"ovn_controller_packet_in_drop",
+			"ovn_controller_packet_in",
+			"ovn_controller_patch_run_95th_percentile",
+			"ovn_controller_patch_run_long_term_avg",
+			"ovn_controller_patch_run_maximum",
+			"ovn_controller_patch_run_minimum",
+			"ovn_controller_patch_run_short_term_avg",
+			"ovn_controller_patch_run_total_samples",
+			"ovn_controller_pinctrl_run_95th_percentile",
+			"ovn_controller_pinctrl_run_long_term_avg",
+			"ovn_controller_pinctrl_run_maximum",
+			"ovn_controller_pinctrl_run_minimum",
+			"ovn_controller_pinctrl_run_short_term_avg",
+			"ovn_controller_pinctrl_run_total_samples",
+			"ovn_controller_rconn_discarded",
+			"ovn_controller_rconn_overflow",
+			"ovn_controller_rconn_queued",
+			"ovn_controller_rconn_sent",
+			"ovn_controller_remote_probe_interval_seconds",
+			"ovn_controller_sb_connection_method",
+			"ovn_controller_southbound_database_connected",
+			"ovn_controller_stream_open",
+			"ovn_controller_txn_aborted",
+			"ovn_controller_txn_error",
+			"ovn_controller_txn_incomplete",
+			"ovn_controller_txn_success",
+			"ovn_controller_txn_try_again",
+			"ovn_controller_txn_unchanged",
+			"ovn_controller_txn_uncommitted",
+			"ovn_controller_vconn_open",
+			"ovn_controller_vconn_received",
+			"ovn_controller_vconn_sent",
+			"promhttp_metric_handler_requests_in_flight",
+			"promhttp_metric_handler_requests_total",
+		},
+	}
+
+	OVNNorthdMetricsTestCase = metricsTestCase{
+		enableOVNNorthd: true,
+		mockRunCommands: []ovntest.TestifyMockHelper{
+			// ovs-appctl -t /var/run/openvswitch/ovn-northd.152.ctl version
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "version"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte(ovnNorthdVersionOutput)), bytes.NewBuffer([]byte("")), nil},
+				CallTimes:  1,
+			},
+			// ovs-appctl -t /var/run/openvswitch/ovn-northd.152.ctl status
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "status"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("Status: standby")), bytes.NewBuffer([]byte("")), nil},
+				CallTimes:  2,
+			},
+			// ovs-appctl -t /var/run/openvswitch/ovn-northd.152.ctl sb-connection-status
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "sb-connection-status"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
+				CallTimes:  2,
+			},
+			// ovs-appctl -t /var/run/openvswitch/ovn-northd.152.ctl nb-connection-status
+			{
+				OnCallMethodName: "RunCmd",
+				OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"),
+					mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "nb-connection-status"},
+				RetArgList: []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
+				CallTimes:  2,
+			},
+		},
+		expectedMetrics: []string{
+			"ovn_northd_build_flows_ctx_95th_percentile",
+			"ovn_northd_build_flows_ctx_long_term_avg",
+			"ovn_northd_build_flows_ctx_maximum",
+			"ovn_northd_build_flows_ctx_minimum",
+			"ovn_northd_build_flows_ctx_short_term_avg",
+			"ovn_northd_build_flows_ctx_total_samples",
+			"ovn_northd_build_info",
+			"ovn_northd_build_lflows_95th_percentile",
+			"ovn_northd_build_lflows_long_term_avg",
+			"ovn_northd_build_lflows_maximum",
+			"ovn_northd_build_lflows_minimum",
+			"ovn_northd_build_lflows_short_term_avg",
+			"ovn_northd_build_lflows_total_samples",
+			"ovn_northd_clear_lflows_ctx_95th_percentile",
+			"ovn_northd_clear_lflows_ctx_long_term_avg",
+			"ovn_northd_clear_lflows_ctx_maximum",
+			"ovn_northd_clear_lflows_ctx_minimum",
+			"ovn_northd_clear_lflows_ctx_short_term_avg",
+			"ovn_northd_clear_lflows_ctx_total_samples",
+			"ovn_northd_lflows_datapaths_95th_percentile",
+			"ovn_northd_lflows_datapaths_long_term_avg",
+			"ovn_northd_lflows_datapaths_maximum",
+			"ovn_northd_lflows_datapaths_minimum",
+			"ovn_northd_lflows_datapaths_short_term_avg",
+			"ovn_northd_lflows_datapaths_total_samples",
+			"ovn_northd_lflows_dp_groups_95th_percentile",
+			"ovn_northd_lflows_dp_groups_long_term_avg",
+			"ovn_northd_lflows_dp_groups_maximum",
+			"ovn_northd_lflows_dp_groups_minimum",
+			"ovn_northd_lflows_dp_groups_short_term_avg",
+			"ovn_northd_lflows_dp_groups_total_samples",
+			"ovn_northd_lflows_igmp_95th_percentile",
+			"ovn_northd_lflows_igmp_long_term_avg",
+			"ovn_northd_lflows_igmp_maximum",
+			"ovn_northd_lflows_igmp_minimum",
+			"ovn_northd_lflows_igmp_short_term_avg",
+			"ovn_northd_lflows_igmp_total_samples",
+			"ovn_northd_lflows_lbs_95th_percentile",
+			"ovn_northd_lflows_lbs_long_term_avg",
+			"ovn_northd_lflows_lbs_maximum",
+			"ovn_northd_lflows_lbs_minimum",
+			"ovn_northd_lflows_lbs_short_term_avg",
+			"ovn_northd_lflows_lbs_total_samples",
+			"ovn_northd_lflows_ports_95th_percentile",
+			"ovn_northd_lflows_ports_long_term_avg",
+			"ovn_northd_lflows_ports_maximum",
+			"ovn_northd_lflows_ports_minimum",
+			"ovn_northd_lflows_ports_short_term_avg",
+			"ovn_northd_lflows_ports_total_samples",
+			"ovn_northd_nb_connection_status",
+			"ovn_northd_ovn_northd_loop_95th_percentile",
+			"ovn_northd_ovn_northd_loop_long_term_avg",
+			"ovn_northd_ovn_northd_loop_maximum",
+			"ovn_northd_ovn_northd_loop_minimum",
+			"ovn_northd_ovn_northd_loop_short_term_avg",
+			"ovn_northd_ovn_northd_loop_total_samples",
+			"ovn_northd_ovnnb_db_run_95th_percentile",
+			"ovn_northd_ovnnb_db_run_long_term_avg",
+			"ovn_northd_ovnnb_db_run_maximum",
+			"ovn_northd_ovnnb_db_run_minimum",
+			"ovn_northd_ovnnb_db_run_short_term_avg",
+			"ovn_northd_ovnnb_db_run_total_samples",
+			"ovn_northd_ovnsb_db_run_95th_percentile",
+			"ovn_northd_ovnsb_db_run_long_term_avg",
+			"ovn_northd_ovnsb_db_run_maximum",
+			"ovn_northd_ovnsb_db_run_minimum",
+			"ovn_northd_ovnsb_db_run_short_term_avg",
+			"ovn_northd_ovnsb_db_run_total_samples",
+			"ovn_northd_pstream_open",
+			"ovn_northd_sb_connection_status",
+			"ovn_northd_status",
+			"ovn_northd_stream_open",
+			"ovn_northd_txn_aborted",
+			"ovn_northd_txn_error",
+			"ovn_northd_txn_incomplete",
+			"ovn_northd_txn_success",
+			"ovn_northd_txn_try_again",
+			"ovn_northd_txn_unchanged",
+			"ovn_northd_txn_uncommitted",
+			"promhttp_metric_handler_requests_in_flight",
+			"promhttp_metric_handler_requests_total",
+		},
+	}
+
+	DefaultMetricsTestCase = metricsTestCase{
+		expectedMetrics: []string{
+			"ovnkube_controller_ready_duration_seconds",
+			"ovnkube_controller_sync_duration_seconds",
+			"ovnkube_controller_build_info",
+			"go_gc_duration_seconds",
+			"go_gc_gogc_percent",
+			"go_gc_gomemlimit_bytes",
+			"go_goroutines",
+			"go_info",
+			"go_memstats_alloc_bytes",
+			"go_memstats_alloc_bytes_total",
+			"go_memstats_buck_hash_sys_bytes",
+			"go_memstats_frees_total",
+			"go_memstats_gc_sys_bytes",
+			"go_memstats_heap_alloc_bytes",
+			"go_memstats_heap_idle_bytes",
+			"go_memstats_heap_inuse_bytes",
+			"go_memstats_heap_objects",
+			"go_memstats_heap_released_bytes",
+			"go_memstats_heap_sys_bytes",
+			"go_memstats_last_gc_time_seconds",
+			"go_memstats_mallocs_total",
+			"go_memstats_mcache_inuse_bytes",
+			"go_memstats_mcache_sys_bytes",
+			"go_memstats_mspan_inuse_bytes",
+			"go_memstats_mspan_sys_bytes",
+			"go_memstats_next_gc_bytes",
+			"go_memstats_other_sys_bytes",
+			"go_memstats_stack_inuse_bytes",
+			"go_memstats_stack_sys_bytes",
+			"go_memstats_sys_bytes",
+			"go_sched_gomaxprocs_threads",
+			"go_threads",
+			"process_cpu_seconds_total",
+			"process_max_fds",
+			"process_network_receive_bytes_total",
+			"process_network_transmit_bytes_total",
+			"process_open_fds",
+			"process_resident_memory_bytes",
+			"process_start_time_seconds",
+			"process_virtual_memory_bytes",
+			"process_virtual_memory_max_bytes",
+			"promhttp_metric_handler_requests_in_flight",
+			"promhttp_metric_handler_requests_total",
+		},
+	}
+
 	dpctlShowOutput = `system@ovs-system:
 lookups: hit:123456 missed:11 lost:22
 flows: 77
@@ -302,603 +929,3 @@ Open vSwitch Library 2.13.0.f945b5c5
 Open vSwitch Library 3.5.0
 `
 )
-
-type metricsTestCase struct {
-	name                string
-	enableOVS           bool
-	enableOVNDB         bool
-	enableOVNController bool
-	enableOVNNorthd     bool
-	registerer          prometheus.Registerer
-	mockRunCommands     []ovntest.TestifyMockHelper
-	expectedMetrics     []string
-}
-
-func TestHandleMetrics(t *testing.T) {
-	// disable Process metrics collector to avoid the test flakiness
-	savedUnprivilegedMode := config.UnprivilegedMode
-	config.UnprivilegedMode = true
-	savedRunner := util.RunCmdExecRunner
-	defer func() {
-		config.UnprivilegedMode = savedUnprivilegedMode
-		util.RunCmdExecRunner = savedRunner
-	}()
-
-	setupAppFs(t)
-
-	// common OVS DB setup
-	ovsVersion := "2.17.0"
-
-	intf1 := vswitchd.Interface{Name: "porta", UUID: buildUUID()}
-	port1 := vswitchd.Port{Name: "porta", UUID: buildUUID()}
-	br1 := vswitchd.Bridge{Name: "br-int", UUID: buildUUID()}
-
-	testDB := []libovsdbtest.TestData{
-		&vswitchd.Interface{
-			UUID: intf1.UUID,
-			Name: intf1.Name,
-			Statistics: map[string]int{
-				"rx_packets": 1000,
-				"tx_packets": 800,
-				"rx_bytes":   100000,
-				"tx_bytes":   80000,
-			},
-		},
-		&vswitchd.Port{UUID: port1.UUID, Name: port1.Name, Interfaces: []string{intf1.UUID}},
-		&vswitchd.Bridge{UUID: br1.UUID, Name: br1.Name, Ports: []string{port1.UUID}},
-		&vswitchd.OpenvSwitch{
-			UUID:       buildUUID(),
-			OVSVersion: &ovsVersion,
-			Bridges:    []string{br1.UUID},
-			ExternalIDs: map[string]string{
-				"ovn-bridge-remote-probe-interval": "100",
-				"ovn-remote-probe-interval":        "200",
-				"ovn-monitor-all":                  "false",
-				"ovn-encap-ip":                     "192.168.1.1",
-				"ovn-encap-type":                   "geneve",
-				"ovn-remote":                       "unix:/var/run/ovn/ovnsb_db.sock",
-				"ovn-k8s-node-port":                "false",
-				"ovn-bridge-mappings":              "physnet:breth0",
-			},
-		},
-	}
-
-	// Setup OVS test harness
-	dbSetup := libovsdbtest.TestSetup{
-		OVSData: testDB,
-	}
-	ovsDBClient, libovsdbCleanup, err := libovsdbtest.NewOVSTestHarness(dbSetup)
-	if err != nil {
-		t.Fatalf("Failed to create OVS test harness: %v", err)
-	}
-	defer libovsdbCleanup.Cleanup()
-
-	// Register OVN-Kube controller base metrics into the default registry, so the
-	// metrics in default registry can be tested.
-	RegisterOVNKubeControllerBase()
-	MetricOVNKubeControllerSyncDuration.WithLabelValues("pods").Set(0)
-
-	testCases := []metricsTestCase{
-		{
-			name:      "OVS metrics",
-			enableOVS: true,
-			mockRunCommands: []ovntest.TestifyMockHelper{
-				// dpctl/dump-dps
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dpctl/dump-dps"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("system@ovs-system")), bytes.NewBuffer([]byte("")), nil},
-				},
-				// dpctl/show
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dpctl/show", "system@ovs-system"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(dpctlShowOutput)), bytes.NewBuffer([]byte("")), nil},
-				},
-				// memory/show
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "memory/show"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(ovsMemoryShowOutput)), bytes.NewBuffer([]byte("")), nil},
-				},
-				// coverage/show
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "coverage/show"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(coverageShowOutput)), bytes.NewBuffer([]byte("")), nil},
-				},
-				// ovs-ofctl dump-aggregate br-int
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dump-aggregate", "br-int"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(ovsOfctlDumpAggregateOutput)), bytes.NewBuffer([]byte("")), nil},
-				},
-			},
-			expectedMetrics: []string{
-				"ovs_build_info",
-				"ovs_vswitchd_bridge_flows_total",
-				"ovs_vswitchd_bridge_ports_total",
-				"ovs_vswitchd_bridge_reconfigure",
-				"ovs_vswitchd_bridge_total",
-				"ovs_vswitchd_bridge",
-				"ovs_vswitchd_dp_flows_lookup_hit",
-				"ovs_vswitchd_dp_flows_lookup_lost",
-				"ovs_vswitchd_dp_flows_lookup_missed",
-				"ovs_vswitchd_dp_flows_total",
-				"ovs_vswitchd_dp_if_total",
-				"ovs_vswitchd_dp_masks_hit_ratio",
-				"ovs_vswitchd_dp_masks_hit",
-				"ovs_vswitchd_dp_masks_total",
-				"ovs_vswitchd_dp_packets_total",
-				"ovs_vswitchd_dp_total",
-				"ovs_vswitchd_dp",
-				"ovs_vswitchd_dpif_execute",
-				"ovs_vswitchd_dpif_flow_del",
-				"ovs_vswitchd_dpif_flow_flush",
-				"ovs_vswitchd_dpif_flow_get",
-				"ovs_vswitchd_dpif_flow_put",
-				"ovs_vswitchd_dpif_port_add",
-				"ovs_vswitchd_dpif_port_del",
-				"ovs_vswitchd_handlers_total",
-				"ovs_vswitchd_hw_offload",
-				"ovs_vswitchd_interface_collisions_total",
-				"ovs_vswitchd_interface_resets_total",
-				"ovs_vswitchd_interface_rx_dropped_total",
-				"ovs_vswitchd_interface_rx_errors_total",
-				"ovs_vswitchd_interface_tx_dropped_total",
-				"ovs_vswitchd_interface_tx_errors_total",
-				"ovs_vswitchd_interface_up_wait_seconds_total",
-				"ovs_vswitchd_interfaces_total",
-				"ovs_vswitchd_netlink_overflow",
-				"ovs_vswitchd_netlink_received",
-				"ovs_vswitchd_netlink_recv_jumbo",
-				"ovs_vswitchd_netlink_sent",
-				"ovs_vswitchd_ofproto_dpif_expired",
-				"ovs_vswitchd_ofproto_flush",
-				"ovs_vswitchd_ofproto_packet_out",
-				"ovs_vswitchd_ofproto_recv_openflow",
-				"ovs_vswitchd_ofproto_reinit_ports",
-				"ovs_vswitchd_packet_in_drop",
-				"ovs_vswitchd_packet_in",
-				"ovs_vswitchd_pstream_open",
-				"ovs_vswitchd_rconn_discarded",
-				"ovs_vswitchd_rconn_overflow",
-				"ovs_vswitchd_rconn_queued",
-				"ovs_vswitchd_rconn_sent",
-				"ovs_vswitchd_revalidators_total",
-				"ovs_vswitchd_stream_open",
-				"ovs_vswitchd_tc_policy",
-				"ovs_vswitchd_txn_aborted",
-				"ovs_vswitchd_txn_error",
-				"ovs_vswitchd_txn_incomplete",
-				"ovs_vswitchd_txn_success",
-				"ovs_vswitchd_txn_try_again",
-				"ovs_vswitchd_txn_unchanged",
-				"ovs_vswitchd_txn_uncommitted",
-				"ovs_vswitchd_upcall_flow_limit_hit",
-				"ovs_vswitchd_upcall_flow_limit_kill",
-				"ovs_vswitchd_vconn_open",
-				"ovs_vswitchd_vconn_received",
-				"ovs_vswitchd_vconn_sent",
-				"ovs_vswitchd_xlate_actions_oversize",
-				"ovs_vswitchd_xlate_actions_too_many_output",
-				"ovs_vswitchd_xlate_actions",
-				"promhttp_metric_handler_requests_in_flight",
-				"promhttp_metric_handler_requests_total",
-			},
-		},
-		{
-			name:        "OVN DB metrics",
-			enableOVNDB: true,
-			mockRunCommands: []ovntest.TestifyMockHelper{
-				// ovs-appctl version
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "version"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("ovsdb-server (Open vSwitch) 3.5.0")), bytes.NewBuffer([]byte("")), nil},
-				},
-				// ovsdb-client  get-schema-version unix:/var/run/openvswitch/ovnnb_db.sock OVN_Northbound
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "get-schema-version", mock.AnythingOfType("string"), "OVN_Northbound"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("7.11.0")), bytes.NewBuffer([]byte("")), nil},
-				},
-				// ovsdb-client  get-schema-version unix:/var/run/openvswitch/ovnnb_db.sock OVN_Southbound
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "get-schema-version", mock.AnythingOfType("string"), "OVN_Southbound"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("20.41.0")), bytes.NewBuffer([]byte("")), nil},
-				},
-				// ovs-appctl  -t /var/run/openvswitch/ovnnb_db.ctl cluster/status OVN_Northbound
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), mock.AnythingOfType("string"), "cluster/status", "OVN_Northbound"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte(`"cluster/status" is not a valid command`)), fmt.Errorf("server returned an error")},
-				},
-				// ovs-appctl  -t /var/run/openvswitch/ovnnb_db.ctl memory/show
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), mock.AnythingOfType("string"), "memory/show"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(ovnDBMemoryShowOutput)), bytes.NewBuffer([]byte("")), nil},
-				},
-				// ovs-appctl  -t /var/run/openvswitch/ovnsb_db.ctl memory/show
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), mock.AnythingOfType("string"), "memory/show"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(ovnDBMemoryShowOutput)), bytes.NewBuffer([]byte("")), nil},
-				},
-			},
-			expectedMetrics: []string{
-				"ovn_db_build_info",
-				"ovn_db_db_size_bytes",
-				"ovn_db_jsonrpc_server_sessions",
-				"ovn_db_ovsdb_monitors",
-				"promhttp_metric_handler_requests_in_flight",
-				"promhttp_metric_handler_requests_total",
-			},
-		},
-		{
-			name:                "OVN Controller metrics",
-			enableOVNController: true,
-			mockRunCommands: []ovntest.TestifyMockHelper{
-				// ovs-ofctl -t 5 dump-aggregate br-int
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "dump-aggregate", "br-int"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(ovnControllerDumpAggregateOutput)), bytes.NewBuffer([]byte("")), nil},
-					CallTimes:        2,
-				},
-				// ovs-appctl -t /var/run/openvswitch/ovn-controller.113.ctl coverage/show
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "coverage/show"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(ovnControllercoverageShowOutput)), bytes.NewBuffer([]byte("")), nil},
-				},
-				// ovs-appctl -t  /var/run/openvswitch/ovn-controller.113.ctl version
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "version"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(ovnControllerVersionOutput)), bytes.NewBuffer([]byte("")), nil},
-				},
-				// ovs-appctl -t  /var/run/openvswitch/ovn-controller.113.ctl connection-status
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "connection-status"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
-				},
-			},
-			expectedMetrics: []string{
-				"ovn_controller_bfd_run_95th_percentile",
-				"ovn_controller_bfd_run_long_term_avg",
-				"ovn_controller_bfd_run_maximum",
-				"ovn_controller_bfd_run_minimum",
-				"ovn_controller_bfd_run_short_term_avg",
-				"ovn_controller_bfd_run_total_samples",
-				"ovn_controller_bridge_mappings",
-				"ovn_controller_build_info",
-				"ovn_controller_ct_zone_commit_95th_percentile",
-				"ovn_controller_ct_zone_commit_long_term_avg",
-				"ovn_controller_ct_zone_commit_maximum",
-				"ovn_controller_ct_zone_commit_minimum",
-				"ovn_controller_ct_zone_commit_short_term_avg",
-				"ovn_controller_ct_zone_commit_total_samples",
-				"ovn_controller_encap_ip",
-				"ovn_controller_encap_type",
-				"ovn_controller_flow_generation_95th_percentile",
-				"ovn_controller_flow_generation_long_term_avg",
-				"ovn_controller_flow_generation_maximum",
-				"ovn_controller_flow_generation_minimum",
-				"ovn_controller_flow_generation_short_term_avg",
-				"ovn_controller_flow_generation_total_samples",
-				"ovn_controller_flow_installation_95th_percentile",
-				"ovn_controller_flow_installation_long_term_avg",
-				"ovn_controller_flow_installation_maximum",
-				"ovn_controller_flow_installation_minimum",
-				"ovn_controller_flow_installation_short_term_avg",
-				"ovn_controller_flow_installation_total_samples",
-				"ovn_controller_if_status_mgr_run_95th_percentile",
-				"ovn_controller_if_status_mgr_run_long_term_avg",
-				"ovn_controller_if_status_mgr_run_maximum",
-				"ovn_controller_if_status_mgr_run_minimum",
-				"ovn_controller_if_status_mgr_run_short_term_avg",
-				"ovn_controller_if_status_mgr_run_total_samples",
-				"ovn_controller_if_status_mgr_update_95th_percentile",
-				"ovn_controller_if_status_mgr_update_long_term_avg",
-				"ovn_controller_if_status_mgr_update_maximum",
-				"ovn_controller_if_status_mgr_update_minimum",
-				"ovn_controller_if_status_mgr_update_short_term_avg",
-				"ovn_controller_if_status_mgr_update_total_samples",
-				"ovn_controller_integration_bridge_geneve_ports",
-				"ovn_controller_integration_bridge_openflow_total",
-				"ovn_controller_integration_bridge_patch_ports",
-				"ovn_controller_lflow_run",
-				"ovn_controller_monitor_all",
-				"ovn_controller_netlink_overflow",
-				"ovn_controller_netlink_received",
-				"ovn_controller_netlink_recv_jumbo",
-				"ovn_controller_netlink_sent",
-				"ovn_controller_ofctrl_seqno_run_95th_percentile",
-				"ovn_controller_ofctrl_seqno_run_long_term_avg",
-				"ovn_controller_ofctrl_seqno_run_maximum",
-				"ovn_controller_ofctrl_seqno_run_minimum",
-				"ovn_controller_ofctrl_seqno_run_short_term_avg",
-				"ovn_controller_ofctrl_seqno_run_total_samples",
-				"ovn_controller_openflow_probe_interval_seconds",
-				"ovn_controller_packet_in_drop",
-				"ovn_controller_packet_in",
-				"ovn_controller_patch_run_95th_percentile",
-				"ovn_controller_patch_run_long_term_avg",
-				"ovn_controller_patch_run_maximum",
-				"ovn_controller_patch_run_minimum",
-				"ovn_controller_patch_run_short_term_avg",
-				"ovn_controller_patch_run_total_samples",
-				"ovn_controller_pinctrl_run_95th_percentile",
-				"ovn_controller_pinctrl_run_long_term_avg",
-				"ovn_controller_pinctrl_run_maximum",
-				"ovn_controller_pinctrl_run_minimum",
-				"ovn_controller_pinctrl_run_short_term_avg",
-				"ovn_controller_pinctrl_run_total_samples",
-				"ovn_controller_rconn_discarded",
-				"ovn_controller_rconn_overflow",
-				"ovn_controller_rconn_queued",
-				"ovn_controller_rconn_sent",
-				"ovn_controller_remote_probe_interval_seconds",
-				"ovn_controller_sb_connection_method",
-				"ovn_controller_southbound_database_connected",
-				"ovn_controller_stream_open",
-				"ovn_controller_txn_aborted",
-				"ovn_controller_txn_error",
-				"ovn_controller_txn_incomplete",
-				"ovn_controller_txn_success",
-				"ovn_controller_txn_try_again",
-				"ovn_controller_txn_unchanged",
-				"ovn_controller_txn_uncommitted",
-				"ovn_controller_vconn_open",
-				"ovn_controller_vconn_received",
-				"ovn_controller_vconn_sent",
-				"promhttp_metric_handler_requests_in_flight",
-				"promhttp_metric_handler_requests_total",
-			},
-		},
-		{
-			name:            "OVN Northd metrics",
-			enableOVNNorthd: true,
-			mockRunCommands: []ovntest.TestifyMockHelper{
-				// ovs-appctl -t /var/run/openvswitch/ovn-northd.152.ctl version
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "version"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte(ovnNorthdVersionOutput)), bytes.NewBuffer([]byte("")), nil},
-					CallTimes:        1,
-				},
-				// ovs-appctl -t /var/run/openvswitch/ovn-northd.152.ctl status
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "status"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("Status: standby")), bytes.NewBuffer([]byte("")), nil},
-					CallTimes:        2,
-				},
-				// ovs-appctl -t /var/run/openvswitch/ovn-northd.152.ctl sb-connection-status
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "sb-connection-status"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
-					CallTimes:        2,
-				},
-				// ovs-appctl -t /var/run/openvswitch/ovn-northd.152.ctl nb-connection-status
-				{
-					OnCallMethodName: "RunCmd",
-					OnCallMethodArgs: []interface{}{mock.AnythingOfType("*mocks.Cmd"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"), "-t", mock.AnythingOfType("string"), "nb-connection-status"},
-					RetArgList:       []interface{}{bytes.NewBuffer([]byte("connected")), bytes.NewBuffer([]byte("")), nil},
-					CallTimes:        2,
-				},
-			},
-			expectedMetrics: []string{
-				"ovn_northd_build_flows_ctx_95th_percentile",
-				"ovn_northd_build_flows_ctx_long_term_avg",
-				"ovn_northd_build_flows_ctx_maximum",
-				"ovn_northd_build_flows_ctx_minimum",
-				"ovn_northd_build_flows_ctx_short_term_avg",
-				"ovn_northd_build_flows_ctx_total_samples",
-				"ovn_northd_build_info",
-				"ovn_northd_build_lflows_95th_percentile",
-				"ovn_northd_build_lflows_long_term_avg",
-				"ovn_northd_build_lflows_maximum",
-				"ovn_northd_build_lflows_minimum",
-				"ovn_northd_build_lflows_short_term_avg",
-				"ovn_northd_build_lflows_total_samples",
-				"ovn_northd_clear_lflows_ctx_95th_percentile",
-				"ovn_northd_clear_lflows_ctx_long_term_avg",
-				"ovn_northd_clear_lflows_ctx_maximum",
-				"ovn_northd_clear_lflows_ctx_minimum",
-				"ovn_northd_clear_lflows_ctx_short_term_avg",
-				"ovn_northd_clear_lflows_ctx_total_samples",
-				"ovn_northd_lflows_datapaths_95th_percentile",
-				"ovn_northd_lflows_datapaths_long_term_avg",
-				"ovn_northd_lflows_datapaths_maximum",
-				"ovn_northd_lflows_datapaths_minimum",
-				"ovn_northd_lflows_datapaths_short_term_avg",
-				"ovn_northd_lflows_datapaths_total_samples",
-				"ovn_northd_lflows_dp_groups_95th_percentile",
-				"ovn_northd_lflows_dp_groups_long_term_avg",
-				"ovn_northd_lflows_dp_groups_maximum",
-				"ovn_northd_lflows_dp_groups_minimum",
-				"ovn_northd_lflows_dp_groups_short_term_avg",
-				"ovn_northd_lflows_dp_groups_total_samples",
-				"ovn_northd_lflows_igmp_95th_percentile",
-				"ovn_northd_lflows_igmp_long_term_avg",
-				"ovn_northd_lflows_igmp_maximum",
-				"ovn_northd_lflows_igmp_minimum",
-				"ovn_northd_lflows_igmp_short_term_avg",
-				"ovn_northd_lflows_igmp_total_samples",
-				"ovn_northd_lflows_lbs_95th_percentile",
-				"ovn_northd_lflows_lbs_long_term_avg",
-				"ovn_northd_lflows_lbs_maximum",
-				"ovn_northd_lflows_lbs_minimum",
-				"ovn_northd_lflows_lbs_short_term_avg",
-				"ovn_northd_lflows_lbs_total_samples",
-				"ovn_northd_lflows_ports_95th_percentile",
-				"ovn_northd_lflows_ports_long_term_avg",
-				"ovn_northd_lflows_ports_maximum",
-				"ovn_northd_lflows_ports_minimum",
-				"ovn_northd_lflows_ports_short_term_avg",
-				"ovn_northd_lflows_ports_total_samples",
-				"ovn_northd_nb_connection_status",
-				"ovn_northd_ovn_northd_loop_95th_percentile",
-				"ovn_northd_ovn_northd_loop_long_term_avg",
-				"ovn_northd_ovn_northd_loop_maximum",
-				"ovn_northd_ovn_northd_loop_minimum",
-				"ovn_northd_ovn_northd_loop_short_term_avg",
-				"ovn_northd_ovn_northd_loop_total_samples",
-				"ovn_northd_ovnnb_db_run_95th_percentile",
-				"ovn_northd_ovnnb_db_run_long_term_avg",
-				"ovn_northd_ovnnb_db_run_maximum",
-				"ovn_northd_ovnnb_db_run_minimum",
-				"ovn_northd_ovnnb_db_run_short_term_avg",
-				"ovn_northd_ovnnb_db_run_total_samples",
-				"ovn_northd_ovnsb_db_run_95th_percentile",
-				"ovn_northd_ovnsb_db_run_long_term_avg",
-				"ovn_northd_ovnsb_db_run_maximum",
-				"ovn_northd_ovnsb_db_run_minimum",
-				"ovn_northd_ovnsb_db_run_short_term_avg",
-				"ovn_northd_ovnsb_db_run_total_samples",
-				"ovn_northd_pstream_open",
-				"ovn_northd_sb_connection_status",
-				"ovn_northd_status",
-				"ovn_northd_stream_open",
-				"ovn_northd_txn_aborted",
-				"ovn_northd_txn_error",
-				"ovn_northd_txn_incomplete",
-				"ovn_northd_txn_success",
-				"ovn_northd_txn_try_again",
-				"ovn_northd_txn_unchanged",
-				"ovn_northd_txn_uncommitted",
-				"promhttp_metric_handler_requests_in_flight",
-				"promhttp_metric_handler_requests_total",
-			},
-		},
-		{
-			name:       "default registry metrics",
-			registerer: prometheus.DefaultRegisterer,
-			expectedMetrics: []string{
-				"ovnkube_controller_ready_duration_seconds",
-				"ovnkube_controller_sync_duration_seconds",
-				"ovnkube_controller_build_info",
-				"go_gc_duration_seconds",
-				"go_gc_gogc_percent",
-				"go_gc_gomemlimit_bytes",
-				"go_goroutines",
-				"go_info",
-				"go_memstats_alloc_bytes",
-				"go_memstats_alloc_bytes_total",
-				"go_memstats_buck_hash_sys_bytes",
-				"go_memstats_frees_total",
-				"go_memstats_gc_sys_bytes",
-				"go_memstats_heap_alloc_bytes",
-				"go_memstats_heap_idle_bytes",
-				"go_memstats_heap_inuse_bytes",
-				"go_memstats_heap_objects",
-				"go_memstats_heap_released_bytes",
-				"go_memstats_heap_sys_bytes",
-				"go_memstats_last_gc_time_seconds",
-				"go_memstats_mallocs_total",
-				"go_memstats_mcache_inuse_bytes",
-				"go_memstats_mcache_sys_bytes",
-				"go_memstats_mspan_inuse_bytes",
-				"go_memstats_mspan_sys_bytes",
-				"go_memstats_next_gc_bytes",
-				"go_memstats_other_sys_bytes",
-				"go_memstats_stack_inuse_bytes",
-				"go_memstats_stack_sys_bytes",
-				"go_memstats_sys_bytes",
-				"go_sched_gomaxprocs_threads",
-				"go_threads",
-				"process_cpu_seconds_total",
-				"process_max_fds",
-				"process_network_receive_bytes_total",
-				"process_network_transmit_bytes_total",
-				"process_open_fds",
-				"process_resident_memory_bytes",
-				"process_start_time_seconds",
-				"process_virtual_memory_bytes",
-				"process_virtual_memory_max_bytes",
-				"promhttp_metric_handler_requests_in_flight",
-				"promhttp_metric_handler_requests_total",
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Configure server options
-			opts := MetricServerOptions{
-				BindAddress:                "127.0.0.1:0", // Use random port for testing
-				EnableOVSMetrics:           tc.enableOVS,
-				EnableOVNDBMetrics:         tc.enableOVNDB,
-				EnableOVNControllerMetrics: tc.enableOVNController,
-				EnableOVNNorthdMetrics:     tc.enableOVNNorthd,
-				Registerer:                 tc.registerer,
-				OVSDBClient:                ovsDBClient,
-			}
-			// Mock the exec runner for RunOvsVswitchdAppCtl calls
-			mockCmd := new(mock_k8s_io_utils_exec.Cmd)
-			mockExecRunner := new(mocks.ExecRunner)
-			util.RunCmdExecRunner = mockExecRunner
-			ovntest.ProcessMockFnList(&mockExecRunner.Mock, tc.mockRunCommands)
-
-			mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
-			mockKexecIface.Mock.On("Command", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe().Return(mockCmd)
-			mockKexecIface.Mock.On("Command", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe().Return(mockCmd)
-			mockKexecIface.Mock.On("Command", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe().Return(mockCmd)
-			_ = util.SetSpecificExec(mockKexecIface)
-
-			// Add cleanup for mock expectations
-			defer func() {
-				mockExecRunner.AssertExpectations(t)
-				mockKexecIface.AssertExpectations(t)
-			}()
-
-			// Create server with OVS client
-			server := NewMetricServer(opts)
-			server.registerMetrics()
-
-			// Iterate server registry to list all registered metric names.
-			regMetrics, err := server.registerer.(prometheus.Gatherer).Gather()
-			if err != nil {
-				t.Fatalf("Failed to gather metrics: %v", err)
-			}
-			gatherMetrics := []string{}
-			for _, metric := range regMetrics {
-				gatherMetrics = append(gatherMetrics, *metric.Name)
-			}
-			t.Logf("gatherMetrics: %v", gatherMetrics)
-
-			// Test the /metrics endpoint
-			rec := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "/metrics", nil)
-			server.mux.ServeHTTP(rec, req)
-			if rec.Code != http.StatusOK {
-				t.Errorf("Expected status 200, got %d", rec.Code)
-			}
-
-			got := rec.Body.String()
-			if len(got) == 0 {
-				t.Error("Expected non-empty metrics response")
-			}
-
-			gotMetrics := []string{}
-			for _, line := range strings.Split(got, "\n") {
-				if strings.HasPrefix(line, "# TYPE ") {
-					m := strings.Split(line, " ")[2]
-					gotMetrics = append(gotMetrics, m)
-				}
-			}
-
-			if diff := cmp.Diff(gotMetrics, tc.expectedMetrics, cmpopts.SortSlices(func(x, y string) bool {
-				return x < y
-			})); diff != "" {
-				t.Errorf("mismatch (-got +want):\n%s", diff)
-			}
-		})
-	}
-}

--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
-
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -43,9 +41,7 @@ func TestNewMetricServerRunAndShutdown(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var ovsDBClient libovsdbclient.Client
-
-	server := NewMetricServer(opts, ovsDBClient)
+	server := NewMetricServer(opts)
 	require.NotNil(t, server, "Server should not be nil")
 	require.NotNil(t, server.mux, "Server mux should not be nil")
 	require.NotNil(t, server.registerer, "Server registerer should not be nil")
@@ -103,9 +99,7 @@ func TestNewMetricServerRunAndFailOnFatalError(t *testing.T) {
 		EnableOVNNorthdMetrics:     false,
 	}
 
-	var ovsDBClient libovsdbclient.Client
-
-	server := NewMetricServer(opts, ovsDBClient)
+	server := NewMetricServer(opts)
 	require.NotNil(t, server, "Server should not be nil")
 	require.NotNil(t, server.mux, "Server mux should not be nil")
 	require.NotNil(t, server.registerer, "Server registerer should not be nil")
@@ -844,6 +838,7 @@ func TestHandleMetrics(t *testing.T) {
 				EnableOVNControllerMetrics: tc.enableOVNController,
 				EnableOVNNorthdMetrics:     tc.enableOVNNorthd,
 				Registerer:                 tc.registerer,
+				OVSDBClient:                ovsDBClient,
 			}
 			// Mock the exec runner for RunOvsVswitchdAppCtl calls
 			mockCmd := new(mock_k8s_io_utils_exec.Cmd)
@@ -864,7 +859,7 @@ func TestHandleMetrics(t *testing.T) {
 			}()
 
 			// Create server with OVS client
-			server := NewMetricServer(opts, ovsDBClient)
+			server := NewMetricServer(opts)
 			server.registerMetrics()
 
 			// Iterate server registry to list all registered metric names.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description

Added optional CLI flags `--tls-min-version` and `--tls-cipher-suites` to the ovnkube process for configuring TLS parameters for the metrics server.

See individual commits for details.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TLS configuration via config file and CLI, including minimum TLS version and cipher-suite selection.
  * Updated the metrics server to use unified runtime options for consistent TLS and pprof behavior, including improved wiring for OVS metrics.
* **Bug Fixes**
  * Improved metrics startup/shutdown behavior for more reliable operation and clearer runtime behavior under failure conditions.
* **Tests**
  * Migrated and expanded metrics server tests to a BDD suite, adding coverage for metrics output, pprof, TLS enforcement, and graceful shutdown/fatal bind scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->