### PR TITLE
node: set gateway FDB on DPU host representor

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -81,10 +81,13 @@ type BridgeConfiguration struct {
 
 	// variables that are only set on creation and never changed
 	// don't require mutex lock to read
-	nodeName    string
-	bridgeName  string
-	uplinkName  string
-	gwIface     string
+	nodeName   string
+	bridgeName string
+	uplinkName string
+	gwIface    string
+	// gwIfaceRep is the OVS representor port for the gateway MAC when one exists.
+	// In DPU mode this is the host representor. In accelerated full mode this is
+	// the representor of the configured gateway VF/SF.
 	gwIfaceRep  string
 	interfaceID string
 
@@ -198,6 +201,7 @@ func NewBridgeConfiguration(ovsClient libovsdbclient.Client, intfName, nodeName,
 					config.Gateway.DPUHostGatewayRepresentorInterface, bridgeName, repErr, stderr)
 			}
 			klog.Infof("Adding host representor interface %s to bridge %s", config.Gateway.DPUHostGatewayRepresentorInterface, bridgeName)
+			res.gwIfaceRep = config.Gateway.DPUHostGatewayRepresentorInterface
 		}
 		res.bridgeName = bridgeName
 		res.gwIface = bridgeName
@@ -249,8 +253,7 @@ func NewBridgeConfiguration(ovsClient libovsdbclient.Client, intfName, nodeName,
 
 	// for DPU we use the host MAC address for the Gateway configuration
 	if config.IsModeDPU() {
-		res.macAddress, err = util.GetDPUOps().GetHostGatewayMACAddress(res.bridgeName, nodeName)
-		if err != nil {
+		if err := res.setDPUHostGatewayConfiguration(nodeName); err != nil {
 			return nil, err
 		}
 	}
@@ -263,12 +266,42 @@ func NewBridgeConfiguration(ovsClient libovsdbclient.Client, intfName, nodeName,
 	return &res, nil
 }
 
+func (b *BridgeConfiguration) setDPUHostGatewayConfiguration(nodeName string) error {
+	if b.gwIfaceRep == "" {
+		b.gwIfaceRep = config.Gateway.DPUHostGatewayRepresentorInterface
+	}
+	if b.gwIfaceRep == "" {
+		// When the DPU host representor was not provided explicitly, discover
+		// it by inspecting the ports attached to the gateway bridge.
+		klog.V(5).Infof("No DPU host gateway representor configured, discovering host representor from bridge %s", b.bridgeName)
+		hostRep, err := util.GetDPUOps().GetDPUHostRepInterface(b.bridgeName)
+		if err != nil {
+			return err
+		}
+		b.gwIfaceRep = hostRep
+	}
+	macAddress, err := util.GetDPUOps().GetHostGatewayMACAddress(b.bridgeName, nodeName)
+	if err != nil {
+		return err
+	}
+	b.macAddress = macAddress
+	return nil
+}
+
 func (b *BridgeConfiguration) GetGatewayIface() string {
 	return b.gwIface
 }
 
 func (b *BridgeConfiguration) GetGatewayIfaceRep() string {
 	return b.gwIfaceRep
+}
+
+// GetStaticFDBPort returns the OVS bridge port that owns the gateway MAC.
+func (b *BridgeConfiguration) GetStaticFDBPort() string {
+	if b.gwIfaceRep != "" {
+		return b.gwIfaceRep
+	}
+	return b.bridgeName
 }
 
 // UpdateInterfaceIPAddresses sets and returns the bridge's current ips
@@ -423,33 +456,17 @@ func (b *BridgeConfiguration) ConfigureBridgePorts() error {
 		b.ofPortPhys = ofportPhys
 	}
 
-	// Get ofport representing the host. That is, host representor port in case of DPUs, ovsLocalPort otherwise.
-	var hostOVSInterfaceName string
-	if config.IsModeDPU() {
-		var stderr string
-		hostRep, err := util.GetDPUOps().GetDPUHostRepInterface(b.bridgeName)
+	// Get ofport representing the host. That is, the representor when present, ovsLocalPort otherwise.
+	b.ofPortHost = nodetypes.OvsLocalPort
+	hostOVSInterfaceName := b.bridgeName
+	if b.gwIfaceRep != "" {
+		ofPortHost, stderr, err := util.RunOVSVsctl("get", "interface", b.gwIfaceRep, "ofport")
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get ofport of gateway representor %s, stderr: %q, error: %v",
+				b.gwIfaceRep, stderr, err)
 		}
-
-		b.ofPortHost, stderr, err = util.RunOVSVsctl("get", "interface", hostRep, "ofport")
-		if err != nil {
-			return fmt.Errorf("failed to get ofport of host interface %s, stderr: %q, error: %v",
-				hostRep, stderr, err)
-		}
-		hostOVSInterfaceName = hostRep
-	} else {
-		var err error
-		if b.gwIfaceRep != "" {
-			b.ofPortHost, _, err = util.RunOVSVsctl("get", "interface", b.gwIfaceRep, "ofport")
-			if err != nil {
-				return fmt.Errorf("failed to get ofport of bypass rep %s, error: %v", b.gwIfaceRep, err)
-			}
-			hostOVSInterfaceName = b.gwIfaceRep
-		} else {
-			b.ofPortHost = nodetypes.OvsLocalPort
-			hostOVSInterfaceName = b.bridgeName
-		}
+		b.ofPortHost = ofPortHost
+		hostOVSInterfaceName = b.gwIfaceRep
 	}
 
 	// Ensure the host port on the bridge carries the configured VLAN tag when requested.

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package bridgeconfig
+
+import "testing"
+
+func TestGetStaticFDBPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		bridge   *BridgeConfiguration
+		expected string
+	}{
+		{
+			name: "uses bridge when representor is absent",
+			bridge: &BridgeConfiguration{
+				bridgeName: "br-ex",
+			},
+			expected: "br-ex",
+		},
+		{
+			name: "uses representor when present",
+			bridge: &BridgeConfiguration{
+				bridgeName: "ovsbr1",
+				gwIfaceRep: "pf0hpf",
+			},
+			expected: "pf0hpf",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.bridge.GetStaticFDBPort(); got != tc.expected {
+				t.Fatalf("expected static FDB port %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -446,14 +446,11 @@ func gatewayInitInternal(ovsClient libovsdbclient.Client, nodeName, gwIntf, egre
 	}
 
 	if config.IsModeDPU() || config.IsModeFull() {
-		// Set static FDB entry for sharedGW MAC.
-		// If `GatewayIfaceRep` port is present, use it instead of LOCAL (bridge name).
-		gwport := gatewayBridge.GetBridgeName()                           // Default is LOCAL port for the bridge.
-		if repPort := gatewayBridge.GetGatewayIfaceRep(); repPort != "" { // We have an accelerated switchdev device for GW.
-			gwport = repPort
-		}
-
-		if err := util.SetStaticFDBEntry(gatewayBridge.GetBridgeName(), gwport, gatewayBridge.GetMAC()); err != nil {
+		if err := util.SetStaticFDBEntry(
+			gatewayBridge.GetBridgeName(),
+			gatewayBridge.GetStaticFDBPort(),
+			gatewayBridge.GetMAC(),
+			config.Gateway.VLANID); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -198,7 +198,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: fmt.Sprintf("%t", hwOffload),
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-appctl -t /var/run/openvswitch/ovs-vswitchd.1234.ctl fdb/add breth0 breth0 0 " + eth0MAC,
+			fmt.Sprintf("ovs-appctl -t /var/run/openvswitch/ovs-vswitchd.1234.ctl fdb/add breth0 breth0 %d %s", gatewayVLANID, eth0MAC),
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_node1-to-br-int ofport",
@@ -681,7 +681,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Output: "false",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovs-appctl -t /var/run/openvswitch/ovs-vswitchd.1234.ctl fdb/add %s %s 0 %s", brphys, brphys, hostMAC),
+			fmt.Sprintf("ovs-appctl -t /var/run/openvswitch/ovs-vswitchd.1234.ctl fdb/add %s %s %d %s", brphys, hostRep, gatewayVLANID, hostMAC),
 		})
 		// GetDPUHostRepInterface
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -830,14 +830,13 @@ func DetectCheckPktLengthSupport(bridge string) (bool, error) {
 	return false, nil
 }
 
-// SetStaticFDBEntry programs a static MAC entry into the OVS FIB and disables MAC learning for this entry
-func SetStaticFDBEntry(bridge, port string, mac net.HardwareAddr) error {
-	// Assume default VLAN for local port
-	vlan := "0"
+// SetStaticFDBEntry programs a static MAC entry into the OVS FIB and disables MAC learning for this entry.
+func SetStaticFDBEntry(bridge, port string, mac net.HardwareAddr, vlanID uint) error {
+	vlan := fmt.Sprintf("%d", vlanID)
 	stdout, stderr, err := RunOvsVswitchdAppCtl("fdb/add", bridge, port, vlan, mac.String())
 	if err != nil {
-		return fmt.Errorf("failed to add FDB entry to OVS for LOCAL port, "+
-			"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+		return fmt.Errorf("failed to add FDB entry to OVS for port %s, "+
+			"stdout: %q, stderr: %q, error: %v", port, stdout, stderr, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Populate gwIfaceRep for DPU bridges with the host representor. Reuse that field when selecting the static FDB port and host ofport. Program the static FDB entry on the configured gateway VLAN. Full-mode accelerated gateways keep existing VF/SF behavior. Non-representor bridges still fall back to LOCAL.

Signed-off-by: Tim Rozet <trozet@nvidia.com>

Assisted-by: OpenAI Codex <codex@openai.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gateway configuration now explicitly tracks the static forwarding database (FDB) port for host traffic.
  * Static FDB entries now accept a configurable VLAN ID.

* **Bug Fixes**
  * Improved DPU mode initialization for host gateway representor selection and MAC/FDB setup.

* **Tests**
  * Added unit test coverage for static FDB port resolution.
  * Updated gateway initialization tests to validate VLAN-aware FDB programming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->