### PR TITLE
stop trying to override local firewalls

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1450,9 +1450,6 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 					"-i ovn-k8s-mp0 -j ACCEPT",
 					"-o ovn-k8s-mp0 -j ACCEPT",
 				},
-				"INPUT": []string{
-					"-i ovn-k8s-mp0 -m comment --comment from OVN to localhost -j ACCEPT",
-				},
 			},
 			"mangle": {
 				"OUTPUT": []string{

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -367,9 +367,8 @@ func delExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
 	return deleteIptRules(getGatewayForwardRules(cidrs))
 }
 
-func getLocalGatewayFilterRules(ifname string, cidr *net.IPNet) []nodeipt.Rule {
+func getLocalGatewayFilterRules(ifname string, protocol iptables.Protocol) []nodeipt.Rule {
 	// Allow packets to/from the gateway interface in case defaults deny
-	protocol := getIPTablesProtocol(cidr.IP.String())
 	return []nodeipt.Rule{
 		{
 			Table: "filter",
@@ -403,15 +402,17 @@ func getLocalGatewayFilterRules(ifname string, cidr *net.IPNet) []nodeipt.Rule {
 }
 
 // initLocalGatewayIPTFilterRules sets up iptables rules for interfaces
-func initLocalGatewayIPTFilterRules(ifname string, cidr *net.IPNet) error {
-	// Insert the filter table rules because they need to be evaluated BEFORE the DROP rules
-	// we have for forwarding. DO NOT change the ordering; specially important
-	// during SGW->LGW rollouts and restarts.
-	err := insertIptRules(getLocalGatewayFilterRules(ifname, cidr))
-	if err != nil {
-		return fmt.Errorf("unable to insert forwarding rules %v", err)
+func initLocalGatewayIPTFilterRules(ifname string) error {
+	for _, protocol := range clusterIPTablesProtocols() {
+		// Insert (rather than append) the filter table rules because they need to
+		// be evaluated BEFORE the DROP rules we have for forwarding. DO NOT
+		// change the ordering; especially important during SGW->LGW rollouts and
+		// restarts.
+		err := insertIptRules(getLocalGatewayFilterRules(ifname, protocol))
+		if err != nil {
+			return fmt.Errorf("unable to insert forwarding rules %v", err)
+		}
 	}
-	// NOTE: nftables masquerade rules are now handled separately in initLocalGatewayNFTNATRules
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -368,7 +368,6 @@ func delExternalBridgeServiceForwardingRules(cidrs []*net.IPNet) error {
 }
 
 func getLocalGatewayFilterRules(ifname string, protocol iptables.Protocol) []nodeipt.Rule {
-	// Allow packets to/from the gateway interface in case defaults deny
 	return []nodeipt.Rule{
 		{
 			Table: "filter",
@@ -388,29 +387,28 @@ func getLocalGatewayFilterRules(ifname string, protocol iptables.Protocol) []nod
 			},
 			Protocol: protocol,
 		},
-		{
-			Table: "filter",
-			Chain: "INPUT",
-			Args: []string{
-				"-i", ifname,
-				"-m", "comment", "--comment", "from OVN to localhost",
-				"-j", "ACCEPT",
-			},
-			Protocol: protocol,
-		},
 	}
 }
 
-// initLocalGatewayIPTFilterRules sets up iptables rules for interfaces
+// initLocalGatewayIPTFilterRules creates or deletes iptables forward rules for the
+// management port.
 func initLocalGatewayIPTFilterRules(ifname string) error {
 	for _, protocol := range clusterIPTablesProtocols() {
-		// Insert (rather than append) the filter table rules because they need to
-		// be evaluated BEFORE the DROP rules we have for forwarding. DO NOT
-		// change the ordering; especially important during SGW->LGW rollouts and
-		// restarts.
-		err := insertIptRules(getLocalGatewayFilterRules(ifname, protocol))
-		if err != nil {
-			return fmt.Errorf("unable to insert forwarding rules %v", err)
+		rules := getLocalGatewayFilterRules(ifname, protocol)
+		if config.Gateway.DisableForwarding {
+			// Insert (rather than append) the filter table rules because they
+			// need to be evaluated BEFORE the DROP rules we have for
+			// forwarding. DO NOT change the ordering; especially important
+			// during SGW->LGW rollouts and restarts.
+			err := insertIptRules(rules)
+			if err != nil {
+				return fmt.Errorf("unable to insert forwarding rules %v", err)
+			}
+		} else {
+			err := deleteIptRules(rules)
+			if err != nil {
+				return fmt.Errorf("unable to clean up stale forwarding rules %v", err)
+			}
 		}
 	}
 	return nil

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -28,12 +28,16 @@ func initLocalGateway(hostSubnets []*net.IPNet, mgmtPort managementport.Interfac
 		return nil
 	}
 
-	klog.Info("Adding iptables masquerading rules for new local gateway")
+	klog.Info("Adding iptables/nftables masquerading rules for new local gateway")
 
-	var allCIDRs []*net.IPNet
+	// Set up iptables filter rules to allow traffic to/from the management port.
 	ifName := mgmtPort.GetInterfaceName()
+	if err := initLocalGatewayIPTFilterRules(ifName); err != nil {
+		return fmt.Errorf("failed to add local forwarding rules for: %s, err: %v", ifName, err)
+	}
 
-	// First pass: collect all CIDRs and setup iptables filter rules per interface
+	// Set up nftables masquerade rules for this node's subnets.
+	var allCIDRs []*net.IPNet
 	for _, hostSubnet := range hostSubnets {
 		// local gateway mode uses mp0 as default path for all ingress traffic into OVN
 		nextHop, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(hostSubnet), mgmtPort.GetAddresses())
@@ -41,18 +45,11 @@ func initLocalGateway(hostSubnets []*net.IPNet, mgmtPort managementport.Interfac
 			return fmt.Errorf("failed to find management port address: %w", err)
 		}
 
-		// add iptables masquerading for mp0 to exit the host for egress
 		cidr := nextHop.IP.Mask(nextHop.Mask)
 		cidrNet := &net.IPNet{IP: cidr, Mask: nextHop.Mask}
 		allCIDRs = append(allCIDRs, cidrNet)
-
-		// Setup iptables filter rules for this interface/CIDR
-		if err := initLocalGatewayIPTFilterRules(ifName, cidrNet); err != nil {
-			return fmt.Errorf("failed to add local NAT rules for: %s, err: %v", ifName, err)
-		}
 	}
 
-	// setup nftables masquerade rules for all CIDRs (v4, v6 or dualstack)
 	if len(allCIDRs) > 0 {
 		if err := initLocalGatewayNFTNATRules(allCIDRs...); err != nil {
 			return fmt.Errorf("failed to setup nftables masquerade rules: %w", err)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -33,7 +33,7 @@ func initLocalGateway(hostSubnets []*net.IPNet, mgmtPort managementport.Interfac
 	// Set up iptables filter rules to allow traffic to/from the management port.
 	ifName := mgmtPort.GetInterfaceName()
 	if err := initLocalGatewayIPTFilterRules(ifName); err != nil {
-		return fmt.Errorf("failed to add local forwarding rules for: %s, err: %v", ifName, err)
+		return fmt.Errorf("failed to configure local forwarding rules for: %s, err: %v", ifName, err)
 	}
 
 	// Set up nftables masquerade rules for this node's subnets.


### PR DESCRIPTION
## 📑 Description
This makes it so ovn-kubernetes no longer does things intended to try to work around local firewalls that are blocking it. This was a thing that you could do in the iptables world, but it doesn't work in the nftables world (since an `accept` in ovn-k's tables can't override a `drop` in the firewall's tables). People need to just configure their firewalls to not block OVN-K's traffic.

(Note that this is not just a "porting ovn-kubernetes to nftables" thing; if ovn-kubernetes stayed with iptables but your system's firewall package switched to nftables, then that would also break ovn-k's attempts to bypass the firewall. So this is inevitable no matter what we do.)

This is part of #6512 / #6392, split out to make PRs smaller.

cc @bpickard22