### PR TITLE
test: enable relaxed service names in kind

### DIFF
--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -1,5 +1,15 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+# Upgrade CI creates the pre-upgrade kind cluster from master before checking
+# out the PR branch. K8s 1.36 e2e can then run the digit-prefixed Service DNS
+# test against that pre-upgrade API server. K8s 1.35 keeps
+# RelaxedServiceNameValidation alpha/default-off, so enable it with kind's
+# documented top-level featureGates field instead of kubeadm component patches.
+# TODO: Remove this explicit gate after ovn-kubernetes/ovn-kubernetes#6417
+# lands and master creates K8s 1.36+ kind clusters, where this gate is
+# beta/default-on.
+featureGates:
+  RelaxedServiceNameValidation: true
 networking:
   # kube proxy will be disabled
   kubeProxyMode: "none"


### PR DESCRIPTION
Issue: upgrade CI can run the Kubernetes 1.36 e2e binary against the pre-upgrade Kubernetes 1.35 API server built from master. The failing test is [sig-network] DNS should work with a service name that starts with a digit [FeatureGate:RelaxedServiceNameValidation] [Beta]. It creates a Service such as 1kubernetes/1test-svc and the 1.35 API server rejects it with metadata.name validation because digit-prefixed Service names require RelaxedServiceNameValidation.

Why it happened: RelaxedServiceNameValidation is Alpha and default-off in Kubernetes 1.35, then Beta and default-on in Kubernetes 1.36. PRs that bump the e2e binary to 1.36 can make upgrade jobs exercise the newer conformance test against the base cluster before the PR branch is checked out and applied. Without the feature gate on master, the pre-upgrade API server rejects the numeric-prefix Service name before OVN-Kubernetes behavior is involved.

What was needed: enable the feature gate on the master kind API server so upgrade jobs can run the 1.36 numeric Service-name DNS conformance test without adding a skip or dynamic probe workaround to the Kubernetes 1.36 bump PR.

What changed: contrib/kind.yaml.j2 now passes RelaxedServiceNameValidation=true only to kube-apiserver extraArgs. The controller-manager, scheduler, and kubelet are unchanged because Service object name validation is enforced by the API server.

After the fix: kind clusters created from master accept digit-prefixed Services, so upgrade CI can run the 1.36 DNS conformance test against the pre-upgrade API server instead of failing on API validation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the cluster template configuration to enable relaxed service name validation, allowing digit-prefixed Service names that were previously rejected under default API server validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->