### PR TITLE
clean up 2 sysctl utils

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -582,7 +582,7 @@ func getIntfName(gatewayIntf string) (string, error) {
 func bridgedGatewayNodeSetup(ovsClient libovsdbclient.Client, nodeName, bridgeName, physicalNetworkName string) (string, error) {
 	// IPv6 forwarding is enabled globally
 	if config.IPv4Mode {
-		err := util.SetforwardingModeForInterface(bridgeName)
+		err := util.SetForwardingModeForInterface(bridgeName)
 		if err != nil {
 			return "", err
 		}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -144,7 +144,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovs-vsctl --timeout=15 -- --if-exists del-port br-int " + mpPortLegacyName + " -- --may-exist add-port br-int " + mpPortName + " -- set interface " + mpPortName + " mac=\"0a:58:0a:01:01:02\" type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mpPortLegacyName,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp0/forwarding=1",
+			Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 			Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 		})
 
@@ -174,7 +174,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		})
 		if config.IPv4Mode {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net/ipv4/conf/breth0/forwarding=1",
+				Cmd:    "sysctl -w net.ipv4.conf.breth0.forwarding = 1",
 				Output: "net.ipv4.conf.breth0.forwarding = 1",
 			})
 		}
@@ -221,7 +221,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: "0",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp0/rp_filter=2",
+			Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
 			Output: "net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -647,7 +647,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		})
 		if config.IPv4Mode {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net/ipv4/conf/brp0/forwarding=1",
+				Cmd:    "sysctl -w net.ipv4.conf.brp0.forwarding = 1",
 				Output: "net.ipv4.conf.brp0.forwarding = 1",
 			})
 		}
@@ -1100,7 +1100,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			"ovs-vsctl --timeout=15 -- --if-exists del-port br-int " + mpPortLegacyName + " -- --may-exist add-port br-int " + mpPortName + " -- set interface " + mpPortName + " mac=\"0a:58:0a:01:01:02\" type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mpPortLegacyName,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp0/forwarding=1",
+			Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 			Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 		})
 
@@ -1139,7 +1139,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 		})
 		if config.IPv4Mode {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net/ipv4/conf/breth0/forwarding=1",
+				Cmd:    "sysctl -w net.ipv4.conf.breth0.forwarding = 1",
 				Output: "net.ipv4.conf.breth0.forwarding = 1",
 			})
 		}
@@ -1188,7 +1188,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`
 			Output: "0",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp0/rp_filter=2",
+			Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
 			Output: "net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -66,14 +66,14 @@ func getCreationFakeCommands(fexec *ovntest.FakeExec, mgtPort, mgtPortMAC, netNa
 	})
 
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "sysctl -w net/ipv4/conf/" + mgtPort + "/forwarding=1",
+		Cmd:    "sysctl -w net.ipv4.conf." + mgtPort + ".forwarding = 1",
 		Output: "net.ipv4.conf." + mgtPort + ".forwarding = 1",
 	})
 }
 
 func getRPFilterLooseModeFakeCommands(fexec *ovntest.FakeExec) {
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp3/rp_filter=2",
+		Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp3.rp_filter = 2",
 		Output: "net.ipv4.conf.ovn-k8s-mp3.rp_filter = 2",
 	})
 }
@@ -101,7 +101,7 @@ func setManagementPortFakeCommands(fexec *ovntest.FakeExec, nodeName string) {
 		"ovs-vsctl --timeout=15 -- --if-exists del-port br-int " + mpPortLegacyName + " -- --may-exist add-port br-int " + mpPortName + " -- set interface " + mpPortName + " mac=\"0a:58:64:80:00:02\" type=internal mtu_request=1400 external-ids:iface-id=" + mpPortLegacyName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp0/forwarding=1",
+		Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 		Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -131,7 +131,7 @@ func setManagementPortFakeCommands(fexec *ovntest.FakeExec, nodeName string) {
 		Output: "0",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp0/rp_filter=2",
+		Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
 		Output: "net.ipv4.conf.ovn-k8s-mp0.rp_filter = 2",
 	})
 }
@@ -161,7 +161,7 @@ func setUpGatewayFakeOVSCommands(fexec *ovntest.FakeExec) {
 	})
 	if config.IPv4Mode {
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "sysctl -w net/ipv4/conf/breth0/forwarding=1",
+			Cmd:    "sysctl -w net.ipv4.conf.breth0.forwarding = 1",
 			Output: "net.ipv4.conf.breth0.forwarding = 1",
 		})
 	}

--- a/go-controller/pkg/node/managementport/port_linux.go
+++ b/go-controller/pkg/node/managementport/port_linux.go
@@ -315,7 +315,7 @@ func setupManagementPortIPFamilyConfig(link netlink.Link, mpcfg *managementPortC
 
 	// IPv6 forwarding is enabled globally
 	if protocol == iptables.ProtocolIPv4 {
-		err := util.SetforwardingModeForInterface(types.K8sMgmtIntfName)
+		err := util.SetForwardingModeForInterface(types.K8sMgmtIntfName)
 		if err != nil {
 			klog.Warning(err)
 		}

--- a/go-controller/pkg/node/managementport/port_linux_test.go
+++ b/go-controller/pkg/node/managementport/port_linux_test.go
@@ -237,7 +237,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 		// We do not enable per-interface forwarding for IPv6
 		if cfg.family == netlink.FAMILY_V4 {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp0/forwarding=1",
+				Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 				Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 			})
 		}
@@ -473,7 +473,7 @@ func testManagementPortDPUHost(ctx *cli.Context, fexec *ovntest.FakeExec, testNS
 		// We do not enable per-interface forwarding for IPv6
 		if cfg.family == netlink.FAMILY_V4 {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "sysctl -w net/ipv4/conf/ovn-k8s-mp0/forwarding=1",
+				Cmd:    "sysctl -w net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 				Output: "net.ipv4.conf.ovn-k8s-mp0.forwarding = 1",
 			})
 		}

--- a/go-controller/pkg/node/managementport/port_udn_linux.go
+++ b/go-controller/pkg/node/managementport/port_udn_linux.go
@@ -301,7 +301,7 @@ func (mp *udnManagementPortOVS) create() error {
 	// STEP3
 	// IPv6 forwarding is enabled globally
 	if ipv4, _ := mp.IPMode(); ipv4 {
-		err = util.SetforwardingModeForInterface(mp.ifName)
+		err = util.SetForwardingModeForInterface(mp.ifName)
 		if err != nil {
 			return err
 		}
@@ -365,7 +365,7 @@ func (mp *udnManagementPortNetdev) create() error {
 	}
 
 	if ipv4, _ := mp.IPMode(); ipv4 {
-		err = util.SetforwardingModeForInterface(mp.ifName)
+		err = util.SetForwardingModeForInterface(mp.ifName)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -1010,29 +1010,34 @@ func ipAddrExistsAtInterface(ipAddr net.IP, iface net.Interface) (bool, error) {
 	return false, nil
 }
 
+// The sysctl fs interface uses slash as the path separator and allows interface names to
+// contain dots. But the CLI uses dots as the separator and expects interface names to
+// have been rewritten to use slashes instead.
+func sysctlIfName(ifName string) string {
+	return strings.ReplaceAll(ifName, ".", "/")
+}
+
 // SetForwardingModeForInterface updates the forwarding options for the specified interface
 func SetForwardingModeForInterface(ifName string) error {
-	// we use forward slash as path separator to allow dotted interfaceName e.g. foo.200
-	stdout, stderr, err := RunSysctl("-w", fmt.Sprintf("net/ipv4/conf/%s/forwarding=1", ifName))
-	// systctl output enforces dot as path separator
-	if err != nil || stdout != fmt.Sprintf("net.ipv4.conf.%s.forwarding = 1", strings.ReplaceAll(ifName, ".", "/")) {
+	setVal := fmt.Sprintf("net.ipv4.conf.%s.forwarding = 1", sysctlIfName(ifName))
+	stdout, stderr, err := RunSysctl("-w", setVal)
+	if err != nil || stdout != setVal {
 		return fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
 			ifName, stdout, stderr, err)
 	}
 	return nil
 }
 
-// SetRPFilterLooseModeForInterface update the reverse path filtering options for the specified interface
+const rpFilterLooseMode = "2"
+
+// SetRPFilterLooseModeForInterface updates the reverse path filtering options for the
+// specified interface to avoid dropping packets with masqueradeIP coming out of
+// managementport interface.
+// NOTE: v6 doesn't have rp_filter strict mode block
 func SetRPFilterLooseModeForInterface(ifName string) error {
-	// update the reverse path filtering options for the specified interface to avoid dropping packets with masqueradeIP
-	// coming out of managementport interface
-	// NOTE: v6 doesn't have rp_filter strict mode block
-	rpFilterLooseMode := "2"
-	// TODO: Convert testing framework to mock golang module utilities. Example:
-	// we use forward slash as path separator to allow dotted mgmtPortName e.g. foo.200
-	stdout, stderr, err := RunSysctl("-w", fmt.Sprintf("net/ipv4/conf/%s/rp_filter=%s", ifName, rpFilterLooseMode))
-	// systctl output enforces dot as path separator
-	if err != nil || stdout != fmt.Sprintf("net.ipv4.conf.%s.rp_filter = %s", strings.ReplaceAll(ifName, ".", "/"), rpFilterLooseMode) {
+	setVal := fmt.Sprintf("net.ipv4.conf.%s.rp_filter = %s", sysctlIfName(ifName), rpFilterLooseMode)
+	stdout, stderr, err := RunSysctl("-w", setVal)
+	if err != nil || stdout != setVal {
 		return fmt.Errorf("could not set the correct rp_filter value for interface %s: stdout: %v, stderr: %v, err: %v",
 			ifName, stdout, stderr, err)
 	}

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -1010,8 +1010,8 @@ func ipAddrExistsAtInterface(ipAddr net.IP, iface net.Interface) (bool, error) {
 	return false, nil
 }
 
-// SetforwardingModeForInterface update the forwarding options for the specified interface
-func SetforwardingModeForInterface(ifName string) error {
+// SetForwardingModeForInterface updates the forwarding options for the specified interface
+func SetForwardingModeForInterface(ifName string) error {
 	// we use forward slash as path separator to allow dotted interfaceName e.g. foo.200
 	stdout, stderr, err := RunSysctl("-w", fmt.Sprintf("net/ipv4/conf/%s/forwarding=1", ifName))
 	// systctl output enforces dot as path separator


### PR DESCRIPTION
drive-by fix while working on forwarding stuff:

1. The function `SetforwardModeForInterface` has obviously-wrong capitalization.
2. That function and `SetRPFilterLooseModeForInterface` had a workaround to deal with the fact that sysctl names use "." as a separator but may contain interface names which can contain "." as well. This was noticed in #5312 and then worked around, but the workaround ended up being more complicated than necessary; see the commit message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized per-interface sysctl handling (consistent dotted kernel parameter format) for forwarding and rp_filter settings
  * Centralized interface-name rewriting and forwarding-mode configuration for management and gateway interfaces
  * Updated tests to reflect the unified sysctl behavior and parameter formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->