### PR TITLE
unit test: shut down FakeOVN in UDN sync tests

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -392,6 +392,7 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 				},
 			},
 		)
+		DeferCleanup(fakeOVN.shutdown)
 		Expect(fakeOVN.NewUserDefinedNetworkController(nad)).To(Succeed())
 		controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
 		Expect(ok).To(BeTrue())
@@ -439,6 +440,7 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 			},
 			namespace,
 		)
+		DeferCleanup(fakeOVN.shutdown)
 		Expect(fakeOVN.NewUserDefinedNetworkController(nad)).To(Succeed())
 		controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
 		Expect(ok).To(BeTrue())


### PR DESCRIPTION
Two BaseUserDefinedNetworkController specs start FakeOVN but never stop it. That can leave the address-set manager worker running into the next Ginkgo spec.

GitHub CI hit this under the race detector when egressservices_test called config.PrepareTestConfig while addresssetmanager.reconcileNamespace was still reading config.Kubernetes.HostNetworkNamespace from the leaked worker.  This was seen in https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/27531088885/job/81369083029?pr=6473 

Register FakeOVN shutdown with DeferCleanup in both specs so their informers and controllers stop before later tests reset global config.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test cleanup procedures to ensure proper resource disposal after test completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->