### PR TITLE
area-merge: deduplicate check runs by name, keep latest only

### DIFF
--- a/.github/scripts/area-merge.js
+++ b/.github/scripts/area-merge.js
@@ -225,6 +225,20 @@ module.exports = async ({ github, context, core }) => {
       checkPage++;
     }
 
+    // Deduplicate check runs by name, keeping only the most recent per name.
+    // GitHub returns all runs for a SHA including stale ones from earlier
+    // workflow invocations (e.g. cancelled runs before a close/reopen retry).
+    const latestByName = new Map();
+    for (const run of allCheckRuns) {
+      const existing = latestByName.get(run.name);
+      const runTime = run.started_at ? new Date(run.started_at).getTime() : 0;
+      const existingTime = existing && existing.started_at ? new Date(existing.started_at).getTime() : 0;
+      if (!existing || runTime > existingTime) {
+        latestByName.set(run.name, run);
+      }
+    }
+    const checkRuns = Array.from(latestByName.values());
+
     const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
       owner: context.repo.owner,
       repo: context.repo.repo,
@@ -234,7 +248,7 @@ module.exports = async ({ github, context, core }) => {
     const pendingChecks = [];
     const failedChecks = [];
 
-    for (const run of allCheckRuns) {
+    for (const run of checkRuns) {
       if (run.name === 'area-merge') continue;
       if (run.status !== 'completed') {
         pendingChecks.push(run.name);

--- a/.github/scripts/area-merge.js
+++ b/.github/scripts/area-merge.js
@@ -231,8 +231,8 @@ module.exports = async ({ github, context, core }) => {
     const latestByName = new Map();
     for (const run of allCheckRuns) {
       const existing = latestByName.get(run.name);
-      const runTime = run.started_at ? new Date(run.started_at).getTime() : 0;
-      const existingTime = existing && existing.started_at ? new Date(existing.started_at).getTime() : 0;
+      const runTime = new Date(run.started_at || run.created_at || 0).getTime();
+      const existingTime = existing ? new Date(existing.started_at || existing.created_at || 0).getTime() : 0;
       if (!existing || runTime > existingTime) {
         latestByName.set(run.name, run);
       }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
GitHub's `listForRef` API returns all check runs for a SHA, including stale runs from earlier workflow invocations (e.g. cancelled runs from before a close/reopen retry). The area-merge bot was evaluating all of them, so old cancelled/failed runs blocked /area-maintainer-approved even when the latest run for each check had passed.

Deduplicate check runs by name, keeping only the most recent one per name (by started_at timestamp), before evaluating status/conclusion.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI check evaluation by deduplicating check runs with the same run name, using the most recent run to determine pending/failed status.
  * Updated merge gating and status/commenting behavior to rely on the deduplicated set of check runs, avoiding stale or duplicate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->