### PR TITLE
fix: correct typos and nil error return in unidling controller

### DIFF
--- a/go-controller/pkg/ovn/controller/unidling/unidle.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle.go
@@ -63,7 +63,7 @@ func NewController(recorder record.EventRecorder, serviceInformer cache.SharedIn
 	// FIXME: libovsdb event handlers should be added before the Monitor is set
 	// manually populate the current events. we may get an event twice, but this
 	// shouldn't cause issues as we'll just log an error message
-	klog.Info("Populating Initial ContollerEvent events")
+	klog.Info("Populating initial ControllerEvent events")
 
 	var controllerEvents []sbdb.ControllerEvent
 	ctx, cancel := context.WithTimeout(context.Background(), config.Default.OVSDBTxnTimeout)
@@ -78,7 +78,7 @@ func NewController(recorder record.EventRecorder, serviceInformer cache.SharedIn
 		}
 	}()
 
-	// we only process events on unidling, there is no reconcilation
+	// we only process events on unidling, there is no reconciliation
 	klog.Info("Setting up event handlers for services")
 	_, err = serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: uc.onServiceAdd,
@@ -195,7 +195,7 @@ func (uc *unidlingController) handleLbEmptyBackendsEvent(event sbdb.ControllerEv
 
 	vip, ok := event.EventInfo["vip"]
 	if !ok {
-		return err
+		return fmt.Errorf("vip not found in controller event %s with event_info %v", event.UUID, event.EventInfo)
 	}
 	proto := event.EventInfo["protocol"]
 	var protocol corev1.Protocol


### PR DESCRIPTION
## Summary
- Fix typo "ContollerEvent" → "ControllerEvent" in log message (line 66)
- Fix typo "reconcilation" → "reconciliation" in comment (line 81)
- Fix bug: missing "vip" key in `ControllerEvent.EventInfo` returned `nil` error instead of a descriptive error, silently swallowing the failure

## Test plan
- [ ] Verify typo fixes in log output
- [ ] Verify `handleLbEmptyBackendsEvent` returns error when "vip" key is missing from event info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unidling controller error handling when required VIP details are missing, ensuring failures are correctly reported and include helpful event context.

* **Documentation**
  * Updated unidling controller log wording and inline comments for clearer, consistent messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->