### PR TITLE
cluster manager: clear stale pidfile before start

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -2042,6 +2042,8 @@ ovn-cluster-manager() {
   }
   echo "ovn_cluster_manager_ssl_opts=${ovn_cluster_manager_ssl_opts}"
 
+  rm -f ${OVN_RUNDIR}/ovnkube-cluster-manager.pid
+
   echo "=============== ovn-cluster-manager ========== control plane node only"
   /usr/bin/ovnkube --init-cluster-manager ${K8S_NODE} \
     ${anp_enabled_flag} \


### PR DESCRIPTION
During the [PR upgrade job](https://github.com/ovn-kubernetes/ovn-kubernetes/actions/runs/27538492605/job/81395723302?pr=6473), ovnkube-cluster-manager exited repeatedly before it could log anything. The `ovnkube.sh` entrypoint only reported its generic `pid 22 terminated` message, and the control-plane pod entered `CrashLoopBackOff`.

job logs:
```
2026-06-15T10:15:49.4025096Z + echo 'Waiting for k8s to create ovnkube-control-plane pods (timeout 238)...'                                                                                                                                                                                                                   
2026-06-15T10:15:49.4025845Z Waiting for k8s to create ovnkube-control-plane pods (timeout 238)...                                                                                                                                                                                                                            
2026-06-15T10:15:49.4027196Z + kubectl wait pods -n ovn-kubernetes -l name=ovnkube-control-plane --for condition=Ready --timeout=238s                                                                                                                                                                                         
2026-06-15T10:19:47.4420420Z error: timed out waiting for the condition on pods/ovnkube-control-plane-6cbd547cff-sd68g                                                                                                                                                                                                        
2026-06-15T10:19:47.4449180Z make: *** [Makefile:45: upgrade-ovn] Error 1                                                                                                                                                                                                                                                     
2026-06-15T10:19:47.4450136Z make: Leaving directory '/home/runner/work/ovn-kubernetes/ovn-kubernetes/test'                                                                                                                                                                                                                   
2026-06-15T10:19:47.4481312Z ##[error]Process completed with exit code 2.  
```
kubelet (notice the `pid 22 terminated` error message):
```
Jun 15 10:18:28 ovn-control-plane kubelet[690]: I0615 10:18:28.100434     690 status_manager.go:1065] "Patch status for pod" pod="ovn-kubernetes/ovnkube-control-plane-6cbd547cff-sd68g" podUID="e3f6ff84-2db3-4e64-809d-fee0b2568504"                                                                                        
patch="{\"metadata\":{\"uid\":\"e3f6ff84-2db3-4e64-809d-fee0b2568504\"},\"status\":{\"containerStatuses\":[{\"allocatedResources\":{\"cpu\":\"100m\",\"memory\":\"300Mi\"},\"containerID\":\"containerd://e4b81ab855cecbccff6857e1069d204b3cd216365fcc0ca1a17c4be761e6ddb1\",\"image\":\"docker.io/library/ovn-daemonset-fedo\
ra:pr\",\"imageID\":\"sha256:ecc7998bc14d81fd1fc880e1557b2536b2d1eb5f61e53978c4fa2d9ef74d59cf\",\"lastState\":{\"terminated\":{\"containerID\":\"containerd://e4b81ab855cecbccff6857e1069d204b3cd216365fcc0ca1a17c4be761e6ddb1\",\"exitCode\":6,\"finishedAt\":\"2026-06-15T10:17:24Z\",\"message\":\"==================      
ovnkube.sh --- version: 1.3.0 ================\\n ==================== command: ovn-cluster-manager\\n =================== hostname: ovn-control-plane\\n =================== daemonset version 1.3.0\\n =================== Image built from ovn-kubernetes ref: HEAD  commit:                                               
2360a3737b030f2de725d73a66cfbb5e5f6a2253\\novn_encap_port_flag=--encap-port=6081\\negressip_flags: --enable-egress-ip,                                                                                                                                                                                                        
--egressip-node-healthcheck-port=9107\\negressservice_enabled_flag=--enable-egress-service\\nanp_enabled_flag=--enable-admin-network-policy\\negressfirewall_enabled_flag=--enable-egress-firewall\\negressqos_enabled_flag=--enable-egress-qos\\nhybrid_overlay_flags: \\novn_v4_join_subnet_opt:                            
--gateway-v4-join-subnet=100.64.0.0/16\\novn_v6_join_subnet_opt: --gateway-v6-join-subnet=fd98::/64\\novn_v4_masquerade_subnet_opt=\\novn_v6_masquerade_subnet_opt=\\novn_v4_transit_subnet_opt=100.88.0.0/16\\novn_v6_transit_subnet_opt=fd97::/64\\nmulticast_enabled_flag: \\nmulti_network_enabled_flag:                  
\\nnetwork_segmentation_enabled_flag=\\nnetwork_connect_enabled_flag=\\npre_conf_udn_addr_enable_flag=\\nroute_advertisements_enabled_flag=\\nevpn_enabled_flag=\\novnkube_config_file_flag=--config-file=/run/ovnkube-config/ovnkube.conf\\npersistent_ips_enabled_flag:                                                     
--enable-persistent-ips\\novnkube_cluster_manager_metrics_bind_address: 172.18.0.3:9411\\novnkube_metrics_tls_opts:                                                                                                                                                                                                           
\\novnkube_enable_multi_external_gateway_flag=--enable-multi-external-gateway\\nempty_lb_events_flag=\\nnetwork_qos_enabled_flag=\\novn_enable_dnsnameresolver_flag=\\ndynamic_udn_allocation_flag=\\ndynamic_udn_grace_period=--udn-deletion-grace-period                                                                    
120s\\novn_allow_icmp_netpol_flag=\\novn_cluster_manager_ssl_opts=\\n=============== ovn-cluster-manager ========== control plane node only\\n=============== ovn-cluster-manager ========== running\\n=============== pid 22 terminated ==========                                                                           
\\n\",\"reason\":\"Error\",\"startedAt\":\"2026-06-15T10:17:24Z\"}},\"name\":\"ovnkube-cluster-manager\",\"ready\":false,\"resources\":{\"requests\":{\"cpu\":\"100m\",\"memory\":\"300Mi\"}},\"restartCount\":5,\"started\":false,\"state\":{\"waiting\":{\"message\":\"back-off 2m40s restarting failed                     
container=ovnkube-cluster-manager                                                                                                                                                                                                                                                                                             
pod=ovnkube-control-plane-6cbd547cff-sd68g_ovn-kubernetes(e3f6ff84-2db3-4e64-809d-fee0b2568504)\",\"reason\":\"CrashLoopBackOff\"}},\"user\":{\"linux\":{\"gid\":0,\"supplementalGroups\":[0],\"uid\":0}},\"volumeMounts\":[{\"mountPath\":\"/var/run/dbus/\",\"name\":\"host-var-run-dbus\",\"readOnly\":true,\"recursiveRea\
dOnly\":\"Disabled\"},{\"mountPath\":\"/var/log/ovn-kubernetes/\",\"name\":\"host-var-log-ovnkube\"},{\"mountPath\":\"/var/run/openvswitch/\",\"name\":\"host-var-run-ovs\"},{\"mountPath\":\"/var/run/ovn/\",\"name\":\"host-var-run-ovs\"},{\"mountPath\":\"/ovn-cert\",\"name\":\"host-ovn-cert\",\"readOnly\":true,\"recu\
rsiveReadOnly\":\"Disabled\"},{\"mountPath\":\"/run/ovnkube-config\",\"name\":\"ovnkube-config\",\"readOnly\":true,\"recursiveReadOnly\":\"Disabled\"},{\"mountPath\":\"/var/run/secrets/kubernetes.io/serviceaccount\",\"name\":\"kube-api-access-82g66\",\"readOnly\":true,\"recursiveReadOnly\":\"Disabled\"}]}]}}"  


```

The `ovnkube.sh` entrypoint for cluster manager supervises ovnkube through `${OVN_RUNDIR}/ovnkube-cluster-manager.pid`, but unlike the other entrypoints (ovnkube-controller, ovnkube-controller-with-node, ovn-node, ovn-controller...) it does not clear that
pidfile before launching the executable. If the file is left from a previous container and its PID exists in the current process namespace, `setupPIDFile` can fail before logging is initialized.

Clear the cluster manager pidfile before starting ovnkube. This gives the cluster manager entrypoint the same pidfile handling as the other entrypoints and avoids carrying pidfile state across replaced containers during an upgrade.

Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6337