### PR TITLE
Add an explicit ai-slop label for coderabbit slop detection

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -8,6 +8,9 @@ reviews:
   poem: true
   review_status: true
   collapse_walkthrough: false
+  slop_detection:
+    enabled: true
+    label: "coderabbit/ai-slop"
   auto_review:
     enabled: true
     drafts: false


### PR DESCRIPTION
Coderabbit automatically has slop-detection switched on in all public repos: https://docs.coderabbit.ai/pr-reviews/slop-detection but I haven't seen yet it triggering this on any PRs as part of its "PR Walkthrough" section. So let's do an explicit label for easier tracking of this and when we add code guidelines/ review guidelines for coderabbitai in future, we can add more tailored checks for slops.

Used https://docs.coderabbit.ai/configuration/yaml-validator for validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled slop detection configuration with automatic content labeling in project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->