### PR TITLE
contrib: bump KubeVirt to v1.8.4

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -859,7 +859,7 @@ install_kubevirt() {
     # nightly tag - install specific nightly (i.e 20240910)
     # KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-"stable"}
 
-    KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-"v1.6.2"}
+    KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-"v1.8.4"}
 
     for node in $(kubectl get node --no-headers  -o custom-columns=":metadata.name"); do
         $OCI_BIN exec -t $node bash -c "echo 'fs.inotify.max_user_watches=1048576' >> /etc/sysctl.conf"

--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -2037,9 +2037,16 @@ ip route add %[3]s via %[4]s
 				WithPolling(time.Second).
 				Should(Succeed(), step)
 
-			// expect 2 addresses on dual-stack deployments; 1 on single-stack
+			// IPv6 is not supported for secondaries with IPAM since
+			// KubeVirt does not run a DHCPv6 server for bridge bindings,
+			// so the VMI status will only report IPv4 addresses.
+			// For primary UDNs, expect dual-stack (2 addresses); for
+			// secondaries, expect IPv4 only (1 address).
 			step = by(vmi.Name, "Wait for addresses at the virtual machine")
 			expectedNumberOfAddresses := len(dualCIDRs)
+			if td.role != udnv1.NetworkRolePrimary {
+				expectedNumberOfAddresses = 1
+			}
 			expectedAddreses := virtualMachineAddressesFromStatus(vmi, expectedNumberOfAddresses)
 			if _, hasIPRequests := vmi.Annotations[kubevirt.AddressesAnnotation]; hasIPRequests {
 				Expect(expectedAddreses).To(ConsistOf(filterIPs(fr.ClientSet, staticIPv4, staticIPv6)), "expected addresses should be consistent with the static IPs")


### PR DESCRIPTION
## 📑 Description

Bump the pinned KubeVirt version used by the kind-based e2e lanes from `v1.6.2` to the latest stable `v1.8.4` in `contrib/kind-common.sh`.

This fixes an intermittent failure in the `kv-live-migration` lane where, after a **successful** live migration, the post-migration check `checkLiveMigrationSucceeded` (`test/e2e/kubevirt.go:714`, _"should move source pod to Completed"_) times out because the **source** virt-launcher pod hangs and never reaches `Succeeded`.

Root cause is a `SIGCHLD` reaping race in KubeVirt's `virt-launcher-monitor` (v1.6.2): it performs a single `Wait4` per signal, and because POSIX signals coalesce it can miss the launcher main pid's exit and block indefinitely on `<-exitStatus`. The source pod therefore stays `Running` (~67s observed, vs ~8s for healthy pods in the same run) until the test tears it down. Fixed upstream by [kubevirt/kubevirt#15676](https://github.com/kubevirt/kubevirt/pull/15676) ("Monitor: Reap all processes"), first released in KubeVirt **v1.6.4**.

Additionally, KubeVirt v1.8.4 includes [kubevirt/kubevirt#17536](https://github.com/kubevirt/kubevirt/pull/17536) ("net, netpod: Remove caching of IPv6 from bridge binding ifaces"), which correctly stops reporting the pod's IPv6 address in VMI status for bridge bindings since KubeVirt does not run a DHCPv6 server for them. The e2e test `should keep ip after restart of VirtualMachine with Secondary/Localnet ingress snat` was relying on this incorrect behavior (expecting 2 addresses for dual-stack secondaries when only IPv4 is actually served). The second commit fixes the test expectation to match: secondary networks now expect only 1 address (IPv4) from VMI status, consistent with the existing comment that IPv6 is not supported for secondaries with IPAM.

Related: #6561

## Additional Information for reviewers

NONE

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default KubeVirt version used by the setup tooling to **v1.8.4**. When a version isn’t explicitly set, installation now pulls the operator and matching CR releases for **v1.8.4**.
* **Tests**
  * Refined end-to-end VMI address checks to account for **network role–dependent** IP reporting, improving test stability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->