### PR TITLE
doc: fix typo: 'resolover' to 'resolver'

### DIFF
--- a/docs/features/network-security-controls/dns-name-resolution.md
+++ b/docs/features/network-security-controls/dns-name-resolution.md
@@ -1,4 +1,4 @@
-# DNS name resolover
+# DNS name resolver
 
 ## Introduction
 
@@ -19,7 +19,7 @@ CRD will be used by ovnk to get the latest IP addresses corresponding to a DNS n
 the feature is enabled. However, the cluster administrator does not need to interact with
 the CR. 
 
-## Configuring DNS name resolover in a cluster
+## Configuring DNS name resolver in a cluster
 
 Always check the dependencies on the [Requirements page](../requirements.md)
 


### PR DESCRIPTION
## 📑 Description
Fixed a minor typo in the documentation ("resolover" to "resolver").

## Additional Information for reviewers
Only updated a typo in the documentation. No code changes were made.
I found the typo in this web page:
https://ovn-kubernetes.io/features/network-security-controls/dns-name-resolution/#dns-name-resolover



## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
I verified the spelling in the Cambridge Dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling errors in DNS name resolver documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->