### PR TITLE
Bump Ubuntu version to 26.04 to get OVN 26.03

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -11,7 +11,7 @@
 #
 # So this file will change over time.
 
-FROM ubuntu:25.10
+FROM ubuntu:26.04
 
 USER root
 

--- a/dist/images/Dockerfile.ubuntu.arm64
+++ b/dist/images/Dockerfile.ubuntu.arm64
@@ -11,7 +11,7 @@
 #
 # So this file will change over time.
 
-FROM ubuntu:25.10
+FROM ubuntu:26.04
 
 USER root
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR bumps the Ubuntu version in Dockerfile.ubuntu and Dockerfile.ubuntu.arm64 to 26.04 to get OVN 26.03 inbox.  
https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6532 upgraded the OVN schema in ovn-k8s and updated the Fedora image to install OVN 26.03 corresponding to that, but Ubuntu* images were missed. This was causing ovnkube-node-dpu bringup to fail due to schema mismatch.   

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
