### PR TITLE
e2e: add single-subnet UDN compatibility mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -445,6 +445,7 @@ jobs:
         # Valid options are:
         # target: ["shard-conformance", "control-plane", "multi-homing", "node-ip-mac-migration",
         #          "external-gateway", "kv-live-migration", "network-segmentation",
+        #          "network-segmentation-single-subnet",
         #          "network-segmentation-dynamic", "bgp", "bgp-no-overlay", "bgp-loose-isolation",
         #          "evpn", "traffic-flow-test-only", "tools", "serial"]
         #         shard-conformance: hybrid-overlay = multicast-enable = emptylb-enable = false
@@ -485,6 +486,7 @@ jobs:
           - {"target": "control-plane", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "forwarding": "disable-forwarding"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "local", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
+          - {"target": "network-segmentation-single-subnet", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "dualstack", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "multi-udn-subnets": "false"}
           - {"target": "network-segmentation-dynamic", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "cni-mode": "unprivileged"}
           - {"target": "network-segmentation", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6", "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "bgp", "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "snatGW", "second-bridge": "1br", "ic": "ic-single-node-zones", "routeadvertisements": "advertise-default", "network-segmentation": "enable-network-segmentation", "dns-name-resolver": "enable-dns-name-resolver"}
@@ -529,6 +531,7 @@ jobs:
       ENABLE_NETWORK_CONNECT: "${{ startsWith(matrix.target, 'network-segmentation') }}"
       ENABLE_PRE_CONF_UDN_ADDR: "${{ matrix.ic == 'ic-single-node-zones' && (startsWith(matrix.target, 'network-segmentation') || matrix.network-segmentation == 'enable-network-segmentation') }}"
       ADVERTISED_UDN_ISOLATION_MODE: "${{ matrix.advertised-udn-isolation-mode }}"
+      OVN_E2E_ENABLE_MULTI_UDN_SUBNETS: "${{ matrix.multi-udn-subnets != 'false' }}"
       # Override PARALLEL=true for Serial tests target to run Serial tests
       PARALLEL: "${{ matrix.target != 'serial' }}"
       OVN_UNPRIVILEGED_MODE: "${{ matrix.cni-mode == 'unprivileged' }}"

--- a/contrib/kind-helm.sh
+++ b/contrib/kind-helm.sh
@@ -648,6 +648,10 @@ install_online_ovn_kubernetes_crds() {
   run_kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
 }
 
+install_single_subnet_udn_admission_policy() {
+  run_kubectl apply -f "${DIR}/network-segmentation/admission.single-subnet.yaml"
+}
+
 check_dependencies
 parse_args "$@"
 set_default_params
@@ -750,6 +754,10 @@ fi
 
 if [ "$ENABLE_MULTI_NET" == true ]; then
   enable_multi_net
+fi
+
+if [ "$ENABLE_NETWORK_SEGMENTATION" == true ] && [ "${OVN_E2E_ENABLE_MULTI_UDN_SUBNETS:-true}" == "false" ]; then
+  install_single_subnet_udn_admission_policy
 fi
 
 # if ! kubectl wait -n ovn-kubernetes --for=condition=ready pods --all --timeout=300s ; then

--- a/contrib/network-segmentation/admission.single-subnet.yaml
+++ b/contrib/network-segmentation/admission.single-subnet.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Enforce at most one Layer3 subnet per IP family on UserDefinedNetwork.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: userdefinednetwork-layer3-subnets-single-family
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["k8s.ovn.org"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["userdefinednetworks"]
+  validations:
+    - expression: "!has(object.spec.layer3) || !has(object.spec.layer3.subnets) || size(object.spec.layer3.subnets) <= 2"
+      message: "spec.layer3.subnets may define at most 2 CIDRs"
+      reason: Invalid
+    - expression: "!has(object.spec.layer3) || !has(object.spec.layer3.subnets) || size(object.spec.layer3.subnets) != 2 || !isCIDR(object.spec.layer3.subnets[0].cidr) || !isCIDR(object.spec.layer3.subnets[1].cidr) || cidr(object.spec.layer3.subnets[0].cidr).ip().family() != cidr(object.spec.layer3.subnets[1].cidr).ip().family()"
+      message: "When 2 CIDRs are set, they must be from different IP families"
+      reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: userdefinednetwork-layer3-subnets-single-family-binding
+spec:
+  policyName: userdefinednetwork-layer3-subnets-single-family
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+      - apiGroups: ["k8s.ovn.org"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["userdefinednetworks"]
+
+---
+# Enforce at most one Layer3 subnet per IP family on ClusterUserDefinedNetwork.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: clusteruserdefinednetwork-layer3-subnets-single-family
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["k8s.ovn.org"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["clusteruserdefinednetworks"]
+  validations:
+    - expression: "!has(object.spec.network.layer3) || !has(object.spec.network.layer3.subnets) || size(object.spec.network.layer3.subnets) <= 2"
+      message: "spec.network.layer3.subnets may define at most 2 CIDRs"
+      reason: Invalid
+    - expression: "!has(object.spec.network.layer3) || !has(object.spec.network.layer3.subnets) || size(object.spec.network.layer3.subnets) != 2 || !isCIDR(object.spec.network.layer3.subnets[0].cidr) || !isCIDR(object.spec.network.layer3.subnets[1].cidr) || cidr(object.spec.network.layer3.subnets[0].cidr).ip().family() != cidr(object.spec.network.layer3.subnets[1].cidr).ip().family()"
+      message: "When 2 CIDRs are set, they must be from different IP families"
+      reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: clusteruserdefinednetwork-layer3-subnets-single-family-binding
+spec:
+  policyName: clusteruserdefinednetwork-layer3-subnets-single-family
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+      - apiGroups: ["k8s.ovn.org"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["clusteruserdefinednetworks"]

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -187,7 +187,7 @@ func newTestNetworkSubnetsAllocator() func(bool) ([]string, []string) {
 		v4 := []string{fmt.Sprintf("172.%d.0.0/16", 30+i)}
 		// Allocated networks for ipv6 are 2014:100:201::0/60, 2014:100:202::0/60, ... (non-overlapping /60s)
 		v6 := []string{fmt.Sprintf("2014:100:%d::0/60", 200+i)}
-		if multiSubnet {
+		if multiSubnet && multiUDNSubnetsEnabled() {
 			v4 = []string{
 				fmt.Sprintf("172.%d.0.0/23/24", 30+i),
 				fmt.Sprintf("172.%d.0.0/16/24", 31+i),

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -30,6 +30,8 @@ import (
 
 // https://github.com/kubernetes/kubernetes/blob/v1.16.4/test/e2e/e2e_test.go#L62
 
+var enableMultiUDNSubnets bool
+
 // handleFlags sets up all flags and parses the command line.
 func handleFlags() {
 	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
@@ -37,6 +39,7 @@ func handleFlags() {
 	framework.RegisterClusterFlags(flag.CommandLine)
 	diagnostics.RegisterFlags(flag.CommandLine)
 	flag.StringVar(&reportPath, "report-path", "/tmp/kind/logs", "the path to be used to dump test failure information")
+	flag.BoolVar(&enableMultiUDNSubnets, "enable-multi-udn-subnets", true, "enable primary UDN/CUDN e2e coverage that uses multiple subnets per IP family")
 	flag.Parse()
 }
 

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -40,6 +40,10 @@ func joinStrings(vals ...string) string {
 	return strings.Join(vals, ",")
 }
 
+func multiUDNSubnetsEnabled() bool {
+	return enableMultiUDNSubnets
+}
+
 func primaryLayer3MultiCIDRs() string {
 	return joinStrings(primaryLayer3MultiIPv4CIDRs(), primaryLayer3MultiIPv6CIDRs())
 }
@@ -65,11 +69,19 @@ func primaryLayer3IPv6CIDRs() (string, string) {
 }
 
 func primaryLayer3MultiIPv4CIDRs() string {
+	if !multiUDNSubnetsEnabled() {
+		subnet, _ := allocators.GetFirstUDNSubnets()
+		return subnet
+	}
 	subnet1, subnet2 := primaryLayer3IPv4CIDRs()
 	return joinStrings(subnet1, subnet2)
 }
 
 func primaryLayer3MultiIPv6CIDRs() string {
+	if !multiUDNSubnetsEnabled() {
+		_, subnet := allocators.GetFirstUDNSubnets()
+		return subnet
+	}
 	subnet1, subnet2 := primaryLayer3IPv6CIDRs()
 	return joinStrings(subnet1, subnet2)
 }

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -945,6 +945,12 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 	})
 
 	Context("layer3 primary network with multi-subnets", func() {
+		BeforeEach(func() {
+			if !multiUDNSubnetsEnabled() {
+				e2eskipper.Skipf("skipping multi-subnet UDN runtime coverage when --enable-multi-udn-subnets=false")
+			}
+		})
+
 		DescribeTableSubtree("created using",
 			func(createNetworkFn func(netConfig *networkAttachmentConfigParams) error) {
 

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -65,6 +65,22 @@ const (
 	netexecPort            = 8080
 )
 
+func primaryLayer3RouteAdvertisementSubnets(v4Primary, v4Secondary, v6Primary, v6Secondary string) []udnv1.Layer3Subnet {
+	subnets := []udnv1.Layer3Subnet{
+		{CIDR: udnv1.CIDR(v4Primary), HostSubnet: 24},
+		{CIDR: udnv1.CIDR(v6Primary), HostSubnet: 64},
+	}
+	if !multiUDNSubnetsEnabled() {
+		return subnets
+	}
+	return []udnv1.Layer3Subnet{
+		{CIDR: udnv1.CIDR(v4Primary), HostSubnet: 24},
+		{CIDR: udnv1.CIDR(v4Secondary), HostSubnet: 24},
+		{CIDR: udnv1.CIDR(v6Primary), HostSubnet: 64},
+		{CIDR: udnv1.CIDR(v6Secondary), HostSubnet: 64},
+	}
+}
+
 func init() {
 	if os.Getenv("ENABLE_ROUTE_ADVERTISEMENTS") == "true" {
 		images.Add(images.FRR())
@@ -964,19 +980,12 @@ var _ = ginkgo.Describe("BGP: Pod to external server when CUDN network is advert
 						Topology: udnv1.NetworkTopologyLayer3,
 						Layer3: &udnv1.Layer3Config{
 							Role: "Primary",
-							Subnets: []udnv1.Layer3Subnet{{
-								CIDR:       "103.103.0.0/23",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "103.104.0.0/16",
-								HostSubnet: 24,
-							}, {
-								CIDR:       "2014:100:200::0/63",
-								HostSubnet: 64,
-							}, {
-								CIDR:       "2014:100:201::0/48",
-								HostSubnet: 64,
-							}},
+							Subnets: primaryLayer3RouteAdvertisementSubnets(
+								"103.103.0.0/23",
+								"103.104.0.0/16",
+								"2014:100:200::0/63",
+								"2014:100:201::0/48",
+							),
 						},
 					},
 				},
@@ -2051,19 +2060,12 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					Topology: udnv1.NetworkTopologyLayer3,
 					Layer3: &udnv1.Layer3Config{
 						Role: "Primary",
-						Subnets: []udnv1.Layer3Subnet{{
-							CIDR:       "102.102.0.0/23",
-							HostSubnet: 24,
-						}, {
-							CIDR:       "102.104.0.0/16",
-							HostSubnet: 24,
-						}, {
-							CIDR:       "2013:100:200::0/63",
-							HostSubnet: 64,
-						}, {
-							CIDR:       "2013:100:201::0/48",
-							HostSubnet: 64,
-						}},
+						Subnets: primaryLayer3RouteAdvertisementSubnets(
+							"102.102.0.0/23",
+							"102.104.0.0/16",
+							"2013:100:200::0/63",
+							"2013:100:201::0/48",
+						),
 					},
 				},
 			},
@@ -2077,19 +2079,12 @@ var _ = ginkgo.DescribeTableSubtree("BGP: isolation between advertised networks"
 					Topology: udnv1.NetworkTopologyLayer3,
 					Layer3: &udnv1.Layer3Config{
 						Role: "Primary",
-						Subnets: []udnv1.Layer3Subnet{{
-							CIDR:       "103.103.0.0/23",
-							HostSubnet: 24,
-						}, {
-							CIDR:       "103.104.0.0/16",
-							HostSubnet: 24,
-						}, {
-							CIDR:       "2014:100:200::0/63",
-							HostSubnet: 64,
-						}, {
-							CIDR:       "2014:100:201::0/48",
-							HostSubnet: 64,
-						}},
+						Subnets: primaryLayer3RouteAdvertisementSubnets(
+							"103.103.0.0/23",
+							"103.104.0.0/16",
+							"2014:100:200::0/63",
+							"2014:100:201::0/48",
+						),
 					},
 				},
 			},

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -121,6 +121,10 @@ if [ "$OVN_NETWORK_QOS_ENABLE" != "true" ]; then
   skip "e2e NetworkQoS validation"
 fi
 
+if [ "${OVN_E2E_ENABLE_MULTI_UDN_SUBNETS:-true}" != "true" ]; then
+  skip "Network Segmentation: API validations.*ClusterUserDefinedNetwork, layer3, multi-subnets"
+fi
+
 # Only run Node IP/MAC address migration tests if they are explicitly requested
 IP_MIGRATION_TESTS="Node IP and MAC address migration"
 if [[ "${WHAT}" != "${IP_MIGRATION_TESTS}"* ]]; then
@@ -261,6 +265,11 @@ pushd e2e
 
 go mod download
 
+E2E_MULTI_UDN_SUBNETS_ARGS=()
+if [ -n "${OVN_E2E_ENABLE_MULTI_UDN_SUBNETS:-}" ]; then
+  E2E_MULTI_UDN_SUBNETS_ARGS+=(--enable-multi-udn-subnets="${OVN_E2E_ENABLE_MULTI_UDN_SUBNETS}")
+fi
+
 if [ "$ENABLE_EVPN" = true ] && [[ "${WHAT}" != "${KV_LIVE_MIGRATION_TESTS}"* ]]; then
   # EVPN tests are parallel-safe (unique per-test resource names, randomized
   # subnets). Use the ginkgo CLI so that -procs=3 spawns 3 coordinated worker
@@ -281,7 +290,8 @@ if [ "$ENABLE_EVPN" = true ] && [[ "${WHAT}" != "${KV_LIVE_MIGRATION_TESTS}"* ]]
         -provider skeleton \
         -kubeconfig "${KUBECONFIG}" \
         ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \
-        ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"}
+        ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"} \
+        "${E2E_MULTI_UDN_SUBNETS_ARGS[@]}"
 else
   go test -test.timeout ${GO_TEST_TIMEOUT}m -v . \
           -ginkgo.v \
@@ -294,6 +304,7 @@ else
           -provider skeleton \
           -kubeconfig ${KUBECONFIG} \
           ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \
-          ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"}
+          ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"} \
+          "${E2E_MULTI_UDN_SUBNETS_ARGS[@]}"
 fi
 popd


### PR DESCRIPTION
## 📑 Description

Add an e2e flag to disable multi-subnet UDN coverage and keep the default behavior unchanged.

Wire the flag through the e2e runner, add a dedicated network-segmentation CI lane, and apply a single-subnet admission policy during kind setup when the flag is disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an admission validation policy to deny invalid user-defined network subnet configurations (including excessive CIDRs and same-family dual-CIDR cases).

* **Tests**
  * Introduced a new flag and environment-controlled toggle to enable or disable multi-subnet behavior during E2E runs.
  * Updated E2E tests to conditionally run or skip multi-subnet coverage based on the toggle.
  * Streamlined the E2E test matrix by reducing the number of tested network segmentation combinations to focus on primary scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->