### PR TITLE
area-merge: use GitHub App token for branch protection bypass

### DIFF
--- a/.github/workflows/area-merge.yml
+++ b/.github/workflows/area-merge.yml
@@ -13,13 +13,19 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/area-maintainer-approved')) ||
       github.event_name == 'check_suite'
-    permissions:
-      contents: write
-      pull-requests: write
-      checks: read
-      statuses: read
     runs-on: ubuntu-latest
     steps:
+      - name: Generate merge app token
+        id: merge-app-token-generator
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.OVN_KUBERNETES_MERGE_BOT }}
+          private-key: ${{ secrets.OVN_KUBERNETES_MERGE_BOT }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-checks: read
+          permission-statuses: read
+
       - name: Checkout base branch (for CODEOWNERS and scripts)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -32,7 +38,7 @@ jobs:
       - name: Area maintainer merge check
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.merge-app-token-generator.outputs.token }}
           script: |
             const script = require('./.github/scripts/area-merge.js');
             await script({ github, context, core });

--- a/docs/developer-guide/areas.md
+++ b/docs/developer-guide/areas.md
@@ -24,6 +24,27 @@ in the governance docs.
   authorization before merging.
 * PRs that touch files across multiple areas require a repo Maintainer to merge.
 
+## Merge Bot (ovn-kubernetes-merge-bot)
+
+The area merge workflow uses a dedicated GitHub App called
+**ovn-kubernetes-merge-bot** to perform merges. This is required because the
+repository's branch protection rules restrict who can push to `master`. The
+app is added to the branch protection allow-list, enabling it to merge PRs on
+behalf of area maintainers once all checks pass.
+
+**Configuration:**
+
+| Item | Location |
+|---|---|
+| GitHub App | Installed on the `ovn-kubernetes` org ([app settings](https://github.com/organizations/ovn-kubernetes/settings/apps/ovn-kubernetes-merge-bot)) |
+| Client ID | Repository variable: `OVN_KUBERNETES_MERGE_BOT` |
+| Private key | Repository secret: `OVN_KUBERNETES_MERGE_BOT` |
+| Branch protection | `master` — app listed under "Restrict who can push to matching branches" |
+
+The workflow generates a short-lived installation token via
+[`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)
+at the start of each run. No long-lived access tokens are used during workflow execution.
+
 ## Current Areas
 
 ### Virtualization


### PR DESCRIPTION
    The default GITHUB_TOKEN cannot push to branches with "restrict who
    can push" branch protection rights enabled via GUI. 
    Switch to a dedicated new GitHub App (ovn_kubernetes_merge_bot)
    whose installation token is authorized in the branch protection allow-list.
    
    Co-authored-by: Cursor <cursoragent@cursor.com>
    Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added a new developer guide section explaining the Merge Bot (ovn-kubernetes-merge-bot), its configuration, and how it supports branch protection constraints on `master`.

* **Chores**
  * Updated the area merge workflow to authenticate using a short-lived GitHub App token with explicit permissions, instead of the default workflow token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->