### PR TITLE
ovn: scope GR-to-cluster-router routes to node subnet in no-overlay mode

### DIFF
--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -521,7 +521,21 @@ func (gw *GatewayManager) updateGWRouterStaticRoutes(gwConfig *GatewayConfig, ex
 	gwRouter *nbdb.LogicalRouter) error {
 	if len(gwConfig.ovnClusterLRPToJoinIfAddrs) > 0 {
 		// this is only the case for layer3 topology
-		for _, entry := range gwConfig.clusterSubnets {
+		//
+		// In overlay mode the gateway router routes the whole cluster subnet(s)
+		// towards the ovn_cluster_router so it can reach pods on every node
+		// through the distributed router (over the transit switch).
+		//
+		// In no-overlay mode there is no transit switch: traffic destined to pods
+		// on other nodes must leave through the default route to the physical
+		// network instead of being forwarded to the ovn_cluster_router. So the
+		// gateway router should only route this node's local host subnet(s)
+		// towards the ovn_cluster_router (to reach pods local to this node).
+		drRoutedSubnets := gwConfig.clusterSubnets
+		if gw.netInfo.Transport() == types.NetworkTransportNoOverlay {
+			drRoutedSubnets = gwConfig.hostSubnets
+		}
+		for _, entry := range drRoutedSubnets {
 			drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(entry), gwConfig.ovnClusterLRPToJoinIfAddrs)
 			if err != nil {
 				return fmt.Errorf("failed to add a static route in GR %s with distributed "+
@@ -560,6 +574,38 @@ func (gw *GatewayManager) updateGWRouterStaticRoutes(gwConfig *GatewayConfig, ex
 				&lrsr.Nexthop)
 			if err != nil {
 				return fmt.Errorf("failed to add a static route %+v in GR %s with distributed router as the nexthop, err: %v", lrsr, gw.gwRouterName, err)
+			}
+		}
+		// The set of subnets routed towards the ovn_cluster_router differs
+		// between overlay and no-overlay mode (see above), so on a transition
+		// between the two transports (e.g. an upgrade) the gateway router can be
+		// left with stale routes from the previous mode. Remove them so the
+		// gateway router converges to the correct set of distributed-router
+		// routes for the current transport.
+		if gw.netInfo.Transport() == types.NetworkTransportNoOverlay {
+			// We now only route this node's host subnet(s) towards the
+			// ovn_cluster_router. Remove any stale full cluster-subnet route
+			// pointing at the distributed router (programmed previously in
+			// overlay mode), so the gateway router does not forward off-node pod
+			// traffic to the ovn_cluster_router.
+			hostSubnetSet := sets.New[string]()
+			for _, hostSubnet := range gwConfig.hostSubnets {
+				hostSubnetSet.Insert(hostSubnet.String())
+			}
+			if err := gw.deleteStaleDRRoutes(gwConfig, gwConfig.clusterSubnets, hostSubnetSet); err != nil {
+				return err
+			}
+		} else {
+			// We now route the whole cluster subnet(s) towards the
+			// ovn_cluster_router. Remove any stale per-host subnet route pointing
+			// at the distributed router (programmed previously in no-overlay
+			// mode), so it does not shadow the cluster-subnet route.
+			clusterSubnetSet := sets.New[string]()
+			for _, clusterSubnet := range gwConfig.clusterSubnets {
+				clusterSubnetSet.Insert(clusterSubnet.String())
+			}
+			if err := gw.deleteStaleDRRoutes(gwConfig, gwConfig.hostSubnets, clusterSubnetSet); err != nil {
+				return err
 			}
 		}
 	}
@@ -649,6 +695,34 @@ func (gw *GatewayManager) updateGWRouterStaticRoutes(gwConfig *GatewayConfig, ex
 			p, &lrsr.Nexthop)
 		if err != nil {
 			return fmt.Errorf("error creating static route %+v in GR %s: %v", lrsr, gw.gwRouterName, err)
+		}
+	}
+	return nil
+}
+
+// deleteStaleDRRoutes removes routes on the gateway router that point at the
+// distributed router (ovn_cluster_router) for any subnet in staleSubnets,
+// skipping subnets present in keepSubnets. It is used to clean up routes left
+// over from the previous network transport when transitioning between overlay
+// and no-overlay mode (the two modes route a different set of subnets towards
+// the distributed router).
+func (gw *GatewayManager) deleteStaleDRRoutes(gwConfig *GatewayConfig, staleSubnets []*net.IPNet, keepSubnets sets.Set[string]) error {
+	for _, subnet := range staleSubnets {
+		if keepSubnets.Has(subnet.String()) {
+			continue
+		}
+		drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(subnet), gwConfig.ovnClusterLRPToJoinIfAddrs)
+		if err != nil {
+			continue
+		}
+		prefix := subnet.String()
+		nexthop := drLRPIfAddr.IP.String()
+		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+			return item.IPPrefix == prefix && item.Nexthop == nexthop && item.OutputPort == nil
+		}
+		if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(gw.nbClient, gw.gwRouterName, p); err != nil {
+			return fmt.Errorf("failed to delete stale route %s via %s in GR %s: %v",
+				prefix, nexthop, gw.gwRouterName, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -2104,6 +2104,117 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 	})
 })
 
+var _ = ginkgo.Describe("Gateway Router static routes to the distributed router", func() {
+	const (
+		drNextHop      = "100.65.0.1"
+		clusterSubnet  = "10.193.0.0/16"
+		nodeHostSubnet = "10.193.0.0/24"
+	)
+
+	var (
+		fakeOvn      *FakeOVN
+		gwRouterName = types.GWRouterPrefix + nodeName
+	)
+
+	ginkgo.BeforeEach(func() {
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		config.Gateway.Mode = config.GatewayModeShared
+		config.Gateway.EphemeralPortRange = config.DefaultEphemeralPortRange
+		fakeOvn = NewFakeOVN(true)
+	})
+
+	ginkgo.AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	// drRoutePrefixes returns the IP prefixes of the gateway router's static
+	// routes whose nexthop is the distributed router (ovn_cluster_router) join
+	// switch port.
+	drRoutePrefixes := func() []string {
+		routes, err := libovsdbops.GetRouterLogicalRouterStaticRoutesWithPredicate(
+			fakeOvn.nbClient,
+			&nbdb.LogicalRouter{Name: gwRouterName},
+			func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.Nexthop == drNextHop
+			})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		prefixes := make([]string, 0, len(routes))
+		for _, route := range routes {
+			prefixes = append(prefixes, route.IPPrefix)
+		}
+		return prefixes
+	}
+
+	// runUpdate seeds a gateway router (plus any pre-existing static routes) and
+	// invokes updateGWRouterStaticRoutes for the default network.
+	runUpdate := func(gwConfig *GatewayConfig, seedRoutes ...*nbdb.LogicalRouterStaticRoute) {
+		gwRouter := &nbdb.LogicalRouter{
+			UUID: gwRouterName + "-UUID",
+			Name: gwRouterName,
+		}
+		nbData := []libovsdbtest.TestData{gwRouter}
+		for _, route := range seedRoutes {
+			nbData = append(nbData, route)
+			gwRouter.StaticRoutes = append(gwRouter.StaticRoutes, route.UUID)
+		}
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: nbData}, &corev1.NodeList{
+			Items: []corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
+			},
+		})
+
+		gw := newGatewayManager(fakeOvn, nodeName)
+		externalRouterPort := types.GWRouterToExtSwitchPrefix + gwRouterName
+		gomega.Expect(gw.updateGWRouterStaticRoutes(gwConfig, externalRouterPort, gwRouter)).To(gomega.Succeed())
+	}
+
+	newGWConfig := func() *GatewayConfig {
+		return &GatewayConfig{
+			annoConfig:                 &util.L3GatewayConfig{},
+			hostSubnets:                ovntest.MustParseIPNets(nodeHostSubnet),
+			clusterSubnets:             ovntest.MustParseIPNets(clusterSubnet),
+			ovnClusterLRPToJoinIfAddrs: ovntest.MustParseIPNets(drNextHop + "/16"),
+		}
+	}
+
+	ginkgo.It("routes the whole cluster subnet via the distributed router in overlay mode", func() {
+		// default (empty) transport == overlay
+		runUpdate(newGWConfig())
+		gomega.Expect(drRoutePrefixes()).To(gomega.ConsistOf(clusterSubnet))
+	})
+
+	ginkgo.It("routes only the node host subnet via the distributed router in no-overlay mode", func() {
+		config.Default.Transport = types.NetworkTransportNoOverlay
+		runUpdate(newGWConfig())
+		gomega.Expect(drRoutePrefixes()).To(gomega.ConsistOf(nodeHostSubnet))
+	})
+
+	ginkgo.It("removes a stale cluster subnet route via the distributed router in no-overlay mode", func() {
+		config.Default.Transport = types.NetworkTransportNoOverlay
+		staleRoute := &nbdb.LogicalRouterStaticRoute{
+			UUID:     "stale-cluster-subnet-route-UUID",
+			IPPrefix: clusterSubnet,
+			Nexthop:  drNextHop,
+		}
+		runUpdate(newGWConfig(), staleRoute)
+		// the stale /16 must be gone, leaving only the node's /24
+		gomega.Expect(drRoutePrefixes()).To(gomega.ConsistOf(nodeHostSubnet))
+	})
+
+	ginkgo.It("removes a stale node host subnet route via the distributed router in overlay mode", func() {
+		// default (empty) transport == overlay; simulate an upgrade from
+		// no-overlay where the GR was left with only the node's /24 route.
+		staleRoute := &nbdb.LogicalRouterStaticRoute{
+			UUID:     "stale-host-subnet-route-UUID",
+			IPPrefix: nodeHostSubnet,
+			Nexthop:  drNextHop,
+		}
+		runUpdate(newGWConfig(), staleRoute)
+		// the stale /24 must be gone, leaving only the cluster /16
+		gomega.Expect(drRoutePrefixes()).To(gomega.ConsistOf(clusterSubnet))
+	})
+})
+
 func newGatewayManager(ovn *FakeOVN, nodeName string) *GatewayManager {
 	controller := ovn.controller
 	return NewGatewayManager(


### PR DESCRIPTION

## 📑 Description
Fixes gateway-router routing for layer3 networks (default network and Layer-3 CUDNs) running with transport=no-overlay. Previously every node's gateway router (GR_*) got a static route for the entire cluster/CUDN subnet (e.g. 10.193.0.0/16) pointing at the ovn_cluster_router join-switch port (100.65.0.1). With no transit switch in no-overlay mode, that caused the GR to forward off-node pod traffic into the distributed router instead of out the default route to the physical fabric.

In GatewayManager.updateGWRouterStaticRoutes() (go-controller/pkg/ovn/gateway.go):
- When netInfo.Transport() == no-overlay, build the GR-to-distributed-router routes from the node's host subnet(s) (gwConfig.hostSubnets) instead of the cluster subnet(s) (gwConfig.clusterSubnets). Overlay mode is unchanged.
- Clean up any pre-existing full cluster-subnet route via the distributed router, so the change is idempotent across upgrades and overlay↔no-overlay transitions.

Result — each node's GR carries only its own host subnet route:
cat-cp-2:   10.193.0.0/24 via 100.65.0.1
cat-gpu-1:  10.193.1.0/24 via 100.65.0.1
cat-gpu-3:  10.193.2.0/24 via 100.65.0.1

Scope / notes
- Gated on transport (no-overlay), the actual determinant of transit-switch absence — so it applies to both managed and unmanaged routing, and to the DPU ovnkube-controller programming the CUDN's GR.
- Only the GR static route is changed; the SNAT/NAT path still iterates cluster subnets (out of scope here).

Testing
- make test for pkg/ovn (race-enabled, in container): 530 Passed | 0 Failed.
- make lint: 0 issues. gofmt / go vet clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway-router static route programming to correctly follow the current transport mode (overlay vs no-overlay).
  * Added automatic cleanup of stale distributed-router-related static routes after transport-mode changes to prevent route conflicts.

* **Tests**
  * Added new test coverage for gateway-router static routing across transport modes, including verification of both correct route creation and stale route removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->