### PR TITLE
area-merge: remove token downscoping, use app installation permissions

### DIFF
--- a/.github/workflows/area-merge.yml
+++ b/.github/workflows/area-merge.yml
@@ -21,10 +21,6 @@ jobs:
         with:
           client-id: ${{ vars.OVN_KUBERNETES_MERGE_BOT }}
           private-key: ${{ secrets.OVN_KUBERNETES_MERGE_BOT }}
-          permission-contents: write
-          permission-pull-requests: write
-          permission-checks: read
-          permission-statuses: read
 
       - name: Checkout base branch (for CODEOWNERS and scripts)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
Remove explicit permission-* inputs from create-github-app-token so the token inherits all permissions from the app installation. This fixes "Resource not accessible by integration" when merging PRs that are behind master and master has workflow file changes (requires workflows: write which was not in the downscoped list).

Permissions are now managed entirely via the GitHub App UI.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->