### PR TITLE
Fix data race in EVPN node controller unit test

### DIFF
--- a/go-controller/pkg/node/controllers/evpn/evpn_node_controller_test.go
+++ b/go-controller/pkg/node/controllers/evpn/evpn_node_controller_test.go
@@ -1269,8 +1269,10 @@ var _ = Describe("EVPN node controller", func() {
 			ensuredMu.Lock()
 			ensuredCfgs = nil
 			ensuredMu.Unlock()
+			fakeNM.Lock()
 			fakeNM.NADNetworks = nil
 			fakeNM.PrimaryNetworks = nil
+			fakeNM.Unlock()
 			fakeNM.TriggerHandlers(nadKey, nil, true)
 
 			Eventually(func() bool {


### PR DESCRIPTION

## 📑 Description

Hold fakeNM.Lock() when writing to NADNetworks and PrimaryNetworks during the network removal simulation, matching the pattern used in all other test files (egressfirewall_test.go, controller_test.go, controller_components_test.go). Without the lock, the test goroutine races with the controller goroutine reading these fields via DoWithLock().


## Additional Information for reviewers

Sample data race I hit when running `make test` locally on unrelated changes:
```
------------------------------
EVPN node controller address change reconciliation reconciles VTEP with VID/VNI mappings when a network is added or removed
/go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller_test.go:1174
I0623 08:29:51.789789   29140 factory.go:557] Starting watch factory
I0623 08:29:51.789940   29140 reflector.go:367] "Starting reflector" type="*v1.Node" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.789973   29140 reflector.go:367] "Starting reflector" type="*v1.Pod" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.789990   29140 reflector.go:411] "Listing and watching" type="*v1.Node" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.789943   29140 reflector.go:367] "Starting reflector" type="*v1.Service" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.789999   29140 reflector.go:367] "Starting reflector" type="*v1.Namespace" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.789938   29140 reflector.go:367] "Starting reflector" type="*v1.EndpointSlice" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790051   29140 reflector.go:411] "Listing and watching" type="*v1.Namespace" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790053   29140 reflector.go:411] "Listing and watching" type="*v1.Service" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790074   29140 reflector.go:411] "Listing and watching" type="*v1.EndpointSlice" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790007   29140 reflector.go:411] "Listing and watching" type="*v1.Pod" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790234   29140 reflector.go:446] "Caches populated" type="*v1.Node" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790242   29140 reflector.go:446] "Caches populated" type="*v1.Namespace" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790278   29140 reflector.go:446] "Caches populated" type="*v1.Pod" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790369   29140 reflector.go:446] "Caches populated" type="*v1.EndpointSlice" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.790415   29140 reflector.go:446] "Caches populated" type="*v1.Service" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:51.795028   29140 factory.go:1971] *v1.Namespace informer cache synced successfully
I0623 08:29:51.795053   29140 factory.go:1971] *v1.EndpointSlice informer cache synced successfully
I0623 08:29:51.795062   29140 factory.go:1971] *v1.Node informer cache synced successfully
I0623 08:29:51.795071   29140 factory.go:1971] *v1.Pod informer cache synced successfully
I0623 08:29:51.795083   29140 factory.go:1971] *v1.Service informer cache synced successfully
I0623 08:29:51.795717   29140 reflector.go:367] "Starting reflector" type="*v1.NetworkAttachmentDefinition" resyncPeriod="0s" reflector="github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/factory.go:117"
I0623 08:29:51.795758   29140 reflector.go:411] "Listing and watching" type="*v1.NetworkAttachmentDefinition" reflector="github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/factory.go:117"
I0623 08:29:51.795867   29140 reflector.go:446] "Caches populated" type="*v1.NetworkAttachmentDefinition" reflector="github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/factory.go:117"
I0623 08:29:51.800285   29140 factory.go:1971] *v1.NetworkAttachmentDefinition informer cache synced successfully
I0623 08:29:51.800418   29140 reflector.go:367] "Starting reflector" type="*v1.UserDefinedNetwork" resyncPeriod="0s" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.800426   29140 reflector.go:367] "Starting reflector" type="*v1.ClusterUserDefinedNetwork" resyncPeriod="0s" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.800471   29140 reflector.go:411] "Listing and watching" type="*v1.UserDefinedNetwork" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.800479   29140 reflector.go:411] "Listing and watching" type="*v1.ClusterUserDefinedNetwork" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.800681   29140 reflector.go:446] "Caches populated" type="*v1.ClusterUserDefinedNetwork" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.800694   29140 reflector.go:446] "Caches populated" type="*v1.UserDefinedNetwork" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.805731   29140 factory.go:1971] *v1.UserDefinedNetwork informer cache synced successfully
I0623 08:29:51.805748   29140 factory.go:1971] *v1.ClusterUserDefinedNetwork informer cache synced successfully
I0623 08:29:51.805855   29140 reflector.go:367] "Starting reflector" type="*v1.VTEP" resyncPeriod="0s" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.805876   29140 reflector.go:411] "Listing and watching" type="*v1.VTEP" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.805945   29140 reflector.go:446] "Caches populated" type="*v1.VTEP" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.810914   29140 factory.go:1971] *v1.VTEP informer cache synced successfully
I0623 08:29:51.811003   29140 reflector.go:367] "Starting reflector" type="*v1.RouteAdvertisements" resyncPeriod="0s" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.811040   29140 reflector.go:411] "Listing and watching" type="*v1.RouteAdvertisements" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.811167   29140 reflector.go:446] "Caches populated" type="*v1.RouteAdvertisements" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:51.816216   29140 factory.go:1971] *v1.RouteAdvertisements informer cache synced successfully
I0623 08:29:51.816262   29140 factory.go:676] Watch Factory start up complete, took: 26.468529ms
I0623 08:29:51.976329   29140 evpn_node_controller.go:179] Starting EVPN node controller
I0623 08:29:51.976368   29140 controller.go:153] Adding controller evpn-node-vtep-controller event handlers
I0623 08:29:51.976378   29140 controller.go:153] Adding controller evpn-pod-neighbor-controller event handlers
I0623 08:29:51.976451   29140 shared_informer.go:349] "Waiting for caches to sync" controller="evpn-node-vtep-controller"
I0623 08:29:51.976474   29140 shared_informer.go:356] "Caches are synced" controller="evpn-node-vtep-controller"
I0623 08:29:51.976471   29140 shared_informer.go:349] "Waiting for caches to sync" controller="evpn-pod-neighbor-controller"
I0623 08:29:51.976504   29140 shared_informer.go:356] "Caches are synced" controller="evpn-pod-neighbor-controller"
I0623 08:29:51.976533   29140 shared_informer.go:349] "Waiting for caches to sync" controller="evpn-node"
I0623 08:29:51.976549   29140 shared_informer.go:356] "Caches are synced" controller="evpn-node"
I0623 08:29:51.976597   29140 shared_informer.go:349] "Waiting for caches to sync" controller="evpn-pod"
I0623 08:29:51.976613   29140 shared_informer.go:356] "Caches are synced" controller="evpn-pod"
I0623 08:29:51.976649   29140 controller.go:177] Starting controller evpn-node-vtep-controller with 1 workers
I0623 08:29:51.976672   29140 controller.go:177] Starting controller evpn-nad-reconciler with 1 workers
I0623 08:29:51.976685   29140 controller.go:177] Starting controller evpn-pod-neighbor-controller with 1 workers
  STEP: allowing any NDM calls throughout the test @ 06/23/26 08:29:51.976
  STEP: creating an unmanaged VTEP and setting up addresses @ 06/23/26 08:29:51.976
I0623 08:29:51.977153   29140 kube.go:266] Setting annotations map[k8s.ovn.org/vteps:{"vtep1":{"ips":["100.64.0.1"]}}] on node node1
  STEP: simulating a network add with EVPN VID/VNI mappings @ 06/23/26 08:29:51.977
  STEP: verifying VID/VNI mappings on the VXLAN device @ 06/23/26 08:29:51.977
I0623 08:29:51.981901   29140 evpn_node_controller.go:396] Applying EVPN devices for VTEP vtep1: bridge=evbr-vtep1, IPv4=100.64.0.1, IPv6=<nil>
I0623 08:29:51.983330   29140 model_client.go:377] Create operations generated as: [{Op:insert Table:Interface Row:map[external_ids:{GoMap:map[iface-id:macvrf-mynet_ovn_layer2_switch]} name:ovl2.5 type:internal] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName:u4238782213 correlationID:}]
I0623 08:29:51.983493   29140 model_client.go:377] Create operations generated as: [{Op:insert Table:Port Row:map[bond_fake_iface:false external_ids:{GoMap:map[evpn-vtep:vtep1]} fake_bridge:false interfaces:{GoSet:[{GoUUID:u4238782213}]} name:ovl2.5 protected:false] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName:u4238782214 correlationID:}]
I0623 08:29:51.983641   29140 model_client.go:402] Mutate operations generated as: [{Op:mutate Table:Bridge Row:map[] Rows:[] Columns:[] Mutations:[{Column:ports Mutator:insert Value:{GoSet:[{GoUUID:u4238782214}]}}] Timeout:<nil> Where:[where column _uuid == {a59451c0-5faa-4b4c-a24f-f2103ee1b6de}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.983704   29140 transact.go:46] Configuring OVN: [{Op:insert Table:Interface Row:map[external_ids:{GoMap:map[iface-id:macvrf-mynet_ovn_layer2_switch]} name:ovl2.5 type:internal] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName:u4238782213 correlationID:} {Op:insert Table:Port Row:map[bond_fake_iface:false external_ids:{GoMap:map[evpn-vtep:vtep1]} fake_bridge:false interfaces:{GoSet:[{GoUUID:u4238782213}]} name:ovl2.5 protected:false] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName:u4238782214 correlationID:} {Op:mutate Table:Bridge Row:map[] Rows:[] Columns:[] Mutations:[{Column:ports Mutator:insert Value:{GoSet:[{GoUUID:u4238782214}]}}] Timeout:<nil> Where:[where column _uuid == {a59451c0-5faa-4b4c-a24f-f2103ee1b6de}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.987572   29140 evpn_node_controller.go:381] VTEP vtep1 OVS port not yet available (failed to ensure OVS port ovl2.5: failed to get OVS port link ovl2.5: Link not found), will retry
I0623 08:29:51.987757   29140 evpn_node_controller.go:396] Applying EVPN devices for VTEP vtep1: bridge=evbr-vtep1, IPv4=100.64.0.1, IPv6=<nil>
  STEP: verifying L3 and L2 SVIs were created with correct VLAN IDs and bridge parent @ 06/23/26 08:29:51.987
  STEP: simulating network removal and verifying VXLAN has no mappings @ 06/23/26 08:29:51.987
==================
WARNING: DATA RACE
Write at 0x00c001e84a88 by goroutine 118082:
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn.init.func1.2.9()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller_test.go:1273 +0x1bc4
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/node.go:524 +0x2e
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:942 +0x6ed

Previous read at 0x00c001e84a88 by goroutine 118079:
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager.(*FakeNetworkManager).DoWithLock()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager/fake.go:244 +0x64
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn.(*Controller).collectEVPNNetworks()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller.go:495 +0x13c
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn.(*Controller).ensureDevices()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller.go:410 +0x745
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn.(*Controller).reconcile()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller.go:373 +0x5ef
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn.(*Controller).reconcile-fm()
      <autogenerated>:1 +0x47
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller.(*controller[go.shape.struct { k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta "json:\",inline\""; k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta "json:\"metadata,omitempty\""; Spec github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1.VTEPSpec "json:\"spec\""; Status github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1.VTEPStatus "json:\"status,omitempty\"" }]).processNextQueueItem()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller/controller.go:274 +0x1a3
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller.(*controller[go.shape.struct { k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta "json:\",inline\""; k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta "json:\"metadata,omitempty\""; Spec github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1.VTEPSpec "json:\"spec\""; Status github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1.VTEPStatus "json:\"status,omitempty\"" }]).startWorkers.func1()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller/controller.go:184 +0xc4

Goroutine 118082 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:907 +0x1452
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/group.go:231 +0x10e4
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/group.go:381 +0x1206
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:515 +0x11f1
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:136 +0x6d3
  github.com/onsi/ginkgo/v2.RunSpecs()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/core_dsl.go:314 +0xe84
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn.TestEVPNController()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/suite_test.go:15 +0x4d
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x44

Goroutine 118079 (running) created at:
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller.(*controller[go.shape.struct { k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta "json:\",inline\""; k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta "json:\"metadata,omitempty\""; Spec github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1.VTEPSpec "json:\"spec\""; Status github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1.VTEPStatus "json:\"status,omitempty\"" }]).startWorkers()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller/controller.go:181 +0x2e7
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller.(*controller[github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1.VTEP]).startWorkers()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller/controller.go:172 +0x36
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller.StartWithInitialSync()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controller/controller.go:367 +0x41b
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn.(*Controller).Start()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller.go:188 +0x436
  github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn.init.func1.2.1()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller_test.go:830 +0xb54
  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/node.go:524 +0x2e
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
      /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:942 +0x6ed
==================
I0623 08:29:51.989653   29140 evpn_node_controller.go:455] Network test-ns/test-nad removed, reconciling VTEP vtep1
I0623 08:29:51.991385   29140 model_client.go:386] Update operations generated as: [{Op:update Table:Interface Row:map[external_ids:{GoMap:map[iface-id:macvrf-mynet_ovn_layer2_switch]} type:internal] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[where column _uuid == {34a2f1b6-1689-4cec-a268-ad7ce7fa73fe}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.991690   29140 model_client.go:386] Update operations generated as: [{Op:update Table:Port Row:map[external_ids:{GoMap:map[evpn-vtep:vtep1]}] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[where column _uuid == {134f4816-50a5-4339-84c0-29c21f62d242}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.991833   29140 model_client.go:402] Mutate operations generated as: [{Op:mutate Table:Bridge Row:map[] Rows:[] Columns:[] Mutations:[{Column:ports Mutator:insert Value:{GoSet:[{GoUUID:134f4816-50a5-4339-84c0-29c21f62d242}]}}] Timeout:<nil> Where:[where column _uuid == {a59451c0-5faa-4b4c-a24f-f2103ee1b6de}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.991898   29140 transact.go:46] Configuring OVN: [{Op:update Table:Interface Row:map[external_ids:{GoMap:map[iface-id:macvrf-mynet_ovn_layer2_switch]} type:internal] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[where column _uuid == {34a2f1b6-1689-4cec-a268-ad7ce7fa73fe}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:} {Op:update Table:Port Row:map[external_ids:{GoMap:map[evpn-vtep:vtep1]}] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[where column _uuid == {134f4816-50a5-4339-84c0-29c21f62d242}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:} {Op:mutate Table:Bridge Row:map[] Rows:[] Columns:[] Mutations:[{Column:ports Mutator:insert Value:{GoSet:[{GoUUID:134f4816-50a5-4339-84c0-29c21f62d242}]}}] Timeout:<nil> Where:[where column _uuid == {a59451c0-5faa-4b4c-a24f-f2103ee1b6de}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.994166   29140 evpn_node_controller.go:381] VTEP vtep1 OVS port not yet available (failed to ensure OVS port ovl2.5: failed to get OVS port link ovl2.5: Link not found), will retry
I0623 08:29:51.995388   29140 evpn_node_controller.go:396] Applying EVPN devices for VTEP vtep1: bridge=evbr-vtep1, IPv4=100.64.0.1, IPv6=<nil>
I0623 08:29:51.995866   29140 evpn_node_controller.go:605] OVS port ovl2.5 no longer needed for VTEP vtep1, removing
I0623 08:29:51.996010   29140 model_client.go:411] Delete operations generated as: [{Op:delete Table:Interface Row:map[] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[where column _uuid == {34a2f1b6-1689-4cec-a268-ad7ce7fa73fe}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.996139   29140 model_client.go:411] Delete operations generated as: [{Op:delete Table:Port Row:map[] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[where column _uuid == {134f4816-50a5-4339-84c0-29c21f62d242}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.996270   29140 model_client.go:402] Mutate operations generated as: [{Op:mutate Table:Bridge Row:map[] Rows:[] Columns:[] Mutations:[{Column:ports Mutator:delete Value:{GoSet:[{GoUUID:134f4816-50a5-4339-84c0-29c21f62d242}]}}] Timeout:<nil> Where:[where column _uuid == {a59451c0-5faa-4b4c-a24f-f2103ee1b6de}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
I0623 08:29:51.996349   29140 transact.go:46] Configuring OVN: [{Op:delete Table:Interface Row:map[] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[where column _uuid == {34a2f1b6-1689-4cec-a268-ad7ce7fa73fe}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:} {Op:delete Table:Port Row:map[] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[where column _uuid == {134f4816-50a5-4339-84c0-29c21f62d242}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:} {Op:mutate Table:Bridge Row:map[] Rows:[] Columns:[] Mutations:[{Column:ports Mutator:delete Value:{GoSet:[{GoUUID:134f4816-50a5-4339-84c0-29c21f62d242}]}}] Timeout:<nil> Where:[where column _uuid == {a59451c0-5faa-4b4c-a24f-f2103ee1b6de}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName: correlationID:}]
  [FAILED] in [It] - /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller_test.go:1285 @ 06/23/26 08:29:52.99
I0623 08:29:52.990858   29140 evpn_node_controller.go:240] Stopping EVPN node controller
I0623 08:29:53.001634   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.001770   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.001831   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.001993   29140 reflector.go:373] "Stopping reflector" type="*v1.RouteAdvertisements" resyncPeriod="0s" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:53.002495   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.002687   29140 reflector.go:373] "Stopping reflector" type="*v1.UserDefinedNetwork" resyncPeriod="0s" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:53.002814   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.003249   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.003366   29140 reflector.go:373] "Stopping reflector" type="*v1.NetworkAttachmentDefinition" resyncPeriod="0s" reflector="github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/factory.go:117"
I0623 08:29:53.016653   29140 reflector.go:373] "Stopping reflector" type="*v1.ClusterUserDefinedNetwork" resyncPeriod="0s" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:53.017006   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.017616   29140 reflector.go:373] "Stopping reflector" type="*v1.Service" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:53.019726   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.019835   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.019850   29140 reflector.go:373] "Stopping reflector" type="*v1.Node" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:53.019873   29140 reflector.go:373] "Stopping reflector" type="*v1.VTEP" resyncPeriod="0s" reflector="github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/vtep/v1/apis/informers/externalversions/factory.go:129"
I0623 08:29:53.019936   29140 reflector.go:373] "Stopping reflector" type="*v1.EndpointSlice" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:53.019847   29140 reflector.go:373] "Stopping reflector" type="*v1.Pod" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:53.019954   29140 watch.go:218] "Stopping fake watcher"
I0623 08:29:53.020035   29140 reflector.go:373] "Stopping reflector" type="*v1.Namespace" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:161"
I0623 08:29:53.023484   29140 factory.go:682] Stopping watch factory
• [FAILED] [1.293 seconds]
EVPN node controller address change reconciliation [It] reconciles VTEP with VID/VNI mappings when a network is added or removed
/go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller_test.go:1174

  [FAILED] Timed out after 1.000s.
  Expected
      <bool>: false
  to be true
  In [It] at: /go/src/github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/controllers/evpn/evpn_node_controller_test.go:1285 @ 06/23/26 08:29:52.99
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved synchronization in EVPN node controller tests for enhanced test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->