### PR TITLE
Fix UDN masqueradeIP ARP storm

### DIFF
--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -297,6 +297,15 @@ func (gw *GatewayManager) createGWRouter(gwConfig *GatewayConfig) (*nbdb.Logical
 	if gw.netInfo.GetNetworkName() == types.DefaultNetworkName {
 		logicalRouterOptions["snat-ct-zone"] = "0"
 	}
+	// Defensive: since nat-addresses=router isn't set on UDN external
+	// switch ports, there is no extra benefit from setting this to true
+	// today. However, the default (false) would allow GARP/RARP if
+	// nat-addresses were ever added back; keeping it true ensures that
+	// any future change enabling GARPs on UDN GRs must explicitly
+	// justify which traffic flow requires it.
+	if gw.netInfo.IsUserDefinedNetwork() {
+		logicalRouterOptions["disable_garp_rarp"] = "true"
+	}
 	if gw.netInfo.TopologyType() == types.Layer2Topology {
 		// When multiple networks are set of the same logical-router-port
 		// the networks get lexicographically sorted; thus there is no
@@ -1271,26 +1280,32 @@ func (gw *GatewayManager) addExternalSwitch(prefix, interfaceID, gatewayRouter, 
 
 	// Also add the port to connect the external_switch to the router.
 	externalSwitchPortToRouter := prefix + types.EXTSwitchToGWRouterPrefix + gatewayRouter
+	etorOptions := map[string]string{
+		libovsdbops.RouterPort: externalRouterPort,
+	}
+	if !gw.netInfo.IsUserDefinedNetwork() {
+		// nat-addresses=router programs OVN to send GARPs for all external IPs
+		// that the logical switch port has been configured to use. This is
+		// necessary for egress IP because if an egress IP is moved between two
+		// nodes, the nodes need to actively update the ARP cache of all neighbors
+		// as to notify them the change. If this is not the case: packets will
+		// continue to be routed to the old node which hosted the egress IP before
+		// it was moved, and the connections will fail.
+		// For UDNs this is not set: UDN GRs only carry masquerade IPs which are
+		// link-local and identical across nodes, so GARPs for them cause an ARP
+		// storm on the physical network. EgressIP for UDNs has no SNATs on the
+		// GR, so nat-addresses=router is not needed.
+		etorOptions["nat-addresses"] = "router"
+
+		// Setting nat-addresses to router will send out GARPs for all externalIPs and LB VIPs
+		// hosted on the GR. Setting exclude-lb-vips-from-garp to true will make sure GARPs for
+		// LB VIPs are not sent, thereby preventing GARP overload.
+		etorOptions["exclude-lb-vips-from-garp"] = "true"
+	}
 	externalLogicalSwitchPortToRouter := nbdb.LogicalSwitchPort{
-		Name: externalSwitchPortToRouter,
-		Type: "router",
-		Options: map[string]string{
-			libovsdbops.RouterPort: externalRouterPort,
-
-			// This option will program OVN to start sending GARPs for all external IPS
-			// that the logical switch port has been configured to use. This is
-			// necessary for egress IP because if an egress IP is moved between two
-			// nodes, the nodes need to actively update the ARP cache of all neighbors
-			// as to notify them the change. If this is not the case: packets will
-			// continue to be routed to the old node which hosted the egress IP before
-			// it was moved, and the connections will fail.
-			"nat-addresses": "router",
-
-			// Setting nat-addresses to router will send out GARPs for all externalIPs and LB VIPs
-			// hosted on the GR. Setting exclude-lb-vips-from-garp to true will make sure GARPs for
-			// LB VIPs are not sent, thereby preventing GARP overload.
-			"exclude-lb-vips-from-garp": "true",
-		},
+		Name:      externalSwitchPortToRouter,
+		Type:      "router",
+		Options:   etorOptions,
 		Addresses: []string{macAddress},
 	}
 

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes.go
@@ -49,12 +49,11 @@ func (pbr *PolicyBasedRoutesManager) AddSameNodeIPPolicy(nodeName, mgmtPortIP st
 		return fmt.Errorf("invalid other host address(es): %v", otherHostAddrs)
 	}
 	l3Prefix := getIPCIDRPrefix(hostIfCIDR)
+	inport := pbr.netInfo.GetNetworkScopedRouterToSwitchPortName(nodeName)
+	networkScopedSwitchName := pbr.netInfo.GetNetworkScopedSwitchName(nodeName)
 	matches := sets.New[string]()
 	for _, hostIP := range append(otherHostAddrs, hostIfCIDR.IP.String()) {
-		// embed nodeName as comment so that it is easier to delete these rules later on.
-		// logical router policy doesn't support external_ids to stash metadata
-		networkScopedSwitchName := pbr.netInfo.GetNetworkScopedSwitchName(nodeName)
-		matchStr := generateNodeIPMatch(networkScopedSwitchName, l3Prefix, hostIP)
+		matchStr := generateNodeIPMatch(inport, l3Prefix, hostIP, networkScopedSwitchName)
 		matches = matches.Insert(matchStr)
 	}
 
@@ -262,8 +261,8 @@ func (pbr *PolicyBasedRoutesManager) createPolicyBasedRoutes(match, priority, ne
 	return nil
 }
 
-func generateNodeIPMatch(switchName, ipPrefix, hostIP string) string {
-	return fmt.Sprintf(`inport == "%s%s" && %s.dst == %s /* %s */`, ovntypes.RouterToSwitchPrefix, switchName, ipPrefix, hostIP, switchName)
+func generateNodeIPMatch(inport, ipPrefix, hostIP, switchName string) string {
+	return fmt.Sprintf(`inport == "%s" && %s.dst == %s /* %s */`, inport, ipPrefix, hostIP, switchName)
 }
 
 func generateHostCIDRMatch(ipPrefix, nodePrimaryCIDRPrefix, clusterPodSubnetPrefix string) string {

--- a/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
+++ b/go-controller/pkg/ovn/gatewayrouter/policybasedroutes_test.go
@@ -170,7 +170,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
@@ -197,14 +197,14 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip2-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostOtherAddrIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostOtherAddrIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
@@ -245,7 +245,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v6Prefix, node1HostIPv6Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv6Str},
 				},
@@ -278,14 +278,14 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-v4-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-v6-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v6Prefix, node1HostIPv6Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv6Str},
 				},
@@ -323,14 +323,14 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-v4-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-v6-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(udnL3Network.info.GetNetworkScopedSwitchName(node1Name), v6Prefix, node1HostIPv6Str),
+					Match:    generateNodeIPMatch(udnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v6Prefix, node1HostIPv6Str, udnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1UDNMgntIPv6Str},
 					ExternalIDs: map[string]string{
@@ -355,7 +355,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				})},
@@ -368,7 +368,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
@@ -389,7 +389,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				})},
@@ -402,7 +402,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
@@ -430,7 +430,7 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				}),
@@ -449,14 +449,14 @@ func TestAddSameNodeIPPolicy(t *testing.T) {
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(cdnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, cdnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1CDNMgntIPv4Str},
 				},
 				&nbdb.LogicalRouterPolicy{
 					UUID:     "node-ip-lrp2-uuid",
 					Priority: nodeSubNetPrio,
-					Match:    generateNodeIPMatch(udnL3Network.info.GetNetworkScopedSwitchName(node1Name), v4Prefix, node1HostIPv4Str),
+					Match:    generateNodeIPMatch(udnL3Network.info.GetNetworkScopedRouterToSwitchPortName(node1Name), v4Prefix, node1HostIPv4Str, udnL3Network.info.GetNetworkScopedSwitchName(node1Name)),
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{node1UDNMgntIPv4Str},
 					ExternalIDs: map[string]string{

--- a/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer2_user_defined_network_controller.go
@@ -1147,14 +1147,15 @@ func (oc *Layer2UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", networkName, networkID, err)
 	}
 
-	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
+	for _, masqIP := range masqIPs {
+		hostMask := util.GetIPFullMask(masqIP.IP)
+		l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses,
+			&net.IPNet{IP: masqIP.IP, Mask: hostMask})
+	}
 
 	// Always SNAT to the per network masquerade IP.
 	var externalIPs []net.IP
 	for _, masqIP := range masqIPs {
-		if masqIP == nil {
-			continue
-		}
 		externalIPs = append(externalIPs, masqIP.IP)
 	}
 

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller.go
@@ -1177,14 +1177,15 @@ func (oc *Layer3UserDefinedNetworkController) nodeGatewayConfig(node *corev1.Nod
 		return nil, fmt.Errorf("failed to get masquerade IPs, network %s (%d): %v", networkName, networkID, err)
 	}
 
-	l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses, masqIPs...)
+	for _, masqIP := range masqIPs {
+		hostMask := util.GetIPFullMask(masqIP.IP)
+		l3GatewayConfig.IPAddresses = append(l3GatewayConfig.IPAddresses,
+			&net.IPNet{IP: masqIP.IP, Mask: hostMask})
+	}
 
 	// Always SNAT to the per network masquerade IP.
 	var externalIPs []net.IP
 	for _, masqIP := range masqIPs {
-		if masqIP == nil {
-			continue
-		}
 		externalIPs = append(externalIPs, masqIP.IP)
 	}
 

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -2065,14 +2065,14 @@ func expectedLogicalRouterPolicy(routerPolicyUUID1 string, netInfo util.NetInfo,
 		priority      = 1004
 		rerouteAction = "reroute"
 	)
+	inport := netInfo.GetNetworkScopedRouterToSwitchPortName(nodeName)
 	networkScopedSwitchName := netInfo.GetNetworkScopedSwitchName(nodeName)
-	lrpName := fmt.Sprintf("%s%s", types.RouterToSwitchPrefix, networkScopedSwitchName)
 
 	return &nbdb.LogicalRouterPolicy{
 		UUID:        routerPolicyUUID1,
 		Action:      rerouteAction,
 		ExternalIDs: standardNonDefaultNetworkExtIDs(netInfo),
-		Match:       fmt.Sprintf("inport == %q && ip4.dst == %s /* %s */", lrpName, destIP, networkScopedSwitchName),
+		Match:       fmt.Sprintf("inport == %q && ip4.dst == %s /* %s */", inport, destIP, networkScopedSwitchName),
 		Nexthops:    []string{nextHop},
 		Priority:    priority,
 	}

--- a/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
+++ b/go-controller/pkg/ovn/layer3_user_defined_network_controller_test.go
@@ -2122,7 +2122,7 @@ func nodePhysicalIPAddress() *net.IPNet {
 func udnGWSNATAddress() *net.IPNet {
 	return &net.IPNet{
 		IP:   net.ParseIP("169.254.169.13"),
-		Mask: net.CIDRMask(24, 32),
+		Mask: net.CIDRMask(32, 32),
 	}
 }
 
@@ -2172,9 +2172,7 @@ func expectedExternalSwitchAndLSPs(netInfo util.NetInfo, gwConfig util.L3Gateway
 
 func externalSwitchRouterPortOptions(gatewayRouterName string) map[string]string {
 	return map[string]string{
-		"nat-addresses":             "router",
-		"exclude-lb-vips-from-garp": "true",
-		libovsdbops.RouterPort:      types.GWRouterToExtSwitchPrefix + gatewayRouterName,
+		libovsdbops.RouterPort: types.GWRouterToExtSwitchPrefix + gatewayRouterName,
 	}
 }
 
@@ -2236,6 +2234,7 @@ func gwRouterOptions(gwConfig util.L3GatewayConfig) map[string]string {
 		"chassis":                       gwConfig.ChassisID,
 		"always_learn_from_arp_request": "false",
 		"dynamic_neigh_routers":         dynamicNeighRouters,
+		"disable_garp_rarp":             "true",
 	}
 }
 

--- a/test/e2e/route_advertisements.go
+++ b/test/e2e/route_advertisements.go
@@ -2190,17 +2190,32 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 						target := nodePortServiceTarget(ipFamily, nodes.Items[2].Name, svcNodePortNetARemoteNodeBackend)
 						return clientPod.Name, clientPod.Namespace, target, podsNetA[2].Name, false
 					}),
-				ginkgo.Entry("[ETP=Cluster] UDN pod to the same node nodeport service in different UDN network should not work",
-					// FIXME: This test should work: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5419
-					// This traffic flow is expected to work eventually but doesn't work today on Layer3 (v4 and v6) and Layer2 (v4 and v6) networks.
-					// Reason it doesn't work today is because UDN networks don't have MAC bindings for masqueradeIPs of other networks.
-					// Traffic flow: UDN pod in network A -> samenode nodeIP:nodePort service of networkB
-					// UDN pod in networkA -> ovn-switch -> ovn-cluster-router (SNAT to masqueradeIP of networkA) -> mpX interface ->
-					// enters the host and hits IPTables rules to DNAT to clusterIP:Port of service of networkB.
-					// Then it hits the pkt_mark flows on breth0 and get's sent into networkB's patchport where it hits the GR.
-					// On the GR we DNAT to backend pod and SNAT to joinIP.
-					// Reply: Pod replies and now OVN in networkB tries to ARP for the masqueradeIP of networkA which is the source and simply
-					// fails as it doesn't know how to reach this masqueradeIP.
+				ginkgo.Entry("[ETP=Cluster] UDN pod to the same node nodeport service in different UDN network should only work for IPv6",
+					// FIXME: IPv4 should also work: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5419
+					//
+					// Cross-UDN same-node nodeport traffic goes through the management port in both
+					// local and shared gateway modes (the priority 1004 LRP on the cluster router
+					// reroutes traffic destined for the local node's IP to the management port):
+					// UDN pod in networkA -> ovn-switch -> ovn-cluster-router (SNAT to masqueradeIP)
+					// -> mpX interface -> host nftables (DNAT nodePort->clusterIP) -> breth0 table 0 -> table 2
+					//
+					// IPv6 works: nftables "fib daddr type local" succeeds for IPv6 regardless of
+					// incoming interface, so the pkt_mark is set and breth0 table 2 dispatches the
+					// packet to networkB's patch port. The mask narrowing (/112 -> /128) on the GR
+					// external port makes the static route (fd69::/112 -> fd69::4) take effect for
+					// the reply, routing it back through the management port to networkA.
+					//
+					// IPv4 fails: the kernel's IPv4 FIB lookup in "fib daddr type local" is
+					// interface-aware. Since the node IP (e.g. 172.18.0.2) is local on breth0, not
+					// on ovn-k8s-mpX, the lookup fails and the pkt_mark is never set:
+					//   $ ip route get 172.18.0.2 iif ovn-k8s-mp7
+					//   RTNETLINK answers: Invalid argument
+					//   $ ip -6 route get fc00:f853:ccd:e793::2 iif ovn-k8s-mp7
+					//   local fc00:f853:ccd:e793::2 ... iif ovn-k8s-mp7 pref medium
+					// Without the mark, the packet hits the priority=200 drop flow in breth0 table 2
+					// (nw_src=masqueradeIP -> drop).
+					// The original pkt_mark design (PR#4792) was intended for external clients hitting
+					// the node IP, not for cross-UDN traffic arriving on a UDN management port.
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
 						clientPod := podsNetA[0]
 						node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodes.Items[0].Name, metav1.GetOptions{})
@@ -2211,15 +2226,16 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 							nodeIP = nodeIPv6
 						}
 						nodePort := svcNodePortNetB.Spec.Ports[0].NodePort
-						// sourceIP will be joinSubnetIP for nodeports, so only using hostname endpoint
-						expectedOut := curlConnectionTimeoutCode
-						if isDynamicUDNEnabled() && cudnBTemplate.Spec.Network.Topology == udnv1.NetworkTopologyLayer3 {
-							// network B is not active on the client's node: for L3
-							// networks the connection is rejected instead of timing
-							// out, for both IP families
-							expectedOut = curlConnectionRefusedCode
+						expectErr = ipFamily == utilnet.IPv4
+						if isDynamicUDNEnabled() {
+							// network B is not active on the client's node: the
+							// nodeport is unreachable for both families
+							expectErr = true
+							expectedOutput = curlConnectionRefusedCode
+						} else if expectErr {
+							expectedOutput = curlConnectionTimeoutCode
 						}
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", expectedOut, true
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePort)) + "/hostname", expectedOutput, expectErr
 					}),
 				ginkgo.Entry("[ETP=Cluster] UDN pod to a different node nodeport service in different UDN network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
@@ -2296,9 +2312,20 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", "", false
 					}),
 
-				ginkgo.Entry("[ETP=LOCAL] UDN pod to the same node nodeport service in different UDN network should not work",
+				ginkgo.Entry("[ETP=LOCAL] UDN pod to the same node nodeport service in different UDN network should only work for IPv6 in SGW",
+					// FIXME: IPv4 should also work: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5419
+					// Shared Gateway (SGW):
+					//   IPv4 fails because nftables "fib daddr type local" does not match when the
+					//   packet arrives on ovn-k8s-mpX (kernel IPv4 FIB lookup is interface-aware).
+					//   Without the pkt_mark, the packet is dropped by breth0 table 2 isolation flows.
+					//   IPv6 works because "fib daddr type local" succeeds for IPv6 regardless of
+					//   incoming interface, so pkt_mark is set and breth0 dispatches the packet correctly.
+					// Local Gateway (LGW):
+					//   Both IPv4 and IPv6 fail. ETP=Local DNATs to the host masquerade IP (fd69::3 /
+					//   169.254.0.3), which routes back to the UDN management port (each UDN routing
+					//   table has a route for the masquerade IP pointing to its own mp), creating a
+					//   routing loop between the management port and OVN.
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {
-						// FIXME: This test should work: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5419
 						clientPod := podNetB
 						node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), clientPod.Spec.NodeName, metav1.GetOptions{})
 						framework.ExpectNoError(err)
@@ -2308,7 +2335,11 @@ var _ = ginkgo.Describe("BGP: isolation", feature.RouteAdvertisements, func() {
 							nodeIP = nodeIPv6
 						}
 						nodePortA := svcNodePortETPLocalNetA.Spec.Ports[0].NodePort
-						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", curlConnectionTimeoutCode, true
+						expectErr = ipFamily == utilnet.IPv4 || IsGatewayModeLocal(f.ClientSet)
+						if expectErr {
+							expectedOutput = curlConnectionTimeoutCode
+						}
+						return clientPod.Name, clientPod.Namespace, net.JoinHostPort(nodeIP, fmt.Sprint(nodePortA)) + "/hostname", expectedOutput, expectErr
 					}),
 				ginkgo.Entry("[ETP=LOCAL] UDN pod to a different node nodeport service in different UDN network should work",
 					func(ipFamily utilnet.IPFamily) (clientName string, clientNamespace string, dst string, expectedOutput string, expectErr bool) {


### PR DESCRIPTION
## 📑 Description

    Fix UDN masquerade ARP storm on br-ex/UDN GR's
    
    Use /32 (/128 for IPv6) mask for UDN masquerade IPs on GR external
    ports instead of inheriting the wide masquerade subnet mask (e.g. /17).
    
    The wide mask created a connected route on every CUDN GR for the
    entire masquerade subnet. In OVN, connected routes have higher
    administrative distance than static routes:
    
      #define ROUTE_PRIO_OFFSET_CONNECTED 6
      #define ROUTE_PRIO_OFFSET_STATIC    4
    
    So even though a static route existed (e.g. 169.254.0.0/17 ->
    169.254.0.4 via rtoe-GR_*), the connected route from the /17 network
    on the external port took priority for the same prefix length. This
    meant the static route and its static MAC binding were effectively
    unused, and OVN fell back to ARP resolution for every IP in the /17
    range, causing an O(N^2) ARP storm across all masquerade IPs and
    nodes.
    
    Narrowing to /32 host masks eliminates the wide connected route,
    allowing the static route to take effect. This is safe because:
    - Static routes for the masquerade subnet still exist on the GR and
      point to the DummyNextHopIP via the external port.
    - Static MAC bindings (with override_dynamic_mac=true) are already
      created for both the DummyNextHopIP and the host masquerade IPs on
      the GR external port (rtoe-GR_*), so no ARP resolution is needed.
    
    TODO: the static route for UDNs should also be narrowed to match the
    specific masquerade IPs (/32 or /128) instead of the full subnet,
    making the routing intent explicit.
    
    Remove nat-addresses=router from UDN external switch ports. UDN GRs
    only carry masquerade IPs which are link-local and identical across
    nodes, so GARPs for them flood the physical network. EgressIP for UDNs
    has no SNATs on the GR so nat-addresses=router is not needed.
    
    Set disable_garp_rarp=true on UDN gateway routers as a defensive
    measure. This does not affect KubeVirt VM live migration GARPs since
    those are sent for VIF ports on the logical switch, which have no peer
    relationship with the GR and are therefore not subject to this flag.

## Additional Information for reviewers

 Provided above

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [x] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it

As long as nothing in CI breaks.