### PR TITLE
Skip IP collision scan for L2/localnet pod deletion

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -247,9 +247,14 @@ func (bnc *BaseNetworkController) deletePodLogicalPort(pod *corev1.Pod, portInfo
 			podDesc, expectedSwitchName, switchName, portUUID)
 	}
 
-	shouldRelease, err := bnc.shouldReleaseDeletedPod(pod, switchName, nadKey, podIfAddrs)
-	if err != nil {
-		return nil, fmt.Errorf("unable to determine if ip should be released: %v", err)
+	// IP collision check only needed when this controller owns IPAM.
+	// For L2/localnet, cluster-manager allocates IPs centrally.
+	shouldRelease := false
+	if bnc.allocatesPodAnnotation() {
+		shouldRelease, err = bnc.shouldReleaseDeletedPod(pod, switchName, nadKey, podIfAddrs)
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine if ip should be released: %v", err)
+		}
 	}
 
 	var allOps, ops []ovsdb.Operation
@@ -1132,11 +1137,7 @@ func (bnc *BaseNetworkController) shouldReleaseDeletedPod(pod *corev1.Pod, switc
 	}
 
 	var shouldRelease bool
-	// for user-defined network IPs allocated from cluster manager, we will check
-	// if other pods are using the same IPs just in case we are processing
-	// events in different order than cluster manager did (best effort, there
-	// can still be issues with this)
-	if !bnc.allocatesPodAnnotation() || !zoneOwnsSubnet {
+	if !zoneOwnsSubnet {
 		shouldRelease, err = shouldReleasePodIPs()
 	} else {
 		shouldRelease, err = bnc.lsManager.ConditionalIPRelease(switchName, podIfAddrs, shouldReleasePodIPs)


### PR DESCRIPTION
pprof during CUDN scale cleanup showed high CPU on every worker node in findPodWithIPAddresses, which scans all cluster pods with full JSON annotation unmarshal to detect IP collisions before releasing IPs. For L2/localnet topologies this is dead work: cluster-manager owns IPAM, and the caller in
removePodForUserDefinedNetwork already skips releasePodIPs when allocatesPodAnnotation() is false. The scan result was always discarded.

Skip shouldReleaseDeletedPod entirely when the controller does not own IPAM, and clean up the now-unreachable
allocatesPodAnnotation() condition inside that function.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Pod IP release behavior during pod deletion for improved accuracy in different deployment configurations.
  * Refined IP address release logic to use more appropriate conditions when determining the IP release method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->