### PR TITLE
chore: Fix allocatePodAnnotation() return value

### DIFF
--- a/go-controller/pkg/allocator/pod/pod_annotation.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation.go
@@ -122,14 +122,14 @@ func allocatePodAnnotation(
 	// no id allocation
 	var idAllocator id.NamedAllocator
 
-	allocateToPodWithRollback := func(pod *corev1.Pod) (*corev1.Pod, func(), error) {
+	allocateToPodWithRollback := func(currentPod *corev1.Pod) (*corev1.Pod, func(), error) {
 		var rollback func()
-		pod, podAnnotation, rollback, err = allocatePodAnnotationWithRollback(
+		updatedPod, podAnnotation, rollback, err = allocatePodAnnotationWithRollback(
 			ipAllocator,
 			idAllocator,
 			netInfo,
 			node,
-			pod,
+			currentPod,
 			nadKey,
 			network,
 			claimsReconciler,
@@ -137,7 +137,7 @@ func allocatePodAnnotation(
 			reallocateIP,
 			networkRole,
 		)
-		return pod, rollback, err
+		return updatedPod, rollback, err
 	}
 
 	err = util.UpdatePodWithRetryOrRollback(
@@ -151,7 +151,7 @@ func allocatePodAnnotation(
 		return nil, nil, err
 	}
 
-	return pod, podAnnotation, nil
+	return updatedPod, podAnnotation, nil
 }
 
 // AllocatePodAnnotationWithTunnelID allocates the PodAnnotation which includes
@@ -211,14 +211,14 @@ func allocatePodAnnotationWithTunnelID(
 	podAnnotation *util.PodAnnotation,
 	err error) {
 
-	allocateToPodWithRollback := func(pod *corev1.Pod) (*corev1.Pod, func(), error) {
+	allocateToPodWithRollback := func(currentPod *corev1.Pod) (*corev1.Pod, func(), error) {
 		var rollback func()
-		pod, podAnnotation, rollback, err = allocatePodAnnotationWithRollback(
+		updatedPod, podAnnotation, rollback, err = allocatePodAnnotationWithRollback(
 			ipAllocator,
 			idAllocator,
 			netInfo,
 			node,
-			pod,
+			currentPod,
 			nadKey,
 			network,
 			claimsReconciler,
@@ -226,7 +226,7 @@ func allocatePodAnnotationWithTunnelID(
 			reallocateIP,
 			networkRole,
 		)
-		return pod, rollback, err
+		return updatedPod, rollback, err
 	}
 
 	err = util.UpdatePodWithRetryOrRollback(
@@ -240,7 +240,7 @@ func allocatePodAnnotationWithTunnelID(
 		return nil, nil, err
 	}
 
-	return pod, podAnnotation, nil
+	return updatedPod, podAnnotation, nil
 }
 
 // validateStaticIPRequest checks if a static IP request can be honored when IPAM is enabled for the given network.

--- a/go-controller/pkg/allocator/pod/pod_annotation_test.go
+++ b/go-controller/pkg/allocator/pod/pod_annotation_test.go
@@ -17,6 +17,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/id"
 	ipam "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/ip"
@@ -24,6 +27,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/allocator/mac"
 	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/persistentips"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -119,6 +123,140 @@ func (m *macRegistryStub) Reserve(_ string, mac net.HardwareAddr) error {
 func (m *macRegistryStub) Release(_ string, mac net.HardwareAddr) error {
 	m.releaseMAC = mac
 	return nil
+}
+
+func Test_allocatePodAnnotationReturnsUpdatedPod(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	origFeatureConfig := config.OVNKubernetesFeature
+	origDefaultConfig := config.Default
+	origIPv4Mode := config.IPv4Mode
+	origIPv6Mode := config.IPv6Mode
+	t.Cleanup(func() {
+		config.OVNKubernetesFeature = origFeatureConfig
+		config.Default = origDefaultConfig
+		config.IPv4Mode = origIPv4Mode
+		config.IPv6Mode = origIPv6Mode
+	})
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+	config.IPv4Mode = true
+	config.IPv6Mode = false
+	config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
+		{CIDR: ovntest.MustParseIPNet("10.128.0.0/14"), HostSubnetLength: 24},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "namespace",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+		},
+	}
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	g.Expect(podIndexer.Add(pod)).To(gomega.Succeed())
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"k8s.ovn.org/node-subnets": `{"default":["10.128.0.0/24"]}`,
+			},
+		},
+	}
+
+	updatedPod, podAnnotation, err := allocatePodAnnotation(
+		corelisters.NewPodLister(podIndexer),
+		&kube.Kube{KClient: fake.NewSimpleClientset(pod.DeepCopy())},
+		&ipAllocatorStub{nextIPs: ovntest.MustParseIPNets("10.128.0.3/24")},
+		&util.DefaultNetInfo{},
+		node,
+		pod,
+		types.DefaultNetworkName,
+		nil,
+		nil,
+		nil,
+		false,
+		types.NetworkRolePrimary,
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(updatedPod).NotTo(gomega.BeNil())
+	g.Expect(podAnnotation.MAC).NotTo(gomega.BeNil())
+	g.Expect(pod.Annotations).To(gomega.BeNil())
+
+	updatedPodAnnotation, err := util.UnmarshalPodAnnotation(updatedPod.Annotations, types.DefaultNetworkName)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(util.StringSlice(updatedPodAnnotation.IPs)).To(gomega.Equal(util.StringSlice(podAnnotation.IPs)))
+	g.Expect(updatedPodAnnotation.MAC.String()).To(gomega.Equal(podAnnotation.MAC.String()))
+	g.Expect(updatedPodAnnotation.Role).To(gomega.Equal(podAnnotation.Role))
+}
+
+func Test_allocatePodAnnotationWithTunnelIDReturnsUpdatedPod(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	origFeatureConfig := config.OVNKubernetesFeature
+	t.Cleanup(func() {
+		config.OVNKubernetesFeature = origFeatureConfig
+	})
+	config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+	network := &nadapi.NetworkSelectionElement{
+		Name:      "network",
+		Namespace: "namespace",
+	}
+	nadKey := util.GetNADName(network.Namespace, network.Name)
+	netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{
+		Topology: types.Layer2Topology,
+		NetConf: cnitypes.NetConf{
+			Name: network.Name,
+		},
+		NADName: nadKey,
+		Role:    types.NetworkRolePrimary,
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	initialMAC := net.HardwareAddr{0x0a, 0x58, 0x0a, 0x80, 0x00, 0x02}
+	podAnnotations, err := util.MarshalPodAnnotation(nil, &util.PodAnnotation{
+		MAC: initialMAC,
+	}, nadKey)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pod",
+			Namespace:   "namespace",
+			Annotations: podAnnotations,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+		},
+	}
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	g.Expect(podIndexer.Add(pod)).To(gomega.Succeed())
+
+	updatedPod, podAnnotation, err := allocatePodAnnotationWithTunnelID(
+		corelisters.NewPodLister(podIndexer),
+		&kube.Kube{KClient: fake.NewSimpleClientset(pod.DeepCopy())},
+		nil,
+		&idAllocatorStub{nextID: 100},
+		netInfo,
+		&corev1.Node{},
+		pod,
+		nadKey,
+		network,
+		nil,
+		nil,
+		false,
+		types.NetworkRolePrimary,
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(updatedPod).NotTo(gomega.BeNil())
+	g.Expect(podAnnotation.TunnelID).To(gomega.Equal(100))
+
+	updatedPodAnnotation, err := util.UnmarshalPodAnnotation(updatedPod.Annotations, nadKey)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(updatedPodAnnotation).To(gomega.Equal(podAnnotation))
+	g.Expect(updatedPodAnnotation.TunnelID).To(gomega.Equal(100))
 }
 
 func Test_allocatePodAnnotationWithRollback(t *testing.T) {

--- a/go-controller/pkg/util/pod.go
+++ b/go-controller/pkg/util/pod.go
@@ -47,17 +47,17 @@ func UpdatePodWithRetryOrRollback(podLister listers.PodLister, kube kube.Interfa
 		}
 
 		// Informer cache should not be mutated, so copy the object
-		pod = oldPod.DeepCopy()
-		pod, rollback, err := allocate(pod)
+		currentPod := oldPod.DeepCopy()
+		updatedPod, rollback, err := allocate(currentPod)
 		if err != nil {
 			return err
 		}
 
-		if pod == nil {
+		if updatedPod == nil {
 			return nil
 		}
 
-		err = kube.PatchPodStatusAnnotations(oldPod, pod)
+		err = kube.PatchPodStatusAnnotations(oldPod, updatedPod)
 		if err != nil && rollback != nil {
 			rollback()
 		}


### PR DESCRIPTION
## 📑 Description
Return the pod produced by annotation allocation instead of the original input pod, so callers receive the object containing the updated annotations. 

The fixed issue only results in extra retries and doesn't affect the final outcome.

## How to verify it
Add a unit test to ensure the return value is correct.  