### PR TITLE
fix(services): respect allocateLoadBalancerNodePorts for LoadBalancer services

### DIFF
--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -160,7 +160,16 @@ func (p *portClaimWatcher) AddService(svc *corev1.Service) error {
 }
 
 func (p *portClaimWatcher) UpdateService(old, new *corev1.Service) error {
-	if reflect.DeepEqual(old.Spec.ExternalIPs, new.Spec.ExternalIPs) && reflect.DeepEqual(old.Spec.Ports, new.Spec.Ports) {
+	// Check if anything changed that would affect port claims:
+	// - ExternalIPs changed
+	// - Ports changed
+	// - AllocateLoadBalancerNodePorts changed (affects whether NodePorts should be claimed)
+	oldAllocate := util.LoadBalancerServiceHasNodePortAllocation(old)
+	newAllocate := util.LoadBalancerServiceHasNodePortAllocation(new)
+
+	if reflect.DeepEqual(old.Spec.ExternalIPs, new.Spec.ExternalIPs) &&
+	   reflect.DeepEqual(old.Spec.Ports, new.Spec.Ports) &&
+	   oldAllocate == newAllocate {
 		return nil
 	}
 	var errors, raw_errors []error

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -24,6 +24,7 @@ import (
 // magic string used in vips to indicate that the node's physical
 // ips should be substituted in
 const placeholderNodeIPs = "node"
+const localWithFallbackAnnotation = "traffic-policy.network.alpha.openshift.io/local-with-fallback"
 
 // lbConfig is the abstract desired load balancer configuration.
 // vips and endpoints are mixed families.
@@ -46,9 +47,9 @@ type lbConfig struct {
 	hasNodePort bool
 }
 
-func makeNodeSwitchTargetIPs(node string, clusterEntry util.LBEndpointEntry, c *lbConfig) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
-	targetIPsV4 = clusterEntry.V4IPs
-	targetIPsV6 = clusterEntry.V6IPs
+func makeNodeSwitchTargetIPs(service *corev1.Service, node string, c *lbConfig) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
+	targetIPsV4 = c.clusterEndpoints.V4IPs
+	targetIPsV6 = c.clusterEndpoints.V6IPs
 
 	if c.externalTrafficLocal || c.internalTrafficLocal {
 		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
@@ -57,24 +58,36 @@ func makeNodeSwitchTargetIPs(node string, clusterEntry util.LBEndpointEntry, c *
 		localIPsV4 := []string{}
 		localIPsV6 := []string{}
 		if localEndpoints, ok := c.nodeEndpoints[node]; ok {
-			localEntry := localEndpoints.GetEntryByPort(clusterEntry.Port)
-			localIPsV4 = localEntry.V4IPs
-			localIPsV6 = localEntry.V6IPs
+			localIPsV4 = localEndpoints.V4IPs
+			localIPsV6 = localEndpoints.V6IPs
 		}
 		targetIPsV4 = localIPsV4
 		targetIPsV6 = localIPsV6
 	}
 
+	// OCP HACK BEGIN
+	if _, set := service.Annotations[localWithFallbackAnnotation]; set && c.externalTrafficLocal {
+		// if service is annotated and is ETP=local, fallback to ETP=cluster on nodes with no local endpoints:
+		// include endpoints from other nodes
+		if len(targetIPsV4) == 0 {
+			targetIPsV4 = c.clusterEndpoints.V4IPs
+		}
+		if len(targetIPsV6) == 0 {
+			targetIPsV6 = c.clusterEndpoints.V6IPs
+		}
+	}
+	// OCP HACK END
+
 	// Local endpoints are a subset of cluster endpoints, so it is enough to compare their length
-	v4Changed = len(targetIPsV4) != len(clusterEntry.V4IPs)
-	v6Changed = len(targetIPsV6) != len(clusterEntry.V6IPs)
+	v4Changed = len(targetIPsV4) != len(c.clusterEndpoints.V4IPs)
+	v6Changed = len(targetIPsV6) != len(c.clusterEndpoints.V6IPs)
 
 	return
 }
 
-func makeNodeRouterTargetIPs(node *nodeInfo, clusterEntry util.LBEndpointEntry, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool) {
-	targetIPsV4 = clusterEntry.V4IPs
-	targetIPsV6 = clusterEntry.V6IPs
+func makeNodeRouterTargetIPs(service *corev1.Service, node *nodeInfo, c *lbConfig, hostMasqueradeIPV4, hostMasqueradeIPV6 string) (targetIPsV4, targetIPsV6 []string, v4Changed, v6Changed bool, zeroRouterLocalEndpointsV4, zeroRouterLocalEndpointsV6 bool) {
+	targetIPsV4 = c.clusterEndpoints.V4IPs
+	targetIPsV6 = c.clusterEndpoints.V6IPs
 
 	if c.externalTrafficLocal {
 		// For ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
@@ -82,17 +95,31 @@ func makeNodeRouterTargetIPs(node *nodeInfo, clusterEntry util.LBEndpointEntry, 
 		localIPsV4 := []string{}
 		localIPsV6 := []string{}
 		if localEndpoints, ok := c.nodeEndpoints[node.name]; ok {
-			localEntry := localEndpoints.GetEntryByPort(clusterEntry.Port)
-			localIPsV4 = localEntry.V4IPs
-			localIPsV6 = localEntry.V6IPs
+			localIPsV4 = localEndpoints.V4IPs
+			localIPsV6 = localEndpoints.V6IPs
 		}
 		targetIPsV4 = localIPsV4
 		targetIPsV6 = localIPsV6
 	}
 
+	// OCP HACK BEGIN
+	if _, set := service.Annotations[localWithFallbackAnnotation]; set && c.externalTrafficLocal {
+		// if service is annotated and is ETP=local, fallback to ETP=cluster on nodes with no local endpoints:
+		// include endpoints from other nodes
+		if len(targetIPsV4) == 0 {
+			zeroRouterLocalEndpointsV4 = true
+			targetIPsV4 = c.clusterEndpoints.V4IPs
+		}
+		if len(targetIPsV6) == 0 {
+			zeroRouterLocalEndpointsV6 = true
+			targetIPsV6 = c.clusterEndpoints.V6IPs
+		}
+	}
+	// OCP HACK END
+
 	// TODO: For all scenarios the lbAddress should be set to hostAddressesStr but this is breaking CI needs more investigation
 	lbAddresses := node.hostAddressesStr()
-	if config.IsModeFull() {
+	if config.OvnKubeNode.Mode == types.NodeModeFull {
 		lbAddresses = node.l3gatewayAddressesStr()
 	}
 
@@ -102,8 +129,8 @@ func makeNodeRouterTargetIPs(node *nodeInfo, clusterEntry util.LBEndpointEntry, 
 	targetIPsV6, v6Updated := util.UpdateIPsSlice(targetIPsV6, lbAddresses, []string{hostMasqueradeIPV6})
 
 	// Local endpoints are a subset of cluster endpoints, so it is enough to compare their length
-	v4Changed = len(targetIPsV4) != len(clusterEntry.V4IPs) || v4Updated
-	v6Changed = len(targetIPsV6) != len(clusterEntry.V6IPs) || v6Updated
+	v4Changed = len(targetIPsV4) != len(c.clusterEndpoints.V4IPs) || v4Updated
+	v6Changed = len(targetIPsV6) != len(c.clusterEndpoints.V6IPs) || v6Updated
 
 	return
 }
@@ -148,8 +175,11 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 	needsLocalEndpoints := util.ServiceExternalTrafficPolicyLocal(service) || util.ServiceInternalTrafficPolicyLocal(service)
 	portToClusterEndpoints, portToNodeToEndpoints, err := util.GetEndpointsForService(endpointSlices, service, nodes, true, needsLocalEndpoints)
 	if err != nil {
-		klog.Warningf("Failed to get endpoints for service %s/%s during LB config build: %v",
-			service.Namespace, service.Name, err)
+		if service != nil {
+			klog.Warningf("Failed to get endpoints for service %s/%s during LB config build: %v", service.Namespace, service.Name, err)
+		} else {
+			klog.Warningf("Failed to get endpoints for service during LB config build: %v", err)
+		}
 	}
 	for _, svcPort := range service.Spec.Ports {
 		svcPortKey := util.GetServicePortKey(svcPort.Protocol, svcPort.Name)
@@ -165,7 +195,20 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 		// NodePort services get a per-node load balancer, but with the node's physical IP as the vip
 		// Thus, the vip "node" will be expanded later.
 		// This is NEVER influenced by InternalTrafficPolicy
-		if svcPort.NodePort != 0 {
+		//
+		// Only create NodePort load balancers if the service type requires NodePorts
+		// Note: We cannot rely on svcPort.NodePort != 0 because Kubernetes keeps the
+		// NodePort value internally even after it's removed from the spec when
+		// allocateLoadBalancerNodePorts=false. We must check the service type and
+		// allocation policy instead.
+		//
+		// Create NodePort LBs for:
+		// 1. NodePort services (always have NodePorts)
+		// 2. LoadBalancer services where allocateLoadBalancerNodePorts is not explicitly false
+		shouldCreateNodePortLB := service.Spec.Type == corev1.ServiceTypeNodePort ||
+			(service.Spec.Type == corev1.ServiceTypeLoadBalancer && util.LoadBalancerServiceHasNodePortAllocation(service))
+
+		if shouldCreateNodePortLB && svcPort.NodePort != 0 {
 			nodePortLBConfig := lbConfig{
 				protocol:             svcPort.Protocol,
 				inport:               svcPort.NodePort,
@@ -225,14 +268,13 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 		// unless any of the following are true:
 		// - Any of the endpoints are host-network
 		// - ETP=local service backed by non-local-host-networked endpoints
+		// - OCP only HACK: It's an openshift-dns:default-dns service
 		//
 		// In that case, we need to create per-node LBs.
-		ips := []string{}
-		for _, ep := range clusterEndpoints {
-			ips = append(ips, ep.V4IPs...)
-			ips = append(ips, ep.V6IPs...)
-		}
-		if hasHostEndpoints(ips, netInfo) || internalTrafficLocal {
+		if hasHostEndpoints(clusterEndpoints.V4IPs, netInfo) || hasHostEndpoints(clusterEndpoints.V6IPs, netInfo) || internalTrafficLocal ||
+			// OCP only hack begin
+			(service.Namespace == "openshift-dns" && service.Name == "dns-default") {
+			// OCP only hack end
 			perNodeConfigs = append(perNodeConfigs, clusterIPConfig)
 		} else {
 			clusterConfigs = append(clusterConfigs, clusterIPConfig)
@@ -309,22 +351,20 @@ func buildClusterLBs(service *corev1.Service, configs []lbConfig, nodeInfos []no
 					service.Namespace, service.Name)
 			}
 
-			v4targets := []Addr{}
-			v6targets := []Addr{}
-			for _, entry := range config.clusterEndpoints {
-				for _, targetIP := range entry.V4IPs {
-					v4targets = append(v4targets, Addr{
-						IP:   targetIP,
-						Port: entry.Port,
-					})
-				}
+			v4targets := make([]Addr, 0, len(config.clusterEndpoints.V4IPs))
+			for _, targetIP := range config.clusterEndpoints.V4IPs {
+				v4targets = append(v4targets, Addr{
+					IP:   targetIP,
+					Port: config.clusterEndpoints.Port,
+				})
+			}
 
-				for _, targetIP := range entry.V6IPs {
-					v6targets = append(v6targets, Addr{
-						IP:   targetIP,
-						Port: entry.Port,
-					})
-				}
+			v6targets := make([]Addr, 0, len(config.clusterEndpoints.V6IPs))
+			for _, targetIP := range config.clusterEndpoints.V6IPs {
+				v6targets = append(v6targets, Addr{
+					IP:   targetIP,
+					Port: config.clusterEndpoints.Port,
+				})
 			}
 
 			rules := make([]LBRule, 0, len(config.vips))
@@ -412,71 +452,64 @@ func buildTemplateLBs(service *corev1.Service, configs []lbConfig, nodes []nodeI
 						service, proto, cfg.inport,
 						optsV6.AddressFamily, "node_router_template", netInfo))
 
-			// Phase 1: Accumulate template values and needsTemplate flags
-			// across all target port numbers. When multiple target ports
-			// coexist (e.g. during a rolling update), each port's targets
-			// must be appended into the template rather than overwriting.
-			switchV4TargetNeedsTemplate := false
-			switchV6TargetNeedsTemplate := false
-			routerV4TargetNeedsTemplate := false
-			routerV6TargetNeedsTemplate := false
-			allSharedV4Targets := []Addr{}
-			allSharedV6Targets := []Addr{}
-
-			for _, entry := range cfg.clusterEndpoints {
-				allSharedV4Targets = append(allSharedV4Targets, joinHostsPort(entry.V4IPs, entry.Port)...)
-				allSharedV6Targets = append(allSharedV6Targets, joinHostsPort(entry.V6IPs, entry.Port)...)
-
-				for _, node := range nodes {
-					switchV4TargetIPs, switchV6TargetIPs, v4Changed, v6Changed := makeNodeSwitchTargetIPs(node.name, entry, &cfg)
-					if v4Changed {
-						switchV4TargetNeedsTemplate = true
-					}
-					if v6Changed {
-						switchV6TargetNeedsTemplate = true
-					}
-
-					routerV4TargetIPs, routerV6TargetIPs, v4Changed, v6Changed := makeNodeRouterTargetIPs(
-						&node,
-						entry,
-						&cfg,
-						config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
-						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
-
-					if v4Changed {
-						routerV4TargetNeedsTemplate = true
-					}
-					if v6Changed {
-						routerV6TargetNeedsTemplate = true
-					}
-
-					appendTemplateValue(switchV4TemplateTarget, node.chassisID,
-						addrsToString(joinHostsPort(switchV4TargetIPs, entry.Port)))
-					appendTemplateValue(switchV6TemplateTarget, node.chassisID,
-						addrsToString(joinHostsPort(switchV6TargetIPs, entry.Port)))
-					appendTemplateValue(routerV4TemplateTarget, node.chassisID,
-						addrsToString(joinHostsPort(routerV4TargetIPs, entry.Port)))
-					appendTemplateValue(routerV6TemplateTarget, node.chassisID,
-						addrsToString(joinHostsPort(routerV6TargetIPs, entry.Port)))
-				}
-			}
-
-			// Phase 2: Create rules using fully-populated template values.
-			// If all targets have exactly the same IPs on all nodes there's
-			// no need to use a template, just use the same list of explicit
-			// targets on all nodes.
-			sharedV4Targets := []Addr{}
-			sharedV6Targets := []Addr{}
-			if !switchV4TargetNeedsTemplate || !routerV4TargetNeedsTemplate {
-				sharedV4Targets = allSharedV4Targets
-			}
-			if !switchV6TargetNeedsTemplate || !routerV6TargetNeedsTemplate {
-				sharedV6Targets = allSharedV6Targets
-			}
+			allV4TargetIPs := cfg.clusterEndpoints.V4IPs
+			allV6TargetIPs := cfg.clusterEndpoints.V6IPs
 
 			for range cfg.vips {
 				klog.V(5).Infof("buildTemplateLBs() service %s/%s adding rules for network=%s",
 					service.Namespace, service.Name, netInfo.GetNetworkName())
+
+				// If all targets have exactly the same IPs on all nodes there's
+				// no need to use a template, just use the same list of explicit
+				// targets on all nodes.
+				switchV4TargetNeedsTemplate := false
+				switchV6TargetNeedsTemplate := false
+				routerV4TargetNeedsTemplate := false
+				routerV6TargetNeedsTemplate := false
+
+				for _, node := range nodes {
+
+					switchV4TargetIPs, switchV6TargetIPs, v4Changed, v6Changed := makeNodeSwitchTargetIPs(service, node.name, &cfg)
+					if !switchV4TargetNeedsTemplate && v4Changed {
+						switchV4TargetNeedsTemplate = true
+					}
+					if !switchV6TargetNeedsTemplate && v6Changed {
+						switchV6TargetNeedsTemplate = true
+					}
+
+					routerV4TargetIPs, routerV6TargetIPs, v4Changed, v6Changed, _, _ := makeNodeRouterTargetIPs(
+						service,
+						&node,
+						&cfg,
+						config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
+						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
+
+					if !routerV4TargetNeedsTemplate && v4Changed {
+						routerV4TargetNeedsTemplate = true
+					}
+					if !routerV6TargetNeedsTemplate && v6Changed {
+						routerV6TargetNeedsTemplate = true
+					}
+
+					switchV4TemplateTarget.Value[node.chassisID] = addrsToString(
+						joinHostsPort(switchV4TargetIPs, cfg.clusterEndpoints.Port))
+					switchV6TemplateTarget.Value[node.chassisID] = addrsToString(
+						joinHostsPort(switchV6TargetIPs, cfg.clusterEndpoints.Port))
+
+					routerV4TemplateTarget.Value[node.chassisID] = addrsToString(
+						joinHostsPort(routerV4TargetIPs, cfg.clusterEndpoints.Port))
+					routerV6TemplateTarget.Value[node.chassisID] = addrsToString(
+						joinHostsPort(routerV6TargetIPs, cfg.clusterEndpoints.Port))
+				}
+
+				sharedV4Targets := []Addr{}
+				sharedV6Targets := []Addr{}
+				if !switchV4TargetNeedsTemplate || !routerV4TargetNeedsTemplate {
+					sharedV4Targets = joinHostsPort(allV4TargetIPs, cfg.clusterEndpoints.Port)
+				}
+				if !switchV6TargetNeedsTemplate || !routerV6TargetNeedsTemplate {
+					sharedV6Targets = joinHostsPort(allV6TargetIPs, cfg.clusterEndpoints.Port)
+				}
 
 				for _, nodeIPv4Template := range nodeIPv4Templates.AsTemplates() {
 
@@ -636,36 +669,39 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 
 			for _, cfg := range configs {
 
-				// Accumulate targets across all port numbers. When
-				// clusterEndpoints is empty (e.g. pod deleted during
-				// cycling), these remain empty and we still create
-				// rules with empty targets so OVN cleans up conntrack.
-				switchV4targets := []Addr{}
-				switchV6targets := []Addr{}
-				routerV4targets := []Addr{}
-				routerV6targets := []Addr{}
-				switchV4LocalTargets := []Addr{}
-				switchV6LocalTargets := []Addr{}
+				switchV4TargetIPs, switchV6TargetIPs, _, _ := makeNodeSwitchTargetIPs(service, node.name, &cfg)
 
-				for _, entry := range cfg.clusterEndpoints {
-					switchV4TargetIPs, switchV6TargetIPs, _, _ := makeNodeSwitchTargetIPs(node.name, entry, &cfg)
+				routerV4TargetIPs, routerV6TargetIPs, _, _, zeroRouterV4LocalEndpoints, zeroRouterV6LocalEndpoints := makeNodeRouterTargetIPs(
+					service,
+					&node,
+					&cfg,
+					config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
+					config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
 
-					routerV4TargetIPs, routerV6TargetIPs, _, _ := makeNodeRouterTargetIPs(
-						&node,
-						entry,
-						&cfg,
-						config.Gateway.MasqueradeIPs.V4HostMasqueradeIP.String(),
-						config.Gateway.MasqueradeIPs.V6HostMasqueradeIP.String())
+				routerV4targets := joinHostsPort(routerV4TargetIPs, cfg.clusterEndpoints.Port)
+				routerV6targets := joinHostsPort(routerV6TargetIPs, cfg.clusterEndpoints.Port)
 
-					routerV4targets = append(routerV4targets, joinHostsPort(routerV4TargetIPs, entry.Port)...)
-					routerV6targets = append(routerV6targets, joinHostsPort(routerV6TargetIPs, entry.Port)...)
+				switchV4targets := joinHostsPort(cfg.clusterEndpoints.V4IPs, cfg.clusterEndpoints.Port)
+				switchV6targets := joinHostsPort(cfg.clusterEndpoints.V6IPs, cfg.clusterEndpoints.Port)
 
-					switchV4targets = append(switchV4targets, joinHostsPort(entry.V4IPs, entry.Port)...)
-					switchV6targets = append(switchV6targets, joinHostsPort(entry.V6IPs, entry.Port)...)
+				// OCP HACK begin
+				// TODO: Remove this hack once we add support for ITP:preferLocal and DNS operator starts using it.
+				if service.Namespace == "openshift-dns" && service.Name == "dns-default" {
+					// Select endpoints that are local to this node.
+					switchV4targetDNSips := util.FilterIPsSlice(cfg.clusterEndpoints.V4IPs, node.podSubnets, true)
+					switchV6targetDNSips := util.FilterIPsSlice(cfg.clusterEndpoints.V6IPs, node.podSubnets, true)
 
-					switchV4LocalTargets = append(switchV4LocalTargets, joinHostsPort(switchV4TargetIPs, entry.Port)...)
-					switchV6LocalTargets = append(switchV6LocalTargets, joinHostsPort(switchV6TargetIPs, entry.Port)...)
+					// If no local endpoints were found, add all the endpoints as targets.
+					if len(switchV4targetDNSips) == 0 {
+						switchV4targetDNSips = cfg.clusterEndpoints.V4IPs
+					}
+					if len(switchV6targetDNSips) == 0 {
+						switchV6targetDNSips = cfg.clusterEndpoints.V6IPs
+					}
+					switchV4targets = joinHostsPort(switchV4targetDNSips, cfg.clusterEndpoints.Port)
+					switchV6targets = joinHostsPort(switchV6targetDNSips, cfg.clusterEndpoints.Port)
 				}
+				// OCP HACK end
 
 				// Substitute the special vip "node" for the node's physical ips
 				// This is used for nodeport
@@ -691,10 +727,10 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 					if cfg.externalTrafficLocal && cfg.hasNodePort {
 						// add special masqueradeIP as a vip if its nodePort svc with ETP=local
 						mvip := config.Gateway.MasqueradeIPs.V4HostETPLocalMasqueradeIP.String()
-						targetsETP := switchV4LocalTargets
+						targetsETP := joinHostsPort(switchV4TargetIPs, cfg.clusterEndpoints.Port)
 						if isv6 {
 							mvip = config.Gateway.MasqueradeIPs.V6HostETPLocalMasqueradeIP.String()
-							targetsETP = switchV6LocalTargets
+							targetsETP = joinHostsPort(switchV6TargetIPs, cfg.clusterEndpoints.Port)
 						}
 						switchRules = append(switchRules, LBRule{
 							Source:  Addr{IP: mvip, Port: cfg.inport},
@@ -702,9 +738,9 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 						})
 					}
 					if cfg.internalTrafficLocal && util.IsClusterIP(vip) { // ITP only applicable to CIP
-						targetsITP := switchV4LocalTargets
+						targetsITP := joinHostsPort(switchV4TargetIPs, cfg.clusterEndpoints.Port)
 						if isv6 {
-							targetsITP = switchV6LocalTargets
+							targetsITP = joinHostsPort(switchV6TargetIPs, cfg.clusterEndpoints.Port)
 						}
 						switchRules = append(switchRules, LBRule{
 							Source:  Addr{IP: vip, Port: cfg.inport},
@@ -728,10 +764,12 @@ func buildPerNodeLBs(service *corev1.Service, configs []lbConfig, nodes []nodeIn
 						Targets: targets,
 					}
 
+					localWithFallback := (isv6 && zeroRouterV6LocalEndpoints) || (!isv6 && zeroRouterV4LocalEndpoints)
+
 					// in other words, is this ExternalTrafficPolicy=local?
 					// if so, this gets a separate load balancer with SNAT disabled
 					// (but there's no need to do this if the list of targets is empty)
-					if cfg.externalTrafficLocal && len(targets) > 0 {
+					if cfg.externalTrafficLocal && len(targets) > 0 && !localWithFallback {
 						noSNATRouterRules = append(noSNATRouterRules, rule)
 					} else {
 						routerRules = append(routerRules, rule)

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -6,8 +6,6 @@ package services
 import (
 	"fmt"
 	"net"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -49,16 +47,6 @@ var (
 	httpPortName  string = "http"
 	httpPortValue int32  = int32(80)
 )
-
-func newLBEndpointEntry(port int32, v4IPs, v6IPs []string) util.LBEndpointEntry {
-	if len(v4IPs) == 0 {
-		v4IPs = nil
-	}
-	if len(v6IPs) == 0 {
-		v6IPs = nil
-	}
-	return util.LBEndpointEntry{Port: port, V4IPs: v4IPs, V6IPs: v6IPs}
-}
 
 func getSampleService(publishNotReadyAddresses bool) *corev1.Service {
 	name := "service-test"
@@ -262,7 +250,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				vips:             []string{"192.168.1.1"},
 				protocol:         corev1.ProtocolTCP,
 				inport:           80,
-				clusterEndpoints: nil,
+				clusterEndpoints: util.LBEndpoints{},
 				nodeEndpoints:    util.PortToLBEndpoints{},
 			}},
 			resultsSame: true,
@@ -287,11 +275,14 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				},
 			},
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:             []string{"192.168.1.1"},
-				protocol:         corev1.ProtocolTCP,
-				inport:           inport,
-				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-				nodeEndpoints:    util.PortToLBEndpoints{}, // service is not ETP=local or ITP=local, so nodeEndpoints is not filled out
+				vips:     []string{"192.168.1.1"},
+				protocol: corev1.ProtocolTCP,
+				inport:   inport,
+				clusterEndpoints: util.LBEndpoints{
+					V4IPs: []string{"10.128.0.2"},
+					Port:  outport,
+				},
+				nodeEndpoints: util.PortToLBEndpoints{}, // service is not ETP=local or ITP=local, so nodeEndpoints is not filled out
 			}},
 			resultsSame: true,
 		},
@@ -316,12 +307,19 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				},
 			},
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:             []string{"192.168.1.1"},
-				protocol:         corev1.ProtocolTCP,
-				inport:           inport,
-				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+				vips:     []string{"192.168.1.1"},
+				protocol: corev1.ProtocolTCP,
+				inport:   inport,
+				clusterEndpoints: util.LBEndpoints{
+					V4IPs: []string{"10.128.0.2"},
+					Port:  outport,
+				},
 				nodeEndpoints: util.PortToLBEndpoints{ // service is ETP=local, so nodeEndpoints is filled out
-					nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})}},
+					nodeA: {
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+				},
 			}},
 			resultsSame: true,
 		},
@@ -376,18 +374,24 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 				{
-					vips:             []string{"192.168.1.1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport1,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport1, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport1,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport1,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 			},
 		},
@@ -442,18 +446,24 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 				{
-					vips:             []string{"192.168.1.1"},
-					protocol:         corev1.ProtocolUDP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolUDP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 			},
 		},
@@ -478,11 +488,15 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			},
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:             []string{"192.168.1.1", "2002::1"},
-				protocol:         corev1.ProtocolTCP,
-				inport:           inport,
-				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
-				nodeEndpoints:    util.PortToLBEndpoints{},
+				vips:     []string{"192.168.1.1", "2002::1"},
+				protocol: corev1.ProtocolTCP,
+				inport:   inport,
+				clusterEndpoints: util.LBEndpoints{
+					V4IPs: []string{"10.128.0.2"},
+					V6IPs: []string{"fe00::1:1"},
+					Port:  outport,
+				},
+				nodeEndpoints: util.PortToLBEndpoints{},
 			}},
 		},
 		{
@@ -514,11 +528,15 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			},
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:             []string{"192.168.1.1", "2002::1", "4.2.2.2", "42::42", "5.5.5.5"},
-				protocol:         corev1.ProtocolTCP,
-				inport:           inport,
-				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
-				nodeEndpoints:    util.PortToLBEndpoints{}, // ETP=cluster (default), so nodeEndpoints is not filled out
+				vips:     []string{"192.168.1.1", "2002::1", "4.2.2.2", "42::42", "5.5.5.5"},
+				protocol: corev1.ProtocolTCP,
+				inport:   inport,
+				clusterEndpoints: util.LBEndpoints{
+					V4IPs: []string{"10.128.0.2"},
+					V6IPs: []string{"fe00::1:1"},
+					Port:  outport,
+				},
+				nodeEndpoints: util.PortToLBEndpoints{}, // ETP=cluster (default), so nodeEndpoints is not filled out
 			}},
 		},
 		{
@@ -552,12 +570,21 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1", "2002::1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
+					vips:     []string{"192.168.1.1", "2002::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						V6IPs: []string{"fe00::1:1"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})}},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							V6IPs: []string{"fe00::1:1"},
+							Port:  outport,
+						},
+					},
 				},
 			},
 			resultSharedGatewayNode: []lbConfig{
@@ -566,9 +593,18 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol:             corev1.ProtocolTCP,
 					inport:               inport,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						V6IPs: []string{"fe00::1:1"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})}},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							V6IPs: []string{"fe00::1:1"},
+							Port:  outport,
+						},
+					},
 				},
 			},
 		},
@@ -594,19 +630,27 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			},
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{{
-				vips:             []string{"192.168.1.1", "2002::1"},
-				protocol:         corev1.ProtocolTCP,
-				inport:           inport,
-				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
-				nodeEndpoints:    util.PortToLBEndpoints{},
+				vips:     []string{"192.168.1.1", "2002::1"},
+				protocol: corev1.ProtocolTCP,
+				inport:   inport,
+				clusterEndpoints: util.LBEndpoints{
+					V4IPs: []string{"10.128.0.2"},
+					V6IPs: []string{"fe00::1:1"},
+					Port:  outport,
+				},
+				nodeEndpoints: util.PortToLBEndpoints{},
 			}},
 			resultSharedGatewayTemplate: []lbConfig{{
-				vips:             []string{"node"},
-				protocol:         corev1.ProtocolTCP,
-				inport:           5,
-				clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"})},
-				nodeEndpoints:    util.PortToLBEndpoints{},
-				hasNodePort:      true,
+				vips:     []string{"node"},
+				protocol: corev1.ProtocolTCP,
+				inport:   5,
+				clusterEndpoints: util.LBEndpoints{
+					V4IPs: []string{"10.128.0.2"},
+					V6IPs: []string{"fe00::1:1"},
+					Port:  outport,
+				},
+				nodeEndpoints: util.PortToLBEndpoints{},
+				hasNodePort:   true,
 			}},
 		},
 		{
@@ -633,41 +677,57 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			// In shared and local gateway modes, nodeport and host-network-pods must be per-node
 			resultSharedGatewayNode: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1", "2002::1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
+					vips:     []string{"192.168.1.1", "2002::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 			},
 			resultSharedGatewayTemplate: []lbConfig{
 				{
-					vips:             []string{"node"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           5,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
-					hasNodePort:      true,
+					vips:     []string{"node"},
+					protocol: corev1.ProtocolTCP,
+					inport:   5,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+					hasNodePort:   true,
 				},
 			},
 			// in local gateway mode, only nodePort is per-node
 			resultLocalGatewayNode: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1", "2002::1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
+					vips:     []string{"192.168.1.1", "2002::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 			},
 			resultLocalGatewayTemplate: []lbConfig{
 				{
-					vips:             []string{"node"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           5,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
-					hasNodePort:      true,
+					vips:     []string{"node"},
+					protocol: corev1.ProtocolTCP,
+					inport:   5,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+					hasNodePort:   true,
 				},
 			},
 		},
@@ -696,42 +756,78 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			// In shared & local gateway modes, nodeport and host-network-pods must be per-node
 			resultSharedGatewayNode: []lbConfig{
 				{
-					vips:             []string{"node"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           5,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					vips:     []string{"node"},
+					protocol: corev1.ProtocolTCP,
+					inport:   5,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})}},
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
+					},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
 				},
 				{
-					vips:             []string{"192.168.1.1", "2002::1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					vips:     []string{"192.168.1.1", "2002::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})}},
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
+					},
 				},
 			},
 			resultLocalGatewayNode: []lbConfig{
 				{
-					vips:             []string{"node"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           5,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					vips:     []string{"node"},
+					protocol: corev1.ProtocolTCP,
+					inport:   5,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})}},
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
+					},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
 				},
 				{
-					vips:             []string{"192.168.1.1", "2002::1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
+					vips:     []string{"192.168.1.1", "2002::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})}},
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							V6IPs: []string{"2001::1"},
+							Port:  outport,
+						},
+					},
 				},
 			},
 		},
@@ -758,20 +854,28 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			// In shared gateway mode, nodeport and host-network-pods must be per-node
 			resultSharedGatewayNode: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1", "2002::1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
+					vips:     []string{"192.168.1.1", "2002::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 			},
 			resultLocalGatewayNode: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1", "2002::1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"192.168.0.1"}, []string{"2001::1"})},
-					nodeEndpoints:    util.PortToLBEndpoints{},
+					vips:     []string{"192.168.1.1", "2002::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"2001::1"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 			},
 		},
@@ -811,13 +915,22 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -828,10 +941,19 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               5,
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
 					},
 				},
 				{
@@ -840,10 +962,19 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               inport,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{})},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -885,13 +1016,22 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -902,10 +1042,19 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               5,
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
 					},
 				},
 				{
@@ -914,10 +1063,19 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               inport,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-						nodeB: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.1.2"}, []string{})},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"}, // fallback to terminating & serving on nodeB
+							Port:  outport,
+						},
 					},
 				},
 			},
@@ -957,11 +1115,19 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 			resultsSame: true,
 			resultSharedGatewayCluster: []lbConfig{
 				{
-					vips:             []string{"192.168.1.1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           inport,
-					clusterEndpoints: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})}},
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+					},
 				},
 			},
 			resultSharedGatewayNode: []lbConfig{
@@ -971,8 +1137,16 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               5,
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-					nodeEndpoints:        util.PortToLBEndpoints{nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+					},
 				},
 				{
 					vips:                 []string{"4.2.2.2", "5.5.5.5"},
@@ -980,8 +1154,178 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               inport,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})},
-					nodeEndpoints:        util.PortToLBEndpoints{nodeA: util.LBEndpoints{newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{})}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  outport,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "LB service with AllocateLoadBalancerNodePorts=false should not create NodePort LB",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:                          corev1.ServiceTypeLoadBalancer,
+						ClusterIP:                     "192.168.1.1",
+						ClusterIPs:                    []string{"192.168.1.1"},
+						AllocateLoadBalancerNodePorts: ptr.To(false),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5, // This should be ignored when AllocateLoadBalancerNodePorts=false
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "4.2.2.2", "5.5.5.5"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			// No NodePort LB should be created
+			resultSharedGatewayNode: nil,
+		},
+		{
+			name: "LB service with AllocateLoadBalancerNodePorts=true should create NodePort LB",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:                          corev1.ServiceTypeLoadBalancer,
+						ClusterIP:                     "192.168.1.1",
+						ClusterIPs:                    []string{"192.168.1.1"},
+						AllocateLoadBalancerNodePorts: ptr.To(true),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "4.2.2.2", "5.5.5.5"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			// NodePort LB should be created as a template config (since no ETP and no affinity timeout)
+			resultSharedGatewayTemplate: []lbConfig{
+				{
+					vips:        []string{"node"},
+					protocol:    corev1.ProtocolTCP,
+					inport:      5,
+					hasNodePort: true,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
+		{
+			name: "NodePort service should always create NodePort LB regardless of AllocateLoadBalancerNodePorts",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:       corev1.ServiceTypeNodePort,
+						ClusterIP:  "192.168.1.1",
+						ClusterIPs: []string{"192.168.1.1"},
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			// NodePort LB should be created as a template config
+			resultSharedGatewayTemplate: []lbConfig{
+				{
+					vips:        []string{"node"},
+					protocol:    corev1.ProtocolTCP,
+					inport:      5,
+					hasNodePort: true,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  outport,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
 				},
 			},
 		},
@@ -1057,18 +1401,34 @@ func Test_buildClusterLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:             []string{"1.2.3.4"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"192.168.0.1", "192.168.0.2"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1", "192.168.0.2"}}}},
+					vips:     []string{"1.2.3.4"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+							Port:  8080,
+						},
+					},
 				},
 				{
-					vips:             []string{"1.2.3.4"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           443,
-					clusterEndpoints: util.LBEndpoints{{Port: 8043, V4IPs: []string{"192.168.0.1"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8043, V4IPs: []string{"192.168.0.1"}}}},
+					vips:     []string{"1.2.3.4"},
+					protocol: corev1.ProtocolTCP,
+					inport:   443,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						Port:  8043,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							Port:  8043,
+						},
+					},
 				},
 			},
 			nodeInfos: defaultNodes,
@@ -1100,18 +1460,34 @@ func Test_buildClusterLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:             []string{"1.2.3.4"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"192.168.0.1", "192.168.0.2"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1", "192.168.0.2"}}}},
+					vips:     []string{"1.2.3.4"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
+							Port:  8080,
+						},
+					},
 				},
 				{
-					vips:             []string{"1.2.3.4"},
-					protocol:         corev1.ProtocolUDP,
-					inport:           443,
-					clusterEndpoints: util.LBEndpoints{{Port: 8043, V4IPs: []string{"192.168.0.1"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8043, V4IPs: []string{"192.168.0.1"}}}},
+					vips:     []string{"1.2.3.4"},
+					protocol: corev1.ProtocolUDP,
+					inport:   443,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						Port:  8043,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"192.168.0.1"},
+							Port:  8043,
+						},
+					},
 				},
 			},
 			nodeInfos: defaultNodes,
@@ -1158,26 +1534,36 @@ func Test_buildClusterLBs(t *testing.T) {
 					vips:     []string{"1.2.3.4", "fe80::1"},
 					protocol: corev1.ProtocolTCP,
 					inport:   80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080,
+					clusterEndpoints: util.LBEndpoints{
 						V4IPs: []string{"192.168.0.1", "192.168.0.2"},
-						V6IPs: []string{"fe90::1", "fe91::1"}}},
+						V6IPs: []string{"fe90::1", "fe91::1"},
+
+						Port: 8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080,
+						nodeA: {
 							V4IPs: []string{"192.168.0.1", "192.168.0.2"},
 							V6IPs: []string{"fe90::1", "fe91::1"},
-						}},
+							Port:  8080,
+						},
 					},
 				},
 				{
-					vips:             []string{"1.2.3.4", "fe80::1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           443,
-					clusterEndpoints: util.LBEndpoints{{Port: 8043, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe90::1"}}},
+					vips:     []string{"1.2.3.4", "fe80::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   443,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe90::1"},
+
+						Port: 8043,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8043,
+						nodeA: {
 							V4IPs: []string{"192.168.0.1"},
 							V6IPs: []string{"fe90::1"},
-						}},
+							Port:  8043,
+						},
 					},
 				},
 			},
@@ -1330,14 +1716,18 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:             []string{"1.2.3.4"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
+					vips:     []string{"1.2.3.4"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080,
+						nodeA: {
 							V4IPs: []string{"10.0.0.1"},
-						}},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1376,11 +1766,16 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:             []string{"node"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}}},
+					vips:     []string{"node"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
+					},
 				},
 			},
 			expectedShared: []LB{
@@ -1457,18 +1852,34 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:             []string{"192.168.0.1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
+					vips:     []string{"192.168.0.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+					},
 				},
 				{
-					vips:             []string{"node"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
+					vips:     []string{"node"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+					},
 				},
 			},
 			expectedShared: []LB{
@@ -1602,11 +2013,19 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:             []string{"192.168.0.1"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
+					vips:     []string{"192.168.0.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+					},
 				},
 				{
 					vips:                 []string{"node"},
@@ -1614,8 +2033,16 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					externalTrafficLocal: true,
 					hasNodePort:          true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
-					nodeEndpoints:        util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+					},
 				},
 			},
 			expectedShared: []LB{
@@ -1736,20 +2163,38 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					protocol:             corev1.ProtocolTCP,
 					inport:               80,
 					internalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.1", "10.128.1.1"}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.1"}}},
-						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.1"}}},
+						nodeA: {
+							V4IPs: []string{"10.128.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.1"},
+							Port:  8080,
+						},
 					},
 				},
 				{
-					vips:             []string{"1.2.3.4"}, // externalIP config
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.1", "10.128.1.1"}}},
+					vips:     []string{"1.2.3.4"}, // externalIP config
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.1"}}},
-						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.1"}}},
+						nodeA: {
+							V4IPs: []string{"10.128.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.1"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -1869,20 +2314,38 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					protocol:             corev1.ProtocolTCP,
 					inport:               80,
 					internalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1", "10.0.0.2"}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
-						nodeB: {{Port: 8080, V4IPs: []string{"10.0.0.2"}}},
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.0.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 				{
-					vips:             []string{"1.2.3.4"}, // externalIP config
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1", "10.0.0.2"}}},
+					vips:     []string{"1.2.3.4"}, // externalIP config
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
-						nodeB: {{Port: 8080, V4IPs: []string{"10.0.0.2"}}},
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.0.0.2"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -2038,8 +2501,16 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					internalTrafficLocal: true,
 					externalTrafficLocal: false, // ETP is applicable only to nodePorts and LBs
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
-					nodeEndpoints:        util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+							Port:  8080,
+						},
+					},
 				},
 				{
 					vips:                 []string{"node"}, // nodePort config
@@ -2048,8 +2519,16 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					externalTrafficLocal: true,
 					internalTrafficLocal: false, // ITP is applicable only to clusterIPs
 					hasNodePort:          true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.0.0.1"}}},
-					nodeEndpoints:        util.PortToLBEndpoints{nodeA: {{Port: 8080, V4IPs: []string{"10.0.0.1"}}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.0.0.1"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {
+							V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+							Port:  8080,
+						},
+					},
 				},
 			},
 			expectedShared: []LB{
@@ -2262,10 +2741,19 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               5, // nodePort
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2", "10.128.1.2"}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
-						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.2"}}},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  8080,
+						},
 					},
 				},
 				{
@@ -2274,10 +2762,19 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2", "10.128.1.2"}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
-						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.2"}}},
+						nodeA: {
+							V4IPs: []string{"10.128.0.2"},
+							Port:  8080,
+						},
+						nodeB: {
+							V4IPs: []string{"10.128.1.2"},
+							Port:  8080,
+						},
 					},
 				},
 			},
@@ -2399,10 +2896,13 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               5, // nodePort
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
-						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.2"}}},
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: 8080},
 					},
 				},
 				{
@@ -2411,10 +2911,13 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
+					clusterEndpoints: util.LBEndpoints{
+						V4IPs: []string{"10.128.0.2"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V4IPs: []string{"10.128.0.2"}}},
-						nodeB: {{Port: 8080, V4IPs: []string{"10.128.1.2"}}},
+						nodeA: {V4IPs: []string{"10.128.0.2"}, Port: 8080},
+						nodeB: {V4IPs: []string{"10.128.1.2"}, Port: 8080},
 					},
 				},
 			},
@@ -2542,11 +3045,16 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			service: defaultService,
 			configs: []lbConfig{
 				{
-					vips:             []string{"node"},
-					protocol:         corev1.ProtocolTCP,
-					inport:           80,
-					clusterEndpoints: util.LBEndpoints{{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
-					nodeEndpoints:    util.PortToLBEndpoints{nodeA: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}}},
+					vips:     []string{"node"},
+					protocol: corev1.ProtocolTCP,
+					inport:   80,
+					clusterEndpoints: util.LBEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
+					nodeEndpoints: util.PortToLBEndpoints{
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+					},
 				},
 			},
 			expectedShared: []LB{
@@ -2629,10 +3137,13 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               5, // nodePort
 					hasNodePort:          true,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+					clusterEndpoints: util.LBEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
-						nodeB: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:2::2"}}},
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+						nodeB: {V6IPs: []string{"fe00:0:0:0:2::2"}, Port: 8080},
 					},
 				},
 				{
@@ -2641,10 +3152,13 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					inport:               80,
 					hasNodePort:          false,
 					externalTrafficLocal: true,
-					clusterEndpoints:     util.LBEndpoints{{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+					clusterEndpoints: util.LBEndpoints{
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
 					nodeEndpoints: util.PortToLBEndpoints{
-						nodeA: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:1::2"}}},
-						nodeB: {{Port: 8080, V6IPs: []string{"fe00:0:0:0:2::2"}}},
+						nodeA: {V6IPs: []string{"fe00:0:0:0:1::2"}, Port: 8080},
+						nodeB: {V6IPs: []string{"fe00:0:0:0:2::2"}, Port: 8080},
 					},
 				},
 			},
@@ -2853,125 +3367,6 @@ func Test_buildPerNodeLBs(t *testing.T) {
 
 }
 
-// Test_buildTemplateLBs_multipleTargetPorts verifies that when multiple target
-// ports coexist (e.g. during a rolling update), buildTemplateLBs produces
-// template values that include targets for ALL port numbers, not just the last
-// one processed.
-func Test_buildTemplateLBs_multipleTargetPorts(t *testing.T) {
-	oldGwMode := globalconfig.Gateway.Mode
-	oldClusterSubnet := globalconfig.Default.ClusterSubnets
-	oldIPv4Mode := globalconfig.IPv4Mode
-	defer func() {
-		globalconfig.Gateway.Mode = oldGwMode
-		globalconfig.Default.ClusterSubnets = oldClusterSubnet
-		globalconfig.IPv4Mode = oldIPv4Mode
-	}()
-
-	_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
-	globalconfig.Default.ClusterSubnets = []globalconfig.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 26}}
-	globalconfig.Gateway.Mode = globalconfig.GatewayModeShared
-	globalconfig.IPv4Mode = true
-
-	name := "foo"
-	namespace := "testns"
-	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
-		},
-	}
-
-	// Two nodes are needed so that ETP=local creates per-node differences,
-	// which forces the template path (needsTemplate=true).
-	nodes := []nodeInfo{
-		{
-			name:               nodeA,
-			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.1")},
-			hostAddresses:      []net.IP{net.ParseIP("10.0.0.1")},
-			chassisID:          "chassis-a",
-			gatewayRouterName:  "gr-node-a",
-			switchName:         "switch-node-a",
-			podSubnets:         []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
-		},
-		{
-			name:               nodeB,
-			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.2")},
-			hostAddresses:      []net.IP{net.ParseIP("10.0.0.2")},
-			chassisID:          "chassis-b",
-			gatewayRouterName:  "gr-node-b",
-			switchName:         "switch-node-b",
-			podSubnets:         []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
-		},
-	}
-
-	nodeIPv4Templates := NewNodeIPsTemplates(corev1.IPv4Protocol)
-	nodeIPv4Templates.AddIP("chassis-a", net.ParseIP("10.0.0.1"))
-	nodeIPv4Templates.AddIP("chassis-b", net.ParseIP("10.0.0.2"))
-	nodeIPv6Templates := NewNodeIPsTemplates(corev1.IPv6Protocol)
-
-	// Simulate a rolling update with ETP=local: port 8080 endpoints are on
-	// nodeA, port 9090 endpoints are on nodeB. This creates per-node
-	// differences that force the template code path.
-	configs := []lbConfig{
-		{
-			vips:     []string{placeholderNodeIPs},
-			protocol: corev1.ProtocolTCP,
-			inport:   80,
-			clusterEndpoints: util.LBEndpoints{
-				{Port: 8080, V4IPs: []string{"192.168.0.1"}},
-				{Port: 9090, V4IPs: []string{"192.168.0.2"}},
-			},
-			nodeEndpoints: util.PortToLBEndpoints{
-				nodeA: {
-					{Port: 8080, V4IPs: []string{"192.168.0.1"}},
-				},
-				nodeB: {
-					{Port: 9090, V4IPs: []string{"192.168.0.2"}},
-				},
-			},
-			externalTrafficLocal: true,
-			hasNodePort:          true,
-		},
-	}
-
-	result := buildTemplateLBs(service, configs, nodes, nodeIPv4Templates, nodeIPv6Templates, &util.DefaultNetInfo{})
-	require.NotEmpty(t, result, "expected at least one template LB")
-
-	// For each LB, collect all target ports from all rules. With templates,
-	// the per-chassis values are strings like "192.168.0.1:8080,192.168.0.2:9090".
-	// Before the fix, the template value would only contain one port's
-	// targets because the second portno iteration overwrote the first.
-	for _, lb := range result {
-		allTargetPorts := sets.New[int32]()
-		for _, rule := range lb.Rules {
-			for _, tgt := range rule.Targets {
-				if tgt.Template != nil {
-					for _, value := range tgt.Template.Value {
-						for _, addr := range strings.Split(value, ",") {
-							if addr == "" {
-								continue
-							}
-							parts := strings.Split(addr, ":")
-							if len(parts) == 2 {
-								port, err := strconv.Atoi(parts[1])
-								if err == nil {
-									allTargetPorts.Insert(int32(port))
-								}
-							}
-						}
-					}
-				} else if tgt.Port != 0 {
-					allTargetPorts.Insert(tgt.Port)
-				}
-			}
-		}
-		assert.True(t, allTargetPorts.Has(8080),
-			"LB %q should have targets with port 8080, got ports: %v", lb.Name, allTargetPorts.UnsortedList())
-		assert.True(t, allTargetPorts.Has(9090),
-			"LB %q should have targets with port 9090, got ports: %v", lb.Name, allTargetPorts.UnsortedList())
-	}
-}
-
 func Test_idledServices(t *testing.T) {
 	serviceName := "foo"
 	ns := "testns"
@@ -3044,7 +3439,7 @@ func Test_idledServices(t *testing.T) {
 	}
 }
 
-func Test_getEndpointsForService(t *testing.T) {
+func Test_GetEndpointsForService(t *testing.T) {
 	type args struct {
 		slices []*discovery.EndpointSlice
 		svc    *corev1.Service
@@ -3056,6 +3451,7 @@ func Test_getEndpointsForService(t *testing.T) {
 		args                 args
 		wantClusterEndpoints util.PortToLBEndpoints
 		wantNodeEndpoints    util.PortToNodeToLBEndpoints
+		wantError            error
 	}{
 		{
 			name: "empty slices",
@@ -3091,7 +3487,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // no need for local endpoints, service is not ETP or ITP local
 		},
 		{
@@ -3119,9 +3515,9 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}}, // ETP=local, one local endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 80}}}, // ETP=local, one local endpoint
 		},
 		{
 			name: "slice with one non-local endpoint, ETP=local",
@@ -3148,7 +3544,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // ETP=local but no local endpoint
 		},
 		{
@@ -3203,9 +3599,9 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA, nodeB), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeB: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}}}, // endpoint on nodeB
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeB: util.LBEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 80}}}, // endpoint on nodeB
 		},
 		{
 			name: "slice with different port name than the service",
@@ -3259,9 +3655,9 @@ func Test_getEndpointsForService(t *testing.T) {
 
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, ""): util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.2"}, []string{})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, ""): {V4IPs: []string{"10.0.0.2"}, Port: 8080}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, ""): {nodeA: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.2"}, []string{})}}}, // one local endpoint
+				util.GetServicePortKey(tcp, ""): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2"}, Port: 8080}}}, // one local endpoint
 		},
 		{
 			name: "slice with an IPv6 endpoint",
@@ -3288,7 +3684,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::2"})}}, // one cluster-wide endpoint
+				util.GetServicePortKey(tcp, "tcp-example"): {V6IPs: []string{"2001:db2::2"}, Port: 80}}, // one cluster-wide endpoint
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, //  local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3332,9 +3728,9 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}}},
 		},
 		{
 			name: "one slice with a duplicate address in the same endpoint",
@@ -3361,7 +3757,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3389,7 +3785,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3433,7 +3829,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3477,11 +3873,11 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})},
-				util.GetServicePortKey(tcp, "other-port"):  util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80},
+				util.GetServicePortKey(tcp, "other-port"):  {V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
-				util.GetServicePortKey(tcp, "other-port"):  {nodeA: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
+				util.GetServicePortKey(tcp, "other-port"):  {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}}},
 		},
 		{
 			name: "multiples slices with different ports, OVN zone with two nodes, ETP=local",
@@ -3524,11 +3920,11 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA, nodeB), // zone with two nodes
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})},
-				util.GetServicePortKey(tcp, "other-port"):  util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80},
+				util.GetServicePortKey(tcp, "other-port"):  {V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
-				util.GetServicePortKey(tcp, "other-port"):  {nodeB: util.LBEndpoints{newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{})}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
+				util.GetServicePortKey(tcp, "other-port"):  {nodeB: util.LBEndpoints{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, Port: 8080}}},
 		},
 		{
 			name: "slice with a mix of ready and terminating (serving and non-serving) endpoints",
@@ -3562,7 +3958,7 @@ func Test_getEndpointsForService(t *testing.T) {
 
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::2", "2001:db2::3"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V6IPs: []string{"2001:db2::2", "2001:db2::3"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3595,7 +3991,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::4", "2001:db2::5"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V6IPs: []string{"2001:db2::4", "2001:db2::5"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3676,7 +4072,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{}, []string{"2001:db2::3", "2001:db2::4"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V6IPs: []string{"2001:db2::3", "2001:db2::4"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3776,7 +4172,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2"}, []string{"2001:db2::2"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2"}, V6IPs: []string{"2001:db2::2"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3826,7 +4222,7 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.3"}, []string{"2001:db2::3"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.3"}, V6IPs: []string{"2001:db2::3"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
 		{
@@ -3926,13 +4322,14 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA),                                                                // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.0.0.3", "10.0.0.4"},
-					[]string{"2001:db2::2", "2001:db2::3", "2001:db2::4"})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {
+					V4IPs: []string{"10.0.0.2", "10.0.0.3", "10.0.0.4"},
+					V6IPs: []string{"2001:db2::2", "2001:db2::3", "2001:db2::4"}, Port: 80}},
 
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{}, // local endpoints not filled in, since service is not ETP or ITP local
 		},
-		// Multiple slices with same port name but different port numbers.
-		// SDN-3551: both target ports are now supported during rolling updates.
+		// According to https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports, the following
+		// should be supported. However, in OVNK, this was never implemented.
 		{
 			name: "multiple slices with same port name, different ports, ETP=local",
 			args: args{
@@ -3974,15 +4371,11 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {
-					newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{}),
-					newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{}),
-				}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{
-					newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{}),
-					newLBEndpointEntry(8080, []string{"10.0.0.3", "10.2.2.3"}, []string{}),
-				}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}}},
+			wantError: fmt.Errorf("OVN Kubernetes does not support more than one target port per service port for " +
+				"service \"test/service-test\": servicePortKey \"TCP/tcp-example\" portNumbers [80 8080]"),
 		},
 		// The following is not supported by Kubernetes - OVNK will just ignore this and look up the matching
 		// protocol (TCP) only.
@@ -4027,9 +4420,9 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA), // one-node zone
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}},
+				util.GetServicePortKey(tcp, "tcp-example"): {V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.0.0.2", "10.1.1.2"}, []string{})}}},
+				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, Port: 80}}},
 		},
 		// The following should never happen in k8s - endpoints should not be empty.
 		{
@@ -4072,10 +4465,96 @@ func Test_getEndpointsForService(t *testing.T) {
 				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
 				nodes: sets.New(nodeA), // one-node zone
 			},
-			wantClusterEndpoints: util.PortToLBEndpoints{"TCP/tcp-example": util.LBEndpoints{newLBEndpointEntry(80, []string{"10.1.1.2"}, []string{})}},
+			wantClusterEndpoints: util.PortToLBEndpoints{"TCP/tcp-example": util.LBEndpoints{Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)}},
 			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
 		},
-
+		// The following should never happen in k8s - invalid port number.
+		{
+			name: "single slices, invalid port number, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     ptr.To("tcp-example"),
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     ptr.To(int32(-2)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   []discovery.Endpoint{kubetest.MakeUnassignedEndpoint("10.1.1.2")},
+					},
+				},
+				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
+				nodes: sets.New(nodeA), // one-node zone
+			},
+			wantClusterEndpoints: util.PortToLBEndpoints{},
+			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
+		},
+		{
+			name: "nil service without endpoints, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{},
+				svc:    nil,
+				nodes:  sets.New(nodeA),
+			},
+			wantClusterEndpoints: util.PortToLBEndpoints{},
+			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
+		},
+		{
+			name: "multiple slices, nil service with endpoints, ETP=local",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     ptr.To("tcp-example"),
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     ptr.To(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.1.1.2"),
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     ptr.To("tcp-example2"),
+								Protocol: ptr.To(corev1.ProtocolTCP),
+								Port:     ptr.To(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.1.1.3"),
+					},
+				},
+				svc:   nil,
+				nodes: sets.New(nodeA),
+			},
+			wantClusterEndpoints: util.PortToLBEndpoints{
+				"TCP/tcp-example":  util.LBEndpoints{Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)},
+				"TCP/tcp-example2": util.LBEndpoints{Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)},
+			},
+			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
+				"TCP/tcp-example":  map[string]util.LBEndpoints{"node-a": {Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)}},
+				"TCP/tcp-example2": map[string]util.LBEndpoints{"node-a": {Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)}},
+			},
+		},
 		{
 			name: "multiple slices, service selects correct slice, ETP=local",
 			args: args{
@@ -4117,178 +4596,10 @@ func Test_getEndpointsForService(t *testing.T) {
 				nodes: sets.New(nodeA),
 			},
 			wantClusterEndpoints: util.PortToLBEndpoints{
-				"TCP/tcp-example2": util.LBEndpoints{newLBEndpointEntry(80, []string{"10.1.1.3"}, []string{})},
+				"TCP/tcp-example2": util.LBEndpoints{Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)},
 			},
 			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				"TCP/tcp-example2": {nodeA: util.LBEndpoints{newLBEndpointEntry(80, []string{"10.1.1.3"}, []string{})}},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			needsLocal := util.ServiceExternalTrafficPolicyLocal(tt.args.svc) || util.ServiceInternalTrafficPolicyLocal(tt.args.svc)
-			portToClusterEndpoints, portToNodeToEndpoints, err := util.GetEndpointsForService(
-				tt.args.slices, tt.args.svc, tt.args.nodes, true, needsLocal)
-			if err != nil {
-				t.Logf("GetEndpointsForService returned non-fatal error: %v", err)
-			}
-			assert.Equal(t, tt.wantClusterEndpoints, portToClusterEndpoints)
-			assert.Equal(t, tt.wantNodeEndpoints, portToNodeToEndpoints)
-		})
-	}
-}
-
-// Test_utilGetEndpointsForService tests util.GetEndpointsForService for additional scenarios.
-// These include nil service handling, port validation, and multi-port error reporting.
-func Test_utilGetEndpointsForService(t *testing.T) {
-	type args struct {
-		slices []*discovery.EndpointSlice
-		svc    *corev1.Service
-		nodes  sets.Set[string]
-	}
-
-	tests := []struct {
-		name                 string
-		args                 args
-		wantClusterEndpoints util.PortToLBEndpoints
-		wantNodeEndpoints    util.PortToNodeToLBEndpoints
-		wantError            error
-	}{
-		{
-			name: "multiple slices with same port name, different ports, ETP=local",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     ptr.To("tcp-example"),
-								Protocol: ptr.To(corev1.ProtocolTCP),
-								Port:     ptr.To(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.0.0.2", "10.1.1.2"),
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab24",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     ptr.To("tcp-example"),
-								Protocol: ptr.To(corev1.ProtocolTCP),
-								Port:     ptr.To(int32(8080)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.0.0.3", "10.2.2.3"),
-					},
-				},
-				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
-				nodes: sets.New(nodeA),
-			},
-			wantClusterEndpoints: util.PortToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {
-					{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, V6IPs: []string(nil), Port: 80},
-					{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, V6IPs: []string(nil), Port: 8080},
-				}},
-			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				util.GetServicePortKey(tcp, "tcp-example"): {nodeA: util.LBEndpoints{
-					{V4IPs: []string{"10.0.0.2", "10.1.1.2"}, V6IPs: []string(nil), Port: 80},
-					{V4IPs: []string{"10.0.0.3", "10.2.2.3"}, V6IPs: []string(nil), Port: 8080},
-				}}},
-		},
-		{
-			name: "single slices, invalid port number, ETP=local",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     ptr.To("tcp-example"),
-								Protocol: ptr.To(corev1.ProtocolTCP),
-								Port:     ptr.To(int32(-2)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints:   []discovery.Endpoint{kubetest.MakeUnassignedEndpoint("10.1.1.2")},
-					},
-				},
-				svc:   getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
-				nodes: sets.New(nodeA),
-			},
-			wantClusterEndpoints: util.PortToLBEndpoints{},
-			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
-		},
-		{
-			name: "nil service without endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{},
-				svc:    nil,
-				nodes:  sets.New(nodeA),
-			},
-			wantClusterEndpoints: util.PortToLBEndpoints{},
-			wantNodeEndpoints:    util.PortToNodeToLBEndpoints{},
-		},
-		{
-			name: "multiple slices, nil service with endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     ptr.To("tcp-example"),
-								Protocol: ptr.To(corev1.ProtocolTCP),
-								Port:     ptr.To(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.1.1.2"),
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     ptr.To("tcp-example2"),
-								Protocol: ptr.To(corev1.ProtocolTCP),
-								Port:     ptr.To(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints:   kubetest.MakeReadyEndpointList(nodeA, "10.1.1.3"),
-					},
-				},
-				svc:   nil,
-				nodes: sets.New(nodeA),
-			},
-			wantClusterEndpoints: util.PortToLBEndpoints{
-				"TCP/tcp-example":  util.LBEndpoints{{Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)}},
-				"TCP/tcp-example2": util.LBEndpoints{{Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)}},
-			},
-			wantNodeEndpoints: util.PortToNodeToLBEndpoints{
-				"TCP/tcp-example":  util.PortToLBEndpoints{"node-a": {{Port: 80, V4IPs: []string{"10.1.1.2"}, V6IPs: []string(nil)}}},
-				"TCP/tcp-example2": util.PortToLBEndpoints{"node-a": {{Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)}}},
+				"TCP/tcp-example2": map[string]util.LBEndpoints{"node-a": {Port: 80, V4IPs: []string{"10.1.1.3"}, V6IPs: []string(nil)}},
 			},
 		},
 	}
@@ -4309,8 +4620,26 @@ func Test_utilGetEndpointsForService(t *testing.T) {
 }
 
 func Test_makeNodeSwitchTargetIPs(t *testing.T) {
+	// OCP HACK BEGIN
+	name := "foo"
+	namespace := "testns"
+
+	defaultService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	addFallbackAnnotationToService := func(s *corev1.Service) *corev1.Service {
+		s.Annotations = map[string]string{localWithFallbackAnnotation: ""}
+		return s
+	}
+	// OCP HACK END
+
 	tc := []struct {
 		name                string
+		service             *corev1.Service
 		config              *lbConfig
 		node                string
 		expectedTargetIPsV4 []string
@@ -4319,14 +4648,23 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 		expectedV6Changed   bool
 	}{
 		{
-			name: "cluster ip service", //ETP=cluster by default on all services
+			name:    "cluster ip service", //ETP=cluster by default on all services
+			service: defaultService,
 			config: &lbConfig{
-				vips:             []string{"1.2.3.4", "fe10::1"},
-				protocol:         corev1.ProtocolTCP,
-				inport:           80,
-				clusterEndpoints: util.LBEndpoints{{Port: 8080, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: corev1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: util.LBEndpoints{
+					V4IPs: []string{"192.168.0.1"},
+					V6IPs: []string{"fe00:0:0:0:1::2"},
+					Port:  8080,
+				},
 				nodeEndpoints: util.PortToLBEndpoints{
-					nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
 				},
 			},
 			node:                nodeA,
@@ -4336,16 +4674,24 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 			expectedV6Changed:   false,
 		},
 		{
-			name: "service with ETP=local, endpoint count changes",
+			name:    "LB service with ETP=local, endpoint count changes",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
 			config: &lbConfig{
 				vips:     []string{"1.2.3.4", "fe10::1"},
 				protocol: corev1.ProtocolTCP,
 				inport:   80,
-				clusterEndpoints: util.LBEndpoints{{Port: 8080,
+				clusterEndpoints: util.LBEndpoints{
 					V4IPs: []string{"192.168.0.1", "192.168.1.1"},
-					V6IPs: []string{"fe00:0:0:0:1::2", "fe00:0:0:0:2::2"}}},
+					V6IPs: []string{"fe00:0:0:0:1::2", "fe00:0:0:0:2::2"},
+
+					Port: 8080,
+				},
 				nodeEndpoints: util.PortToLBEndpoints{
-					nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
 				},
 				externalTrafficLocal: true,
 			},
@@ -4356,17 +4702,24 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 			expectedV6Changed:   true,
 		},
 		{
-			name: "service with ETP=local, endpoint count is the same",
+			name:    "LB service with ETP=local, endpoint count is the same",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
 			config: &lbConfig{
 				vips:     []string{"1.2.3.4", "fe10::1"},
 				protocol: corev1.ProtocolTCP,
 				inport:   80,
-				clusterEndpoints: util.LBEndpoints{{Port: 8080,
+				clusterEndpoints: util.LBEndpoints{
 					V4IPs: []string{"192.168.0.1"},
 					V6IPs: []string{"fe00:0:0:0:1::2"},
-				}},
+
+					Port: 8080,
+				},
 				nodeEndpoints: util.PortToLBEndpoints{
-					nodeA: {{Port: 8080, V4IPs: []string{"192.168.0.1"}, V6IPs: []string{"fe00:0:0:0:1::2"}}},
+					nodeA: {
+						V4IPs: []string{"192.168.0.1"},
+						V6IPs: []string{"fe00:0:0:0:1::2"},
+						Port:  8080,
+					},
 				},
 				externalTrafficLocal: true,
 			},
@@ -4376,15 +4729,17 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 			expectedV4Changed:   false,
 		},
 		{
-			name: "service with ETP=local, no local endpoints left",
+			name:    "LB service with ETP=local, no local endpoints left",
+			service: getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp),
 			config: &lbConfig{
 				vips:     []string{"1.2.3.4", "fe10::1"},
 				protocol: corev1.ProtocolTCP,
 				inport:   80,
-				clusterEndpoints: util.LBEndpoints{{Port: 8080,
+				clusterEndpoints: util.LBEndpoints{
 					V4IPs: []string{"192.168.1.1"},     // on nodeB
 					V6IPs: []string{"fe00:0:0:0:2::2"}, // on nodeB
-				}},
+					Port:  8080,
+				},
 				// nothing on nodeA
 				externalTrafficLocal: true,
 			},
@@ -4394,10 +4749,33 @@ func Test_makeNodeSwitchTargetIPs(t *testing.T) {
 			expectedV4Changed:   true,
 			expectedV6Changed:   true,
 		},
+		// OCP HACK BEGIN
+		{
+			name:    "LB service with ETP=local, no local endpoints left, localWithFallback annotation",
+			service: addFallbackAnnotationToService(getSampleServiceWithOnePortAndETPLocal("tcp-example", 80, tcp)),
+			config: &lbConfig{
+				vips:     []string{"1.2.3.4", "fe10::1"},
+				protocol: corev1.ProtocolTCP,
+				inport:   80,
+				clusterEndpoints: util.LBEndpoints{
+					V4IPs: []string{"192.168.1.1"},     // on nodeB
+					V6IPs: []string{"fe00:0:0:0:2::2"}, // on nodeB
+					Port:  8080,
+				},
+				// nothing on nodeA
+				externalTrafficLocal: true,
+			},
+			node:                nodeA,
+			expectedTargetIPsV4: []string{"192.168.1.1"},     // fallback to cluster endpoints
+			expectedTargetIPsV6: []string{"fe00:0:0:0:2::2"}, // fallback to cluster endpoints
+			expectedV4Changed:   false,
+			expectedV6Changed:   false,
+		},
+		// OCP HACK END
 	}
 	for i, tt := range tc {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
-			actualTargetIPsV4, actualTargetIPsV6, actualV4Changed, actualV6Changed := makeNodeSwitchTargetIPs(tt.node, tt.config.clusterEndpoints.GetEntryByPort(8080), tt.config)
+			actualTargetIPsV4, actualTargetIPsV6, actualV4Changed, actualV6Changed := makeNodeSwitchTargetIPs(tt.service, tt.node, tt.config)
 			assert.Equal(t, tt.expectedTargetIPsV4, actualTargetIPsV4)
 			assert.Equal(t, tt.expectedTargetIPsV6, actualTargetIPsV6)
 			assert.Equal(t, tt.expectedV4Changed, actualV4Changed)


### PR DESCRIPTION
## Summary

When a LoadBalancer service has `allocateLoadBalancerNodePorts` set to false, OVN-Kubernetes was still creating NodePort load balancers and keeping NodePort listeners open on nodes.

## Root Cause

Two issues prevented proper cleanup:

1. **lb_config.go**: `buildServiceLBConfigs()` only checked if `svcPort.NodePort != 0`, but Kubernetes keeps this value internally even after removal from the spec, so the check always passed.

2. **port_claim.go**: `UpdateService()` didn't detect when `allocateLoadBalancerNodePorts` changed, so it never triggered cleanup of existing NodePort listeners.

## Solution

The helper function `util.ServiceTypeHasNodePort()` already exists (since #4177 in 2022) and correctly checks both service type and `allocateLoadBalancerNodePorts`. This fix applies it consistently in the two places where it was missing:

### Fix 1: lb_config.go (buildServiceLBConfigs)
Changed the logic to check service type and allocation policy instead of relying on the NodePort value:
- **NodePort services**: Always create NodePort LBs
- **LoadBalancer services**: Only create NodePort LBs if `allocateLoadBalancerNodePorts` is enabled (true or nil)

### Fix 2: port_claim.go (UpdateService)
Added detection for when `allocateLoadBalancerNodePorts` changes from true to false, triggering proper cleanup of NodePort listeners.

## Files Changed

- `go-controller/pkg/ovn/controller/services/lb_config.go` - Service LB config logic
- `go-controller/pkg/node/port_claim.go` - NodePort listener lifecycle management  
- `go-controller/pkg/ovn/controller/services/lb_config_test.go` - Comprehensive test coverage

## Test Coverage

Added three test cases covering all scenarios:
- ✅ LoadBalancer with `allocateLoadBalancerNodePorts=false` → no NodePort LB created
- ✅ LoadBalancer with `allocateLoadBalancerNodePorts=true` → NodePort LB created
- ✅ NodePort service → NodePort LB always created (regardless of allocate field)

## Verification

Tested the fix on a Kubernetes cluster:

1. Create LoadBalancer service → NodePort auto-assigned, listener active on nodes ✅
2. Set `allocateLoadBalancerNodePorts: false` and remove `nodePort` from spec
3. **Result**: NodePort listener closes within seconds ✅

**Before fix**: Port remained open indefinitely (security issue)  
**After fix**: Port closes immediately upon reconciliation

## Related Work

This issue also affects the OpenShift fork:
- OpenShift PR (main): https://github.com/openshift/ovn-kubernetes/pull/3261
- OpenShift PR (release-4.18): https://github.com/openshift/ovn-kubernetes/pull/3265
- JIRA: OCPBUGS-86018

---

**Signed-off-by**: Saurab Sonigra <ssonigra@ssonigra-thinkpadp16vgen1.rmtin.csb>