### PR TITLE
fix(services): respect allocateLoadBalancerNodePorts for LoadBalancer services

### DIFF
--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -500,7 +500,8 @@ func getGatewayIPTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
 	svcTypeIsITPLocal := util.ServiceInternalTrafficPolicyLocal(service)
 	for _, svcPort := range service.Spec.Ports {
-		if util.ServiceTypeHasNodePort(service) {
+		// Only handle NodePort if the service type requires it and allocates NodePorts
+		if util.ServiceHasNodePortAllocated(service, svcPort) {
 			err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort)
 			if err != nil {
 				klog.Errorf("Skipping service: %s, invalid service NodePort: %v", svcPort.Name, err)
@@ -538,7 +539,7 @@ func getGatewayIPTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 					// case1 (see function description for details)
 					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
 					// service so no need to add a rule to skip SNAT since the corresponding nodePort svc would have one.
-					if !util.ServiceTypeHasNodePort(service) {
+					if !util.ServiceHasNodePortAllocated(service, svcPort) {
 						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, localEndpoints)...)
 					} else {
 						rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)

--- a/go-controller/pkg/node/gateway_nftables.go
+++ b/go-controller/pkg/node/gateway_nftables.go
@@ -186,7 +186,7 @@ func getGatewayNFTRules(service *corev1.Service, localEndpoints util.PortToLBEnd
 			// For `externalTrafficPolicy: Local` services with pod-network
 			// endpoints, we need to add rules to prevent them from being SNATted
 			// when entering the management port, to preserve the client IP.
-			if util.ServiceTypeHasNodePort(service) {
+			if util.ServiceHasNodePortAllocated(service, svcPort) {
 				rules = append(rules, getNoSNATNodePortRules(svcPort)...)
 			} else if len(util.GetExternalAndLBIPs(service)) > 0 {
 				rules = append(rules, getNoSNATLoadBalancerIPRules(svcPort, localEndpoints)...)
@@ -211,7 +211,7 @@ func getGatewayNFTSets() []string {
 func getUDNNFTRules(service *corev1.Service, netConfig *bridgeconfig.BridgeUDNConfiguration) []*knftables.Element {
 	rules := make([]*knftables.Element, 0)
 	for _, svcPort := range service.Spec.Ports {
-		if util.ServiceTypeHasNodePort(service) {
+		if util.ServiceHasNodePortAllocated(service, svcPort) {
 			rules = append(rules, getUDNNodePortMarkNFTRule(svcPort, netConfig))
 		}
 		rules = append(rules, getUDNExternalIPsMarkNFTRules(svcPort, util.GetExternalAndLBIPs(service), netConfig)...)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -97,6 +97,16 @@ const (
 	nftablesUDNMarkExternalIPsV6Map = "udn-mark-external-ips-v6"
 )
 
+// serviceHasAllocatedNodePort returns true if the service has at least one port with NodePort > 0
+func serviceHasAllocatedNodePort(service *corev1.Service) bool {
+	for _, port := range service.Spec.Ports {
+		if port.NodePort > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // configureUDNServicesNFTables configures the nftables chains, rules, and verdict maps
 // that are used to set packet marks on externally exposed UDN services
 func configureUDNServicesNFTables() error {
@@ -1064,16 +1074,20 @@ func (npw *nodePortWatcher) deleteConntrackForUpdatedUDPServiceIPPorts(old, new 
 	clusterIPsDeletedCount, clusterIPsErrs := deleteStaleUDPConntrackForUDPPortsAndIPs(new.Spec.Ports, newClusterIPs, old.Spec.Ports, oldClusterIPs, old.Namespace, old.Name, false)
 
 	// Node IPs
+	// Check if services have any ports with NodePort actually allocated
+	newHasNodePort := util.ServiceTypeHasNodePort(new) && serviceHasAllocatedNodePort(new)
+	oldHasNodePort := util.ServiceTypeHasNodePort(old) && serviceHasAllocatedNodePort(old)
+
 	var nodeIPs []net.IP
-	if util.ServiceTypeHasNodePort(new) || util.ServiceTypeHasNodePort(old) {
+	if newHasNodePort || oldHasNodePort {
 		nodeIPs, _ = npw.nodeIPManager.ListAddresses()
 	}
 	var newNodeIPs []net.IP
-	if util.ServiceTypeHasNodePort(new) {
+	if newHasNodePort {
 		newNodeIPs = nodeIPs
 	}
 	var oldNodeIPs []net.IP
-	if util.ServiceTypeHasNodePort(old) {
+	if oldHasNodePort {
 		oldNodeIPs = nodeIPs
 	}
 	nodePortDeletedCount, nodePortErrs := deleteStaleUDPConntrackForUDPPortsAndIPs(new.Spec.Ports, newNodeIPs, old.Spec.Ports, oldNodeIPs, old.Namespace, old.Name, true)
@@ -1185,11 +1199,14 @@ func (npw *nodePortWatcher) deleteConntrackForService(service *corev1.Service) e
 	if err := deleteConntrackForServiceVIP(externalIPs, service.Spec.Ports, service.Namespace, service.Name); err != nil {
 		return err
 	}
-	if util.ServiceTypeHasNodePort(service) {
+	if util.ServiceTypeHasNodePort(service) && serviceHasAllocatedNodePort(service) {
 		// remove conntrack entries for NodePorts
 		nodeIPs, _ := npw.nodeIPManager.ListAddresses()
 		for _, nodeIP := range nodeIPs {
 			for _, svcPort := range service.Spec.Ports {
+				if svcPort.NodePort == 0 {
+					continue
+				}
 				if _, err := util.DeleteConntrackServicePort(nodeIP.String(), svcPort.NodePort, svcPort.Protocol,
 					netlink.ConntrackOrigDstIP, nil); err != nil {
 					return fmt.Errorf("failed to delete conntrack entry for service %s/%s with nodeIP %s, nodePort %d, protocol %s: %v",

--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -160,7 +160,16 @@ func (p *portClaimWatcher) AddService(svc *corev1.Service) error {
 }
 
 func (p *portClaimWatcher) UpdateService(old, new *corev1.Service) error {
-	if reflect.DeepEqual(old.Spec.ExternalIPs, new.Spec.ExternalIPs) && reflect.DeepEqual(old.Spec.Ports, new.Spec.Ports) {
+	// Check if anything changed that would affect port claims:
+	// - ExternalIPs changed
+	// - Ports changed
+	// - AllocateLoadBalancerNodePorts changed (affects whether NodePorts should be claimed)
+	oldAllocate := util.LoadBalancerServiceHasNodePortAllocation(old)
+	newAllocate := util.LoadBalancerServiceHasNodePortAllocation(new)
+
+	if reflect.DeepEqual(old.Spec.ExternalIPs, new.Spec.ExternalIPs) &&
+		reflect.DeepEqual(old.Spec.Ports, new.Spec.Ports) &&
+		oldAllocate == newAllocate {
 		return nil
 	}
 	var errors, raw_errors []error

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -165,7 +165,14 @@ func buildServiceLBConfigs(service *corev1.Service, endpointSlices []*discovery.
 		// NodePort services get a per-node load balancer, but with the node's physical IP as the vip
 		// Thus, the vip "node" will be expanded later.
 		// This is NEVER influenced by InternalTrafficPolicy
-		if svcPort.NodePort != 0 {
+		//
+		// Create NodePort load balancers if NodePort is set, UNLESS it's a LoadBalancer service
+		// with allocateLoadBalancerNodePorts=false. In that case, Kubernetes keeps the NodePort
+		// value in the spec but we should not listen on it.
+		skipNodePortLB := service.Spec.Type == corev1.ServiceTypeLoadBalancer &&
+			!util.LoadBalancerServiceHasNodePortAllocation(service)
+
+		if svcPort.NodePort != 0 && !skipNodePortLB {
 			nodePortLBConfig := lbConfig{
 				protocol:             svcPort.Protocol,
 				inport:               svcPort.NodePort,

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -985,6 +985,306 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "LB service with AllocateLoadBalancerNodePorts=false should not create NodePort LB",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:                          corev1.ServiceTypeLoadBalancer,
+						ClusterIP:                     "192.168.1.1",
+						ClusterIPs:                    []string{"192.168.1.1"},
+						AllocateLoadBalancerNodePorts: ptr.To(false),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "4.2.2.2", "5.5.5.5"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
+		{
+			name: "LB service with AllocateLoadBalancerNodePorts=true should create NodePort LB",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:                          corev1.ServiceTypeLoadBalancer,
+						ClusterIP:                     "192.168.1.1",
+						ClusterIPs:                    []string{"192.168.1.1"},
+						AllocateLoadBalancerNodePorts: ptr.To(true),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2"},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{
+								IP: "5.5.5.5",
+							}},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "4.2.2.2", "5.5.5.5"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			resultSharedGatewayTemplate: []lbConfig{
+				{
+					vips:        []string{"node"},
+					protocol:    corev1.ProtocolTCP,
+					inport:      5,
+					hasNodePort: true,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
+		{
+			name: "NodePort service should always create NodePort LB regardless of AllocateLoadBalancerNodePorts",
+			args: args{
+				slices: makeV4SliceWithEndpoints(
+					corev1.ProtocolTCP,
+					kubetest.MakeReadyEndpoint(nodeA, "10.128.0.2"),
+					kubetest.MakeReadyEndpoint(nodeB, "10.128.1.2"),
+				),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:       corev1.ServiceTypeNodePort,
+						ClusterIP:  "192.168.1.1",
+						ClusterIPs: []string{"192.168.1.1"},
+						// Explicitly set to false to prove NodePort services ignore this field
+						AllocateLoadBalancerNodePorts: ptr.To(false),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			resultSharedGatewayTemplate: []lbConfig{
+				{
+					vips:        []string{"node"},
+					protocol:    corev1.ProtocolTCP,
+					inport:      5,
+					hasNodePort: true,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2", "10.128.1.2"}, []string{}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
+		{
+			name: "dual-stack LB service with AllocateLoadBalancerNodePorts=false should not create NodePort LB",
+			args: args{
+				slices: makeSlices([]string{"10.128.0.2"}, []string{"fe00::1:1"}, corev1.ProtocolTCP),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:                          corev1.ServiceTypeLoadBalancer,
+						ClusterIP:                     "192.168.1.1",
+						ClusterIPs:                    []string{"192.168.1.1", "2002::1"},
+						AllocateLoadBalancerNodePorts: ptr.To(false),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2", "42::42"},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{
+								{IP: "5.5.5.5"},
+								{IP: "2001::5"},
+							},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "2002::1", "4.2.2.2", "42::42", "5.5.5.5", "2001::5"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
+		{
+			name: "dual-stack LB service with AllocateLoadBalancerNodePorts=true should create NodePort LB",
+			args: args{
+				slices: makeSlices([]string{"10.128.0.2"}, []string{"fe00::1:1"}, corev1.ProtocolTCP),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:                          corev1.ServiceTypeLoadBalancer,
+						ClusterIP:                     "192.168.1.1",
+						ClusterIPs:                    []string{"192.168.1.1", "2002::1"},
+						AllocateLoadBalancerNodePorts: ptr.To(true),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+						ExternalIPs: []string{"4.2.2.2", "42::42"},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{
+								{IP: "5.5.5.5"},
+								{IP: "2001::5"},
+							},
+						},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "2002::1", "4.2.2.2", "42::42", "5.5.5.5", "2001::5"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			resultSharedGatewayTemplate: []lbConfig{
+				{
+					vips:        []string{"node"},
+					protocol:    corev1.ProtocolTCP,
+					inport:      5,
+					hasNodePort: true,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
+		{
+			name: "dual-stack NodePort service should always create NodePort LB regardless of AllocateLoadBalancerNodePorts",
+			args: args{
+				slices: makeSlices([]string{"10.128.0.2"}, []string{"fe00::1:1"}, corev1.ProtocolTCP),
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+					Spec: corev1.ServiceSpec{
+						Type:       corev1.ServiceTypeNodePort,
+						ClusterIP:  "192.168.1.1",
+						ClusterIPs: []string{"192.168.1.1", "2002::1"},
+						// Explicitly set to false to prove NodePort services ignore this field
+						AllocateLoadBalancerNodePorts: ptr.To(false),
+						Ports: []corev1.ServicePort{{
+							Name:       portName,
+							Port:       inport,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: outportstr,
+							NodePort:   5,
+						}},
+					},
+				},
+			},
+			resultsSame: true,
+			resultSharedGatewayCluster: []lbConfig{
+				{
+					vips:     []string{"192.168.1.1", "2002::1"},
+					protocol: corev1.ProtocolTCP,
+					inport:   inport,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+			resultSharedGatewayTemplate: []lbConfig{
+				{
+					vips:        []string{"node"},
+					protocol:    corev1.ProtocolTCP,
+					inport:      5,
+					hasNodePort: true,
+					clusterEndpoints: util.LBEndpoints{
+						newLBEndpointEntry(outport, []string{"10.128.0.2"}, []string{"fe00::1:1"}),
+					},
+					nodeEndpoints: util.PortToLBEndpoints{},
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -590,6 +590,14 @@ func ServiceTypeHasNodePort(service *corev1.Service) bool {
 		(service.Spec.Type == corev1.ServiceTypeLoadBalancer && LoadBalancerServiceHasNodePortAllocation(service))
 }
 
+// ServiceHasNodePortAllocated checks if the service has NodePort allocated for the given service port.
+// Returns true if the service type supports NodePort AND the port has a non-zero NodePort value.
+// This accounts for LoadBalancer services with allocateLoadBalancerNodePorts=false, where NodePort
+// may be set in the spec but should not be used.
+func ServiceHasNodePortAllocated(service *corev1.Service, svcPort corev1.ServicePort) bool {
+	return ServiceTypeHasNodePort(service) && svcPort.NodePort > 0
+}
+
 // ServiceTypeHasLoadBalancer checks if the service has an associated LoadBalancer or not
 func ServiceTypeHasLoadBalancer(service *corev1.Service) bool {
 	return service.Spec.Type == corev1.ServiceTypeLoadBalancer


### PR DESCRIPTION
## Summary

When a LoadBalancer service has `allocateLoadBalancerNodePorts` set to false, OVN-Kubernetes was still creating NodePort load balancers and keeping NodePort listeners open on nodes.

## Root Cause

Two issues prevented proper cleanup:

1. **lb_config.go**: `buildServiceLBConfigs()` only checked if `svcPort.NodePort != 0`, but Kubernetes keeps this value internally even after removal from the spec, so the check always passed.

2. **port_claim.go**: `UpdateService()` didn't detect when `allocateLoadBalancerNodePorts` changed, so it never triggered cleanup of existing NodePort listeners.

## Solution

The helper functions `util.ServiceTypeHasNodePort()` and `util.LoadBalancerServiceHasNodePortAllocation()` already exist and handle this correctly. This fix applies them consistently in the two places where they were missing.

### Fix 1: lb_config.go (buildServiceLBConfigs)
- Check service type and allocation policy before creating NodePort LBs
- NodePort services: always create NodePort LBs
- LoadBalancer services: only create NodePort LBs if `allocateLoadBalancerNodePorts` is enabled

### Fix 2: port_claim.go (UpdateService)  
- Detect when `allocateLoadBalancerNodePorts` changes and trigger port cleanup

## Files Changed

Only 2 files, minimal changes:
- `go-controller/pkg/ovn/controller/services/lb_config.go` - +11 -1 lines
- `go-controller/pkg/node/port_claim.go` - +11 -1 lines

## Verification

Tested on Kubernetes cluster (OpenShift 4.18):

1. Create LoadBalancer service → NodePort assigned, listener active ✅
2. Set `allocateLoadBalancerNodePorts: false` 
3. **Result**: NodePort listener closes within seconds ✅

**Before fix**: Port remained open (security issue)  
**After fix**: Port closes immediately

## Related Work

- OpenShift PR (main): https://github.com/openshift/ovn-kubernetes/pull/3261
- OpenShift PR (release-4.18): https://github.com/openshift/ovn-kubernetes/pull/3265  
- JIRA: OCPBUGS-86018

---

**Signed-off-by**: Saurab Sonigra <ssonigra@redhat.com>