### PR TITLE
Prevent POD IP leakage for secondary host EgressIP with nftables

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -858,6 +858,18 @@ func (nc *DefaultNodeNetworkController) Init(ctx context.Context) error {
 	}
 	klog.Infof("Node %s ready for ovn initialization with subnet %s", nc.name, util.JoinIPNets(subnets, ","))
 
+	// Setup nftables chain for secondary host EgressIP protection
+	// Use cluster-wide subnets because traffic from any node can be rerouted to this egress node
+	if config.IsModeDPUHost() || config.IsModeFull() {
+		clusterSubnets := make([]*net.IPNet, 0, len(config.Default.ClusterSubnets))
+		for _, entry := range config.Default.ClusterSubnets {
+			clusterSubnets = append(clusterSubnets, entry.CIDR)
+		}
+		if err := setupSecondaryEgressIPNFTChain(clusterSubnets); err != nil {
+			return fmt.Errorf("failed to setup secondary EgressIP nftables chain: %w", err)
+		}
+	}
+
 	// Create CNI Server
 	if config.IsModeDPUHost() || config.IsModeFull() {
 		kclient, ok := nc.Kube.(*kube.Kube)

--- a/go-controller/pkg/node/node_nftables.go
+++ b/go-controller/pkg/node/node_nftables.go
@@ -6,6 +6,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"net"
 
 	utilnet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
@@ -201,6 +202,67 @@ func setupPMTUDNFTChain() error {
 	err = nft.Run(context.TODO(), tx)
 	if err != nil {
 		return fmt.Errorf("could not update nftables rule for PMTUD: %v", err)
+	}
+	return nil
+}
+
+const nftSecondaryEgressIPChain = "secondary-egressip-check"
+
+// setupSecondaryEgressIPNFTChain sets up nftables chain and rules for secondary host EgressIP.
+// Runs in postrouting after iptables SNAT. Drops packets with SecondaryEgressIPMark that still
+// have source IP from node subnets (indicating SNAT rule was not applied).
+func setupSecondaryEgressIPNFTChain(nodeSubnets []*net.IPNet) error {
+	if len(nodeSubnets) == 0 {
+		return nil
+	}
+
+	nft, err := nodenft.GetNFTablesHelper()
+	if err != nil {
+		return fmt.Errorf("failed to get nftables helper: %w", err)
+	}
+
+	tx := nft.NewTransaction()
+
+	// Create postrouting chain with priority 150 (after iptables NAT at priority 100)
+	tx.Add(&knftables.Chain{
+		Name:     nftSecondaryEgressIPChain,
+		Comment:  knftables.PtrTo("Drop secondary EgressIP packets if SNAT not applied"),
+		Type:     knftables.PtrTo(knftables.FilterType),
+		Hook:     knftables.PtrTo(knftables.PostroutingHook),
+		Priority: knftables.PtrTo(knftables.BaseChainPriority("150")), // After iptables NAT (priority 100)
+	})
+
+	// Flush existing rules
+	tx.Flush(&knftables.Chain{
+		Name: nftSecondaryEgressIPChain,
+	})
+
+	// Add drop rule for each node subnet
+	for _, subnet := range nodeSubnets {
+		if subnet.IP.To4() != nil && config.IPv4Mode {
+			tx.Add(&knftables.Rule{
+				Chain: nftSecondaryEgressIPChain,
+				Rule: knftables.Concat(
+					"meta mark", types.SecondaryEgressIPMark,
+					"ip saddr", subnet.String(),
+					"counter drop",
+				),
+			})
+		} else if subnet.IP.To4() == nil && config.IPv6Mode {
+			tx.Add(&knftables.Rule{
+				Chain: nftSecondaryEgressIPChain,
+				Rule: knftables.Concat(
+					"meta mark", types.SecondaryEgressIPMark,
+					"ip6 saddr", subnet.String(),
+					"counter drop",
+				),
+			})
+		}
+	}
+
+	err = nft.Run(context.TODO(), tx)
+	if err != nil {
+		return fmt.Errorf("failed to setup secondary EgressIP nftables chain: %w", err)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2773,7 +2773,7 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 			if err != nil {
 				return err
 			}
-			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, mark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name)
+			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, mark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name, isOVNNetwork)
 			if err != nil {
 				return fmt.Errorf("unable to create logical router policy ops %v, err: %v", status, err)
 			}
@@ -2795,7 +2795,7 @@ func (e *EgressIPController) addPodEgressIPAssignment(ni util.NetInfo, egressIPN
 	// don't add a reroute policy if the egress node towards which we are adding this doesn't exist
 	if loadedEgressNode && loadedPodNode {
 		if isLocalZonePod || (isLocalZoneEgressNode && ni.IsUserDefinedNetwork() && ni.TopologyType() == types.Layer2Topology) {
-			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, mark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name)
+			ops, err = e.createReroutePolicyOps(ni, ops, podIPs, status, mark, egressIPName, nextHopIP, routerName, pod.Namespace, pod.Name, isOVNNetwork)
 			if err != nil {
 				return fmt.Errorf("unable to create logical router policy ops, err: %v", err)
 			}
@@ -3226,7 +3226,7 @@ func (e *EgressIPController) getNextHop(ni util.NetInfo, egressNodeName, egressI
 // pods to the appropriate management port or transit switch port.
 // This function should be called with lock on nodeZoneState cache key status.Node
 func (e *EgressIPController) createReroutePolicyOps(ni util.NetInfo, ops []ovsdb.Operation, podIPNets []*net.IPNet, status egressipv1.EgressIPStatusItem,
-	mark util.EgressIPMark, egressIPName, nextHopIP, routerName, podNamespace, podName string) ([]ovsdb.Operation, error) {
+	mark util.EgressIPMark, egressIPName, nextHopIP, routerName, podNamespace, podName string, isOVNNetwork bool) ([]ovsdb.Operation, error) {
 	isEgressIPv6 := utilnet.IsIPv6String(status.EgressIP)
 	ipFamily := getEIPIPFamily(isEgressIPv6)
 	options := make(map[string]string)
@@ -3235,6 +3235,10 @@ func (e *EgressIPController) createReroutePolicyOps(ni util.NetInfo, ops []ovsdb
 			return nil, fmt.Errorf("egressIP %s object must contain a mark for user defined networks", egressIPName)
 		}
 		addPktMarkToLRPOptions(options, mark.String())
+	}
+	// Set mark for secondary host EgressIP
+	if !isOVNNetwork {
+		options["pkt_mark"] = types.SecondaryEgressIPMark
 	}
 	dbIDs := getEgressIPLRPReRouteDbIDs(egressIPName, podNamespace, podName, ipFamily, ni.GetNetworkName(), e.controllerName)
 	p := libovsdbops.GetPredicate[*nbdb.LogicalRouterPolicy](dbIDs, nil)

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -158,6 +158,7 @@ const (
 	// Packet marking
 	EgressIPNodeConnectionMark         = "1008"
 	EgressIPReplyTrafficConnectionMark = 42
+	SecondaryEgressIPMark              = "1009" // Mark for secondary host EgressIP to enable nftables protection
 
 	// primary user defined network's default join subnet value
 	// users can configure custom values using NADs

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -38,6 +38,7 @@ import (
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	utilnet "k8s.io/utils/net"
 )
@@ -3063,6 +3064,144 @@ spec:
 			}, 30*time.Second, 2*time.Second).Should(gomega.BeTrue(),
 				"Neighbor entry should appear")
 			gomega.Expect(neighborMAC).Should(gomega.Equal(inf.MAC), "neighbor entry should have the correct MAC address")
+		})
+
+		ginkgo.It("[secondary-host-eip] should prevent pod IP leakage during reconciliation when new pod added to existing EgressIP namespace", func() {
+			if isUserDefinedNetwork(netConfigParams) {
+				ginkgo.Skip("Unsupported for UDNs")
+			}
+
+			const (
+				numStressPods  = 50 // Create many pods to slow down reconciliation
+				triggerPodName = "trigger-pod"
+				podNamePrefix  = "stress-pod"
+			)
+
+			egressIPSecondaryHost := "10.10.10.100"
+			if isIPv6TestRun {
+				egressIPSecondaryHost = "2001:db8:abcd:1234::100"
+			}
+
+			ginkgo.By("Step 0: Set egress node as available for egress")
+			egressNodeAvailabilityHandler := egressNodeAvailabilityHandlerViaLabel{f}
+			egressNodeAvailabilityHandler.Enable(egress1Node.name)
+			defer egressNodeAvailabilityHandler.Restore(egress1Node.name)
+
+			ginkgo.By("Step 1: Label namespace for egress IP selection")
+			podNamespace := f.Namespace
+			namespaceLabels := map[string]string{
+				"egress-test": "true",
+			}
+			updateNamespaceLabels(f, podNamespace, namespaceLabels)
+
+			ginkgo.By(fmt.Sprintf("Step 2: Create %d stress pods and collect their IPs", numStressPods))
+			for i := 0; i < numStressPods; i++ {
+				podName := fmt.Sprintf("%s-%d", podNamePrefix, i)
+				_, err := createGenericPodWithLabel(f, podName, pod1Node.name, f.Namespace.Name,
+					getAgnHostHTTPPortBindFullCMD(clusterNetworkHTTPPort), podEgressLabel)
+				framework.ExpectNoError(err, "failed to create stress pod %s", podName)
+				podIP, err := getPodIPWithRetry(f.ClientSet, isIPv6TestRun, f.Namespace.Name, podName)
+				framework.ExpectNoError(err, "failed to get IP for stress pod %s", podName)
+				framework.Logf("Stress pod %s has IP %s", podName, podIP.String())
+			}
+
+			ginkgo.By("Step 4: Create EgressIP object targeting the namespace and pods")
+			egressIPConfig := `apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: ` + egressIPName + `
+spec:
+    egressIPs:
+    - "` + egressIPSecondaryHost + `"
+    podSelector:
+        matchLabels:
+            wants: egress
+    namespaceSelector:
+        matchLabels:
+            egress-test: "true"
+`
+			framework.ExpectNoError(os.WriteFile(egressIPYaml, []byte(egressIPConfig), 0644),
+				"failed to write EgressIP config")
+			defer func() {
+				if err := os.Remove(egressIPYaml); err != nil {
+					framework.Logf("Unable to remove the EgressIP config from disk: %v", err)
+				}
+			}()
+			e2ekubectl.RunKubectlOrDie("default", "create", "-f", egressIPYaml)
+
+			ginkgo.By("Step 5: Verify EgressIP status is assigned to egress node")
+			statuses := verifyEgressIPStatusLengthEquals(1, nil)
+			gomega.Expect(statuses[0].Node).To(gomega.Equal(egress1Node.name),
+				"EgressIP should be assigned to egress node")
+			gomega.Expect(statuses[0].EgressIP).To(gomega.Equal(egressIPSecondaryHost),
+				"EgressIP should match configured address")
+
+			ginkgo.By("Step 7: Start packet capture on external container BEFORE creating trigger pod")
+			targetIP := secondaryTargetExternalContainer.GetIPv4()
+			if isIPv6TestRun {
+				targetIP = secondaryTargetExternalContainer.GetIPv6()
+			}
+			targetPort := secondaryTargetExternalContainer.GetPortStr()
+
+			ginkgo.By("Step 8: Create trigger pod with netexec server")
+			dst := net.JoinHostPort(targetIP, targetPort)
+			connectCmd := fmt.Sprintf("while true; do curl -s --max-time 0.1 --connect-timeout 0.1 http://%s/clientip; echo ; done", dst)
+			p, err := createGenericPodWithLabel(f, triggerPodName, pod1Node.name, f.Namespace.Name,
+				[]string{"/bin/sh", "-c", connectCmd}, podEgressLabel)
+			framework.ExpectNoError(err, "failed to create trigger pod")
+
+			ginkgo.By("Step 9: Get trigger pod IP for leak detection")
+			triggerPodIP := p.Status.PodIP
+			framework.Logf("Trigger pod %s has IP %s - will verify this IP never appears as source", triggerPodName, triggerPodIP)
+
+			ginkgo.By("Step 10: Wait for traffic generation - pod is sending requests continuously")
+			framework.Logf("Waiting 30 seconds while trigger pod sends continuous traffic and collects responses...")
+			time.Sleep(10 * time.Second)
+
+			ginkgo.By("Step 11: Check trigger pod logs to verify NO pod IP as source")
+			containerName := fmt.Sprintf("%s-container", triggerPodName)
+			podLogs, err := e2epod.GetPodLogs(context.TODO(), f.ClientSet, f.Namespace.Name, triggerPodName, containerName)
+			framework.ExpectNoError(err, "failed to get trigger pod logs")
+			// The /clientip endpoint returns the source IP in format "IP:port"
+			// For IPv4: "10.10.10.100:12345", for IPv6: "[2001:db8::1]:12345"
+			// Use net.SplitHostPort to properly parse both IPv4 and IPv6
+			lines := strings.Split(podLogs, "\n")
+			podIPCount := 0
+			egressIPCount := 0
+			totalResponses := 0
+
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				sourceIP, _, err := net.SplitHostPort(line)
+				if err != nil {
+					continue
+				}
+				totalResponses++
+
+				if sourceIP == triggerPodIP {
+					podIPCount++
+					framework.Logf("LEAK DETECTED: Pod IP %s found as source in response: %s", triggerPodIP, line)
+				} else if sourceIP == egressIPSecondaryHost {
+					egressIPCount++
+				}
+			}
+
+			framework.Logf("Analyzed %d responses from /clientip endpoint", totalResponses)
+			framework.Logf("Responses with pod IP %s as source: %d", triggerPodIP, podIPCount)
+			framework.Logf("Responses with EgressIP %s as source: %d", egressIPSecondaryHost, egressIPCount)
+
+			gomega.Expect(podIPCount).To(gomega.Equal(0),
+				"CRITICAL: Found %d responses with pod IP %s as source - indicates traffic leak during race window!",
+				podIPCount, triggerPodIP)
+
+			gomega.Expect(egressIPCount).To(gomega.BeNumerically(">", 0),
+				"Should see responses with EgressIP %s as source", egressIPSecondaryHost)
+
+			framework.Logf("SUCCESS: All %d responses used EgressIP, ZERO used pod IP - no leakage detected!", egressIPCount)
+			framework.Logf("Test completed successfully - pod IP leak prevention is working correctly")
 		})
 
 		// two pods attached to different namespaces but the same role primary user defined network


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
    When a new pod is added to an existing EgressIP namespace with many pods,
    there's a window where the OVN logical router policy (LRP) is created but
    the node-side iptables SNAT rule hasn't been applied yet. During this
    window, pod traffic egresses with the pod IP instead of the egress IP.
    
    This condition occurs because:
    - OVN controller creates LRP immediately (annotation already exists)
    - Node controller reconciles all existing pods sequentially before
      creating SNAT rule for the new pod
    - Packets matching LRP are rerouted to egress node but SNAT doesn't
    - Node controller reconciles all existing pods sequentially before
      creating SNAT rule for the new pod
    - Packets matching LRP are rerouted to egress node but SNAT doesn't
      happen → pod IP leaks
    
    Solution:
    - OVN controller: Set packet mark 1009 in LRP for secondary host EgressIP
      (when !isOVNNetwork) to tag packets processed by OVN
    - Node controller: Add nftables postrouting chain (priority 150, after
      iptables NAT at ~100) that drops packets with mark 1009 that still have
      source IP from node subnets

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
