### PR TITLE
node: don't short-circuit management port IP ingress to the physical bridge

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeflows.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeflows.go
@@ -1062,13 +1062,13 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 	if ofPortPhys != "" {
 		defaultNetConfig := b.netConfig[types.DefaultNetworkName]
 		// table 0, Ingress/Egress flows for MEG enabled pods and advertised UDNs
-		// priority 300: Ingress traffic to MEG pods and advertised UDNs
-		// priority 301: Ingress traffic to node management traffic
+		// priority 300: Ingress traffic to MEG pods and advertised UDNs. The node management port IP is part of <nodeSubnet>
+		// and is handled by this flow as well, so it retraces the gateway router instead of being short-circuited to the physical
+		// bridge LOCAL port.
 		// priority 104: Egress traffic from advertised UDNs or MEG enabled pods
 		// priority 103: For egressIP, drop packets coming from pods from other nodes headed externally that were not SNATed.
 		// example flows in SGW mode EIP enabled:
 		//   table=0, n_packets=0, n_bytes=0, priority=300,ip,in_port=eth0,nw_dst=<nodeSubnet> actions=output:4
-		//   table=0, n_packets=0, n_bytes=0, priority=301,ip,in_port=eth0,nw_dst=<mgmtIP> actions=output:LOCAL
 		//   table=0, n_packets=0, n_bytes=0, priority=104,ip,in_port=4,dl_src=02:42:ac:12:00:03,nw_src=<nodeSubnet> actions=output:eth0
 		//   table=0, n_packets=0, n_bytes=0, priority=103,ip,in_port=4,nw_src=<clusterSubnet> actions=drop
 		// example flows in LGW mode EIP enabled:
@@ -1077,7 +1077,6 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 		//   table=0, n_packets=0, n_bytes=0, priority=103,ip,in_port=4,nw_src=<clusterSubnet> actions=drop
 		// example flows in SGW mode EIP disabled:
 		//   table=0, n_packets=0, n_bytes=0, priority=300,ip,in_port=eth0,nw_dst=<nodeSubnet> actions=output:4
-		//   table=0, n_packets=0, n_bytes=0, priority=301,ip,in_port=eth0,nw_dst=<mgmtIP> actions=output:LOCAL
 		//   table=0, n_packets=0, n_bytes=0, priority=104,ip,in_port=4,dl_src=02:42:ac:12:00:03,nw_src=<nodeSubnet> actions=output:eth0
 		// example flows in LGW mode EIP disabled:
 		//   table=0, n_packets=0, n_bytes=0, priority=300,ip,in_port=eth0,nw_dst=<nodeSubnet> actions=output:LOCAL
@@ -1123,22 +1122,6 @@ func (b *BridgeConfiguration) commonFlows(hostSubnets []*net.IPNet) ([]string, e
 					fmt.Sprintf("cookie=%s, priority=300, table=0, in_port=%s, %s, %s_dst=%s, "+
 						"actions=output:%s",
 						nodetypes.DefaultOpenFlowCookie, ofPortPhys, ipv, ipv, subnet, output))
-				// except node management traffic
-				mgmtIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(subnet), netConfig.ManagementIPs)
-				if err != nil {
-					return nil, fmt.Errorf("failed to find the management IP matching the IP family of the subnet %q", subnet)
-				}
-
-				if mgmtIP == nil {
-					return nil, fmt.Errorf("unable to determine management IP for subnet %s", subnet.String())
-				}
-				if config.Gateway.Mode != config.GatewayModeLocal {
-					dftFlows = append(dftFlows,
-						fmt.Sprintf("cookie=%s, priority=301, table=0, in_port=%s, %s, %s_dst=%s, "+
-							"actions=output:%s",
-							nodetypes.DefaultOpenFlowCookie, ofPortPhys, ipv, ipv, mgmtIP.IP, nodetypes.OvsLocalPort),
-					)
-				}
 
 				if disableSNATMultipleGWs || isNetworkAdvertised {
 					// MEG and advertised UDN networks requires that local pod traffic can leave the node without SNAT.

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -1443,7 +1443,7 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 
 			Expect(udnGateway.AddNetwork()).To(Succeed())
 			flowMap = udnGateway.gateway.openflowManager.flowCache
-			Expect(flowMap["DEFAULT"]).To(HaveLen(80))                                      // 18 UDN Flows, 5 advertisedUDN flows, and 2 packet mark flows (IPv4+IPv6) are added by default
+			Expect(flowMap["DEFAULT"]).To(HaveLen(78))                                      // 18 UDN Flows, 3 advertisedUDN flows, and 2 packet mark flows (IPv4+IPv6) are added by default (management-port ingress is no longer carved out to LOCAL)
 			Expect(udnGateway.openflowManager.defaultBridge.GetNetConfigLen()).To(Equal(2)) // default network + UDN network
 			defaultUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("default")
 			bridgeUdnConfig := udnGateway.openflowManager.defaultBridge.GetNetworkConfig("bluenet")


### PR DESCRIPTION
In shared gateway mode the priority 301 OpenFlow rule on the gateway bridge sends external/underlay traffic destined to the node management port IP (ovn-k8s-mp0) straight to the physical bridge LOCAL port:

  priority=301,ip,in_port=<phys>,nw_dst=<mgmtIP> actions=output:LOCAL

The management port IP is an OVN logical switch port that lives on br-int behind the gateway router. Traffic to it - for example replies for connections a host process opened to a remote pod via ovn-k8s-mp0 - must retrace the gateway router so the conntrack zones are reversed and the packet egresses ovn-k8s-mp0. The node is multi-homed: the uplink PF is on the physical bridge while ovn-k8s-mp0 is on br-int, and those two paths are not interchangeable. Handing the reply to the physical bridge LOCAL port short-circuits OVN.

On a regular node this happened to work by accident: LOCAL is the same host kernel that owns the management IP, loose rp_filter let the wrong-interface arrival through, and there is no L3 NAT on the wire to reverse. With NoOverlay/DPU it breaks outright - ovn-k8s-mp0 is reachable only through the gateway router, so the reply is delivered to a LOCAL port where nothing owns the IP (on a DPU, the DPU's own kernel) and the connection never completes.

Drop the priority 301 carve-out. The management IP is part of <nodeSubnet>, so the existing priority 300 flow already handles it correctly: in SGW it sends the traffic into OVN via the patch port, where the gateway router reverses it back out ovn-k8s-mp0; in LGW it is forwarded to the host kernel which then routes it.

Note: see also the discussion in the community slack.