### PR TITLE
Allow networks to start while route advertisements settle

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -2409,13 +2409,7 @@ exit
 			cache.WaitForCacheSync(context.Background().Done(), hasSynced...)
 
 			err = nm.Start()
-			// some test cases start with a bad RA status, avoid asserting
-			// initial sync in this case as it will fail
-			if tt.ra == nil || tt.ra.Status == nil || *tt.ra.Status == metav1.ConditionTrue {
-				g.Expect(err).ToNot(gomega.HaveOccurred())
-			} else {
-				g.Expect(err).To(gomega.HaveOccurred())
-			}
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 			// we just need the inital sync
 			nm.Stop()
 

--- a/go-controller/pkg/networkmanager/network_controller.go
+++ b/go-controller/pkg/networkmanager/network_controller.go
@@ -15,6 +15,7 @@ import (
 	nadlisters "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/listers/k8s.cni.cncf.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -418,7 +419,7 @@ func (c *networkController) syncNetwork(network string) error {
 	}
 
 	// fetch other relevant network information
-	err := c.gatherNetwork(want)
+	err := c.gatherNetwork(want, have)
 	if err != nil {
 		return fmt.Errorf("failed to fetch other network information for network %s: %w", network, err)
 	}
@@ -511,14 +512,14 @@ func (c *networkController) deleteNetwork(network string) error {
 	return nil
 }
 
-func (c *networkController) gatherNetwork(network util.MutableNetInfo) error {
+func (c *networkController) gatherNetwork(network util.MutableNetInfo, current util.NetInfo) error {
 	if network == nil {
 		return nil
 	}
-	return c.setAdvertisements(network)
+	return c.setAdvertisements(network, current)
 }
 
-func (c *networkController) setAdvertisements(network util.MutableNetInfo) error {
+func (c *networkController) setAdvertisements(network util.MutableNetInfo, current util.NetInfo) error {
 	if !network.IsDefault() && !network.IsPrimaryNetwork() {
 		return nil
 	}
@@ -556,6 +557,13 @@ func (c *networkController) setAdvertisements(network util.MutableNetInfo) error
 	eipAdvertisements := map[string][]string{}
 	for raName := range raNames {
 		ra, err := c.raLister.Get(raName)
+		if apierrors.IsNotFound(err) {
+			// A stale NAD annotation should not prevent a network controller
+			// from starting. Preserve the current advertised state until the
+			// RouteAdvertisements controller removes the stale annotation.
+			preserveAdvertisements(network, current)
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -571,9 +579,15 @@ func (c *networkController) setAdvertisements(network util.MutableNetInfo) error
 			continue
 		}
 		if accepted.Status != metav1.ConditionTrue || accepted.ObservedGeneration != ra.Generation {
-			// if the RA is not accepted, we commit to no change, best to
-			// preserve the old config while we can't validate new config
-			return fmt.Errorf("failed to reconcile network %q: RouteAdvertisements %q not in accepted status", network.GetNetworkName(), ra.Name)
+			// The RA is not accepted yet (e.g. a brand-new network whose
+			// subnets haven't been allocated). Don't abort here: starting the
+			// controller is what lets the node allocator assign subnets, which
+			// is in turn what lets the RA become accepted - aborting would
+			// deadlock the two. Keep the previously-advertised VRFs (empty for
+			// a new network) for now; the RA's later transition to Accepted
+			// re-triggers this sync and fills in the real VRFs.
+			preserveAdvertisements(network, current)
+			return nil
 		}
 
 		nodeSelector, err := metav1.LabelSelectorAsSelector(&ra.Spec.NodeSelector)
@@ -606,6 +620,19 @@ func (c *networkController) setAdvertisements(network util.MutableNetInfo) error
 	network.SetPodNetworkAdvertisedVRFs(podAdvertisements)
 	network.SetEgressIPAdvertisedVRFs(eipAdvertisements)
 	return nil
+}
+
+// preserveAdvertisements carries the currently-advertised VRFs over to the
+// network being synced, so a missing or not-yet-accepted RouteAdvertisements
+// neither blocks the controller from starting nor clears existing advertisement
+// state. For a brand-new network, current is nil and the advertised VRFs are
+// left empty.
+func preserveAdvertisements(network util.MutableNetInfo, current util.NetInfo) {
+	if current == nil {
+		return
+	}
+	network.SetPodNetworkAdvertisedVRFs(current.GetPodNetworkAdvertisedVRFs())
+	network.SetEgressIPAdvertisedVRFs(current.GetEgressIPAdvertisedVRFs())
 }
 
 func (c *networkController) hasRouteAdvertisements() bool {

--- a/go-controller/pkg/networkmanager/network_controller_test.go
+++ b/go-controller/pkg/networkmanager/network_controller_test.go
@@ -112,12 +112,16 @@ func TestSetAdvertisements(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		network         *ovncnitypes.NetConf
-		ra              *ratypes.RouteAdvertisements
-		node            corev1.Node
-		expectNoNetwork bool
-		expected        map[string][]string
+		name                      string
+		network                   *ovncnitypes.NetConf
+		ra                        *ratypes.RouteAdvertisements
+		node                      corev1.Node
+		missingRA                 bool
+		expectNoNetwork           bool
+		existingPodAdvertisements map[string][]string
+		existingEIPAdvertisements map[string][]string
+		expected                  map[string][]string
+		expectedEIP               map[string][]string
 	}{
 		{
 			name:    "reconciles VRF advertisements for selected node of default node network controller",
@@ -150,24 +154,59 @@ func TestSetAdvertisements(t *testing.T) {
 			node:    otherNode,
 		},
 		{
-			name:    "ignores advertisements that are not accepted",
+			name:    "ignores advertisements with no Accepted condition",
 			network: defaultNetwork,
 			ra:      &podNetworkRANotAccepted,
 			node:    testNode,
 		},
 		{
-			name:            "fails for advertisements that are rejected",
-			network:         primaryNetwork,
-			ra:              &podNetworkRARejected,
-			node:            testNode,
-			expectNoNetwork: true,
+			name:    "starts new network without advertisements when advertisements are rejected",
+			network: primaryNetwork,
+			ra:      &podNetworkRARejected,
+			node:    testNode,
 		},
 		{
-			name:            "fails for advertisements that are old",
-			network:         primaryNetwork,
-			ra:              &podNetworkRAOutdated,
-			node:            testNode,
-			expectNoNetwork: true,
+			name:    "starts new network without advertisements when advertisements are old",
+			network: primaryNetwork,
+			ra:      &podNetworkRAOutdated,
+			node:    testNode,
+		},
+		{
+			name:    "preserves existing advertisements when advertisements are rejected",
+			network: primaryNetwork,
+			ra:      &podNetworkRARejected,
+			node:    testNode,
+			existingPodAdvertisements: map[string][]string{
+				testNodeName: {"previous-pod-vrf"},
+			},
+			existingEIPAdvertisements: map[string][]string{
+				testNodeName: {"previous-eip-vrf"},
+			},
+			expected: map[string][]string{
+				testNodeName: {"previous-pod-vrf"},
+			},
+			expectedEIP: map[string][]string{
+				testNodeName: {"previous-eip-vrf"},
+			},
+		},
+		{
+			name:      "preserves existing advertisements when route advertisement is missing",
+			network:   primaryNetwork,
+			ra:        &podNetworkRA,
+			node:      testNode,
+			missingRA: true,
+			existingPodAdvertisements: map[string][]string{
+				testNodeName: {"previous-pod-vrf"},
+			},
+			existingEIPAdvertisements: map[string][]string{
+				testNodeName: {"previous-eip-vrf"},
+			},
+			expected: map[string][]string{
+				testNodeName: {"previous-pod-vrf"},
+			},
+			expectedEIP: map[string][]string{
+				testNodeName: {"previous-eip-vrf"},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -198,8 +237,10 @@ func TestSetAdvertisements(t *testing.T) {
 
 			_, err = fakeClient.KubeClient.CoreV1().Nodes().Create(context.Background(), &tt.node, metav1.CreateOptions{})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), tt.ra, metav1.CreateOptions{})
-			g.Expect(err).ToNot(gomega.HaveOccurred())
+			if !tt.missingRA {
+				_, err = fakeClient.RouteAdvertisementsClient.K8sV1().RouteAdvertisements().Create(context.Background(), tt.ra, metav1.CreateOptions{})
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}
 			_, err = fakeClient.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(context.Background(), nad, metav1.CreateOptions{})
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -213,6 +254,19 @@ func TestSetAdvertisements(t *testing.T) {
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			mutableNetInfo := util.NewMutableNetInfo(netInfo)
 			mutableNetInfo.AddNADs(testNADName)
+
+			if tt.existingPodAdvertisements != nil || tt.existingEIPAdvertisements != nil {
+				existingNetInfo := util.NewMutableNetInfo(netInfo)
+				existingNetInfo.AddNADs(testNADName)
+				existingNetInfo.SetPodNetworkAdvertisedVRFs(tt.existingPodAdvertisements)
+				existingNetInfo.SetEgressIPAdvertisedVRFs(tt.existingEIPAdvertisements)
+				existingController := &testNetworkController{
+					ReconcilableNetInfo: util.NewReconcilableNetInfo(existingNetInfo),
+					tcm:                 tcm,
+				}
+				tcm.controllers[testNetworkKey(netInfo)] = existingController
+				nm.setNetworkState(existingNetInfo.GetNetworkName(), &networkControllerState{controller: existingController})
+			}
 
 			nm.getNADKeysForNetwork = func(networkName string) []string {
 				if networkName == mutableNetInfo.GetNetworkName() {
@@ -244,6 +298,10 @@ func TestSetAdvertisements(t *testing.T) {
 					tt.expected = map[string][]string{}
 				}
 				g.Expect(reconcilable.GetPodNetworkAdvertisedVRFs()).To(gomega.Equal(tt.expected))
+				if tt.expectedEIP == nil {
+					tt.expectedEIP = map[string][]string{}
+				}
+				g.Expect(reconcilable.GetEgressIPAdvertisedVRFs()).To(gomega.Equal(tt.expectedEIP))
 			}
 
 			g.Eventually(meetsExpectations).Should(gomega.Succeed())


### PR DESCRIPTION
A primary network selected by a RouteAdvertisements could deadlock and never get its per-node subnets allocated.

`setAdvertisements()` resolves the RAs referenced by a network's NAD annotation and, when a referenced RA is not yet Accepted, returns an error that aborted `syncNetwork()` before `ensureNetwork()` ran. The network controller therefore never started and its node allocator never wrote the host-subnet annotation. But an RA only becomes `Accepted` once every selected network already has those subnets, so the two states blocked each other in a deadlok; a startup-ordering race decided which networks got stuck.

Subnet allocation is orthogonal to route advertisement and should not be gated on it. Instead of aborting, preserve the network's previously-advertised VRFs (empty for a brand-new network) and let `syncNetwork()` proceed to start the controller. Subnets are then allocated, the RA becomes Accepted, and that RA status change re-triggers a sync which fills in the real advertised VRFs. Apply the same handling when the referenced RA is missing (a stale NAD annotation) so a leftover reference cannot block startup either.

Visually:

```
   ┌────────────────────────────────────┐        ┌────────────────────────────────────┐
   │  NETWORK MANAGER                   │        │  RA CONTROLLER                     │
   │  (networkmanager/                  │        │  (routeadvertisements/             │
   │   network_controller.go)           │        │   controller.go)                   │
   ├────────────────────────────────────┤        ├────────────────────────────────────┤
   │  setAdvertisements() :573-576      │        │  reconcile() :277                  │
   │   reads NAD annotation → RA name   │        │   └ reconcileRouteAdvertisements   │
   │   looks up that RA                 │        │      └ generateFRRConfigurations   │
   │   RA.Accepted != True ──▶ ERROR    │        │         └ getPrefixes() :688       │
   │   → ensureNetwork() skipped        │        │            tenant-1 has no subnets │
   │   → controller never starts        │        │            ──▶ errConfig           │
   │   → allocator never writes subnets │        │   updateRAStatus() :298,1407       │
   │                                    │        │    err != nil ──▶ Accepted = False │
   └────────────────────────────────────┘        └────────────────────────────────────┘

          BLOCKS ▲                                              │ BLOCKS
                 │                                              │
                 │   "RA not Accepted"          "tenant-1 has no subnets"
                 │                                              │
                 │                                              ▼
        ┌────────┴────────────────┐                  ┌───────────────────────────┐
        │ controller won't start  │ ◀──────────────  │ RA won't be Accepted      │
        │ → no subnets            │   A needs B      │ → blocks A                │
        └─────────────────────────┘   B needs A      └───────────────────────────┘

```