### PR TITLE
config: make routing table ID start configurable

### DIFF
--- a/docs/installation/ovn_k8s.conf.5
+++ b/docs/installation/ovn_k8s.conf.5
@@ -114,6 +114,19 @@ The port, by default, is 6442. E.g., ssl:1.2.3.4:6642
 .TP
 \fBserver-cacert\fR=
 
+.SH [OvnKubeNode]
+.TP
+\fBrouting-table-id-start\fR=
+Optional start of the Linux route table ID range managed by ovnkube-node for
+generated VRF tables, such as UDN VRFs, and EgressIP route tables. The route
+table ID is calculated by adding this value to the Linux interface index.
+Values lower than 1000 or greater than 2147483647 are rejected. If unset,
+ovnkube-node uses its built-in default.
+Changing this value while UserDefinedNetwork or ClusterUserDefinedNetwork VRFs
+or EgressIP assignments exist is not supported. Delete those networks and
+EgressIP assignments, and allow ovnkube-node to clean up their VRFs and route
+tables before changing this value.
+
 .SH [Gateway]
 .TP
 \fBmode\fR=shared

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -68,6 +68,15 @@ const DefaultDBTxnTimeout = time.Second * 100
 // DefaultEphemeralPortRange is used for unit testing only
 const DefaultEphemeralPortRange = "32768-60999"
 
+// MinimumRoutingTableIDStart is the lowest allowed start of OVN-managed Linux route table IDs.
+const MinimumRoutingTableIDStart = 1000
+
+// MaximumRoutingTableIDStart is capped so adding any Linux interface index still fits in a uint32 route table ID.
+const MaximumRoutingTableIDStart = 1<<31 - 1
+
+// DefaultRoutingTableIDStart is the default start of OVN-managed Linux route table IDs.
+const DefaultRoutingTableIDStart = MinimumRoutingTableIDStart
+
 // The following are global config parameters that other modules may access directly
 var (
 	// Build information. Populated at build-time.
@@ -235,6 +244,7 @@ var (
 		Mode:                      types.NodeModeFull,
 		DPUNodeLeaseRenewInterval: 10,
 		DPUNodeLeaseDuration:      40,
+		RoutingTableIDStart:       DefaultRoutingTableIDStart,
 	}
 
 	ClusterManager = ClusterManagerConfig{
@@ -652,6 +662,8 @@ type OvnKubeNodeConfig struct {
 	DPUNodeLeaseRenewInterval int    `gcfg:"dpu-node-lease-renew-interval"`
 	DPUNodeLeaseDuration      int    `gcfg:"dpu-node-lease-duration"`
 	SimulateDPU               bool   `gcfg:"simulate-dpu"`
+	// RoutingTableIDStart is added to interface indexes to derive OVN-managed Linux route table IDs.
+	RoutingTableIDStart int `gcfg:"routing-table-id-start"`
 }
 
 // ClusterManagerConfig holds configuration for ovnkube-cluster-manager
@@ -1780,6 +1792,14 @@ var OvnKubeNodeFlags = []cli.Flag{
 		Usage:       "Use simulated DPU operations instead of real SR-IOV/switchdev hardware. Required for Kind and VM-based DPU simulation environments.",
 		Value:       OvnKubeNode.SimulateDPU,
 		Destination: &cliConfig.OvnKubeNode.SimulateDPU,
+	},
+	&cli.IntFlag{
+		Name: "ovnkube-node-routing-table-id-start",
+		Usage: fmt.Sprintf("Start of the Linux route table ID range managed by ovnkube-node "+
+			"for generated VRF and route tables. Must be between %d and %d",
+			MinimumRoutingTableIDStart, MaximumRoutingTableIDStart),
+		Value:       OvnKubeNode.RoutingTableIDStart,
+		Destination: &cliConfig.OvnKubeNode.RoutingTableIDStart,
 	},
 }
 
@@ -2945,6 +2965,14 @@ func buildOvnKubeNodeConfig(cli, file *config) error {
 	if OvnKubeNode.DPUNodeLeaseDuration <= OvnKubeNode.DPUNodeLeaseRenewInterval {
 		return fmt.Errorf("invalid dpu-node-lease-duration '%d'. must be > dpu-node-lease-renew-interval '%d'",
 			OvnKubeNode.DPUNodeLeaseDuration, OvnKubeNode.DPUNodeLeaseRenewInterval)
+	}
+	if OvnKubeNode.RoutingTableIDStart < MinimumRoutingTableIDStart {
+		return fmt.Errorf("invalid routing-table-id-start '%d'. must be >= %d",
+			OvnKubeNode.RoutingTableIDStart, MinimumRoutingTableIDStart)
+	}
+	if OvnKubeNode.RoutingTableIDStart > MaximumRoutingTableIDStart {
+		return fmt.Errorf("invalid routing-table-id-start '%d'. must be <= %d",
+			OvnKubeNode.RoutingTableIDStart, MaximumRoutingTableIDStart)
 	}
 
 	// Warn the user if both MgmtPortNetdev and MgmtPortDPResourceName are specified since they

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -340,6 +340,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeFull))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal(""))
 			gomega.Expect(OvnKubeNode.MgmtPortDPResourceName).To(gomega.Equal(""))
+			gomega.Expect(OvnKubeNode.RoutingTableIDStart).To(gomega.Equal(DefaultRoutingTableIDStart))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal(""))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
 			gomega.Expect(Gateway.DisableForwarding).To(gomega.BeFalse())
@@ -392,6 +393,41 @@ var _ = Describe("Config Operations", func() {
 		err2 := app.Run([]string{app.Name})
 		gomega.Expect(err2).NotTo(gomega.HaveOccurred())
 
+	})
+
+	It("parses routing table ID start from config file", func() {
+		err := os.WriteFile(cfgFile.Name(), []byte(`[ovnkubenode]
+routing-table-id-start=2002
+`), 0o644)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		app.Action = func(ctx *cli.Context) error {
+			cfgPath, err := InitConfig(ctx, kexec.New(), nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(cfgPath).To(gomega.Equal(cfgFile.Name()))
+			gomega.Expect(OvnKubeNode.RoutingTableIDStart).To(gomega.Equal(2002))
+			return nil
+		}
+
+		err = app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	It("parses routing table ID start from CLI", func() {
+		app.Action = func(ctx *cli.Context) error {
+			cfgPath, err := InitConfig(ctx, kexec.New(), nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(cfgPath).To(gomega.Equal(cfgFile.Name()))
+			gomega.Expect(OvnKubeNode.RoutingTableIDStart).To(gomega.Equal(2003))
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"--config-file=" + cfgFile.Name(),
+			"--ovnkube-node-routing-table-id-start=2003",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	It("uses environment variables", func() {
@@ -1516,39 +1552,33 @@ udn-allowed-default-services= ns/svc, ns1/svc1
 	})
 
 	Describe("OVN Kube Node config", func() {
+		nodeConfig := func() OvnKubeNodeConfig {
+			return OvnKubeNode
+		}
+
 		// NOTE: We test this here as the test that overrides values also sets hybridOverlay to true
 		// which yields an invalid configuration.
 		It("Overrides value from Config file", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeFull,
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-					DPUNodeLeaseRenewInterval: OvnKubeNode.DPUNodeLeaseRenewInterval,
-				},
-			}
-			file := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeDPU,
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-					DPUNodeLeaseRenewInterval: OvnKubeNode.DPUNodeLeaseRenewInterval,
-				},
-			}
+			fileNodeConfig := nodeConfig()
+			fileNodeConfig.Mode = types.NodeModeDPU
+
+			cliConfig := config{OvnKubeNode: nodeConfig()}
+			file := config{OvnKubeNode: fileNodeConfig}
 			err := buildOvnKubeNodeConfig(&cliConfig, &file)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeDPU))
 		})
 
 		It("Overrides value from CLI", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeDPUHost,
-					MgmtPortNetdev:            "enp1s0f0v0",
-					MgmtPortDPResourceName:    "openshift.io/mgmtvf",
-					DPUNodeLeaseRenewInterval: 5,
-					DPUNodeLeaseDuration:      20,
-				},
-			}
-			err := buildOvnKubeNodeConfig(&cliConfig, &config{})
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.Mode = types.NodeModeDPUHost
+			cliNodeConfig.MgmtPortNetdev = "enp1s0f0v0"
+			cliNodeConfig.MgmtPortDPResourceName = "openshift.io/mgmtvf"
+			cliNodeConfig.DPUNodeLeaseRenewInterval = 5
+			cliNodeConfig.DPUNodeLeaseDuration = 20
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
+			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeDPUHost))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal("enp1s0f0v0"))
@@ -1557,51 +1587,93 @@ udn-allowed-default-services= ns/svc, ns1/svc1
 			gomega.Expect(OvnKubeNode.DPUNodeLeaseDuration).To(gomega.Equal(20))
 		})
 
+		It("Overrides routing table ID start from Config file", func() {
+			cliConfig := config{OvnKubeNode: nodeConfig()}
+			file := config{OvnKubeNode: nodeConfig()}
+			file.OvnKubeNode.RoutingTableIDStart = 2000
+
+			err := buildOvnKubeNodeConfig(&cliConfig, &file)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(OvnKubeNode.RoutingTableIDStart).To(gomega.Equal(2000))
+		})
+
+		It("Overrides routing table ID start from CLI", func() {
+			cliConfig := config{OvnKubeNode: nodeConfig()}
+			cliConfig.OvnKubeNode.RoutingTableIDStart = 2001
+			file := config{OvnKubeNode: nodeConfig()}
+			file.OvnKubeNode.RoutingTableIDStart = 2000
+
+			err := buildOvnKubeNodeConfig(&cliConfig, &file)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(OvnKubeNode.RoutingTableIDStart).To(gomega.Equal(2001))
+		})
+
+		It("Fails if routing table ID start is below the reserved range", func() {
+			cliConfig := config{OvnKubeNode: nodeConfig()}
+			cliConfig.OvnKubeNode.RoutingTableIDStart = MinimumRoutingTableIDStart - 1
+
+			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: nodeConfig()})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("routing-table-id-start"))
+		})
+
+		It("Succeeds if routing table ID start is at the maximum", func() {
+			cliConfig := config{OvnKubeNode: nodeConfig()}
+			cliConfig.OvnKubeNode.RoutingTableIDStart = MaximumRoutingTableIDStart
+
+			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: nodeConfig()})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(OvnKubeNode.RoutingTableIDStart).To(gomega.Equal(MaximumRoutingTableIDStart))
+		})
+
+		It("Fails if routing table ID start is above the maximum", func() {
+			cliConfig := config{OvnKubeNode: nodeConfig()}
+			cliConfig.OvnKubeNode.RoutingTableIDStart = MaximumRoutingTableIDStart + 1
+
+			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: nodeConfig()})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("routing-table-id-start"))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("must be <="))
+		})
+
 		It("Fails with unsupported mode", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode: "invalid",
-				},
-			}
-			err := buildOvnKubeNodeConfig(&cliConfig, &config{})
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.Mode = "invalid"
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
+			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("unexpected ovnkube-node-mode"))
 		})
 
 		It("Fails if hybrid overlay is enabled and ovnkube node mode is not full", func() {
 			HybridOverlay.Enabled = true
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode: types.NodeModeDPU,
-				},
-			}
-			err := buildOvnKubeNodeConfig(&cliConfig, &config{})
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.Mode = types.NodeModeDPU
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
+			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring(
 				"hybrid overlay is not supported with ovnkube-node mode"))
 		})
 
 		It("Fails if DPU node lease renew interval is negative", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeFull,
-					DPUNodeLeaseRenewInterval: -1,
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-				},
-			}
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.DPUNodeLeaseRenewInterval = -1
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
 			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("dpu-node-lease-renew-interval"))
 		})
 
 		It("Succeeds if DPU node lease renew interval is zero", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeFull,
-					DPUNodeLeaseRenewInterval: 0,
-					DPUNodeLeaseDuration:      10,
-				},
-			}
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.DPUNodeLeaseRenewInterval = 0
+			cliNodeConfig.DPUNodeLeaseDuration = 10
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
 			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(OvnKubeNode.DPUNodeLeaseRenewInterval).To(gomega.Equal(0))
@@ -1609,25 +1681,21 @@ udn-allowed-default-services= ns/svc, ns1/svc1
 		})
 
 		It("Fails if DPU node lease duration is non-positive", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                 types.NodeModeFull,
-					DPUNodeLeaseDuration: 0,
-				},
-			}
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.DPUNodeLeaseDuration = 0
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
 			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("dpu-node-lease-duration"))
 		})
 
 		It("Fails if DPU node lease duration is less than or equal to renew interval", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeFull,
-					DPUNodeLeaseRenewInterval: 10,
-					DPUNodeLeaseDuration:      10,
-				},
-			}
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.DPUNodeLeaseRenewInterval = 10
+			cliNodeConfig.DPUNodeLeaseDuration = 10
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
 			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.Or(
@@ -1637,68 +1705,42 @@ udn-allowed-default-services= ns/svc, ns1/svc1
 		})
 
 		It("Fails if management port is provided and ovnkube node mode is dpu", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeDPU,
-					MgmtPortNetdev:            "enp1s0f0v0",
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-					DPUNodeLeaseRenewInterval: OvnKubeNode.DPUNodeLeaseRenewInterval,
-				},
-			}
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.Mode = types.NodeModeDPU
+			cliNodeConfig.MgmtPortNetdev = "enp1s0f0v0"
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
 			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must not be provided"))
 		})
 
 		It("Fails if management port is not provided and ovnkube node mode is dpu-host", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeDPUHost,
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-					DPUNodeLeaseRenewInterval: OvnKubeNode.DPUNodeLeaseRenewInterval,
-				},
-			}
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.Mode = types.NodeModeDPUHost
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
 			err := buildOvnKubeNodeConfig(&cliConfig, &config{OvnKubeNode: OvnKubeNode})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must be provided"))
 		})
 
 		It("Succeeds if management netdev provided in the full mode", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeFull,
-					MgmtPortNetdev:            "ens1f0v0",
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-					DPUNodeLeaseRenewInterval: OvnKubeNode.DPUNodeLeaseRenewInterval,
-				},
-			}
-			file := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeFull,
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-					DPUNodeLeaseRenewInterval: OvnKubeNode.DPUNodeLeaseRenewInterval,
-				},
-			}
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.MgmtPortNetdev = "ens1f0v0"
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
+			file := config{OvnKubeNode: nodeConfig()}
 			err := buildOvnKubeNodeConfig(&cliConfig, &file)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
 		It("Succeeds if management port device plugin resource name provided in the full mode", func() {
-			cliConfig := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeFull,
-					MgmtPortDPResourceName:    "openshift.io/mgmtvf",
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-					DPUNodeLeaseRenewInterval: OvnKubeNode.DPUNodeLeaseRenewInterval,
-				},
-			}
-			file := config{
-				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                      types.NodeModeFull,
-					DPUNodeLeaseDuration:      OvnKubeNode.DPUNodeLeaseDuration,
-					DPUNodeLeaseRenewInterval: OvnKubeNode.DPUNodeLeaseRenewInterval,
-				},
-			}
+			cliNodeConfig := nodeConfig()
+			cliNodeConfig.MgmtPortDPResourceName = "openshift.io/mgmtvf"
+
+			cliConfig := config{OvnKubeNode: cliNodeConfig}
+			file := config{OvnKubeNode: nodeConfig()}
 			err := buildOvnKubeNodeConfig(&cliConfig, &file)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -54,12 +54,11 @@ import (
 )
 
 const (
-	rulePriority        = 6000 // the priority of the ip routing rules created by the controller. Egress Service priority is 5000.
-	ruleFwMarkPriority  = 5999 // the priority of the ip routing rules for LGW mode when we want to skip processing eip ip rules because dst is a node ip. Pkt will be fw marked with 1008.
-	routingTableIDStart = 1000
-	chainName           = "OVN-KUBE-EGRESS-IP-MULTI-NIC"
-	iptChainName        = utiliptables.Chain(chainName)
-	maxRetries          = 15
+	rulePriority       = 6000 // the priority of the ip routing rules created by the controller. Egress Service priority is 5000.
+	ruleFwMarkPriority = 5999 // the priority of the ip routing rules for LGW mode when we want to skip processing eip ip rules because dst is a node ip. Pkt will be fw marked with 1008.
+	chainName          = "OVN-KUBE-EGRESS-IP-MULTI-NIC"
+	iptChainName       = utiliptables.Chain(chainName)
+	maxRetries         = 15
 )
 
 var (

--- a/go-controller/pkg/node/vrfmanager/vrf_manager.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
@@ -191,7 +192,7 @@ func (vrfm *Controller) sync(vrf vrf) error {
 		if !ok {
 			return fmt.Errorf("node has another non VRF device with same name %s", vrf.name)
 		}
-		if vrfDev.Table < util.RoutingTableIDStart {
+		if vrfDev.Table < uint32(config.OvnKubeNode.RoutingTableIDStart) {
 			return fmt.Errorf("node has another VRF device with same name %s that is not managed by ovn-kubernetes", vrf.name)
 		}
 		if vrfDev.Table != vrf.table {
@@ -257,8 +258,8 @@ func (vrfm *Controller) AddVRF(name string, slaveInterface string, table uint32,
 	if len(name) > 15 {
 		return fmt.Errorf("VRF Manager: VRF name %s must be within 15 characters", name)
 	}
-	if table < util.RoutingTableIDStart {
-		return fmt.Errorf("VRF Manager: cannot manage a VRF %s with table %d lower than %d", name, table, util.RoutingTableIDStart)
+	if table < uint32(config.OvnKubeNode.RoutingTableIDStart) {
+		return fmt.Errorf("VRF Manager: cannot manage a VRF %s with table %d lower than %d", name, table, config.OvnKubeNode.RoutingTableIDStart)
 	}
 	var (
 		vrfDev vrf
@@ -378,7 +379,7 @@ func (vrfm *Controller) repair(validVRFs sets.Set[string]) error {
 			// not a vrf device
 			continue
 		}
-		if vrf.Table < util.RoutingTableIDStart {
+		if vrf.Table < uint32(config.OvnKubeNode.RoutingTableIDStart) {
 			// vrf device not managed by us
 			continue
 		}

--- a/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
+++ b/go-controller/pkg/node/vrfmanager/vrf_manager_test.go
@@ -17,6 +17,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	netlink_mocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
@@ -95,6 +96,7 @@ var _ = ginkgo.Describe("VRF manager", func() {
 	}
 
 	ginkgo.BeforeEach(func() {
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		c = NewController(routemanager.NewController())
 
 		nlMock = &mocks.NetLinkOps{}
@@ -145,6 +147,24 @@ var _ = ginkgo.Describe("VRF manager", func() {
 			gomega.Expect(err).Should(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("uses configured routing table ID start for ownership checks", func() {
+			config.OvnKubeNode.RoutingTableIDStart = 2000
+
+			err := c.AddVRF("this.name.is.ok", "other", 1999, nil)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("lower than 2000"))
+
+			err = c.AddVRF(vrfLinkName1, "", 2000, nil)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("not managed by ovn-kubernetes"))
+
+			nlMock.On("LinkList").Return([]netlink.Link{buildVRF(vrfLinkName1), buildVRF(vrfLinkName2)}, nil)
+			err = c.Repair(sets.New[string]())
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			nlMock.AssertNotCalled(ginkgo.GinkgoT(), "LinkDelete", buildVRF(vrfLinkName1))
+			nlMock.AssertCalled(ginkgo.GinkgoT(), "LinkDelete", buildVRF(vrfLinkName2))
+		})
+
 		ginkgo.It("delete VRF", func() {
 			err := c.AddVRF(vrfLinkName2, "", getVRFTable(vrfLinkName2), nil)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -189,6 +209,7 @@ var _ = ginkgo.Describe("VRF manager tests with a network namespace", func() {
 		wg     *sync.WaitGroup
 	)
 	ginkgo.BeforeEach(func() {
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
 		var err error
 		testNS, err = testutils.NewNS()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -18,10 +18,8 @@ import (
 	"github.com/vishvananda/netlink"
 
 	utilnet "k8s.io/utils/net"
-)
 
-const (
-	RoutingTableIDStart = 1000
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 )
 
 var ErrorNoIP = errors.New("no IP available")
@@ -479,7 +477,7 @@ func IPNetsToIPs(ipNets []*net.IPNet) []net.IP {
 // CalculateRouteTableID will calculate route table ID based on the network
 // interface index
 func CalculateRouteTableID(ifIndex int) int {
-	return ifIndex + RoutingTableIDStart
+	return ifIndex + config.OvnKubeNode.RoutingTableIDStart
 }
 
 // RouteEqual compare two routes

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -13,10 +13,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	mock_k8s_io_utils_exec "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
 )
+
+func TestCalculateRouteTableID(t *testing.T) {
+	require.NoError(t, config.PrepareTestConfig())
+	t.Cleanup(func() {
+		require.NoError(t, config.PrepareTestConfig())
+	})
+
+	assert.Equal(t, 1005, CalculateRouteTableID(5))
+
+	config.OvnKubeNode.RoutingTableIDStart = 2000
+	assert.Equal(t, 2005, CalculateRouteTableID(5))
+}
 
 func TestNextSloppyIP(t *testing.T) {
 	tests := []struct {

--- a/helm/ovn-kubernetes/templates/ovn-setup.yaml
+++ b/helm/ovn-kubernetes/templates/ovn-setup.yaml
@@ -80,6 +80,11 @@ data:
     frr-namespace = {{ .Values.global.managedBGPFRRNamespace | default "frr-k8s-system" }}
 {{- end }}
 {{- end }}
+{{- if hasKey .Values.global "routingTableIDStart" }}
+
+    [ovnkubenode]
+    routing-table-id-start = {{ .Values.global.routingTableIDStart }}
+{{- end }}
 
 {{- if or .Values.global.skipCallToK8s (eq (include "needNamespace" $hostNetworkNamespace) "true") }}
 ---

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -67,6 +67,9 @@ global:
   enableNetworkSegmentation: false
   # -- Configure to use route advertisements feature with ovn-kubernetes
   enableRouteAdvertisements: false
+  # -- Optional Linux routing table ID start used by ovnkube-node for generated VRF/route tables.
+  # -- Minimum: 1000. If unset, ovnkube-node uses its built-in default.
+  # routingTableIDStart: 1002
   # -- Configure to enable no-overlay mode for the default network
   enableNoOverlay: false
   # -- Configure to enable SNAT for outbound traffic in no-overlay mode

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -81,6 +81,9 @@ global:
   advertiseDefaultNetwork: false
   # -- Pod network isolation between advertised UDN networks. (strict or loose)
   advertisedUDNIsolationMode: "strict"
+  # -- Optional Linux routing table ID start used by ovnkube-node for generated VRF/route tables.
+  # -- Minimum: 1000. If unset, ovnkube-node uses its built-in default.
+  # routingTableIDStart: 1002
   # -- Configure to enable no-overlay mode for the default network
   enableNoOverlay: false
   # -- Configure to enable SNAT for outbound traffic in no-overlay mode


### PR DESCRIPTION
Add an ovnkube-node routing-table-id-start config knob for the Linux route table range used by generated VRF and route tables. Keep the default in ovnkube code, and have Helm render the value only when global.routingTableIDStart is explicitly provided.

Validate the start value against the reserved lower range and cap it so adding a Linux interface index still fits in a uint32 route table ID.

We hit this in downstream where our DPU was using VRF 1001 for its host management, and then OVNK took it over for a CUDN and broke the DPU.

Assisted-by: Codex <codex@openai.com>

