### PR TITLE
Optimize network sync, namespace filtering, and SNAT cleanup

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -647,20 +647,7 @@ func (as *ovnAddressSet) hasOnlyAddresses(addresses ...string) bool {
 		return false
 	}
 
-	for _, address := range addresses {
-		found := false
-		for _, existingAddress := range existingAddresses {
-			if existingAddress == address {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-
-	return true
+	return sets.New(existingAddresses...).HasAll(addresses...)
 }
 
 // deleteAddresses removes selected addresses from the existing address_set

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -50,6 +51,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/syncmap"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	utilerrors "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/errors"
 )
 
 // CommonNetworkControllerInfo structure is place holder for all fields shared among controllers.
@@ -211,7 +213,7 @@ func (oc *BaseNetworkController) reconcile(netInfo util.NetInfo, setNodeFailed f
 	reconcilePendingPods := !oc.IsDefault() && oc.updateNADKeysChanged(nadKeys)
 	reconcileNamespaces := sets.NewString()
 	if oc.IsPrimaryNetwork() {
-		// since CanServeNamespace filters out namespace events for namespaces unknown
+		// since shouldFilterNamespace filters out namespace events for namespaces unknown
 		// to be served by this primary network, we need to reconcile namespaces once
 		// the network is reconfigured to serve a namespace.
 		reconcileNamespaces = sets.NewString(netInfo.GetNADNamespaces()...).Difference(
@@ -292,6 +294,9 @@ func (oc *BaseNetworkController) doReconcile(reconcileRoutes, reconcilePendingPo
 			continue
 		}
 		namespaceAdded = true
+		if err := oc.addRemotePodsInNamespace(ns); err != nil {
+			klog.Errorf("Failed to requeue remote pods for namespace %s on network %s: %v", ns, oc.GetNetworkName(), err)
+		}
 	}
 	if namespaceAdded {
 		oc.retryNamespaces.RequestRetryObjs()
@@ -336,24 +341,37 @@ func (oc *BaseUserDefinedNetworkController) FilterOutResource(objType reflect.Ty
 	}
 }
 
-func (oc *BaseUserDefinedNetworkController) shouldFilterNamespace(namespace string) bool {
-	if !oc.IsPrimaryNetwork() || oc.networkManager == nil {
-		return !util.CanServeNamespace(oc.GetNetInfo(), namespace)
+// shouldFilterNamespace reports whether namespace's events should be filtered out because
+// it doesn't belong to this network. For primary networks, this asks the network manager
+// for the namespace's actual primary NAD rather than checking this controller's own NetInfo,
+// which under Dynamic UDN can diverge from it.
+func (bnc *BaseNetworkController) shouldFilterNamespace(namespace string) bool {
+	// Default network handles all namespaces
+	// Secondary networks can handle pods from different namespaces
+	if !bnc.IsPrimaryNetwork() {
+		return false
+	}
+	if bnc.networkManager == nil {
+		return !bnc.hasNADNamespace(namespace)
 	}
 
-	nadKey, err := oc.networkManager.GetPrimaryNADForNamespace(namespace)
+	nadKey, err := bnc.networkManager.GetPrimaryNADForNamespace(namespace)
 	if err != nil {
-		return false
+		return util.IsInvalidPrimaryNetworkError(err)
 	}
 	if nadKey == types.DefaultNetworkName {
 		return true
 	}
 
-	networkName := oc.networkManager.GetNetworkNameForNADKey(nadKey)
+	networkName := bnc.networkManager.GetNetworkNameForNADKey(nadKey)
 	if networkName == "" {
-		return !util.CanServeNamespace(oc.GetNetInfo(), namespace)
+		return !bnc.hasNADNamespace(namespace)
 	}
-	return networkName != oc.GetNetworkName()
+	return networkName != bnc.GetNetworkName()
+}
+
+func (bnc *BaseNetworkController) hasNADNamespace(namespace string) bool {
+	return slices.Contains(bnc.GetNADNamespaces(), namespace)
 }
 
 func getNetworkControllerName(netName string) string {
@@ -688,6 +706,38 @@ func (bnc *BaseNetworkController) addAllPodsOnNode(nodeName string) []error {
 	}
 	bnc.retryPods.RequestRetryObjs()
 	return errs
+}
+
+// addRemotePodsInNamespace requeues non-terminal remote pods in a namespace once it
+// becomes served by this network. Their Add may have been filtered by shouldFilterNamespace
+// while GetPrimaryNADForNamespace returned InvalidPrimaryNetworkError, and by then they can
+// be past Pending, so RequeuePendingPods misses them. Local pods are skipped: they can't get
+// past Pending without this controller's processing them.
+func (bnc *BaseNetworkController) addRemotePodsInNamespace(namespace string) error {
+	pods, err := bnc.watchFactory.GetPods(namespace)
+	if err != nil {
+		return fmt.Errorf("unable to list pods in namespace %s: %w", namespace, err)
+	}
+
+	var errs []error
+	podsAdded := false
+	for _, pod := range pods {
+		pod := *pod
+		if util.PodCompleted(&pod) || util.PodWantsHostNetwork(&pod) || bnc.isPodScheduledinLocalZone(&pod) {
+			continue
+		}
+		klog.V(5).Infof("Adding remote running pod %s/%s to retryPods for network %s",
+			pod.Namespace, pod.Name, bnc.GetNetworkName())
+		if err := bnc.retryPods.AddRetryObjWithAddNoBackoff(&pod); err != nil {
+			errs = append(errs, fmt.Errorf("failed to add pod %s/%s to retryPods: %w", pod.Namespace, pod.Name, err))
+			continue
+		}
+		podsAdded = true
+	}
+	if podsAdded {
+		bnc.retryPods.RequestRetryObjs()
+	}
+	return utilerrors.Join(errs...)
 }
 
 // getNamespaceLocked locks namespacesMutex, looks up ns, and (if found), returns it with

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -150,6 +150,9 @@ func (bnc *BaseNetworkController) syncNamespaces(namespaces []interface{}) error
 		if !ok {
 			return fmt.Errorf("spurious object in syncNamespaces: %v", nsInterface)
 		}
+		if bnc.shouldFilterNamespace(ns.Name) {
+			continue
+		}
 		expectedNs[ns.Name] = true
 		if bnc.multicastSupport && isNamespaceMulticastEnabled(ns.Annotations) {
 			nsWithMulticast[ns.Name] = true

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -26,6 +26,7 @@ import (
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/addresssetmanager"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/udnenabledsvc"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/retry"
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -463,6 +464,47 @@ var _ = Describe("BaseUserDefinedNetworkController", func() {
 		// Should skip pod without error when GetActiveNetworkForNamespace returns InvalidPrimaryNetworkError
 		err = controller.bnc.syncPodsForUserDefinedNetwork(initialPodList)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("picks up an already-running remote pod when its namespace newly joins a running primary UDN", func() {
+		config.OVNKubernetesFeature.EnableNetworkSegmentation = true
+		config.OVNKubernetesFeature.EnableMultiNetwork = true
+
+		const (
+			localNode    = "node-local"
+			newNamespace = "greenamespace"
+		)
+		// bluenet is already running, serving a different namespace
+		initialNad := ovntest.GenerateNAD("bluenet", "initialnad", "bluenamespace",
+			types.Layer3Topology, "100.128.0.0/16", types.NetworkRolePrimary)
+
+		remotePod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: newNamespace, Name: "remote-running"},
+			Spec:       corev1.PodSpec{NodeName: "node-remote"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		}
+		namespaceObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: newNamespace}}
+
+		fakeOVN := NewFakeOVN(false)
+		fakeOVN.start(namespaceObj, remotePod)
+		DeferCleanup(fakeOVN.shutdown)
+
+		Expect(fakeOVN.NewUserDefinedNetworkController(initialNad)).To(Succeed())
+		controller, ok := fakeOVN.userDefinedNetworkControllers["bluenet"]
+		Expect(ok).To(BeTrue())
+		bnc := controller.bnc
+
+		bnc.localZoneNodes = &sync.Map{}
+		bnc.localZoneNodes.Store(localNode, true)
+
+		// bluenet now also picks up greenamespace, where remotePod is already Running
+		afterInfo := util.NewMutableNetInfo(bnc.GetNetInfo())
+		afterInfo.AddNADs(util.GetNADName(newNamespace, "rednad"))
+		Expect(bnc.reconcile(afterInfo, func(string) {})).To(Succeed())
+
+		key, err := retry.GetResourceKey(remotePod)
+		Expect(err).NotTo(HaveOccurred())
+		retry.CheckRetryObjectEventually(key, true, bnc.retryPods)
 	})
 
 })

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -190,57 +190,64 @@ func (gw *GatewayManager) cleanupStalePodSNATs(nodeName string, nodeIPs []*net.I
 	if gw.netInfo.IsUserDefinedNetwork() && gw.getNetworkNameForNADKey == nil {
 		return fmt.Errorf("missing NAD resolver for network %q", gw.netInfo.GetNetworkName())
 	}
-	// collect all the pod IPs for which we should be doing the SNAT;
-	// if DisableSNATMultipleGWs==false we consider all
-	// the SNATs stale
-	podIPsWithSNAT := sets.New[string]()
-	if config.Gateway.DisableSNATMultipleGWs {
-		pods, err := gw.watchFactory.GetAllPods()
-		if err != nil {
-			return fmt.Errorf("unable to list existing pods on node: %s, %w",
-				nodeName, err)
-		}
-		for _, pod := range pods {
-			pod := *pod
-			if !util.PodScheduled(&pod) { //if the pod is not scheduled we should not remove the nat
-				continue
-			}
-			if pod.Spec.NodeName != nodeName {
-				continue
-			}
-			if util.PodCompleted(&pod) {
-				collidingPod, err := findPodWithIPAddresses(gw.watchFactory, gw.netInfo, []net.IP{utilnet.ParseIPSloppy(pod.Status.PodIP)}, "", gw.getNetworkNameForNADKey) //even if a pod is completed we should still delete the nat if the ip is not in use anymore
-				if err != nil {
-					return fmt.Errorf("lookup for pods with same ip as %s %s failed: %w", pod.Namespace, pod.Name, err)
-				}
-				if collidingPod != nil { //if the ip is in use we should not remove the nat
-					continue
-				}
-			}
-			podIPs, err := util.GetPodIPsOfNetwork(&pod, gw.netInfo, gw.getNetworkNameForNADKey)
-			if err != nil && errors.Is(err, util.ErrNoPodIPFound) {
-				// It is possible that the pod is scheduled during this time, but the LSP add or
-				// IP Allocation has not happened and it is waiting for the WatchPods to start
-				// after WatchNodes completes (This function is called during syncNodes). So since
-				// the pod doesn't have any IPs, there is no SNAT here to keep for this pod so we skip
-				// this pod from processing and move onto the next one.
-				klog.Warningf("Unable to fetch podIPs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-				continue // no-op
-			} else if err != nil {
-				return fmt.Errorf("unable to fetch podIPs for pod %s/%s: %w", pod.Namespace, pod.Name, err)
-			}
-			for _, podIP := range podIPs {
-				podIPsWithSNAT.Insert(podIP.String())
-			}
-		}
-	}
 
 	gatewayRouter := &nbdb.LogicalRouter{
 		Name: gw.gwRouterName,
 	}
 	routerNATs, err := libovsdbops.GetRouterNATs(gw.nbClient, gatewayRouter)
-	if err != nil && errors.Is(err, libovsdbclient.ErrNotFound) {
+	if err != nil {
 		return fmt.Errorf("unable to get NAT entries for router %s on node %s: %w", gatewayRouter.Name, nodeName, err)
+	}
+	if len(routerNATs) == 0 {
+		// no nats, nothing to clean up
+		return nil
+	}
+
+	// collect all the pod IPs for which we should be doing the SNAT;
+	// if DisableSNATMultipleGWs==false we consider all
+	// the SNATs stale
+	podIPsWithSNAT := sets.New[string]()
+	if config.Gateway.DisableSNATMultipleGWs {
+		// For UDNs, only scan namespaces attached to this network.
+		// For the default network NADNamespaces is empty; GetPods("")
+		// falls back to listing all pods (ListAllByNamespace on "").
+		nadNamespaces := gw.netInfo.GetNADNamespaces()
+		if len(nadNamespaces) == 0 {
+			nadNamespaces = []string{""}
+		}
+		for _, ns := range nadNamespaces {
+			pods, err := gw.watchFactory.GetPods(ns)
+			if err != nil {
+				return fmt.Errorf("unable to list existing pods in namespace %q: %w", ns, err)
+			}
+			for _, pod := range pods {
+				if !util.PodScheduled(pod) {
+					continue
+				}
+				if pod.Spec.NodeName != nodeName {
+					continue
+				}
+				if util.PodCompleted(pod) {
+					collidingPod, err := findPodWithIPAddresses(gw.watchFactory, gw.netInfo, []net.IP{utilnet.ParseIPSloppy(pod.Status.PodIP)}, "", gw.getNetworkNameForNADKey)
+					if err != nil {
+						return fmt.Errorf("lookup for pods with same ip as %s %s failed: %w", pod.Namespace, pod.Name, err)
+					}
+					if collidingPod != nil {
+						continue
+					}
+				}
+				podIPs, err := util.GetPodIPsOfNetwork(pod, gw.netInfo, gw.getNetworkNameForNADKey)
+				if err != nil && errors.Is(err, util.ErrNoPodIPFound) {
+					klog.Warningf("Unable to fetch podIPs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+					continue
+				} else if err != nil {
+					return fmt.Errorf("unable to fetch podIPs for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+				}
+				for _, podIP := range podIPs {
+					podIPsWithSNAT.Insert(podIP.String())
+				}
+			}
+		}
 	}
 
 	nodeIPset := sets.New(util.IPNetsIPToStringSlice(nodeIPs)...)

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -4,6 +4,7 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -16,6 +17,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/utils/net"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	nodecontroller "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/controllers/node"
@@ -2606,5 +2609,217 @@ var _ = ginkgo.Describe("AddPodSNATOps", func() {
 		}
 		gomega.Expect(foundNATOp).To(gomega.BeTrue(), "Should have NAT insert operation")
 
+	})
+})
+
+var _ = ginkgo.Describe("cleanupStalePodSNATs", func() {
+	var (
+		fakeOvn *FakeOVN
+	)
+	const testNode = "test-node"
+
+	ginkgo.BeforeEach(func() {
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		fakeOvn = NewFakeOVN(true)
+	})
+
+	ginkgo.AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	ginkgo.It("returns error when router does not exist", func() {
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{})
+
+		gw := newGatewayManager(fakeOvn, testNode)
+		nodeIPs := ovntest.MustParseIPNets("169.255.33.2/24")
+		gwLRPIPs := ovntest.MustParseIPs("100.64.0.3")
+
+		err := gw.cleanupStalePodSNATs(testNode, nodeIPs, gwLRPIPs)
+		gomega.Expect(errors.Is(err, libovsdbclient.ErrNotFound)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("deletes stale pod SNAT", func() {
+		gwRouterName := "GR_" + testNode
+		staleNAT := &nbdb.NAT{
+			UUID:       "stale-nat-UUID",
+			Type:       nbdb.NATTypeSNAT,
+			ExternalIP: "169.255.33.2",
+			LogicalIP:  "10.128.0.5",
+		}
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				&nbdb.LogicalRouter{
+					UUID: gwRouterName + "-UUID",
+					Name: gwRouterName,
+					Nat:  []string{staleNAT.UUID},
+				},
+				staleNAT,
+			},
+		})
+
+		gw := newGatewayManager(fakeOvn, testNode)
+		nodeIPs := ovntest.MustParseIPNets("169.255.33.2/24")
+		gwLRPIPs := ovntest.MustParseIPs("100.64.0.3")
+
+		err := gw.cleanupStalePodSNATs(testNode, nodeIPs, gwLRPIPs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		expectedDB := []libovsdbtest.TestData{
+			&nbdb.LogicalRouter{
+				UUID: gwRouterName + "-UUID",
+				Name: gwRouterName,
+				Nat:  []string{},
+			},
+		}
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDB))
+	})
+
+	ginkgo.It("preserves SNAT for gateway LRP IP", func() {
+		gwRouterName := "GR_" + testNode
+		gwLRPNAT := &nbdb.NAT{
+			UUID:       "gwlrp-nat-UUID",
+			Type:       nbdb.NATTypeSNAT,
+			ExternalIP: "169.255.33.2",
+			LogicalIP:  "100.64.0.3",
+		}
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				&nbdb.LogicalRouter{
+					UUID: gwRouterName + "-UUID",
+					Name: gwRouterName,
+					Nat:  []string{gwLRPNAT.UUID},
+				},
+				gwLRPNAT,
+			},
+		})
+
+		gw := newGatewayManager(fakeOvn, testNode)
+		nodeIPs := ovntest.MustParseIPNets("169.255.33.2/24")
+		gwLRPIPs := ovntest.MustParseIPs("100.64.0.3")
+
+		err := gw.cleanupStalePodSNATs(testNode, nodeIPs, gwLRPIPs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		expectedDB := []libovsdbtest.TestData{
+			&nbdb.LogicalRouter{
+				UUID: gwRouterName + "-UUID",
+				Name: gwRouterName,
+				Nat:  []string{gwLRPNAT.UUID},
+			},
+			gwLRPNAT,
+		}
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDB))
+	})
+
+	ginkgo.It("preserves SNAT for active pod when DisableSNATMultipleGWs is true", func() {
+		gwRouterName := "GR_" + testNode
+		podNAT := &nbdb.NAT{
+			UUID:       "pod-nat-UUID",
+			Type:       nbdb.NATTypeSNAT,
+			ExternalIP: "169.255.33.2",
+			LogicalIP:  "10.128.0.5",
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["10.128.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`,
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: testNode,
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: "10.128.0.5",
+			},
+		}
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				&nbdb.LogicalRouter{
+					UUID: gwRouterName + "-UUID",
+					Name: gwRouterName,
+					Nat:  []string{podNAT.UUID},
+				},
+				podNAT,
+			},
+		},
+			&corev1.PodList{Items: []corev1.Pod{*pod}},
+		)
+
+		config.Gateway.DisableSNATMultipleGWs = true
+		gw := newGatewayManager(fakeOvn, testNode)
+		nodeIPs := ovntest.MustParseIPNets("169.255.33.2/24")
+		gwLRPIPs := ovntest.MustParseIPs("100.64.0.3")
+
+		err := gw.cleanupStalePodSNATs(testNode, nodeIPs, gwLRPIPs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		expectedDB := []libovsdbtest.TestData{
+			&nbdb.LogicalRouter{
+				UUID: gwRouterName + "-UUID",
+				Name: gwRouterName,
+				Nat:  []string{podNAT.UUID},
+			},
+			podNAT,
+		}
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDB))
+	})
+
+	ginkgo.It("deletes pod SNAT when DisableSNATMultipleGWs is false", func() {
+		gwRouterName := "GR_" + testNode
+		podNAT := &nbdb.NAT{
+			UUID:       "pod-nat-UUID",
+			Type:       nbdb.NATTypeSNAT,
+			ExternalIP: "169.255.33.2",
+			LogicalIP:  "10.128.0.5",
+		}
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{
+				&nbdb.LogicalRouter{
+					UUID: gwRouterName + "-UUID",
+					Name: gwRouterName,
+					Nat:  []string{podNAT.UUID},
+				},
+				podNAT,
+			},
+		},
+			&corev1.PodList{Items: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["10.128.0.5/24"],"mac_address":"0a:58:0a:80:00:05"}}`,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: testNode,
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						PodIP: "10.128.0.5",
+					},
+				},
+			}},
+		)
+
+		config.Gateway.DisableSNATMultipleGWs = false
+		gw := newGatewayManager(fakeOvn, testNode)
+		nodeIPs := ovntest.MustParseIPNets("169.255.33.2/24")
+		gwLRPIPs := ovntest.MustParseIPs("100.64.0.3")
+
+		err := gw.cleanupStalePodSNATs(testNode, nodeIPs, gwLRPIPs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		expectedDB := []libovsdbtest.TestData{
+			&nbdb.LogicalRouter{
+				UUID: gwRouterName + "-UUID",
+				Name: gwRouterName,
+				Nat:  []string{},
+			},
+		}
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDB))
 	})
 })

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -2042,25 +2042,6 @@ func ParseNetworkIDFromVRFName(vrf string) int {
 	return id
 }
 
-// CanServeNamespace determines whether the given network can serve a specific namespace.
-//
-// For default and secondary networks it always returns true.
-// For primary networks, it checks if the namespace is explicitly listed in the network's
-// associated namespaces.
-func CanServeNamespace(network NetInfo, namespace string) bool {
-	// Default network handles all namespaces
-	// Secondary networks can handle pods from different namespaces
-	if !network.IsPrimaryNetwork() {
-		return true
-	}
-	for _, ns := range network.GetNADNamespaces() {
-		if ns == namespace {
-			return true
-		}
-	}
-	return false
-}
-
 // GetNetworkRole returns the role of this controller's
 // network for the given pod
 // Expected values are:

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -401,12 +401,47 @@ func SecondaryNetworkPodIPs(pod *corev1.Pod, networkInfo NetInfo, getNetworkName
 	if getNetworkNameForNADKey == nil {
 		return nil, fmt.Errorf("missing NAD resolver for network %q", networkInfo.GetNetworkName())
 	}
-	podNADKeys, err := PodNADKeys(pod, networkInfo, getNetworkNameForNADKey)
+	if networkInfo.IsPrimaryNetwork() {
+		podNetworks, err := UnmarshalPodAnnotationAllNetworks(pod.Annotations)
+		if err != nil {
+			return nil, err
+		}
+		for nadKey, ann := range podNetworks {
+			networkName := getNetworkNameForNADKey(nadKey)
+			if networkName == "" || networkName != networkInfo.GetNetworkName() {
+				continue
+			}
+			annIPs, err := podAnnotationIPs(&ann)
+			if err != nil {
+				return nil, err
+			}
+			ips = append(ips, annIPs...)
+		}
+		return ips, nil
+	}
+
+	on, networkMap, err := getPodNADToNetworkMapping(pod, networkInfo, getNetworkNameForNADKey)
+	if err != nil {
+		return nil, err
+	} else if !on {
+		return []net.IP{}, nil
+	}
+
+	podNetworks, err := UnmarshalPodAnnotationAllNetworks(pod.Annotations)
 	if err != nil {
 		return nil, err
 	}
-	for _, nadKey := range podNADKeys {
-		ips = append(ips, getAnnotatedPodIPs(pod, nadKey)...)
+
+	for nadKey := range networkMap {
+		ann, ok := podNetworks[nadKey]
+		if !ok {
+			continue
+		}
+		annIPs, err := podAnnotationIPs(&ann)
+		if err != nil {
+			return nil, err
+		}
+		ips = append(ips, annIPs...)
 	}
 	return ips, nil
 }
@@ -447,6 +482,25 @@ func PodNADKeys(pod *corev1.Pod, netinfo NetInfo, getNetworkNameForNADKey func(n
 		nadKeys = append(nadKeys, nadKey)
 	}
 	return nadKeys, nil
+}
+
+func podAnnotationIPs(ann *podAnnotation) ([]net.IP, error) {
+	ipStrs := ann.IPs
+	if len(ipStrs) > 0 && ann.IP != "" && ann.IP != ipStrs[0] {
+		return nil, fmt.Errorf("bad annotation data (ip_address and ip_addresses conflict)")
+	}
+	if len(ipStrs) == 0 && ann.IP != "" {
+		ipStrs = []string{ann.IP}
+	}
+	ips := make([]net.IP, 0, len(ipStrs))
+	for _, ipStr := range ipStrs {
+		ip, _, err := net.ParseCIDR(ipStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse pod IP %q: %v", ipStr, err)
+		}
+		ips = append(ips, ip)
+	}
+	return ips, nil
 }
 
 func getAnnotatedPodIPs(pod *corev1.Pod, nadKey string) []net.IP {

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -428,6 +428,89 @@ func newDummyNetInfo(namespace, networkName string) NetInfo {
 	return mutableNetInfo
 }
 
+func newPrimaryNetInfo(namespace, networkName string) NetInfo {
+	netInfo, _ := newLayer3NetConfInfo(&ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{Name: networkName},
+		Role:    types.NetworkRolePrimary,
+	})
+	mutableNetInfo := NewMutableNetInfo(netInfo)
+	mutableNetInfo.AddNADs(GetNADName(namespace, networkName))
+	return mutableNetInfo
+}
+
+func TestSecondaryNetworkPodIPs(t *testing.T) {
+	nadResolver := func(nadKey string) string {
+		switch nadKey {
+		case "ns1/mynet":
+			return "mynet"
+		case "ns2/mynet":
+			return "mynet"
+		default:
+			return ""
+		}
+	}
+
+	tests := []struct {
+		desc        string
+		annotations map[string]string
+		netInfo     NetInfo
+		wantIPs     []net.IP
+		wantErr     bool
+	}{
+		{
+			desc: "primary network: matching NAD key returns IPs",
+			annotations: map[string]string{
+				types.OvnPodAnnotationName: `{"ns1/mynet":{"ip_addresses":["10.0.0.5/24"],"mac_address":"0a:58:0a:00:00:05"}}`,
+			},
+			netInfo: newPrimaryNetInfo("ns1", "mynet"),
+			wantIPs: []net.IP{net.ParseIP("10.0.0.5")},
+		},
+		{
+			desc: "primary network: unrelated NAD key returns no IPs",
+			annotations: map[string]string{
+				types.OvnPodAnnotationName: `{"ns1/othernet":{"ip_addresses":["10.0.0.5/24"],"mac_address":"0a:58:0a:00:00:05"}}`,
+			},
+			netInfo: newPrimaryNetInfo("ns1", "mynet"),
+			wantIPs: []net.IP{},
+		},
+		{
+			desc: "primary network: multiple matching NADs returns all IPs",
+			annotations: map[string]string{
+				types.OvnPodAnnotationName: `{"ns1/mynet":{"ip_addresses":["10.0.0.5/24"],"mac_address":"0a:58:0a:00:00:05"},"ns2/mynet":{"ip_addresses":["10.0.1.5/24"],"mac_address":"0a:58:0a:00:01:05"}}`,
+			},
+			netInfo: newPrimaryNetInfo("ns1", "mynet"),
+			wantIPs: []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.1.5")},
+		},
+		{
+			desc: "primary network: bad annotation returns error",
+			annotations: map[string]string{
+				types.OvnPodAnnotationName: `not-json`,
+			},
+			netInfo: newPrimaryNetInfo("ns1", "mynet"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pod",
+					Namespace:   "ns1",
+					Annotations: tc.annotations,
+				},
+			}
+			ips, err := SecondaryNetworkPodIPs(pod, tc.netInfo, nadResolver)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.wantIPs, ips)
+		})
+	}
+}
+
 func TestUnmarshalUDNOpenPortsAnnotation(t *testing.T) {
 	intRef := func(i int) *int {
 		return &i


### PR DESCRIPTION
Summary
  - Use sets.HasAll for O(n) membership check in hasOnlyAddresses
  - Skip namespaces not served by this network in syncNamespaces, shouldFilterNamespace treats IsInvalidPrimaryNetworkError as a signal to filter
  - Early-exit cleanupStalePodSNATs when no NATs exist; scope pod listing to NAD namespaces for UDN
  - Remove redundant JSON unmarshal in SecondaryNetworkPodIPs