### PR TITLE
Fix RA string %!w(<nil>)  when no subnets

### DIFF
--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -684,8 +684,11 @@ func (c *Controller) generateFRRConfigurations(ra *ratypes.RouteAdvertisements) 
 				}
 			} else {
 				subnets, err = getHostSubnets(nodeName, network)
-				if err != nil || len(subnets) == 0 {
+				if err != nil {
 					return nil, fmt.Errorf("%w: will wait for subnet annotation to be set for node %q and network %q: %w", errConfig, nodeName, network, err)
+				}
+				if len(subnets) == 0 {
+					return nil, fmt.Errorf("%w: will wait for subnet annotation to be set for node %q and network %q", errConfig, nodeName, network)
 				}
 			}
 


### PR DESCRIPTION
📑 Description
Fix misleading RouteAdvertisements status messages when a node has a subnet annotation but is missing the subnet for the selected network.

In generateFRRConfigurations, the layer3 pod-network path treated "host subnet lookup returned an error" and "host subnet list is empty" as one case. When getHostSubnets succeeded with an empty slice (e.g. the node has subnets for other networks but not the one being advertised), the code still used %w with a nil err, producing a status message like:

configuration error: will wait for subnet annotation to be set for node "node" and network "default": %!w(<nil>)

This change splits the two cases so the empty-subnet path returns a clean message without wrapping nil.

Fixes #

Additional Information for reviewers
Changed file: go-controller/pkg/clustermanager/routeadvertisements/controller.go

What changed: In getPrefixes() inside generateFRRConfigurations(), the combined check:

if err != nil || len(subnets) == 0 {
    return nil, fmt.Errorf("...: %w", ..., err)
}
was split into:

err != nil — still wraps the underlying error
len(subnets) == 0 with err == nil — returns the same user-facing message without %w on nil
Behavior: Unchanged functionally — the RA still gets Accepted=False with reason ConfigurationError and requeues until the subnet annotation is populated. Only the status message text is fixed.

Existing test coverage: The unit test "fails to reconcile when subnet annotation is missing for network" in controller_test.go already exercises this path (node has {"red":"1.1.0.0/24"} but RA advertises the default network).

✅ Checks

 My code requires changes to the documentation

 if so, I have updated the documentation as required

 My code does not require changes to the documentation

 My code requires tests

 if so, I have added and/or updated the tests as required

 My code does not require tests

 All the tests have passed in the CI
How to verify it
Unit tests:

cd go-controller
go test ./pkg/clustermanager/routeadvertisements/... -run 'TestControllerReconcile/fails_to_reconcile_when_subnet_annotation_is_missing_for_network'
Manual verification:

Create a RouteAdvertisements that advertises pod networks on a layer3 UDN/default network.

Ensure a selected node has a host subnet annotation for a different network (or no entry for the selected network), but not for the network the RA selects.

Check the RA status condition message — it should read:

configuration error: will wait for subnet annotation to be set for node "<node>" and network "<network>"

and should not contain %!w(<nil>) or w(<nil>).

After the cluster-manager sets the missing subnet annotation, the RA should reconcile to Accepted=True.
