### PR TITLE
Fix remote chassis not recreated after chassis-id change on non-DPU controllers

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -564,9 +564,11 @@ func (oc *DefaultNetworkController) ReconcileNode(oldNode, newNode *corev1.Node,
 			klog.Infof("Node %q in remote zone %q, network %q, needs interconnect zone sync up",
 				newNode.Name, util.GetNodeZone(newNode), oc.GetNetworkName())
 		}
-		// Reprovisioning the DPU, including OVS, changes the chassis system ID without changing the node.
-		// Delete the stale remote chassis mapping so the new chassis can be associated cleanly.
-		if oldNode != nil && config.OvnKubeNode.Mode == types.NodeModeDPU && nodeChassisChanged(oldNode, newNode) {
+		// When the chassis system ID changes (e.g. DPU reprovisioning), delete the
+		// stale remote chassis mapping so the new chassis can be associated cleanly.
+		if oldNode != nil && nodeChassisChanged(oldNode, newNode) {
+			klog.Infof("Node %q chassis-id changed from %q to %q, deleting stale remote chassis",
+				newNode.Name, oldNode.Annotations[util.OvnNodeChassisID], newNode.Annotations[util.OvnNodeChassisID])
 			if err := oc.zoneChassisHandler.DeleteRemoteZoneNode(oldNode); err != nil {
 				aggregatedErrors = append(aggregatedErrors, err)
 			}


### PR DESCRIPTION
## Summary

- Remove `NodeModeDPU` guard from remote chassis deletion on chassis-id change so it works on all controller modes
- Add log message when deleting stale chassis due to chassis-id change

## Problem

When a remote DPU worker node's chassis-id changes (e.g., after DPU reprovisioning that regenerates the OVS `system-id`), the ovnkube-controller running on master nodes (in `NodeModeFull`) fails to delete the stale remote chassis and recreate it. This is because the chassis deletion + `syncZoneIC` trigger was guarded by `config.OvnKubeNode.Mode == types.NodeModeDPU`, which checks the **local** controller's mode — not the remote node's mode. On masters, this is `NodeModeFull`, so the guard is always false.

The stale chassis is eventually cleaned up by the periodic `syncChassis()`, but the new chassis is never created — leaving the remote node permanently without a chassis entry in the master's SBDB, breaking all cross-zone traffic.

## Root Cause

`config.OvnKubeNode.Mode` is the mode of the currently running ovnkube process, not the remote node's mode. The guard was added in #5307 assuming it would only run on DPU-mode controllers, but in IC mode every node runs its own ovnkube-controller — masters run in `NodeModeFull`.

The L2 UDN controller already handles chassis-id changes correctly without this guard.

## Fix

Remove the `NodeModeDPU` guard so the stale chassis cleanup fires on any controller that detects a `nodeChassisChanged` on a remote node. The existing block already sets `syncZoneIC = true`, which triggers `AddRemoteZoneNode` to create the new chassis.

Fixes: https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6627

## Test plan

- [ ] Deploy cluster with DPU workers in IC mode
- [ ] Reprovision DPU (causing new OVS system-id)
- [ ] Verify old chassis is deleted from master's SBDB
- [ ] Verify new chassis is created in master's SBDB
- [ ] Verify cross-zone traffic works after reprovisioning

Made with [Cursor](https://cursor.com)