### PR TITLE
docs: fix typo in OKEP 5193 CUDN spec

### DIFF
--- a/docs/okeps/okep-5193-user-defined-networks.md
+++ b/docs/okeps/okep-5193-user-defined-networks.md
@@ -611,8 +611,8 @@ type ClusterUserDefinedNetwork struct {
     Status ClusterUserDefinedNetworkStatus `json:"status,omitempty"`
 }
 
-// ClusterUserDefinedNetwork defines the desired state of ClusterUserDefinedNetwork.
-type ClusterUserDefinedNetwork struct {
+// ClusterUserDefinedNetworkSpec defines the desired state of ClusterUserDefinedNetwork.
+type ClusterUserDefinedNetworkSpec struct {
     // NamespaceSelector Label selector for which namespace network should be available for.
     // +kubebuilder:validation:Required
     // +required


### PR DESCRIPTION
  ## 📑 Description

  Fix a typo in OKEP 5193 where the ClusterUserDefinedNetwork spec type was incorrectly shown as `ClusterUserDefinedNetwork`.

  The snippet now uses the correct `ClusterUserDefinedNetworkSpec` type, matching the `Spec ClusterUserDefinedNetworkSpec` field shown above it.

  ## Additional Information for reviewers

  Changed only `docs/okeps/okep-5193-user-defined-networks.md`.

  This is a documentation-only correction to the sample Go type declaration in the Cluster scoped CRD section.

  ## ✅ Checks

  - [ ] My code requires changes to the documentation
  - [ ] if so, I have updated the documentation as required
  - [ ] My code does not require changes to the documentation
  - [ ] My code requires tests
  - [ ] if so, I have added and/or updated the tests as required
  - [ ] My code does not require tests
  - [ ] All the tests have passed in the CI

  ## How to verify it

  Review the Cluster scoped CRD section in `docs/okeps/okep-5193-user-defined-networks.md` and confirm the spec type is declared as `ClusterUserDefinedNetworkSpec`.