### PR TITLE
area-merge: prevent bot comment feedback loop

### DIFF
--- a/.github/scripts/area-merge.js
+++ b/.github/scripts/area-merge.js
@@ -8,13 +8,30 @@
 const fs = require('fs');
 
 module.exports = async ({ github, context, core }) => {
+  // Comments created by this workflow are posted under the GitHub App
+  // identity (e.g. "ovn-kubernetes-merge-bot[bot]"), NOT "github-actions[bot]".
+  // Unlike the default GITHUB_TOKEN, comments created with an App token DO
+  // trigger new issue_comment workflow runs, so the bot must be able to
+  // recognize its own comments to avoid reacting to them in a loop.
+  const botLogin = process.env.BOT_LOGIN || 'ovn-kubernetes-merge-bot[bot]';
+
   // --- Determine which PRs to process and who triggered ---
   let pullNumbers = [];
   let commenter = null;
 
   if (context.eventName === 'issue_comment') {
+    // Defense in depth (the workflow `if` also enforces this): only accept
+    // the command at the start of a comment authored by a human. Bot
+    // status/error messages merely mentioning the command must never be
+    // treated as a merge request.
+    const comment = context.payload.comment;
+    if (comment.user.type === 'Bot' ||
+        !comment.body.trim().startsWith('/area-maintainer-approved')) {
+      core.info('Ignoring comment: authored by a bot or not a /area-maintainer-approved command');
+      return;
+    }
     pullNumbers.push(context.payload.issue.number);
-    commenter = context.payload.comment.user.login.toLowerCase();
+    commenter = comment.user.login.toLowerCase();
   } else if (context.eventName === 'check_suite') {
     const suite = context.payload.check_suite;
     for (const pr of (suite.pull_requests || [])) {
@@ -133,8 +150,8 @@ module.exports = async ({ github, context, core }) => {
       allComments = await fetchAllComments(prNumber);
       const mergeComment = [...allComments]
         .reverse()
-        .find(c => c.body.includes('/area-maintainer-approved') &&
-                   c.user.login !== 'github-actions[bot]' &&
+        .find(c => c.body.trim().startsWith('/area-maintainer-approved') &&
+                   c.user.type !== 'Bot' &&
                    c.user.login.toLowerCase() !== prAuthor);
       if (mergeComment) {
         requester = mergeComment.user.login.toLowerCase();
@@ -153,7 +170,7 @@ module.exports = async ({ github, context, core }) => {
       if (!allComments) allComments = await fetchAllComments(prNumber);
       const waitingMarker = `<!-- area-merge-sha:${pr.head.sha} -->`;
       const isWaiting = allComments.some(c =>
-        c.user.login === 'github-actions[bot]' &&
+        c.user.login === botLogin &&
         c.body.includes(waitingMarker)
       );
       if (!isWaiting) {
@@ -301,7 +318,7 @@ module.exports = async ({ github, context, core }) => {
       const shaMarker = `<!-- area-merge-sha:${ref} -->`;
       if (!allComments) allComments = await fetchAllComments(prNumber);
       const alreadyWaiting = allComments.some(c =>
-        c.user.login === 'github-actions[bot]' &&
+        c.user.login === botLogin &&
         c.body.includes(shaMarker)
       );
       if (!alreadyWaiting) {

--- a/.github/workflows/area-merge.yml
+++ b/.github/workflows/area-merge.yml
@@ -8,10 +8,17 @@ on:
 
 jobs:
   area-merge:
+    # Only react to /area-maintainer-approved at the start of a comment, and
+    # never to comments authored by bots. Comments posted by this workflow use
+    # a GitHub App token, so (unlike the default GITHUB_TOKEN) they DO trigger
+    # new issue_comment events — matching the command anywhere in any comment
+    # body previously caused the bot to react to its own status/error messages
+    # in an infinite loop.
     if: >
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/area-maintainer-approved')) ||
+       github.event.comment.user.type != 'Bot' &&
+       startsWith(github.event.comment.body, '/area-maintainer-approved')) ||
       github.event_name == 'check_suite'
     runs-on: ubuntu-latest
     steps:
@@ -33,6 +40,10 @@ jobs:
 
       - name: Area maintainer merge check
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          # The login the bot's own comments are posted under, used by
+          # area-merge.js to recognize (and ignore) its own comments.
+          BOT_LOGIN: ${{ steps.merge-app-token-generator.outputs.app-slug }}[bot]
         with:
           github-token: ${{ steps.merge-app-token-generator.outputs.token }}
           script: |


### PR DESCRIPTION
## 📑 Description
<!-- Add a brief description of the pr -->

Fixes the `/area-maintainer-approved` merge bot replying to itself in an
infinite loop, as happened on #6597 (153 error comments in ~30 minutes).

Root cause chain:
1. The workflow gate used `contains(comment.body, '/area-maintainer-approved')`, matching the command **anywhere** in **any** comment — including the bot's own status/error messages, which quote the command.
2. Bot comments are posted with a **GitHub App token** (`ovn-kubernetes-merge-bot[bot]`). Unlike the default `GITHUB_TOKEN`, App-token comments **do** trigger new `issue_comment` workflow runs.
3. Each self-triggered run evaluated the bot itself as the requester, failed the area maintainer check, and posted another error comment quoting the command → loop.

On top of that, `area-merge.js` still assumed its comments were authored by `github-actions[bot]`, so the `check_suite` waiting-marker lookup never matched and the promised "merge automatically when all checks pass" never fired.

## Additional Information for reviewers

- `.github/workflows/area-merge.yml`: the gate now requires the command at the **start** of the comment (`startsWith`) and rejects comments authored by bots (`comment.user.type != 'Bot'`). The `app-slug` output of `create-github-app-token` is passed to the script as `BOT_LOGIN` so it can recognize its own comments without hardcoding the App name.
- `.github/scripts/area-merge.js`:
  - defense-in-depth guard mirroring the workflow gate (bot comments / non-anchored commands are ignored even if the workflow condition regresses);
  - `check_suite` requester detection now requires the command at the start of the comment and skips all bot authors (previously only `github-actions[bot]`);
  - the waiting-marker (`isWaiting`) and dedup (`alreadyWaiting`) lookups now match comments authored by the App login instead of `github-actions[bot]`, repairing auto-merge-on-CI-completion and preventing duplicate "waiting" comments.

The loop scenario from #6597 was replayed against the patched script with a mocked Octokit: the bot's error comment, its "waiting" comment and a human quote-reply are all ignored; a genuine `/area-maintainer-approved` from an area maintainer proceeds through authorization, CI gating and merge; a `check_suite` event with only bot/quoted comments finds no requester and exits silently.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

On a fork with the merge bot App installed:
1. Comment `/area-maintainer-approved` as an area maintainer on a PR with pending CI → the bot posts a single "waiting" comment and does **not** react to it.
2. Post a comment merely quoting the command (e.g. replying to a bot message) → no workflow run is dispatched.
3. Let CI complete → the PR is merged automatically (previously the waiting-marker lookup never matched, so this path was dead).
