### PR TITLE
routemanager: normalize IPv6 route metric to kernel default

### DIFF
--- a/go-controller/pkg/node/routemanager/route_manager.go
+++ b/go-controller/pkg/node/routemanager/route_manager.go
@@ -194,6 +194,11 @@ func (c *Controller) hasRouteInStore(r *netlink.Route) bool {
 	return route != nil && util.RouteEqual(r, route)
 }
 
+// ipv6DefaultRouteMetric is the metric the kernel assigns to IPv6 routes added
+// without an explicit one (IP6_RT_PRIO_USER in include/net/ip6_route.h). IPv4
+// routes default to metric 0.
+const ipv6DefaultRouteMetric = 1024
+
 func validateAndNormalizeRoute(r *netlink.Route) (*netlink.Route, error) {
 	if r == nil {
 		return nil, fmt.Errorf("nil route provided")
@@ -201,7 +206,26 @@ func validateAndNormalizeRoute(r *netlink.Route) (*netlink.Route, error) {
 	if r.Table == unix.RT_TABLE_UNSPEC {
 		r.Table = unix.RT_TABLE_MAIN
 	}
+	// The kernel assigns IPv6 routes a default metric of 1024 when none is
+	// given, so a store key derived from Priority 0 would never match the
+	// same route as reported by the kernel in events and dumps, breaking
+	// event-driven restore and making sync() re-add the route every period.
+	// Normalize the priority so the store key matches the kernel's view.
+	if r.Priority == 0 && isIPv6Route(r) {
+		r.Priority = ipv6DefaultRouteMetric
+	}
 	return r, nil
+}
+
+func isIPv6Route(r *netlink.Route) bool {
+	switch {
+	case r.Dst != nil && r.Dst.IP != nil:
+		return r.Dst.IP.To4() == nil
+	case r.Gw != nil:
+		return r.Gw.To4() == nil
+	default:
+		return r.Family == netlink.FAMILY_V6
+	}
 }
 
 func keyFromNetlink(r *netlink.Route) key {

--- a/go-controller/pkg/node/routemanager/route_manager_test.go
+++ b/go-controller/pkg/node/routemanager/route_manager_test.go
@@ -277,6 +277,73 @@ var _ = ginkgo.Describe("Route Manager", func() {
 		})
 	})
 
+	ginkgo.Context("IPv6 default metric", func() {
+		v6Subnet := ovntest.MustParseIPNet("fd99::/64")
+
+		ginkgo.It("stores IPv6 routes under the kernel-assigned default metric", func() {
+			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Dst: v6Subnet, Table: mainTableID, Type: unix.RTN_UNICAST}
+			gomega.Expect(addRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
+
+			var kernelRoute *netlink.Route
+			gomega.Eventually(func() *netlink.Route {
+				err := testNS.Do(func(ns.NetNS) error {
+					filter, mask := filterRouteByTable(loLink.Attrs().Index, mainTableID)
+					routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, filter, mask)
+					if err != nil {
+						return err
+					}
+					for i := range routes {
+						if routes[i].Dst != nil && routes[i].Dst.String() == v6Subnet.String() {
+							kernelRoute = &routes[i]
+							break
+						}
+					}
+					return nil
+				})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				return kernelRoute
+			}, time.Second).ShouldNot(gomega.BeNil())
+
+			// the kernel assigns IPv6 routes a default metric of 1024
+			// (IP6_RT_PRIO_USER) when none is specified
+			gomega.Expect(kernelRoute.Priority).To(gomega.Equal(ipv6DefaultRouteMetric))
+			// the store key must match the kernel-reported route, otherwise
+			// event-driven restore never triggers for IPv6 routes and sync
+			// re-adds them every period
+			rm.Lock()
+			_, found := rm.store[keyFromNetlink(kernelRoute)]
+			rm.Unlock()
+			gomega.Expect(found).To(gomega.BeTrue(), "managed IPv6 route must be stored under the kernel-reported key")
+
+			// deleting with an unset metric must remove both the kernel route
+			// and the store entry
+			gomega.Expect(delRouteViaManager(rm, testNS, r)).Should(gomega.Succeed())
+			gomega.Eventually(func() bool {
+				found := false
+				err := testNS.Do(func(ns.NetNS) error {
+					filter, mask := filterRouteByTable(loLink.Attrs().Index, mainTableID)
+					routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, filter, mask)
+					if err != nil {
+						return err
+					}
+					for i := range routes {
+						if routes[i].Dst != nil && routes[i].Dst.String() == v6Subnet.String() {
+							found = true
+							break
+						}
+					}
+					return nil
+				})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				return found
+			}, time.Second).Should(gomega.BeFalse())
+			rm.Lock()
+			storeLen := len(rm.store)
+			rm.Unlock()
+			gomega.Expect(storeLen).To(gomega.BeZero())
+		})
+	})
+
 	ginkgo.Context("runtime sync", func() {
 		ginkgo.It("reapplies managed route that was removed (gw IP, mtu, src IP)", func() {
 			r := netlink.Route{LinkIndex: loLink.Attrs().Index, Gw: loGWIP, Dst: loSubnet, MTU: loMTU, Src: loIP, Table: mainTableID, Type: unix.RTN_UNICAST}
@@ -360,6 +427,37 @@ var _ = ginkgo.Describe("Route Manager", func() {
 })
 
 var _ = ginkgo.Describe("Route Manager", func() {
+	ginkgo.It("normalizes unset IPv6 route metric to the kernel default", func() {
+		v6Dst := ovntest.MustParseIPNet("fd00::/64")
+		v4Dst := ovntest.MustParseIPNet("10.0.0.0/24")
+		v6GW := ovntest.MustParseIP("fd00::1")
+
+		// IPv6 route without an explicit metric gets the kernel default
+		r, err := validateAndNormalizeRoute(&netlink.Route{Dst: v6Dst})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(r.Priority).To(gomega.Equal(ipv6DefaultRouteMetric))
+
+		// an explicit metric is preserved
+		r, err = validateAndNormalizeRoute(&netlink.Route{Dst: v6Dst, Priority: 100})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(r.Priority).To(gomega.Equal(100))
+
+		// IPv4 routes keep the kernel default of 0
+		r, err = validateAndNormalizeRoute(&netlink.Route{Dst: v4Dst})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(r.Priority).To(gomega.BeZero())
+
+		// family detection falls back to the gateway for routes without Dst
+		r, err = validateAndNormalizeRoute(&netlink.Route{Gw: v6GW})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(r.Priority).To(gomega.Equal(ipv6DefaultRouteMetric))
+
+		// and to the Family field when neither Dst nor Gw is set
+		r, err = validateAndNormalizeRoute(&netlink.Route{Family: netlink.FAMILY_V6})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(r.Priority).To(gomega.Equal(ipv6DefaultRouteMetric))
+	})
+
 	ginkgo.It("partially compares expected routes with installed routes", func() {
 		values := map[string]any{
 			"int":             1,


### PR DESCRIPTION
We create linux routes without specifying a priority and we store them in cache. That works very well for IPv4 routes, as it defaults to `0`. For IPv6, the default when creating routes through netlink is `1024`, so we store IPv6 routes as having prio=0, while netlink creates them with prio=1024 and that breaks our comparisons in the code base. 

This is not a _huge_ problem, as it'll surface only if an external component or a cluster admin deletes a route that was created by OVNK. In that case, the deleted route will be eventually re-added (within 2 minutes) by the periodic `sync` from route manager. 

We can however set the priority explicitly for IPv6 routes and have a cache that is consistent with what is seen through netlink.

---
I'll paste some AI-generated diagrams to illustrate this better:

```
caller: routeManager.Add({Dst: fd00::/48, Table: 254})     # Priority unset
                    │
        route_manager.go: addRoute()
        validateAndNormalizeRoute()  ── normalizes Table, NOT Priority
                    │
        store key: {fd00::/48, 254, 0}      ◄── manager's view
        kernel:     fd00::/48 table 254 metric 1024  ◄── kernel's view
```

Consequences:

1. **Event-driven restore never fires.** On external deletion, the
   `RTM_DELROUTE` event carries metric 1024; `processNetlinkEvent()` looks up
   `{dst, table, 1024}`, misses the store entry keyed 0, and ignores the
   deletion. Callers' periodic `Add()` doesn't help either: it short-circuits
   on the store hit without checking the kernel. The route stays gone until
   the next periodic `sync()` — up to 2 minutes of broken IPv6 traffic.

2. **`sync()` churns forever.** The kernel copy (keyed 1024) is never
   recognized as the stored route (keyed 0), so every sync period the route
   looks missing and a redundant `RouteReplace` is issued for every managed
   IPv6 route, even when healthy.


