### PR TITLE
ovnkube.sh: unify gateway option loading from OVS external_ids

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -575,30 +575,59 @@ check_health() {
   return 1
 }
 
-get_dpu_gw_options() {
-  # If ovn_gateway_opts or ovn_gateway_router_subnet is not set as environment variable, gather them from ovs settings
-  if [[ ${ovn_gateway_opts} == "" ]]; then
-    # get the gateway interface
-    gw_iface=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-interface | tr -d \")
-    if [[ ${gw_iface} == "" ]]; then
-      echo "Couldn't get OVN Gateway Interface from ovs external_ids setting"
-    else
-      ovn_gateway_opts="--gateway-interface=${gw_iface} "
-    fi
+get_gw_options() {
+  # Build a map from the existing gateway options and overlay any ovn-gw-*
+  # values from OVS external_ids. This preserves global options while allowing
+  # node-local OVS settings to override/add gateway parameters.
+  local opt
+  local key
+  local value
+  declare -A gw_opts_map=()
 
-    # get the gateway nexthop
-    gw_nexthop=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-nexthop | tr -d \")
-    if [[ ${gw_nexthop} == "" ]]; then
-      echo "Couldn't get OVN Gateway NextHop from ovs external_ids setting"
+  for opt in ${ovn_gateway_opts}; do
+    if [[ ${opt} == --*=* ]]; then
+      gw_opts_map["${opt%%=*}"]="${opt#*=}"
+    elif [[ ${opt} == --* ]]; then
+      gw_opts_map["${opt}"]=""
+    fi
+  done
+
+  # get the gateway interface
+  value=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-interface | tr -d \")
+  if [[ -n ${value} ]]; then
+    gw_opts_map["--gateway-interface"]="${value}"
+  fi
+
+  # get the gateway nexthop
+  value=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-nexthop | tr -d \")
+  if [[ -n ${value} ]]; then
+    gw_opts_map["--gateway-nexthop"]="${value}"
+  fi
+
+  # get the gateway vlanid
+  value=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-vlanid | tr -d \")
+  if [[ -n ${value} ]]; then
+    gw_opts_map["--gateway-vlanid"]="${value}"
+  fi
+
+  ovn_gateway_opts=""
+  for key in "${!gw_opts_map[@]}"; do
+    value="${gw_opts_map["${key}"]}"
+    if [[ ${value} == "" ]]; then
+      ovn_gateway_opts+="${key} "
     else
-      ovn_gateway_opts+="--gateway-nexthop=${gw_nexthop} "
+      ovn_gateway_opts+="${key}=${value} "
+    fi
+  done
+
+  # Get gateway options for DPUs
+  if [[ ${ovnkube_node_mode} == "dpu" ]]; then
+    # this is only required if the DPU and DPU Host are in different subnets
+    if [[ ${ovn_gateway_router_subnet} == "" ]]; then
+      ovn_gateway_router_subnet=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-router-subnet | tr -d \")
     fi
   fi
 
-  # this is only required if the DPU and DPU Host are in different subnets
-  if [[ ${ovn_gateway_router_subnet} == "" ]]; then
-    ovn_gateway_router_subnet=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-router-subnet | tr -d \")
-  fi
 }
 
 display_file() {
@@ -1548,17 +1577,9 @@ ovnkube-controller-with-node() {
     fi
   fi
 
-  # Get gateway options for DPUs
-  if [[ ${ovnkube_node_mode} == "dpu" ]]; then
-      get_dpu_gw_options
-  fi
-
-  if [[ ${ovnkube_node_mode} != "dpu-host" && ! ${ovn_gateway_opts} =~ "gateway-vlanid" ]]; then
-      # get the gateway vlanid
-      gw_vlanid=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-vlanid | tr -d \")
-      if [[ -n ${gw_vlanid} ]]; then
-        ovn_gateway_opts+="--gateway-vlanid=${gw_vlanid}"
-      fi
+  # Get gateway options from OVS for full and dpu modes.
+  if [[ ${ovnkube_node_mode} != "dpu-host" ]]; then
+      get_gw_options
   fi
 
   ovnkube_node_mgmt_port_netdev_flag=
@@ -2354,17 +2375,9 @@ ovn-node() {
     ovn_dpu_host_gateway_representor_interface_flag="--dpu-host-gateway-representor-interface=${ovn_dpu_host_gateway_representor_interface}"
   fi
 
-  # Get gateway options for DPUs
-  if [[ ${ovnkube_node_mode} == "dpu" ]]; then
-      get_dpu_gw_options
-  fi
-
-  if [[ ${ovnkube_node_mode} != "dpu-host" && ! ${ovn_gateway_opts} =~ "gateway-vlanid" ]]; then
-      # get the gateway vlanid
-      gw_vlanid=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-gw-vlanid | tr -d \")
-      if [[ -n ${gw_vlanid} ]]; then
-        ovn_gateway_opts+="--gateway-vlanid=${gw_vlanid}"
-      fi
+  # Get gateway options from OVS for full and dpu modes.
+  if [[ ${ovnkube_node_mode} != "dpu-host" ]]; then
+      get_gw_options
   fi
 
   ovn_unprivileged_flag="--unprivileged-mode"


### PR DESCRIPTION
## 📑 Description

Refactor gateway option handling to use a single get_gw_options helper for non-dpu-host node modes. The helper now merges OVN_GATEWAY_OPTS with OVS external_ids values for --gateway-interface, --gateway-nexthop, and --gateway-vlanid, allowing node-specific OVS settings to override configured values. Keep ovn-gw-router-subnet loading scoped to dpu mode.

## Additional Information for reviewers


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI  

## How to verify it

This can be verified with e2e test env with DPU. 