### PR TITLE
egressip: fix missed re-evaluation when cloud egress-ipconfig annotation changes

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -1803,6 +1803,163 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("cloud egress IP config annotation update should trigger egress IP re-evaluation", func() {
+			// When cloud-network-config-controller adds or corrects the
+			// cloud.network.openshift.io/egress-ipconfig annotation on a node (e.g.
+			// adding an IPv6 subnet that was initially absent because the AWS subnet's
+			// IPv6 CIDR block was not yet in "associated" state), the node update
+			// handler must call addEgressNode so that previously-unassigned EgressIPs
+			// can be reconsidered and assigned.
+			//
+			// The EgressIP has a single IPv6 address so that one node is sufficient —
+			// the assignment algorithm disallows two IPs from the same EgressIP object
+			// on the same node.
+			app.Action = func(*cli.Context) error {
+				config.Kubernetes.PlatformType = string(ocpconfigapi.AWSPlatformType)
+
+				nodeIPv4 := "192.168.126.12/24"
+				egressIPv6 := "fc00:f853:ccd:e793::101"
+
+				// Node starts with IPv4-only cloud egress-ipconfig — simulates CNCC
+				// not yet having observed the IPv6 CIDR association on the cloud subnet.
+				node := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf(`{"ipv4": "%s", "ipv6": ""}`, nodeIPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf(`{"default":["%s"]}`, v4NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf(`["%s"]`, nodeIPv4),
+							"cloud.network.openshift.io/egress-ipconfig": fmt.Sprintf(
+								`[{"interface":"eth0","ifaddr":{"ipv4":"%s"},"capacity":{}}]`, nodeIPv4),
+						},
+						Labels: map[string]string{"k8s.ovn.org/egress-assignable": ""},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				}
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec:       egressipv1.EgressIPSpec{EgressIPs: []string{egressIPv6}},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP}},
+					&corev1.NodeList{Items: []corev1.Node{node}},
+				)
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchCloudPrivateIPConfig()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Phase 1: wait for the node ADD event to be processed (node appears
+				// in the allocator cache). The IPv6 EgressIP remains unassigned because
+				// the node's cloud egress-ipconfig has no IPv6 subnet yet.
+				gomega.Eventually(doesEgressIPAllocatorContainSafely).WithArguments(node1Name).Should(gomega.BeTrue())
+				ipv6CPIPCName := ipStringToCloudPrivateIPConfigName(egressIPv6)
+				gomega.Consistently(func() error {
+					_, err := fakeClusterManagerOVN.fakeClient.CloudNetworkClient.CloudV1().
+						CloudPrivateIPConfigs().Get(context.TODO(), ipv6CPIPCName, metav1.GetOptions{})
+					return err
+				}).ShouldNot(gomega.Succeed())
+
+				// Phase 2: CNCC corrects the annotation to add the IPv6 subnet.
+				node.Annotations["cloud.network.openshift.io/egress-ipconfig"] = fmt.Sprintf(
+					`[{"interface":"eth0","ifaddr":{"ipv4":"%s","ipv6":"fc00:f853:ccd:e793::/64"},"capacity":{}}]`,
+					nodeIPv4)
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(
+					context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// The annotation change must trigger addEgressNode → reconcileEgressIP
+				// runs for the still-unassigned IPv6 EgressIP → CloudPrivateIPConfig
+				// is created, proving the early-return guard was not hit.
+				gomega.Eventually(func() error {
+					_, err := fakeClusterManagerOVN.fakeClient.CloudNetworkClient.CloudV1().
+						CloudPrivateIPConfigs().Get(context.TODO(), ipv6CPIPCName, metav1.GetOptions{})
+					return err
+				}).Should(gomega.Succeed())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("unrelated annotation update should not trigger egress IP re-evaluation on cloud platform", func() {
+			// Counterpart to the test above: changing an annotation that is neither
+			// cloud.network.openshift.io/egress-ipconfig, k8s.ovn.org/host-cidrs,
+			// nor node readiness must NOT call addEgressNode (early-return guard).
+			app.Action = func(*cli.Context) error {
+				config.Kubernetes.PlatformType = string(ocpconfigapi.AWSPlatformType)
+
+				nodeIPv4 := "192.168.126.12/24"
+				egressIPv6 := "fc00:f853:ccd:e793::101"
+
+				node := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf(`{"ipv4": "%s", "ipv6": ""}`, nodeIPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf(`{"default":["%s"]}`, v4NodeSubnet),
+							util.OVNNodeHostCIDRs:             fmt.Sprintf(`["%s"]`, nodeIPv4),
+							"cloud.network.openshift.io/egress-ipconfig": fmt.Sprintf(
+								`[{"interface":"eth0","ifaddr":{"ipv4":"%s"},"capacity":{}}]`, nodeIPv4),
+						},
+						Labels: map[string]string{"k8s.ovn.org/egress-assignable": ""},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				}
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec:       egressipv1.EgressIPSpec{EgressIPs: []string{egressIPv6}},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP}},
+					&corev1.NodeList{Items: []corev1.Node{node}},
+				)
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchCloudPrivateIPConfig()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Wait for the node ADD event to be fully processed before sending
+				// the unrelated UPDATE.
+				gomega.Eventually(doesEgressIPAllocatorContainSafely).WithArguments(node1Name).Should(gomega.BeTrue())
+
+				// Touch an unrelated annotation — readiness, host-cidrs, and
+				// cloud egress-ipconfig are all unchanged.
+				node.Annotations["test"] = "dummy"
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(
+					context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// IPv6 CloudPrivateIPConfig must remain absent throughout — the
+				// early-return guard should fire since no relevant annotation changed.
+				ipv6CPIPCName := ipStringToCloudPrivateIPConfigName(egressIPv6)
+				gomega.Consistently(func() error {
+					_, err := fakeClusterManagerOVN.fakeClient.CloudNetworkClient.CloudV1().
+						CloudPrivateIPConfigs().Get(context.TODO(), ipv6CPIPCName, metav1.GetOptions{})
+					return err
+				}).ShouldNot(gomega.Succeed())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("IPv6 assignment", func() {

--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -128,6 +128,7 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 		isNewReady := h.eIPC.isEgressNodeReady(newNode)
 		isNewReachable := h.eIPC.isEgressNodeReachable(newNode)
 		isHostCIDRsAltered := util.NodeHostCIDRsAnnotationChanged(oldNode, newNode)
+		isCloudEgressIPConfigAltered := util.CloudEgressIPConfigAnnotationChanged(oldNode, newNode)
 		h.eIPC.setNodeEgressReady(newNode.Name, isNewReady)
 		if !oldHadEgressLabel && newHasEgressLabel {
 			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
@@ -142,7 +143,7 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 			}
 			return nil
 		}
-		if isOldReady == isNewReady && !isHostCIDRsAltered {
+		if isOldReady == isNewReady && !isHostCIDRsAltered && !isCloudEgressIPConfigAltered {
 			return nil
 		}
 		if !isNewReady {
@@ -151,7 +152,17 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 				return err
 			}
 		} else if isNewReady && isNewReachable {
-			klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
+			// Build a log message that captures all reasons we are re-evaluating,
+			// so operators can correlate annotation changes with re-assignments even
+			// when multiple conditions change simultaneously.
+			switch {
+			case isCloudEgressIPConfigAltered && isHostCIDRsAltered:
+				klog.Infof("Node: %s cloud egress IP config annotation and host CIDRs changed, re-evaluating egress IP assignments", newNode.Name)
+			case isCloudEgressIPConfigAltered:
+				klog.Infof("Node: %s cloud egress IP config annotation changed, re-evaluating egress IP assignments", newNode.Name)
+			default:
+				klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
+			}
 			h.eIPC.setNodeEgressReachable(newNode.Name, isNewReachable)
 			if err := h.eIPC.addEgressNode(newNode.Name); err != nil {
 				return err

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -886,6 +886,14 @@ func NodeHostCIDRsAnnotationChanged(oldNode, newNode *corev1.Node) bool {
 	return oldNode.Annotations[OVNNodeHostCIDRs] != newNode.Annotations[OVNNodeHostCIDRs]
 }
 
+// CloudEgressIPConfigAnnotationChanged returns true if the cloud egress IP
+// configuration annotation changed between oldNode and newNode. This annotation
+// is managed by cloud-network-config-controller and carries the IPv4/IPv6
+// subnets and capacity for egress IP assignment on cloud platforms.
+func CloudEgressIPConfigAnnotationChanged(oldNode, newNode *corev1.Node) bool {
+	return oldNode.Annotations[cloudEgressIPConfigAnnotationKey] != newNode.Annotations[cloudEgressIPConfigAnnotationKey]
+}
+
 // ParseNodeHostCIDRs returns the parsed host CIDRS living on a node
 func ParseNodeHostCIDRs(node *corev1.Node) (sets.Set[string], error) {
 	addrAnnotation, ok := node.Annotations[OVNNodeHostCIDRs]

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -812,6 +812,67 @@ func TestNodeDontSNATSubnetAnnotationChanged(t *testing.T) {
 	}
 }
 
+func TestCloudEgressIPConfigAnnotationChanged(t *testing.T) {
+	v4Only := `[{"interface":"eth0","ifaddr":{"ipv4":"192.168.126.12/24"},"capacity":{}}]`
+	dualStack := `[{"interface":"eth0","ifaddr":{"ipv4":"192.168.126.12/24","ipv6":"fc00:f853:ccd:e793::12/64"},"capacity":{}}]`
+
+	tests := []struct {
+		desc    string
+		oldNode *corev1.Node
+		newNode *corev1.Node
+		result  bool
+	}{
+		{
+			desc:    "annotation added",
+			oldNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}},
+			newNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				cloudEgressIPConfigAnnotationKey: v4Only,
+			}}},
+			result: true,
+		},
+		{
+			desc: "annotation removed",
+			oldNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				cloudEgressIPConfigAnnotationKey: v4Only,
+			}}},
+			newNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}},
+			result:  true,
+		},
+		{
+			desc: "annotation value changed (IPv6 subnet added)",
+			oldNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				cloudEgressIPConfigAnnotationKey: v4Only,
+			}}},
+			newNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				cloudEgressIPConfigAnnotationKey: dualStack,
+			}}},
+			result: true,
+		},
+		{
+			desc: "false: annotation unchanged",
+			oldNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				cloudEgressIPConfigAnnotationKey: v4Only,
+			}}},
+			newNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				cloudEgressIPConfigAnnotationKey: v4Only,
+			}}},
+			result: false,
+		},
+		{
+			desc:    "false: annotation absent in both",
+			oldNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}},
+			newNode: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}},
+			result:  false,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			assert.Equal(t, tc.result, CloudEgressIPConfigAnnotationChanged(tc.oldNode, tc.newNode))
+		})
+	}
+}
+
 func TestParseNodeDontSNATSubnetsList(t *testing.T) {
 	tests := []struct {
 		desc        string


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

On cloud platforms (e.g. AWS), cloud-network-config-controller (CNCC) populates the cloud.network.openshift.io/egress-ipconfig annotation on nodes to advertise the available IPv4/IPv6 subnets and egress IP capacity. In some cases — such as when a subnet's IPv6 CIDR block is not yet in "associated" state at cluster startup — CNCC writes an IPv4-only annotation initially and later adds the IPv6 subnet once the cloud-side association completes.

Before this fix, the node update handler's early-return guard only checked for changes to node readiness and k8s.ovn.org/host-cidrs. A change to cloud.network.openshift.io/egress-ipconfig alone was silently dropped, leaving any EgressIP that required the newly-added IPv6 subnet permanently unassigned.


Made with Sonnet 4.6 Medium

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Additional Information for reviewers
Two files changed:

pkg/util/node_annotations.go — adds CloudEgressIPConfigAnnotationChanged(), a small helper that mirrors the existing NodeHostCIDRsAnnotationChanged() pattern.

pkg/clustermanager/egressip_event_handler.go — extends the early-return guard in UpdateResource to also check CloudEgressIPConfigAnnotationChanged. When the annotation changes and the node is ready and reachable, addEgressNode is called so previously-unassigned EgressIPs are reconsidered. A distinct log line is emitted for the cloud annotation case to help operators correlate annotation changes with re-assignments.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

Unit tests are included in both changed packages:

pkg/util/node_annotations_unit_test.go — TestCloudEgressIPConfigAnnotationChanged: 5 table-driven cases covering annotation added, removed, value changed, unchanged, and absent in both nodes.

pkg/clustermanager/egressip_controller_test.go — two new integration tests:
"cloud egress IP config annotation update should trigger egress IP re-evaluation" — starts a node with IPv4-only egress-ipconfig and an unassigned IPv6 EgressIP, then updates the annotation to add the IPv6 subnet; verifies that CloudPrivateIPConfig is subsequently created.
"unrelated annotation update should not trigger egress IP re-evaluation on cloud platform" — same setup, but only touches an unrelated annotation; verifies that CloudPrivateIPConfig is never created (early-return guard fires correctly).