### PR TITLE
test: Use proper TLS certificate validation in metrics server tests

### DIFF
--- a/go-controller/pkg/metrics/server_test.go
+++ b/go-controller/pkg/metrics/server_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -367,11 +368,18 @@ func newMetricsTestDriver() *metricsTestDriver {
 }
 
 func (t *metricsTestDriver) testTLSHandshake(clientVersion int, clientCipherSuites []uint16, verify func(Gomega, tls.ConnectionState, error)) {
+	// Load the server's certificate to create a trusted cert pool
+	certPool := x509.NewCertPool()
+	certPEM, err := os.ReadFile(t.opts.CertFile)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(certPool.AppendCertsFromPEM(certPEM)).To(BeTrue())
+
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
-		MinVersion:         uint16(clientVersion),
-		MaxVersion:         uint16(clientVersion),
-		CipherSuites:       clientCipherSuites,
+		RootCAs:      certPool,
+		ServerName:   "localhost", // matches the cert's CommonName/DNSNames
+		MinVersion:   uint16(clientVersion),
+		MaxVersion:   uint16(clientVersion),
+		CipherSuites: clientCipherSuites,
 	}
 
 	Eventually(func(g Gomega) {


### PR DESCRIPTION
Replace InsecureSkipVerify with proper certificate validation. The test already generates a valid self-signed cert, so validate it properly rather than bypass validation.

This improves test realism, avoids setting a bad example, and satisfies security scanners (Snyk, gosec, CodeQL) without adding complexity.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
