### PR TITLE
ovnkube-identity: allow pod-network annotation updates before default network

### DIFF
--- a/go-controller/pkg/ovnwebhook/podadmission.go
+++ b/go-controller/pkg/ovnwebhook/podadmission.go
@@ -39,6 +39,12 @@ var interconnectPodAnnotations = map[string]checkPodAnnot{
 
 		podAnnot, err := util.UnmarshalPodAnnotation(map[string]string{types.OvnPodAnnotationName: v.value}, types.DefaultNetworkName)
 		if err != nil {
+			// When a pod attaches to multiple NADs, the ovnkube-node network
+			// controllers may patch the pod-networks annotation in any order. If a
+			// secondary/primary network controller sets its annotation before the
+			// default network controller, there is no default network entry yet.
+			// The subnet check below only applies to the default network, so there
+			// is nothing to validate in that case.
 			if util.IsAnnotationNotSetError(err) {
 				return nil
 			}

--- a/go-controller/pkg/ovnwebhook/podadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/podadmission_test.go
@@ -280,6 +280,33 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "ovnkube-node can set OvnPodAnnotationName annotation for a secondary NAD before the default network entry exists",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{"k8s.ovn.org/node-subnets": `{"default":"192.168.0.0/24"}`},
+				},
+			},
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: userName,
+				}},
+			}),
+			oldObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+			newObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{util.OvnPodAnnotationName: `{"test/primary":{"ip_addresses":["10.1.0.4/24"],"mac_address":"0a:58:0a:01:00:04","role":"primary"}}`},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+		},
+		{
 			name: "ovnkube-node can modify DPUConnectionDetailsAnnot annotation on a pod",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## 📑 Description

When a pod is attached to multiple NADs, ovnkube-node network controllers can patch `k8s.ovn.org/pod-networks` in non-deterministic order. A secondary/primary controller may update the annotation before the default network controller adds the `default` entry.

The pod admission webhook previously always unmarshaled the default network view for `k8s.ovn.org/pod-networks` validation. If the `default` NAD key was not yet present, unmarshal returned an annotation-not-set error and the webhook rejected the patch request, causing unnecessary retries.

Handle this ordering case by treating "default NAD key not set yet" as a valid intermediate state: skip default-network subnet validation in that specific case and continue to allow the update. Keep existing validation behavior for all other errors and for cases where default-network data is present.


## Additional Information for reviewers



## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI 

## How to verify it
Unit test