### PR TITLE
Support update of chassis-id without re-creating the node.

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -565,8 +565,10 @@ func (oc *DefaultNetworkController) ReconcileNode(oldNode, newNode *corev1.Node,
 				newNode.Name, util.GetNodeZone(newNode), oc.GetNetworkName())
 		}
 		// Reprovisioning the DPU, including OVS, changes the chassis system ID without changing the node.
+		// Same can happen with the non-DPU nodes in the testing environment where the node is re-provisioned
+		// without being deleted from the cluster.
 		// Delete the stale remote chassis mapping so the new chassis can be associated cleanly.
-		if oldNode != nil && config.OvnKubeNode.Mode == types.NodeModeDPU && nodeChassisChanged(oldNode, newNode) {
+		if oldNode != nil && nodeChassisChanged(oldNode, newNode) {
 			if err := oc.zoneChassisHandler.DeleteRemoteZoneNode(oldNode); err != nil {
 				aggregatedErrors = append(aggregatedErrors, err)
 			}


### PR DESCRIPTION
This was only previously supported for the DPU mode, but I have also seen this happening on a test cluster (hopefully people won't do it in prod), but if the node chassis has changed, and we can see it, it always makes sense to delete current chassis, because the update will certainly fail otherwise.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
