### PR TITLE
[perf] fix netpol selection for cudn-l2 job

### DIFF
--- a/contrib/perf/workloads/cudn-density-l2-pods-netpol.yml
+++ b/contrib/perf/workloads/cudn-density-l2-pods-netpol.yml
@@ -55,6 +55,8 @@ jobs:
       replicas: 1
 
     - objectTemplate: workloads/templates/udn-density/np-allow-from-clients.yml
+      inputVars:
+        nsPrefix: cudn-density-l2-namespaces
       replicas: 1
 
     - objectTemplate: workloads/templates/udn-density/service.yml

--- a/contrib/perf/workloads/templates/udn-density/np-allow-from-clients.yml
+++ b/contrib/perf/workloads/templates/udn-density/np-allow-from-clients.yml
@@ -10,7 +10,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: "{{.JobName}}-{{.Iteration}}"
+          kubernetes.io/metadata.name: "{{.nsPrefix}}-{{.Iteration}}"
       podSelector:
         matchLabels:
           app: client

--- a/contrib/perf/workloads/udn-density-l2-pods-netpol.yml
+++ b/contrib/perf/workloads/udn-density-l2-pods-netpol.yml
@@ -52,6 +52,8 @@ jobs:
         replicas: 1
 
       - objectTemplate: workloads/templates/udn-density/np-allow-from-clients.yml
+        inputVars:
+          nsPrefix: udn-density-l2-pods-netpol
         replicas: 1
 
       - objectTemplate: workloads/templates/udn-density/service.yml

--- a/contrib/perf/workloads/udn-density-l3-pods-netpol.yml
+++ b/contrib/perf/workloads/udn-density-l3-pods-netpol.yml
@@ -52,6 +52,8 @@ jobs:
         replicas: 1
 
       - objectTemplate: workloads/templates/udn-density/np-allow-from-clients.yml
+        inputVars:
+          nsPrefix: udn-density-l3-pods-netpol
         replicas: 1
 
       - objectTemplate: workloads/templates/udn-density/service.yml


### PR DESCRIPTION
Job name doesn't match namespace in which objects are created, so netpol selector would be wrong.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
