### PR TITLE
docs: add agent skills for OKEP authoring

### DIFF
--- a/.agents/skills/create-okep-issue/SKILL.md
+++ b/.agents/skills/create-okep-issue/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: create-okep-issue
+description: Open a GitHub enhancement tracking issue for a new OVN-Kubernetes feature. Use when the user wants to propose a new feature, open an enhancement issue, or before writing an OKEP.
+---
+
+# Create OKEP Issue
+
+Interview the user to define the problem space, then open a GitHub enhancement tracking issue.
+The issue number becomes the OKEP number.
+
+## Steps
+
+1. **Interview** — ask one question at a time until you can clearly answer both:
+   - *What would you like to be added?* — the feature description
+   - *Why is this needed?* — the rationale
+
+   Look up anything discoverable in the codebase rather than asking. Provide a recommended
+   answer for each question and wait for the user to confirm or correct it.
+
+   Done when: the user confirms both answers are accurate.
+
+2. **Open the issue**:
+   ```bash
+   gh issue create \
+     --title "<title>" \
+     --label "kind/feature" \
+     --body "## What would you like to be added?
+
+   <description>
+
+   ## Why is this needed?
+
+   <rationale>"
+   ```
+
+3. **Report the issue number** — hand it to the user and note that it is the OKEP number
+   for when they run `write-okep`.

--- a/.agents/skills/write-okep/SKILL.md
+++ b/.agents/skills/write-okep/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: write-okep
+description: Draft an OVN-Kubernetes Enhancement Proposal (OKEP). Use when the user wants to write, draft, or create an OKEP or design doc for OVN-Kubernetes. If no GitHub issue exists yet, run create-okep-issue first.
+---
+
+# Write an OKEP
+
+## Steps
+
+1. **Get the issue number** — if the user doesn't have one, run `create-okep-issue` first.
+   The issue number is the OKEP number.
+
+2. **Read the GitHub issue** for initial context:
+   ```bash
+   gh issue view <issue> --comments
+   ```
+   Extract the feature description, rationale, and any design discussion from comments.
+
+3. **Interview** — work through the design one question at a time. For each question:
+   provide your recommended answer, then wait for confirmation before moving on.
+   Look up anything discoverable in the codebase rather than asking.
+   The decisions are the user's — put each one and wait.
+
+   Done when: no open design questions remain.
+
+4. **Gap-check** — read `docs/okeps/okep-4368-template.md` and test the design against
+   every section (testing, backwards compatibility, version skew, alternatives, etc.).
+   For any section not yet covered, ask one targeted question.
+
+   Done when: every template section has a clear answer.
+
+5. **Scaffold** `docs/okeps/okep-<issue>-<slug>.md` from the template at
+   `docs/okeps/okep-4368-template.md`. Every section must be complete — no TBDs.
+
+6. **Register** in `mkdocs.yml` under `Enhancement Proposals:`:
+   ```yaml
+   - Feature Title: okeps/okep-<issue>-<slug>.md
+   ```
+
+7. **Review** — check every item before declaring done:
+   - [ ] Issue link present in header
+   - [ ] File named `okep-<issue>-<slug>.md`
+   - [ ] All template sections complete — no TBDs or empty placeholders
+   - [ ] `mkdocs.yml` entry added


### PR DESCRIPTION
## 📑 Description

Add two agent skills under `.agents/skills/` to guide AI coding assistants
through the OVN-Kubernetes Enhancement Proposal (OKEP) workflow, following
the [agents.md](https://agents.md/) open standard.

- **create-okep-issue** — interviews the user to define the problem space and
  rationale, then opens a GitHub enhancement tracking issue (the issue number
  becomes the OKEP number).
- **write-okep** — drives the full OKEP drafting process: reads the tracking
  issue, interviews through design decisions, gap-checks against the OKEP
  template, scaffolds the document, registers it in `mkdocs.yml`, and runs a
  completion checklist.

## Additional Information for reviewers

Two new files added:
- `.agents/skills/create-okep-issue/SKILL.md`
- `.agents/skills/write-okep/SKILL.md`

These are markdown instruction files only — no Go code, no tests, no runtime
impact. They are picked up by AI coding agents that support the agents.md
standard (e.g. Claude Code, pi, Cursor) and provide guided workflows for
OKEP authoring.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [x] All the tests have passed in the CI

## How to verify it

No unit or e2e tests — these are agent instruction files (markdown only).
To verify manually, use an AI coding agent that supports agents.md in a
checkout of this branch and ask it to "write an OKEP" or "create an OKEP
issue". The agent should follow the structured workflow defined in the
skill files.