### PR TITLE
test(kubevirt): deflake "with pre-copy fails" migration e2e

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -1104,8 +1104,7 @@ config:
 			// Do just one migration that will fail
 			if td.shouldExpectFailure {
 				by(vm.Name, "Live migrate virtual machine to check failed migration")
-				liveMigrateVirtualMachine(vm.Name)
-				checkLiveMigrationFailed(vm.Name)
+				liveMigrateFailed(vmi)
 				checkConnectivityAndNetworkPolicies(vm.Name, externalContainer, serverAddresses, serverPort, "after live migrate to check failed migration")
 			} else {
 				originalNode := vmi.Status.NodeName
@@ -1430,24 +1429,6 @@ config:
 					vmCreationRetries++
 					return err
 				}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
-			}
-
-			for _, vm := range vms {
-				By(fmt.Sprintf("Create virtual machine %s", vm.Name))
-				if td.shouldExpectFailure {
-					By("annotating the VMI with `fail fast`")
-					vmKey := types.NamespacedName{Namespace: namespace, Name: vm.Name}
-					var vmi kubevirtv1.VirtualMachineInstance
-
-					Eventually(func() error {
-						err = crClient.Get(context.TODO(), vmKey, &vmi)
-						if err == nil {
-							vmi.ObjectMeta.Annotations[kubevirtv1.FuncTestLauncherFailFastAnnotation] = "true"
-							err = crClient.Update(context.TODO(), &vmi)
-						}
-						return err
-					}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
-				}
 			}
 
 			for _, vm := range vms {


### PR DESCRIPTION
## 📑 Description

De-flakes the KubeVirt live-migration e2e test
`"with pre-copy fails, should keep connectivity"`. The test intermittently
times out after 300s waiting for the `VirtualMachineInstanceMigration` (VMIM)
to reach `Failed` while it stays stuck at `Scheduling`.

Fixes #6667

### Why this matters

The test forced the migration to fail by annotating the VMI with
`kubevirtv1.FuncTestLauncherFailFastAnnotation = "true"` **at VMI creation
time**. That annotation makes the target virt-launcher crash immediately at
process startup, i.e. **before** virt-controller hands the migration off to the
target virt-handler. Whether the crash or the handoff wins is a race:

- Handoff wins -> the failure propagates -> the VMIM reaches `Failed` -> the
  test passes.
- Crash wins -> the controller logs `"target pod ... shutdown during migration"`
  with no handoff -> nothing drives the VMIM to `Failed`; the VMI goes
  `Succeeded` and is restarted by `runStrategy: Always`, and the VMIM is
  orphaned at `Scheduling` -> `checkLiveMigrationFailed` hits its 5-minute
  timeout -> flake.

The sibling helper `liveMigrateFailed()` already injects failure the
deterministic way: it sets `FuncTestForceLauncherMigrationFailureAnnotation`
**after** handoff, inside the migration state machine, so the VMIM reliably
walks `Scheduling -> Scheduled -> TargetReady -> Failed`. Tests using it do not
flake. This PR routes the failure path through that helper and removes the racy
pre-handoff fail-fast annotation.

This is distinct from #3986 / #6044, which cover the "pre-copy **succeeds**"
variant.

## Additional Information for reviewers

Two edits, both in `test/e2e/kubevirt.go`, test-only, no production code:

1. In the `shouldExpectFailure` branch of `runLiveMigrationTest`, replaced the
   inline `liveMigrateVirtualMachine(vm.Name)` + `checkLiveMigrationFailed(vm.Name)`
   with a call to the existing `liveMigrateFailed(vmi)` helper (the `vmi` is
   already populated earlier in the same function). That helper annotates with
   `FuncTestForceLauncherMigrationFailureAnnotation`, migrates, and asserts
   `MigrationFailed`.
2. Deleted the now-redundant loop that annotated each VMI with
   `FuncTestLauncherFailFastAnnotation` right after VM creation. Failure
   injection now happens after the VM is Ready and the migration is under the
   migration controller, eliminating the pre-handoff race.

`FuncTestLauncherFailFastAnnotation` is no longer referenced anywhere in the
file; the `types` and `kubevirtv1` imports remain used elsewhere. There is no
behavioral change to the "succeeds" entries.

Special notes for reviewers: AI was used for assistance in preparing this
change. The de-flake was reasoned from the issue's root-cause analysis and
compile-verified locally, but not executed against a live KubeVirt cluster
(see "How to verify it"). CI / maintainer confirmation on the live suite would
be appreciated.

## ✅ Checks

- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required

This change is e2e-test-only and is exercised by the repository's KubeVirt CI job; it cannot be run headless locally, so confirmation that the full suite passes is left to CI on this PR.


## How to verify it

The change is confined to e2e test scaffolding and can only be fully exercised
on a live multi-node KubeVirt live-migration cluster, which cannot be run
headless. What was verified locally on `master`:

- `test/e2e` compiles and vets clean: `go vet .` in `test/e2e/` passes with no
  findings for the `e2e` package (`kubevirt.go`).
- `gofmt -l test/e2e/kubevirt.go` is clean.
- `FuncTestLauncherFailFastAnnotation` no longer appears in the file; imports
  remain satisfied.

Full confidence rests on the CI KubeVirt job running the
`"with pre-copy fails, should keep connectivity"` entry and confirming the VMIM
now reaches `Failed` deterministically without the 300s / 5-minute timeouts.
