### PR TITLE
cni: make cni request timeout configurable

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -86,6 +86,11 @@ physical interface as a trunk.
 
 ## CNI Config
 
+Set the `CNI_REQUEST_TIMEOUT` environment variable to override the timeout for
+CNI shim requests to the local CNI server. The value must be a positive Go
+duration (for example, `45s`). When unset, the default is the two-minute CRI
+operation timeout.
+
 ## Kubernetes Config
 
 ## Metrics Config

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -41,6 +41,13 @@ import (
 const kubeletDefaultCRIOperationTimeout = 2 * time.Minute
 const resourceNameAnnot = "k8s.v1.cni.cncf.io/resourceName"
 
+func cniRequestTimeout() time.Duration {
+	if config.CNI.CNIRequestTimeout > 0 {
+		return config.CNI.CNIRequestTimeout
+	}
+	return kubeletDefaultCRIOperationTimeout
+}
+
 // *** The Server is PRIVATE API between OVN components and may be
 // changed at any time.  It is in no way a supported interface or API. ***
 //
@@ -259,8 +266,7 @@ func (s *Server) handleCNIRequest(r *http.Request) (result []byte, err error) {
 	if err := json.Unmarshal(b, &cr); err != nil {
 		return nil, err
 	}
-	// Match the Kubelet default CRI operation timeout of 2m.
-	ctx, cancel := context.WithTimeout(context.Background(), kubeletDefaultCRIOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cniRequestTimeout())
 	defer cancel()
 
 	cmd, ok := cr.Env["CNI_COMMAND"]

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -139,6 +139,17 @@ func setupLogging(conf *ovncnitypes.NetConf) {
 	}
 }
 
+func cniRequestTimeoutFromNetConf(conf *ovncnitypes.NetConf) time.Duration {
+	if conf != nil && conf.CNIRequestTimeout != "" {
+		timeout, err := time.ParseDuration(conf.CNIRequestTimeout)
+		if err == nil && timeout > 0 {
+			return timeout
+		}
+		klog.Warningf("Invalid CNI request timeout %q; using default %s", conf.CNIRequestTimeout, kubeletDefaultCRIOperationTimeout)
+	}
+	return kubeletDefaultCRIOperationTimeout
+}
+
 // report the CNI request processing time to CNI server. This is used for the cni_request_duration_seconds metrics
 func (p *Plugin) postMetrics(startTime time.Time, cmd command, err error) {
 	elapsedTime := time.Since(startTime).Seconds()
@@ -248,7 +259,7 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 		// plugging an interface into Pod is on the Shim.
 
 		// Use the IPAM details from ovnkube-node to configure the pod interface
-		ctx, cancel := context.WithTimeout(context.Background(), kubeletDefaultCRIOperationTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), cniRequestTimeoutFromNetConf(conf))
 		defer cancel()
 		pr, err := cniRequestToPodRequest(req, ctx)
 		if err != nil {
@@ -327,7 +338,7 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 
 	// if Result is nil, then ovnkube-node is running in unprivileged mode so unconfigure the Interface from here.
 	if response.Result == nil {
-		ctx, cancel := context.WithTimeout(context.Background(), kubeletDefaultCRIOperationTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), cniRequestTimeoutFromNetConf(conf))
 		defer cancel()
 		pr, err = cniRequestToPodRequest(req, ctx)
 		if err != nil {

--- a/go-controller/pkg/cni/cnishim_test.go
+++ b/go-controller/pkg/cni/cnishim_test.go
@@ -18,9 +18,36 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ovncnitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 )
+
+func TestCNIRequestTimeout(t *testing.T) {
+	require.NoError(t, config.PrepareTestConfig())
+	t.Cleanup(func() { require.NoError(t, config.PrepareTestConfig()) })
+
+	require.Equal(t, kubeletDefaultCRIOperationTimeout, cniRequestTimeout())
+	config.CNI.CNIRequestTimeout = 45 * time.Second
+	require.Equal(t, 45*time.Second, cniRequestTimeout())
+
+	for _, test := range []struct {
+		name    string
+		timeout string
+		want    time.Duration
+	}{
+		{name: "configured", timeout: "45s", want: 45 * time.Second},
+		{name: "missing", want: kubeletDefaultCRIOperationTimeout},
+		{name: "invalid", timeout: "invalid", want: kubeletDefaultCRIOperationTimeout},
+		{name: "zero", timeout: "0s", want: kubeletDefaultCRIOperationTimeout},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, cniRequestTimeoutFromNetConf(&ovncnitypes.NetConf{
+				CNIRequestTimeout: test.timeout,
+			}))
+		})
+	}
+}
 
 func TestCmdAdd_PrivilegedMode(t *testing.T) {
 	// Setup: CNI server returns non-nil Result

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -114,6 +114,8 @@ type NetConf struct {
 	// LogFileMaxAge represents the maximum number
 	// of days to retain old log files
 	LogFileMaxAge int `json:"logfile-maxage"`
+	// CNIRequestTimeout overrides the default timeout used by the CNI shim.
+	CNIRequestTimeout string `json:"cniRequestTimeout,omitempty"`
 	// Runtime arguments passed by the NPWG implementation (e.g. multus)
 	RuntimeConfig struct {
 		// see https://github.com/k8snetworkplumbingwg/device-info-spec
@@ -154,6 +156,7 @@ func (n NetConf) MarshalJSON() ([]byte, error) {
 		LogFileMaxSize        int         `json:"logfile-maxsize"`
 		LogFileMaxBackups     int         `json:"logfile-maxbackups"`
 		LogFileMaxAge         int         `json:"logfile-maxage"`
+		CNIRequestTimeout     string      `json:"cniRequestTimeout,omitempty"`
 		RuntimeConfig         struct {
 			CNIDeviceInfoFile string `json:"CNIDeviceInfoFile,omitempty"`
 		} `json:"runtimeConfig,omitempty"`
@@ -183,6 +186,7 @@ func (n NetConf) MarshalJSON() ([]byte, error) {
 		LogFileMaxSize:        n.LogFileMaxSize,
 		LogFileMaxBackups:     n.LogFileMaxBackups,
 		LogFileMaxAge:         n.LogFileMaxAge,
+		CNIRequestTimeout:     n.CNIRequestTimeout,
 		RuntimeConfig:         n.RuntimeConfig,
 	})
 }

--- a/go-controller/pkg/cni/types/types_test.go
+++ b/go-controller/pkg/cni/types/types_test.go
@@ -10,8 +10,9 @@ import (
 
 func TestNetConfMarshalJSONIncludesOutboundSNAT(t *testing.T) {
 	netConf := NetConf{
-		Transport:    "no-overlay",
-		OutboundSNAT: "enabled",
+		Transport:         "no-overlay",
+		OutboundSNAT:      "enabled",
+		CNIRequestTimeout: "45s",
 	}
 
 	rawNetConf, err := json.Marshal(netConf)
@@ -20,8 +21,9 @@ func TestNetConfMarshalJSONIncludesOutboundSNAT(t *testing.T) {
 	}
 
 	var parsedNetConf struct {
-		Transport    string `json:"transport"`
-		OutboundSNAT string `json:"outboundSNAT"`
+		Transport         string `json:"transport"`
+		OutboundSNAT      string `json:"outboundSNAT"`
+		CNIRequestTimeout string `json:"cniRequestTimeout"`
 	}
 	if err := json.Unmarshal(rawNetConf, &parsedNetConf); err != nil {
 		t.Fatalf("failed to unmarshal NetConf: %v", err)
@@ -32,5 +34,8 @@ func TestNetConfMarshalJSONIncludesOutboundSNAT(t *testing.T) {
 	}
 	if parsedNetConf.OutboundSNAT != netConf.OutboundSNAT {
 		t.Fatalf("expected outboundSNAT %q, got %q", netConf.OutboundSNAT, parsedNetConf.OutboundSNAT)
+	}
+	if parsedNetConf.CNIRequestTimeout != netConf.CNIRequestTimeout {
+		t.Fatalf("expected CNI request timeout %q, got %q", netConf.CNIRequestTimeout, parsedNetConf.CNIRequestTimeout)
 	}
 }

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -41,6 +41,9 @@ func WriteCNIConfig() error {
 		LogFileMaxBackups: Logging.LogFileMaxBackups,
 		LogFileMaxAge:     Logging.LogFileMaxAge,
 	}
+	if CNI.CNIRequestTimeout > 0 {
+		netConf.CNIRequestTimeout = CNI.CNIRequestTimeout.String()
+	}
 
 	newBytes, err := json.Marshal(netConf)
 	if err != nil {

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -436,6 +436,8 @@ type CNIConfig struct {
 	ConfDir string `gcfg:"conf-dir"`
 	// Plugin specifies the name of the CNI plugin
 	Plugin string `gcfg:"plugin"`
+	// CNIRequestTimeout overrides the default timeout for CNI requests when set.
+	CNIRequestTimeout time.Duration `gcfg:"cni-request-timeout"`
 }
 
 // KubernetesConfig holds Kubernetes-related parsed config file parameters and command-line overrides
@@ -2003,6 +2005,27 @@ func reconcileKubernetesAuthFields(k *KubernetesConfig, override *KubernetesConf
 	}
 }
 
+func buildCNIConfig(cli, file *config) error {
+	if err := overrideFields(&CNI, &file.CNI, &savedCNI); err != nil {
+		return err
+	}
+	if err := overrideFields(&CNI, &cli.CNI, &savedCNI); err != nil {
+		return err
+	}
+
+	if timeout, exists := os.LookupEnv("CNI_REQUEST_TIMEOUT"); exists && timeout != "" {
+		duration, err := time.ParseDuration(timeout)
+		if err != nil {
+			return fmt.Errorf("invalid CNI_REQUEST_TIMEOUT %q: %w", timeout, err)
+		}
+		if duration <= 0 {
+			return fmt.Errorf("invalid CNI_REQUEST_TIMEOUT %q: must be greater than zero", timeout)
+		}
+		CNI.CNIRequestTimeout = duration
+	}
+	return nil
+}
+
 func buildKubernetesConfig(exec kexec.Interface, cli, file *config, saPath string, defaults *Defaults) error {
 	// values for token, cacert, kubeconfig, api-server may be found in several places.
 	// Priority order (highest first): OVS config, command line options, config file,
@@ -2744,11 +2767,7 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 		defaults = &Defaults{}
 	}
 
-	// Build config that needs no special processing
-	if err = overrideFields(&CNI, &cfg.CNI, &savedCNI); err != nil {
-		return "", err
-	}
-	if err = overrideFields(&CNI, &cliConfig.CNI, &savedCNI); err != nil {
+	if err = buildCNIConfig(&cliConfig, &cfg); err != nil {
 		return "", err
 	}
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -318,6 +318,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(IPFIX.CacheActiveTimeout).To(gomega.Equal(uint(60)))
 			gomega.Expect(CNI.ConfDir).To(gomega.Equal("/etc/cni/net.d"))
 			gomega.Expect(CNI.Plugin).To(gomega.Equal("ovn-k8s-cni-overlay"))
+			gomega.Expect(CNI.CNIRequestTimeout).To(gomega.BeZero())
 			gomega.Expect(Kubernetes.Kubeconfig).To(gomega.Equal(""))
 			gomega.Expect(Kubernetes.BootstrapKubeconfig).To(gomega.Equal(""))
 			gomega.Expect(Kubernetes.CertDir).To(gomega.Equal(""))
@@ -486,6 +487,30 @@ routing-table-id-start=2002
 		err = app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+	})
+
+	It("uses CNI_REQUEST_TIMEOUT environment variable", func() {
+		GinkgoT().Setenv("CNI_REQUEST_TIMEOUT", "45s")
+
+		app.Action = func(ctx *cli.Context) error {
+			_, err := InitConfigSa(ctx, kexec.New(), tmpDir, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(CNI.CNIRequestTimeout).To(gomega.Equal(45 * time.Second))
+			return nil
+		}
+		err := app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	It("rejects invalid CNI_REQUEST_TIMEOUT environment variable", func() {
+		GinkgoT().Setenv("CNI_REQUEST_TIMEOUT", "0s")
+
+		app.Action = func(ctx *cli.Context) error {
+			_, err := InitConfigSa(ctx, kexec.New(), tmpDir, nil)
+			return err
+		}
+		err := app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
+		gomega.Expect(err).To(gomega.MatchError(`invalid CNI_REQUEST_TIMEOUT "0s": must be greater than zero`))
 	})
 
 	It("overrides defaults with config file options", func() {


### PR DESCRIPTION
Allow CNI request processing to be configured through CNI_REQUEST_TIMEOUT, the current default is the hard coded two minute CRI operation timeout. This is retained as the fallback when no override is supplied.



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->



## Additional Information for reviewers
This PR provides a mitigation for the a scale scenario, where when a large set of OVS port operations(especially add operations with SRIOV VFs and DPDK ports) are performed, CNI times out before port can be completed for the 99 percentile pods. 
This this we can configure the CNI timeout to better suit such environments.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->


