### PR TITLE
node: skip configureGlobalForwarding tests in CI without root access

### DIFF
--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -3585,7 +3585,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("disable-forwarding", func() {
-		It("adds or removes iptables rules upon change in forwarding mode", func() {
+		ovntest.OnSupportedPlatformsIt("adds or removes iptables rules upon change in forwarding mode", func() {
 			app.Action = func(*cli.Context) error {
 				config.Default.ClusterSubnets = []config.CIDRNetworkEntry{
 					{CIDR: ovntest.MustParseIPNet("fd00:10:1::/48"), HostSubnetLength: 64},
@@ -3696,7 +3696,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("updates the default FORWARD policy correctly according to the config", func() {
+		ovntest.OnSupportedPlatformsIt("updates the default FORWARD policy correctly according to the config", func() {
 			expectedTablesEmpty := map[string]util.FakeTable{
 				"filter": {
 					"FORWARD": []string{},


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->
configureGlobalForwarding() may write /proc/sys/net/ipv6/conf/all/forwarding when IPv6 is enabled and per-interface forwarding is unavailable. That sysctl update requires root, so the disable-forwarding tests in gateway_localnet_linux_test.go fail in CI jobs that run without elevated privileges.

Use ovntest.OnSupportedPlatformsIt() for the two tests that invoke configureGlobalForwarding() directly, so they are skipped on unsupported platforms and still run locally or in environments with the required capabilities.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
