### PR TITLE
config: make default network NAD configurable

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -265,6 +265,16 @@ ovn_enable_multi_external_gateway=${OVN_ENABLE_MULTI_EXTERNAL_GATEWAY:-false}
 ovn_enable_ovnkube_identity=${OVN_ENABLE_OVNKUBE_IDENTITY:-true}
 #OVN_ENABLE_PERSISTENT_IPS - enable IPAM for virtualization workloads (KubeVirt persistent IPs)
 ovn_enable_persistent_ips=${OVN_ENABLE_PERSISTENT_IPS:-false}
+# OVNKUBE_CLUSTER_DEFAULT_NAD - namespace/name of the default cluster wide net-attach-def.
+# When unset, ovnkube defaults to <ovn-config-namespace>/default.
+ovnkube_cluster_default_nad=${OVNKUBE_CLUSTER_DEFAULT_NAD:-}
+
+# only pass the flag when the env variable is set, otherwise let ovnkube
+# resolve the default
+ovnkube_cluster_default_nad_flag=
+if [[ -n "${ovnkube_cluster_default_nad}" ]]; then
+  ovnkube_cluster_default_nad_flag="--cluster-default-nad=${ovnkube_cluster_default_nad}"
+fi
 
 # OVNKUBE_NODE_MODE - is the mode which ovnkube node operates
 ovnkube_node_mode=${OVNKUBE_NODE_MODE:-"full"}
@@ -1290,6 +1300,7 @@ ovnkube-controller() {
     ${ovn_enable_dnsnameresolver_flag} \
     ${dynamic_udn_allocation_flag} \
     ${dynamic_udn_grace_period} \
+    ${ovnkube_cluster_default_nad_flag} \
     ${ovn_allow_icmp_netpol_flag} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --gateway-mode=${ovn_gateway_mode} \
@@ -1811,6 +1822,7 @@ ovnkube-controller-with-node() {
     ${sflow_targets} \
     ${dynamic_udn_allocation_flag} \
     ${dynamic_udn_grace_period} \
+    ${ovnkube_cluster_default_nad_flag} \
     ${network_qos_enabled_flag} \
     ${ovn_enable_dnsnameresolver_flag} \
     ${ovn_disable_requestedchassis_flag} \
@@ -2105,6 +2117,7 @@ ovn-cluster-manager() {
     ${network_qos_enabled_flag} \
     ${dynamic_udn_allocation_flag} \
     ${dynamic_udn_grace_period} \
+    ${ovnkube_cluster_default_nad_flag} \
     ${ovn_enable_dnsnameresolver_flag} \
     ${ovn_allow_icmp_netpol_flag} \
     ${ovnkube_metrics_scale_enable_flag} \
@@ -2509,6 +2522,7 @@ ovn-node() {
         ${sflow_targets} \
         ${dynamic_udn_allocation_flag} \
         ${dynamic_udn_grace_period} \
+        ${ovnkube_cluster_default_nad_flag} \
         ${network_qos_enabled_flag} \
         --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
         --export-ovs-metrics \

--- a/go-controller/pkg/clustermanager/nooverlay/controller.go
+++ b/go-controller/pkg/clustermanager/nooverlay/controller.go
@@ -23,7 +23,6 @@ import (
 	ratypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/routeadvertisements/v1"
 	apitypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
 
 // validationErrorType represents different types of validation failures
@@ -297,8 +296,8 @@ func (c *Controller) emitEvent(eventType, reason, message string) {
 	c.recorder.Eventf(
 		&corev1.ObjectReference{
 			Kind:      "NetworkAttachmentDefinition",
-			Name:      types.DefaultNetworkName,
-			Namespace: config.Kubernetes.OVNConfigNamespace,
+			Name:      config.Default.ClusterDefaultNetworkNAD.Name,
+			Namespace: config.Default.ClusterDefaultNetworkNAD.Namespace,
 		},
 		eventType,
 		reason,

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -296,7 +296,7 @@ func (c *Controller) ReconcileNetwork(_ string, old, new util.NetInfo) {
 		// if the namespaces served by a network changed, it is possible that
 		// those namespaces are served or no longer served by the default
 		// network, so reconcile it as well
-		c.nadController.Reconcile(config.Kubernetes.OVNConfigNamespace + "/" + types.DefaultNetworkName)
+		c.nadController.Reconcile(config.Default.ClusterDefaultNADName)
 	}
 }
 
@@ -1642,7 +1642,7 @@ func (c *Controller) getSelectedNADs(networkSelectors apitypes.NetworkSelectors)
 			// make sure a NAD exists for it
 			nad, err := util.EnsureDefaultNetworkNAD(c.nadLister, c.nadClient)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get/create default network NAD: %w", err)
+				return nil, fmt.Errorf("failed to ensure default network NAD: %w", err)
 			}
 			selected = append(selected, nad)
 		case apitypes.ClusterUserDefinedNetworks:

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -2628,11 +2628,12 @@ exit
 				g.Expect(err).ToNot(gomega.HaveOccurred())
 			}
 
+			defaultNADName := config.Default.ClusterDefaultNetworkNAD
 			var defaultNAD *nadtypes.NetworkAttachmentDefinition
 			for _, nad := range tt.nads {
 				n, err := fakeClientset.NetworkAttchDefClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nad.Namespace).Create(context.Background(), nad.NAD(), metav1.CreateOptions{})
 				g.Expect(err).ToNot(gomega.HaveOccurred())
-				if nad.Name == types.DefaultNetworkName && nad.Namespace == config.Kubernetes.OVNConfigNamespace {
+				if nad.Name == defaultNADName.Name && nad.Namespace == defaultNADName.Namespace {
 					defaultNAD = n
 				}
 			}
@@ -2673,7 +2674,7 @@ exit
 			// prime the default network NAD namespace
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.Kubernetes.OVNConfigNamespace,
+					Name: config.Default.ClusterDefaultNetworkNAD.Namespace,
 				},
 			}
 			_, err = fakeClientset.KubeClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
@@ -2843,7 +2844,7 @@ func TestController_reconcileOnNetworkActivity(t *testing.T) {
 	_, err = fakeClientset.KubeClient.CoreV1().Nodes().Create(context.Background(), node.Node(), metav1.CreateOptions{})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	for _, namespace := range []string{"blue", config.Kubernetes.OVNConfigNamespace} {
+	for _, namespace := range []string{"blue", config.Default.ClusterDefaultNetworkNAD.Namespace} {
 		_, err = fakeClientset.KubeClient.CoreV1().Namespaces().Create(context.Background(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
 		g.Expect(err).ToNot(gomega.HaveOccurred())

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/urfave/cli/v2"
 	gcfg "gopkg.in/gcfg.v1"
@@ -374,6 +375,13 @@ type DefaultConfig struct {
 	// Accepts: "" (empty, uses OVN default overlay) or "no-overlay".
 	// Defaults to "" (empty).
 	Transport string `gcfg:"transport"`
+
+	// ClusterDefaultNADName is the namespace/name of the default cluster network
+	// NAD. When empty, it resolves to OVNConfigNamespace/default.
+	ClusterDefaultNADName string `gcfg:"cluster-default-nad"`
+	// ClusterDefaultNetworkNAD is the parsed form of ClusterDefaultNADName,
+	// populated in completeDefaultConfig.
+	ClusterDefaultNetworkNAD *nettypes.NetworkSelectionElement
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -788,6 +796,14 @@ var (
 )
 
 func init() {
+	// ClusterDefaultNetworkNAD is normally resolved in completeDefaultConfig, but
+	// unit tests rely on PrepareTestConfig instead of the full init flow. Seed a
+	// valid default here, before savedDefault is captured below, so it is never
+	// nil and PrepareTestConfig restores a usable value for those tests.
+	// ClusterDefaultNADName is deliberately left empty so that savedDefault
+	// records it as unset and CLI/file overrides are still detected.
+	Default.ClusterDefaultNetworkNAD, _ = parseClusterDefaultNAD(defaultClusterDefaultNADName())
+
 	// Cache original default config values
 	savedDefault = Default
 	savedLogging = Logging
@@ -1076,6 +1092,13 @@ var CommonFlags = []cli.Flag{
 		Value:       Default.Transport,
 		Usage:       "Transport technology for the default network. When unset, the OVN default overlay transport is used. (no-overlay)",
 		Destination: &cliConfig.Default.Transport,
+	},
+	&cli.StringFlag{
+		Name:  "cluster-default-nad",
+		Value: Default.ClusterDefaultNADName,
+		Usage: "Namespace/name of the default cluster network NAD. " +
+			"When unset, defaults to <ovn-config-namespace>/" + types.DefaultNetworkName + ".",
+		Destination: &cliConfig.Default.ClusterDefaultNADName,
 	},
 	&cli.BoolFlag{
 		Name:        "unprivileged-mode",
@@ -2623,7 +2646,45 @@ func completeDefaultConfig(allSubnets *ConfigSubnets) error {
 	Default.OVNMasqConntrackZone = Default.ConntrackZone + 2
 	Default.HostNodePortConntrackZone = Default.ConntrackZone + 3
 	Default.ReassemblyConntrackZone = Default.ConntrackZone + 4
+
+	// Resolve here rather than at package init so that the fallback picks up
+	// --ovn-config-namespace, which is only merged into Kubernetes by
+	// buildKubernetesConfig earlier in InitConfig.
+	if Default.ClusterDefaultNADName == "" {
+		Default.ClusterDefaultNADName = defaultClusterDefaultNADName()
+	}
+	Default.ClusterDefaultNetworkNAD, err = parseClusterDefaultNAD(Default.ClusterDefaultNADName)
+	if err != nil {
+		return err
+	}
 	return nil
+}
+
+// defaultClusterDefaultNADName returns the location of the default cluster
+// network NAD when cluster-default-nad is not configured: the default network
+// NAD in the namespace ovn-kubernetes itself runs in.
+func defaultClusterDefaultNADName() string {
+	return Kubernetes.OVNConfigNamespace + "/" + types.DefaultNetworkName
+}
+
+// parseClusterDefaultNAD parses a "namespace/name" cluster-default-nad value
+// into a NetworkSelectionElement, returning an error if it is malformed. The
+// namespace and NAD name are validated as Kubernetes resource names.
+func parseClusterDefaultNAD(name string) (*nettypes.NetworkSelectionElement, error) {
+	nsAndName := strings.Split(name, "/")
+	if len(nsAndName) != 2 || nsAndName[0] == "" || nsAndName[1] == "" {
+		return nil, fmt.Errorf("cluster-default-nad %q must be in the format of \"namespace/name\"", name)
+	}
+	if errs := validation.ValidateNamespaceName(nsAndName[0], false); len(errs) != 0 {
+		return nil, fmt.Errorf("cluster-default-nad %q has an invalid namespace: %s", name, strings.Join(errs, ", "))
+	}
+	if errs := validation.NameIsDNSSubdomain(nsAndName[1], false); len(errs) != 0 {
+		return nil, fmt.Errorf("cluster-default-nad %q has an invalid name: %s", name, strings.Join(errs, ", "))
+	}
+	return &nettypes.NetworkSelectionElement{
+		Namespace: nsAndName[0],
+		Name:      nsAndName[1],
+	}, nil
 }
 
 // parseServicesNamespacedNames splits the input string by `,` and returns a slice

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -1482,6 +1482,70 @@ udn-allowed-default-services= ns/svc, ns1/svc1
 		err = app.Run(cliArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	Describe("parseClusterDefaultNAD", func() {
+		It("parses a namespace/name value", func() {
+			nad, err := parseClusterDefaultNAD("custom-namespace/custom-nad")
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(nad.Namespace).To(gomega.Equal("custom-namespace"))
+			gomega.Expect(nad.Name).To(gomega.Equal("custom-nad"))
+		})
+
+		DescribeTable("rejects malformed values",
+			func(value string) {
+				nad, err := parseClusterDefaultNAD(value)
+
+				gomega.Expect(err).To(gomega.MatchError(
+					fmt.Sprintf(`cluster-default-nad %q must be in the format of "namespace/name"`, value),
+				))
+				gomega.Expect(nad).To(gomega.BeNil())
+			},
+			Entry("empty value", ""),
+			Entry("missing namespace", "/name"),
+			Entry("missing name", "namespace/"),
+			Entry("missing separator", "name"),
+			Entry("too many separators", "namespace/name/extra"),
+			Entry("empty component between separators", "namespace//name"),
+			Entry("leading and trailing separators", "/namespace/name/"),
+			Entry("only separators", "//"),
+		)
+
+		It("rejects an invalid namespace", func() {
+			nad, err := parseClusterDefaultNAD("BadNS/default")
+
+			gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(
+				`cluster-default-nad "BadNS/default" has an invalid namespace`,
+			)))
+			gomega.Expect(nad).To(gomega.BeNil())
+		})
+
+		DescribeTable("rejects a name that is not a DNS-1123 subdomain",
+			func(value string) {
+				nad, err := parseClusterDefaultNAD(value)
+
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(
+					fmt.Sprintf(`cluster-default-nad %q has an invalid name`, value),
+				)))
+				gomega.Expect(nad).To(gomega.BeNil())
+			},
+			Entry("underscore", "namespace/invalid_name"),
+			Entry("uppercase", "namespace/UpperCase"),
+			Entry("dot", "namespace/."),
+			Entry("dot dot", "namespace/.."),
+			Entry("percent", "namespace/a%b"),
+			Entry("leading dash", "namespace/-name"),
+		)
+
+		It("accepts a dotted name", func() {
+			nad, err := parseClusterDefaultNAD("namespace/my.nad")
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(nad.Namespace).To(gomega.Equal("namespace"))
+			gomega.Expect(nad.Name).To(gomega.Equal("my.nad"))
+		})
+	})
+
 	Describe("OvnDBAuth operations", func() {
 		It("configures client southbound DB auth to unix socket via external_ids", func() {
 			fexec := ovntest.NewFakeExec()

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -1517,7 +1517,7 @@ func GetAnnotatedNetworkName(netattachdef *nettypes.NetworkAttachmentDefinition)
 	if netattachdef == nil {
 		return ""
 	}
-	if netattachdef.Name == types.DefaultNetworkName && netattachdef.Namespace == config.Kubernetes.OVNConfigNamespace {
+	if netattachdef.Name == config.Default.ClusterDefaultNetworkNAD.Name && netattachdef.Namespace == config.Default.ClusterDefaultNetworkNAD.Namespace {
 		return types.DefaultNetworkName
 	}
 	return netattachdef.Annotations[types.OvnNetworkNameAnnotation]
@@ -1843,11 +1843,12 @@ func getPodNADToNetworkMappingWithPredicate(
 // overrideActiveNSEWithDefaultNSE overrides the provided active NetworkSelectionElement with the IP and MAC requests from
 // the default NetworkSelectionElement after validating its namespace and name.
 func overrideActiveNSEWithDefaultNSE(defaultNSE, activeNSE *nettypes.NetworkSelectionElement) error {
-	if defaultNSE.Namespace != config.Kubernetes.OVNConfigNamespace {
-		return fmt.Errorf("unexpected default NSE namespace %q, expected %q", defaultNSE.Namespace, config.Kubernetes.OVNConfigNamespace)
+	expected := config.Default.ClusterDefaultNetworkNAD
+	if defaultNSE.Namespace != expected.Namespace {
+		return fmt.Errorf("unexpected default NSE namespace %q, expected %q", defaultNSE.Namespace, expected.Namespace)
 	}
-	if defaultNSE.Name != types.DefaultNetworkName {
-		return fmt.Errorf("unexpected default NSE name %q, expected %q", defaultNSE.Name, types.DefaultNetworkName)
+	if defaultNSE.Name != expected.Name {
+		return fmt.Errorf("unexpected default NSE name %q, expected %q", defaultNSE.Name, expected.Name)
 	}
 	activeNSE.IPRequest = defaultNSE.IPRequest
 	activeNSE.MacRequest = defaultNSE.MacRequest

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -1842,7 +1842,7 @@ func getPodNADToNetworkMappingWithPredicate(
 
 // overrideActiveNSEWithDefaultNSE overrides the provided active NetworkSelectionElement with the IP and MAC requests from
 // the default NetworkSelectionElement after validating its namespace and name.
-func overrideActiveNSEWithDefaultNSE(defaultNSE, activeNSE *nettypes.NetworkSelectionElement) error {
+func overrideActiveNSEWithDefaultNSE(defaultNSE, activeNSE *nettypes.NetworkSelectionElement, topologyType string) error {
 	expected := config.Default.ClusterDefaultNetworkNAD
 	if defaultNSE.Namespace != expected.Namespace {
 		return fmt.Errorf("unexpected default NSE namespace %q, expected %q", defaultNSE.Namespace, expected.Namespace)
@@ -1850,8 +1850,16 @@ func overrideActiveNSEWithDefaultNSE(defaultNSE, activeNSE *nettypes.NetworkSele
 	if defaultNSE.Name != expected.Name {
 		return fmt.Errorf("unexpected default NSE name %q, expected %q", defaultNSE.Name, expected.Name)
 	}
-	activeNSE.IPRequest = defaultNSE.IPRequest
-	activeNSE.MacRequest = defaultNSE.MacRequest
+	// Layer2 accepts requested IPs and MACs. Layer3 accepts only a MAC to retain node-local IPAM.
+	switch topologyType {
+	case types.Layer2Topology:
+		// Limit the static ip and mac requests to the layer2 primary UDN
+		activeNSE.IPRequest = defaultNSE.IPRequest
+		activeNSE.MacRequest = defaultNSE.MacRequest
+	case types.Layer3Topology:
+		// Limit mac requests to the layer3 primary UDN
+		activeNSE.MacRequest = defaultNSE.MacRequest
+	}
 	return nil
 }
 
@@ -1930,18 +1938,11 @@ func GetPodNADToNetworkMappingWithActiveNetwork(
 		}
 	}
 
-	// Feature gate integration: EnablePreconfiguredUDNAddresses controls default network IP/MAC transfer to active network
-	if IsPreconfiguredUDNAddressesEnabled() {
-		// Limit the static ip and mac requests to the layer2 primary UDN when EnablePreconfiguredUDNAddresses is enabled, we
-		// don't need to explicitly check this is primary UDN since
-		// the "active network" concept is exactly that.
-		if activeNetwork.TopologyType() == types.Layer2Topology {
-			// If there are static IPs and MACs at the default NSE, override the active NSE with them
-			if defaultNSE != nil {
-				if err := overrideActiveNSEWithDefaultNSE(defaultNSE, activeNSE); err != nil {
-					return false, nil, err
-				}
-			}
+	// Feature gate integration: EnablePreconfiguredUDNAddresses controls default network IP/MAC transfer to active network,
+	// we don't need to explicitly check this is primary UDN since the "active network" concept is exactly that.
+	if IsPreconfiguredUDNAddressesEnabled() && defaultNSE != nil {
+		if err := overrideActiveNSEWithDefaultNSE(defaultNSE, activeNSE, activeNetwork.TopologyType()); err != nil {
+			return false, nil, err
 		}
 	}
 

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -1453,7 +1453,7 @@ func TestGetPodNADToNetworkMappingWithActiveNetwork(t *testing.T) {
 		},
 
 		{
-			desc: "default-network ips and mac is is ignored for Layer3 topology",
+			desc: "default-network MAC is applied and IPs are ignored for Layer3 topology",
 			inputNetConf: &ovncnitypes.NetConf{
 				NetConf:  cnitypes.NetConf{Name: networkName},
 				Topology: ovntypes.Layer3Topology,
@@ -1476,7 +1476,59 @@ func TestGetPodNADToNetworkMappingWithActiveNetwork(t *testing.T) {
 					Name:       "attachment1",
 					Namespace:  "ns1",
 					IPRequest:  nil,
-					MacRequest: "",
+					MacRequest: "aa:bb:cc:dd:ee:ff",
+				},
+			},
+			enablePreconfiguredUDNAddresses: true,
+		},
+		{
+			desc: "default-network IPs and MAC are ignored for Layer3 topology when the feature is disabled",
+			inputNetConf: &ovncnitypes.NetConf{
+				NetConf:  cnitypes.NetConf{Name: networkName},
+				Topology: ovntypes.Layer3Topology,
+				NADName:  GetNADName(namespaceName, attachmentName),
+				Role:     ovntypes.NetworkRolePrimary,
+			},
+			inputPrimaryUDNConfig: &ovncnitypes.NetConf{
+				NetConf:  cnitypes.NetConf{Name: networkName},
+				Topology: ovntypes.Layer3Topology,
+				NADName:  GetNADName(namespaceName, attachmentName),
+				Role:     ovntypes.NetworkRolePrimary,
+			},
+			inputPodAnnotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: GetNADName(namespaceName, "another-network"),
+				DefNetworkAnnotation:         `[{"namespace": "ovn-kubernetes", "name": "default", "ips": ["192.168.0.3/24", "fda6::3/48"], "mac": "aa:bb:cc:dd:ee:ff"}]`,
+			},
+			expectedIsAttachmentRequested: true,
+			expectedNetworkSelectionElements: map[string]*nadv1.NetworkSelectionElement{
+				"ns1/attachment1": {
+					Name:      "attachment1",
+					Namespace: "ns1",
+				},
+			},
+		},
+		{
+			desc: "default-network NAD without a MAC is ignored for Layer3 topology",
+			inputNetConf: &ovncnitypes.NetConf{
+				NetConf:  cnitypes.NetConf{Name: networkName},
+				Topology: ovntypes.Layer3Topology,
+				NADName:  GetNADName(namespaceName, attachmentName),
+				Role:     ovntypes.NetworkRolePrimary,
+			},
+			inputPrimaryUDNConfig: &ovncnitypes.NetConf{
+				NetConf:  cnitypes.NetConf{Name: networkName},
+				Topology: ovntypes.Layer3Topology,
+				NADName:  GetNADName(namespaceName, attachmentName),
+				Role:     ovntypes.NetworkRolePrimary,
+			},
+			inputPodAnnotations: map[string]string{
+				DefNetworkAnnotation: `[{"namespace": "ovn-kubernetes", "name": "default"}]`,
+			},
+			expectedIsAttachmentRequested: true,
+			expectedNetworkSelectionElements: map[string]*nadv1.NetworkSelectionElement{
+				"ns1/attachment1": {
+					Name:      "attachment1",
+					Namespace: "ns1",
 				},
 			},
 			enablePreconfiguredUDNAddresses: true,

--- a/go-controller/pkg/util/nad.go
+++ b/go-controller/pkg/util/nad.go
@@ -15,27 +15,27 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 )
 
-// EnsureDefaultNetworkNAD ensures that a well-known NAD exists for the
-// default network in ovn-k namespace. This will allow the users to customize
-// the primary UDN attachments with static IPs, and/or MAC address requests, by
-// using the multus-cni `default network` feature.
+// EnsureDefaultNetworkNAD ensures that a NAD exists for the default network at
+// the location configured by the cluster-default-nad option. This allows users
+// to customize the primary UDN attachments with static IPs, and/or MAC address
+// requests, by using the multus-cni `default network` feature.
 func EnsureDefaultNetworkNAD(nadLister nadlisters.NetworkAttachmentDefinitionLister, nadClient nadclientset.Interface) (*nadtypes.NetworkAttachmentDefinition, error) {
-	nad, err := nadLister.NetworkAttachmentDefinitions(config.Kubernetes.OVNConfigNamespace).Get(types.DefaultNetworkName)
+	namespace, name := config.Default.ClusterDefaultNetworkNAD.Namespace, config.Default.ClusterDefaultNetworkNAD.Name
+	nad, err := nadLister.NetworkAttachmentDefinitions(namespace).Get(name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 	if nad != nil {
 		return nad, nil
 	}
-	return nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(config.Kubernetes.OVNConfigNamespace).Create(
+	return nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Create(
 		context.Background(),
 		&nadtypes.NetworkAttachmentDefinition{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      types.DefaultNetworkName,
-				Namespace: config.Kubernetes.OVNConfigNamespace,
+				Name:      name,
+				Namespace: namespace,
 			},
 			Spec: nadtypes.NetworkAttachmentDefinitionSpec{
 				Config: fmt.Sprintf("{\"cniVersion\": \"%s\", \"name\": \"ovn-kubernetes\", \"type\": \"%s\"}", config.CNISpecVersion, config.CNI.Plugin),

--- a/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-control-plane/templates/ovnkube-control-plane.yaml
@@ -151,6 +151,8 @@ spec:
           value: {{ default "" .Values.global.dynamicUDNGracePeriod | quote }}
         - name: OVN_ADVERTISED_UDN_ISOLATION_MODE
           value: {{ default "strict" .Values.global.advertisedUDNIsolationMode | quote }}
+        - name: OVNKUBE_CLUSTER_DEFAULT_NAD
+          value: {{ default "" .Values.global.clusterDefaultNAD | quote }}
         - name: OVN_NO_OVERLAY_ENABLE
           value: {{ default "false" .Values.global.enableNoOverlay | quote }}
         - name: OVN_HYBRID_OVERLAY_NET_CIDR

--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu-host/templates/ovnkube-node-dpu-host.yaml
@@ -232,6 +232,8 @@ spec:
           value: {{ hasKey .Values.global "enableRouteAdvertisements" | ternary .Values.global.enableRouteAdvertisements false | quote }}
         - name: OVN_ADVERTISED_UDN_ISOLATION_MODE
           value: {{ default "strict" .Values.global.advertisedUDNIsolationMode | quote }}
+        - name: OVNKUBE_CLUSTER_DEFAULT_NAD
+          value: {{ default "" .Values.global.clusterDefaultNAD | quote }}
         - name: OVN_NO_OVERLAY_ENABLE
           value: {{ default "false" .Values.global.enableNoOverlay | quote }}
         - name: OVNKUBE_NODE_MGMT_PORT_NETDEV

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone-dpu/templates/ovnkube-single-node-zone-dpu.yaml
@@ -405,6 +405,8 @@ spec:
           value: {{ default "" .Values.global.dynamicUDNGracePeriod | quote }}
         - name: OVN_ADVERTISED_UDN_ISOLATION_MODE
           value: {{ default "strict" .Values.global.advertisedUDNIsolationMode | quote }}
+        - name: OVNKUBE_CLUSTER_DEFAULT_NAD
+          value: {{ default "" .Values.global.clusterDefaultNAD | quote }}
         - name: OVN_EMPTY_LB_EVENTS
           value: {{ default "" .Values.global.emptyLbEvents | quote }}
         - name: OVN_ACL_LOGGING_RATE_LIMIT

--- a/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-single-node-zone/templates/ovnkube-single-node-zone.yaml
@@ -469,6 +469,8 @@ spec:
           value: {{ default "" .Values.global.dynamicUDNGracePeriod | quote }}
         - name: OVN_ADVERTISED_UDN_ISOLATION_MODE
           value: {{ default "strict" .Values.global.advertisedUDNIsolationMode | quote }}
+        - name: OVNKUBE_CLUSTER_DEFAULT_NAD
+          value: {{ default "" .Values.global.clusterDefaultNAD | quote }}
         - name: OVN_NO_OVERLAY_ENABLE
           value: {{ default "false" .Values.global.enableNoOverlay | quote }}
         - name: OVNKUBE_NODE_MGMT_PORT_NETDEV

--- a/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone-dpu.yaml
@@ -84,6 +84,8 @@ global:
   managedBGPFRRNamespace: "frr-k8s-system"
   # -- Configure to enable workloads with preconfigured network connect to user defined networks (UDN) with ovn-kubernetes
   enablePreconfiguredUDNAddresses: false
+  # -- Namespace/name of the default cluster network NAD. Empty defaults to <ovn-config-namespace>/default
+  #clusterDefaultNAD: ""
   # -- Configure to enable IPsec
   enableIpsec: false
   # -- Use SSL transport for the Egress IP gRPC health-check (NB cert paths

--- a/helm/ovn-kubernetes/values-single-node-zone.yaml
+++ b/helm/ovn-kubernetes/values-single-node-zone.yaml
@@ -98,6 +98,8 @@ global:
   managedBGPFRRNamespace: "frr-k8s-system"
   # -- Configure to enable workloads with preconfigured network connect to user defined networks (UDN) with ovn-kubernetes
   enablePreconfiguredUDNAddresses: false
+  # -- Namespace/name of the default cluster network NAD. Empty defaults to <ovn-config-namespace>/default
+  #clusterDefaultNAD: ""
   # -- Configure to enable IPsec
   enableIpsec: false
   # -- Use SSL transport for the Egress IP gRPC health-check (NB cert paths


### PR DESCRIPTION
Add a `--cluster-default-nad` option (env `OVNKUBE_CLUSTER_DEFAULT_NAD`, Helm value `global.clusterDefaultNAD`) so the namespace/name of the default cluster network NAD can be customized. Defaults to the built-in ovn-kubernetes/default.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
