### PR TITLE
addressset manager: add incremental address set reconciliation

### DIFF
--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -312,8 +312,11 @@ func NewControllerManager(ovnClient *util.OVNClientset, wf *factory.WatchFactory
 			cm.routeImportManager = routeimport.New(config.Default.Zone, cm.nbClient, nil)
 		}
 	}
-	cm.addressSetManager = addresssetmanager.NewAddressSetManager(cm.watchFactory.PodCoreInformer(),
+	cm.addressSetManager, err = addresssetmanager.NewAddressSetManager(cm.watchFactory.PodCoreInformer(),
 		cm.watchFactory.NamespaceInformer(), cm.watchFactory.NodeCoreInformer(), cm.nbClient, cm.networkManager.Interface().GetNetworkNameForNADKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create address set manager: %w", err)
+	}
 
 	return cm, nil
 }

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -74,6 +74,13 @@ type AddressSet interface {
 	DeleteAddresses(addresses []string) error
 	// DeleteAddressesReturnOps returns the ops needed to delete the slice of addresses from the address set
 	DeleteAddressesReturnOps(addresses []string) ([]ovsdb.Operation, error)
+	// ApplyAddressChanges applies incremental add/remove in a single OVN transaction without
+	// reading current address-set state from the libovsdb cache (bypasses hasAddresses /
+	// hasOnlyAddresses). Callers that maintain an accurate in-memory mirror (e.g.
+	// AddressSetManager) use this to avoid redundant OVN cache lookups on every update.
+	// Addresses present in both toAdd and toRemove are dropped as no-ops.
+	// No-op when both toAdd and toRemove are empty (after that filtering).
+	ApplyAddressChanges(toAdd, toRemove []string) error
 	// Destroy deletes the entire address set
 	Destroy() error
 }
@@ -507,6 +514,74 @@ func (as *ovnAddressSets) DeleteAddresses(addresses []string) error {
 	return nil
 }
 
+// ApplyAddressChanges applies toRemove then toAdd in one OVN transaction.
+// Unlike SetAddresses / AddAddresses, it does not read existing addresses from OVN to decide
+// whether a write is needed — the caller must only pass a real delta.
+// Addresses present in both slices are dropped as no-ops before building ops.
+func (as *ovnAddressSets) ApplyAddressChanges(toAdd, toRemove []string) error {
+	var ops []ovsdb.Operation
+	var err error
+	if ops, err = as.ApplyAddressChangesReturnOps(toAdd, toRemove); err != nil {
+		return err
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	_, err = libovsdbops.TransactAndCheck(as.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("failed to apply address changes to address set %s (%v)", as.name, err)
+	}
+	return nil
+}
+
+// ApplyAddressChangesReturnOps builds ops to remove then add addresses without checking
+// whether they already exist in the libovsdb cache. Addresses present in both slices are
+// dropped so no useless mutate ops are emitted.
+func (as *ovnAddressSets) ApplyAddressChangesReturnOps(toAdd, toRemove []string) ([]ovsdb.Operation, error) {
+	toAdd, toRemove = NormalizeAddressChanges(toAdd, toRemove)
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		return nil, nil
+	}
+	var ops []ovsdb.Operation
+	var err error
+	if ops, err = as.DeleteAddressesReturnOps(toRemove); err != nil {
+		return nil, err
+	}
+	var addOps []ovsdb.Operation
+	if addOps, err = as.AddAddressesReturnOpsUnchecked(toAdd); err != nil {
+		return nil, err
+	}
+	ops = append(ops, addOps...)
+	return ops, nil
+}
+
+// AddAddressesReturnOpsUnchecked builds add ops without calling hasAddresses (no OVN cache read).
+// Intended for callers that already validated membership via an in-memory mirror.
+func (as *ovnAddressSets) AddAddressesReturnOpsUnchecked(addresses []string) ([]ovsdb.Operation, error) {
+	var ops []ovsdb.Operation
+	var err error
+	if len(addresses) == 0 {
+		return ops, nil
+	}
+
+	v4addresses, v6addresses := splitAddressesByFamily(getUniqueAddresses(addresses))
+	var op []ovsdb.Operation
+	if as.v6 != nil {
+		if op, err = as.v6.addAddressesUnchecked(v6addresses); err != nil {
+			return nil, fmt.Errorf("failed to add addresses to the v6 set: %w", err)
+		}
+		ops = append(ops, op...)
+	}
+	if as.v4 != nil {
+		if op, err = as.v4.addAddressesUnchecked(v4addresses); err != nil {
+			return nil, fmt.Errorf("failed to add addresses to the v4 set: %w", err)
+		}
+		ops = append(ops, op...)
+	}
+
+	return ops, nil
+}
+
 func (as *ovnAddressSets) DeleteAddressesReturnOps(addresses []string) ([]ovsdb.Operation, error) {
 	var ops []ovsdb.Operation
 	var err error
@@ -584,6 +659,7 @@ func (as *ovnAddressSet) getAddresses() ([]string, error) {
 }
 
 // addAddresses appends the set of addresses to the existing address_set.
+// Skips the write when hasAddresses reports all addresses already present (OVN cache read).
 func (as *ovnAddressSet) addAddresses(addresses []string) ([]ovsdb.Operation, error) {
 	if len(addresses) == 0 {
 		return nil, nil
@@ -595,15 +671,25 @@ func (as *ovnAddressSet) addAddresses(addresses []string) ([]ovsdb.Operation, er
 		return nil, nil
 	}
 
-	klog.V(5).Infof("(%s) adding Addresses (%s) to address set", asDetail(as), uniqAddresses)
+	return as.addAddressesUnchecked(uniqAddresses)
+}
+
+// addAddressesUnchecked builds add ops without checking existing OVN addresses.
+// addresses must already be unique (callers uniquify once before invoking).
+func (as *ovnAddressSet) addAddressesUnchecked(addresses []string) ([]ovsdb.Operation, error) {
+	if len(addresses) == 0 {
+		return nil, nil
+	}
+
+	klog.V(5).Infof("(%s) adding Addresses (%s) to address set", asDetail(as), addresses)
 
 	addrset := nbdb.AddressSet{
 		UUID: as.uuid,
 		Name: as.hashName,
 	}
-	ops, err := libovsdbops.AddAddressesToAddressSetOps(as.nbClient, nil, &addrset, uniqAddresses...)
+	ops, err := libovsdbops.AddAddressesToAddressSetOps(as.nbClient, nil, &addrset, addresses...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to add addresses %v to address set %+v: %v", uniqAddresses, addrset, err)
+		return nil, fmt.Errorf("failed to add addresses %v to address set %+v: %v", addresses, addrset, err)
 	}
 
 	return ops, nil
@@ -714,7 +800,22 @@ func splitAddressesByFamily(addresses []string) (v4, v6 []string) {
 	return
 }
 
-// Takes a slice of addresses and returns a slice with unique address strings
+// GetUniqueAddresses returns a slice with unique address strings. Exported for callers
+// (e.g. AddressSetManager) that need the same dedupe used by SetAddresses / AddAddresses.
+func GetUniqueAddresses(addresses []string) []string {
+	return getUniqueAddresses(addresses)
+}
+
+// NormalizeAddressChanges dedupes each slice and drops addresses present in both toAdd and
+// toRemove (net no-ops that would otherwise emit remove-then-add mutations).
+func NormalizeAddressChanges(toAdd, toRemove []string) (add, remove []string) {
+	addSet := sets.New(toAdd...)
+	removeSet := sets.New(toRemove...)
+	both := addSet.Intersection(removeSet)
+	return addSet.Difference(both).UnsortedList(), removeSet.Difference(both).UnsortedList()
+}
+
+// getUniqueAddresses returns a slice with unique address strings.
 func getUniqueAddresses(addresses []string) []string {
 	s := sets.New[string]()
 	for _, address := range addresses {

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -4,6 +4,9 @@
 package addressset
 
 import (
+	"context"
+	"sync/atomic"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
@@ -16,6 +19,17 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 )
+
+// countingNBClient counts Transact calls so tests can assert no OVN write occurred.
+type countingNBClient struct {
+	libovsdbclient.Client
+	transactCount atomic.Int64
+}
+
+func (c *countingNBClient) Transact(ctx context.Context, ops ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+	c.transactCount.Add(1)
+	return c.Client.Transact(ctx, ops...)
+}
 
 func getDbAddrSets(dbIDs *libovsdbops.DbObjectIDs, ipFamily string, ips []string) *nbdb.AddressSet {
 	asv4, asv6 := GetTestDbAddrSets(dbIDs, ips)
@@ -524,6 +538,108 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("applies address changes without reading existing addresses", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "2.3.4.5"
+					addr3 string = "7.8.9.10"
+				)
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				asFactory = NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
+				as, err := asFactory.NewAddressSet(addrsetDbIDs, []string{addr1, addr2})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = as.ApplyAddressChanges([]string{addr3}, []string{addr1})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState := getDbAsV4(addrsetDbIDs, []string{addr2, addr3})
+				gomega.Eventually(nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+
+				// Contrast: AddAddressesReturnOps skips the write after a membership
+				// cache read when the IP is already present.
+				checkedOps, err := as.AddAddressesReturnOps([]string{addr2})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(checkedOps).To(gomega.BeEmpty(),
+					"AddAddressesReturnOps should no-op when the address is already present")
+
+				// ApplyAddressChanges must still emit ops for an already-present
+				// address; restoring hasAddresses would make this empty.
+				ovnAS, ok := as.(*ovnAddressSets)
+				gomega.Expect(ok).To(gomega.BeTrue())
+				uncheckedOps, err := ovnAS.ApplyAddressChangesReturnOps([]string{addr2}, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(uncheckedOps).NotTo(gomega.BeEmpty(),
+					"ApplyAddressChangesReturnOps must not skip writes via membership cache reads")
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("is a no-op when apply address changes receives empty add and remove", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const addr1 string = "1.2.3.4"
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				countingClient := &countingNBClient{Client: nbClient}
+				asFactory = NewOvnAddressSetFactory(countingClient, config.IPv4Mode, config.IPv6Mode)
+				as, err := asFactory.NewAddressSet(addrsetDbIDs, []string{addr1})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState := getDbAsV4(addrsetDbIDs, []string{addr1})
+				gomega.Eventually(countingClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+				transactsBefore := countingClient.transactCount.Load()
+
+				err = as.ApplyAddressChanges(nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(countingClient.transactCount.Load()).To(gomega.Equal(transactsBefore),
+					"empty ApplyAddressChanges must not write to OVN")
+				gomega.Eventually(countingClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("drops addresses present in both add and remove as no-ops", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "2.3.4.5"
+				)
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				asFactory = NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
+				as, err := asFactory.NewAddressSet(addrsetDbIDs, []string{addr1, addr2})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ovnAS, ok := as.(*ovnAddressSets)
+				gomega.Expect(ok).To(gomega.BeTrue())
+				ops, err := ovnAS.ApplyAddressChangesReturnOps(
+					[]string{addr1, addr2}, []string{addr1})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(ops).To(gomega.HaveLen(1),
+					"addr1 in both slices should cancel; only addr2 add should remain")
+
+				err = as.ApplyAddressChanges([]string{addr1}, []string{addr1})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState := getDbAsV4(addrsetDbIDs, []string{addr1, addr2})
+				gomega.Eventually(nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("Dual stack : when creating an address set object", func() {
@@ -651,6 +767,51 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 	})
 
 	ginkgo.Context("Dual Stack : when manipulating IPs in an address set object", func() {
+		ginkgo.It("applies address changes without reading existing addresses", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "5.6.7.8"
+					addr3 string = "2001:db8::1"
+					addr4 string = "2001:db8::2"
+					addr5 string = "9.10.11.12"
+					addr6 string = "2001:db8::3"
+				)
+
+				_, err := config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				config.IPv6Mode = true
+
+				asFactory = NewOvnAddressSetFactory(nbClient, config.IPv4Mode, config.IPv6Mode)
+				as, err := asFactory.NewAddressSet(addrsetDbIDs, []string{addr1, addr2, addr3, addr4})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = as.ApplyAddressChanges([]string{addr5, addr6}, []string{addr1, addr3})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState := []libovsdbtest.TestData{
+					getDbAddrSets(addrsetDbIDs, ipv4InternalID, []string{addr2, addr5}),
+					getDbAddrSets(addrsetDbIDs, ipv6InternalID, []string{addr4, addr6}),
+				}
+				gomega.Eventually(nbClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+
+				checkedOps, err := as.AddAddressesReturnOps([]string{addr2, addr4})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(checkedOps).To(gomega.BeEmpty(),
+					"AddAddressesReturnOps should no-op when the addresses are already present")
+
+				ovnAS, ok := as.(*ovnAddressSets)
+				gomega.Expect(ok).To(gomega.BeTrue())
+				uncheckedOps, err := ovnAS.ApplyAddressChangesReturnOps([]string{addr2, addr4}, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(uncheckedOps).NotTo(gomega.BeEmpty(),
+					"ApplyAddressChangesReturnOps must not skip writes via membership cache reads")
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 		ginkgo.It("adds IP to an empty dual stack address set", func() {
 			app.Action = func(ctx *cli.Context) error {
 				const addr1 string = "1.2.3.4"

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -404,6 +404,61 @@ func (as *fakeAddressSets) GetAddresses() ([]string, []string) {
 	return v4addresses, v6addresses
 }
 
+// ApplyAddressChanges removes toRemove then adds toAdd in one transaction.
+// Addresses present in both slices are dropped as no-ops. No-op when both slices are empty.
+func (as *fakeAddressSets) ApplyAddressChanges(toAdd, toRemove []string) error {
+	toAdd, toRemove = NormalizeAddressChanges(toAdd, toRemove)
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		return nil
+	}
+
+	v4Remove, v6Remove := splitAddressesByFamily(toRemove)
+	v4Add, v6Add := splitAddressesByFamily(toAdd)
+
+	as.Lock()
+	defer as.Unlock()
+
+	if err := as.validateApplyAddressChangesLocked(); err != nil {
+		return err
+	}
+
+	if as.ipv4 != nil && (len(v4Add) > 0 || len(v4Remove) > 0) {
+		as.ipv4.addresses = computeFakeAddressSetChanges(as.ipv4.addresses, v4Add, v4Remove)
+	}
+	if as.ipv6 != nil && (len(v6Add) > 0 || len(v6Remove) > 0) {
+		as.ipv6.addresses = computeFakeAddressSetChanges(as.ipv6.addresses, v6Add, v6Remove)
+	}
+	return nil
+}
+
+func (as *fakeAddressSets) validateApplyAddressChangesLocked() error {
+	if as.ipv4 != nil {
+		if err := as.ipv4.ensureNotDestroyed(); err != nil {
+			return err
+		}
+	}
+	if as.ipv6 != nil {
+		if err := as.ipv6.ensureNotDestroyed(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func computeFakeAddressSetChanges(current map[string]string, toAdd, toRemove []string) map[string]string {
+	next := make(map[string]string, len(current)+len(toAdd))
+	for k, v := range current {
+		next[k] = v
+	}
+	for _, addr := range getUniqueAddresses(toRemove) {
+		delete(next, addr)
+	}
+	for _, addr := range getUniqueAddresses(toAdd) {
+		next[addr] = addr
+	}
+	return next
+}
+
 func (as *fakeAddressSets) SetAddresses(addresses []string) error {
 	allAddresses := []string{}
 	if as.ipv4 != nil {
@@ -465,6 +520,13 @@ func (as *fakeAddressSets) Destroy() error {
 	}
 	if as.ipv6 != nil {
 		return as.ipv6.destroy()
+	}
+	return nil
+}
+
+func (as *fakeAddressSet) ensureNotDestroyed() error {
+	if atomic.LoadUint32(&as.destroyed) != 0 {
+		return fmt.Errorf("address set %s is destroyed", as.name)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/address_set/mocks/AddressSet.go
+++ b/go-controller/pkg/ovn/address_set/mocks/AddressSet.go
@@ -235,6 +235,24 @@ func (_m *AddressSet) GetName() string {
 	return r0
 }
 
+// ApplyAddressChanges provides a mock function with given fields: toAdd, toRemove
+func (_m *AddressSet) ApplyAddressChanges(toAdd, toRemove []string) error {
+	ret := _m.Called(toAdd, toRemove)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApplyAddressChanges")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string, []string) error); ok {
+		r0 = rf(toAdd, toRemove)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetAddresses provides a mock function with given fields: addresses
 func (_m *AddressSet) SetAddresses(addresses []string) error {
 	ret := _m.Called(addresses)

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -68,6 +68,140 @@ type podSelectorAddressSet struct {
 	// and config.Kubernetes.HostNetworkNamespace address set IPs will be included when that namespace is matched and
 	// podSelector is empty.
 	legacyNetpolMode bool
+
+	// addresses is an authoritative in-memory mirror of the OVN address-set contents.
+	// Incremental reconciles compute add/remove against this cache and skip OVN writes
+	// when the delta is empty, avoiding a full pod list and OVN getAddresses on every event.
+	addresses sets.Set[string]
+	// podAddresses maps "namespace/name" to the IPs that pod currently contributes.
+	// Used to handle IP reuse across pods: an IP is only removed when no remaining selected
+	// pod still contributes it.
+	podAddresses map[string][]string
+	// selectedPods maps namespace name to the set of pod names currently selected into this
+	// address set. Used to diff membership on namespace/node-scoped reconciles.
+	selectedPods map[string]sets.Set[string]
+	// podNodes maps "namespace/name" to the Spec.NodeName last recorded for that selected pod.
+	// Used with podsByNode for O(pods-on-node) membership updates on node-selector changes.
+	podNodes map[string]string
+	// podsByNode maps Spec.NodeName to the set of selected pod keys last known on that node.
+	podsByNode map[string]sets.Set[string]
+	// pendingUpdates batches the triggering event context between enqueue (reconcilePod /
+	// reconcileNamespace / reconcileNode) and reconcileAddressSet. Cleared at the start of
+	// each reconcile under the per-key lock.
+	pendingUpdates addrSetPendingUpdates
+}
+
+// addrSetPendingUpdates records which objects triggered a reconcile so reconcileAddressSet
+// can take an incremental path instead of always rebuilding the full desired address set.
+// Multiple pod-scoped classes (namespace, node-selector, pod) may be coalesced in one
+// snapshot; reconcileAddressSetLocked falls back to full sync when more than one is present.
+type addrSetPendingUpdates struct {
+	// podKeys are "namespace/name" keys for pods that need incremental membership/IP checks.
+	podKeys sets.Set[string]
+	// namespaceKeys are namespaces whose membership may have changed due to label updates.
+	namespaceKeys sets.Set[string]
+	// nodeKeys are nodes that may affect nodeSelector membership or host-network IPs.
+	nodeKeys sets.Set[string]
+	// fullSync forces a full desired-state rebuild (first ensure, host-network namespace create, etc.).
+	fullSync bool
+}
+
+func (u *addrSetPendingUpdates) addPodKey(podKey string) {
+	if u.podKeys == nil {
+		u.podKeys = sets.New[string]()
+	}
+	u.podKeys.Insert(podKey)
+}
+
+func (u *addrSetPendingUpdates) addNamespaceKey(nsKey string) {
+	if u.namespaceKeys == nil {
+		u.namespaceKeys = sets.New[string]()
+	}
+	u.namespaceKeys.Insert(nsKey)
+}
+
+func (u *addrSetPendingUpdates) addNodeKey(nodeKey string) {
+	if u.nodeKeys == nil {
+		u.nodeKeys = sets.New[string]()
+	}
+	u.nodeKeys.Insert(nodeKey)
+}
+
+// snapshot clones pending state for this reconcile. pendingUpdates itself is left
+// intact until a successful reconcile clears it, so a failed attempt keeps the
+// triggering keys for retry (and for coalescing with later events).
+func (u *addrSetPendingUpdates) snapshot() addrSetPendingUpdates {
+	return addrSetPendingUpdates{
+		podKeys:       u.podKeys.Clone(),
+		namespaceKeys: u.namespaceKeys.Clone(),
+		nodeKeys:      u.nodeKeys.Clone(),
+		fullSync:      u.fullSync,
+	}
+}
+
+func (u *addrSetPendingUpdates) clear() {
+	u.podKeys = nil
+	u.namespaceKeys = nil
+	u.nodeKeys = nil
+	u.fullSync = false
+}
+
+// addressSetPodCacheSnapshot is a point-in-time copy of pod membership mirrors used to
+// replace caches after OVN apply without re-listing Kubernetes objects.
+type addressSetPodCacheSnapshot struct {
+	selectedPods map[string]sets.Set[string]
+	podAddresses map[string][]string
+	podNodes     map[string]string
+}
+
+// podCacheEntry records the IPs and node a pod should contribute after a successful OVN apply.
+type podCacheEntry struct {
+	ips      []string
+	nodeName string
+}
+
+// hostNetworkSnapshot is a compute-time snapshot of host-network IPs for this address set
+// (from hostNetworkNamespaceIPsPerNode) plus whether the set currently selects the host-
+// network namespace. Used for OVN desired-state union; not committed as per-AS cache state.
+type hostNetworkSnapshot struct {
+	selecting bool
+	addresses sets.Set[string]
+}
+
+// addressSetCachePlan is the exact pod-cache mutation corresponding to a computed OVN delta.
+// It is built during the compute phase and applied after OVN succeeds without re-listing.
+type addressSetCachePlan struct {
+	podCacheReplace *addressSetPodCacheSnapshot
+	podRemoves      sets.Set[string]
+	podSets         map[string]podCacheEntry
+}
+
+func newAddressSetCachePlan() *addressSetCachePlan {
+	return &addressSetCachePlan{}
+}
+
+func (p *addressSetCachePlan) recordPodRemove(podKey string) {
+	// Full-replace plans already encode membership; incremental records must not mix in.
+	if p.podCacheReplace != nil {
+		return
+	}
+	if p.podRemoves == nil {
+		p.podRemoves = sets.New[string]()
+	}
+	p.podRemoves.Insert(podKey)
+	delete(p.podSets, podKey)
+}
+
+func (p *addressSetCachePlan) recordPodSet(podKey string, ips []string, nodeName string) {
+	// Full-replace plans already encode membership; incremental records must not mix in.
+	if p.podCacheReplace != nil {
+		return
+	}
+	if p.podSets == nil {
+		p.podSets = make(map[string]podCacheEntry)
+	}
+	p.podRemoves.Delete(podKey)
+	p.podSets[podKey] = podCacheEntry{ips: slices.Clone(ips), nodeName: nodeName}
 }
 
 const (
@@ -75,7 +209,38 @@ const (
 	ClusterNodeIPsEgressIPBackRef            = "egressip"
 	ClusterNodeIPsEgressServiceBackRef       = "egressservice"
 	ClusterNodeIPsRouteAdvertisementsBackRef = "route-advertisements"
+
+	// podNodeNameIndex indexes pods by Spec.NodeName for node-scoped membership lookups.
+	podNodeNameIndex = "spec.nodeName"
 )
+
+func podByNodeNameIndexFunc(obj interface{}) ([]string, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod.Spec.NodeName == "" {
+		return []string{}, nil
+	}
+	return []string{pod.Spec.NodeName}, nil
+}
+
+// podNodeNameIndexer is the subset of SharedIndexInformer needed to install podNodeNameIndex.
+type podNodeNameIndexer interface {
+	GetIndexer() cache.Indexer
+	AddIndexers(cache.Indexers) error
+}
+
+// ensurePodNodeNameIndexer installs podNodeNameIndex when absent. Concurrent constructors may
+// race on AddIndexers; only fail if the index is still missing afterwards.
+func ensurePodNodeNameIndexer(informer podNodeNameIndexer) error {
+	if _, exists := informer.GetIndexer().GetIndexers()[podNodeNameIndex]; exists {
+		return nil
+	}
+	if err := informer.AddIndexers(cache.Indexers{podNodeNameIndex: podByNodeNameIndexFunc}); err != nil {
+		if _, exists := informer.GetIndexer().GetIndexers()[podNodeNameIndex]; !exists {
+			return fmt.Errorf("failed to add %q indexer on pod informer: %w", podNodeNameIndex, err)
+		}
+	}
+	return nil
+}
 
 // AddressSetManager manages shared address sets with pod IPs based on provided pod and namespace selectors.
 // It shared across network controllers.
@@ -92,7 +257,10 @@ type AddressSetManager struct {
 	// addressSets stores all currently used address sets.
 	addressSets *syncmap.SyncMap[*podSelectorAddressSet]
 
-	podLister       listers.PodLister
+	podLister listers.PodLister
+	// podIndexer is the shared pod informer indexer; includes podNodeNameIndex for
+	// O(pods-on-node) lookups instead of cluster-wide list+filter.
+	podIndexer      cache.Indexer
 	namespaceLister listers.NamespaceLister
 	nodeLister      listers.NodeLister
 
@@ -110,7 +278,9 @@ type AddressSetManager struct {
 	hostNetworkNamespaceExists bool
 	// local cache of HostNetworkNamespace address set IPs
 	hostNetworkNamespaceIPsPerNode map[string][]string
-	// local cache of address sets that select HostNetworkNamespace
+	// local cache of address sets that select HostNetworkNamespace. Membership is
+	// registered when the host-network cache plan is built so node IP updates during
+	// an in-flight OVN apply still enqueue the address set for reconcile.
 	hostNetworkSelectingAddrSets sets.Set[string]
 
 	clusterNodeIPsLock     sync.RWMutex
@@ -118,7 +288,11 @@ type AddressSetManager struct {
 }
 
 func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInformer coreinformers.NamespaceInformer,
-	nodeInformer coreinformers.NodeInformer, nbClient libovsdbclient.Client, getNetworkNameForNADKey func(nadKey string) string) *AddressSetManager {
+	nodeInformer coreinformers.NodeInformer, nbClient libovsdbclient.Client, getNetworkNameForNADKey func(nadKey string) string) (*AddressSetManager, error) {
+	if err := ensurePodNodeNameIndexer(podInformer.Informer()); err != nil {
+		return nil, fmt.Errorf("failed to ensure pod nodeName indexer: %w", err)
+	}
+
 	m := &AddressSetManager{
 		name:                           "pod-selector-address-set-manager",
 		nbClient:                       nbClient,
@@ -127,6 +301,7 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 		addressSetFactoryDualstack:     addressset.NewOvnAddressSetFactory(nbClient, true, true),
 		addressSets:                    syncmap.NewSyncMap[*podSelectorAddressSet](),
 		podLister:                      podInformer.Lister(),
+		podIndexer:                     podInformer.Informer().GetIndexer(),
 		namespaceLister:                namespaceInformer.Lister(),
 		nodeLister:                     nodeInformer.Lister(),
 		getNetworkNameForNADKey:        getNetworkNameForNADKey,
@@ -177,7 +352,7 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 			MaxAttempts: controller.InfiniteAttempts,
 		},
 	)
-	return m
+	return m, nil
 }
 
 func (m *AddressSetManager) Start() error {
@@ -381,9 +556,17 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 	if !found {
 		// Populate a newly created address set before returning hashes to the caller.
 		// Until reconcile runs, the NB object is empty while ACLs may already reference it
-		// (e.g. on DB ID change or first ensure). This is a one-time sync on creation;
-		// existing sets are kept up to date by the async reconciler on pod/namespace/node events.
-		if reconcileErr := m.reconcileAddressSet(addrSetKey); reconcileErr != nil {
+		// (e.g. on DB ID change or first ensure). Force fullSync so replaceAddressSetContents
+		// builds the desired state and initializes the in-memory mirrors. Existing sets are
+		// kept up to date by the async reconciler on pod/namespace/node events.
+		if reconcileErr := m.addressSets.DoWithLock(addrSetKey, func(key string) error {
+			psAddrSet, ok := m.addressSets.Load(key)
+			if !ok {
+				return nil
+			}
+			psAddrSet.pendingUpdates.fullSync = true
+			return m.reconcileAddressSetLocked(key, psAddrSet)
+		}); reconcileErr != nil {
 			klog.Errorf("Failed to reconcile address set %s on ensure: %v", addrSetKey, reconcileErr)
 			// this only puts key to the queue, no lock
 			m.addressSetReconciler.Reconcile(addrSetKey)
@@ -405,6 +588,7 @@ func (m *AddressSetManager) CleanupForController(controllerName string) error {
 				return fmt.Errorf("failed to destroy address set %s: %w", key, err)
 			}
 			m.addressSets.Delete(key)
+			m.unregisterHostNetworkSelectingAddrSet(key)
 			return nil
 		}); err != nil {
 			errs = append(errs, err)
@@ -423,15 +607,21 @@ func (m *AddressSetManager) DeleteAddressSet(addrSetKey, backRef string) error {
 		if len(psAddrSet.backRefs) == 0 {
 			err := psAddrSet.addressSet.Destroy()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to destroy address set %s: %w", key, err)
 			}
 			m.addressSets.Delete(key)
-			m.hostNetworkNamespaceLock.Lock()
-			m.hostNetworkSelectingAddrSets.Delete(key)
-			m.hostNetworkNamespaceLock.Unlock()
+			m.unregisterHostNetworkSelectingAddrSet(key)
 		}
 		return nil
 	})
+}
+
+// unregisterHostNetworkSelectingAddrSet drops a destroyed address set from host-network
+// tracking so host IP updates do not keep enqueueing stale keys.
+func (m *AddressSetManager) unregisterHostNetworkSelectingAddrSet(key string) {
+	m.hostNetworkNamespaceLock.Lock()
+	defer m.hostNetworkNamespaceLock.Unlock()
+	m.hostNetworkSelectingAddrSets.Delete(key)
 }
 
 func (m *AddressSetManager) podNeedUpdate(old, new *corev1.Pod) bool {
@@ -498,6 +688,9 @@ func (m *AddressSetManager) reconcilePod(podKey string) error {
 				}
 				// check if pod's node matches address set's node selector
 				if pod == nil || addrSet.selectedNodes == nil || addrSet.selectedNodes.Has(pod.Spec.NodeName) {
+					// Record the pod key so reconcileAddressSet can update membership incrementally
+					// without listing all matching pods.
+					addrSet.pendingUpdates.addPodKey(podKey)
 					m.addressSetReconciler.Reconcile(addrSetKey)
 					return nil
 				}
@@ -506,6 +699,9 @@ func (m *AddressSetManager) reconcilePod(podKey string) error {
 			// only check address sets that have previously matched pod's namespace to avoid extra reconciliations
 			previouslyMatchedNamespaces := addrSet.selectedNamespaces
 			if previouslyMatchedNamespaces == nil || previouslyMatchedNamespaces.Has(namespace) {
+				// Record the pod key so reconcileAddressSet can update membership incrementally
+				// without listing all matching pods.
+				addrSet.pendingUpdates.addPodKey(podKey)
 				m.addressSetReconciler.Reconcile(addrSetKey)
 				return nil
 			}
@@ -536,26 +732,44 @@ func (m *AddressSetManager) updateHostNetworkNamespaceExists() error {
 		}
 	}
 	m.hostNetworkNamespaceLock.Lock()
-	defer m.hostNetworkNamespaceLock.Unlock()
 	if err != nil {
-		// namespace was deleted/never existed
+		// Namespace deleted or never existed. Snapshot selecting sets under the lock so we can
+		// enqueue them after clearing global host state (symmetric with the create path), rather
+		// than relying only on reconcileNamespace's later membership loop.
+		wasPresent := m.hostNetworkNamespaceExists
+		addrSetKeys := m.hostNetworkSelectingAddrSets.UnsortedList()
 		clear(m.hostNetworkNamespaceIPsPerNode)
 		m.hostNetworkNamespaceExists = false
+		m.hostNetworkNamespaceLock.Unlock()
+		if wasPresent {
+			// Host IPs are already cleared and exists=false, so the next reconcile sees
+			// selecting=false. Enqueue a host-only pending update (not fullSync) so
+			// deriveUnionAddressDelta drains host IPs without rebuilding all pod membership.
+			return m.enqueueHostNetworkSelectingAddrSetUpdates(addrSetKeys, "", false)
+		}
 		return nil
 	}
-	if !m.hostNetworkNamespaceExists {
+	needsFullSync := !m.hostNetworkNamespaceExists
+	var addrSetKeys []string
+	if needsFullSync {
 		// namespace was just created, get all existing host network IPs
-		ips, err := m.getAllHostNamespaceAddresses()
-		if err != nil {
-			return fmt.Errorf("error getting host network namespace %s IPs: %v", config.Kubernetes.HostNetworkNamespace, err)
+		ips, ipErr := m.getAllHostNamespaceAddresses()
+		if ipErr != nil {
+			m.hostNetworkNamespaceLock.Unlock()
+			return fmt.Errorf("error getting host network namespace %s IPs: %v", config.Kubernetes.HostNetworkNamespace, ipErr)
 		}
-
 		m.hostNetworkNamespaceIPsPerNode = ips
-		for addrSetKey := range m.hostNetworkSelectingAddrSets {
-			m.addressSetReconciler.Reconcile(addrSetKey)
-		}
+		// Snapshot selecting address sets before releasing the lock; per-key locks are taken below.
+		addrSetKeys = m.hostNetworkSelectingAddrSets.UnsortedList()
 	}
 	m.hostNetworkNamespaceExists = true
+	m.hostNetworkNamespaceLock.Unlock()
+
+	if needsFullSync {
+		// Host-network namespace just appeared with a full IP set; force fullSync on sets
+		// that already select it so host-network addresses are rebuilt from scratch.
+		return m.enqueueHostNetworkSelectingAddrSetUpdates(addrSetKeys, "", true)
+	}
 	return nil
 }
 
@@ -583,13 +797,16 @@ func (m *AddressSetManager) reconcileNamespace(nsKey string) error {
 				return err
 			}
 			if currentlyMatchedNamespaces.Has(nsKey) {
-				// this namespace is relevant for this address set, reconcile
+				// Namespace entered or still matches selection; record for namespace-scoped reconcile.
+				addrSet.pendingUpdates.addNamespaceKey(nsKey)
 				m.addressSetReconciler.Reconcile(addrSetKey)
 				return nil
 			}
 			// now check if this address set was matching this namespace before, if yes, reconcile since it might not match anymore
 			previouslyMatchedNamespaces := addrSet.selectedNamespaces
 			if previouslyMatchedNamespaces.Has(nsKey) {
+				// Namespace left selection; record for namespace-scoped reconcile to remove its pods.
+				addrSet.pendingUpdates.addNamespaceKey(nsKey)
 				m.addressSetReconciler.Reconcile(addrSetKey)
 				return nil
 			}
@@ -650,7 +867,8 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 				return err
 			}
 			if currentlyMatchedNodes.Has(nodeKey) {
-				// this node is relevant for this address set, reconcile
+				// Node entered or still matches the node selector; record for node-scoped reconcile.
+				addrSet.pendingUpdates.addNodeKey(nodeKey)
 				m.addressSetReconciler.Reconcile(addrSetKey)
 				return nil
 			}
@@ -658,6 +876,8 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 			previouslyMatchedNodes := addrSet.selectedNodes
 			// previouslyMatchedNodes == nil means the address set hasn't been reconciled yet, so need to reconcile
 			if previouslyMatchedNodes == nil || previouslyMatchedNodes.Has(nodeKey) {
+				// Node left selection (or first reconcile); record for node-scoped reconcile.
+				addrSet.pendingUpdates.addNodeKey(nodeKey)
 				m.addressSetReconciler.Reconcile(addrSetKey)
 				return nil
 			}
@@ -673,40 +893,77 @@ func (m *AddressSetManager) reconcileNode(nodeKey string) error {
 
 func (m *AddressSetManager) updateHostNetworkIPs(nodeName string) error {
 	m.hostNetworkNamespaceLock.Lock()
-	defer m.hostNetworkNamespaceLock.Unlock()
 	if !m.hostNetworkNamespaceExists {
+		m.hostNetworkNamespaceLock.Unlock()
 		return nil
 	}
+	m.hostNetworkNamespaceLock.Unlock()
+
 	node, err := m.nodeLister.Get(nodeName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get node %s: %v", nodeName, err)
+	}
+
+	var addrSetKeys []string
+	m.hostNetworkNamespaceLock.Lock()
+	if !m.hostNetworkNamespaceExists {
+		m.hostNetworkNamespaceLock.Unlock()
+		return nil
 	}
 	if err != nil || config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
 		// delete event OR node started matching hybrid overlay and should be ignored for host network namespace
 		// delete host network IPs for this node from host network namespace's address set
 		updated := len(m.hostNetworkNamespaceIPsPerNode[nodeName]) != 0
 		delete(m.hostNetworkNamespaceIPsPerNode, nodeName)
-
+		if updated {
+			addrSetKeys = m.hostNetworkSelectingAddrSets.UnsortedList()
+		}
+		m.hostNetworkNamespaceLock.Unlock()
 		if !updated {
 			return nil
 		}
-		for addrSetKey := range m.hostNetworkSelectingAddrSets {
-			m.addressSetReconciler.Reconcile(addrSetKey)
-		}
-		return nil
+		return m.enqueueHostNetworkSelectingAddrSetUpdates(addrSetKeys, nodeName, false)
 	}
 	// add/update node event
 	hostNetworkPolicyIPs, err := m.getHostNamespaceAddressesForNode(node)
 	if err != nil {
+		m.hostNetworkNamespaceLock.Unlock()
 		return fmt.Errorf("error parsing annotation for node %s: %w", node.Name, err)
 	}
 	// add the host network IPs for this node to host network namespace's address set
 	// hostNetworkPolicyIPs is built from the annotations and always preserves ips order
 	if slices.Equal(m.hostNetworkNamespaceIPsPerNode[node.Name], hostNetworkPolicyIPs) {
+		m.hostNetworkNamespaceLock.Unlock()
 		return nil
 	}
 	m.hostNetworkNamespaceIPsPerNode[node.Name] = hostNetworkPolicyIPs
-	for addrSetKey := range m.hostNetworkSelectingAddrSets {
+	addrSetKeys = m.hostNetworkSelectingAddrSets.UnsortedList()
+	m.hostNetworkNamespaceLock.Unlock()
+
+	// Host-network IPs for this node changed; enqueue selecting address sets with
+	// a node-key pending update so only host-network delta is recomputed.
+	return m.enqueueHostNetworkSelectingAddrSetUpdates(addrSetKeys, nodeName, false)
+}
+
+// enqueueHostNetworkSelectingAddrSetUpdates records pending updates on host-network selecting
+// address sets and enqueues reconciliation. Must not be called while holding hostNetworkNamespaceLock.
+// When fullSync is false, nodeName may be empty to mark a host-global change (e.g. host NS delete).
+func (m *AddressSetManager) enqueueHostNetworkSelectingAddrSetUpdates(addrSetKeys []string, nodeName string, fullSync bool) error {
+	for _, addrSetKey := range addrSetKeys {
+		if err := m.addressSets.DoWithLock(addrSetKey, func(key string) error {
+			psAddrSet, ok := m.addressSets.Load(key)
+			if !ok {
+				return nil
+			}
+			if fullSync {
+				psAddrSet.pendingUpdates.fullSync = true
+			} else {
+				psAddrSet.pendingUpdates.addNodeKey(nodeName)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 		m.addressSetReconciler.Reconcile(addrSetKey)
 	}
 	return nil
@@ -793,99 +1050,758 @@ func (m *AddressSetManager) getHostNamespaceAddressesForNode(node *corev1.Node) 
 	return ips, nil
 }
 
+// reconcileAddressSet is the workqueue handler for pod-selector address sets.
+// It acquires the per-key lock and delegates to reconcileAddressSetLocked.
 func (m *AddressSetManager) reconcileAddressSet(key string) error {
 	return m.addressSets.DoWithLock(key, func(key string) error {
 		psAddrSet, found := m.addressSets.Load(key)
 		if !found {
 			return nil
 		}
-		matchedNamespaces, err := m.getSelectedNamespaces(psAddrSet)
-		if err != nil {
-			return fmt.Errorf("failed to get selected namespaces for address set %s: %v", key, err)
-		}
-		var pods []*corev1.Pod
-		if matchedNamespaces.all {
-			// no namespace selector, use pod selector only
-			if psAddrSet.podSelector.Empty() {
-				// all cluster pods
-				pods, err = m.podLister.List(labels.Everything())
-				if err != nil {
-					return fmt.Errorf("failed to list pods: %v", err)
-				}
-			} else {
-				// global pod selector
-				pods, err = m.podLister.List(psAddrSet.podSelector)
-				if err != nil {
-					return fmt.Errorf("failed to list pods: %v", err)
-				}
-			}
-		} else {
-			// namespace selector is set, apply pod selector in every namespace
-			for ns := range matchedNamespaces.set {
-				if psAddrSet.podSelector.Empty() {
-					// empty selector means no filtering, select all pods in a given namespace
-					nsPods, err := m.podLister.Pods(ns).List(labels.Everything())
-					if err != nil {
-						return fmt.Errorf("failed to list pods in namespace %s: %v", ns, err)
-					}
-					pods = append(pods, nsPods...)
-				} else {
-					// namespaced pod selector, select matching pods in a given namespace
-					nsPods, err := m.podLister.Pods(ns).List(psAddrSet.podSelector)
-					if err != nil {
-						return fmt.Errorf("failed to list pods in namespace %s: %v", ns, err)
-					}
-					pods = append(pods, nsPods...)
-				}
-			}
-		}
-		// apply node selector filter if it's not empty
-		if psAddrSet.nodeSelector != nil && !psAddrSet.nodeSelector.Empty() {
-			selectedNodes, err := m.getSelectedNodes(psAddrSet.nodeSelector)
-			if err != nil {
-				return fmt.Errorf("failed to get selected nodes for address set %s: %v", key, err)
-			}
-			filtered := make([]*corev1.Pod, 0, len(pods))
-			for _, pod := range pods {
-				if pod.Spec.NodeName != "" && selectedNodes.Has(pod.Spec.NodeName) {
-					filtered = append(filtered, pod)
-				}
-			}
-			pods = filtered
-			psAddrSet.selectedNodes = selectedNodes
-		}
-		ips, err := m.getPodIPs(pods, psAddrSet.netInfo, psAddrSet.legacyNetpolMode)
-		if err != nil {
-			return fmt.Errorf("failed to get pod IPs: %v", err)
-		}
-		// now check if this address set should add hostNetworkNamespace IPs
-		// it only makes sense for the default network
-		if psAddrSet.legacyNetpolMode && psAddrSet.netInfo.IsDefault() && config.Kubernetes.HostNetworkNamespace != "" &&
-			psAddrSet.podSelector.Empty() {
-			// update m.hostNetworkSelectingAddrSets
-			m.hostNetworkNamespaceLock.Lock()
-			if m.hostNetworkNamespaceExists {
-				if matchedNamespaces.Has(config.Kubernetes.HostNetworkNamespace) {
-					for _, hostnetIPs := range m.hostNetworkNamespaceIPsPerNode {
-						ips = append(ips, hostnetIPs...)
-					}
-					m.hostNetworkSelectingAddrSets.Insert(key)
-				} else {
-					m.hostNetworkSelectingAddrSets.Delete(key)
-				}
-			}
-			m.hostNetworkNamespaceLock.Unlock()
-		}
+		return m.reconcileAddressSetLocked(key, psAddrSet)
+	})
+}
 
-		// this operation doesn't check the contents on the address set and will run a db transaction
-		// every time, may be improved.
-		err = psAddrSet.addressSet.SetAddresses(ips)
+// reconcileAddressSetLocked reconciles a pod-selector address set under the per-key lock.
+// It prefers an incremental path driven by pendingUpdates (only the triggering
+// pods/namespaces/nodes) and falls back to a full desired-state rebuild when needed.
+// pendingUpdates is cleared only after a successful reconcile so a failed attempt
+// keeps its triggering keys for retry and for coalescing with later events.
+func (m *AddressSetManager) reconcileAddressSetLocked(key string, psAddrSet *podSelectorAddressSet) error {
+	pending := psAddrSet.pendingUpdates.snapshot()
+
+	matchedNamespaces, err := m.getSelectedNamespaces(psAddrSet)
+	if err != nil {
+		return fmt.Errorf("failed to get selected namespaces for address set %s: %w", key, err)
+	}
+
+	var selectedNodes sets.Set[string]
+	if psAddrSet.nodeSelector != nil && !psAddrSet.nodeSelector.Empty() {
+		selectedNodes, err = m.getSelectedNodes(psAddrSet.nodeSelector)
 		if err != nil {
-			return fmt.Errorf("failed to set addresses for address set %s: %v", key, err)
+			return fmt.Errorf("failed to get selected nodes for address set %s: %w", key, err)
+		}
+	}
+
+	var toAdd, toRemove []string
+	var cachePlan *addressSetCachePlan
+	fullSync := m.needsFullAddressSetSync(psAddrSet, pending)
+	if !fullSync && m.pendingPodUpdateClassCount(pending, psAddrSet) > 1 {
+		// Coalesced namespace/node/pod updates cannot be handled by a single incremental path.
+		klog.V(4).Infof("Address set %s: forcing full sync due to coalesced pending update classes "+
+			"(namespaces=%d pods=%d nodes=%d)", key, pending.namespaceKeys.Len(), pending.podKeys.Len(), pending.nodeKeys.Len())
+		fullSync = true
+	}
+	// First reconcile for a newly created address set: replace OVN contents wholesale
+	// and seed the in-memory mirrors. Avoids diffing against an empty/uninitialized cache.
+	if fullSync && psAddrSet.addresses == nil {
+		if err := m.replaceAddressSetContents(psAddrSet, matchedNamespaces, selectedNodes, key); err != nil {
+			return fmt.Errorf("failed to replace address set contents for %s: %w", key, err)
 		}
 		psAddrSet.selectedNamespaces = matchedNamespaces
+		if psAddrSet.nodeSelector != nil && !psAddrSet.nodeSelector.Empty() {
+			psAddrSet.selectedNodes = selectedNodes
+		}
+		psAddrSet.pendingUpdates.clear()
 		return nil
+	}
+	if fullSync {
+		toAdd, toRemove, cachePlan, err = m.computeFullAddressSetDelta(psAddrSet, matchedNamespaces, selectedNodes, key)
+		if err != nil {
+			return fmt.Errorf("failed to compute full address set delta for %s: %w", key, err)
+		}
+	} else if pending.namespaceKeys.Len() > 0 {
+		// Namespace label change: list pods only in the affected namespaces.
+		cachePlan, err = m.computeNamespaceAddressSetCachePlan(psAddrSet, pending.namespaceKeys, matchedNamespaces, selectedNodes)
+		if err != nil {
+			return fmt.Errorf("failed to compute namespace address set cache plan for %s: %w", key, err)
+		}
+	} else if pending.nodeKeys.Len() > 0 && psAddrSet.nodeSelector != nil && !psAddrSet.nodeSelector.Empty() {
+		// Node selector membership change: update only pods on the affected nodes.
+		cachePlan, err = m.computeNodeAddressSetCachePlan(psAddrSet, pending.nodeKeys, matchedNamespaces, selectedNodes)
+		if err != nil {
+			return fmt.Errorf("failed to compute node address set cache plan for %s: %w", key, err)
+		}
+	} else if pending.podKeys.Len() > 0 {
+		// Pod add/update/delete: process only the pending pod keys.
+		cachePlan, err = m.computePodAddressSetCachePlan(psAddrSet, pending.podKeys, matchedNamespaces, selectedNodes)
+		if err != nil {
+			return fmt.Errorf("failed to compute pod address set cache plan for %s: %w", key, err)
+		}
+	} else if pending.nodeKeys.Len() == 0 {
+		// No pending context (unexpected empty snapshot) — rebuild fully.
+		klog.V(4).Infof("Address set %s: forcing full sync due to empty pending updates", key)
+		fullSync = true
+		toAdd, toRemove, cachePlan, err = m.computeFullAddressSetDelta(psAddrSet, matchedNamespaces, selectedNodes, key)
+		if err != nil {
+			return fmt.Errorf("failed to compute full address set delta for %s: %w", key, err)
+		}
+	}
+	// Only nodeKeys are pending, if any, means a host-network IP change without a nodeSelector.
+	// deriveUnionAddressDelta below will pick up the host-network update.
+	if !fullSync {
+		// Full sync already unions pod + host IPs against addresses in computeFullAddressSetDelta.
+		// Incremental paths must do the same: never remove an IP from OVN while pods or the
+		// current host-network snapshot still contribute it.
+		hostSnapshot := m.buildHostNetworkSnapshot(psAddrSet, matchedNamespaces, key)
+		toAdd, toRemove = m.deriveUnionAddressDelta(psAddrSet, cachePlan, hostSnapshot)
+	}
+
+	// Skip OVN transaction entirely when nothing changed.
+	if err := m.applyAddressSetChanges(psAddrSet, toAdd, toRemove); err != nil {
+		return fmt.Errorf("failed to apply address changes for address set %s: %w", key, err)
+	}
+
+	// Commit the pod-cache snapshot used to compute the OVN delta.
+	m.applyAddressSetCachePlan(psAddrSet, cachePlan)
+
+	psAddrSet.selectedNamespaces = matchedNamespaces
+	if psAddrSet.nodeSelector != nil && !psAddrSet.nodeSelector.Empty() {
+		psAddrSet.selectedNodes = selectedNodes
+	}
+	psAddrSet.pendingUpdates.clear()
+	return nil
+}
+
+// needsFullAddressSetSync returns true when reconcile must rebuild desired state from all
+// matching pods rather than applying an incremental delta.
+func (m *AddressSetManager) needsFullAddressSetSync(psAddrSet *podSelectorAddressSet, pending addrSetPendingUpdates) bool {
+	return pending.fullSync || psAddrSet.addresses == nil || psAddrSet.selectedPods == nil ||
+		psAddrSet.podAddresses == nil || psAddrSet.podNodes == nil || psAddrSet.podsByNode == nil
+}
+
+// pendingPodUpdateClassCount returns how many distinct pod-scoped incremental update classes
+// are present in pending. Host-network-only nodeKeys (no nodeSelector) are excluded because
+// they are handled separately via deriveUnionAddressDelta / buildHostNetworkSnapshot.
+func (m *AddressSetManager) pendingPodUpdateClassCount(pending addrSetPendingUpdates, psAddrSet *podSelectorAddressSet) int {
+	count := 0
+	if pending.namespaceKeys.Len() > 0 {
+		count++
+	}
+	if pending.podKeys.Len() > 0 {
+		count++
+	}
+	if pending.nodeKeys.Len() > 0 && psAddrSet.nodeSelector != nil && !psAddrSet.nodeSelector.Empty() {
+		count++
+	}
+	return count
+}
+
+// computeAddressDelta returns addresses present in desired but not current (toAdd) and
+// present in current but not desired (toRemove). Nil sets are treated as empty.
+func (m *AddressSetManager) computeAddressDelta(current, desired sets.Set[string]) (toAdd, toRemove []string) {
+	if current == nil {
+		current = sets.New[string]()
+	}
+	if desired == nil {
+		desired = sets.New[string]()
+	}
+	return desired.Difference(current).UnsortedList(), current.Difference(desired).UnsortedList()
+}
+
+// applyAddressSetChanges writes toAdd/toRemove to OVN via ApplyAddressChanges and updates
+// the addresses mirror only on success. Returns immediately when both lists are empty.
+func (m *AddressSetManager) applyAddressSetChanges(psAddrSet *podSelectorAddressSet, toAdd, toRemove []string) error {
+	toAdd, toRemove = addressset.NormalizeAddressChanges(toAdd, toRemove)
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		return nil
+	}
+	if err := psAddrSet.addressSet.ApplyAddressChanges(toAdd, toRemove); err != nil {
+		return err
+	}
+	if psAddrSet.addresses == nil {
+		psAddrSet.addresses = sets.New[string]()
+	}
+	for _, addr := range toRemove {
+		psAddrSet.addresses.Delete(addr)
+	}
+	for _, addr := range toAdd {
+		psAddrSet.addresses.Insert(addr)
+	}
+	return nil
+}
+
+// podMatchesAddressSet returns whether pod should currently contribute IPs to the address set,
+// applying namespace/node/pod selectors and legacyNetpolMode host-network / completed-pod rules.
+func (m *AddressSetManager) podMatchesAddressSet(pod *corev1.Pod, psAddrSet *podSelectorAddressSet,
+	matchedNamespaces *selectedNamespaces, selectedNodes sets.Set[string]) bool {
+	if pod == nil {
+		return false
+	}
+	if !matchedNamespaces.Has(pod.Namespace) {
+		return false
+	}
+	if psAddrSet.legacyNetpolMode && pod.Spec.HostNetwork {
+		return false
+	}
+	if util.PodCompleted(pod) {
+		return false
+	}
+	if pod.Annotations[ovntypes.OvnPodAnnotationName] == "" && len(pod.Status.PodIPs) == 0 {
+		return false
+	}
+	if !psAddrSet.podSelector.Matches(labels.Set(pod.Labels)) {
+		return false
+	}
+	if psAddrSet.nodeSelector != nil && !psAddrSet.nodeSelector.Empty() {
+		if pod.Spec.NodeName == "" || !selectedNodes.Has(pod.Spec.NodeName) {
+			return false
+		}
+	}
+	return true
+}
+
+// getPodIPsForPod returns the network IPs for a single pod using the same filtering as getPodIPs.
+func (m *AddressSetManager) getPodIPsForPod(pod *corev1.Pod, netInfo util.NetInfo, noHostNetwork bool) ([]string, error) {
+	ips, err := m.getPodIPs([]*corev1.Pod{pod}, netInfo, noHostNetwork)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get IPs for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	return ips, nil
+}
+
+// ensurePodCacheInitialized lazily allocates the in-memory membership / address mirrors.
+func (psAddrSet *podSelectorAddressSet) ensurePodCacheInitialized() {
+	if psAddrSet.addresses == nil {
+		psAddrSet.addresses = sets.New[string]()
+	}
+	if psAddrSet.podAddresses == nil {
+		psAddrSet.podAddresses = make(map[string][]string)
+	}
+	if psAddrSet.selectedPods == nil {
+		psAddrSet.selectedPods = make(map[string]sets.Set[string])
+	}
+	if psAddrSet.podNodes == nil {
+		psAddrSet.podNodes = make(map[string]string)
+	}
+	if psAddrSet.podsByNode == nil {
+		psAddrSet.podsByNode = make(map[string]sets.Set[string])
+	}
+}
+
+// removePodFromCache drops podKey from the membership mirrors.
+func (psAddrSet *podSelectorAddressSet) removePodFromCache(podKey string) {
+	psAddrSet.ensurePodCacheInitialized()
+	if _, hadPod := psAddrSet.podAddresses[podKey]; !hadPod {
+		return
+	}
+	delete(psAddrSet.podAddresses, podKey)
+	namespace, name, _ := cache.SplitMetaNamespaceKey(podKey)
+	if podSet, ok := psAddrSet.selectedPods[namespace]; ok {
+		podSet.Delete(name)
+		if podSet.Len() == 0 {
+			delete(psAddrSet.selectedPods, namespace)
+		}
+	}
+	if nodeName, ok := psAddrSet.podNodes[podKey]; ok {
+		delete(psAddrSet.podNodes, podKey)
+		if nodePods, ok := psAddrSet.podsByNode[nodeName]; ok {
+			nodePods.Delete(podKey)
+			if nodePods.Len() == 0 {
+				delete(psAddrSet.podsByNode, nodeName)
+			}
+		}
+	}
+}
+
+// addPodToCache records that podKey currently contributes ips on nodeName to the address set.
+func (psAddrSet *podSelectorAddressSet) addPodToCache(podKey string, ips []string, nodeName string) {
+	psAddrSet.ensurePodCacheInitialized()
+	namespace, name, _ := cache.SplitMetaNamespaceKey(podKey)
+	if psAddrSet.selectedPods[namespace] == nil {
+		psAddrSet.selectedPods[namespace] = sets.New[string]()
+	}
+	psAddrSet.selectedPods[namespace].Insert(name)
+	psAddrSet.podAddresses[podKey] = slices.Clone(ips)
+
+	if oldNode, ok := psAddrSet.podNodes[podKey]; ok && oldNode != nodeName {
+		if nodePods, ok := psAddrSet.podsByNode[oldNode]; ok {
+			nodePods.Delete(podKey)
+			if nodePods.Len() == 0 {
+				delete(psAddrSet.podsByNode, oldNode)
+			}
+		}
+	}
+	psAddrSet.podNodes[podKey] = nodeName
+	if nodeName != "" {
+		if psAddrSet.podsByNode[nodeName] == nil {
+			psAddrSet.podsByNode[nodeName] = sets.New[string]()
+		}
+		psAddrSet.podsByNode[nodeName].Insert(podKey)
+	}
+}
+
+// evaluatePodCacheUpdate determines whether podKey should remain in the membership mirrors
+// after reconcile and which IPs it should contribute. Does not compute OVN address deltas.
+func (m *AddressSetManager) evaluatePodCacheUpdate(psAddrSet *podSelectorAddressSet, pod *corev1.Pod,
+	matchedNamespaces *selectedNamespaces, selectedNodes sets.Set[string]) (keepInCache bool, ips []string, err error) {
+	if pod == nil || !m.podMatchesAddressSet(pod, psAddrSet, matchedNamespaces, selectedNodes) {
+		return false, nil, nil
+	}
+	newIPs, err := m.getPodIPsForPod(pod, psAddrSet.netInfo, psAddrSet.legacyNetpolMode)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to evaluate pod cache update for %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	return true, newIPs, nil
+}
+
+// postBatchPodIPSet returns the pod IP set after overlaying plan mutations onto podAddresses.
+// A nil plan (or a plan with no pod changes) yields the current pod IP set. Shared-IP ownership
+// is evaluated across the whole batch so concurrent removals/transfers in one reconcile produce
+// a single correct membership set. Nil podAddresses is treated as empty; this path does not
+// allocate or mutate the OVN addresses mirror.
+func (m *AddressSetManager) postBatchPodIPSet(psAddrSet *podSelectorAddressSet, plan *addressSetCachePlan) sets.Set[string] {
+	podIPs := sets.New[string]()
+
+	if plan != nil && plan.podCacheReplace != nil {
+		for _, ips := range plan.podCacheReplace.podAddresses {
+			podIPs.Insert(ips...)
+		}
+		return podIPs
+	}
+
+	for podKey, ips := range psAddrSet.podAddresses {
+		if plan != nil {
+			if plan.podRemoves.Has(podKey) {
+				continue
+			}
+			if entry, ok := plan.podSets[podKey]; ok {
+				podIPs.Insert(entry.ips...)
+				continue
+			}
+		}
+		podIPs.Insert(ips...)
+	}
+	if plan != nil {
+		for podKey, entry := range plan.podSets {
+			if _, existed := psAddrSet.podAddresses[podKey]; existed {
+				continue
+			}
+			podIPs.Insert(entry.ips...)
+		}
+	}
+	return podIPs
+}
+
+// deriveUnionAddressDelta diffs psAddrSet.addresses against the union of post-batch pod IPs
+// and the desired host-network IP set. Pod and host contributions must not be applied as
+// independent OVN deltas: an IP contributed by both must remain in OVN until neither does.
+func (m *AddressSetManager) deriveUnionAddressDelta(psAddrSet *podSelectorAddressSet, podPlan *addressSetCachePlan,
+	hostSnapshot *hostNetworkSnapshot) (toAdd, toRemove []string) {
+	desired := m.postBatchPodIPSet(psAddrSet, podPlan)
+	if hostSnapshot != nil && hostSnapshot.selecting {
+		desired = desired.Union(hostSnapshot.addresses)
+	}
+	return m.computeAddressDelta(psAddrSet.addresses, desired)
+}
+
+// computePodAddressSetCachePlan builds the pod-cache plan for the given pending pod keys.
+// OVN add/remove is computed later via deriveUnionAddressDelta.
+func (m *AddressSetManager) computePodAddressSetCachePlan(psAddrSet *podSelectorAddressSet, podKeys sets.Set[string],
+	matchedNamespaces *selectedNamespaces, selectedNodes sets.Set[string]) (*addressSetCachePlan, error) {
+	plan := newAddressSetCachePlan()
+	for podKey := range podKeys {
+		namespace, name, splitErr := cache.SplitMetaNamespaceKey(podKey)
+		if splitErr != nil {
+			return nil, fmt.Errorf("failed to split pod key %q: %w", podKey, splitErr)
+		}
+		pod, getErr := m.podLister.Pods(namespace).Get(name)
+		if getErr != nil {
+			if !apierrors.IsNotFound(getErr) {
+				return nil, fmt.Errorf("failed to get pod %s: %w", podKey, getErr)
+			}
+			plan.recordPodRemove(podKey)
+			continue
+		}
+		keepInCache, podIPs, evalErr := m.evaluatePodCacheUpdate(psAddrSet, pod, matchedNamespaces, selectedNodes)
+		if evalErr != nil {
+			return nil, fmt.Errorf("failed to evaluate pod %s for address set cache plan: %w", podKey, evalErr)
+		}
+		if keepInCache {
+			plan.recordPodSet(podKey, podIPs, pod.Spec.NodeName)
+		} else {
+			plan.recordPodRemove(podKey)
+		}
+	}
+	return plan, nil
+}
+
+// listMatchingPodsInNamespace lists pods in namespace that match the address set's pod
+// selector (and node selector when set). Returns nil when the namespace is not selected.
+func (m *AddressSetManager) listMatchingPodsInNamespace(psAddrSet *podSelectorAddressSet, namespace string,
+	matchedNamespaces *selectedNamespaces, selectedNodes sets.Set[string]) ([]*corev1.Pod, error) {
+	if !matchedNamespaces.Has(namespace) {
+		return nil, nil
+	}
+	var pods []*corev1.Pod
+	var err error
+	if psAddrSet.podSelector.Empty() {
+		pods, err = m.podLister.Pods(namespace).List(labels.Everything())
+	} else {
+		pods, err = m.podLister.Pods(namespace).List(psAddrSet.podSelector)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods in namespace %s: %w", namespace, err)
+	}
+	if psAddrSet.nodeSelector == nil || psAddrSet.nodeSelector.Empty() {
+		return pods, nil
+	}
+	filtered := make([]*corev1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod.Spec.NodeName != "" && selectedNodes.Has(pod.Spec.NodeName) {
+			filtered = append(filtered, pod)
+		}
+	}
+	return filtered, nil
+}
+
+// computeNamespaceAddressSetCachePlan builds the pod-cache plan for the affected namespaces:
+// add/update pods that now match, and remove cached pods that no longer match.
+// OVN add/remove is computed later via deriveUnionAddressDelta.
+func (m *AddressSetManager) computeNamespaceAddressSetCachePlan(psAddrSet *podSelectorAddressSet, namespaceKeys sets.Set[string],
+	matchedNamespaces *selectedNamespaces, selectedNodes sets.Set[string]) (*addressSetCachePlan, error) {
+	plan := newAddressSetCachePlan()
+	for ns := range namespaceKeys {
+		pods, listErr := m.listMatchingPodsInNamespace(psAddrSet, ns, matchedNamespaces, selectedNodes)
+		if listErr != nil {
+			return nil, fmt.Errorf("failed to list matching pods in namespace %s: %w", ns, listErr)
+		}
+		desiredPods := sets.New[string]()
+		for _, pod := range pods {
+			podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			keepInCache, podIPs, evalErr := m.evaluatePodCacheUpdate(psAddrSet, pod, matchedNamespaces, selectedNodes)
+			if evalErr != nil {
+				return nil, fmt.Errorf("failed to evaluate pod %s for namespace address set cache plan: %w", podKey, evalErr)
+			}
+			if !keepInCache {
+				continue
+			}
+			desiredPods.Insert(podKey)
+			plan.recordPodSet(podKey, podIPs, pod.Spec.NodeName)
+		}
+		// Drop pods that were selected last reconcile but are no longer desired in this namespace.
+		if cachedPods, ok := psAddrSet.selectedPods[ns]; ok {
+			for podName := range cachedPods {
+				fullPodKey := fmt.Sprintf("%s/%s", ns, podName)
+				if desiredPods.Has(fullPodKey) {
+					continue
+				}
+				plan.recordPodRemove(fullPodKey)
+			}
+		}
+	}
+	return plan, nil
+}
+
+// computeNodeAddressSetCachePlan builds the pod-cache plan for pods on the affected nodes when a
+// nodeSelector is in use (node label changes entering/leaving the selection).
+// Updates are driven from podIndexer.ByIndex for each pending node and from podsByNode for
+// targeted removals, keeping work proportional to pods on those nodes.
+// OVN add/remove is computed later via deriveUnionAddressDelta.
+func (m *AddressSetManager) computeNodeAddressSetCachePlan(psAddrSet *podSelectorAddressSet, nodeKeys sets.Set[string],
+	matchedNamespaces *selectedNamespaces, selectedNodes sets.Set[string]) (*addressSetCachePlan, error) {
+	plan := newAddressSetCachePlan()
+	psAddrSet.ensurePodCacheInitialized()
+	for nodeKey := range nodeKeys {
+		pods, listErr := m.listPodsOnNode(psAddrSet, nodeKey, matchedNamespaces)
+		if listErr != nil {
+			return nil, fmt.Errorf("failed to list pods on node %s for address set cache plan: %w", nodeKey, listErr)
+		}
+		seenOnNode := sets.New[string]()
+		for _, pod := range pods {
+			podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			seenOnNode.Insert(podKey)
+			keepInCache, podIPs, evalErr := m.evaluatePodCacheUpdate(psAddrSet, pod, matchedNamespaces, selectedNodes)
+			if evalErr != nil {
+				return nil, fmt.Errorf("failed to evaluate pod %s for node address set cache plan: %w", podKey, evalErr)
+			}
+			if keepInCache {
+				plan.recordPodSet(podKey, podIPs, pod.Spec.NodeName)
+			} else {
+				plan.recordPodRemove(podKey)
+			}
+		}
+		// Cached pods previously recorded on this node but missing from the index listing
+		// (deleted, moved, or no longer matching) need an explicit membership decision.
+		for podKey := range psAddrSet.podsByNode[nodeKey] {
+			if seenOnNode.Has(podKey) {
+				continue
+			}
+			namespace, name, splitErr := cache.SplitMetaNamespaceKey(podKey)
+			if splitErr != nil {
+				return nil, fmt.Errorf("failed to split pod key %q: %w", podKey, splitErr)
+			}
+			pod, getErr := m.podLister.Pods(namespace).Get(name)
+			if getErr != nil {
+				if apierrors.IsNotFound(getErr) {
+					plan.recordPodRemove(podKey)
+					continue
+				}
+				return nil, fmt.Errorf("failed to get pod %s: %w", podKey, getErr)
+			}
+			keepInCache, podIPs, evalErr := m.evaluatePodCacheUpdate(psAddrSet, pod, matchedNamespaces, selectedNodes)
+			if evalErr != nil {
+				return nil, fmt.Errorf("failed to evaluate pod %s for node address set cache plan: %w", podKey, evalErr)
+			}
+			if keepInCache {
+				plan.recordPodSet(podKey, podIPs, pod.Spec.NodeName)
+			} else {
+				plan.recordPodRemove(podKey)
+			}
+		}
+	}
+	return plan, nil
+}
+
+// listPodsOnNode returns pods on nodeName that match the address set's namespace and pod selectors.
+func (m *AddressSetManager) listPodsOnNode(psAddrSet *podSelectorAddressSet, nodeName string,
+	matchedNamespaces *selectedNamespaces) ([]*corev1.Pod, error) {
+	objs, err := m.podIndexer.ByIndex(podNodeNameIndex, nodeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+	}
+	pods := make([]*corev1.Pod, 0, len(objs))
+	for _, obj := range objs {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok {
+			continue
+		}
+		if !matchedNamespaces.Has(pod.Namespace) {
+			continue
+		}
+		if !psAddrSet.podSelector.Empty() && !psAddrSet.podSelector.Matches(labels.Set(pod.Labels)) {
+			continue
+		}
+		pods = append(pods, pod)
+	}
+	return pods, nil
+}
+
+// listAllMatchingPods returns every pod that matches the address set's namespace, pod, and
+// (when set) node selectors. Used for full-sync builds.
+func (m *AddressSetManager) listAllMatchingPods(psAddrSet *podSelectorAddressSet, matchedNamespaces *selectedNamespaces,
+	selectedNodes sets.Set[string]) ([]*corev1.Pod, error) {
+	var pods []*corev1.Pod
+	if matchedNamespaces.all {
+		var err error
+		if psAddrSet.podSelector.Empty() {
+			pods, err = m.podLister.List(labels.Everything())
+		} else {
+			pods, err = m.podLister.List(psAddrSet.podSelector)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list pods: %w", err)
+		}
+	} else {
+		for ns := range matchedNamespaces.set {
+			nsPods, err := m.listMatchingPodsInNamespace(psAddrSet, ns, matchedNamespaces, selectedNodes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list matching pods in namespace %s: %w", ns, err)
+			}
+			pods = append(pods, nsPods...)
+		}
+	}
+	if psAddrSet.nodeSelector == nil || psAddrSet.nodeSelector.Empty() {
+		return pods, nil
+	}
+	filtered := make([]*corev1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod.Spec.NodeName != "" && selectedNodes.Has(pod.Spec.NodeName) {
+			filtered = append(filtered, pod)
+		}
+	}
+	return filtered, nil
+}
+
+// computeFullAddressSetDelta builds the complete desired address set (all matching pod IPs
+// plus host-network IPs when applicable) and diffs it against the in-memory addresses mirror.
+func (m *AddressSetManager) computeFullAddressSetDelta(psAddrSet *podSelectorAddressSet, matchedNamespaces *selectedNamespaces,
+	selectedNodes sets.Set[string], key string) (toAdd, toRemove []string, plan *addressSetCachePlan, err error) {
+	pods, err := m.listAllMatchingPods(psAddrSet, matchedNamespaces, selectedNodes)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to list matching pods for address set %s: %w", key, err)
+	}
+
+	podSnapshot, err := m.buildPodCacheSnapshot(psAddrSet, pods, matchedNamespaces, selectedNodes)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to build pod cache snapshot for address set %s: %w", key, err)
+	}
+
+	desiredAddresses := sets.New[string]()
+	for _, ips := range podSnapshot.podAddresses {
+		desiredAddresses.Insert(ips...)
+	}
+
+	hostSnapshot := m.buildHostNetworkSnapshot(psAddrSet, matchedNamespaces, key)
+	if hostSnapshot != nil && hostSnapshot.selecting {
+		desiredAddresses.Insert(hostSnapshot.addresses.UnsortedList()...)
+	}
+
+	currentAddresses := psAddrSet.addresses
+	toAdd, toRemove = m.computeAddressDelta(currentAddresses, desiredAddresses)
+	plan = &addressSetCachePlan{
+		podCacheReplace: podSnapshot,
+	}
+	return toAdd, toRemove, plan, nil
+}
+
+// buildPodCacheSnapshot builds a point-in-time pod membership snapshot from the given pods.
+func (m *AddressSetManager) buildPodCacheSnapshot(psAddrSet *podSelectorAddressSet, pods []*corev1.Pod,
+	matchedNamespaces *selectedNamespaces, selectedNodes sets.Set[string]) (*addressSetPodCacheSnapshot, error) {
+	snapshot := &addressSetPodCacheSnapshot{
+		selectedPods: make(map[string]sets.Set[string]),
+		podAddresses: make(map[string][]string),
+		podNodes:     make(map[string]string),
+	}
+	for _, pod := range pods {
+		if !m.podMatchesAddressSet(pod, psAddrSet, matchedNamespaces, selectedNodes) {
+			continue
+		}
+		podIPs, podErr := m.getPodIPsForPod(pod, psAddrSet.netInfo, psAddrSet.legacyNetpolMode)
+		if podErr != nil {
+			return nil, fmt.Errorf("failed to get IPs for pod %s/%s while building cache snapshot: %w", pod.Namespace, pod.Name, podErr)
+		}
+		podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		snapshot.podAddresses[podKey] = slices.Clone(podIPs)
+		snapshot.podNodes[podKey] = pod.Spec.NodeName
+		if snapshot.selectedPods[pod.Namespace] == nil {
+			snapshot.selectedPods[pod.Namespace] = sets.New[string]()
+		}
+		snapshot.selectedPods[pod.Namespace].Insert(pod.Name)
+	}
+	return snapshot, nil
+}
+
+// buildHostNetworkSnapshot snapshots host-network IPs from hostNetworkNamespaceIPsPerNode
+// and registers selector membership so node IP updates during an in-flight OVN apply
+// still enqueue this address set for reconcile.
+func (m *AddressSetManager) buildHostNetworkSnapshot(psAddrSet *podSelectorAddressSet,
+	matchedNamespaces *selectedNamespaces, key string) *hostNetworkSnapshot {
+	if !(psAddrSet.legacyNetpolMode && psAddrSet.netInfo.IsDefault() && config.Kubernetes.HostNetworkNamespace != "" &&
+		psAddrSet.podSelector.Empty()) {
+		return nil
+	}
+	m.hostNetworkNamespaceLock.Lock()
+	defer m.hostNetworkNamespaceLock.Unlock()
+	selecting := m.hostNetworkNamespaceExists && matchedNamespaces.Has(config.Kubernetes.HostNetworkNamespace)
+	if selecting {
+		m.hostNetworkSelectingAddrSets.Insert(key)
+	} else {
+		m.hostNetworkSelectingAddrSets.Delete(key)
+	}
+	addresses := sets.New[string]()
+	if selecting {
+		for _, hostnetIPs := range m.hostNetworkNamespaceIPsPerNode {
+			addresses.Insert(hostnetIPs...)
+		}
+	}
+	return &hostNetworkSnapshot{
+		selecting: selecting,
+		addresses: addresses,
+	}
+}
+
+// applyAddressSetCachePlan applies a precomputed pod-cache mutation after a successful OVN apply.
+func (m *AddressSetManager) applyAddressSetCachePlan(psAddrSet *podSelectorAddressSet, plan *addressSetCachePlan) {
+	if plan == nil {
+		return
+	}
+	if plan.podCacheReplace != nil {
+		psAddrSet.podAddresses = clonePodAddressesMap(plan.podCacheReplace.podAddresses)
+		psAddrSet.selectedPods = cloneSelectedPodsMap(plan.podCacheReplace.selectedPods)
+		psAddrSet.podNodes = clonePodNodesMap(plan.podCacheReplace.podNodes)
+		psAddrSet.podsByNode = buildPodsByNode(psAddrSet.podNodes)
+	} else {
+		for podKey := range plan.podRemoves {
+			psAddrSet.removePodFromCache(podKey)
+		}
+		for podKey, entry := range plan.podSets {
+			psAddrSet.addPodToCache(podKey, entry.ips, entry.nodeName)
+		}
+	}
+}
+
+func clonePodAddressesMap(src map[string][]string) map[string][]string {
+	if src == nil {
+		return make(map[string][]string)
+	}
+	dst := make(map[string][]string, len(src))
+	for podKey, ips := range src {
+		dst[podKey] = slices.Clone(ips)
+	}
+	return dst
+}
+
+func cloneSelectedPodsMap(src map[string]sets.Set[string]) map[string]sets.Set[string] {
+	if src == nil {
+		return make(map[string]sets.Set[string])
+	}
+	dst := make(map[string]sets.Set[string], len(src))
+	for ns, pods := range src {
+		dst[ns] = pods.Clone()
+	}
+	return dst
+}
+
+func clonePodNodesMap(src map[string]string) map[string]string {
+	if src == nil {
+		return make(map[string]string)
+	}
+	dst := make(map[string]string, len(src))
+	for podKey, nodeName := range src {
+		dst[podKey] = nodeName
+	}
+	return dst
+}
+
+func buildPodsByNode(podNodes map[string]string) map[string]sets.Set[string] {
+	podsByNode := make(map[string]sets.Set[string])
+	for podKey, nodeName := range podNodes {
+		if nodeName == "" {
+			continue
+		}
+		if podsByNode[nodeName] == nil {
+			podsByNode[nodeName] = sets.New[string]()
+		}
+		podsByNode[nodeName].Insert(podKey)
+	}
+	return podsByNode
+}
+
+// replaceAddressSetContents performs a one-shot full replace of OVN address-set contents and
+// initializes the in-memory mirrors. Used on first ensure when addresses is nil so ACLs that
+// already reference the set are populated immediately.
+func (m *AddressSetManager) replaceAddressSetContents(psAddrSet *podSelectorAddressSet, matchedNamespaces *selectedNamespaces,
+	selectedNodes sets.Set[string], key string) error {
+	pods, err := m.listAllMatchingPods(psAddrSet, matchedNamespaces, selectedNodes)
+	if err != nil {
+		return fmt.Errorf("failed to list matching pods while replacing address set %s: %w", key, err)
+	}
+
+	podSnapshot, err := m.buildPodCacheSnapshot(psAddrSet, pods, matchedNamespaces, selectedNodes)
+	if err != nil {
+		return fmt.Errorf("failed to build pod cache snapshot while replacing address set %s: %w", key, err)
+	}
+
+	desiredAddresses := []string{}
+	for _, ips := range podSnapshot.podAddresses {
+		desiredAddresses = append(desiredAddresses, ips...)
+	}
+
+	hostSnapshot := m.buildHostNetworkSnapshot(psAddrSet, matchedNamespaces, key)
+	if hostSnapshot != nil && hostSnapshot.selecting {
+		desiredAddresses = append(desiredAddresses, hostSnapshot.addresses.UnsortedList()...)
+	}
+	desiredAddresses = addressset.GetUniqueAddresses(desiredAddresses)
+
+	if err := psAddrSet.addressSet.SetAddresses(desiredAddresses); err != nil {
+		return fmt.Errorf("failed to set addresses while replacing address set %s: %w", key, err)
+	}
+	psAddrSet.addresses = sets.New(desiredAddresses...)
+	m.applyAddressSetCachePlan(psAddrSet, &addressSetCachePlan{
+		podCacheReplace: podSnapshot,
 	})
+	return nil
 }
 
 type selectedNamespaces struct {

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -15,8 +15,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
@@ -56,14 +58,24 @@ func eventuallyExpectEmptyAddressSetsExist(nbClient libovsdbclient.Client, peer 
 	}
 }
 
-// this is a test wrapper to count db transactions
+// this is a test wrapper to count db transactions and optionally inject failures
 type countingClient struct {
 	libovsdbclient.Client
 	transactCount atomic.Int64
+	failRemaining atomic.Int64
 }
 
 func (c *countingClient) Transact(ctx context.Context, ops ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
 	c.transactCount.Add(1)
+	for {
+		n := c.failRemaining.Load()
+		if n <= 0 {
+			break
+		}
+		if c.failRemaining.CompareAndSwap(n, n-1) {
+			return nil, fmt.Errorf("injected OVN failure")
+		}
+	}
 	return c.Client.Transact(ctx, ops...)
 }
 
@@ -95,7 +107,14 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		ip4            = "10.128.1.4"
 		hostNetPodIP   = "10.0.1.1"
 		node1Subnet    = "10.244.0.0/24"
+		node1SubnetV6  = "fd00:10:244::/64"
 		node1MgmtIP    = "10.244.0.2"
+		node1MgmtIPV6  = "fd00:10:244::2"
+		ip1v6          = "2001:db8::1"
+		gwIP1          = "100.64.0.1"
+		gwIP1v6        = "fd98::1"
+		gwIP2          = "100.64.0.2"
+		gwIP2v6        = "fd98::2"
 	)
 	var (
 		addressSetManager  *AddressSetManager
@@ -146,14 +165,44 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		// this is only used for "saves db transactions when IPs don't change" test
 		countingNBClient = &countingClient{Client: libovsdbNBClient}
-		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), countingNBClient,
+		addressSetManager, err = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), countingNBClient,
 			fakeNetworkManager.Interface().GetNetworkNameForNADKey)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
 	startAddrSetManager := func(dbSetup libovsdbtest.TestSetup, namespaces []corev1.Namespace, pods []corev1.Pod) {
 		startAddrSetManagerWithNodes(dbSetup, namespaces, pods, nil)
+	}
+
+	hostNetworkNodeSubnetsAnnotation := func(dualStack bool) string {
+		if dualStack {
+			return fmt.Sprintf(`{"default":["%s","%s"]}`, node1Subnet, node1SubnetV6)
+		}
+		return fmt.Sprintf(`{"default":"%s"}`, node1Subnet)
+	}
+
+	expectAddrSetData := func(dbIDs *libovsdbops.DbObjectIDs, ips []string, dualStack bool) []libovsdbtest.TestData {
+		asV4, asV6 := addressset.GetTestDbAddrSets(dbIDs, ips)
+		if dualStack {
+			return []libovsdbtest.TestData{asV4, asV6}
+		}
+		return []libovsdbtest.TestData{asV4}
+	}
+
+	// forceReconcileAddressSet runs one reconcile under the per-key lock with an explicit
+	// pending snapshot. Callers should Stop() controllers first so the workqueue cannot race.
+	forceReconcileAddressSet := func(addrSetKey string, setupPending func(*podSelectorAddressSet)) error {
+		return addressSetManager.addressSets.DoWithLock(addrSetKey, func(key string) error {
+			psAddrSet, found := addressSetManager.addressSets.Load(key)
+			if !found {
+				return fmt.Errorf("address set %s not found", key)
+			}
+			psAddrSet.pendingUpdates.clear()
+			setupPending(psAddrSet)
+			return addressSetManager.reconcileAddressSetLocked(key, psAddrSet)
+		})
 	}
 
 	ginkgo.It("validates selectors", func() {
@@ -661,13 +710,361 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// expect 2 transactions: 1 to create addr set and 1 to set IPs
 		gomega.Expect(countingNBClient.transactCount.Load()).To(gomega.Equal(int64(2)))
 
-		// Now update pod labels, which will cause the address set reconciliation
+		addressSetManager.Stop()
 		ns1pod1.Labels["newLabel"] = "newValue"
 		_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), ns1pod1, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Consistently(addressSetManager.nbClient, 200*time.Millisecond, 50*time.Millisecond).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+		gomega.Eventually(func() string {
+			pod, getErr := addressSetManager.podLister.Pods(namespace1.Name).Get(ns1pod1.Name)
+			if getErr != nil {
+				return ""
+			}
+			return pod.Labels["newLabel"]
+		}).Should(gomega.Equal("newValue"))
+
+		addrSetKey := getInternalKey(&metav1.LabelSelector{}, nil, nil, namespace1.Name, controllerName, false)
+		err = forceReconcileAddressSet(addrSetKey, func(psAddrSet *podSelectorAddressSet) {
+			psAddrSet.pendingUpdates.addPodKey(fmt.Sprintf("%s/%s", namespace1.Name, ns1pod1.Name))
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 		// no new transactions should happen since IPs don't change
 		gomega.Expect(countingNBClient.transactCount.Load()).To(gomega.Equal(int64(2)))
+	})
+
+	ginkgo.DescribeTable("incrementally updates address set when a pod's IPs change",
+		func(initialIPs, updatedIPs []string, ipv6Mode bool, initialTransacts, afterUpdateTransacts int64) {
+			config.IPv4Mode = true
+			config.IPv6Mode = ipv6Mode
+
+			namespace1 := *testing.NewNamespace(namespaceName1)
+			ns1pod1 := testing.NewPodWithLabelsAllIPFamilies(namespace1.Name, "ns1pod1", nodeName, initialIPs, nil)
+
+			startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*ns1pod1})
+
+			_, _, _, err := addressSetManager.EnsureAddressSet(
+				&metav1.LabelSelector{}, nil, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			dbIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, namespace1.Name, controllerName, false)
+			expectedASv4, expectedASv6 := addressset.GetTestDbAddrSets(dbIDs, initialIPs)
+			expectedData := []libovsdbtest.TestData{expectedASv4}
+			if ipv6Mode {
+				expectedData = append(expectedData, expectedASv6)
+			}
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectedData))
+			gomega.Expect(countingNBClient.transactCount.Load()).To(gomega.Equal(initialTransacts))
+
+			ns1pod1.Status.PodIP = updatedIPs[0]
+			ns1pod1.Status.PodIPs = make([]corev1.PodIP, 0, len(updatedIPs))
+			for _, ip := range updatedIPs {
+				ns1pod1.Status.PodIPs = append(ns1pod1.Status.PodIPs, corev1.PodIP{IP: ip})
+			}
+			_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), ns1pod1, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			expectedASv4, expectedASv6 = addressset.GetTestDbAddrSets(dbIDs, updatedIPs)
+			expectedData = []libovsdbtest.TestData{expectedASv4}
+			if ipv6Mode {
+				expectedData = append(expectedData, expectedASv6)
+			}
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectedData))
+			// one additional ApplyAddressChanges transaction commits all family mutations together
+			gomega.Expect(countingNBClient.transactCount.Load()).To(gomega.Equal(afterUpdateTransacts))
+		},
+		ginkgo.Entry("IPv4",
+			[]string{ip1}, []string{ip2}, false,
+			int64(2), // create (1) + SetAddresses (1)
+			int64(3),
+		),
+		ginkgo.Entry("dual-stack",
+			[]string{ip1, "2001:db8::1"}, []string{ip2, "2001:db8::2"}, true,
+			int64(3), // create both families (1) + SetAddresses per family (2)
+			int64(4),
+		),
+	)
+
+	ginkgo.It("removes pod IPs when a pod stops matching the selector", func() {
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		matchingPod := testing.NewPodWithLabels(namespace1.Name, "matching-pod", nodeName, ip1, map[string]string{podLabelKey: "match"})
+
+		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*matchingPod})
+
+		podSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{podLabelKey: "match"},
+		}
+		_, _, _, err := addressSetManager.EnsureAddressSet(
+			podSelector, nil, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dbIDs := GetPodSelectorAddrSetDbIDs(podSelector, nil, nil, namespace1.Name, controllerName, false)
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{ip1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+		matchingPod.Labels[podLabelKey] = "no-match"
+		_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), matchingPod, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		emptyAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
+	})
+
+	ginkgo.It("updates address set when namespace enters and leaves namespace selector", func() {
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		namespace2 := *testing.NewNamespace(namespaceName2)
+		namespace2.Labels = map[string]string{"name": "other"}
+		podInNs2 := testing.NewPod(namespaceName2, "ns2pod1", nodeName, ip3)
+
+		startAddrSetManager(initialDB, []corev1.Namespace{namespace1, namespace2}, []corev1.Pod{*podInNs2})
+
+		nsSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{"name": namespaceName2},
+		}
+		_, _, _, err := addressSetManager.EnsureAddressSet(
+			&metav1.LabelSelector{}, nsSelector, nil, namespaceName1, "backRef", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dbIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nsSelector, nil, namespaceName1, controllerName, false)
+		emptyAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
+
+		// namespace enters selection
+		namespace2.Labels = map[string]string{"name": namespaceName2}
+		_, err = clientSet.KubeClient.CoreV1().Namespaces().Update(context.TODO(), &namespace2, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{ip3})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+		// namespace leaves selection
+		namespace2.Labels = map[string]string{"name": "other"}
+		_, err = clientSet.KubeClient.CoreV1().Namespaces().Update(context.TODO(), &namespace2, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
+	})
+
+	ginkgo.It("keeps a shared pod IP until the last owning pod is deleted", func() {
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		sharedIP := ip1
+		pod1 := testing.NewPod(namespace1.Name, "pod1", nodeName, sharedIP)
+		pod2 := testing.NewPod(namespace1.Name, "pod2", nodeName, sharedIP)
+
+		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*pod1, *pod2})
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(
+			&metav1.LabelSelector{}, nil, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dbIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, namespace1.Name, controllerName, false)
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{sharedIP})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+		addressSetManager.Stop()
+		err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Delete(context.TODO(), pod1.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(func() bool {
+			_, getErr := addressSetManager.podLister.Pods(namespace1.Name).Get(pod1.Name)
+			return apierrors.IsNotFound(getErr)
+		}).Should(gomega.BeTrue())
+
+		addrSetKey := getInternalKey(&metav1.LabelSelector{}, nil, nil, namespace1.Name, controllerName, false)
+		err = forceReconcileAddressSet(addrSetKey, func(psAddrSet *podSelectorAddressSet) {
+			psAddrSet.pendingUpdates.addPodKey(fmt.Sprintf("%s/%s", namespace1.Name, pod1.Name))
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+		err = addressSetManager.addressSets.DoWithLock(addrSetKey, func(key string) error {
+			psAddrSet, found := addressSetManager.addressSets.Load(key)
+			gomega.Expect(found).To(gomega.BeTrue())
+			gomega.Expect(psAddrSet.addresses.Has(sharedIP)).To(gomega.BeTrue())
+			_, stillCached := psAddrSet.podAddresses[fmt.Sprintf("%s/%s", namespace1.Name, pod2.Name)]
+			gomega.Expect(stillCached).To(gomega.BeTrue())
+			return nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Delete(context.TODO(), pod2.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(func() bool {
+			_, getErr := addressSetManager.podLister.Pods(namespace1.Name).Get(pod2.Name)
+			return apierrors.IsNotFound(getErr)
+		}).Should(gomega.BeTrue())
+		err = forceReconcileAddressSet(addrSetKey, func(psAddrSet *podSelectorAddressSet) {
+			psAddrSet.pendingUpdates.addPodKey(fmt.Sprintf("%s/%s", namespace1.Name, pod2.Name))
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		emptyAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{})
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
+	})
+
+	ginkgo.It("full-syncs when pod and namespace pending updates are coalesced", func() {
+		// Without full sync, coalesced pending would only run the namespace incremental path and
+		// drop the pod IP change. Stop controllers, mutate API+pending, then reconcile once.
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		namespace2 := *testing.NewNamespace(namespaceName2)
+		namespace2.Labels = map[string]string{"name": "other"}
+		podInNs1 := testing.NewPod(namespace1.Name, "ns1pod1", nodeName, ip1)
+		podInNs2 := testing.NewPod(namespace2.Name, "ns2pod1", nodeName, ip3)
+
+		startAddrSetManager(initialDB,
+			[]corev1.Namespace{namespace1, namespace2},
+			[]corev1.Pod{*podInNs1, *podInNs2})
+
+		nsSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{"name": namespaceName1},
+		}
+		_, _, _, err := addressSetManager.EnsureAddressSet(
+			&metav1.LabelSelector{}, nsSelector, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dbIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nsSelector, nil, namespace1.Name, controllerName, false)
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{ip1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+		// Prevent background reconciles from splitting the coalesced pending update.
+		addressSetManager.Stop()
+
+		namespace2.Labels = map[string]string{"name": namespaceName1}
+		_, err = clientSet.KubeClient.CoreV1().Namespaces().Update(context.TODO(), &namespace2, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		podInNs1.Status.PodIP = ip2
+		podInNs1.Status.PodIPs = []corev1.PodIP{{IP: ip2}}
+		_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), podInNs1, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		gomega.Eventually(func() string {
+			ns, err := addressSetManager.namespaceLister.Get(namespace2.Name)
+			if err != nil {
+				return ""
+			}
+			return ns.Labels["name"]
+		}).Should(gomega.Equal(namespaceName1))
+		gomega.Eventually(func() string {
+			pod, err := addressSetManager.podLister.Pods(namespace1.Name).Get(podInNs1.Name)
+			if err != nil {
+				return ""
+			}
+			return pod.Status.PodIP
+		}).Should(gomega.Equal(ip2))
+
+		addrSetKey := getInternalKey(&metav1.LabelSelector{}, nsSelector, nil, namespace1.Name, controllerName, false)
+		err = addressSetManager.addressSets.DoWithLock(addrSetKey, func(key string) error {
+			psAddrSet, found := addressSetManager.addressSets.Load(key)
+			if !found {
+				return fmt.Errorf("address set %s not found", key)
+			}
+			psAddrSet.pendingUpdates.clear()
+			psAddrSet.pendingUpdates.addNamespaceKey(namespace2.Name)
+			psAddrSet.pendingUpdates.addPodKey(fmt.Sprintf("%s/%s", namespace1.Name, podInNs1.Name))
+			gomega.Expect(addressSetManager.pendingPodUpdateClassCount(psAddrSet.pendingUpdates.snapshot(), psAddrSet)).
+				To(gomega.Equal(2))
+			return addressSetManager.reconcileAddressSetLocked(key, psAddrSet)
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		expectedAS, _ = addressset.GetTestDbAddrSets(dbIDs, []string{ip2, ip3})
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+	})
+
+	ginkgo.It("retries with full sync after OVN apply failure clears pending updates", func() {
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		ns1pod1 := testing.NewPod(namespace1.Name, "ns1pod1", nodeName, ip1)
+		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*ns1pod1})
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(
+			&metav1.LabelSelector{}, nil, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dbIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, namespace1.Name, controllerName, false)
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{ip1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+		// Fail the next OVN transaction (the incremental ApplyAddressChanges for the IP change).
+		countingNBClient.failRemaining.Store(1)
+
+		ns1pod1.Status.PodIP = ip2
+		ns1pod1.Status.PodIPs = []corev1.PodIP{{IP: ip2}}
+		_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), ns1pod1, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// First attempt clears pending and fails (marking fullSync); retry rebuilds fully.
+		expectedAS, _ = addressset.GetTestDbAddrSets(dbIDs, []string{ip2})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+	})
+
+	ginkgo.It("retains pending updates on retry after apply failure even if another pod event arrives first", func() {
+		// pendingUpdates is cleared only on success. A failed pod-A update must keep A's key
+		// so a later pod-B event coalesces with it instead of replacing it with a B-only path.
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		podA := testing.NewPod(namespace1.Name, "pod-a", nodeName, ip1)
+		startAddrSetManager(initialDB, []corev1.Namespace{namespace1}, []corev1.Pod{*podA})
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(
+			&metav1.LabelSelector{}, nil, nil, namespace1.Name, "backRef", controllerName, &util.DefaultNetInfo{}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		dbIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, nil, nil, namespace1.Name, controllerName, false)
+		expectedAS, _ := addressset.GetTestDbAddrSets(dbIDs, []string{ip1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+		addressSetManager.Stop()
+
+		podA.Status.PodIP = ip2
+		podA.Status.PodIPs = []corev1.PodIP{{IP: ip2}}
+		_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Update(context.TODO(), podA, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(func() string {
+			pod, getErr := addressSetManager.podLister.Pods(namespace1.Name).Get(podA.Name)
+			if getErr != nil {
+				return ""
+			}
+			return pod.Status.PodIP
+		}).Should(gomega.Equal(ip2))
+
+		addrSetKey := getInternalKey(&metav1.LabelSelector{}, nil, nil, namespace1.Name, controllerName, false)
+		podAKey := fmt.Sprintf("%s/%s", namespace1.Name, podA.Name)
+		countingNBClient.failRemaining.Store(1)
+		err = forceReconcileAddressSet(addrSetKey, func(psAddrSet *podSelectorAddressSet) {
+			psAddrSet.pendingUpdates.addPodKey(podAKey)
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("injected OVN failure"))
+
+		err = addressSetManager.addressSets.DoWithLock(addrSetKey, func(key string) error {
+			psAddrSet, found := addressSetManager.addressSets.Load(key)
+			if !found {
+				return fmt.Errorf("address set %s not found", key)
+			}
+			gomega.Expect(psAddrSet.pendingUpdates.podKeys.Has(podAKey)).To(gomega.BeTrue(),
+				"failed reconcile must retain the pending pod key so a later event cannot drop it")
+			gomega.Expect(psAddrSet.pendingUpdates.fullSync).To(gomega.BeFalse())
+			return nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		podB := testing.NewPod(namespace1.Name, "pod-b", nodeName, ip3)
+		_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Create(context.TODO(), podB, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(func() error {
+			_, getErr := addressSetManager.podLister.Pods(namespace1.Name).Get(podB.Name)
+			return getErr
+		}).Should(gomega.Succeed())
+
+		// Simulate the pod-B event enqueueing B; A's failed pending key must still be present.
+		err = addressSetManager.addressSets.DoWithLock(addrSetKey, func(key string) error {
+			psAddrSet, found := addressSetManager.addressSets.Load(key)
+			if !found {
+				return fmt.Errorf("address set %s not found", key)
+			}
+			gomega.Expect(psAddrSet.pendingUpdates.podKeys.Has(podAKey)).To(gomega.BeTrue())
+			psAddrSet.pendingUpdates.addPodKey(fmt.Sprintf("%s/%s", namespace1.Name, podB.Name))
+			return addressSetManager.reconcileAddressSetLocked(key, psAddrSet)
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		expectedAS, _ = addressset.GetTestDbAddrSets(dbIDs, []string{ip2, ip3})
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 	})
 
 	ginkgo.It("CleanupForController removes controller entries", func() {
@@ -688,6 +1085,65 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
 
 		gomega.Expect(addressSetManager.CleanupForController(controllerName)).To(gomega.Succeed())
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveEmptyData())
+	})
+
+	ginkgo.It("unregisters destroyed address sets from host-network selecting cache", func() {
+		// Destroy paths must drop hostNetworkSelectingAddrSets entries; otherwise host IP
+		// updates keep enqueueing keys that no longer exist in addressSets.
+		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+		hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+		gwIP1 := "100.64.0.1"
+		testNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet),
+					"k8s.ovn.org/node-id":      "1",
+				},
+			},
+		}
+		startAddrSetManagerWithNodes(initialDB, []corev1.Namespace{hostNetNamespace}, nil, []corev1.Node{testNode})
+
+		addrSetKey, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", controllerName, true)
+		expectedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{node1MgmtIP, gwIP1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+		gomega.Eventually(func() bool {
+			addressSetManager.hostNetworkNamespaceLock.RLock()
+			defer addressSetManager.hostNetworkNamespaceLock.RUnlock()
+			return addressSetManager.hostNetworkSelectingAddrSets.Has(addrSetKey)
+		}).Should(gomega.BeTrue())
+
+		gomega.Expect(addressSetManager.DeleteAddressSet(addrSetKey, "backRef")).To(gomega.Succeed())
+		gomega.Expect(func() bool {
+			addressSetManager.hostNetworkNamespaceLock.RLock()
+			defer addressSetManager.hostNetworkNamespaceLock.RUnlock()
+			return addressSetManager.hostNetworkSelectingAddrSets.Has(addrSetKey)
+		}()).To(gomega.BeFalse())
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveEmptyData())
+
+		// Re-create and verify CleanupForController also unregisters.
+		addrSetKey, _, _, err = addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+		gomega.Eventually(func() bool {
+			addressSetManager.hostNetworkNamespaceLock.RLock()
+			defer addressSetManager.hostNetworkNamespaceLock.RUnlock()
+			return addressSetManager.hostNetworkSelectingAddrSets.Has(addrSetKey)
+		}).Should(gomega.BeTrue())
+
+		gomega.Expect(addressSetManager.CleanupForController(controllerName)).To(gomega.Succeed())
+		gomega.Expect(func() bool {
+			addressSetManager.hostNetworkNamespaceLock.RLock()
+			defer addressSetManager.hostNetworkNamespaceLock.RUnlock()
+			return addressSetManager.hostNetworkSelectingAddrSets.Has(addrSetKey)
+		}()).To(gomega.BeFalse())
 		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveEmptyData())
 	})
 
@@ -825,6 +1281,43 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			emptyAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{})
 			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 		})
+
+		ginkgo.It("enters and leaves node selector for all-namespaces sets via pod nodeName index", func() {
+			// Empty namespace selector → matchedNamespaces.all; computeNodeAddressSetCachePlan
+			// updates only pods on the pending node via listPodsOnNode / podsByNode.
+			namespace2 := *testing.NewNamespace(namespaceName2)
+			podOnNodeInNs2 := testing.NewPod(namespace2.Name, "ns2pod", node1.Name, ip3)
+			_, err := clientSet.KubeClient.CoreV1().Namespaces().Create(context.TODO(), &namespace2, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			_, err = clientSet.KubeClient.CoreV1().Pods(namespace2.Name).Create(context.TODO(), podOnNodeInNs2, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			allPodsSelector := &metav1.LabelSelector{}
+			allNamespacesSelector := &metav1.LabelSelector{}
+			specialNodeSelector := &metav1.LabelSelector{
+				MatchLabels: map[string]string{nodeLabelKey: "special-node"},
+			}
+			asID := GetPodSelectorAddrSetDbIDs(allPodsSelector, allNamespacesSelector, specialNodeSelector, "", controllerName, false)
+			_, _, _, err = addressSetManager.EnsureAddressSet(allPodsSelector, allNamespacesSelector, specialNodeSelector,
+				"", "backRef-all-ns", controllerName, &util.DefaultNetInfo{}, false)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			emptyAS, _ := addressset.GetTestDbAddrSets(asID, []string{})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
+
+			node1Copy := node1.DeepCopy()
+			node1Copy.Labels = map[string]string{nodeLabelKey: "special-node"}
+			_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), node1Copy, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// BeforeEach pod on node1 (ip1) plus the ns2 pod found via the nodeName index (ip3).
+			expectedAS, _ := addressset.GetTestDbAddrSets(asID, []string{ip1, ip3})
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+			node1Copy.Labels = map[string]string{nodeLabelKey: nodeTypeWorker}
+			_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), node1Copy, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
+		})
 	})
 
 	ginkgo.It("reconciles HostNetworkNamespace IPs", func() {
@@ -890,8 +1383,9 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = clientSet.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
+		addressSetManager, err = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
 			func(_ string) string { return "" })
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		// run EnsureAddressSet again, otherwise address set won't be reconciled with no users
@@ -901,6 +1395,248 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		restartedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{node2MgmtIP})
 		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{restartedAS}))
 	})
+
+	ginkgo.DescribeTable("keeps shared IPs when only one of pod/host ownership is removed",
+		func(dualStack bool) {
+			// Legacy netpol address sets union pod IPs with HostNetworkNamespace IPs. An IP present
+			// in both mirrors must remain in OVN until neither owns it.
+			config.IPv4Mode = true
+			config.IPv6Mode = dualStack
+			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+			hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+			namespace1 := *testing.NewNamespace(namespaceName1)
+
+			hostAndGW := []string{node1MgmtIP, gwIP1}
+			sharedMgmt := []string{node1MgmtIP}
+			if dualStack {
+				hostAndGW = append(hostAndGW, node1MgmtIPV6, gwIP1v6)
+				sharedMgmt = append(sharedMgmt, node1MgmtIPV6)
+			}
+
+			testNode := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": hostNetworkNodeSubnetsAnnotation(dualStack),
+						"k8s.ovn.org/node-id":      "1",
+					},
+				},
+			}
+			// Pod IPs intentionally overlap with the host-network management IPs.
+			overlappingPod := testing.NewPodWithLabelsAllIPFamilies(namespace1.Name, "overlap-pod", nodeName, sharedMgmt, nil)
+			startAddrSetManagerWithNodes(initialDB,
+				[]corev1.Namespace{hostNetNamespace, namespace1},
+				[]corev1.Pod{*overlappingPod},
+				[]corev1.Node{testNode})
+
+			_, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+				"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+				"", controllerName, true)
+			expectedData := expectAddrSetData(hostNSASIDs, hostAndGW, dualStack)
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectedData))
+
+			// Pod leaves while host still owns the shared management IP(s) — OVN must keep them.
+			addressSetManager.Stop()
+			err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Delete(context.TODO(), overlappingPod.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() bool {
+				_, getErr := addressSetManager.podLister.Pods(namespace1.Name).Get(overlappingPod.Name)
+				return apierrors.IsNotFound(getErr)
+			}).Should(gomega.BeTrue())
+
+			addrSetKey := getInternalKey(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil, "", controllerName, true)
+			err = forceReconcileAddressSet(addrSetKey, func(psAddrSet *podSelectorAddressSet) {
+				psAddrSet.pendingUpdates.addPodKey(fmt.Sprintf("%s/%s", namespace1.Name, overlappingPod.Name))
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectedData))
+			err = addressSetManager.addressSets.DoWithLock(addrSetKey, func(key string) error {
+				psAddrSet, found := addressSetManager.addressSets.Load(key)
+				gomega.Expect(found).To(gomega.BeTrue())
+				for _, ip := range sharedMgmt {
+					gomega.Expect(psAddrSet.addresses.Has(ip)).To(gomega.BeTrue())
+				}
+				return nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Re-add a pod with the shared IP(s), then drop host ownership (delete node).
+			remainingPod := testing.NewPodWithLabelsAllIPFamilies(namespace1.Name, "remaining-pod", nodeName, sharedMgmt, nil)
+			_, err = clientSet.KubeClient.CoreV1().Pods(namespace1.Name).Create(context.TODO(), remainingPod, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() error {
+				_, getErr := addressSetManager.podLister.Pods(namespace1.Name).Get(remainingPod.Name)
+				return getErr
+			}).Should(gomega.Succeed())
+			err = forceReconcileAddressSet(addrSetKey, func(psAddrSet *podSelectorAddressSet) {
+				psAddrSet.pendingUpdates.addPodKey(fmt.Sprintf("%s/%s", namespace1.Name, remainingPod.Name))
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectedData))
+
+			err = clientSet.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() bool {
+				_, getErr := addressSetManager.nodeLister.Get(testNode.Name)
+				return apierrors.IsNotFound(getErr)
+			}).Should(gomega.BeTrue())
+			// Controllers are stopped; apply the host-network IP cache update that reconcileNode
+			// would have performed, then force the selecting address-set reconcile.
+			gomega.Expect(addressSetManager.updateHostNetworkIPs(testNode.Name)).To(gomega.Succeed())
+			err = forceReconcileAddressSet(addrSetKey, func(psAddrSet *podSelectorAddressSet) {
+				psAddrSet.pendingUpdates.addNodeKey(testNode.Name)
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectAddrSetData(hostNSASIDs, sharedMgmt, dualStack)))
+		},
+		ginkgo.Entry("IPv4", false),
+		ginkgo.Entry("dual-stack", true),
+	)
+
+	ginkgo.DescribeTable("updates host-network annotation IPs without disturbing unrelated pod IPs",
+		func(dualStack bool) {
+			// Host-only incremental path: node annotation change must rewrite host IPs while a
+			// non-overlapping selected pod IP stays put (deriveUnionAddressDelta).
+			config.IPv4Mode = true
+			config.IPv6Mode = dualStack
+			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+			hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+			namespace1 := *testing.NewNamespace(namespaceName1)
+
+			podIPs := []string{ip1}
+			initialIPs := []string{ip1, node1MgmtIP, gwIP1}
+			updatedIPs := []string{ip1, node1MgmtIP, gwIP2}
+			if dualStack {
+				podIPs = append(podIPs, ip1v6)
+				initialIPs = append(initialIPs, ip1v6, node1MgmtIPV6, gwIP1v6)
+				updatedIPs = append(updatedIPs, ip1v6, node1MgmtIPV6, gwIP2v6)
+			}
+
+			testNode := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": hostNetworkNodeSubnetsAnnotation(dualStack),
+						"k8s.ovn.org/node-id":      "1",
+					},
+				},
+			}
+			regularPod := testing.NewPodWithLabelsAllIPFamilies(namespace1.Name, "regular-pod", nodeName, podIPs, nil)
+			startAddrSetManagerWithNodes(initialDB,
+				[]corev1.Namespace{hostNetNamespace, namespace1},
+				[]corev1.Pod{*regularPod},
+				[]corev1.Node{testNode})
+
+			_, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+				"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+				"", controllerName, true)
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectAddrSetData(hostNSASIDs, initialIPs, dualStack)))
+
+			testNode.Annotations["k8s.ovn.org/node-id"] = "2"
+			_, err = clientSet.KubeClient.CoreV1().Nodes().Update(context.TODO(), &testNode, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectAddrSetData(hostNSASIDs, updatedIPs, dualStack)))
+		},
+		ginkgo.Entry("IPv4", false),
+		ginkgo.Entry("dual-stack", true),
+	)
+
+	ginkgo.DescribeTable("drains host-network IPs when the host network namespace is deleted",
+		func(dualStack bool) {
+			config.IPv4Mode = true
+			config.IPv6Mode = dualStack
+			config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+			hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+
+			hostAndGW := []string{node1MgmtIP, gwIP1}
+			if dualStack {
+				hostAndGW = append(hostAndGW, node1MgmtIPV6, gwIP1v6)
+			}
+
+			testNode := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": hostNetworkNodeSubnetsAnnotation(dualStack),
+						"k8s.ovn.org/node-id":      "1",
+					},
+				},
+			}
+			startAddrSetManagerWithNodes(initialDB, []corev1.Namespace{hostNetNamespace}, nil, []corev1.Node{testNode})
+
+			_, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+				"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+				"", controllerName, true)
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectAddrSetData(hostNSASIDs, hostAndGW, dualStack)))
+
+			err = clientSet.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), hostNetNamespace.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData(expectAddrSetData(hostNSASIDs, []string{}, dualStack)))
+		},
+		ginkgo.Entry("IPv4", false),
+		ginkgo.Entry("dual-stack", true),
+	)
+
+	ginkgo.It("enqueues selecting address sets for host-only reconcile when the host network namespace is deleted", func() {
+		// Enqueue from updateHostNetworkNamespaceExists itself (not only reconcileNamespace),
+		// using host-only pending so host IPs drain without a full pod rebuild.
+		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
+		hostNetNamespace := *testing.NewNamespace(config.Kubernetes.HostNetworkNamespace)
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		gwIP1 := "100.64.0.1"
+		testNode := corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"default\":\"%s\"}", node1Subnet),
+					"k8s.ovn.org/node-id":      "1",
+				},
+			},
+		}
+		regularPod := testing.NewPod(namespace1.Name, "regular-pod", nodeName, ip1)
+		startAddrSetManagerWithNodes(initialDB,
+			[]corev1.Namespace{hostNetNamespace, namespace1},
+			[]corev1.Pod{*regularPod},
+			[]corev1.Node{testNode})
+
+		_, _, _, err := addressSetManager.EnsureAddressSet(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", "backRef", controllerName, &util.DefaultNetInfo{}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		hostNSASIDs := GetPodSelectorAddrSetDbIDs(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil,
+			"", controllerName, true)
+		expectedAS, _ := addressset.GetTestDbAddrSets(hostNSASIDs, []string{ip1, node1MgmtIP, gwIP1})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+
+		addressSetManager.Stop()
+		err = clientSet.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), hostNetNamespace.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(func() bool {
+			_, getErr := addressSetManager.namespaceLister.Get(hostNetNamespace.Name)
+			return apierrors.IsNotFound(getErr)
+		}).Should(gomega.BeTrue())
+
+		gomega.Expect(addressSetManager.updateHostNetworkNamespaceExists()).To(gomega.Succeed())
+		addrSetKey := getInternalKey(&metav1.LabelSelector{}, &metav1.LabelSelector{}, nil, "", controllerName, true)
+		err = addressSetManager.addressSets.DoWithLock(addrSetKey, func(key string) error {
+			psAddrSet, found := addressSetManager.addressSets.Load(key)
+			if !found {
+				return fmt.Errorf("address set %s not found", key)
+			}
+			gomega.Expect(psAddrSet.pendingUpdates.fullSync).To(gomega.BeFalse())
+			gomega.Expect(psAddrSet.pendingUpdates.nodeKeys.Has("")).To(gomega.BeTrue())
+			return addressSetManager.reconcileAddressSetLocked(key, psAddrSet)
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		expectedAS, _ = addressset.GetTestDbAddrSets(hostNSASIDs, []string{ip1})
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{expectedAS}))
+	})
+
 	ginkgo.It("updates IPs for existing nodes when the host network traffic namespace is created", func() {
 		config.Kubernetes.HostNetworkNamespace = "ovn-host-network"
 		// this is calculated based on node-id
@@ -1013,6 +1749,15 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		emptyAS, _ = addressset.GetTestDbAddrSets(hostNSASIDs, []string{})
 		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyAS}))
 	})
+
+	ginkgo.It("allows a second NewAddressSetManager when the pod nodeName indexer already exists", func() {
+		startAddrSetManager(initialDB, nil, nil)
+		second, err := NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
+			fakeNetworkManager.Interface().GetNetworkNameForNADKey)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(second).NotTo(gomega.BeNil())
+		second.Stop()
+	})
 })
 
 var _ = ginkgo.Describe("shortLabelSelectorString function", func() {
@@ -1082,5 +1827,62 @@ var _ = ginkgo.Describe("shortLabelSelectorString function", func() {
 			MatchLabels: map[string]string{"k2": "v2", "k1": "v1", "k3": "v3"},
 		}
 		gomega.Expect(shortLabelSelectorString(ls1)).To(gomega.Equal(shortLabelSelectorString(ls2)))
+	})
+})
+
+type stubPodNodeNameIndexer struct {
+	indexer        cache.Indexer
+	addIndexersErr error
+	// installOnError installs the indexers before returning addIndexersErr, simulating a
+	// concurrent constructor that won the race.
+	installOnError bool
+	addCalls       int
+}
+
+func (s *stubPodNodeNameIndexer) GetIndexer() cache.Indexer { return s.indexer }
+
+func (s *stubPodNodeNameIndexer) AddIndexers(indexers cache.Indexers) error {
+	s.addCalls++
+	if s.addIndexersErr != nil {
+		if s.installOnError {
+			_ = s.indexer.AddIndexers(indexers)
+		}
+		return s.addIndexersErr
+	}
+	return s.indexer.AddIndexers(indexers)
+}
+
+var _ = ginkgo.Describe("ensurePodNodeNameIndexer", func() {
+	ginkgo.It("is a no-op when the indexer already exists", func() {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+			podNodeNameIndex: podByNodeNameIndexFunc,
+		})
+		stub := &stubPodNodeNameIndexer{indexer: indexer}
+		gomega.Expect(ensurePodNodeNameIndexer(stub)).To(gomega.Succeed())
+		gomega.Expect(stub.addCalls).To(gomega.Equal(0))
+	})
+
+	ginkgo.It("returns an error when AddIndexers fails and the index is still missing", func() {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		stub := &stubPodNodeNameIndexer{
+			indexer:        indexer,
+			addIndexersErr: fmt.Errorf("boom"),
+		}
+		err := ensurePodNodeNameIndexer(stub)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring(podNodeNameIndex))
+		gomega.Expect(stub.addCalls).To(gomega.Equal(1))
+	})
+
+	ginkgo.It("tolerates AddIndexers error when a concurrent constructor installed the index", func() {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		stub := &stubPodNodeNameIndexer{
+			indexer:        indexer,
+			addIndexersErr: fmt.Errorf("indexer conflict"),
+			installOnError: true,
+		}
+		gomega.Expect(ensurePodNodeNameIndexer(stub)).To(gomega.Succeed())
+		_, exists := stub.indexer.GetIndexers()[podNodeNameIndex]
+		gomega.Expect(exists).To(gomega.BeTrue())
 	})
 })

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -593,13 +593,16 @@ func newAdvertisedSNATTestControllerForTopology(
 		t.Fatalf("failed to create libovsdb test harness: %v", err)
 	}
 	t.Cleanup(libovsdbCleanup.Cleanup)
-	addressSetManager := addresssetmanager.NewAddressSetManager(
+	addressSetManager, err := addresssetmanager.NewAddressSetManager(
 		watchFactory.PodCoreInformer(),
 		watchFactory.NamespaceInformer(),
 		watchFactory.NodeCoreInformer(),
 		nbClient,
 		networkmanager.Default().Interface().GetNetworkNameForNADKey,
 	)
+	if err != nil {
+		t.Fatalf("failed to create address set manager: %v", err)
+	}
 	return &BaseUserDefinedNetworkController{
 			BaseNetworkController: BaseNetworkController{
 				controllerName:      controllerName,

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -597,8 +597,9 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 
 		recorder = record.NewFakeRecorder(10)
 		netManager := networkmanager.Default()
-		addressSetManager := addresssetmanager.NewAddressSetManager(f.PodCoreInformer(), f.NamespaceInformer(),
+		addressSetManager, err := addresssetmanager.NewAddressSetManager(f.PodCoreInformer(), f.NamespaceInformer(),
 			f.NodeCoreInformer(), nbClient, netManager.Interface().GetNetworkNameForNADKey)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "creating address set manager should succeed")
 		oc, err = NewOvnController(
 			fakeClient,
 			f,

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -290,8 +290,9 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 	}
 
 	o.portCache = NewPortCache(o.stopChan)
-	o.addressSetManager = addresssetmanager.NewAddressSetManager(o.watcher.PodCoreInformer(),
+	o.addressSetManager, err = addresssetmanager.NewAddressSetManager(o.watcher.PodCoreInformer(),
 		o.watcher.NamespaceInformer(), o.watcher.NodeCoreInformer(), o.nbClient, o.networkManager.Interface().GetNetworkNameForNADKey)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "creating address set manager should succeed")
 
 	kubeOVN := &kube.KubeOVN{
 		Kube:      kube.Kube{KClient: o.fakeClient.KubeClient},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

The reconcile logic of address set manager lists the pods selected by the address set to get the corresponding addresses and then uses SetAddresses() to update the complete address set. In SetAddresses() the current contents of the address set is fetched and then matched. The address set is updated only when the addresses don't match.

The above workflow leads to degraded performance at scale, since the NBDB and in turn the ovn-controller is flooded with consecutive update requests, thus increasing the CPU consumption. As the ovn-controller is swamped with requests, the pods which are created during this time take a longer time to get ready as the ovn-controller struggles to add the corresponding logical port of the pod. Though there's variability with the podReadyLatency metric, the CPU metrics are always impacted.

To alleviate this performace bottleneck, this PR introduces incremental address set reconcilitian instead of full sync on every event. Following changes are introduced:

Avoid rebuilding and rewriting the full OVN address set on every pod, namespace, or node event.
- Track selected membership and current OVN contents in memory, and reconcile only the objects that triggered the update
- Write the OVN delta in one transaction, then update local membership state only if that write succeeds
- When pods and host-network IPs share a set, compute the desired contents from both sources together so a still-owned IP is not removed
- Add AddressSet support for applying an add/remove delta without re-reading membership from OVN
- Speed up node-selector updates with a pod-by-node index; fail construction if the index cannot be installed
- Fall back to a full rebuild on first ensure, mixed event types in one reconcile, or retries after a failed apply


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Unit tests are added to verify the incremental reconcile logic. Since, this PR is an internal reconcile/cache optimization, so unit tests that assert incremental deltas, no-op empty writes, and host-network registration are sufficient. Separate e2e tests are not added.
