### PR TITLE
Fix typo in error message for ovsdb-server PID

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -47,7 +47,7 @@ func ovnControllerReadiness(target string) error {
 	// dependent on are running and you need to use ovs-appctl via the unix control path
 	ovsdbPid, err := os.ReadFile("/var/run/openvswitch/ovsdb-server.pid")
 	if err != nil {
-		return fmt.Errorf("failed to get pid for osvdb-server process: %v", err)
+		return fmt.Errorf("failed to get pid for ovsdb-server process: %v", err)
 	}
 	ctlFile := fmt.Sprintf("/var/run/openvswitch/ovsdb-server.%s.ctl", strings.Trim(string(ovsdbPid), " \n"))
 	_, _, err = util.RunOVSAppctlWithTimeout(5, "-t", ctlFile, "ovsdb-server/list-dbs")

--- a/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go
@@ -155,7 +155,7 @@ func CreateNetworkPolicySetting(networkAdapterName string) (*hcn.NetworkPolicy, 
 		NetworkAdapterName: networkAdapterName,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed ot marshal network adapter policy: %v", err)
+		return nil, fmt.Errorf("failed to marshal network adapter policy: %v", err)
 	}
 
 	return &hcn.NetworkPolicy{


### PR DESCRIPTION
Error says "osvdb-server" — should be "ovsdb-server". This is a user-facing readiness probe error that makes debugging harder.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
