### PR TITLE
ci: trigger area-merge bot from PR review bodies

### DIFF
--- a/.github/scripts/area-merge.js
+++ b/.github/scripts/area-merge.js
@@ -1,7 +1,8 @@
 // Area Maintainer Merge Bot
 //
 // Parses CODEOWNERS to determine area maintainer authorization, then verifies
-// file scope and CI status before merging PRs via /area-maintainer-approved.
+// file scope and CI status before merging PRs via /area-maintainer-approved
+// (issued either as a PR comment or in a PR review body).
 //
 // Called from .github/workflows/area-merge.yml via actions/github-script.
 
@@ -32,6 +33,17 @@ module.exports = async ({ github, context, core }) => {
     }
     pullNumbers.push(context.payload.issue.number);
     commenter = comment.user.login.toLowerCase();
+  } else if (context.eventName === 'pull_request_review') {
+    // Same defense in depth for the command placed in a PR review body
+    // (e.g. an "Approve" review whose summary starts with the command).
+    const review = context.payload.review;
+    if (review.user.type === 'Bot' ||
+        !(review.body || '').trim().startsWith('/area-maintainer-approved')) {
+      core.info('Ignoring review: authored by a bot or not a /area-maintainer-approved command');
+      return;
+    }
+    pullNumbers.push(context.payload.pull_request.number);
+    commenter = review.user.login.toLowerCase();
   } else if (context.eventName === 'check_suite') {
     const suite = context.payload.check_suite;
     for (const pr of (suite.pull_requests || [])) {
@@ -114,6 +126,25 @@ module.exports = async ({ github, context, core }) => {
     return allComments;
   }
 
+  async function fetchAllReviews(prNumber) {
+    const allReviews = [];
+    let page = 1;
+    while (true) {
+      const { data: reviews } = await github.rest.pulls.listReviews({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: prNumber,
+        per_page: 100,
+        page: page,
+      });
+      if (reviews.length === 0) break;
+      allReviews.push(...reviews);
+      if (reviews.length < 100) break;
+      page++;
+    }
+    return allReviews;
+  }
+
   // --- Process each PR ---
   for (const prNumber of pullNumbers) {
     core.info(`Processing PR #${prNumber}`);
@@ -143,18 +174,25 @@ module.exports = async ({ github, context, core }) => {
       continue;
     }
 
-    // For check_suite retries, find who previously ran /area-maintainer-approved
+    // For check_suite retries, find who previously ran /area-maintainer-approved,
+    // either in a PR comment or in a PR review body.
     let requester = commenter;
     let allComments = null;
     if (!requester) {
       allComments = await fetchAllComments(prNumber);
-      const mergeComment = [...allComments]
-        .reverse()
-        .find(c => c.body.trim().startsWith('/area-maintainer-approved') &&
-                   c.user.type !== 'Bot' &&
-                   c.user.login.toLowerCase() !== prAuthor);
-      if (mergeComment) {
-        requester = mergeComment.user.login.toLowerCase();
+      const reviews = await fetchAllReviews(prNumber);
+      const isMergeRequest = c =>
+        (c.body || '').trim().startsWith('/area-maintainer-approved') &&
+        c.user.type !== 'Bot' &&
+        c.user.login.toLowerCase() !== prAuthor;
+      const mergeRequest = [...allComments, ...reviews]
+        .filter(isMergeRequest)
+        .sort((a, b) =>
+          new Date(a.created_at || a.submitted_at || 0) -
+          new Date(b.created_at || b.submitted_at || 0))
+        .pop();
+      if (mergeRequest) {
+        requester = mergeRequest.user.login.toLowerCase();
       }
     }
 

--- a/.github/workflows/area-merge.yml
+++ b/.github/workflows/area-merge.yml
@@ -3,22 +3,27 @@ name: "Area Maintainer Merge"
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
   check_suite:
     types: [completed]
 
 jobs:
   area-merge:
-    # Only react to /area-maintainer-approved at the start of a comment, and
-    # never to comments authored by bots. Comments posted by this workflow use
-    # a GitHub App token, so (unlike the default GITHUB_TOKEN) they DO trigger
-    # new issue_comment events — matching the command anywhere in any comment
-    # body previously caused the bot to react to its own status/error messages
-    # in an infinite loop.
+    # Only react to /area-maintainer-approved at the start of a comment or a
+    # PR review body, and never to comments authored by bots. Comments posted
+    # by this workflow use a GitHub App token, so (unlike the default
+    # GITHUB_TOKEN) they DO trigger new issue_comment events — matching the
+    # command anywhere in any comment body previously caused the bot to react
+    # to its own status/error messages in an infinite loop.
     if: >
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        github.event.comment.user.type != 'Bot' &&
        startsWith(github.event.comment.body, '/area-maintainer-approved')) ||
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.user.type != 'Bot' &&
+       startsWith(github.event.review.body, '/area-maintainer-approved')) ||
       github.event_name == 'check_suite'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 📑 Description

The `area-merge` workflow only listened to `issue_comment` events, so an area maintainer submitting a PR **review** whose body starts with `/area-maintainer-approved` (a natural place to put the command when approving) was silently ignored — this is exactly what happened on #6668, where the command was placed in the review summary and the merge bot never fired.

This PR:
- Adds a `pull_request_review` (`submitted`) trigger to `.github/workflows/area-merge.yml`, with the same bot-author and command-prefix guards as the comment path.
- Handles the new event in `.github/scripts/area-merge.js` (PR number from `payload.pull_request`, requester from `payload.review.user`).
- Extends the `check_suite` re-evaluation path to also search PR review bodies (not just issue comments) when looking up who previously issued `/area-maintainer-approved`.

## Additional Information for reviewers

No behavior change for the existing comment-based flow. Review bodies can be `null` (e.g. plain approvals without text), so the script guards with `(review.body || '')`.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

Submit a PR review whose body starts with `/area-maintainer-approved` on a PR touching only files of your area; the "Area Maintainer Merge" workflow should now run and process it, same as a plain comment.