### PR TITLE
util: wait for the bridge to inherit the NIC MAC address in NicToBridge

### DIFF
--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -270,7 +270,8 @@ func NicToBridge(ovsClient libovsdbclient.Client, iface string) (string, error) 
 	}
 
 	bridge := GetBridgeName(iface)
-	if err := ovsops.CreateOrUpdateNicBridge(ovsClient, bridge, iface, ifaceLink.Attrs().HardwareAddr.String()); err != nil {
+	nicMAC := ifaceLink.Attrs().HardwareAddr.String()
+	if err := ovsops.CreateOrUpdateNicBridge(ovsClient, bridge, iface, nicMAC); err != nil {
 		klog.Errorf("Failed to create OVS bridge %q: %v", bridge, err)
 		return "", err
 	}
@@ -291,14 +292,18 @@ func NicToBridge(ovsClient libovsdbclient.Client, iface string) (string, error) 
 
 	// Unlike `ovs-vsctl add-br`, the libovsdb transaction returns as soon as
 	// the OVSDB row is committed — ovs-vswitchd may not yet have materialised
-	// the kernel netdev. Poll briefly so callers see the same "bridge ready
-	// for use" semantics as the legacy shell-out.
+	// the kernel netdev or applied its configuration. Poll until the netdev
+	// exists with the MAC address inherited from the NIC, so callers see the
+	// same "bridge ready for use" semantics as the legacy shell-out. In
+	// particular, the bridge must not be brought up before its MAC address is
+	// set: the kernel would generate the IPv6 link-local address from the
+	// initial random MAC address and would not regenerate it when the MAC
+	// address changes on a live interface.
 	var bridgeLink netlink.Link
 	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(_ context.Context) (bool, error) {
 		bridgeLink, err = netLinkOps.LinkByName(bridge)
 		if err != nil {
-			var notFound netlink.LinkNotFoundError
-			if errors.As(err, &notFound) {
+			if netLinkOps.IsLinkNotFoundError(err) {
 				// netdev hasn't materialised yet; keep polling.
 				return false, nil
 			}
@@ -306,9 +311,13 @@ func NicToBridge(ovsClient libovsdbclient.Client, iface string) (string, error) 
 			// going to be fixed by waiting — exit immediately.
 			return false, err
 		}
+		if bridgeLink.Attrs().HardwareAddr.String() != nicMAC {
+			// hwaddr not applied yet; keep polling.
+			return false, nil
+		}
 		return true, nil
 	}); err != nil {
-		return "", fmt.Errorf("bridge %q netdev did not appear: %w", bridge, err)
+		return "", fmt.Errorf("bridge %q netdev did not appear with the MAC address %s of NIC %q: %w", bridge, nicMAC, iface, err)
 	}
 
 	// save ip addresses to bridge.

--- a/go-controller/pkg/util/nicstobridge_test.go
+++ b/go-controller/pkg/util/nicstobridge_test.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -357,6 +358,11 @@ func TestNicToBridge(t *testing.T) {
 	// below is defined in net_linux.go
 	netLinkOps = mockNetLinkOps
 
+	nicHWAddr, err := net.ParseMAC("00:11:22:33:44:55")
+	require.NoError(t, err)
+	randomHWAddr, err := net.ParseMAC("66:77:88:99:aa:bb")
+	require.NoError(t, err)
+
 	rootOvs := func() []libovsdbtest.TestData {
 		return []libovsdbtest.TestData{&vswitchd.OpenvSwitch{UUID: "root-ovs"}}
 	}
@@ -429,6 +435,7 @@ func TestNicToBridge(t *testing.T) {
 				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Dst: ovntest.MustParseIPNet("10.168.1.0/24")}}, nil}},
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "IsLinkNotFoundError", OnCallMethodArgType: []string{"*errors.errorString"}, RetArgList: []interface{}{false}},
 			},
 			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
@@ -446,7 +453,7 @@ func TestNicToBridge(t *testing.T) {
 				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}, CallTimes: 2},
 			},
 		},
 		{
@@ -462,8 +469,7 @@ func TestNicToBridge(t *testing.T) {
 				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
-				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}, CallTimes: 3},
 			},
 		},
 		{
@@ -481,13 +487,39 @@ func TestNicToBridge(t *testing.T) {
 				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
 			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
-				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}, CallTimes: 3},
+			},
+		},
+		{
+			desc:           "bridge is not used until it inherits the NIC MAC address",
+			inpIface:       "eth0",
+			outBridge:      "breth0",
+			initialOvsData: rootOvs(),
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{}, nil}},
+				// the bridge netdev first materialises with a random MAC
+				// address, then ovs-vswitchd applies the NIC MAC address
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+			},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "eth0", HardwareAddr: nicHWAddr}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "breth0", HardwareAddr: randomHWAddr}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "breth0", HardwareAddr: nicHWAddr}}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			// reset the shared mocks so that one case cannot leak
+			// expectations or recorded calls into the next
+			mockNetLinkOps.Mock.ExpectedCalls = nil
+			mockNetLinkOps.Mock.Calls = nil
+			mockLink.Mock.ExpectedCalls = nil
+			mockLink.Mock.Calls = nil
 			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
 			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 


### PR DESCRIPTION
`NicToBridge` creates the bridge with the NIC MAC address in its `other-config:hwaddr`, but the libovsdb transaction returns as soon as the OVSDB row is committed and the netdev existence poll doesn't wait for ovs-vswitchd to have applied the configuration; ovs-vsctl add-br used to.

If the bridge is brought up while it still carries its initial random MAC address, it starts exchanging traffic with a MAC address and an IPv6 link-local address that are not the NIC's. The MAC address is corrected as soon as ovs-vswitchd applies the configuration, but the link-local address is not regenerated on a live interface and persists. Among other things, the node uses it as the BGP nexthop of the IPv6 routes it advertises, which is how a CI run caught this: all its IPv6 route checks expect the nexthop to match the eth0 link-local address that the bridge normally inherits along with its MAC address.

Poll until the bridge netdev exists with the NIC MAC address before moving IP addresses and routes to it and bringing it up.


Fixes https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6692

