### PR TITLE
udn: add VRF routes for all UDN cluster subnets

### DIFF
--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -897,15 +897,23 @@ func (udng *UserDefinedNetworkGateway) computeRoutesForUDN(mpLink netlink.Link) 
 				})
 				continue
 			}
+			// Route every cluster subnet of the same IP family via this
+			// node's gateway IP into OVN. A multi-subnet Layer3 UDN has more
+			// than one cluster subnet; routing only the subnet that contains
+			// the local gateway IP left host-networked traffic destined to
+			// pods on the network's other cluster subnets without a route
+			// into OVN, so it fell through to the VRF default route and left
+			// the node via the external gateway.
 			for _, clusterSubnet := range udng.Subnets() {
-				if clusterSubnet.CIDR.Contains(gwIP.IP) {
-					retVal = append(retVal, netlink.Route{
-						LinkIndex: mpLink.Attrs().Index,
-						Dst:       clusterSubnet.CIDR,
-						Gw:        gwIP.IP,
-						Table:     udng.vrfTableId,
-					})
+				if utilnet.IsIPv6CIDR(clusterSubnet.CIDR) != utilnet.IsIPv6(gwIP.IP) {
+					continue
 				}
+				retVal = append(retVal, netlink.Route{
+					LinkIndex: mpLink.Attrs().Index,
+					Dst:       clusterSubnet.CIDR,
+					Gw:        gwIP.IP,
+					Table:     udng.vrfTableId,
+				})
 			}
 		}
 	}

--- a/go-controller/pkg/node/gateway_udn_test.go
+++ b/go-controller/pkg/node/gateway_udn_test.go
@@ -2127,6 +2127,80 @@ var _ = Describe("UserDefinedNetworkGateway", func() {
 		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 	})
 
+	ovntest.OnSupportedPlatformsIt("should compute routes for all cluster subnets of a multi-subnet user defined network", func() {
+		config.Gateway.Interface = "eth0"
+		config.IPv4Mode = true
+		config.IPv6Mode = true
+		config.Kubernetes.ServiceCIDRs = ovntest.MustParseIPNets("10.96.0.0/16", "fd00:10:96::/112")
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-subnets": fmt.Sprintf("{\"%s\":[\"%s\", \"%s\"]}", netName, v4NodeSubnet, v6NodeSubnet),
+				},
+			},
+		}
+		// A multi-subnet Layer3 UDN with two IPv4 and two IPv6 cluster subnets.
+		// The node only owns a host subnet out of the first subnet of each family.
+		nad := ovntest.GenerateNAD(netName, "rednad", "greenamespace",
+			types.Layer3Topology, "100.128.0.0/16/24,100.129.0.0/16/24,ae70::/60/64,ae71::/60/64", types.NetworkRolePrimary)
+		ovntest.AnnotateNADWithNetworkID(netID, nad)
+		netInfo, err := util.ParseNADInfo(nad)
+		Expect(err).NotTo(HaveOccurred())
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			ofm := getDummyOpenflowManager()
+			udnGateway, err := NewUserDefinedNetworkGateway(netInfo, node, nil, nil, vrf, nil,
+				&gateway{openflowManager: ofm}, nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			mplink, err := netlink.LinkByName(mgtPort)
+			Expect(err).NotTo(HaveOccurred())
+			vrfTableId := util.CalculateRouteTableID(mplink.Attrs().Index)
+			udnGateway.vrfTableId = vrfTableId
+
+			routes, err := udnGateway.computeRoutesForUDN(mplink)
+			Expect(err).NotTo(HaveOccurred())
+			// Compared to a single-subnet UDN (10 routes) there is one extra
+			// cluster subnet route per IP family, so 12 routes total.
+			Expect(routes).To(HaveLen(12))
+
+			// IPv4 ETP=Local service masquerade IP route
+			Expect(*routes[4].Dst).To(Equal(*ovntest.MustParseIPNet("169.254.169.3/32")))
+			Expect(routes[4].LinkIndex).To(Equal(mplink.Attrs().Index))
+			Expect(routes[4].Gw.Equal(ovntest.MustParseIP("100.128.0.1"))).To(BeTrue())
+
+			// Both IPv4 cluster subnets are routed via the node's IPv4 gateway IP.
+			Expect(*routes[5].Dst).To(Equal(*ovntest.MustParseIPNet("100.128.0.0/16")))
+			Expect(routes[5].LinkIndex).To(Equal(mplink.Attrs().Index))
+			Expect(routes[5].Gw.Equal(ovntest.MustParseIP("100.128.0.1"))).To(BeTrue())
+			Expect(*routes[6].Dst).To(Equal(*ovntest.MustParseIPNet("100.129.0.0/16")))
+			Expect(routes[6].LinkIndex).To(Equal(mplink.Attrs().Index))
+			Expect(routes[6].Gw.Equal(ovntest.MustParseIP("100.128.0.1"))).To(BeTrue())
+
+			// IPv6 ETP=Local service masquerade IP route
+			Expect(*routes[7].Dst).To(Equal(*ovntest.MustParseIPNet("fd69::3/128")))
+			Expect(routes[7].LinkIndex).To(Equal(mplink.Attrs().Index))
+			Expect(routes[7].Gw.Equal(ovntest.MustParseIP("ae70::1"))).To(BeTrue())
+
+			// Both IPv6 cluster subnets are routed via the node's IPv6 gateway IP.
+			Expect(*routes[8].Dst).To(Equal(*ovntest.MustParseIPNet("ae70::/60")))
+			Expect(routes[8].LinkIndex).To(Equal(mplink.Attrs().Index))
+			Expect(routes[8].Gw.Equal(ovntest.MustParseIP("ae70::1"))).To(BeTrue())
+			Expect(*routes[9].Dst).To(Equal(*ovntest.MustParseIPNet("ae71::/60")))
+			Expect(routes[9].LinkIndex).To(Equal(mplink.Attrs().Index))
+			Expect(routes[9].Gw.Equal(ovntest.MustParseIP("ae70::1"))).To(BeTrue())
+
+			// IPv4 and IPv6 default unreachable routes.
+			Expect(*routes[10].Dst).To(Equal(*ovntest.MustParseIPNet("0.0.0.0/0")))
+			Expect(routes[10].Type).To(Equal(unix.RTN_UNREACHABLE))
+			Expect(*routes[11].Dst).To(Equal(*ovntest.MustParseIPNet("::/0")))
+			Expect(routes[11].Type).To(Equal(unix.RTN_UNREACHABLE))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+	})
+
 	ovntest.OnSupportedPlatformsIt("should create a route import VRF in DPU mode", func() {
 		config.OvnKubeNode.Mode = types.NodeModeDPU
 		config.Gateway.Mode = config.GatewayModeShared

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -155,6 +155,26 @@ func getNetCIDRSubnet(netCIDR string) (string, error) {
 	return "", fmt.Errorf("invalid network cidr: %q", netCIDR)
 }
 
+// containingNetworkSubnet returns the configured UDN network subnet that contains
+// the given node subnet. clusterCIDRsv4/v6 are maps of configured network
+// subnets keyed by their CIDR string (for example "10.0.0.0/23").
+func containingNetworkSubnet(nodeSubnet *net.IPNet, clusterCIDRsv4, clusterCIDRsv6 map[string]struct{}) (string, error) {
+	candidates := clusterCIDRsv4
+	if utilnet.IsIPv6CIDR(nodeSubnet) {
+		candidates = clusterCIDRsv6
+	}
+	for cidr := range candidates {
+		_, networkSubnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return "", fmt.Errorf("invalid configured network subnet %q: %w", cidr, err)
+		}
+		if networkSubnet.Contains(nodeSubnet.IP) {
+			return cidr, nil
+		}
+	}
+	return "", fmt.Errorf("node subnet %s is not contained in any configured network subnet", nodeSubnet)
+}
+
 type networkAttachmentConfigParams struct {
 	cidr                string
 	excludeCIDRs        []string

--- a/test/e2e/network_segmentation.go
+++ b/test/e2e/network_segmentation.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	udnv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/userdefinednetwork/v1"
+	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	ovnkubeutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
 	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/feature"
@@ -956,150 +957,286 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 					}
 				})
 
-				DescribeTable(
-					"can perform east/west traffic between nodes on different CIDR",
+				DescribeTableSubtree("with",
 					func(netConfig *networkAttachmentConfigParams) {
-						By("validate test config")
-						cidr2nodev4 := make(map[string]*v1.Node)
-						cidr2nodev6 := make(map[string]*v1.Node)
-						netConfig.cidr = filterCIDRsAndJoin(f.ClientSet, netConfig.cidr)
-						for _, cidr := range strings.Split(netConfig.cidr, ",") {
-							c, err := getNetCIDRSubnet(cidr)
+						var (
+							networkName                                  string
+							vrfName                                      string
+							nodes                                        []*v1.Node
+							nodeToNodeSubnetV4, nodeToNodeSubnetv6       map[string]string
+							nodeToNetworkSubnetV4, nodeToNetworkSubnetV6 map[string]string
+							clusterCIDRsv4, clusterCIDRsv6               map[string]struct{}
+							ipv4, ipv6                                   bool
+						)
+
+						BeforeEach(func() {
+							By("validate test config")
+							clusterCIDRsv4 = make(map[string]struct{})
+							clusterCIDRsv6 = make(map[string]struct{})
+							netConfig.cidr = filterCIDRsAndJoin(f.ClientSet, netConfig.cidr)
+							for _, cidr := range strings.Split(netConfig.cidr, ",") {
+								c, err := getNetCIDRSubnet(cidr)
+								Expect(err).NotTo(HaveOccurred())
+								if utilnet.IsIPv4CIDRString(c) {
+									clusterCIDRsv4[c] = struct{}{}
+								} else {
+									clusterCIDRsv6[c] = struct{}{}
+								}
+							}
+
+							ipv4, ipv6 = getSupportedIPFamilies(cs)
+							if ipv4 {
+								Expect(len(clusterCIDRsv4)).To(BeNumerically(">=", 2), "need at least 2 different IPv4 CIDRs")
+							}
+							if ipv6 {
+								Expect(len(clusterCIDRsv6)).To(BeNumerically(">=", 2), "need at least 2 different IPv6 CIDRs")
+							}
+							By("creating the network with multiple CIDRs")
+							netConfig.namespace = f.Namespace.Name
+							Expect(createNetworkFn(netConfig)).To(Succeed())
+
+							By("waiting for node subnet allocation on all schedulable nodes")
+							nad, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Get(context.TODO(), netConfig.name, metav1.GetOptions{})
 							Expect(err).NotTo(HaveOccurred())
-							if utilnet.IsIPv4CIDRString(c) {
-								cidr2nodev4[c] = nil
-							} else {
-								cidr2nodev6[c] = nil
-							}
-						}
-
-						ipv4, ipv6 := getSupportedIPFamilies(cs)
-						if ipv4 {
-							Expect(len(cidr2nodev4)).To(BeNumerically(">=", 2), "need at least 2 different IPv4 CIDRs")
-						}
-						if ipv6 {
-							Expect(len(cidr2nodev6)).To(BeNumerically(">=", 2), "need at least 2 different IPv6 CIDRs")
-						}
-						By("creating the network with multiple CIDRs")
-						netConfig.namespace = f.Namespace.Name
-						Expect(createNetworkFn(netConfig)).To(Succeed())
-
-						By("ensure have 2 scheduable Nodes on different CIDR")
-						nad, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Get(context.TODO(), netConfig.name, metav1.GetOptions{})
-						Expect(err).NotTo(HaveOccurred())
-						networkName := nad.Annotations["k8s.ovn.org/network-name"]
-
-						if isDynamicUDNEnabled() {
-							nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
-							Expect(err).NotTo(HaveOccurred())
-							for i := range nodeList.Items {
-								node := &nodeList.Items[i]
-								runUDNPod(cs, f.Namespace.Name, podConfiguration{
-									name:         fmt.Sprintf("subnet-allocator-%d", i),
-									namespace:    f.Namespace.Name,
-									containerCmd: []string{"/agnhost", "pause"},
-									nodeSelector: map[string]string{nodeHostnameKey: node.Name},
-								}, nil)
-							}
-						}
-
-						node2cidrv4 := map[string]string{}
-						node2cidrv6 := map[string]string{}
-						clientNodeName, serverNodeName := "", ""
-						Eventually(func() error {
-							nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
-							if err != nil {
-								return err
+							networkName = nad.Annotations["k8s.ovn.org/network-name"]
+							networkID := nad.Annotations[ovntypes.OvnNetworkIDAnnotation]
+							Expect(networkID).NotTo(BeEmpty())
+							vrfName = fmt.Sprintf("%s%s%s", ovntypes.UDNVRFDevicePrefix, networkID, ovntypes.UDNVRFDeviceSuffix)
+							udnNamespace, udnName := ovnkubeutil.ParseNetworkName(networkName)
+							if udnNamespace == "" && udnName != "" && len(udnName) <= 15 {
+								vrfName = udnName
 							}
 
-							node2cidrv4 = map[string]string{}
-							node2cidrv6 = map[string]string{}
-							nodes := []*v1.Node{}
-							for i := range nodeList.Items {
-								node := &nodeList.Items[i]
-								ipnets, err := ovnkubeutil.ParseNodeHostSubnetAnnotation(node, networkName)
+							if isDynamicUDNEnabled() {
+								nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
+								Expect(err).NotTo(HaveOccurred())
+								for i := range nodeList.Items {
+									node := &nodeList.Items[i]
+									runUDNPod(cs, f.Namespace.Name, podConfiguration{
+										name:         fmt.Sprintf("subnet-allocator-%d", i),
+										namespace:    f.Namespace.Name,
+										containerCmd: []string{"/agnhost", "pause"},
+										nodeSelector: map[string]string{nodeHostnameKey: node.Name},
+									}, nil)
+								}
+							}
+
+							Eventually(func() error {
+								nodeList, err := e2enode.GetReadySchedulableNodes(context.TODO(), cs)
 								if err != nil {
-									if ovnkubeutil.IsAnnotationNotSetError(err) {
-										continue
-									}
 									return err
 								}
-								nodes = append(nodes, node)
-								for _, ipnet := range ipnets {
-									if utilnet.IsIPv4CIDR(ipnet) {
-										node2cidrv4[node.Name] = ipnet.String()
-									} else {
-										node2cidrv6[node.Name] = ipnet.String()
+
+								nodeToNodeSubnetV4 = map[string]string{}
+								nodeToNodeSubnetv6 = map[string]string{}
+								nodeToNetworkSubnetV4 = map[string]string{}
+								nodeToNetworkSubnetV6 = map[string]string{}
+								nodes = nil
+								for i := range nodeList.Items {
+									node := &nodeList.Items[i]
+									ipnets, err := ovnkubeutil.ParseNodeHostSubnetAnnotation(node, networkName)
+									if err != nil {
+										if ovnkubeutil.IsAnnotationNotSetError(err) {
+											continue
+										}
+										return err
+									}
+									nodes = append(nodes, node)
+									for _, ipnet := range ipnets {
+										networkSubnet, err := containingNetworkSubnet(ipnet, clusterCIDRsv4, clusterCIDRsv6)
+										if err != nil {
+											return err
+										}
+										if utilnet.IsIPv4CIDR(ipnet) {
+											nodeToNodeSubnetV4[node.Name] = ipnet.String()
+											nodeToNetworkSubnetV4[node.Name] = networkSubnet
+										} else {
+											nodeToNodeSubnetv6[node.Name] = ipnet.String()
+											nodeToNetworkSubnetV6[node.Name] = networkSubnet
+										}
 									}
 								}
-							}
+								if len(nodes) != len(nodeList.Items) {
+									return fmt.Errorf("only %d/%d nodes have a node subnet allocated for network %q", len(nodes), len(nodeList.Items), networkName)
+								}
+								if ipv4 && len(nodeToNodeSubnetV4) != len(nodes) {
+									return fmt.Errorf("only %d/%d nodes have an IPv4 node subnet allocated for network %q", len(nodeToNodeSubnetV4), len(nodes), networkName)
+								}
+								if ipv6 && len(nodeToNodeSubnetv6) != len(nodes) {
+									return fmt.Errorf("only %d/%d nodes have an IPv6 node subnet allocated for network %q", len(nodeToNodeSubnetv6), len(nodes), networkName)
+								}
+								return nil
+							}, 60*time.Second, 2*time.Second).Should(Succeed())
+						})
 
-							// find a pair of nodes with different IPv4 and IPv6 CIDRs
-							clientNodeName, serverNodeName = "", ""
+						findNodePair := func(sameNetworkSubnet bool) (string, string) {
+							GinkgoHelper()
 							for i := 0; i < len(nodes)-1; i++ {
 								for j := i + 1; j < len(nodes); j++ {
 									ni, nj := nodes[i].Name, nodes[j].Name
-									if (!ipv4 || node2cidrv4[ni] != "" && node2cidrv4[nj] != "" && node2cidrv4[ni] != node2cidrv4[nj]) &&
-										(!ipv6 || node2cidrv6[ni] != "" && node2cidrv6[nj] != "" && node2cidrv6[ni] != node2cidrv6[nj]) {
-										clientNodeName, serverNodeName = ni, nj
-										return nil
+									v4Match := !ipv4 ||
+										nodeToNetworkSubnetV4[ni] != "" &&
+											nodeToNetworkSubnetV4[nj] != "" &&
+											(nodeToNetworkSubnetV4[ni] == nodeToNetworkSubnetV4[nj]) == sameNetworkSubnet
+									v6Match := !ipv6 ||
+										nodeToNetworkSubnetV6[ni] != "" &&
+											nodeToNetworkSubnetV6[nj] != "" &&
+											(nodeToNetworkSubnetV6[ni] == nodeToNetworkSubnetV6[nj]) == sameNetworkSubnet
+									if v4Match && v6Match {
+										return ni, nj
 									}
 								}
 							}
-							return fmt.Errorf("can not find a pair of nodes with different IPv4 and IPv6 CIDRs")
-						}, 30*time.Second, 2*time.Second).Should(Succeed())
-
-						Expect(clientNodeName != "" && serverNodeName != "").To(BeTrue(), "can not find a pair of nodes with different IPv4 and IPv6 CIDRs")
-						By("creating pods on nodes")
-						clientPodConfig := podConfiguration{
-							name:         "client-pod",
-							namespace:    f.Namespace.Name,
-							nodeSelector: map[string]string{nodeHostnameKey: clientNodeName},
+							relation := "different"
+							if sameNetworkSubnet {
+								relation = "the same"
+							}
+							Fail(fmt.Sprintf("can not find two nodes allocated from %s IPv4 and IPv6 network subnets", relation))
+							return "", ""
 						}
-						serverPodConfig := podConfiguration{
-							name:         "server-pod",
-							namespace:    f.Namespace.Name,
-							containerCmd: httpServerContainerCmd(podClusterNetPort),
-							nodeSelector: map[string]string{nodeHostnameKey: serverNodeName},
-						}
-						runUDNPod(cs, f.Namespace.Name, clientPodConfig, nil)
-						runUDNPod(cs, f.Namespace.Name, serverPodConfig, nil)
 
-						clientIPs, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, clientPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
-						Expect(err).NotTo(HaveOccurred())
-						for _, clientIP := range clientIPs {
-							if utilnet.IsIPv4CIDR(clientIP) {
-								Expect(inRange(node2cidrv4[clientNodeName], clientIP.IP.String())).To(Succeed())
-							} else {
-								Expect(inRange(node2cidrv6[clientNodeName], clientIP.IP.String())).To(Succeed())
+						assertHostToPodConnectivity := func(clientNodeName, serverNodeName string) {
+							GinkgoHelper()
+
+							By(fmt.Sprintf("creating a primary UDN server pod on node %s", serverNodeName))
+							serverPodConfig := podConfiguration{
+								name:         "server-pod",
+								namespace:    f.Namespace.Name,
+								containerCmd: httpServerContainerCmd(podClusterNetPort),
+								nodeSelector: map[string]string{nodeHostnameKey: serverNodeName},
+							}
+							runUDNPod(cs, f.Namespace.Name, serverPodConfig, nil)
+
+							By(fmt.Sprintf("creating a host network client pod on node %s", clientNodeName))
+							hostNetPod, err := createPod(
+								f,
+								"client-pod-host",
+								clientNodeName,
+								f.Namespace.Name,
+								[]string{"sleep", "3600"},
+								nil,
+								func(pod *v1.Pod) {
+									pod.Spec.HostNetwork = true
+									pod.Spec.Containers[0].Image = images.Netshoot()
+									pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
+										Privileged: pointer.Bool(true),
+									}
+								},
+							)
+							Expect(err).NotTo(HaveOccurred())
+
+							serverIPs, err := getPodAnnotationIPsForAttachment(
+								cs,
+								f.Namespace.Name,
+								serverPodConfig.name,
+								namespacedName(f.Namespace.Name, netConfig.name),
+							)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(serverIPs).NotTo(BeEmpty())
+
+							for _, serverIP := range serverIPs {
+								By(fmt.Sprintf(
+									"checking host network pod on node %s can reach primary UDN pod %s on node %s through VRF %s",
+									clientNodeName,
+									serverIP.IP,
+									serverNodeName,
+									vrfName,
+								))
+								Eventually(func() error {
+									output, err := e2ekubectl.RunKubectl(
+										hostNetPod.Namespace,
+										"exec",
+										hostNetPod.Name,
+										"--",
+										"curl",
+										"--fail",
+										"--silent",
+										"--show-error",
+										"--connect-timeout",
+										"2",
+										"--max-time",
+										"5",
+										"--interface",
+										vrfName,
+										"http://"+net.JoinHostPort(serverIP.IP.String(), fmt.Sprintf("%d", podClusterNetPort)),
+									)
+									if err != nil {
+										return fmt.Errorf("failed to connect through VRF %s: %w; output: %s", vrfName, err, output)
+									}
+									return nil
+								}, 6*time.Minute, 6*time.Second).Should(Succeed())
 							}
 						}
 
-						serverIPs, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, serverPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
-						Expect(err).NotTo(HaveOccurred())
-						for _, serverIP := range serverIPs {
-							if utilnet.IsIPv4CIDR(serverIP) {
-								Expect(inRange(node2cidrv4[serverNodeName], serverIP.IP.String())).To(Succeed())
-							} else {
-								Expect(inRange(node2cidrv6[serverNodeName], serverIP.IP.String())).To(Succeed())
-							}
-						}
+						It("can perform east/west traffic between nodes on different CIDR", func() {
+							clientNodeName, serverNodeName := findNodePair(false)
 
-						By("asserting the *client* pod can contact the server pod exposed endpoint")
-						for _, serverIP := range serverIPs {
-							Eventually(func() error {
-								return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP.IP.String(), podClusterNetPort)
-							}, 6*time.Minute, 6*time.Second).Should(Succeed())
-						}
+							By("creating pods on nodes")
+							clientPodConfig := podConfiguration{
+								name:         "client-pod",
+								namespace:    f.Namespace.Name,
+								nodeSelector: map[string]string{nodeHostnameKey: clientNodeName},
+							}
+							serverPodConfig := podConfiguration{
+								name:         "server-pod",
+								namespace:    f.Namespace.Name,
+								containerCmd: httpServerContainerCmd(podClusterNetPort),
+								nodeSelector: map[string]string{nodeHostnameKey: serverNodeName},
+							}
+							runUDNPod(cs, f.Namespace.Name, clientPodConfig, nil)
+							runUDNPod(cs, f.Namespace.Name, serverPodConfig, nil)
+
+							clientIPs, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, clientPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
+							Expect(err).NotTo(HaveOccurred())
+							for _, clientIP := range clientIPs {
+								if utilnet.IsIPv4CIDR(clientIP) {
+									Expect(inRange(nodeToNodeSubnetV4[clientNodeName], clientIP.IP.String())).To(Succeed())
+								} else {
+									Expect(inRange(nodeToNodeSubnetv6[clientNodeName], clientIP.IP.String())).To(Succeed())
+								}
+							}
+
+							serverIPs, err := getPodAnnotationIPsForAttachment(cs, f.Namespace.Name, serverPodConfig.name, namespacedName(f.Namespace.Name, netConfig.name))
+							Expect(err).NotTo(HaveOccurred())
+							for _, serverIP := range serverIPs {
+								if utilnet.IsIPv4CIDR(serverIP) {
+									Expect(inRange(nodeToNodeSubnetV4[serverNodeName], serverIP.IP.String())).To(Succeed())
+								} else {
+									Expect(inRange(nodeToNodeSubnetv6[serverNodeName], serverIP.IP.String())).To(Succeed())
+								}
+							}
+
+							By("asserting the *client* pod can contact the server pod exposed endpoint")
+							for _, serverIP := range serverIPs {
+								Eventually(func() error {
+									return reachServerPodFromClient(cs, serverPodConfig, clientPodConfig, serverIP.IP.String(), podClusterNetPort)
+								}, 6*time.Minute, 6*time.Second).Should(Succeed())
+							}
+						})
+
+						It("can perform host to pod traffic via UDN VRF between nodes on different CIDR", func() {
+							clientNodeName, serverNodeName := findNodePair(false)
+							assertHostToPodConnectivity(clientNodeName, serverNodeName)
+						})
+
+						It("can perform host to pod traffic via UDN VRF between nodes on same CIDR", func() {
+							clientNodeName, serverNodeName := findNodePair(true)
+							assertHostToPodConnectivity(clientNodeName, serverNodeName)
+						})
+
+						It("can perform host to pod traffic via UDN VRF on same node", func() {
+							Expect(nodes).NotTo(BeEmpty())
+							assertHostToPodConnectivity(nodes[0].Name, nodes[0].Name)
+						})
 					},
 					Entry("L3 primary network",
 						&networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
 							// Use multiple CIDRs per IP family. The first CIDR
-							// is just big enough to allocate hostSubnets for
+							// is just big enough to allocate subnets for
 							// the first two nodes, remaining nodes will be
-							// allocated hostSubnets from the second CIDR
+							// allocated subnets from the second CIDR.
 							cidr: primaryLayer3MultiCIDRs(),
 							role: "primary",
 						},
@@ -1143,10 +1280,6 @@ var _ = Describe("Network Segmentation", feature.NetworkSegmentation, func() {
 						e2eskipper.Skipf("need at least 3 ready schedulable nodes to run this test")
 					}
 
-					// Use multiple CIDRs per IP family. The first CIDR is just
-					// big enough to allocate hostSubnets for the first two
-					// nodes, remaining nodes will be allocated hostSubnets from
-					// the second CIDR
 					userDefinedNetworkIPv4Subnet1, userDefinedNetworkIPv4Subnet2 := primaryLayer3IPv4CIDRs()
 					userDefinedNetworkIPv6Subnet1, userDefinedNetworkIPv6Subnet2 := primaryLayer3IPv6CIDRs()
 					By("creating the initial network with one CIDR")


### PR DESCRIPTION
## 📑 Description

Host-networked pods cannot reach regular pod IPs on a primary Layer3 UDN when:

1. Traffic is sent from host network with the UDN VRF, and
2. The source node and destination pod are on different UDN cluster subnets.

Connectivity works when both nodes are on the same UDN cluster subnet, but fails across subnets.

Example topology

UDN cluster subnets:
  - 10.1.0.0/16/17
  - 10.2.0.0/16/17
 
Node host subnets:
  - ovn-control-plane: 10.2.0.0/17
  - ovn-worker:          10.1.0.0/17
  - ovn-worker2:         10.1.128.0/17
  
From ovn-control-plane, pinging a pod on ovn-worker (10.1.0.4) or ovn-worker2 (10.1.128.4) via the UDN VRF fails. Pinging a pod on the same subnet (10.2.0.4) succeeds.

### Symptoms
On the source node, route lookup inside the UDN VRF shows the difference:
```bash
# Same cluster subnet as source node -> into OVN via management port (works)
$ ip route get 10.2.0.4 vrf mp1-udn-vrf
10.2.0.4 dev ovn-k8s-mp1 table 1009 src 10.2.0.2
# Other UDN cluster subnet -> falls through to VRF default route (fails)
$ ip route get 10.1.0.4 vrf mp1-udn-vrf
10.1.0.4 via 172.18.0.1 dev breth0 table 1009 src 10.2.0.2
```
Traffic to pods on other UDN cluster subnets leaves the node via the external gateway instead of entering OVN through the management port.

### Notes

Host→pod on a primary UDN requires binding sockets to the UDN VRF device; traffic in the default VRF is expected to fail.

### Fix
Program a management-port route for every cluster subnet of the same IP family in a Layer3 UDN VRF, not only the subnet that contains the node's local gateway IP.

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI 

This PR fixes a bug which introduced by UDN multi-subnets support, no documentation change required

## How to verify it
Add a unit test to verify multi-subnet UDNs install routes for all cluster subnets via the node's gateway IP.
