### PR TITLE
UT fix: Stabilize transit switch IP reallocation test

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_test.go
@@ -1616,12 +1616,22 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 							return fmt.Errorf("transit switch ips for node %s not allocated", n.Name)
 						}
 
+						// Wait for the other initial node annotation writer before testing reallocation.
+						hostSubnets, err := util.ParseNodeHostSubnetAnnotation(updatedNode, ovntypes.DefaultNetworkName)
+						if err != nil {
+							return fmt.Errorf("error parsing host subnet annotation for node %s: %v", n.Name, err)
+						}
+						if len(hostSubnets) < 1 {
+							return fmt.Errorf("host subnet for node %s not allocated", n.Name)
+						}
+
 						return nil
 					}).ShouldNot(gomega.HaveOccurred())
 				}
 
 				// Clear the transit switch port ip annotation from node 1.
-				node1, _ := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), "node1", metav1.GetOptions{})
+				node1, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), "node1", metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				nodeAnnotations := node1.Annotations
 				nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{KClient: kubeFakeClient}, "node1")
 				for k, v := range nodeAnnotations {
@@ -1651,7 +1661,10 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 					if len(transitSwitchIps) < 1 {
 						return fmt.Errorf("transit switch ips for node node1 not allocated")
 					}
-					gomega.Expect(node1TransitSwitchIps).To(gomega.Equal(updatedNode1TransitSwitchIps))
+					if node1TransitSwitchIps != updatedNode1TransitSwitchIps {
+						return fmt.Errorf("expected transit switch ips %q for node node1, got %q",
+							node1TransitSwitchIps, updatedNode1TransitSwitchIps)
+					}
 					return nil
 				}).ShouldNot(gomega.HaveOccurred())
 


### PR DESCRIPTION
The cluster manager has independent initial writers for node and network annotations. The test could observe the transit address before the default network writer completed, then save the address while that writer had temporarily removed it.

Wait for both the default host subnet and transit address before deleting the transit annotation. Return address mismatches through Eventually so transient states are retried instead of failing immediately.

Fixes: #6594


Assisted-By: OpenAI Codex <codex@openai.com>

