### PR TITLE
Stabilize RouteAdvertisements preservation test

### DIFF
--- a/go-controller/pkg/networkmanager/network_controller_test.go
+++ b/go-controller/pkg/networkmanager/network_controller_test.go
@@ -249,8 +249,6 @@ func TestSetAdvertisements(t *testing.T) {
 			err = wf.Start()
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			defer wf.Shutdown()
-			g.Expect(nm.Start()).To(gomega.Succeed())
-			defer nm.Stop()
 
 			netInfo, err := util.NewNetInfo(tt.network)
 			g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -278,6 +276,8 @@ func TestSetAdvertisements(t *testing.T) {
 			}
 
 			nm.EnsureNetwork(mutableNetInfo)
+			g.Expect(nm.Start()).To(gomega.Succeed())
+			defer nm.Stop()
 
 			meetsExpectations := func(g gomega.Gomega) {
 				tcm.Lock()


### PR DESCRIPTION
Commit 585b72c222 ("Allow networks to start while route advertisements settle") added coverage that installs an existing network controller and verifies its advertised VRFs are preserved when a referenced RouteAdvertisements object is missing.

The fixture started the network manager before installing that existing controller and before ensuring the desired network. An initial Node event could reconcile the injected controller while no desired network was registered, stop it as stale, and let a later EnsureNetwork create a replacement with empty advertised VRFs. The assertion therefore depended on goroutine scheduling.

Install the existing controller state and call EnsureNetwork before starting the network manager. Initial sync now sees both current and desired state and exercises the intended preservation path deterministically.


