### PR TITLE
ovn: complete egress node setup after reroute retry

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -1037,6 +1037,9 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 		if fromRetryLoop {
 			_, shouldSyncReroute = h.oc.syncEIPNodeRerouteFailed.Load(node.Name)
 			_, shouldSyncEIPNode = h.oc.syncEIPNodeFailed.Load(node.Name)
+			// addEgressNode runs after the reroute setup, so a reroute failure
+			// means that the egress node setup was never attempted.
+			shouldSyncEIPNode = shouldSyncEIPNode || shouldSyncReroute
 		}
 
 		if shouldSyncReroute {
@@ -1116,16 +1119,19 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		h.oc.eIPC.nodeZoneState.Store(newNode.Name, h.oc.isLocalZoneNode(newNode))
 		h.oc.eIPC.nodeZoneState.UnlockKey(newNode.Name)
 
-		_, syncEIPNodeRerouteFailed := h.oc.syncEIPNodeRerouteFailed.Load(newNode.Name)
+		_, rerouteRetryPending := h.oc.syncEIPNodeRerouteFailed.Load(newNode.Name)
+		newNodeIsLocal := h.oc.isLocalZoneNode(newNode)
+		nodeBecameLocal := !h.oc.isLocalZoneNode(oldNode) && newNodeIsLocal
 
 		// node moved from remote -> local or previously failed reroute config
-		if (!h.oc.isLocalZoneNode(oldNode) || syncEIPNodeRerouteFailed) && h.oc.isLocalZoneNode(newNode) {
+		if nodeBecameLocal || (rerouteRetryPending && newNodeIsLocal) {
 			if err := h.oc.eIPC.ensureDefaultNoRerouteQoSRules(newNode.Name); err != nil {
+				h.oc.syncEIPNodeRerouteFailed.Store(newNode.Name, true)
 				return err
 			}
 		}
 		// update the nodeIP in the default-reRoute (102 priority) destination address-set
-		if syncEIPNodeRerouteFailed || util.NodeHostCIDRsAnnotationChanged(oldNode, newNode) {
+		if rerouteRetryPending || util.NodeHostCIDRsAnnotationChanged(oldNode, newNode) {
 			klog.Infof("Egress IP detected IP address change for node %s. Updating no re-route policies", newNode.Name)
 			err := h.oc.eIPC.ensureDefaultNoRerouteNodePolicies()
 			if err != nil {
@@ -1136,7 +1142,7 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		}
 
 		_, syncEIPNodeFailed := h.oc.syncEIPNodeFailed.Load(newNode.Name)
-		if syncEIPNodeFailed {
+		if syncEIPNodeFailed || rerouteRetryPending || nodeBecameLocal {
 			err := h.oc.eIPC.addEgressNode(newNode)
 			if err != nil {
 				h.oc.syncEIPNodeFailed.Store(newNode.Name, true)

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -6443,6 +6444,101 @@ var _ = ginkgo.Describe("OVN EgressIP Operations cluster default network", func(
 		})
 	})
 	ginkgo.Context("WatchEgressNodes", func() {
+		ginkgo.DescribeTable("retries egress node setup after reroute setup failed", func(update bool) {
+			app.Action = func(*cli.Context) error {
+				node := getNodeObj(node1Name, map[string]string{
+					util.OvnNodeID:       "1",
+					util.OvnNodeZoneName: node1Name,
+				}, nil)
+				fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.NBGlobal{Name: node1Name},
+						&nbdb.LogicalRouter{
+							Name: types.OVNClusterRouter,
+							UUID: types.OVNClusterRouter + "-UUID",
+						},
+						&nbdb.LogicalSwitch{
+							Name: node1Name,
+							UUID: node1Name + "-UUID",
+						},
+					},
+				}, &corev1.NodeList{Items: []corev1.Node{node}})
+				gomega.Expect(fakeOvn.controller.eIPC.initClusterEgressPolicies(nil)).To(gomega.Succeed())
+
+				fakeOvn.controller.syncEIPNodeRerouteFailed.Store(node.Name, true)
+				handler := &defaultNetworkControllerEventHandler{
+					objType: factory.EgressNodeType,
+					oc:      fakeOvn.controller,
+				}
+				if update {
+					gomega.Expect(handler.UpdateResource(&node, &node, true)).To(gomega.Succeed())
+				} else {
+					gomega.Expect(handler.AddResource(&node, true)).To(gomega.Succeed())
+				}
+
+				var routes []nbdb.LogicalRouterStaticRoute
+				err := fakeOvn.nbClient.WhereCache(func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.IPPrefix == v4ClusterSubnet &&
+						route.Policy != nil && *route.Policy == nbdb.LogicalRouterStaticRoutePolicySrcIP
+				}).List(context.Background(), &routes)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(routes).To(gomega.HaveLen(1))
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		},
+			ginkgo.Entry("during an add retry", false),
+			ginkgo.Entry("during an update", true),
+		)
+
+		ginkgo.It("creates egress node routes when a node becomes local", func() {
+			app.Action = func(*cli.Context) error {
+				localNode := getNodeObj(node1Name, map[string]string{
+					util.OvnNodeID:       "1",
+					util.OvnNodeZoneName: node1Name,
+				}, nil)
+				remoteNode := localNode.DeepCopy()
+				remoteNode.Annotations[util.OvnNodeZoneName] = node2Name
+
+				fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.NBGlobal{Name: node1Name},
+						&nbdb.LogicalRouter{
+							Name: types.OVNClusterRouter,
+							UUID: types.OVNClusterRouter + "-UUID",
+						},
+						&nbdb.LogicalSwitch{
+							Name: node1Name,
+							UUID: node1Name + "-UUID",
+						},
+					},
+				}, &corev1.NodeList{Items: []corev1.Node{localNode}})
+				handler := &defaultNetworkControllerEventHandler{
+					objType: factory.EgressNodeType,
+					oc:      fakeOvn.controller,
+				}
+				gomega.Expect(handler.UpdateResource(remoteNode, &localNode, false)).NotTo(gomega.Succeed())
+				_, rerouteRetryPending := fakeOvn.controller.syncEIPNodeRerouteFailed.Load(localNode.Name)
+				gomega.Expect(rerouteRetryPending).To(gomega.BeTrue())
+
+				gomega.Expect(fakeOvn.controller.eIPC.initClusterEgressPolicies(nil)).To(gomega.Succeed())
+				gomega.Expect(handler.UpdateResource(&localNode, &localNode, true)).To(gomega.Succeed())
+				_, rerouteRetryPending = fakeOvn.controller.syncEIPNodeRerouteFailed.Load(localNode.Name)
+				gomega.Expect(rerouteRetryPending).To(gomega.BeFalse())
+
+				var routes []nbdb.LogicalRouterStaticRoute
+				err := fakeOvn.nbClient.WhereCache(func(route *nbdb.LogicalRouterStaticRoute) bool {
+					return route.IPPrefix == v4ClusterSubnet &&
+						route.Policy != nil && *route.Policy == nbdb.LogicalRouterStaticRoutePolicySrcIP
+				}).List(context.Background(), &routes)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(routes).To(gomega.HaveLen(1))
+				return nil
+			}
+
+			gomega.Expect(app.Run([]string{app.Name})).To(gomega.Succeed())
+		})
 
 		ginkgo.It("should populated egress node data as they are tagged `egress assignable` with variants of IPv4/IPv6", func() {
 			app.Action = func(*cli.Context) error {


### PR DESCRIPTION
A reroute-stage failure returns before addEgressNode runs, but the retry path previously retried only the failed stage. Treat the downstream egress node setup as pending whenever reroute setup failed, for both add retries and subsequent updates.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
