### PR TITLE
Port miscellaneous uses of iptables in e2e to nftables

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -40,7 +40,6 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	testutils "k8s.io/kubernetes/test/utils"
-	kexec "k8s.io/utils/exec"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -358,48 +357,6 @@ func createServiceForPodsWithLabel(f *framework.Framework, namespace string, ser
 		return "", errors.Wrapf(err, "Failed to get service %s %s", service.Name, namespace)
 	}
 	return res.Spec.ClusterIP, nil
-}
-
-// forwardIPWithIPTables inserts an iptables rule to always accept source and destination of arg ip
-func forwardIPWithIPTables(ip string) (func() error, error) {
-	isIPv6 := utilnet.IsIPv6String(ip)
-	ipTablesBin := "iptables"
-	if isIPv6 {
-		ipTablesBin = "ip6tables"
-	}
-	mask := "/32"
-	if isIPv6 {
-		mask = "/128"
-	}
-
-	var cleanUpFns []func() error
-	cleanUp := func() error {
-		var errs []error
-		for _, cleanUpFn := range cleanUpFns {
-			if err := cleanUpFn(); err != nil {
-				errs = append(errs, err)
-			}
-		}
-		return utilerrors.AggregateGoroutines(cleanUpFns...)
-	}
-	exec := kexec.New()
-	_, err := exec.Command("sudo", ipTablesBin, "-I", "FORWARD", "-s", ip+mask, "-j", "ACCEPT").CombinedOutput()
-	if err != nil {
-		return cleanUp, fmt.Errorf("failed to insert rule to forward IP %q: %w", ip+mask, err)
-	}
-	cleanUpFns = append(cleanUpFns, func() error {
-		exec.Command("sudo", ipTablesBin, "-D", "FORWARD", "-s", ip+mask, "-j", "ACCEPT").CombinedOutput()
-		return nil
-	})
-	_, err = exec.Command("sudo", ipTablesBin, "-I", "FORWARD", "-d", ip+mask, "-j", "ACCEPT").CombinedOutput()
-	if err != nil {
-		return cleanUp, fmt.Errorf("failed to insert rule to forward IP %q: %w", ip+mask, err)
-	}
-	cleanUpFns = append(cleanUpFns, func() error {
-		exec.Command("sudo", ipTablesBin, "-D", "FORWARD", "-d", ip+mask, "-j", "ACCEPT").CombinedOutput()
-		return nil
-	})
-	return cleanUp, nil
 }
 
 // updatesNamespace labels while preserving the required UDN label
@@ -769,9 +726,6 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		framework.Logf("Target node is %q and IP is %q", targetNodeName, targetNodeIP)
 		err = setupHostRedirectPod(f, secondaryExternalContainer, targetNodeName, targetNodeIP, IsIPv6Cluster(f.ClientSet))
 		framework.ExpectNoError(err)
-
-		cleanUp, err := forwardIPWithIPTables(redirectIP)
-		ginkgo.DeferCleanup(cleanUp)
 
 		// start TCP client
 		go func() {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -58,25 +58,36 @@ const (
 	localNodePortStableProbeCount        = 3
 )
 
-// setupHostRedirectPod
-func setupHostRedirectPod(f *framework.Framework, externalContainer infraapi.ExternalContainer, nodeName, nodeIP string, isIPv6 bool) error {
+// setupHostRedirectPod:
+//   - adds a route to externalContainer for redirectIP pointing to nodeIP
+//   - adds an nftables rule to nodeName redirecting redirectIP traffic to itself
+//   - creates a hostNetwork pod on nodeName that accepts traffic on redirectPort.
+//
+// The net effect is that traffic addressed to redirectIP:redirectPort from
+// externalContainer will end up at the created hostNetwork pod. The returned cleanup
+// function will remove the nftables rules on nodeName.
+//
+// Note that setupHostRedirectPod() is not parallel-safe; you can't call it twice with the
+// same nodeName without cleaning up in between.
+func setupHostRedirectPod(f *framework.Framework, externalContainer infraapi.ExternalContainer, nodeName, nodeIP string, isIPv6 bool) (func() error, error) {
 	mask := 32
 	ipCmd := []string{"ip"}
+	nftFamily := ""
 	if isIPv6 {
 		mask = 128
 		ipCmd = []string{"ip", "-6"}
+		nftFamily = "6"
 	}
+
+	// Add the route to the externalContainer; no cleanup is needed for this part
+	// because external containers only persist for a single test's lifetime.
 	cmd := []string{}
 	cmd = append(cmd, ipCmd...)
 	cmd = append(cmd, "route", "add", fmt.Sprintf("%s/%d", redirectIP, mask), "via", nodeIP)
-	_, err := infraprovider.Get().ExecExternalContainerCommand(externalContainer, cmd) // cleanup not needed because containers persist for a single tests lifetime
+	_, err := infraprovider.Get().ExecExternalContainerCommand(externalContainer, cmd)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	// setup redirect iptables rule in node
-	ipTablesArgs := []string{"PREROUTING", "-t", "nat", "--dst", redirectIP, "-j", "REDIRECT"}
-	updateIPTablesRulesForNode("insert", nodeName, ipTablesArgs, isIPv6)
 
 	command := []string{
 		"bash", "-c",
@@ -105,10 +116,24 @@ func setupHostRedirectPod(f *framework.Framework, externalContainer infraapi.Ext
 	podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
 	_, err = podClient.Create(context.Background(), pod, metav1.CreateOptions{})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = e2epod.WaitForPodNotPending(context.TODO(), f.ClientSet, f.Namespace.Name, tcpServer)
-	return err
+	if err != nil {
+		return nil, err
+	}
+
+	// setup redirect rule on the node
+	rule := fmt.Sprintf("ip%s daddr %s redirect", nftFamily, redirectIP)
+	execNodeNFT(nodeName, "add table inet ovn-kube-e2e")
+	execNodeNFT(nodeName, "add chain inet ovn-kube-e2e prerouting { type nat hook prerouting priority dstnat ; }")
+	execNodeNFT(nodeName, "flush chain inet ovn-kube-e2e prerouting")
+	execNodeNFT(nodeName, "add rule inet ovn-kube-e2e prerouting "+rule)
+	cleanup := func() error {
+		execNodeNFT(nodeName, "delete chain inet ovn-kube-e2e prerouting")
+		return nil
+	}
+	return cleanup, nil
 }
 
 // checkContinuousConnectivity creates a pod and checks that it can connect to the given host over tries*2 seconds.
@@ -724,8 +749,9 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		}
 		gomega.Expect(targetNodeIP).NotTo(gomega.BeEmpty(), "unable to find Node IP for secondary network")
 		framework.Logf("Target node is %q and IP is %q", targetNodeName, targetNodeIP)
-		err = setupHostRedirectPod(f, secondaryExternalContainer, targetNodeName, targetNodeIP, IsIPv6Cluster(f.ClientSet))
+		cleanUp, err := setupHostRedirectPod(f, secondaryExternalContainer, targetNodeName, targetNodeIP, IsIPv6Cluster(f.ClientSet))
 		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(cleanUp)
 
 		// start TCP client
 		go func() {

--- a/test/e2e/egress_services.go
+++ b/test/e2e/egress_services.go
@@ -1350,9 +1350,6 @@ spec:
 							expected = net.nodesV6IPs[nodes[i].Name]
 							dst = sharedIPv6
 						}
-						cleanUp, err := forwardIPWithIPTables(dst)
-						ginkgo.DeferCleanup(cleanUp)
-						framework.ExpectNoError(err, "must add rules to always forward IP")
 
 						gomega.Eventually(func() error {
 							return curlAgnHostClientIPFromPod(f.Namespace.Name, pod, expected, dst, podHTTPPort)
@@ -1366,9 +1363,6 @@ spec:
 							return curlAgnHostHostnameFromPod(f.Namespace.Name, pod, net.containerName, dst, podHTTPPort)
 						}, 1*time.Second, 200*time.Millisecond).ShouldNot(gomega.HaveOccurred(), "reached an external container with the wrong hostname")
 					}
-					cleanUp, err := forwardIPWithIPTables(net.serviceIP)
-					ginkgo.DeferCleanup(cleanUp)
-					framework.ExpectNoError(err, "must add rules to always forward IP")
 					//FIXME(mk): whole test case is broken for multi platform
 					reachAllServiceBackendsFromExternalContainer(infraapi.ExternalContainer{Name: net.containerName}, net.serviceIP, podHTTPPort, net.createdPods)
 				}

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -148,7 +148,7 @@ func (h *egressNodeAvailabilityHandlerViaHealthCheck) checkMode(restore bool) (s
 
 // setMode reconfigures ovnkube, if needed, to use the health check type, either
 // GRPC or Legacy, as indicated by the h.Legacy setting. Additionaly it can
-// configure an iptables rule to drop the health check traffic on the given
+// configure an nftables rule to drop the health check traffic on the given
 // node. If restore is true, it will restore the configuration to the one first
 // observed.
 func (h *egressNodeAvailabilityHandlerViaHealthCheck) setMode(nodeName string, reject, restore bool) {

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -3605,15 +3605,21 @@ func setupIPv6NetworkForExternalClient(svcLoadBalancerIP string, svcLoadBalancer
 	err = buildAndRunCommand(fmt.Sprintf("sudo ip -6 route add %s via %s", svcLoadBalancerIP, nodeIP))
 	framework.ExpectNoError(err, "failed to add route for external load balancer service")
 
-	err = buildAndRunCommand(fmt.Sprintf("sudo ip6tables -t filter -I FORWARD -d %s -p tcp -m tcp --dport %d -j ACCEPT", svcLoadBalancerIP, svcLoadBalancerPort))
-	framework.ExpectNoError(err, "failed to add iptables rule for service")
+	err = buildAndRunCommand("sudo nft add table inet ovn-kube-e2e")
+	framework.ExpectNoError(err, "failed to add nft rules for service")
+	err = buildAndRunCommand("sudo nft add chain inet ovn-kube-e2e fwd-external-v6 { type filter hook forward priority filter ; }")
+	framework.ExpectNoError(err, "failed to add nft rules for service")
+	err = buildAndRunCommand("sudo nft flush chain inet ovn-kube-e2e fwd-external-v6")
+	framework.ExpectNoError(err, "failed to add nft rules for service")
+	err = buildAndRunCommand(fmt.Sprintf("sudo nft add rule inet ovn-kube-e2e fwd-external-v6 ip6 daddr %s tcp dport %d accept", svcLoadBalancerIP, svcLoadBalancerPort))
+	framework.ExpectNoError(err, "failed to add nft rules for service")
 }
 
 func cleanupIPv6NetworkForExternalClient(svcLoadBalancerIP string, svcLoadBalancerPort int) {
 	cleanupNetNamespace()
 	buildAndRunCommand("sudo ip -6 route delete fc00:f853:ccd:e223::2")
 	buildAndRunCommand(fmt.Sprintf("sudo ip -6 route delete %s", svcLoadBalancerIP))
-	buildAndRunCommand(fmt.Sprintf("sudo ip6tables -t filter -D FORWARD -d %s -p tcp -m tcp --dport %d -j ACCEPT", svcLoadBalancerIP, svcLoadBalancerPort))
+	buildAndRunCommand("sudo nft delete chain inet ovn-kube-e2e fwd-external-v6")
 }
 
 func setupNetNamespaceAndLinks() {

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -3513,7 +3513,6 @@ func setupIPv4NetworkForExternalClient(svcLoadBalancerIP string, svcLoadBalancer
 	//                   |                                  172.18.0.1                                  |
 	//                   |                                                     ip route add 192.168.223.0/24 via 192.168.222.2
 	//                   |                                                     ip route add <svc-ip> via|<endpoint-node-ip>
-	//                   |                                                     iptables -t filter -I FORWARD -d <svc-ip> -p tcp -m tcp --dport <svc-port> -j ACCEPT
 	//                   |                                                                              |
 	//                   |  vm                                    192.168.222.1                         |
 	//                   +----------------------------------------+-------------------------------------+
@@ -3544,9 +3543,6 @@ func setupIPv4NetworkForExternalClient(svcLoadBalancerIP string, svcLoadBalancer
 	err = buildAndRunCommand("sudo ip route add 192.168.223.0/24 via 192.168.222.2")
 	framework.ExpectNoError(err, "failed to add route for client to handle reverse service traffic")
 
-	err = buildAndRunCommand(fmt.Sprintf("sudo iptables -t filter -I FORWARD -d %s -p tcp -m tcp --dport %d -j ACCEPT", svcLoadBalancerIP, svcLoadBalancerPort))
-	framework.ExpectNoError(err, "failed to add iptables rule for service")
-
 	err = buildAndRunCommand(fmt.Sprintf("sudo ip route add %s via %s", svcLoadBalancerIP, nodeIP))
 	framework.ExpectNoError(err, "failed to add route for external load balancer service")
 }
@@ -3555,7 +3551,6 @@ func cleanupIPv4NetworkForExternalClient(svcLoadBalancerIP string, svcLoadBalanc
 	cleanupNetNamespace()
 	buildAndRunCommand("sudo ip route delete 192.168.223.0/24 via 192.168.222.2")
 	buildAndRunCommand(fmt.Sprintf("sudo ip route delete %s", svcLoadBalancerIP))
-	buildAndRunCommand(fmt.Sprintf("sudo iptables -t filter -D FORWARD -d %s -p tcp -m tcp --dport %d -j ACCEPT", svcLoadBalancerIP, svcLoadBalancerPort))
 }
 
 func setupIPv6NetworkForExternalClient(svcLoadBalancerIP string, svcLoadBalancerPort int, nodeIP string) {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1148,47 +1148,31 @@ func setUnsetTemplateContainerEnv(c kubernetes.Interface, namespace, resource, c
 	framework.ExpectNoError(err)
 }
 
-// allowOrDropNodeInputTrafficOnPort ensures or deletes a drop iptables
-// input rule for the specified node, protocol and port
+// allowOrDropNodeInputTrafficOnPort ensures or deletes a drop nftables input rule for the
+// specified node, protocol and port
 func allowOrDropNodeInputTrafficOnPort(op, nodeName, protocol, port string) {
-	ipTablesArgs := []string{"INPUT", "-p", protocol, "--dport", port, "-j", "DROP"}
+	// Create a chain name specific to this protocol/port. Ensure that the chain exists
+	// (so we can "nft delete" it without error) then either fill it in or delete it.
+	chain := fmt.Sprintf("drop-%s-%s", protocol, port)
+	execNodeNFT(nodeName, "add table inet ovn-kube-e2e")
+	execNodeNFT(nodeName, fmt.Sprintf("add chain inet ovn-kube-e2e %s { type filter hook input priority filter ; }", chain))
+
 	switch op {
 	case "Allow":
-		op = "delete"
+		execNodeNFT(nodeName, fmt.Sprintf("delete chain inet ovn-kube-e2e %s", chain))
 	case "Drop":
-		op = "insert"
+		execNodeNFT(nodeName, fmt.Sprintf("flush chain inet ovn-kube-e2e %s", chain))
+		execNodeNFT(nodeName, fmt.Sprintf("add rule inet ovn-kube-e2e %s %s dport %s drop", chain, protocol, port))
 	default:
 		framework.Failf("unsupported op %s", op)
 	}
-	updateIPTablesRulesForNode(op, nodeName, ipTablesArgs, false)
-	updateIPTablesRulesForNode(op, nodeName, ipTablesArgs, true)
 }
 
-func updateIPTablesRulesForNode(op, nodeName string, ipTablesArgs []string, ipv6 bool) {
-	iptables := "iptables"
-	if ipv6 {
-		iptables = "ip6tables"
-	}
-	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, append([]string{iptables, "-v", "--check"}, ipTablesArgs...))
-	// errors known to be equivalent to not found
-	notFound1 := "No chain/target/match by that name"
-	notFound2 := "does a matching rule exist in that chain?"
-	notFound := err != nil && (strings.Contains(err.Error(), notFound1) || strings.Contains(err.Error(), notFound2))
-	if err != nil && !notFound {
-		framework.Failf("failed to check existence of %s rule on node %s: %v", iptables, nodeName, err)
-	}
-	if op == "delete" && notFound {
-		// rule is not there
-		return
-	} else if op == "insert" && err == nil {
-		// rule is already there
-		return
-	}
-	framework.Logf("%s %s rule: %q on node %s", op, iptables, strings.Join(ipTablesArgs, ","), nodeName)
-	args := []string{iptables, "--" + op}
-	_, err = infraprovider.Get().ExecK8NodeCommand(nodeName, append(args, ipTablesArgs...))
+func execNodeNFT(nodeName, nftCmd string) {
+	framework.Logf("node %s, nft %v", nodeName, nftCmd)
+	_, err := infraprovider.Get().ExecK8NodeCommand(nodeName, []string{"nft", nftCmd})
 	if err != nil {
-		framework.Failf("failed to update %s rule on node %s: %v", iptables, nodeName, err)
+		framework.Failf("failed to update nft rule on node %s: %v", nodeName, err)
 	}
 }
 


### PR DESCRIPTION
A handful of e2e tests use iptables to redirect or block traffic for various test cases. This updates them to use nftables.