### PR TITLE
Preserve ovs-vsctl port and bridge semantics

### DIFF
--- a/go-controller/pkg/libovsdb/ops/vswitchdb.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/model"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -155,6 +156,33 @@ func GetPortBridge(ovsClient libovsdbclient.Client, portName string) (*vswitchd.
 	return nil, fmt.Errorf("no bridge contains port %q: %w", portName, libovsdbclient.ErrNotFound)
 }
 
+// getInterfacePort returns the OVS port that owns the named interface.
+// Returns ErrNotFound if the interface does not exist or no port references it.
+func getInterfacePort(ovsClient libovsdbclient.Client, interfaceName string) (*vswitchd.Port, error) {
+	iface, err := GetOVSInterface(ovsClient, interfaceName)
+	if err != nil {
+		return nil, err
+	}
+	ports, err := FindOVSPortsWithPredicate(ovsClient, func(port *vswitchd.Port) bool {
+		for _, uuid := range port.Interfaces {
+			if uuid == iface.UUID {
+				return true
+			}
+		}
+		return false
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(ports) > 1 {
+		return nil, fmt.Errorf("OVSDB corruption: interface %q is referenced by multiple ports: %w", interfaceName, errMultipleResults)
+	}
+	if len(ports) == 1 {
+		return ports[0], nil
+	}
+	return nil, fmt.Errorf("no port contains interface %q: %w", interfaceName, libovsdbclient.ErrNotFound)
+}
+
 // CreateOrUpdateNicBridge creates (or reconfigures) an OVS bridge for an
 // uplink NIC. It sets fail-mode=standalone, the supplied hardware address,
 // and external_ids bridge-id/bridge-uplink on the bridge; attaches the
@@ -190,13 +218,22 @@ func CreateOrUpdateNicBridge(ovsClient libovsdbclient.Client, bridgeName, uplink
 		}
 		existing, err := GetPortBridge(ovsClient, portName)
 		if err != nil {
+			if !errors.Is(err, libovsdbclient.ErrNotFound) {
+				return fmt.Errorf("failed to check existing bridge for port %q: %w", portName, err)
+			}
+		} else if existing.Name != bridgeName {
+			return fmt.Errorf("port %q is already attached to bridge %q", portName, existing.Name)
+		}
+
+		owner, err := getInterfacePort(ovsClient, portName)
+		if err != nil {
 			if errors.Is(err, libovsdbclient.ErrNotFound) {
 				continue
 			}
-			return fmt.Errorf("failed to check existing bridge for port %q: %w", portName, err)
+			return fmt.Errorf("failed to check existing port for interface %q: %w", portName, err)
 		}
-		if existing.Name != bridgeName {
-			return fmt.Errorf("port %q is already attached to bridge %q", portName, existing.Name)
+		if owner.Name != portName {
+			return fmt.Errorf("interface %q is already attached to port %q", portName, owner.Name)
 		}
 	}
 
@@ -335,6 +372,20 @@ func DeleteBridgeOps(ovsClient libovsdbclient.Client, ops []ovsdb.Operation, bri
 		}
 		return nil, err
 	}
+
+	// Flow_Sample_Collector_Set is a root table with a strong reference to
+	// Bridge. ovs-vsctl del-br removes these rows before deleting the bridge;
+	// otherwise OVSDB rejects the transaction for referential-integrity.
+	collector := &vswitchd.FlowSampleCollectorSet{}
+	collectorOps, err := ovsClient.WhereAll(collector, model.Condition{
+		Field:    &collector.Bridge,
+		Function: ovsdb.ConditionEqual,
+		Value:    bridge.UUID,
+	}).Delete()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build flow sample collector delete operations for bridge %q: %w", bridgeName, err)
+	}
+	ops = append(ops, collectorOps...)
 
 	m := newModelClient(ovsClient)
 	ovs := &vswitchd.OpenvSwitch{Bridges: []string{bridge.UUID}}
@@ -548,6 +599,13 @@ func CreateOrUpdatePodPortOps(ovsClient libovsdbclient.Client, ops []ovsdb.Opera
 	if existing != nil && existing.Name != bridgeName {
 		return nil, fmt.Errorf("port %q is already attached to bridge %q", portName, existing.Name)
 	}
+	owner, err := getInterfacePort(ovsClient, portName)
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return nil, err
+	}
+	if owner != nil && owner.Name != portName {
+		return nil, fmt.Errorf("interface %q is already attached to port %q", portName, owner.Name)
+	}
 
 	iface.Name = portName
 	port.Name = portName
@@ -584,19 +642,29 @@ func CreateOrUpdatePodPortOps(ovsClient libovsdbclient.Client, ops []ovsdb.Opera
 	return m.CreateOrUpdateOps(ops, ifaceModel, portModel, bridgeModel)
 }
 
-// DeletePortWithInterfaces deletes an OVS port and all its interfaces from a
-// bridge. The deletion is scoped to bridgeName: a port that exists with the
-// given name but is attached to a different bridge is left untouched, matching
-// the semantics of `ovs-vsctl --if-exists --with-iface del-port <bridge>
-// <port>`. The function is idempotent - a missing port, or a missing bridge,
-// are both no-ops.
-func DeletePortWithInterfaces(ovsClient libovsdbclient.Client, bridgeName, portName string) error {
-	port, err := GetOVSPort(ovsClient, portName)
+// DeletePortWithInterfaces deletes a named OVS port, or the port containing a
+// named interface, and all of that port's interfaces from a bridge. Like
+// `ovs-vsctl --if-exists --with-iface del-port`, a missing target is a no-op.
+// The deletion is safely scoped to bridgeName: a target attached to another
+// bridge is logged and left untouched.
+func DeletePortWithInterfaces(ovsClient libovsdbclient.Client, bridgeName, portOrInterfaceName string) error {
+	port, err := GetOVSPort(ovsClient, portOrInterfaceName)
 	if err != nil {
-		if errors.Is(err, libovsdbclient.ErrNotFound) {
-			return nil // Port doesn't exist, nothing to delete
+		if !errors.Is(err, libovsdbclient.ErrNotFound) {
+			return err
 		}
-		return err
+		// Match ovs-vsctl del-port --with-iface: if the target is not a
+		// Port name, resolve it as an Interface name and delete its Port.
+		port, err = getInterfacePort(ovsClient, portOrInterfaceName)
+		if err != nil {
+			if errors.Is(err, libovsdbclient.ErrNotFound) {
+				return nil // Neither port nor interface exists
+			}
+			return err
+		}
+	}
+	if port.Name == bridgeName {
+		return nil // The bridge's local port can only be removed with the bridge
 	}
 	bridge, err := GetBridge(ovsClient, bridgeName)
 	if err != nil {
@@ -613,7 +681,7 @@ func DeletePortWithInterfaces(ovsClient libovsdbclient.Client, bridgeName, portN
 		}
 	}
 	if !onBridge {
-		klog.Warningf("OVS port %q exists but is not attached to bridge %q; leaving it untouched", portName, bridgeName)
+		klog.Warningf("OVS port %q exists but is not attached to bridge %q; leaving it untouched", port.Name, bridgeName)
 		return nil // Port lives on a different bridge; out of scope
 	}
 	ops, err := DeletePortWithInterfacesOps(ovsClient, nil, port, bridgeName)

--- a/go-controller/pkg/libovsdb/ops/vswitchdb.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
@@ -45,6 +47,54 @@ func GetOpenvSwitch(ovsClient libovsdbclient.Client) (*vswitchd.OpenvSwitch, err
 	}
 
 	return openvSwitchList[0], nil
+}
+
+// TransactAndCheckAndWaitForVSwitchd transacts ops and waits for ovs-vswitchd
+// to apply them, matching ovs-vsctl's default next_cfg/cur_cfg synchronization.
+func TransactAndCheckAndWaitForVSwitchd(ovsClient libovsdbclient.Client, ops []ovsdb.Operation) error {
+	if len(ops) == 0 {
+		return nil
+	}
+	ovs, err := GetOpenvSwitch(ovsClient)
+	if err != nil {
+		return err
+	}
+	where := []ovsdb.Condition{ovsdb.NewCondition("_uuid", ovsdb.ConditionEqual, ovsdb.UUID{GoUUID: ovs.UUID})}
+	ops = append(ops,
+		ovsdb.Operation{Op: ovsdb.OperationMutate, Table: vswitchd.OpenvSwitchTable, Where: where,
+			Mutations: []ovsdb.Mutation{*ovsdb.NewMutation("next_cfg", ovsdb.MutateOperationAdd, 1)}},
+		ovsdb.Operation{Op: ovsdb.OperationSelect, Table: vswitchd.OpenvSwitchTable, Where: where, Columns: []string{"next_cfg"}},
+	)
+	results, err := TransactAndCheck(ovsClient, ops)
+	if err != nil {
+		return err
+	}
+	rows := results[len(results)-1].Rows
+	if len(rows) != 1 {
+		return fmt.Errorf("expected one Open_vSwitch row, got %d", len(rows))
+	}
+	value := rows[0]["next_cfg"]
+	var nextCfg int
+	switch value := value.(type) {
+	case int:
+		nextCfg = value
+	case float64:
+		nextCfg = int(value)
+	default:
+		return fmt.Errorf("unexpected next_cfg value %T(%v)", value, value)
+	}
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, types.OVSDBTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			ovs := &vswitchd.OpenvSwitch{UUID: ovs.UUID}
+			if err := ovsClient.Get(ctx, ovs); err != nil {
+				return false, err
+			}
+			return ovs.CurCfg >= nextCfg, nil
+		})
+	if err != nil {
+		return fmt.Errorf("waiting for ovs-vswitchd to apply configuration %d: %w", nextCfg, err)
+	}
+	return nil
 }
 
 // UpdateOpenvSwitchExternalIDs merges the given map into the Open_vSwitch

--- a/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
@@ -446,6 +446,31 @@ func TestCreateOrUpdatePodPort(t *testing.T) {
 			t.Errorf("vf0 owner = %q, want br-other", owner.Name)
 		}
 	})
+
+	t.Run("rejects interface already attached to a differently named port", func(t *testing.T) {
+		existingIfaceUUID := buildNamedUUID()
+		existingPortUUID := buildNamedUUID()
+		ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+			OVSData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+				&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int", Ports: []string{existingPortUUID}},
+				&vswitchd.Port{UUID: existingPortUUID, Name: "bond0", Interfaces: []string{existingIfaceUUID}},
+				&vswitchd.Interface{UUID: existingIfaceUUID, Name: "vf0", Type: "system"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("harness setup: %v", err)
+		}
+		t.Cleanup(cleanup.Cleanup)
+
+		err = CreateOrUpdatePodPort(ovsClient, "br-int", "vf0", &vswitchd.Port{}, &vswitchd.Interface{})
+		if err == nil {
+			t.Fatal("expected error when interface vf0 belongs to port bond0")
+		}
+		if _, err := GetOVSPort(ovsClient, "vf0"); !errors.Is(err, libovsdbclient.ErrNotFound) {
+			t.Fatalf("unexpected vf0 port after rejected transaction: %v", err)
+		}
+	})
 }
 
 func TestCreateOrUpdateNicBridge(t *testing.T) {
@@ -561,6 +586,32 @@ func TestCreateOrUpdateNicBridge(t *testing.T) {
 		}
 		if uplinkPort.OtherConfig["transient"] != "true" {
 			t.Errorf("uplink Port.OtherConfig = %v, want transient=true", uplinkPort.OtherConfig)
+		}
+	})
+
+	t.Run("rejects uplink interface already attached to a differently named port", func(t *testing.T) {
+		bridgeUUID := buildNamedUUID()
+		bondPortUUID := buildNamedUUID()
+		uplinkIfaceUUID := buildNamedUUID()
+		ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+			OVSData: []libovsdbtest.TestData{
+				&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+				&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-existing", Ports: []string{bondPortUUID}},
+				&vswitchd.Port{UUID: bondPortUUID, Name: "bond0", Interfaces: []string{uplinkIfaceUUID}},
+				&vswitchd.Interface{UUID: uplinkIfaceUUID, Name: "eth0", Type: "system"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("harness setup: %v", err)
+		}
+		t.Cleanup(cleanup.Cleanup)
+
+		err = CreateOrUpdateNicBridge(ovsClient, "breth0", "eth0", "00:11:22:33:44:55")
+		if err == nil {
+			t.Fatal("expected error when interface eth0 belongs to port bond0")
+		}
+		if _, err := GetBridge(ovsClient, "breth0"); !errors.Is(err, libovsdbclient.ErrNotFound) {
+			t.Fatalf("unexpected breth0 bridge after rejected transaction: %v", err)
 		}
 	})
 }
@@ -833,6 +884,24 @@ func TestDeletePortWithInterfaces(t *testing.T) {
 			},
 		},
 		{
+			desc:      "resolves an interface name to its containing port",
+			portName:  "del-iface",
+			expectErr: false,
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), bridge.DeepCopy(),
+					&vswitchd.Port{UUID: portUUID, Name: "bond0", Interfaces: []string{ifaceUUID}},
+					&vswitchd.Interface{UUID: ifaceUUID, Name: "del-iface", Type: "system"},
+				},
+			},
+			expectedOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(),
+					&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-int"},
+				},
+			},
+		},
+		{
 			desc:      "is a no-op when the port lives on a different bridge",
 			portName:  "del-port",
 			expectErr: false,
@@ -994,6 +1063,23 @@ func TestDeleteBridge(t *testing.T) {
 			expectedOvs: libovsdbtest.TestSetup{
 				OVSData: []libovsdbtest.TestData{
 					&vswitchd.OpenvSwitch{UUID: "root-ovs"},
+				},
+			},
+		},
+		{
+			desc:       "deletes flow sample collectors that reference the bridge",
+			bridgeName: "br-doomed",
+			initialOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					ovs.DeepCopy(), otherBridge.DeepCopy(), bridge.DeepCopy(),
+					port1.DeepCopy(), port2.DeepCopy(), iface1.DeepCopy(), iface2.DeepCopy(),
+					&vswitchd.FlowSampleCollectorSet{UUID: buildNamedUUID(), ID: 42, Bridge: bridgeUUID},
+				},
+			},
+			expectedOvs: libovsdbtest.TestSetup{
+				OVSData: []libovsdbtest.TestData{
+					&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{otherBridgeUUID}},
+					otherBridge.DeepCopy(),
 				},
 			},
 		},

--- a/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
+++ b/go-controller/pkg/libovsdb/ops/vswitchdb_test.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 
@@ -15,6 +18,53 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
+
+func TestTransactAndCheckAndWaitForVSwitchd(t *testing.T) {
+	ovsClient, cleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{OVSData: []libovsdbtest.TestData{
+		&vswitchd.OpenvSwitch{UUID: "root-ovs", NextCfg: 7, CurCfg: 7},
+	}})
+	if err != nil {
+		t.Fatalf("harness setup: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+
+	applied := make(chan error, 1)
+	go func() {
+		applied <- wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true,
+			func(context.Context) (bool, error) {
+				ovs, err := GetOpenvSwitch(ovsClient)
+				if err != nil || ovs.NextCfg != 8 {
+					return false, err
+				}
+				updated := &vswitchd.OpenvSwitch{UUID: ovs.UUID, CurCfg: ovs.NextCfg}
+				ops, err := ovsClient.Where(&vswitchd.OpenvSwitch{UUID: ovs.UUID}).Update(updated, &updated.CurCfg)
+				if err == nil {
+					_, err = TransactAndCheck(ovsClient, ops)
+				}
+				return err == nil, err
+			})
+	}()
+
+	ovs, err := GetOpenvSwitch(ovsClient)
+	if err != nil {
+		t.Fatalf("get Open_vSwitch: %v", err)
+	}
+	updated := &vswitchd.OpenvSwitch{UUID: ovs.UUID, ExternalIDs: map[string]string{"updated": "true"}}
+	ops, err := ovsClient.Where(&vswitchd.OpenvSwitch{UUID: updated.UUID}).Update(updated, &updated.ExternalIDs)
+	if err != nil {
+		t.Fatalf("build update operation: %v", err)
+	}
+	if err := TransactAndCheckAndWaitForVSwitchd(ovsClient, ops); err != nil {
+		t.Fatalf("transaction and wait failed: %v", err)
+	}
+	if err := <-applied; err != nil {
+		t.Fatalf("emulating ovs-vswitchd: %v", err)
+	}
+	ovs, err = GetOpenvSwitch(ovsClient)
+	if err != nil || ovs.NextCfg != 8 || ovs.CurCfg != 8 || ovs.ExternalIDs["updated"] != "true" {
+		t.Fatalf("Open_vSwitch after transaction = %+v, err=%v", ovs, err)
+	}
+}
 
 func TestGetPortBridge(t *testing.T) {
 	bridgeAUUID := buildNamedUUID()

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/knftables"
 
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/factory"
@@ -1961,6 +1962,7 @@ func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
 		if err != nil {
 			return fmt.Errorf("failed to list ovn-localnet-port ports: %w", err)
 		}
+		var ops []ovsdb.Operation
 		for _, port := range ports {
 			bridge, err := ovsops.GetPortBridge(ovsClient, port.Name)
 			if err != nil {
@@ -1969,9 +1971,13 @@ func cleanupSharedGateway(ovsClient libovsdbclient.Client) error {
 				}
 				return fmt.Errorf("failed to find bridge for port %s: %w", port.Name, err)
 			}
-			if err := ovsops.DeletePortWithInterfaces(ovsClient, bridge.Name, port.Name); err != nil {
-				return fmt.Errorf("failed to delete port %s: %w", port.Name, err)
+			ops, err = ovsops.DeletePortWithInterfacesOps(ovsClient, ops, port, bridge.Name)
+			if err != nil {
+				return fmt.Errorf("failed to build operations to delete port %s: %w", port.Name, err)
 			}
+		}
+		if err := ovsops.TransactAndCheckAndWaitForVSwitchd(ovsClient, ops); err != nil {
+			return fmt.Errorf("failed to delete ovn-localnet-port ports: %w", err)
 		}
 
 		// Get the OVS bridge name from ovn-bridge-mappings


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow up on the recent `ovs-vsctl` to libovsdb migrations by adding several safety and cleanup semantics previously provided by `ovs-vsctl`.

This PR:
  - Rejects creating a pod or NIC bridge Port when its Interface is already owned by a differently named Port.
  - Implements `del-port --with-iface` behavior by resolving an Interface name to its owning Port.
  - Deletes `Flow_Sample_Collector_Set` rows referencing a Bridge before deleting that Bridge.

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
