### PR TITLE
kind: support DPU no-overlay external host routing

### DIFF
--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1572,9 +1572,12 @@ deploy_frr_external_container() {
   # can peer with acting as BGP (reflector) external gateway
   pushd "${FRR_TMP_DIR}"/frr-k8s/hack/demo || exit 1
   # modify config template to configure neighbors as route reflector clients
-  # First check if IPv4 network already exists
-  grep -q 'network '"${BGP_SERVER_NET_SUBNET_IPV4}" frr/frr.conf.tmpl || \
-    sed -i '/address-family ipv4 unicast/a \ \ network '"${BGP_SERVER_NET_SUBNET_IPV4}"'' frr/frr.conf.tmpl
+  # First check if IPv4 networks already exist
+  local ipv4_external_prefix
+  for ipv4_external_prefix in ${BGP_SERVER_NET_SUBNET_IPV4} ${BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4:-}; do
+    grep -q 'network '"${ipv4_external_prefix}" frr/frr.conf.tmpl || \
+      sed -i '/address-family ipv4 unicast/a \ \ network '"${ipv4_external_prefix}"'' frr/frr.conf.tmpl
+  done
 
   # Add route reflector client config
   sed -i '/remote-as 64512/a \ neighbor {{ . }} route-reflector-client' frr/frr.conf.tmpl
@@ -1688,10 +1691,24 @@ deploy_bgp_external_server() {
   $OCI_BIN run  --cap-add NET_ADMIN --user 0  -d --network bgpnet  --rm  --name bgpserver -p "${BGP_SERVER_HOST_PORT}:8080"  registry.k8s.io/e2e-test-images/agnhost:2.45 netexec
   # let's make the bgp external server have its default route towards FRR router so that we don't need to add routes during tests back to the pods in the
   # cluster for return traffic
-  local bgp_network_frr_v4 bgp_network_frr_v6 kind_network_frr_v4 kind_network_frr_v6
+  local bgp_network_frr_v4 bgp_network_frr_v6 kind_network_frr_v4 kind_network_frr_v6 ipv4_external_prefix
   bgp_network_frr_v4=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.bgpnet.IPAddress}}' frr)
   echo "FRR bgp network IPv4: ${bgp_network_frr_v4}"
   $OCI_BIN exec bgpserver ip route replace default via "$bgp_network_frr_v4"
+  if [ -n "${BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4:-}" ]; then
+    local frr_default_gw_v4
+    frr_default_gw_v4=$($OCI_BIN exec frr ip -4 route show default | awk '{print $3; exit}')
+    if [ -z "${frr_default_gw_v4}" ]; then
+      echo "error: could not determine FRR default IPv4 gateway for additional external prefixes" >&2
+      exit 1
+    fi
+    # bgpnet is connected; extra host prefixes need RIB routes before strict mode
+    # drops FRR's default route, or BGP will not advertise them.
+    for ipv4_external_prefix in ${BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4}; do
+      echo "Adding FRR route for external IPv4 prefix ${ipv4_external_prefix} via ${frr_default_gw_v4}"
+      $OCI_BIN exec frr ip route replace "${ipv4_external_prefix}" via "${frr_default_gw_v4}"
+    done
+  fi
   if  [ "$PLATFORM_IPV6_SUPPORT" == true ] ; then
     bgp_network_frr_v6=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.bgpnet.GlobalIPv6Address}}' frr)
     echo "FRR bgp network IPv6: ${bgp_network_frr_v6}"
@@ -1818,6 +1835,8 @@ wait_for_frr_k8s() {
 apply_frr_k8s_receive_config() {
   # apply a BGP peer configration with the external gateway that does not
   # exchange routes
+  local ipv4_external_prefix LINE_NUM
+
   pushd "${FRR_TMP_DIR}"/frr-k8s/hack/demo/configs || exit 1
   sed 's/mode: all/mode: filtered/g' receive_all.yaml > receive_filtered.yaml
   if frr_k8s_remote_enabled && [ -n "${DPU_SIM_GATEWAY_NETWORK:-}" ]; then
@@ -1825,6 +1844,11 @@ apply_frr_k8s_receive_config() {
   fi
   # Allow receiving the bgp external server's prefix
   sed -i '/mode: filtered/a\            prefixes:\n            - prefix: '"${BGP_SERVER_NET_SUBNET_IPV4}"'' receive_filtered.yaml
+  for ipv4_external_prefix in ${BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4:-}; do
+    for LINE_NUM in $(grep -n "prefix: ${BGP_SERVER_NET_SUBNET_IPV4}" receive_filtered.yaml | cut -d ':' -f 1 | sort -rn); do
+      sed -i "${LINE_NUM}a\\            - prefix: ${ipv4_external_prefix}" receive_filtered.yaml
+    done
+  done
   # If IPv6 is enabled, add the IPv6 prefix as well
   if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
     # Find all line numbers where the IPv4 prefix is defined

--- a/contrib/kind-common.sh
+++ b/contrib/kind-common.sh
@@ -1898,24 +1898,57 @@ EOF
 configure_frr_k8s_routes() {
   # Add routes for pod networks dynamically into the github runner for return traffic to pass back
   if [ "$ADVERTISE_DEFAULT_NETWORK" = "true" ]; then
+    local kubectl_cmd=(kubectl)
+    local host_kubeconfig ipv4_route_gateway ipv6_route_gateway
+    if frr_k8s_remote_enabled; then
+      host_kubeconfig=$(frr_k8s_host_kubeconfig)
+      if [ -n "${host_kubeconfig}" ]; then
+        kubectl_cmd=(kubectl --kubeconfig "${host_kubeconfig}")
+      fi
+      # DPU-sim no-overlay mode routes worker pod subnets through the external FRR container.
+      if [ "$ENABLE_NO_OVERLAY" == true ] && [ -n "${DPU_SIM_GATEWAY_NETWORK:-}" ] && $OCI_BIN ps --format '{{.Names}}' | grep -Eq '^frr$'; then
+        if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
+          ipv4_route_gateway=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' frr)
+          if [ -z "${ipv4_route_gateway}" ]; then
+            echo "error: could not determine FRR kind network IPv4 address for pod network routes" >&2
+            exit 1
+          fi
+          echo "Using FRR kind network IPv4 ${ipv4_route_gateway} for pod network return routes"
+        fi
+        if [ "$PLATFORM_IPV6_SUPPORT" == true ]; then
+          ipv6_route_gateway=$($OCI_BIN inspect -f '{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}' frr)
+          if [ -z "${ipv6_route_gateway}" ]; then
+            echo "error: could not determine FRR kind network IPv6 address for pod network routes" >&2
+            exit 1
+          fi
+          echo "Using FRR kind network IPv6 ${ipv6_route_gateway} for pod network return routes"
+        fi
+      fi
+    fi
+
     echo "Adding routes for Kubernetes pod networks..."
-    NODES=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
+    NODES=$("${kubectl_cmd[@]}" get nodes -o jsonpath='{.items[*].metadata.name}')
     echo "Found nodes: $NODES"
     for node in $NODES; do
       # Get the addresses
-      node_ips=$(kubectl get node $node -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+      node_ips=$("${kubectl_cmd[@]}" get node $node -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
       # Get subnet information
-      subnet_json=$(kubectl get node $node -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}')
+      subnet_json=$("${kubectl_cmd[@]}" get node $node -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}')
+      node_is_control_plane=$("${kubectl_cmd[@]}" get node "$node" -o json | jq -r '(.metadata.labels // {}) | has("node-role.kubernetes.io/control-plane")')
       
       if [ "$PLATFORM_IPV4_SUPPORT" == true ]; then
         # Extract IPv4 address (first address)
         node_ipv4=$(echo "$node_ips" | awk '{print $1}')
         ipv4_subnet=$(echo "$subnet_json" | jq -r '.default[0]')
+        ipv4_nexthop=$node_ipv4
+        if [ -n "${ipv4_route_gateway}" ] && [ "${node_is_control_plane}" != true ]; then
+          ipv4_nexthop=$ipv4_route_gateway
+        fi
         
         # Add IPv4 route
-        if [ -n "$ipv4_subnet" ] && [ -n "$node_ipv4" ]; then
-          echo "Adding IPv4 route for $node ($node_ipv4): $ipv4_subnet"
-          sudo ip route replace $ipv4_subnet via $node_ipv4
+        if [ -n "$ipv4_subnet" ] && [ -n "$ipv4_nexthop" ]; then
+          echo "Adding IPv4 route for $node via $ipv4_nexthop: $ipv4_subnet"
+          sudo ip route replace "$ipv4_subnet" via "$ipv4_nexthop"
         fi
       fi
 
@@ -1924,10 +1957,14 @@ configure_frr_k8s_routes() {
         # Extract IPv6 address (second address, if present)
         node_ipv6=$(echo "$node_ips" | awk '{print $2}')
         ipv6_subnet=$(echo "$subnet_json" | jq -r '.default[1] // empty')
+        ipv6_nexthop=$node_ipv6
+        if [ -n "${ipv6_route_gateway}" ] && [ "${node_is_control_plane}" != true ]; then
+          ipv6_nexthop=$ipv6_route_gateway
+        fi
         
-        if [ -n "$ipv6_subnet" ] && [ -n "$node_ipv6" ]; then
-          echo "Adding IPv6 route for $node ($node_ipv6): $ipv6_subnet"
-          sudo ip -6 route replace $ipv6_subnet via $node_ipv6
+        if [ -n "$ipv6_subnet" ] && [ -n "$ipv6_nexthop" ]; then
+          echo "Adding IPv6 route for $node via $ipv6_nexthop: $ipv6_subnet"
+          sudo ip -6 route replace "$ipv6_subnet" via "$ipv6_nexthop"
         fi
       fi
     done

--- a/contrib/kind-dpu-sim-no-overlay.sh
+++ b/contrib/kind-dpu-sim-no-overlay.sh
@@ -114,6 +114,8 @@ BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4:-172.27.0.0/16}
 BGP_SERVER_NET_SUBNET_IPV6=${BGP_SERVER_NET_SUBNET_IPV6:-fc00:f853:ccd:e797::/64}
 export BGP_SERVER_NET_SUBNET_IPV4
 export BGP_SERVER_NET_SUBNET_IPV6
+# Advertise the host address Kind uses for external traffic so host-published
+# external servers are reachable through the no-overlay FRR path.
 KIND_EXTERNAL_HOST_IPV4=${KIND_EXTERNAL_HOST_IPV4:-$(detect_kind_external_host_ipv4)}
 if [ -n "${KIND_EXTERNAL_HOST_IPV4}" ]; then
   add_ipv4_external_prefix "${KIND_EXTERNAL_HOST_IPV4}/32"

--- a/contrib/kind-dpu-sim-no-overlay.sh
+++ b/contrib/kind-dpu-sim-no-overlay.sh
@@ -69,6 +69,24 @@ resolve_kind_provider() {
   exit 1
 }
 
+detect_kind_external_host_ipv4() {
+  ip -j route get 1 2>/dev/null | jq -r '.[0].prefsrc // empty' 2>/dev/null || true
+}
+
+add_ipv4_external_prefix() {
+  local prefix=$1
+
+  case " ${BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4:-} " in
+    *" ${prefix} "*) return ;;
+  esac
+
+  if [ -n "${BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4:-}" ]; then
+    BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4="${BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4} ${prefix}"
+  else
+    BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4="${prefix}"
+  fi
+}
+
 cleanup_bgp_artifacts() {
   local provider=$1
 
@@ -96,6 +114,13 @@ BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4:-172.27.0.0/16}
 BGP_SERVER_NET_SUBNET_IPV6=${BGP_SERVER_NET_SUBNET_IPV6:-fc00:f853:ccd:e797::/64}
 export BGP_SERVER_NET_SUBNET_IPV4
 export BGP_SERVER_NET_SUBNET_IPV6
+KIND_EXTERNAL_HOST_IPV4=${KIND_EXTERNAL_HOST_IPV4:-$(detect_kind_external_host_ipv4)}
+if [ -n "${KIND_EXTERNAL_HOST_IPV4}" ]; then
+  add_ipv4_external_prefix "${KIND_EXTERNAL_HOST_IPV4}/32"
+  export BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4
+else
+  echo "warning: could not determine Kind external host IPv4" >&2
+fi
 DPU_SIM_UPLINK_ENABLE=${DPU_SIM_UPLINK_ENABLE:-true}
 DPU_SIM_UPLINK_NETWORK=${DPU_SIM_UPLINK_NETWORK:-dpu-sim-uplink}
 DPU_SIM_UPLINK_SUBNET=${DPU_SIM_UPLINK_SUBNET:-172.31.0.0/24}
@@ -380,6 +405,8 @@ fi
 echo "Using KIND_EXPERIMENTAL_PROVIDER=${KIND_EXPERIMENTAL_PROVIDER}"
 echo "Using KIND_HELM_OVN_TIMEOUT=${KIND_HELM_OVN_TIMEOUT}"
 echo "Using BGP_SERVER_NET_SUBNET_IPV4=${BGP_SERVER_NET_SUBNET_IPV4}"
+echo "Using KIND_EXTERNAL_HOST_IPV4=${KIND_EXTERNAL_HOST_IPV4:-}"
+echo "Using BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4=${BGP_ADDITIONAL_EXTERNAL_PREFIXES_IPV4:-}"
 
 cleanup_bgp_artifacts "${KIND_EXPERIMENTAL_PROVIDER}"
 


### PR DESCRIPTION
## 📑 Description

Add Kind no-overlay routing support for external host prefixes used by DPU
simulator-style deployments.

For no-overlay runs, the Kind BGP helper can now include additional external
IPv4 prefixes in the external FRR advertisement and receive filters. The DPU
no-overlay helper detects the runner host IPv4 address and adds it as a `/32`
external prefix, so host-published services can be reached through the
no-overlay FRR path.

The runner pod-subnet return routes also account for remote frr-k8s DPU
no-overlay mode. Worker pod subnets are routed through the external FRR
container, while overlay and normal Kind deployments continue using node
InternalIP next hops.

## Additional Information for reviewers

Changed areas:

- `contrib/kind-common.sh`
  - supports additional external IPv4 prefixes in FRR advertisements and receive filters
  - routes DPU no-overlay worker pod return traffic through external FRR

- `contrib/kind-dpu-sim-no-overlay.sh`
  - detects the runner host IPv4 address
  - advertises it as a `/32` external prefix for no-overlay FRR routing

## ✅ Checks

- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [ ] All the tests have passed in the CI