### PR TITLE
Fix map-order flake in DPU host representor test

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
@@ -137,8 +137,11 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T)
 	t.Cleanup(func() {
 		util.SetSriovnetOpsInst(origSriovOps)
 	})
+	// GetDPUHostRepInterface iterates bridge ports in map order and returns on
+	// the first PF representor, so eth1 may or may not be probed before pfhpf0.
 	sriovOps.On("GetRepresentorPortFlavour", "eth1").
-		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_UNKNOWN), fmt.Errorf("not a PF representor"))
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_UNKNOWN), fmt.Errorf("not a PF representor")).
+		Maybe()
 	sriovOps.On("GetRepresentorPortFlavour", "pfhpf0").
 		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_PF), nil)
 


### PR DESCRIPTION
`TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor` flakes because `GetDPUHostRepInterface` iterates the ports-to-interfaces map and returns on the first PF-flavour interface, while the test requires the mock for `eth1` to be called. Whenever Go's randomized map iteration visits `pfhpf0` before `eth1`, the `eth1` mock is never called and mockery fails the test at cleanup with "1 out of 2 expectation(s) were met".

Mark the `eth1` expectation with `.Maybe()`: whether the uplink gets probed depends on iteration order, so the test must not require it. The production code is fine as is, since any PF representor is acceptable.

Reproduced with `go test -race -run TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor ./pkg/node/bridgeconfig/ -count=10` (1/10 failures before the fix, 0/30 after).

Fixes #6713