### PR TITLE
fix: reconcile EgressIPs when cloud egress IP config annotation changes

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -128,6 +128,10 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 		isNewReady := h.eIPC.isEgressNodeReady(newNode)
 		isNewReachable := h.eIPC.isEgressNodeReachable(newNode)
 		isHostCIDRsAltered := util.NodeHostCIDRsAnnotationChanged(oldNode, newNode)
+		// Check if cloud egress IP config annotation changed (capacity changes on cloud platforms).
+		// Without this check, when capacity increases (e.g., from 0 to 1), the handler returns early
+		// and never re-evaluates unassigned EgressIPs, leaving them unassigned despite available capacity.
+		isCloudEgressIPConfigAltered := util.NodeCloudEgressIPConfigAnnotationChanged(oldNode, newNode)
 		h.eIPC.setNodeEgressReady(newNode.Name, isNewReady)
 		if !oldHadEgressLabel && newHasEgressLabel {
 			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
@@ -142,7 +146,7 @@ func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj in
 			}
 			return nil
 		}
-		if isOldReady == isNewReady && !isHostCIDRsAltered {
+		if isOldReady == isNewReady && !isHostCIDRsAltered && !isCloudEgressIPConfigAltered {
 			return nil
 		}
 		if !isNewReady {

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -886,6 +886,13 @@ func NodeHostCIDRsAnnotationChanged(oldNode, newNode *corev1.Node) bool {
 	return oldNode.Annotations[OVNNodeHostCIDRs] != newNode.Annotations[OVNNodeHostCIDRs]
 }
 
+// NodeCloudEgressIPConfigAnnotationChanged returns true if the cloud egress IP config annotation changed.
+// This is used to detect when node capacity changes (e.g., additional IPs added/removed on cloud platforms),
+// which should trigger re-evaluation of unassigned EgressIPs.
+func NodeCloudEgressIPConfigAnnotationChanged(oldNode, newNode *corev1.Node) bool {
+	return oldNode.Annotations[cloudEgressIPConfigAnnotationKey] != newNode.Annotations[cloudEgressIPConfigAnnotationKey]
+}
+
 // ParseNodeHostCIDRs returns the parsed host CIDRS living on a node
 func ParseNodeHostCIDRs(node *corev1.Node) (sets.Set[string], error) {
 	addrAnnotation, ok := node.Annotations[OVNNodeHostCIDRs]

--- a/go-controller/pkg/util/node_annotations_test.go
+++ b/go-controller/pkg/util/node_annotations_test.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNodeCloudEgressIPConfigAnnotationChanged(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldAnnotations map[string]string
+		newAnnotations map[string]string
+		expected       bool
+	}{
+		{
+			name: "annotation changed - capacity increased",
+			oldAnnotations: map[string]string{
+				"cloud.network.openshift.io/egress-ipconfig": `[{"interface":"eth0","ifaddr":{"ipv4":"10.0.0.0/24"},"capacity":{"ipv4":0}}]`,
+			},
+			newAnnotations: map[string]string{
+				"cloud.network.openshift.io/egress-ipconfig": `[{"interface":"eth0","ifaddr":{"ipv4":"10.0.0.0/24"},"capacity":{"ipv4":1}}]`,
+			},
+			expected: true,
+		},
+		{
+			name: "annotation unchanged",
+			oldAnnotations: map[string]string{
+				"cloud.network.openshift.io/egress-ipconfig": `[{"interface":"eth0","ifaddr":{"ipv4":"10.0.0.0/24"},"capacity":{"ipv4":1}}]`,
+			},
+			newAnnotations: map[string]string{
+				"cloud.network.openshift.io/egress-ipconfig": `[{"interface":"eth0","ifaddr":{"ipv4":"10.0.0.0/24"},"capacity":{"ipv4":1}}]`,
+			},
+			expected: false,
+		},
+		{
+			name:           "annotation added",
+			oldAnnotations: map[string]string{},
+			newAnnotations: map[string]string{
+				"cloud.network.openshift.io/egress-ipconfig": `[{"interface":"eth0","ifaddr":{"ipv4":"10.0.0.0/24"},"capacity":{"ipv4":1}}]`,
+			},
+			expected: true,
+		},
+		{
+			name: "annotation removed",
+			oldAnnotations: map[string]string{
+				"cloud.network.openshift.io/egress-ipconfig": `[{"interface":"eth0","ifaddr":{"ipv4":"10.0.0.0/24"},"capacity":{"ipv4":1}}]`,
+			},
+			newAnnotations: map[string]string{},
+			expected:       true,
+		},
+		{
+			name:           "both nodes missing annotation",
+			oldAnnotations: map[string]string{},
+			newAnnotations: map[string]string{},
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-node",
+					Annotations: tt.oldAnnotations,
+				},
+			}
+			newNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-node",
+					Annotations: tt.newAnnotations,
+				},
+			}
+
+			result := NodeCloudEgressIPConfigAnnotationChanged(oldNode, newNode)
+			if result != tt.expected {
+				t.Errorf("NodeCloudEgressIPConfigAnnotationChanged() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📑 Description

Fix the EgressIP controller to automatically assign EgressIPs when node IP capacity becomes available on cloud platforms (AWS, Azure, GCP).

The node update handler returns early unless node readiness or host CIDRs change. Cloud IP capacity changes arrive via the `cloud.network.openshift.io/egress-ipconfig` annotation, which is neither of those, so unassigned EgressIPs are never retried — even when capacity becomes available.

Fixes https://issues.redhat.com/browse/OCPBUGS-64575

## Additional Information for reviewers

### Root Cause

The early-return condition in `egressip_event_handler.go` (line 145) short-circuits unless:
- Node readiness changes, OR
- Host CIDRs change (`NodeHostCIDRsAnnotationChanged`)

Since capacity changes occur via the `cloud.network.openshift.io/egress-ipconfig` annotation — neither readiness nor host CIDRs — the handler returns early without re-evaluating unassigned EgressIPs.

### Changes

**`pkg/util/node_annotations.go`**
- Add `NodeCloudEgressIPConfigAnnotationChanged()` — detects changes to `cloud.network.openshift.io/egress-ipconfig` annotation. Follows the same pattern as `NodeHostCIDRsAnnotationChanged()`.

**`pkg/clustermanager/egressip_event_handler.go`**
- Wire `NodeCloudEgressIPConfigAnnotationChanged()` into the early-return guard so capacity changes trigger EgressIP reconciliation.

**`pkg/util/node_annotations_test.go`**
- Unit tests for the new helper function.

## ✅ Checks
- [ ] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI

## How to verify it

### Steps to reproduce
1. Setup an AWS cluster
2. Label one node as egress-assignable
3. Fill up node IP capacity to 0 (add additional IPs from console)
4. Restart CNCC — capacity shows 0
5. Create an EgressIP — it will not be assigned (no capacity)
6. Remove one additional IP from console
7. Delete the CNCC pod to refresh the capacity count
8. CNCC updates annotation with capacity=1
9. **Without fix**: EgressIP stays unassigned. **With fix**: EgressIP is automatically assigned.

### Unit tests
```bash
cd go-controller
go test -v ./pkg/util -run TestNodeCloudEgressIPConfigAnnotationChanged
```

🤖 Generated with [Claude Code](https://claude.ai/code) via `/jira:solve OCPBUGS-64575`