### PR TITLE
unidling: fail controller creation when SB client cache is nil

### DIFF
--- a/go-controller/pkg/ovn/controller/unidling/unidle.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle.go
@@ -47,8 +47,13 @@ func NewController(recorder record.EventRecorder, serviceInformer cache.SharedIn
 	}
 
 	klog.Info("Registering OVN SB ControllerEvent handler")
+	sbCache := sbClient.Cache()
+	if sbCache == nil {
+		// the client cache is only available once the client is connected
+		return nil, fmt.Errorf("SB DB client is not connected, no cache to register the ControllerEvent handler on")
+	}
 	// add all empty lb backend events to a channel
-	sbClient.Cache().AddEventHandler(
+	sbCache.AddEventHandler(
 		&libovsdbcache.EventHandlerFuncs{
 			AddFunc: func(_ string, m model.Model) {
 				if event, ok := m.(*sbdb.ControllerEvent); ok {

--- a/go-controller/pkg/ovn/controller/unidling/unidle_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle_test.go
@@ -45,6 +45,27 @@ var _ = Describe("Unidling Controller", func() {
 		}
 	})
 
+	It("should fail creation when the SB client is not connected", func() {
+		client := fake.NewSimpleClientset()
+		recorder := record.NewFakeRecorder(10)
+		informerFactory := informers.NewSharedInformerFactory(client, 0)
+		serviceInformer := informerFactory.Core().V1().Services().Informer()
+
+		// an SB client that was never connected has a nil cache
+		dbModel, err := sbdb.FullDatabaseModel()
+		Expect(err).NotTo(HaveOccurred())
+		sbClient, err := libovsdbclient.NewOVSDBClient(dbModel)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sbClient.Cache()).To(BeNil())
+
+		_, err = NewController(
+			recorder,
+			serviceInformer,
+			sbClient,
+		)
+		Expect(err).To(MatchError(ContainSubstring("not connected")))
+	})
+
 	It("should respond to a controller event", func() {
 		client := fake.NewSimpleClientset()
 		recorder := record.NewFakeRecorder(10)


### PR DESCRIPTION
The libovsdb client cache is nil until the client is connected. If the SB DB connection is down when the unidling controller is created, `sbClient.Cache().AddEventHandler(...)` in `unidling.NewController` panics with a nil pointer dereference and crashes ovnkube.

We hit this in CI: the MTU readiness e2e test breaks node connectivity, ovnkube-controller restarts during that window and panics at startup, twice in a row, leaving two coredumps that abort the spec. Full analysis with the coredump backtrace in #6719.

The fix returns an error instead of panicking; the caller in `DefaultNetworkController.run` already handles it and the controller start is retried.

Fixes #6719
