### PR TITLE
[WIP] networkpolicy: support peers across connected UDNs

### DIFF
--- a/docs/features/user-defined-networks/cluster-network-connect.md
+++ b/docs/features/user-defined-networks/cluster-network-connect.md
@@ -391,6 +391,18 @@ for the full specification.
 | `ServiceNetwork` | ClusterIP services are accessible across connected networks, but pods cannot reach each other directly. NodePort and LoadBalancer services are already reachable across UDNs by default. |
 | Both | Full pod + service connectivity. |
 
+### Network Policies
+
+For CNCs with `PodNetwork` connectivity, Kubernetes NetworkPolicy peer
+selectors resolve pods on the policy's network and on its directly connected
+networks. This allows a `namespaceSelector`, optionally combined with a
+`podSelector`, to allow ingress from or egress to pods on another connected
+primary UDN. Policy peer selection follows CNC's non-transitive model and does
+not expand across `ServiceNetwork`-only connections.
+
+The policy itself remains scoped to the primary network of its namespace. CNC
+does not cause that policy to be installed on the connected peer networks.
+
 ### Sizing `connectSubnets`
 
 The `connectSubnets` CIDR and `networkPrefix` control how many networks
@@ -560,12 +572,6 @@ Routing Policies
 
 ## Known Issues
 
-* **Network Policies do not span connected networks**: Network Policy
-  peers cannot currently be selected across connected networks. If two
-  UDNs are connected via CNC, a NetworkPolicy in one network cannot
-  reference pods in the other network as ingress/egress peers. Handling
-  overlapping IPs across connected networks is also not yet supported.
-  See [#6331](https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6331).
 * **Advertised networks are not supported in isolated mode**: Connecting
   two BGP-advertised networks that use geneve tunnels for east-west
   traffic is not yet supported. See

--- a/go-controller/pkg/controllermanager/controller_manager.go
+++ b/go-controller/pkg/controllermanager/controller_manager.go
@@ -313,7 +313,7 @@ func NewControllerManager(ovnClient *util.OVNClientset, wf *factory.WatchFactory
 		}
 	}
 	cm.addressSetManager = addresssetmanager.NewAddressSetManager(cm.watchFactory.PodCoreInformer(),
-		cm.watchFactory.NamespaceInformer(), cm.watchFactory.NodeCoreInformer(), cm.nbClient, cm.networkManager.Interface().GetNetworkNameForNADKey)
+		cm.watchFactory.NamespaceInformer(), cm.watchFactory.NodeCoreInformer(), cm.nbClient, cm.networkManager.Interface())
 
 	return cm, nil
 }

--- a/go-controller/pkg/networkmanager/api.go
+++ b/go-controller/pkg/networkmanager/api.go
@@ -43,6 +43,12 @@ type NetworkRefReconciler interface {
 	Reconcile(node string, networkName string)
 }
 
+// PodNetworkConnectReconciler is notified when the direct PodNetwork peers of
+// a network change because of a ClusterNetworkConnect update.
+type PodNetworkConnectReconciler interface {
+	ReconcilePodNetworkConnect(networkNames []string)
+}
+
 type watchFactory interface {
 	NADInformer() nadinformers.NetworkAttachmentDefinitionInformer
 	ClusterNetworkConnectInformer() networkconnectinformer.ClusterNetworkConnectInformer
@@ -114,6 +120,15 @@ type Interface interface {
 	RegisterNetworkRefReconciler(r NetworkRefReconciler) uint64
 	// DeRegisterNetworkRefReconciler removes a previously registered reconciler.
 	DeRegisterNetworkRefReconciler(id uint64)
+	// GetPodNetworkConnectedNetworks returns copies of the networks directly
+	// connected to networkName by a CNC with PodNetwork connectivity. CNC
+	// connectivity is intentionally non-transitive.
+	GetPodNetworkConnectedNetworks(networkName string) []util.NetInfo
+	// RegisterPodNetworkConnectReconciler registers a reconciler to be notified
+	// when a network's direct PodNetwork CNC peers change.
+	RegisterPodNetworkConnectReconciler(r PodNetworkConnectReconciler) uint64
+	// DeRegisterPodNetworkConnectReconciler removes a previously registered reconciler.
+	DeRegisterPodNetworkConnectReconciler(id uint64)
 
 	// GetNetworkByID returns the network with the given ID or nil if not found.
 	// This is an O(1) lookup using an internal index.
@@ -157,6 +172,7 @@ func NewForCluster(
 		recorder,
 		tunnelKeysAllocator,
 		"",
+		false,
 	)
 }
 
@@ -180,6 +196,7 @@ func NewForZone(
 		nil,
 		nil,
 		z,
+		true,
 	)
 }
 
@@ -199,6 +216,7 @@ func NewForNode(
 		nil,
 		nil,
 		node,
+		false,
 	)
 }
 
@@ -215,8 +233,9 @@ func new(
 	recorder record.EventRecorder,
 	tunnelKeysAllocator *id.TunnelKeysAllocator,
 	filterNADsOnNode string,
+	trackPodNetworkConnect bool,
 ) (Controller, error) {
-	return newController(name, zone, node, cm, wf, ovnClient, recorder, tunnelKeysAllocator, filterNADsOnNode)
+	return newController(name, zone, node, cm, wf, ovnClient, recorder, tunnelKeysAllocator, filterNADsOnNode, trackPodNetworkConnect)
 }
 
 // ControllerManager manages controllers. Needs to be provided in order to build
@@ -329,6 +348,16 @@ func (nm defaultNetworkManager) RegisterNetworkRefReconciler(_ NetworkRefReconci
 }
 
 func (nm defaultNetworkManager) DeRegisterNetworkRefReconciler(_ uint64) {}
+
+func (nm defaultNetworkManager) GetPodNetworkConnectedNetworks(_ string) []util.NetInfo {
+	return nil
+}
+
+func (nm defaultNetworkManager) RegisterPodNetworkConnectReconciler(_ PodNetworkConnectReconciler) uint64 {
+	return 0
+}
+
+func (nm defaultNetworkManager) DeRegisterPodNetworkConnectReconciler(_ uint64) {}
 
 func (nm defaultNetworkManager) GetNetworkByID(id int) util.NetInfo {
 	if id != types.DefaultNetworkID {

--- a/go-controller/pkg/networkmanager/fake.go
+++ b/go-controller/pkg/networkmanager/fake.go
@@ -64,8 +64,12 @@ type FakeNetworkManager struct {
 	NADNetworks           map[string]util.NetInfo
 	Reconcilers           []reconcilerRegistration
 	NetworkRefReconcilers []networkRefReconcilerRegistration
-	nextID                uint64
-	nextNetworkRefID      uint64
+	// PodNetworkConnectedNetworks maps a network name to its direct CNC peers.
+	PodNetworkConnectedNetworks  map[string][]util.NetInfo
+	PodNetworkConnectReconcilers []podNetworkConnectReconcilerRegistration
+	nextID                       uint64
+	nextNetworkRefID             uint64
+	nextPodNetworkConnectID      uint64
 	// UDNNamespaces are a list of namespaces that require UDN for primary network
 	UDNNamespaces sets.Set[string]
 	// ActiveNodes tracks node activity per network for Dynamic UDN tests.
@@ -109,6 +113,60 @@ func (fnm *FakeNetworkManager) DeRegisterNetworkRefReconciler(id uint64) {
 			fnm.NetworkRefReconcilers = append(fnm.NetworkRefReconcilers[:i], fnm.NetworkRefReconcilers[i+1:]...)
 			return
 		}
+	}
+}
+
+func (fnm *FakeNetworkManager) RegisterPodNetworkConnectReconciler(r PodNetworkConnectReconciler) uint64 {
+	fnm.Lock()
+	defer fnm.Unlock()
+	fnm.nextPodNetworkConnectID++
+	id := fnm.nextPodNetworkConnectID
+	fnm.PodNetworkConnectReconcilers = append(fnm.PodNetworkConnectReconcilers,
+		podNetworkConnectReconcilerRegistration{id: id, r: r})
+	return id
+}
+
+func (fnm *FakeNetworkManager) DeRegisterPodNetworkConnectReconciler(id uint64) {
+	fnm.Lock()
+	defer fnm.Unlock()
+	for i, rec := range fnm.PodNetworkConnectReconcilers {
+		if rec.id == id {
+			fnm.PodNetworkConnectReconcilers = append(fnm.PodNetworkConnectReconcilers[:i],
+				fnm.PodNetworkConnectReconcilers[i+1:]...)
+			return
+		}
+	}
+}
+
+func (fnm *FakeNetworkManager) GetPodNetworkConnectedNetworks(networkName string) []util.NetInfo {
+	fnm.Lock()
+	defer fnm.Unlock()
+	connectedNetworks := fnm.PodNetworkConnectedNetworks[networkName]
+	result := make([]util.NetInfo, 0, len(connectedNetworks))
+	for _, netInfo := range connectedNetworks {
+		if netInfo != nil {
+			result = append(result, util.NewMutableNetInfo(netInfo))
+		}
+	}
+	return result
+}
+
+// SetPodNetworkConnectedNetworks updates direct CNC peers and notifies
+// registered test consumers.
+func (fnm *FakeNetworkManager) SetPodNetworkConnectedNetworks(networkName string, connectedNetworks ...util.NetInfo) {
+	fnm.Lock()
+	if fnm.PodNetworkConnectedNetworks == nil {
+		fnm.PodNetworkConnectedNetworks = map[string][]util.NetInfo{}
+	}
+	fnm.PodNetworkConnectedNetworks[networkName] = append([]util.NetInfo(nil), connectedNetworks...)
+	reconcilers := make([]PodNetworkConnectReconciler, 0, len(fnm.PodNetworkConnectReconcilers))
+	for _, entry := range fnm.PodNetworkConnectReconcilers {
+		reconcilers = append(reconcilers, entry.r)
+	}
+	fnm.Unlock()
+
+	for _, reconciler := range reconcilers {
+		reconciler.ReconcilePodNetworkConnect([]string{networkName})
 	}
 }
 

--- a/go-controller/pkg/networkmanager/nad_controller.go
+++ b/go-controller/pkg/networkmanager/nad_controller.go
@@ -52,6 +52,9 @@ type nadController struct {
 	// networkRefReconcilers keyed by registration ID.
 	networkRefReconcilers      map[uint64]networkRefReconcilerRegistration
 	nextNetworkRefReconcilerID uint64
+	// podNetworkConnectReconcilers keyed by registration ID.
+	podNetworkConnectReconcilers      map[uint64]podNetworkConnectReconcilerRegistration
+	nextPodNetworkConnectReconcilerID uint64
 
 	name            string
 	stopChan        chan struct{}
@@ -64,8 +67,8 @@ type nadController struct {
 	cncLister       networkconnectlister.ClusterNetworkConnectLister
 
 	controller controller.Controller
-	// cncController tracks CNC connectivity and updates derived
-	// network activity for Dynamic UDN filtering.
+	// cncController tracks CNC connectivity for Dynamic UDN activity and
+	// PodNetwork-aware consumers such as NetworkPolicy.
 	cncController controller.Controller
 	recorder      record.EventRecorder
 
@@ -86,8 +89,15 @@ type nadController struct {
 	// cncsByNetworkID indexes CNCs by their referenced owner network IDs.
 	cncsByNetworkID map[int]sets.Set[string]
 	// cncConnectedNetworks is a symmetric adjacency map where key/value are
-	// network names connected through a CNC.
+	// network names connected through a CNC with any connectivity type. This is
+	// used to derive Dynamic UDN activity, including ServiceNetwork backends.
 	cncConnectedNetworks map[string]sets.Set[string]
+	// cncPodNetworkSelectedNetworks tracks network names selected by each CNC
+	// that enables PodNetwork connectivity.
+	cncPodNetworkSelectedNetworks map[string]sets.Set[string]
+	// cncPodNetworkConnectedNetworks is the direct, symmetric PodNetwork-only
+	// adjacency used by consumers such as NetworkPolicy.
+	cncPodNetworkConnectedNetworks map[string]sets.Set[string]
 
 	// primaryNADs holds a mapping of namespace to NAD of primary UDNs
 	primaryNADs map[string]string
@@ -127,6 +137,11 @@ type networkRefReconcilerRegistration struct {
 	r  NetworkRefReconciler
 }
 
+type podNetworkConnectReconcilerRegistration struct {
+	id uint64
+	r  PodNetworkConnectReconciler
+}
+
 func newController(
 	name string,
 	zone string,
@@ -137,41 +152,48 @@ func newController(
 	recorder record.EventRecorder,
 	tunnelKeysAllocator *id.TunnelKeysAllocator,
 	filterNADsOnNode string,
+	trackPodNetworkConnect bool,
 ) (*nadController, error) {
 	networkController := newNetworkController(name, zone, node, cm, wf)
 	c := &nadController{
-		name:                   fmt.Sprintf("[%s NAD controller]", name),
-		stopChan:               make(chan struct{}),
-		recorder:               recorder,
-		nadLister:              wf.NADInformer().Lister(),
-		nodeLister:             wf.NodeCoreInformer().Lister(),
-		networkController:      networkController,
-		reconcilers:            map[uint64]reconcilerRegistration{},
-		networkRefReconcilers:  map[uint64]networkRefReconcilerRegistration{},
-		nads:                   map[string]string{},
-		nadsByNetwork:          map[string]sets.Set[string]{},
-		dynamicFilterNADs:      map[string]bool{},
-		cncSelectedNetworks:    map[string]sets.Set[string]{},
-		cncNetworkIDs:          map[string]sets.Set[int]{},
-		cncsByNetworkID:        map[int]sets.Set[string]{},
-		cncConnectedNetworks:   map[string]sets.Set[string]{},
-		primaryNADs:            map[string]string{},
-		markedForRemoval:       map[string]time.Time{},
-		dynamicallyRemovedNADs: sets.New[string](),
+		name:                           fmt.Sprintf("[%s NAD controller]", name),
+		stopChan:                       make(chan struct{}),
+		recorder:                       recorder,
+		nadLister:                      wf.NADInformer().Lister(),
+		nodeLister:                     wf.NodeCoreInformer().Lister(),
+		networkController:              networkController,
+		reconcilers:                    map[uint64]reconcilerRegistration{},
+		networkRefReconcilers:          map[uint64]networkRefReconcilerRegistration{},
+		podNetworkConnectReconcilers:   map[uint64]podNetworkConnectReconcilerRegistration{},
+		nads:                           map[string]string{},
+		nadsByNetwork:                  map[string]sets.Set[string]{},
+		dynamicFilterNADs:              map[string]bool{},
+		cncSelectedNetworks:            map[string]sets.Set[string]{},
+		cncNetworkIDs:                  map[string]sets.Set[int]{},
+		cncsByNetworkID:                map[int]sets.Set[string]{},
+		cncConnectedNetworks:           map[string]sets.Set[string]{},
+		cncPodNetworkSelectedNetworks:  map[string]sets.Set[string]{},
+		cncPodNetworkConnectedNetworks: map[string]sets.Set[string]{},
+		primaryNADs:                    map[string]string{},
+		markedForRemoval:               map[string]time.Time{},
+		dynamicallyRemovedNADs:         sets.New[string](),
 	}
 	networkController.getNADKeysForNetwork = c.GetNADKeysForNetwork
 
-	if cm != nil && config.OVNKubernetesFeature.EnableDynamicUDNAllocation {
-		c.podTracker = NewPodTrackerController(fmt.Sprintf("%s pod-tracker", c.name), wf, c.OnNetworkRefChange, c.GetPrimaryNADForNamespace)
-		podID := c.RegisterNADReconciler(c.podTracker.NADReconciler())
-		c.podReconcilerID = podID
-		if config.OVNKubernetesFeature.EnableEgressIP {
-			c.egressIPTracker = NewEgressIPTrackerController(fmt.Sprintf("%s egress-ip-tracker", c.name), wf, c.OnNetworkRefChange, c.GetPrimaryNADForNamespace)
-			eipID := c.RegisterNADReconciler(c.egressIPTracker.NADReconciler())
-			c.eipReconcilerID = eipID
+	if cm != nil {
+		if config.OVNKubernetesFeature.EnableDynamicUDNAllocation {
+			c.podTracker = NewPodTrackerController(fmt.Sprintf("%s pod-tracker", c.name), wf, c.OnNetworkRefChange, c.GetPrimaryNADForNamespace)
+			podID := c.RegisterNADReconciler(c.podTracker.NADReconciler())
+			c.podReconcilerID = podID
+			if config.OVNKubernetesFeature.EnableEgressIP {
+				c.egressIPTracker = NewEgressIPTrackerController(fmt.Sprintf("%s egress-ip-tracker", c.name), wf, c.OnNetworkRefChange, c.GetPrimaryNADForNamespace)
+				eipID := c.RegisterNADReconciler(c.egressIPTracker.NADReconciler())
+				c.eipReconcilerID = eipID
+			}
+			c.filterNADsOnNode = filterNADsOnNode
 		}
-		c.filterNADsOnNode = filterNADsOnNode
-		if util.IsNetworkConnectEnabled() {
+		if util.IsNetworkConnectEnabled() &&
+			(config.OVNKubernetesFeature.EnableDynamicUDNAllocation || trackPodNetworkConnect) {
 			cncInformer := wf.ClusterNetworkConnectInformer()
 			c.cncLister = cncInformer.Lister()
 			c.cncController = controller.NewController(
@@ -462,6 +484,35 @@ func (c *nadController) getNetworkAndConnectedNetworks(networkName string) []str
 	return networks
 }
 
+// GetPodNetworkConnectedNetworks returns copies of the networks directly
+// connected to networkName by CNCs that enable PodNetwork connectivity.
+func (c *nadController) GetPodNetworkConnectedNetworks(networkName string) []util.NetInfo {
+	if networkName == "" {
+		return nil
+	}
+
+	c.RLock()
+	connectedNetworkNames := c.cncPodNetworkConnectedNetworks[networkName].UnsortedList()
+	networkIDs := make(map[string]int, len(connectedNetworkNames))
+	for _, connectedNetworkName := range connectedNetworkNames {
+		networkIDs[connectedNetworkName] = c.networkIDAllocator.GetID(connectedNetworkName)
+	}
+	c.RUnlock()
+
+	sort.Strings(connectedNetworkNames)
+	connectedNetworks := make([]util.NetInfo, 0, len(connectedNetworkNames))
+	for _, connectedNetworkName := range connectedNetworkNames {
+		netInfo := c.GetNetwork(connectedNetworkName)
+		if netInfo == nil {
+			netInfo = c.GetNetworkByID(networkIDs[connectedNetworkName])
+		}
+		if netInfo != nil {
+			connectedNetworks = append(connectedNetworks, util.NewMutableNetInfo(netInfo))
+		}
+	}
+	return connectedNetworks
+}
+
 // reconcileNetworkActivity requeues NAD sync for all NADs belonging to the
 // provided networks. syncNAD recomputes current activity and updates local
 // Dynamic UDN removal state.
@@ -625,6 +676,15 @@ func (c *nadController) networkSelectionsForCNC(cnc *networkconnectv1.ClusterNet
 	return selectedNetworks, networkIDs
 }
 
+func cncEnablesConnectivity(cnc *networkconnectv1.ClusterNetworkConnect, connectivity networkconnectv1.ConnectivityType) bool {
+	for _, configuredConnectivity := range cnc.Spec.Connectivity {
+		if configuredConnectivity == connectivity {
+			return true
+		}
+	}
+	return false
+}
+
 // buildCNCConnectedNetworks returns network name -> connected peer network names
 // derived from each CNC's selected network set.
 func buildCNCConnectedNetworks(selectedNetworksByCNC map[string]sets.Set[string]) map[string]sets.Set[string] {
@@ -683,6 +743,16 @@ func (c *nadController) updateCNCConnectivityLocked() sets.Set[string] {
 	return networksToReconcile
 }
 
+// updateCNCPodNetworkConnectivityLocked refreshes the PodNetwork-only CNC
+// adjacency and returns the networks whose direct peer set changed.
+// Caller must hold nadController lock.
+func (c *nadController) updateCNCPodNetworkConnectivityLocked() sets.Set[string] {
+	connectedNetworks := buildCNCConnectedNetworks(c.cncPodNetworkSelectedNetworks)
+	networksToReconcile := changedCNCNetworks(c.cncPodNetworkConnectedNetworks, connectedNetworks)
+	c.cncPodNetworkConnectedNetworks = connectedNetworks
+	return networksToReconcile
+}
+
 // updateCNCNetworkIDsLocked updates the per-CNC owner ID cache and reverse
 // lookup used to target CNC reconciles when a NAD/network ID becomes available
 // or is removed.
@@ -728,11 +798,15 @@ func (c *nadController) syncAllCNCs() error {
 	}
 
 	selectedNetworksByCNC := map[string]sets.Set[string]{}
+	podNetworkSelectedNetworksByCNC := map[string]sets.Set[string]{}
 	networkIDsByCNC := map[string]sets.Set[int]{}
 	cncsByNetworkID := map[int]sets.Set[string]{}
 	for _, cnc := range cncs {
 		selectedNetworks, networkIDs := c.networkSelectionsForCNC(cnc)
 		selectedNetworksByCNC[cnc.Name] = selectedNetworks
+		if cncEnablesConnectivity(cnc, networkconnectv1.PodNetwork) {
+			podNetworkSelectedNetworksByCNC[cnc.Name] = selectedNetworks
+		}
 		networkIDsByCNC[cnc.Name] = networkIDs
 		for networkID := range networkIDs {
 			indexedCNCs := cncsByNetworkID[networkID]
@@ -746,12 +820,17 @@ func (c *nadController) syncAllCNCs() error {
 
 	c.Lock()
 	c.cncSelectedNetworks = selectedNetworksByCNC
+	c.cncPodNetworkSelectedNetworks = podNetworkSelectedNetworksByCNC
 	c.cncNetworkIDs = networkIDsByCNC
 	c.cncsByNetworkID = cncsByNetworkID
 	networksToReconcile := c.updateCNCConnectivityLocked()
+	podNetworksToReconcile := c.updateCNCPodNetworkConnectivityLocked()
 	c.Unlock()
 
-	c.reconcileNetworkActivity(networksToReconcile.UnsortedList())
+	if config.OVNKubernetesFeature.EnableDynamicUDNAllocation {
+		c.reconcileNetworkActivity(networksToReconcile.UnsortedList())
+	}
+	c.notifyPodNetworkConnectReconcilers(podNetworksToReconcile.UnsortedList())
 	return nil
 }
 
@@ -765,8 +844,10 @@ func (c *nadController) syncCNC(key string) error {
 
 	var selectedNetworks sets.Set[string]
 	var networkIDs sets.Set[int]
+	podNetworkEnabled := false
 	if err == nil {
 		selectedNetworks, networkIDs = c.networkSelectionsForCNC(cnc)
+		podNetworkEnabled = cncEnablesConnectivity(cnc, networkconnectv1.PodNetwork)
 	}
 
 	c.Lock()
@@ -778,11 +859,23 @@ func (c *nadController) syncCNC(key string) error {
 	} else {
 		c.cncSelectedNetworks[key] = selectedNetworks
 	}
+	if c.cncPodNetworkSelectedNetworks == nil {
+		c.cncPodNetworkSelectedNetworks = map[string]sets.Set[string]{}
+	}
+	if selectedNetworks == nil || !podNetworkEnabled {
+		delete(c.cncPodNetworkSelectedNetworks, key)
+	} else {
+		c.cncPodNetworkSelectedNetworks[key] = selectedNetworks
+	}
 	c.updateCNCNetworkIDsLocked(key, networkIDs)
 	networksToReconcile := c.updateCNCConnectivityLocked()
+	podNetworksToReconcile := c.updateCNCPodNetworkConnectivityLocked()
 	c.Unlock()
 
-	c.reconcileNetworkActivity(networksToReconcile.UnsortedList())
+	if config.OVNKubernetesFeature.EnableDynamicUDNAllocation {
+		c.reconcileNetworkActivity(networksToReconcile.UnsortedList())
+	}
+	c.notifyPodNetworkConnectReconcilers(podNetworksToReconcile.UnsortedList())
 	return nil
 }
 
@@ -852,6 +945,28 @@ func (c *nadController) DeRegisterNetworkRefReconciler(id uint64) {
 	delete(c.networkRefReconcilers, id)
 }
 
+// RegisterPodNetworkConnectReconciler registers a reconciler to receive
+// network names whose direct PodNetwork CNC peers changed.
+func (c *nadController) RegisterPodNetworkConnectReconciler(r PodNetworkConnectReconciler) uint64 {
+	c.Lock()
+	defer c.Unlock()
+	if c.podNetworkConnectReconcilers == nil {
+		c.podNetworkConnectReconcilers = map[uint64]podNetworkConnectReconcilerRegistration{}
+	}
+	c.nextPodNetworkConnectReconcilerID++
+	id := c.nextPodNetworkConnectReconcilerID
+	c.podNetworkConnectReconcilers[id] = podNetworkConnectReconcilerRegistration{id: id, r: r}
+	return id
+}
+
+// DeRegisterPodNetworkConnectReconciler removes a previously registered
+// PodNetwork CNC reconciler by ID.
+func (c *nadController) DeRegisterPodNetworkConnectReconciler(id uint64) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.podNetworkConnectReconcilers, id)
+}
+
 // notifyReconcilers enqueues the NAD key to all registered reconcilers
 // Must be called with nadController Mutex locked
 func (c *nadController) notifyReconcilers(key string) {
@@ -868,6 +983,24 @@ func (c *nadController) notifyNetworkRefReconcilers(node, networkName string) {
 	defer c.RUnlock()
 	for _, entry := range c.networkRefReconcilers {
 		entry.r.Reconcile(node, networkName)
+	}
+}
+
+func (c *nadController) notifyPodNetworkConnectReconcilers(networkNames []string) {
+	if len(networkNames) == 0 {
+		return
+	}
+
+	c.RLock()
+	reconcilers := make([]PodNetworkConnectReconciler, 0, len(c.podNetworkConnectReconcilers))
+	for _, entry := range c.podNetworkConnectReconcilers {
+		reconcilers = append(reconcilers, entry.r)
+	}
+	c.RUnlock()
+
+	sort.Strings(networkNames)
+	for _, reconciler := range reconcilers {
+		reconciler.ReconcilePodNetworkConnect(networkNames)
 	}
 }
 

--- a/go-controller/pkg/networkmanager/nad_controller_test.go
+++ b/go-controller/pkg/networkmanager/nad_controller_test.go
@@ -176,6 +176,19 @@ type testNetworkRefReconciler struct {
 	}
 }
 
+type testPodNetworkConnectReconciler struct {
+	updates chan string
+}
+
+func (tr *testPodNetworkConnectReconciler) ReconcilePodNetworkConnect(networkNames []string) {
+	if tr == nil || tr.updates == nil {
+		return
+	}
+	for _, networkName := range networkNames {
+		tr.updates <- networkName
+	}
+}
+
 func (tr *testNetworkRefReconciler) Reconcile(node, networkName string) {
 	if tr == nil || tr.updates == nil {
 		return
@@ -1919,7 +1932,60 @@ func TestNodeHasNetworkIncludesCNCConnectivity(t *testing.T) {
 	g.Expect(nc.NodeHasNetwork("node1", "net-c")).To(gomega.BeFalse())
 }
 
-func TestSyncCNCIncludesClusterIPServiceConnectivity(t *testing.T) {
+func TestGetPodNetworkConnectedNetworksReturnsOnlyDirectPeers(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+
+	newPrimaryNetwork := func(name, subnet string, networkID int) util.MutableNetInfo {
+		netInfo, err := util.NewNetInfo(&ovncnitypes.NetConf{
+			NetConf: cnitypes.NetConf{
+				Name: name,
+				Type: "ovn-k8s-cni-overlay",
+			},
+			Topology: types.Layer2Topology,
+			Role:     types.NetworkRolePrimary,
+			Subnets:  subnet,
+		})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		mutableNetInfo := util.NewMutableNetInfo(netInfo)
+		mutableNetInfo.SetNetworkID(networkID)
+		return mutableNetInfo
+	}
+
+	networks := map[string]util.MutableNetInfo{
+		"net-a": newPrimaryNetwork("net-a", "10.1.0.0/24", 1),
+		"net-b": newPrimaryNetwork("net-b", "10.2.0.0/24", 2),
+		"net-c": newPrimaryNetwork("net-c", "10.3.0.0/24", 3),
+	}
+	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
+	g.Expect(networkIDAllocator.ReserveID(types.DefaultNetworkName, types.DefaultNetworkID)).To(gomega.Succeed())
+	for networkName, netInfo := range networks {
+		g.Expect(networkIDAllocator.ReserveID(networkName, netInfo.GetNetworkID())).To(gomega.Succeed())
+	}
+
+	nc := &nadController{
+		networkIDAllocator: networkIDAllocator,
+		networkController: &networkController{
+			networks: networks,
+			networksByID: map[int]string{
+				1: "net-a",
+				2: "net-b",
+				3: "net-c",
+			},
+		},
+		cncPodNetworkConnectedNetworks: map[string]sets.Set[string]{
+			"net-a": sets.New[string]("net-b"),
+			"net-b": sets.New[string]("net-a", "net-c"),
+			"net-c": sets.New[string]("net-b"),
+		},
+	}
+
+	connectedNetworks := nc.GetPodNetworkConnectedNetworks("net-a")
+	g.Expect(connectedNetworks).To(gomega.HaveLen(1))
+	g.Expect(connectedNetworks[0].GetNetworkName()).To(gomega.Equal("net-b"))
+}
+
+func TestSyncCNCDistinguishesServiceAndPodNetworkConnectivity(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	networkIDAllocator := id.NewIDAllocator("NetworkIDs", MaxNetworks)
@@ -1947,17 +2013,36 @@ func TestSyncCNCIncludesClusterIPServiceConnectivity(t *testing.T) {
 			"net-a": sets.New[string](),
 			"net-b": sets.New[string](),
 		},
-		cncConnectedNetworks: map[string]sets.Set[string]{},
+		cncConnectedNetworks:           map[string]sets.Set[string]{},
+		cncPodNetworkConnectedNetworks: map[string]sets.Set[string]{},
 		cncLister: &fakeCNCLister{
 			cncs: map[string]*networkconnectv1.ClusterNetworkConnect{
 				cnc.Name: cnc,
 			},
 		},
 	}
+	updates := make(chan string, 4)
+	reconcilerID := nc.RegisterPodNetworkConnectReconciler(&testPodNetworkConnectReconciler{updates: updates})
+	defer nc.DeRegisterPodNetworkConnectReconciler(reconcilerID)
 
 	g.Expect(nc.syncAllCNCs()).To(gomega.Succeed())
 	g.Expect(nc.cncConnectedNetworks["net-a"].Has("net-b")).To(gomega.BeTrue())
 	g.Expect(nc.cncConnectedNetworks["net-b"].Has("net-a")).To(gomega.BeTrue())
+	g.Expect(nc.cncPodNetworkConnectedNetworks).To(gomega.BeEmpty())
+	g.Consistently(updates, 100*time.Millisecond).ShouldNot(gomega.Receive())
+
+	cnc.Spec.Connectivity = []networkconnectv1.ConnectivityType{networkconnectv1.PodNetwork}
+	g.Expect(nc.syncCNC(cnc.Name)).To(gomega.Succeed())
+	g.Expect(nc.cncPodNetworkConnectedNetworks["net-a"].Has("net-b")).To(gomega.BeTrue())
+	g.Expect(nc.cncPodNetworkConnectedNetworks["net-b"].Has("net-a")).To(gomega.BeTrue())
+	g.Eventually(updates, time.Second).Should(gomega.Receive(gomega.Equal("net-a")))
+	g.Eventually(updates, time.Second).Should(gomega.Receive(gomega.Equal("net-b")))
+
+	cnc.Spec.Connectivity = []networkconnectv1.ConnectivityType{networkconnectv1.ServiceNetwork}
+	g.Expect(nc.syncCNC(cnc.Name)).To(gomega.Succeed())
+	g.Expect(nc.cncPodNetworkConnectedNetworks).To(gomega.BeEmpty())
+	g.Eventually(updates, time.Second).Should(gomega.Receive(gomega.Equal("net-a")))
+	g.Eventually(updates, time.Second).Should(gomega.Receive(gomega.Equal("net-b")))
 }
 
 func TestSyncCNCSyncsOnlyRequestedCNC(t *testing.T) {

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/generator/udn"
 	libovsdbops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	libovsdbutil "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/util"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/networkmanager"
 	addressset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/syncmap"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
@@ -61,6 +62,13 @@ type podSelectorAddressSet struct {
 	// network-specific fields
 	controllerName string
 	netInfo        util.NetInfo
+	// includePodNetworkCNCPeers makes NetworkPolicy selector address sets
+	// resolve pod IPs from networks directly connected through a CNC with
+	// PodNetwork connectivity.
+	includePodNetworkCNCPeers bool
+	// podNetworkCNCBackRefs tracks which users require CNC expansion because
+	// selector address sets may also be shared with non-policy users.
+	podNetworkCNCBackRefs sets.Set[string]
 
 	// legacyNetpolMode makes nil and empty PodSelectors behave differently (it shouldn't be the case,
 	// but this is a legacy behaviour that customers rely on).
@@ -101,8 +109,12 @@ type AddressSetManager struct {
 	nodeController       controller.Controller
 	addressSetReconciler controller.Reconciler
 
-	// All network controllers are getting this function from the same networkmanager, so we can share it
-	getNetworkNameForNADKey func(nadKey string) string
+	// All network controllers use the same network manager, so selector address
+	// sets can resolve both NADs and direct PodNetwork CNC peers consistently.
+	networkManager networkmanager.Interface
+	// All network controllers are getting this function from the same networkmanager, so we can share it.
+	getNetworkNameForNADKey       func(nadKey string) string
+	podNetworkConnectReconcilerID uint64
 
 	// hostNetworkNamespaceExists, hostNetworkNamespaceIPsPerNode and hostNetworkSelectingAddrSets are protected by the same lock.
 	// can only be taken after the addressSets key lock and never vice versa to avoid deadlocks.
@@ -118,7 +130,7 @@ type AddressSetManager struct {
 }
 
 func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInformer coreinformers.NamespaceInformer,
-	nodeInformer coreinformers.NodeInformer, nbClient libovsdbclient.Client, getNetworkNameForNADKey func(nadKey string) string) *AddressSetManager {
+	nodeInformer coreinformers.NodeInformer, nbClient libovsdbclient.Client, networkManager networkmanager.Interface) *AddressSetManager {
 	m := &AddressSetManager{
 		name:                           "pod-selector-address-set-manager",
 		nbClient:                       nbClient,
@@ -129,7 +141,8 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 		podLister:                      podInformer.Lister(),
 		namespaceLister:                namespaceInformer.Lister(),
 		nodeLister:                     nodeInformer.Lister(),
-		getNetworkNameForNADKey:        getNetworkNameForNADKey,
+		networkManager:                 networkManager,
+		getNetworkNameForNADKey:        networkManager.GetNetworkNameForNADKey,
 		hostNetworkSelectingAddrSets:   sets.New[string](),
 		hostNetworkNamespaceIPsPerNode: make(map[string][]string),
 		clusterNodeIPsBackRefs:         sets.New[string](),
@@ -177,6 +190,7 @@ func NewAddressSetManager(podInformer coreinformers.PodInformer, namespaceInform
 			MaxAttempts: controller.InfiniteAttempts,
 		},
 	)
+	m.podNetworkConnectReconcilerID = networkManager.RegisterPodNetworkConnectReconciler(m)
 	return m
 }
 
@@ -187,7 +201,32 @@ func (m *AddressSetManager) Start() error {
 
 func (m *AddressSetManager) Stop() {
 	klog.Infof("Stopping %s controller", m.name)
+	if m.podNetworkConnectReconcilerID != 0 {
+		m.networkManager.DeRegisterPodNetworkConnectReconciler(m.podNetworkConnectReconcilerID)
+		m.podNetworkConnectReconcilerID = 0
+	}
 	controller.Stop(m.podController, m.nsController, m.nodeController, m.addressSetReconciler)
+}
+
+// ReconcilePodNetworkConnect implements
+// networkmanager.PodNetworkConnectReconciler. CNC changes are network-scoped,
+// so only NetworkPolicy address sets owned by affected network controllers
+// need to be refreshed.
+func (m *AddressSetManager) ReconcilePodNetworkConnect(networkNames []string) {
+	affectedNetworks := sets.New(networkNames...)
+	for _, key := range m.addressSets.GetKeys() {
+		err := m.addressSets.DoWithLock(key, func(key string) error {
+			psAddrSet, found := m.addressSets.Load(key)
+			if found && psAddrSet.includePodNetworkCNCPeers &&
+				affectedNetworks.Has(psAddrSet.netInfo.GetNetworkName()) {
+				m.addressSetReconciler.Reconcile(key)
+			}
+			return nil
+		})
+		if err != nil {
+			klog.Errorf("Failed to queue address set %s after PodNetwork CNC change: %v", key, err)
+		}
+	}
 }
 
 // initialSync will clean up all address sets that don't have ACL reference
@@ -279,7 +318,8 @@ func (m *AddressSetManager) syncClusterNodeIPsAddressSetLocked() error {
 	return nil
 }
 
-// EnsureAddressSet returns address set for requested (podSelector, namespaceSelector, namespace, nodeSelector).
+// EnsureAddressSet ensures an address set for the requested
+// (podSelector, namespaceSelector, namespace, nodeSelector), scoped to one network.
 // If namespaceSelector is nil, namespace will be used with podSelector statically.
 // podSelector should not be nil, use metav1.LabelSelector{} to match all pods.
 // namespaceSelector can only be nil when namespace is set, use metav1.LabelSelector{} to match all namespaces.
@@ -294,6 +334,21 @@ func (m *AddressSetManager) syncClusterNodeIPsAddressSetLocked() error {
 // psAddrSetHashV4, psAddrSetHashV6 may be set to empty string if address set for that ipFamily wasn't created.
 func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector,
 	namespace, backRef, controllerName string, netInfo util.NetInfo, legacyNetpolMode bool) (addrSetKey, psAddrSetHashV4, psAddrSetHashV6 string, err error) {
+	return m.ensureAddressSet(podSelector, namespaceSelector, nodeSelector, namespace, backRef, controllerName,
+		netInfo, legacyNetpolMode, false)
+}
+
+// EnsureAddressSetForNetworkPolicy ensures a selector address set whose pod
+// IPs may come from the policy network or any network directly connected to it
+// through a CNC with PodNetwork connectivity.
+func (m *AddressSetManager) EnsureAddressSetForNetworkPolicy(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector,
+	namespace, backRef, controllerName string, netInfo util.NetInfo, legacyNetpolMode bool) (addrSetKey, psAddrSetHashV4, psAddrSetHashV6 string, err error) {
+	return m.ensureAddressSet(podSelector, namespaceSelector, nodeSelector, namespace, backRef, controllerName,
+		netInfo, legacyNetpolMode, true)
+}
+
+func (m *AddressSetManager) ensureAddressSet(podSelector, namespaceSelector, nodeSelector *metav1.LabelSelector,
+	namespace, backRef, controllerName string, netInfo util.NetInfo, legacyNetpolMode, includePodNetworkCNCPeers bool) (addrSetKey, psAddrSetHashV4, psAddrSetHashV6 string, err error) {
 	nodeSelector = normalizeNodeSelector(nodeSelector)
 	if podSelector == nil {
 		err = fmt.Errorf("pod selector is nil")
@@ -330,7 +385,7 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 	}
 	addrSetKey = getInternalKey(podSelector, namespaceSelector, nodeSelector, namespace, controllerName, legacyNetpolMode)
 
-	var found bool
+	var found, cncScopeChanged bool
 	err = m.addressSets.DoWithLock(addrSetKey, func(key string) error {
 		var psAddrSet *podSelectorAddressSet
 		psAddrSet, found = m.addressSets.Load(key)
@@ -353,15 +408,16 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 				return err
 			}
 			psAddrSet = &podSelectorAddressSet{
-				backRefs:          map[string]bool{},
-				podSelector:       podSel,
-				namespaceSelector: nsSel,
-				namespace:         namespace,
-				nodeSelector:      nodeSel,
-				addressSet:        addrSet,
-				controllerName:    controllerName,
-				netInfo:           netInfo,
-				legacyNetpolMode:  legacyNetpolMode,
+				backRefs:              map[string]bool{},
+				podSelector:           podSel,
+				namespaceSelector:     nsSel,
+				namespace:             namespace,
+				nodeSelector:          nodeSel,
+				addressSet:            addrSet,
+				controllerName:        controllerName,
+				netInfo:               netInfo,
+				legacyNetpolMode:      legacyNetpolMode,
+				podNetworkCNCBackRefs: sets.New[string](),
 				selectedNamespaces: &selectedNamespaces{
 					set: sets.New[string](),
 					// until the first reconcile, we assume all namespaces are selected to avoid missing any updates
@@ -369,6 +425,14 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 				},
 			}
 			m.addressSets.LoadOrStore(key, psAddrSet)
+		}
+		if includePodNetworkCNCPeers {
+			if psAddrSet.podNetworkCNCBackRefs == nil {
+				psAddrSet.podNetworkCNCBackRefs = sets.New[string]()
+			}
+			cncScopeChanged = found && !psAddrSet.includePodNetworkCNCPeers
+			psAddrSet.includePodNetworkCNCPeers = true
+			psAddrSet.podNetworkCNCBackRefs.Insert(backRef)
 		}
 		// psAddrSet is successfully init-ed
 		psAddrSet.backRefs[backRef] = true
@@ -378,7 +442,7 @@ func (m *AddressSetManager) EnsureAddressSet(podSelector, namespaceSelector, nod
 	if err != nil {
 		return
 	}
-	if !found {
+	if !found || cncScopeChanged {
 		// Populate a newly created address set before returning hashes to the caller.
 		// Until reconcile runs, the NB object is empty while ACLs may already reference it
 		// (e.g. on DB ID change or first ensure). This is a one-time sync on creation;
@@ -420,6 +484,7 @@ func (m *AddressSetManager) DeleteAddressSet(addrSetKey, backRef string) error {
 			return nil
 		}
 		delete(psAddrSet.backRefs, backRef)
+		psAddrSet.podNetworkCNCBackRefs.Delete(backRef)
 		if len(psAddrSet.backRefs) == 0 {
 			err := psAddrSet.addressSet.Destroy()
 			if err != nil {
@@ -429,6 +494,9 @@ func (m *AddressSetManager) DeleteAddressSet(addrSetKey, backRef string) error {
 			m.hostNetworkNamespaceLock.Lock()
 			m.hostNetworkSelectingAddrSets.Delete(key)
 			m.hostNetworkNamespaceLock.Unlock()
+		} else if psAddrSet.includePodNetworkCNCPeers && len(psAddrSet.podNetworkCNCBackRefs) == 0 {
+			psAddrSet.includePodNetworkCNCPeers = false
+			m.addressSetReconciler.Reconcile(key)
 		}
 		return nil
 	})
@@ -854,7 +922,12 @@ func (m *AddressSetManager) reconcileAddressSet(key string) error {
 			pods = filtered
 			psAddrSet.selectedNodes = selectedNodes
 		}
-		ips, err := m.getPodIPs(pods, psAddrSet.netInfo, psAddrSet.legacyNetpolMode)
+		networks := []util.NetInfo{psAddrSet.netInfo}
+		if psAddrSet.includePodNetworkCNCPeers {
+			networks = append(networks,
+				m.networkManager.GetPodNetworkConnectedNetworks(psAddrSet.netInfo.GetNetworkName())...)
+		}
+		ips, err := m.getPodIPs(pods, networks, psAddrSet.legacyNetpolMode)
 		if err != nil {
 			return fmt.Errorf("failed to get pod IPs: %v", err)
 		}
@@ -936,8 +1009,9 @@ func (m *AddressSetManager) getSelectedNodes(nodeSelector labels.Selector) (sets
 	return names, nil
 }
 
-func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, netInfo util.NetInfo, noHostNetwork bool) ([]string, error) {
+func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, networks []util.NetInfo, noHostNetwork bool) ([]string, error) {
 	ips := []string{}
+	selectedIPs := sets.New[string]()
 	for _, pod := range pods {
 		if noHostNetwork && pod.Spec.HostNetwork {
 			// skip hostNetwork pods if requested, since they are not selected in legacyNetpolMode
@@ -952,12 +1026,23 @@ func (m *AddressSetManager) getPodIPs(pods []*corev1.Pod, netInfo util.NetInfo, 
 		if util.PodCompleted(pod) {
 			continue
 		}
-		podIPs, err := util.GetPodIPsOfNetwork(pod, netInfo, m.getNetworkNameForNADKey)
-		if err != nil {
-			// not finding pod IPs on a remote pod is common until the other node wires the pod, suppress it
-			return nil, ovntypes.NewSuppressedError(err)
+		for _, netInfo := range networks {
+			if netInfo == nil {
+				continue
+			}
+			podIPs, err := util.GetPodIPsOfNetwork(pod, netInfo, m.getNetworkNameForNADKey)
+			if err != nil {
+				// not finding pod IPs on a remote pod is common until the other node wires the pod, suppress it
+				return nil, ovntypes.NewSuppressedError(err)
+			}
+			for _, podIP := range util.StringSlice(podIPs) {
+				if selectedIPs.Has(podIP) {
+					continue
+				}
+				selectedIPs.Insert(podIP)
+				ips = append(ips, podIP)
+			}
 		}
-		ips = append(ips, util.StringSlice(podIPs)...)
 	}
 	return ips, nil
 }

--- a/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
+++ b/go-controller/pkg/ovn/addresssetmanager/addressset_manager_test.go
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		// this is only used for "saves db transactions when IPs don't change" test
 		countingNBClient = &countingClient{Client: libovsdbNBClient}
 		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), countingNBClient,
-			fakeNetworkManager.Interface().GetNetworkNameForNADKey)
+			fakeNetworkManager.Interface())
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
@@ -312,6 +312,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 	config.IPv4Mode = true
 	config.IPv6Mode = false
 	primaryNetInfo := newNetInfo("primarynet", types.Layer3Topology, types.NetworkRolePrimary, "10.128.1.0/24/27")
+	connectedPrimaryNetInfo := newNetInfo("connectedprimarynet", types.Layer3Topology, types.NetworkRolePrimary, "10.129.1.0/24/27")
 	secondaryNetInfo := newNetInfo("secondarynet", types.Layer2Topology, types.NetworkRoleSecondary, "10.128.1.0/24")
 
 	newPod := func(namespace, name, node, podIP string, netInfo util.NetInfo) *corev1.Pod {
@@ -323,6 +324,39 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 			return testing.NewPodWithSecondaryNADIP(namespace, name, node, "10.244.0.2", netInfo.GetNetworkName(), podIP)
 		}
 	}
+
+	ginkgo.It("updates NetworkPolicy peer IPs when PodNetwork CNC connectivity changes", func() {
+		const peerNamespaceLabel = "cnc-network-policy-peer"
+		namespace1 := *testing.NewNamespace(namespaceName1)
+		namespace2 := *testing.NewNamespace(namespaceName2)
+		namespace2.Labels[peerNamespaceLabel] = "allowed"
+		remotePodIP := "10.129.1.3"
+		remotePod := newPod(namespace2.Name, "remote-pod", nodeName, remotePodIP, connectedPrimaryNetInfo)
+
+		startAddrSetManager(initialDB, []corev1.Namespace{namespace1, namespace2}, []corev1.Pod{*remotePod})
+
+		peer := knet.NetworkPolicyPeer{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{peerNamespaceLabel: "allowed"},
+			},
+		}
+		podSelector := &metav1.LabelSelector{}
+		_, _, _, err := addressSetManager.EnsureAddressSetForNetworkPolicy(
+			podSelector, peer.NamespaceSelector, nil, namespace1.Name, "backRef", controllerName, primaryNetInfo, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		peerASIDs := GetPodSelectorAddrSetDbIDs(podSelector, peer.NamespaceSelector, nil,
+			namespace1.Name, controllerName, true)
+		emptyPeerAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{})
+		gomega.Expect(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyPeerAS}))
+
+		fakeNetworkManager.SetPodNetworkConnectedNetworks(primaryNetInfo.GetNetworkName(), connectedPrimaryNetInfo)
+		connectedPeerAS, _ := addressset.GetTestDbAddrSets(peerASIDs, []string{remotePodIP})
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{connectedPeerAS}))
+
+		fakeNetworkManager.SetPodNetworkConnectedNetworks(primaryNetInfo.GetNetworkName())
+		gomega.Eventually(addressSetManager.nbClient).Should(libovsdbtest.HaveData([]libovsdbtest.TestData{emptyPeerAS}))
+	})
 
 	for _, netInfo := range []util.NetInfo{&util.DefaultNetInfo{}, primaryNetInfo, secondaryNetInfo} {
 		netInfo := netInfo
@@ -891,7 +925,7 @@ var _ = ginkgo.Describe("OVN podSelectorAddressSet", func() {
 		err = clientSet.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		addressSetManager = NewAddressSetManager(wf.PodCoreInformer(), wf.NamespaceInformer(), wf.NodeCoreInformer(), libovsdbNBClient,
-			func(_ string) string { return "" })
+			fakeNetworkManager.Interface())
 		err = addressSetManager.Start()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		// run EnsureAddressSet again, otherwise address set won't be reconciled with no users

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -1171,7 +1171,7 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 		podSelector = &metav1.LabelSelector{}
 	}
 	// np.namespace will be used when fromJSON.NamespaceSelector = nil
-	asKey, ipv4as, ipv6as, err := bnc.addressSetManager.EnsureAddressSet(
+	asKey, ipv4as, ipv6as, err := bnc.addressSetManager.EnsureAddressSetForNetworkPolicy(
 		podSelector, peer.NamespaceSelector, nil, np.namespace, np.getKeyWithKind(), bnc.controllerName, bnc.GetNetInfo(), useNamespaceAddrSet(peer))
 	// even if GetPodSelectorAddressSet failed, add key for future cleanup or retry.
 	np.peerAddressSets = append(np.peerAddressSets, asKey)

--- a/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_user_defined_test.go
@@ -598,7 +598,7 @@ func newAdvertisedSNATTestControllerForTopology(
 		watchFactory.NamespaceInformer(),
 		watchFactory.NodeCoreInformer(),
 		nbClient,
-		networkmanager.Default().Interface().GetNetworkNameForNADKey,
+		networkmanager.Default().Interface(),
 	)
 	return &BaseUserDefinedNetworkController{
 			BaseNetworkController: BaseNetworkController{

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -598,7 +598,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 		recorder = record.NewFakeRecorder(10)
 		netManager := networkmanager.Default()
 		addressSetManager := addresssetmanager.NewAddressSetManager(f.PodCoreInformer(), f.NamespaceInformer(),
-			f.NodeCoreInformer(), nbClient, netManager.Interface().GetNetworkNameForNADKey)
+			f.NodeCoreInformer(), nbClient, netManager.Interface())
 		oc, err = NewOvnController(
 			fakeClient,
 			f,

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -291,7 +291,7 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 
 	o.portCache = NewPortCache(o.stopChan)
 	o.addressSetManager = addresssetmanager.NewAddressSetManager(o.watcher.PodCoreInformer(),
-		o.watcher.NamespaceInformer(), o.watcher.NodeCoreInformer(), o.nbClient, o.networkManager.Interface().GetNetworkNameForNADKey)
+		o.watcher.NamespaceInformer(), o.watcher.NodeCoreInformer(), o.nbClient, o.networkManager.Interface())
 
 	kubeOVN := &kube.KubeOVN{
 		Kube:      kube.Kube{KClient: o.fakeClient.KubeClient},

--- a/test/e2e/cluster_network_connect.go
+++ b/test/e2e/cluster_network_connect.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -2708,6 +2709,96 @@ var _ = Describe("ClusterNetworkConnect OVN-Kubernetes Controller", feature.Netw
 			}
 		}
 	}
+
+	Context("NetworkPolicy", func() {
+		It("allows namespace-selected peers from a directly connected primary network", func() {
+			testID := rand.String(5)
+			cncName := generateCNCName()
+			serverNamespace := fmt.Sprintf("cnc-netpol-server-%s", testID)
+			clientNamespace := fmt.Sprintf("cnc-netpol-client-%s", testID)
+			serverUDN := "server-network"
+			clientUDN := "client-network"
+			peerLabelKey := "cnc-network-policy-peer"
+			cncLabelKey := "cnc-network-policy"
+			serverPodName := "server"
+			clientPodName := "client"
+
+			DeferCleanup(func() {
+				_ = cs.NetworkingV1().NetworkPolicies(serverNamespace).Delete(
+					context.Background(), "allow-connected-peer", metav1.DeleteOptions{})
+				deleteCNC(cncName)
+				_ = cs.CoreV1().Pods(serverNamespace).Delete(context.Background(), serverPodName, metav1.DeleteOptions{})
+				_ = cs.CoreV1().Pods(clientNamespace).Delete(context.Background(), clientPodName, metav1.DeleteOptions{})
+				deleteUDN(serverNamespace, serverUDN)
+				deleteUDN(clientNamespace, clientUDN)
+				deleteNamespace(cs, serverNamespace)
+				deleteNamespace(cs, clientNamespace)
+			})
+
+			By("creating two primary UDNs selected by the same CNC")
+			createUDNNamespaceWithName(cs, serverNamespace, map[string]string{cncLabelKey: testID})
+			createUDNNamespaceWithName(cs, clientNamespace, map[string]string{
+				cncLabelKey:  testID,
+				peerLabelKey: testID,
+			})
+			nextSubnets := newTestNetworkSubnetsAllocator()
+			v4, v6 := nextSubnets(true)
+			createLayer3PrimaryUDNWithSubnets(cs, serverNamespace, serverUDN, v4, v6)
+			v4, v6 = nextSubnets(false)
+			createLayer2PrimaryUDNWithSubnets(cs, clientNamespace, clientUDN, v4, v6)
+			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, serverNamespace, serverUDN),
+				60*time.Second, time.Second).Should(Succeed())
+			Eventually(userDefinedNetworkReadyFunc(f.DynamicClient, clientNamespace, clientUDN),
+				60*time.Second, time.Second).Should(Succeed())
+
+			runUDNPod(cs, serverNamespace, httpServerPodConfig(serverPodName, serverNamespace), nil)
+			clientPod := runUDNPod(cs, clientNamespace, httpServerPodConfig(clientPodName, clientNamespace), nil)
+			serverPodIPs := getPrimaryNetworkPodIPs(serverNamespace, serverPodName, serverUDN)
+
+			By("creating an ingress policy before the networks are connected")
+			_, err := cs.NetworkingV1().NetworkPolicies(serverNamespace).Create(context.Background(), &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "allow-connected-peer",
+					Namespace: serverNamespace,
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+					Ingress: []networkingv1.NetworkPolicyIngressRule{{
+						From: []networkingv1.NetworkPolicyPeer{{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{peerLabelKey: testID},
+							},
+						}},
+					}},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("connecting the networks with PodNetwork connectivity")
+			createOrUpdateCNC(cs, cncName, nil, map[string]string{cncLabelKey: testID})
+			verifyCNCSubnetAnnotationNetworkCount(cncName, 2)
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{clientPodName: clientPod},
+				map[string][]string{serverPodName: serverPodIPs}, true)
+
+			By("removing the peer label while keeping the networks connected")
+			_, err = cs.CoreV1().Namespaces().Patch(context.Background(), clientNamespace, types.MergePatchType,
+				[]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":null}}}`, peerLabelKey)), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{clientPodName: clientPod},
+				map[string][]string{serverPodName: serverPodIPs}, false)
+
+			By("restoring the peer label")
+			_, err = cs.CoreV1().Namespaces().Patch(context.Background(), clientNamespace, types.MergePatchType,
+				[]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, peerLabelKey, testID)), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			verifyCrossNetworkConnectivity(
+				map[string]*corev1.Pod{clientPodName: clientPod},
+				map[string][]string{serverPodName: serverPodIPs}, true)
+		})
+	})
 
 	/*
 	   This test validates end-to-end connectivity through CNC (ClusterNetworkConnect).


### PR DESCRIPTION
Primary network controllers scope namespace and pod selector address sets to pods attached to their own network. As a result, a NetworkPolicy could not select pods in another primary UDN even when a ClusterNetworkConnect provided PodNetwork connectivity.

Track direct PodNetwork peers in the network manager and notify the address set manager when a CNC relationship changes. Expand only NetworkPolicy selector address sets with pod IPs from the policy network and its directly connected peers. Resolve every IP against its exact network attachment so unrelated UDNs remain excluded.

Keep ServiceNetwork connections and transitive CNC relationships out of the policy scope. CNC continues to reject directly connected networks with overlapping pod subnets.

Add unit coverage for CNC relationship changes, selector address sets, and policy ACL behavior. Add an end-to-end test that verifies policy enforcement as namespace labels change, and document the semantics.

Fixes: #6331

Assisted-by: OpenAI Codex <codex@openai.com>

