### PR TITLE
Add enable-udn-arp-proxy and enable-udn-ndp-proxy feature flags

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -545,6 +545,8 @@ type OVNKubernetesFeatureConfig struct {
 	// UDNDeletionGracePeriod specified in number of seconds to wait before garbage collecting a UDN. Applies
 	// only when Dynamic UDN Allocation is enabled.
 	UDNDeletionGracePeriod time.Duration `gcfg:"udn-deletion-grace-period"`
+	EnableUDNARPProxy      bool          `gcfg:"enable-udn-arp-proxy"`
+	EnableUDNNDPProxy      bool          `gcfg:"enable-udn-ndp-proxy"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -1366,6 +1368,20 @@ var OVNK8sFeatureFlags = []cli.Flag{
 			"feature is used.",
 		Destination: &cliConfig.OVNKubernetesFeature.UDNDeletionGracePeriod,
 		Value:       OVNKubernetesFeature.UDNDeletionGracePeriod,
+	},
+	&cli.BoolFlag{
+		Name: "enable-udn-arp-proxy",
+		Usage: "Enable IPv4 broadcast isolation and ARP proxy flows on br-ex. " +
+			"Helps mitigate packet drops and high OVS CPU caused by ARP replies fan-out to UDNs.",
+		Destination: &cliConfig.OVNKubernetesFeature.EnableUDNARPProxy,
+		Value:       OVNKubernetesFeature.EnableUDNARPProxy,
+	},
+	&cli.BoolFlag{
+		Name: "enable-udn-ndp-proxy",
+		Usage: "Enable IPv6 multicast isolation and MAC binding propagation on UDN gateway routers. " +
+			"Helps mitigate packet drops and high OVS CPU caused by network advertisements fan-out to UDNs.",
+		Destination: &cliConfig.OVNKubernetesFeature.EnableUDNNDPProxy,
+		Value:       OVNKubernetesFeature.EnableUDNNDPProxy,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -246,6 +246,8 @@ advertised-udn-isolation-mode=strict
 enable-multi-external-gateway=false
 enable-admin-network-policy=false
 enable-persistent-ips=false
+enable-udn-arp-proxy=false
+enable-udn-ndp-proxy=false
 
 [clustermanager]
 v4-transit-subnet=100.89.0.0/16
@@ -363,6 +365,8 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OVNKubernetesFeature.EnableAdminNetworkPolicy).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EnablePersistentIPs).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.AdvertisedUDNIsolationMode).To(gomega.Equal(AdvertisedUDNIsolationModeStrict))
+			gomega.Expect(OVNKubernetesFeature.EnableUDNARPProxy).To(gomega.BeFalse())
+			gomega.Expect(OVNKubernetesFeature.EnableUDNNDPProxy).To(gomega.BeFalse())
 
 			for _, a := range []OvnAuthConfig{OvnNorth, OvnSouth} {
 				gomega.Expect(a.PrivKey).To(gomega.Equal(""))
@@ -513,6 +517,8 @@ routing-table-id-start=2002
 			"enable-multi-external-gateway=true",
 			"enable-admin-network-policy=true",
 			"enable-persistent-ips=true",
+			"enable-udn-arp-proxy=true",
+			"enable-udn-ndp-proxy=true",
 			"zone=foo",
 		)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -613,6 +619,8 @@ routing-table-id-start=2002
 			gomega.Expect(OVNKubernetesFeature.EnableMultiExternalGateway).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableAdminNetworkPolicy).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnablePersistentIPs).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EnableUDNARPProxy).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EnableUDNNDPProxy).To(gomega.BeTrue())
 			gomega.Expect(HybridOverlay.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("11.132.0.0/14"), 23},
 			}))
@@ -727,6 +735,8 @@ routing-table-id-start=2002
 			gomega.Expect(OVNKubernetesFeature.EnableMultiExternalGateway).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnableAdminNetworkPolicy).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EnablePersistentIPs).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EnableUDNARPProxy).To(gomega.BeTrue())
+			gomega.Expect(OVNKubernetesFeature.EnableUDNNDPProxy).To(gomega.BeTrue())
 			gomega.Expect(HybridOverlay.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("11.132.0.0/14"), 23},
 			}))
@@ -799,6 +809,8 @@ routing-table-id-start=2002
 			"-enable-multi-external-gateway=true",
 			"-enable-admin-network-policy=true",
 			"-enable-persistent-ips=true",
+			"-enable-udn-arp-proxy=true",
+			"-enable-udn-ndp-proxy=true",
 			"-healthz-bind-address=0.0.0.0:4321",
 			"-zone=bar",
 			"-dns-service-namespace=kube-system-2",


### PR DESCRIPTION
These flags control ARP/NDP proxy behavior on br-ex to mitigate packet drops and high OVS CPU caused by ARP replies and network advertisements fan-out to UDNs.


Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

