### PR TITLE
Make DPU the sole Uplink gateway status writer

### DIFF
--- a/go-controller/pkg/node/uplink_gateway_controller.go
+++ b/go-controller/pkg/node/uplink_gateway_controller.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	uplinkv1alpha1 "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/uplink/v1alpha1"
 	uplinkapply "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/uplink/v1alpha1/apis/applyconfiguration/uplink/v1alpha1"
 	uplinkclientset "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/crd/uplink/v1alpha1/apis/clientset/versioned"
@@ -56,9 +57,14 @@ type uplinkGatewayState struct {
 // UplinkGatewayController coordinates gateway programming and readiness for
 // all active CUDNs using an Uplink on the local node.
 type UplinkGatewayController struct {
-	nodeName            string
-	uplinkClient        uplinkclientset.Interface
-	uplinkStateLister   uplinklisters.UplinkStateLister
+	nodeName          string
+	uplinkClient      uplinkclientset.Interface
+	uplinkStateLister uplinklisters.UplinkStateLister
+	// The DPU owns GatewayReady in split-DPU deployments because it is the
+	// component that waits for OVN patch ports and programs OVS/OpenFlow.
+	// DPU-host gateway reconciliation still runs, but must not race the DPU
+	// for ownership of the shared condition.
+	publishStatus       bool
 	mutex               sync.Mutex
 	uplinks             map[string]*uplinkGatewayState
 	uplinkByNetworkName map[string]string
@@ -74,6 +80,7 @@ func NewUplinkGatewayController(
 		nodeName:            nodeName,
 		uplinkClient:        uplinkClient,
 		uplinkStateLister:   uplinkStateLister,
+		publishStatus:       !config.IsModeDPUHost(),
 		uplinks:             map[string]*uplinkGatewayState{},
 		uplinkByNetworkName: map[string]string{},
 	}
@@ -282,6 +289,10 @@ func (c *UplinkGatewayController) publishGatewayConditions(uplinkNames []string)
 // publishGatewayCondition writes the aggregate GatewayReady condition for all
 // active CUDNs using the node-local UplinkState.
 func (c *UplinkGatewayController) publishGatewayCondition(uplinkName string) error {
+	if !c.publishStatus {
+		return nil
+	}
+
 	c.mutex.Lock()
 	uplinkState := c.uplinks[uplinkName]
 	c.mutex.Unlock()

--- a/go-controller/pkg/node/uplink_gateway_controller_test.go
+++ b/go-controller/pkg/node/uplink_gateway_controller_test.go
@@ -254,6 +254,31 @@ func TestUplinkGatewayControllerSerializesSharedUplinkProgramming(t *testing.T) 
 	wg.Wait()
 }
 
+func TestUplinkGatewayControllerDPUHostDoesNotPublishGatewayReady(t *testing.T) {
+	prepareUplinkGatewayControllerTest(t)
+	config.OvnKubeNode.Mode = types.NodeModeDPUHost
+	const (
+		uplinkName = "uplink1"
+		nodeName   = "node-a"
+	)
+	controller, client := newUplinkGatewayControllerForTest(t, uplinkName, nodeName)
+	network := uplinkGatewayNetInfo(t, "red", uplinkName)
+	reconciled := false
+
+	if err := controller.ReconcileNetwork(network, func() error {
+		reconciled = true
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to reconcile DPU-host gateway: %v", err)
+	}
+	if !reconciled {
+		t.Fatal("expected DPU-host gateway reconciliation to run")
+	}
+	if len(client.Actions()) != 0 {
+		t.Fatalf("expected DPU host not to publish GatewayReady, got actions %v", client.Actions())
+	}
+}
+
 func TestUplinkGatewayControllerRejectsMismatchedStateIdentity(t *testing.T) {
 	prepareUplinkGatewayControllerTest(t)
 	const (


### PR DESCRIPTION
In split-DPU deployments, both DPU and DPU-host controllers published the shared GatewayReady condition. Their updates could race and leave CUDN UplinksReady status stale.

Keep DPU-host gateway reconciliation intact, but let only the DPU publish aggregate gateway readiness because it owns patch-port, OVS, and OpenFlow programming.

Add coverage that DPU-host reconciliation runs without writing GatewayReady.
