### PR TITLE
Restore DPU route import for networks without Uplinks

### DIFF
--- a/go-controller/pkg/node/gateway_udn.go
+++ b/go-controller/pkg/node/gateway_udn.go
@@ -491,13 +491,15 @@ func (udng *UserDefinedNetworkGateway) addNetwork() error {
 			udng.GetNetworkName(), err)
 	}
 
-	if config.IsModeDPU() && udng.Uplink() != "" {
+	if config.IsModeDPU() {
 		vrfDeviceName := util.GetNetworkVRFName(udng.NetInfo)
 		if err = udng.ensureDPUVRF(); err != nil {
 			return err
 		}
-		if err = udng.reconcileUplinkGatewayVRFSlave(vrfDeviceName); err != nil {
-			return err
+		if udng.Uplink() != "" {
+			if err = udng.reconcileUplinkGatewayVRFSlave(vrfDeviceName); err != nil {
+				return err
+			}
 		}
 	} else if config.IsModeDPUHost() || config.IsModeFull() {
 		mgmtPortName := util.GetNetworkScopedK8sMgmtHostIntfName(uint(udng.GetNetworkID()))


### PR DESCRIPTION
## 📑 Description

DPU mode stopped creating per-network VRFs when a network did not
reference an Uplink. Route import uses these VRFs as routing-table
anchors, so OVN did not receive remote pod subnet routes for no-overlay
primary networks.

Create the DPU VRF independently of Uplink configuration while keeping
gateway interface attachment conditional on an Uplink being configured.

## Additional Information for reviewers

The DPU gateway startup path now always creates the per-network
route-import VRF. Reconciliation of the Uplink gateway interface remains
conditional on the network referencing an Uplink.

This restores the behavior that existed before Uplink support without
changing Uplink, DPU-host, full-mode, or VRF cleanup behavior.

## ✅ Checks

- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [x] My code does not require tests
- [ ] All the tests have passed in the CI