### PR TITLE
factory: preserve informer initial-list add events

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -2049,10 +2049,10 @@ func noAlternateProxySelector() func(options *metav1.ListOptions) {
 // WithUpdateHandlingForObjReplace decorates given cache.ResourceEventHandler with checking object
 // replace case in the update event. when old and new object have different UIDs, then consider it
 // as a replace and invoke delete handler for old object followed by add handler for new object.
-func WithUpdateHandlingForObjReplace(funcs cache.ResourceEventHandler) cache.ResourceEventHandlerFuncs {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			funcs.OnAdd(obj, false)
+func WithUpdateHandlingForObjReplace(funcs cache.ResourceEventHandler) cache.ResourceEventHandlerDetailedFuncs {
+	return cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj interface{}, isInInitialList bool) {
+			funcs.OnAdd(obj, isInInitialList)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			oldObj := old.(metav1.Object)

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -349,6 +349,104 @@ func (c *handlerCalls) getDeleted() int {
 	return int(atomic.LoadInt32(&c.deleted))
 }
 
+var _ = Describe("Detailed resource event handlers", func() {
+	It("preserves initial-list status through object replacement handling", func() {
+		var (
+			addedInitialList bool
+			added            int
+			deleted          int
+		)
+		handler := WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerDetailedFuncs{
+			AddFunc: func(_ interface{}, isInInitialList bool) {
+				added++
+				addedInitialList = isInInitialList
+			},
+			DeleteFunc: func(interface{}) {
+				deleted++
+			},
+		})
+
+		handler.OnAdd(newPod("initial", "default"), true)
+		Expect(added).To(Equal(1))
+		Expect(addedInitialList).To(BeTrue())
+
+		oldPod := newPod("replacement", "default")
+		newPod := oldPod.DeepCopy()
+		newPod.UID = "replacement-uid"
+		handler.OnUpdate(oldPod, newPod)
+		Expect(deleted).To(Equal(1))
+		Expect(added).To(Equal(2))
+		Expect(addedInitialList).To(BeFalse())
+	})
+
+	It("preserves initial-list status through a federated queued handler", func() {
+		stopChan := make(chan struct{})
+
+		var shutdownWg sync.WaitGroup
+		queuedInternalInformer := &internalInformer{
+			handlers: map[int]map[uint64]*Handler{},
+			queueMap: newQueueMap(1, 1, &shutdownWg, stopChan),
+		}
+		queuedInternalInformer.queueMap.start()
+		defer shutdownWg.Wait()
+		defer close(stopChan)
+
+		isInInitialList := make(chan bool, 1)
+		queuedInternalInformer.handlers[0] = map[uint64]*Handler{
+			1: {
+				base: cache.FilteringResourceEventHandler{
+					FilterFunc: func(interface{}) bool { return true },
+					Handler: cache.ResourceEventHandlerDetailedFuncs{
+						AddFunc: func(_ interface{}, initial bool) {
+							isInInitialList <- initial
+						},
+					},
+				},
+				tombstone: handlerAlive,
+			},
+		}
+		atomic.StoreUint32(&queuedInternalInformer.hasHandlers, hasHandler)
+
+		informer := &informer{
+			oType:             reflect.TypeOf(&corev1.Pod{}),
+			internalInformers: []*internalInformer{queuedInternalInformer},
+		}
+		informer.newFederatedQueuedHandler(0).OnAdd(newPod("initial", "default"), true)
+
+		Eventually(isInInitialList).Should(Receive(BeTrue()))
+	})
+
+	It("marks existing-object replay as an initial list", func() {
+		stopChan := make(chan struct{})
+		sharedInformer := cache.NewSharedIndexInformer(
+			&cache.ListWatch{},
+			&corev1.Pod{},
+			0,
+			cache.Indexers{},
+		)
+		queuedInformer, err := newQueuedInformer(1, reflect.TypeOf(&corev1.Pod{}), sharedInformer, stopChan, 1)
+		Expect(err).NotTo(HaveOccurred())
+		defer queuedInformer.shutdownWg.Wait()
+		defer close(stopChan)
+
+		isInInitialList := make(chan bool, 1)
+		queuedInformer.addHandler(
+			0,
+			1,
+			0,
+			func(interface{}) bool { return true },
+			cache.ResourceEventHandlerDetailedFuncs{
+				AddFunc: func(_ interface{}, initial bool) {
+					isInInitialList <- initial
+				},
+			},
+			[]interface{}{newPod("existing", "default")},
+		)
+
+		Eventually(isInInitialList).Should(Receive(BeTrue()))
+	})
+})
+
 var _ = Describe("Watch Factory Operations", func() {
 	var (
 		ovnClientset                        *util.OVNKubeControllerClientset

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -394,11 +394,11 @@ func ensureObjectOnDelete(obj interface{}, expectedType reflect.Type) (interface
 	return obj, nil
 }
 
-func (i *informer) newFederatedQueuedHandler(internalInformerIndex int) cache.ResourceEventHandlerFuncs {
+func (i *informer) newFederatedQueuedHandler(internalInformerIndex int) cache.ResourceEventHandlerDetailedFuncs {
 	name := i.oType.Elem().Name()
 	intInf := i.internalInformers[internalInformerIndex]
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	return cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj interface{}, isInInitialList bool) {
 			// do not enqueue events to internal informer that has no handlers for better performance
 			if atomic.LoadUint32(&intInf.hasHandlers) == hasNoHandler {
 				return
@@ -407,7 +407,7 @@ func (i *informer) newFederatedQueuedHandler(internalInformerIndex int) cache.Re
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "add").Inc()
 				start := time.Now()
 				intInf.forEachQueuedHandler(func(h *Handler) {
-					h.OnAdd(e.obj, false)
+					h.OnAdd(e.obj, isInInitialList)
 				})
 				metrics.MetricResourceAddLatency.Observe(time.Since(start).Seconds())
 			})
@@ -570,7 +570,7 @@ func newQueuedInformer(queueSize uint32, oType reflect.Type, sharedInformer cach
 		// channel array.
 		for _, obj := range items {
 			addsMap.enqueueEvent(nil, obj, informer.oType, false, func(e *event) {
-				h.OnAdd(e.obj, false)
+				h.OnAdd(e.obj, true)
 			})
 		}
 


### PR DESCRIPTION
## 📑 Description

Preserve isInInitialList when forwarding informer add events through the watch factory’s queued and replacement handlers.

## Additional Information for reviewers

- Switch queued and replacement handler adapters to cache.ResourceEventHandlerDetailedFuncs so the initial-list signal is not discarded.
- Mark existing-object replays for newly registered handlers as initial-list adds.
- Keep synthetic adds created for UID replacement handling marked as non-initial.
- Add unit tests for all initial-list forwarding paths.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI  

## How to verify it
Add new unit tests. 

e2e test isn't necessary for this change because it doesn't introduce any new user-visible behavior. The change only preserves the existing isInInitialList signal when events pass through the queued informer path, aligning it with the behavior of the underlying Kubernetes informer. 