### PR TITLE
CI: add verify-codegen job to ensure generated code is not stale.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,25 @@ jobs:
         working-directory: go-controller
         args: --modules-download-mode=vendor --timeout=15m0s --verbose
 
+  verify-codegen:
+    name: Verify codegen
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go-controller/go.mod'
+        cache: false
+      id: go
+
+    - name: Verify generated code is up to date
+      run: |
+        cd go-controller
+        make verify-codegen
+
   build-base:
     name: Build-base
     runs-on: ubuntu-24.04

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -74,6 +74,10 @@ modelgen: pkg/nbdb/ovn-nb.ovsschema pkg/sbdb/ovn-sb.ovsschema pkg/vswitchd/vswit
 codegen:
 	hack/update-codegen.sh
 
+.PHONY: verify-codegen
+verify-codegen:
+	@GOPATH=${GOPATH} ./hack/verify-codegen.sh || { echo "codegen verification failed! Run 'make codegen mocksgen' and commit the result"; exit 1; }
+
 .PHONY: mocksgen
 mocksgen: ${MOCKERY}
 	${MOCKERY}

--- a/go-controller/hack/update-codegen.sh
+++ b/go-controller/hack/update-codegen.sh
@@ -11,7 +11,7 @@ set -o pipefail
 GOPATH=${GOPATH:-$(go env GOPATH)}
 export PATH="${GOPATH}/bin:${PATH}"
 
-crds=$(ls pkg/crd 2> /dev/null)
+crds=$(find pkg/crd -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
 if [ -z "${crds}" ]; then
   exit
 fi

--- a/go-controller/hack/verify-codegen.sh
+++ b/go-controller/hack/verify-codegen.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit # Nonzero exit code of any of the commands below will fail the test.
+set -o nounset
+set -o pipefail
+
+HERE=$(dirname "$(readlink --canonicalize "$BASH_SOURCE")")
+ROOT=$(readlink --canonicalize "$HERE/..")
+GITROOT=$(git -C "$ROOT" rev-parse --show-toplevel)
+
+cd "$ROOT"
+
+echo "Regenerating generated code (codegen + mocks) to verify it matches the committed tree"
+./hack/update-codegen.sh
+
+# Generated Go lives under go-controller/pkg; CRD manifests are copied to
+# helm/ovn-kubernetes/crds. _output/ is gitignored so it does not affect this check.
+CHANGES=$(git -C "$GITROOT" status --porcelain -- go-controller/pkg helm/ovn-kubernetes/crds)
+if [ -n "$CHANGES" ]; then
+    echo "ERROR: generated code is out of date."
+    echo "Run 'make codegen' in go-controller/ and commit the result."
+    echo "Offending files:"
+    echo "$CHANGES"
+    git -C "$GITROOT" --no-pager diff -- go-controller/pkg helm/ovn-kubernetes/crds
+    exit 1
+fi
+
+echo "Generated code is up to date."


### PR DESCRIPTION
Current PR revealed 2 unrelated codegen updates that were missed on the other PRs because we don't check generated code in our CI.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
