### PR TITLE
e2e: collect dataplane diagnostics for kv live migration ingress flake

### DIFF
--- a/test/e2e/kubevirt.go
+++ b/test/e2e/kubevirt.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -279,12 +280,16 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 
 		checkIperfTraffic = func(iperfLogFile string, execFn func(cmd string) (string, error), timeout time.Duration, stage string) {
 			GinkgoHelper()
+			// Keep the last observed full log around so the failure message
+			// can report the actual downtime instead of just the last line.
+			fullIperfLog := ""
 			// Check the last line eventually show traffic flowing
 			Eventually(func() (string, error) {
 				iperfLog, err := execFn("cat " + iperfLogFile)
 				if err != nil {
 					return "", err
 				}
+				fullIperfLog = iperfLog
 				// Fail fast
 				Expect(iperfLog).NotTo(ContainSubstring("iperf3: error"), stage+": "+iperfLogFile)
 				// Remove last carriage return to properly split by new line.
@@ -303,7 +308,13 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 						ContainSubstring(" sec "),
 						Not(ContainSubstring("0.00 Bytes  0.00 bits/sec")),
 					),
-					stage+": failed checking iperf3 traffic at file "+iperfLogFile,
+					func() string {
+						failureMessage := stage + ": failed checking iperf3 traffic at file " + iperfLogFile
+						if downtime := kubevirt.IperfDowntimeSummary(fullIperfLog); downtime != "" {
+							failureMessage += "\n" + downtime
+						}
+						return failureMessage + "\niperf3 log tail:\n" + kubevirt.TailLines(fullIperfLog, 150)
+					},
 				)
 		}
 
@@ -341,7 +352,10 @@ var _ = Describe("Kubevirt Virtual Machines", feature.VirtualMachineSupport, fun
 				// Redirect stdio so execFn implementations that capture output
 				// do not block waiting for the background iperf3 process to
 				// exit.
-				output, err = execFn(fmt.Sprintf("nohup iperf3 -t 0 -c %[1]s -p %[2]d --pidfile %[3]s --logfile %[4]s >/dev/null 2>&1 &", address, port, iperfPidFile, iperfLogFile))
+				// --forceflush --timestamps='%s ' add a Unix epoch prefix to
+				// every interval line so checkIperfTraffic failures can
+				// report when a stall started and how long it lasted.
+				output, err = execFn(fmt.Sprintf("nohup iperf3 -t 0 --forceflush --timestamps='%%s ' -c %[1]s -p %[2]d --pidfile %[3]s --logfile %[4]s >/dev/null 2>&1 &", address, port, iperfPidFile, iperfLogFile))
 				if err != nil {
 					return fmt.Errorf("failed at starting iperf3 in background %s: %w", output, err)
 				}
@@ -397,8 +411,9 @@ fi
 				return fmt.Errorf("failed starting iperf3 server on external container: %s: %w", output, err)
 			}
 			// Start iperf3 client on the VM connecting to the external container's IPs.
-			// --timestamps='%s ' adds Unix epoch prefix so checkExternalEastWestIperfTraffic
-			// can use iperftest.LogDowntime to verify traffic resumed after migration.
+			// --timestamps='%s ' adds Unix epoch prefix so checkIperfTraffic
+			// failures can use kubevirt.IperfDowntimeSummary to report when a
+			// stall started after migration and how long it lasted.
 			polling := 15 * time.Second
 			for _, ip := range macVRFContainerIPs {
 				logFile := fmt.Sprintf("/tmp/external-east-west_%s_iperf3.log", ip)
@@ -1906,6 +1921,35 @@ ip route add %[3]s via %[4]s
 			testPodsIPs := podsMultusNetworkIPs(iperfServerTestPods, podNetworkStatusByNetConfigPredicate(namespace, cudn.Name, strings.ToLower(string(td.role))))
 
 			serverIPs, serverPort := exposeVMIperfServer(td, vmi, expectedAddreses)
+
+			// On failure collect the dataplane state (conntrack with zones,
+			// OpenFlow flows, ofproto/trace of the ingress flow, ...) needed
+			// to debug NodePort ingress disruptions after live migration,
+			// see https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6581
+			// It is written to the nodes /var/log so it becomes part of the
+			// CI kind-logs artifacts. Registered with DeferCleanup so it
+			// runs before the provider context cleanup removes the external
+			// container and the iperf3 clients with it.
+			DeferCleanup(func() {
+				if !CurrentSpecReport().Failed() {
+					return
+				}
+				testDirName := strings.Trim(
+					regexp.MustCompile(`[^A-Za-z0-9._-]+`).ReplaceAllString(CurrentSpecReport().LeafNodeText, "_"),
+					"_",
+				)
+				kubevirt.CollectIngressFlakeDiagnostics(infraprovider.Get(), fr.ClientSet, kubevirt.IngressFlakeDiagnostics{
+					TestDirName: testDirName + "-" + fr.UniqueName,
+					ClientIPs:   externalContainerIPs,
+					EntryIPs:    serverIPs,
+					NodePort:    serverPort,
+					VMIPs:       expectedAddreses,
+					VMName:      vmi.Name,
+					ClientExec: func(cmd string) (string, error) {
+						return infraprovider.Get().ExecExternalContainerCommand(externalContainer, []string{"bash", "-c", cmd})
+					},
+				})
+			})
 
 			// IPv6 is not support for secondaries with IPAM so guest will
 			// have only ipv4.

--- a/test/e2e/kubevirt/diagnostics.go
+++ b/test/e2e/kubevirt/diagnostics.go
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	utilnet "k8s.io/utils/net"
+
+	"github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/deploymentconfig"
+	infraapi "github.com/ovn-kubernetes/ovn-kubernetes/test/e2e/infraprovider/api"
+)
+
+const (
+	// diagnosticsNodeBaseDir is where diagnostics are written as seen from
+	// the node filesystem. It is intentionally a subdirectory of the OVS/OVN
+	// log directory: `kind export logs` copies each node's /var/log into the
+	// CI "kind-logs-*" artifact, so everything written here can be
+	// downloaded from GitHub CI without any workflow changes.
+	diagnosticsNodeBaseDir = "/var/log/openvswitch/e2e-kv-diagnostics"
+	// diagnosticsOVNPodBaseDir is the same host directory as seen from the
+	// ovnkube-node pod containers, which mount the node's
+	// /var/log/openvswitch at /var/log/ovn (and /var/log/openvswitch).
+	diagnosticsOVNPodBaseDir = "/var/log/ovn/e2e-kv-diagnostics"
+
+	ovnControllerContainerName = "ovn-controller"
+)
+
+// IngressFlakeDiagnostics carries the parameters of the NodePort ingress
+// traffic whose dataplane state should be collected on failure, see
+// https://github.com/ovn-kubernetes/ovn-kubernetes/issues/6581
+type IngressFlakeDiagnostics struct {
+	// TestDirName is the per spec directory name the diagnostics are
+	// written to, it should be unique per spec run.
+	TestDirName string
+	// ClientIPs are the iperf3 client source addresses (the external
+	// container addresses).
+	ClientIPs []string
+	// EntryIPs are the node addresses the iperf3 clients connect to (the
+	// NodePort service entry points).
+	EntryIPs []string
+	// NodePort is the NodePort the iperf3 clients connect to.
+	NodePort int32
+	// VMIPs are the VM addresses backing the NodePort service.
+	VMIPs []string
+	// VMName is the VirtualMachine name, used to locate the virt-launcher
+	// OVS interfaces for reply direction traces.
+	VMName string
+	// ClientExec optionally executes a command on the iperf3 client
+	// (external container) to snapshot the client side TCP state.
+	ClientExec func(cmd string) (string, error)
+}
+
+// CollectIngressFlakeDiagnostics dumps, for every cluster node, the
+// dataplane state needed to debug NodePort ingress traffic disruptions:
+// conntrack (host and OVS datapath with zones), the br-int ct-zone
+// assignments, OpenFlow flows, ovn-controller incremental engine stats and
+// ofproto/trace of the ingress flow in both directions. Everything is
+// written under /var/log/openvswitch/e2e-kv-diagnostics on each node so it
+// ends up in the CI kind-logs artifacts. All collection is best effort:
+// errors are logged and never fail the test.
+func CollectIngressFlakeDiagnostics(p infraapi.Provider, cs kubernetes.Interface, diag IngressFlakeDiagnostics) {
+	if diag.TestDirName == "" {
+		framework.Logf("ingress flake diagnostics: empty TestDirName, skipping collection")
+		return
+	}
+	nodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		framework.Logf("ingress flake diagnostics: failed listing nodes: %v", err)
+		return
+	}
+	framework.Logf("ingress flake diagnostics: collecting into %s/%s on every node", diagnosticsNodeBaseDir, diag.TestDirName)
+	for _, node := range nodes.Items {
+		if output, err := p.ExecK8NodeCommand(node.Name, []string{"bash", "-c", diag.hostScript(node.Name)}); err != nil {
+			framework.Logf("ingress flake diagnostics: host collection failed on node %s: %s: %v", node.Name, output, err)
+		}
+		if err := diag.collectOVN(cs, node.Name); err != nil {
+			framework.Logf("ingress flake diagnostics: ovn collection failed on node %s: %v", node.Name, err)
+		}
+	}
+	diag.collectClient()
+}
+
+// hostScript composes the script collecting node (host network namespace)
+// state, writing to the diagnostics directory as seen from the node
+// filesystem.
+func (diag IngressFlakeDiagnostics) hostScript(nodeName string) string {
+	dir := fmt.Sprintf("%s/%s", diagnosticsNodeBaseDir, diag.TestDirName)
+	return fmt.Sprintf(`
+mkdir -p %[1]s
+{
+echo "### $(date -u +%%FT%%T.%%3NZ) host state for node %[2]s"
+echo "=== conntrack -L (ipv4)"; conntrack -L 2>&1
+echo "=== conntrack -L (ipv6)"; conntrack -L -f ipv6 2>&1
+echo "=== nft list ruleset"; nft list ruleset 2>&1
+echo "=== ip -br addr"; ip -br addr 2>&1
+echo "=== ip route show table all"; ip route show table all 2>&1
+echo "=== ip -6 route show table all"; ip -6 route show table all 2>&1
+echo "=== ip rule"; ip rule 2>&1; ip -6 rule 2>&1
+} > %[1]s/%[2]s-host.log 2>&1
+`, dir, nodeName)
+}
+
+// collectOVN collects OVS/OVN state from the ovn-controller container of the
+// ovnkube-node pod running on the given node; that container has the OVS and
+// OVN tooling, the ovn-controller control socket and mounts the node's
+// /var/log/openvswitch at /var/log/ovn, so its output lands on the node
+// filesystem and hence in the CI artifacts.
+func (diag IngressFlakeDiagnostics) collectOVN(cs kubernetes.Interface, nodeName string) error {
+	ovnNamespace := deploymentconfig.Get().OVNKubernetesNamespace()
+	pods, err := cs.CoreV1().Pods(ovnNamespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=ovnkube-node",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to locate ovnkube-node pod on %s: %w", nodeName, err)
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no ovnkube-node pod found on node %s", nodeName)
+	}
+	output, err := e2ekubectl.RunKubectl(ovnNamespace,
+		"exec", pods.Items[0].Name, "-c", ovnControllerContainerName, "--",
+		"bash", "-c", diag.ovnScript(nodeName, deploymentconfig.Get().ExternalBridgeName(), deploymentconfig.Get().PrimaryInterfaceName()))
+	if err != nil {
+		return fmt.Errorf("%s: %w", output, err)
+	}
+	return nil
+}
+
+// ovnScript composes the script collecting OVS/OVN state, writing to the
+// diagnostics directory as seen from the ovnkube-node pod containers.
+func (diag IngressFlakeDiagnostics) ovnScript(nodeName, externalBridge, primaryInterface string) string {
+	dir := fmt.Sprintf("%s/%s", diagnosticsOVNPodBaseDir, diag.TestDirName)
+	return fmt.Sprintf(`
+mkdir -p %[1]s
+{
+echo "### $(date -u +%%FT%%T.%%3NZ) OVS/OVN state for node %[2]s"
+echo "=== ct-zone map: ovs-vsctl get Bridge br-int external_ids"; ovs-vsctl get Bridge br-int external_ids
+echo "=== ovs-appctl dpctl/dump-conntrack -m"; ovs-appctl dpctl/dump-conntrack -m
+echo "=== ovs-ofctl show br-int"; ovs-ofctl show br-int
+echo "=== ovs-ofctl show %[3]s"; ovs-ofctl show %[3]s
+echo "=== ovs-vsctl list Interface"; ovs-vsctl --columns=name,ofport,external_ids list Interface
+echo "=== ovn-appctl -t ovn-controller inc-engine/show-stats"; ovn-appctl -t ovn-controller inc-engine/show-stats
+%[4]s
+echo "=== ovs-ofctl dump-flows br-int"; ovs-ofctl dump-flows br-int
+echo "=== ovs-ofctl dump-flows %[3]s"; ovs-ofctl dump-flows %[3]s
+} > %[1]s/%[2]s-ovn.log 2>&1
+`, dir, nodeName, externalBridge, diag.traceScript(externalBridge, primaryInterface))
+}
+
+// traceScript composes the ofproto/trace section of the OVS/OVN collection
+// script. It traces the ingress NodePort flow in the forward direction
+// (client to node, entering through the external bridge uplink) and, on the
+// node(s) hosting a virt-launcher OVS interface of the VM, in the reply
+// direction (VM to client, entering br-int through the VM interface). Each
+// trace runs twice: once with conntrack lookups resolving to new and once
+// resolving to established (plus rpl in the reply direction), to tell apart
+// "flows dropped the packet" from "conntrack state was lost".
+func (diag IngressFlakeDiagnostics) traceScript(externalBridge, primaryInterface string) string {
+	script := []string{
+		// Resolve the external bridge uplink ofport (the port named after
+		// the primary interface, e.g. eth0 on kind).
+		fmt.Sprintf(`uplink=$(ovs-ofctl show %[1]s | sed -n 's/^ *\([0-9]\+\)(%[2]s).*/\1/p' | head -1)
+uplink=${uplink:-1}
+# Client source port of the established iperf3 NodePort connection, from the
+# datapath conntrack; falls back to a synthetic port if not found.
+sport=$(ovs-appctl dpctl/dump-conntrack | grep -o "sport=[0-9]*,dport=%[3]d" | head -1 | sed 's/sport=\([0-9]*\).*/\1/')
+sport=${sport:-12345}
+echo "=== ofproto/trace parameters: uplink=$uplink sport=$sport"
+trace() {
+	local bridge=$1 ctstate=$2 flow=$3
+	flow=${flow//__SPORT__/$sport}
+	echo "--- ofproto/trace $bridge $flow (ct: new)"
+	ovs-appctl ofproto/trace "$bridge" "$flow"
+	echo "--- ofproto/trace $bridge $flow (ct: $ctstate)"
+	ovs-appctl ofproto/trace --ct-next "$ctstate" --ct-next "$ctstate" --ct-next "$ctstate" --ct-next "$ctstate" "$bridge" "$flow"
+}`, externalBridge, primaryInterface, diag.NodePort),
+	}
+	// Forward direction: client -> nodeIP:nodePort through the external
+	// bridge uplink.
+	for _, entryIP := range diag.EntryIPs {
+		clientIP, found := matchIPFamily(diag.ClientIPs, entryIP)
+		if !found {
+			continue
+		}
+		script = append(script, fmt.Sprintf(`trace %s 'trk,est' "in_port=$uplink,%s"`,
+			externalBridge, tcpTraceFlow(clientIP, entryIP, "__SPORT__", fmt.Sprintf("%d", diag.NodePort))))
+	}
+	// Reply direction: VM -> client entering br-int through the
+	// virt-launcher interface, only on nodes hosting one. Conntrack lookups
+	// resolve with the rpl flag since this is the reply direction of the
+	// client initiated NodePort connection.
+	script = append(script, fmt.Sprintf(`vmports=$(ovs-vsctl --columns=name,ofport,external_ids list Interface | awk -v RS='' '/virt-launcher-%s/' | sed -n 's/^ofport *: \([0-9]\+\).*/\1/p')
+echo "=== virt-launcher ofports: $vmports"
+for vmport in $vmports; do`, diag.VMName))
+	for _, vmIP := range diag.VMIPs {
+		clientIP, found := matchIPFamily(diag.ClientIPs, vmIP)
+		if !found {
+			continue
+		}
+		script = append(script, fmt.Sprintf(`	trace br-int 'trk,est,rpl' "in_port=$vmport,%s"`,
+			tcpTraceFlow(vmIP, clientIP, fmt.Sprintf("%d", iperf3DefaultPort), "__SPORT__")))
+	}
+	script = append(script, "done")
+	return strings.Join(script, "\n")
+}
+
+const iperf3DefaultPort = 5201
+
+// tcpTraceFlow composes an ofproto/trace TCP flow for the right IP family.
+func tcpTraceFlow(srcIP, dstIP, srcPort, dstPort string) string {
+	if utilnet.IsIPv6String(srcIP) {
+		return fmt.Sprintf("tcp6,ipv6_src=%s,ipv6_dst=%s,tp_src=%s,tp_dst=%s", srcIP, dstIP, srcPort, dstPort)
+	}
+	return fmt.Sprintf("tcp,nw_src=%s,nw_dst=%s,tp_src=%s,tp_dst=%s", srcIP, dstIP, srcPort, dstPort)
+}
+
+// matchIPFamily returns the first IP from ips with the same family as ip.
+func matchIPFamily(ips []string, ip string) (string, bool) {
+	for _, candidate := range ips {
+		if utilnet.IsIPv6String(candidate) == utilnet.IsIPv6String(ip) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// collectClient logs the client side TCP socket state of the iperf3
+// connections, which shows zero-window/persist stance and retransmission
+// timers from the client point of view.
+func (diag IngressFlakeDiagnostics) collectClient() {
+	if diag.ClientExec == nil {
+		return
+	}
+	output, err := diag.ClientExec(fmt.Sprintf("ss -tni 'dport = :%d'", diag.NodePort))
+	if err != nil {
+		framework.Logf("ingress flake diagnostics: client ss failed: %s: %v", output, err)
+		return
+	}
+	framework.Logf("ingress flake diagnostics: client TCP state for NodePort %d:\n%s", diag.NodePort, output)
+}

--- a/test/e2e/kubevirt/diagnostics_test.go
+++ b/test/e2e/kubevirt/diagnostics_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubevirt
+
+import (
+	"strings"
+	"testing"
+)
+
+func dualStackDiagnostics() IngressFlakeDiagnostics {
+	return IngressFlakeDiagnostics{
+		TestDirName: "spec-under-test",
+		ClientIPs:   []string{"172.18.0.99", "fc00:f853:ccd:e793::99"},
+		EntryIPs:    []string{"172.18.0.3", "fc00:f853:ccd:e793::3"},
+		NodePort:    30666,
+		VMIPs:       []string{"10.20.16.9", "fd10:0:14:1000::9"},
+		VMName:      "worker-test1",
+	}
+}
+
+func TestTCPTraceFlow(t *testing.T) {
+	if flow := tcpTraceFlow("172.18.0.99", "172.18.0.3", "__SPORT__", "30666"); flow != "tcp,nw_src=172.18.0.99,nw_dst=172.18.0.3,tp_src=__SPORT__,tp_dst=30666" {
+		t.Fatalf("unexpected IPv4 trace flow: %s", flow)
+	}
+	if flow := tcpTraceFlow("fd10:0:14:1000::9", "fc00:f853:ccd:e793::99", "5201", "__SPORT__"); flow != "tcp6,ipv6_src=fd10:0:14:1000::9,ipv6_dst=fc00:f853:ccd:e793::99,tp_src=5201,tp_dst=__SPORT__" {
+		t.Fatalf("unexpected IPv6 trace flow: %s", flow)
+	}
+}
+
+func TestMatchIPFamily(t *testing.T) {
+	ips := []string{"172.18.0.99", "fc00:f853:ccd:e793::99"}
+	if ip, found := matchIPFamily(ips, "10.20.16.9"); !found || ip != "172.18.0.99" {
+		t.Fatalf("expected IPv4 match 172.18.0.99, got %q found=%v", ip, found)
+	}
+	if ip, found := matchIPFamily(ips, "fd10::9"); !found || ip != "fc00:f853:ccd:e793::99" {
+		t.Fatalf("expected IPv6 match fc00:f853:ccd:e793::99, got %q found=%v", ip, found)
+	}
+	if ip, found := matchIPFamily([]string{"172.18.0.99"}, "fd10::9"); found {
+		t.Fatalf("expected no IPv6 match from IPv4 only list, got %q", ip)
+	}
+	if ip, found := matchIPFamily(nil, "10.20.16.9"); found {
+		t.Fatalf("expected no match from empty list, got %q", ip)
+	}
+}
+
+func TestTraceScriptDualStack(t *testing.T) {
+	script := dualStackDiagnostics().traceScript("breth0", "eth0")
+	for _, expected := range []string{
+		// Uplink and client source port resolution.
+		`uplink=$(ovs-ofctl show breth0 | sed -n 's/^ *\([0-9]\+\)(eth0).*/\1/p' | head -1)`,
+		`sport=$(ovs-appctl dpctl/dump-conntrack | grep -o "sport=[0-9]*,dport=30666"`,
+		// Forward direction traces with forward conntrack state, per family.
+		`trace breth0 'trk,est' "in_port=$uplink,tcp,nw_src=172.18.0.99,nw_dst=172.18.0.3,tp_src=__SPORT__,tp_dst=30666"`,
+		`trace breth0 'trk,est' "in_port=$uplink,tcp6,ipv6_src=fc00:f853:ccd:e793::99,ipv6_dst=fc00:f853:ccd:e793::3,tp_src=__SPORT__,tp_dst=30666"`,
+		// Reply direction traces with reply conntrack state, per family.
+		`trace br-int 'trk,est,rpl' "in_port=$vmport,tcp,nw_src=10.20.16.9,nw_dst=172.18.0.99,tp_src=5201,tp_dst=__SPORT__"`,
+		`trace br-int 'trk,est,rpl' "in_port=$vmport,tcp6,ipv6_src=fd10:0:14:1000::9,ipv6_dst=fc00:f853:ccd:e793::99,tp_src=5201,tp_dst=__SPORT__"`,
+		// Reply traces only run on nodes hosting a virt-launcher interface.
+		`/virt-launcher-worker-test1/`,
+		// The trace function simulates both new and the passed conntrack state.
+		`ovs-appctl ofproto/trace --ct-next "$ctstate" --ct-next "$ctstate" --ct-next "$ctstate" --ct-next "$ctstate" "$bridge" "$flow"`,
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("expected trace script to contain %q, got:\n%s", expected, script)
+		}
+	}
+}
+
+func TestTraceScriptUnmatchedIPFamilies(t *testing.T) {
+	diag := dualStackDiagnostics()
+	// IPv6 only client cannot trace against IPv4 entry/VM addresses.
+	diag.ClientIPs = []string{"fc00:f853:ccd:e793::99"}
+	diag.EntryIPs = []string{"172.18.0.3"}
+	diag.VMIPs = []string{"10.20.16.9"}
+	script := diag.traceScript("breth0", "eth0")
+	if strings.Contains(script, "trace breth0 'trk,est' ") {
+		t.Fatalf("expected no forward traces for unmatched families, got:\n%s", script)
+	}
+	if strings.Contains(script, "trace br-int 'trk,est,rpl' ") {
+		t.Fatalf("expected no reply traces for unmatched families, got:\n%s", script)
+	}
+}
+
+func TestHostScript(t *testing.T) {
+	script := dualStackDiagnostics().hostScript("ovn-worker")
+	for _, expected := range []string{
+		"mkdir -p /var/log/openvswitch/e2e-kv-diagnostics/spec-under-test",
+		"conntrack -L 2>&1",
+		"conntrack -L -f ipv6 2>&1",
+		"nft list ruleset",
+		"> /var/log/openvswitch/e2e-kv-diagnostics/spec-under-test/ovn-worker-host.log 2>&1",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("expected host script to contain %q, got:\n%s", expected, script)
+		}
+	}
+}
+
+func TestOVNScript(t *testing.T) {
+	script := dualStackDiagnostics().ovnScript("ovn-worker", "breth0", "eth0")
+	for _, expected := range []string{
+		"mkdir -p /var/log/ovn/e2e-kv-diagnostics/spec-under-test",
+		"ovs-vsctl get Bridge br-int external_ids",
+		"ovs-appctl dpctl/dump-conntrack -m",
+		"ovs-ofctl dump-flows br-int",
+		"ovs-ofctl dump-flows breth0",
+		"ovn-appctl -t ovn-controller inc-engine/show-stats",
+		"> /var/log/ovn/e2e-kv-diagnostics/spec-under-test/ovn-worker-ovn.log 2>&1",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("expected ovn script to contain %q, got:\n%s", expected, script)
+		}
+	}
+}
+
+func TestCollectClient(t *testing.T) {
+	diag := dualStackDiagnostics()
+	executedCmd := ""
+	diag.ClientExec = func(cmd string) (string, error) {
+		executedCmd = cmd
+		return "ESTAB 0 0 172.18.0.99:33686 172.18.0.3:30666", nil
+	}
+	diag.collectClient()
+	if executedCmd != "ss -tni 'dport = :30666'" {
+		t.Fatalf("unexpected client command: %q", executedCmd)
+	}
+	// Without a client exec function nothing runs and nothing panics.
+	diag.ClientExec = nil
+	diag.collectClient()
+}

--- a/test/e2e/kubevirt/iperf.go
+++ b/test/e2e/kubevirt/iperf.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubevirt
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// iperfIntervalRegexp matches iperf3 client interval lines, with an optional
+// leading Unix epoch prefix produced by `--timestamps='%s '`, for example:
+//
+//	1752499477 [  5]  54.00-55.00  sec  0.00 Bytes  0.00 bits/sec    0   3.93 MBytes
+//	[  5]  54.00-55.00  sec  1.25 MBytes  10.5 Mbits/sec    0   3.93 MBytes
+var iperfIntervalRegexp = regexp.MustCompile(`^(?:(\d+(?:\.\d+)?)\s+)?\[\s*\d+\]\s+(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)\s+sec\s+(.*)$`)
+
+const iperfZeroThroughput = "0.00 Bytes  0.00 bits/sec"
+
+type iperfStall struct {
+	// begin and end are the interval offsets in seconds since the iperf3
+	// client started.
+	begin, end float64
+	// beginEpoch is the Unix epoch of the first zero-throughput line of the
+	// stall, zero if the log has no `--timestamps` prefix.
+	beginEpoch float64
+	// ongoing is true when the log ends while the stall is still in
+	// progress.
+	ongoing bool
+}
+
+// IperfDowntimeSummary parses iperf3 client interval output and returns a
+// human readable summary of the zero-throughput stalls found in it, so
+// failures report the actual outage rather than just the last log line. It
+// returns an empty string when the log contains no interval lines or no
+// stalls. Lines with or without the Unix epoch prefix from
+// `--timestamps='%s '` are supported; the wall clock stall start is only
+// reported when the prefix is present.
+func IperfDowntimeSummary(iperfLog string) string {
+	stalls := []iperfStall{}
+	intervals := 0
+	var current *iperfStall
+	for _, line := range strings.Split(iperfLog, "\n") {
+		match := iperfIntervalRegexp.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		intervals++
+		begin, _ := strconv.ParseFloat(match[2], 64)
+		end, _ := strconv.ParseFloat(match[3], 64)
+		if strings.Contains(match[4], iperfZeroThroughput) {
+			if current == nil {
+				epoch := float64(0)
+				if match[1] != "" {
+					epoch, _ = strconv.ParseFloat(match[1], 64)
+				}
+				current = &iperfStall{begin: begin, beginEpoch: epoch}
+			}
+			current.end = end
+			continue
+		}
+		if current != nil {
+			stalls = append(stalls, *current)
+			current = nil
+		}
+	}
+	if current != nil {
+		current.ongoing = true
+		stalls = append(stalls, *current)
+	}
+	if intervals == 0 || len(stalls) == 0 {
+		return ""
+	}
+	summary := []string{fmt.Sprintf("iperf3 downtime summary: %d intervals parsed, %d stall(s):", intervals, len(stalls))}
+	for _, stall := range stalls {
+		line := fmt.Sprintf("- zero throughput from interval %.2fs to %.2fs (%.2fs)", stall.begin, stall.end, stall.end-stall.begin)
+		if stall.beginEpoch > 0 {
+			line += fmt.Sprintf(", started at %s", time.Unix(int64(stall.beginEpoch), 0).UTC().Format(time.RFC3339))
+		}
+		if stall.ongoing {
+			line += ", still ongoing at the end of the log"
+		}
+		summary = append(summary, line)
+	}
+	return strings.Join(summary, "\n")
+}
+
+// TailLines returns at most n trailing lines of s.
+func TailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/test/e2e/kubevirt/iperf_test.go
+++ b/test/e2e/kubevirt/iperf_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubevirt
+
+import (
+	"strings"
+	"testing"
+)
+
+const iperfLogWithStall = `1752499420 [  5]  50.00-51.00  sec  1.25 MBytes  10.5 Mbits/sec    0   3.93 MBytes
+1752499421 [  5]  51.00-52.00  sec  1.25 MBytes  10.5 Mbits/sec    0   3.93 MBytes
+1752499422 [  5]  52.00-53.00  sec  0.00 Bytes  0.00 bits/sec    0   3.93 MBytes
+1752499423 [  5]  53.00-54.00  sec  0.00 Bytes  0.00 bits/sec    0   3.93 MBytes
+1752499424 [  5]  54.00-55.00  sec  0.00 Bytes  0.00 bits/sec    0   3.93 MBytes
+`
+
+const iperfLogWithRecoveredStall = `[  5]  50.00-51.00  sec  1.25 MBytes  10.5 Mbits/sec    0   3.93 MBytes
+[  5]  51.00-52.00  sec  0.00 Bytes  0.00 bits/sec    0   3.93 MBytes
+[  5]  52.00-53.00  sec  0.00 Bytes  0.00 bits/sec    0   3.93 MBytes
+[  5]  53.00-54.00  sec  1.25 MBytes  10.5 Mbits/sec    0   3.93 MBytes
+`
+
+const iperfLogHealthy = `1752499420 [  5]  50.00-51.00  sec  1.25 MBytes  10.5 Mbits/sec    0   3.93 MBytes
+1752499421 [  5]  51.00-52.00  sec  1.25 MBytes  10.5 Mbits/sec    0   3.93 MBytes
+`
+
+func TestIperfDowntimeSummaryOngoingStall(t *testing.T) {
+	summary := IperfDowntimeSummary(iperfLogWithStall)
+	for _, expected := range []string{
+		"5 intervals parsed, 1 stall(s)",
+		"from interval 52.00s to 55.00s (3.00s)",
+		"started at 2025-07-14T13:23:42Z",
+		"still ongoing at the end of the log",
+	} {
+		if !strings.Contains(summary, expected) {
+			t.Fatalf("expected summary to contain %q, got:\n%s", expected, summary)
+		}
+	}
+}
+
+func TestIperfDowntimeSummaryRecoveredStallWithoutTimestamps(t *testing.T) {
+	summary := IperfDowntimeSummary(iperfLogWithRecoveredStall)
+	for _, expected := range []string{
+		"4 intervals parsed, 1 stall(s)",
+		"from interval 51.00s to 53.00s (2.00s)",
+	} {
+		if !strings.Contains(summary, expected) {
+			t.Fatalf("expected summary to contain %q, got:\n%s", expected, summary)
+		}
+	}
+	for _, unexpected := range []string{"started at", "ongoing"} {
+		if strings.Contains(summary, unexpected) {
+			t.Fatalf("expected summary to not contain %q, got:\n%s", unexpected, summary)
+		}
+	}
+}
+
+func TestIperfDowntimeSummaryHealthyLog(t *testing.T) {
+	if summary := IperfDowntimeSummary(iperfLogHealthy); summary != "" {
+		t.Fatalf("expected empty summary for healthy log, got:\n%s", summary)
+	}
+	if summary := IperfDowntimeSummary("iperf3: error - unable to connect"); summary != "" {
+		t.Fatalf("expected empty summary for non interval log, got:\n%s", summary)
+	}
+}
+
+func TestTailLines(t *testing.T) {
+	if tail := TailLines("a\nb\nc\n", 2); tail != "b\nc" {
+		t.Fatalf("expected tail to be 'b\\nc', got %q", tail)
+	}
+	if tail := TailLines("a\nb", 5); tail != "a\nb" {
+		t.Fatalf("expected tail to be 'a\\nb', got %q", tail)
+	}
+}


### PR DESCRIPTION
## 📑 Description

The kubevirt `Primary/Layer2 ingress snat` specs flake with the NodePort iperf3 traffic stalled after live migration (#6581). The CI artifacts have no conntrack, OpenFlow or packet evidence to debug it, and the failing check only prints the last iperf3 log line.

This PR makes the failing specs collect that evidence:

- The north/south iperf3 clients run with timestamps and, on failure, the check reports when the stall started and how long it lasted, plus the log tail.
- When the spec fails, every node dumps: conntrack, nftables, routes, the br-int ct-zone map, OVS datapath conntrack, OpenFlow flows and `ofproto/trace` of the ingress traffic in both directions. The iperf3 client TCP socket state (`ss -tni`) is also logged.

The dumps go to `/var/log/openvswitch/e2e-kv-diagnostics/` on each node, so `kind export logs` ships them with the CI `kind-logs-*` artifacts — no workflow changes. Nothing runs when the spec passes.

Related to #6581 (flake tracking issue — intentionally not using `Fixes`).

## Additional Information for reviewers
N/S

## ✅ Checks
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [x] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

Run e2e tests.
