### PR TITLE
RA controller: fix raw FRR config for unnumbered BGP neighbors

### DIFF
--- a/docs/features/bgp-integration/route-advertisements.md
+++ b/docs/features/bgp-integration/route-advertisements.md
@@ -143,6 +143,16 @@ in shared gateway mode.
 > previous example must correspond to the remote BGP router's configuration
 > (router ID, AS number, accept routes, etc...), and vice versa.
 
+> [!NOTE]
+> A neighbor can be defined by IP `address` or, for unnumbered BGP peering, by
+> node `interface`; one of the two must be specified. A neighbor defined by
+> address peers over a session of that address family and is only advertised
+> prefixes of the same family. FRR establishes an unnumbered session over an
+> IPv4 address derived from a /30 or /31 on the interface or, failing that,
+> over the peer's IPv6 link-local address; in either case the session can
+> carry prefixes of both IP families (RFC 8950), so OVN-Kubernetes advertises
+> prefixes of both families to interface-defined neighbors.
+
 ### Import routes from the default VRF into a CUDN
 
 Assuming we have a CUDN:

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -1021,19 +1021,31 @@ func (c *Controller) generateFRRConfiguration(
 				)
 			}
 
+			// FRR establishes an unnumbered session over an IPv4 address
+			// derived from a /30 or /31 on the interface or, failing that,
+			// over the peer's IPv6 link-local address. In either case the
+			// session can carry prefixes of both families (RFC 8950), so
+			// don't filter by family.
+			isUnnumbered := isUnnumberedNeighbor(neighbor)
 			isIPV6 := utilnet.IsIPv6String(neighbor.Address)
-			advertisePrefixes := util.MatchAllIPNetsStringFamily(isIPV6, advertisePrefixes)
-			if len(advertisePrefixes) == 0 {
+			advertisePrefixesForNeighbor := advertisePrefixes
+			if !isUnnumbered {
+				advertisePrefixesForNeighbor = util.MatchAllIPNetsStringFamily(isIPV6, advertisePrefixes)
+			}
+			if len(advertisePrefixesForNeighbor) == 0 {
 				continue
 			}
 
 			neighbor.ToAdvertise = frrtypes.Advertise{
 				Allowed: frrtypes.AllowedOutPrefixes{
 					Mode:     frrtypes.AllowRestricted,
-					Prefixes: advertisePrefixes,
+					Prefixes: advertisePrefixesForNeighbor,
 				},
 			}
-			if nextHop := dpuHostGatewayNextHops[isIPV6]; nextHop != "" {
+			if isUnnumbered {
+				neighbor.ToAdvertise.NextHop.IPv4 = dpuHostGatewayNextHops[false]
+				neighbor.ToAdvertise.NextHop.IPv6 = dpuHostGatewayNextHops[true]
+			} else if nextHop := dpuHostGatewayNextHops[isIPV6]; nextHop != "" {
 				if isIPV6 {
 					neighbor.ToAdvertise.NextHop.IPv6 = nextHop
 				} else {
@@ -1044,8 +1056,12 @@ func (c *Controller) generateFRRConfiguration(
 			// For no-overlay networks, add routes to pod subnets to the accepted routes list
 			// frr-k8s will merge the prefixes from both the generated and the base FRRConfiguration
 			if len(allNoOverlayPodSubnets) > 0 {
-				// Filter pod subnets by IP family to match the neighbor
-				filteredPodSubnets := util.MatchAllIPNetsStringFamily(isIPV6, allNoOverlayPodSubnets)
+				// Filter pod subnets by IP family to match the neighbor;
+				// unnumbered neighbors carry both families
+				filteredPodSubnets := allNoOverlayPodSubnets
+				if !isUnnumbered {
+					filteredPodSubnets = util.MatchAllIPNetsStringFamily(isIPV6, allNoOverlayPodSubnets)
+				}
 				if len(filteredPodSubnets) > 0 {
 					neighbor.ToReceive = frrtypes.Receive{
 						Allowed: frrtypes.AllowedInPrefixes{
@@ -1205,14 +1221,19 @@ func (c *Controller) generateFRRConfiguration(
 			// dedup, ordered
 			// router level - injects the prefix into BGP
 			routers[defaultIdx].Prefixes = sets.List(sets.New(routers[defaultIdx].Prefixes...).Insert(vtepIPs...))
-			// neighbor level - advertise this node's VTEP IPs and accept VTEP CIDRs
+			// neighbor level - advertise this node's VTEP IPs and accept VTEP
+			// CIDRs; unnumbered neighbors carry both families
 			for i := range routers[defaultIdx].Neighbors {
 				allPrefixes := routers[defaultIdx].Prefixes
+				isUnnumbered := isUnnumberedNeighbor(routers[defaultIdx].Neighbors[i])
 				isIPV6 := utilnet.IsIPv6String(routers[defaultIdx].Neighbors[i].Address)
-				routers[defaultIdx].Neighbors[i].ToAdvertise.Allowed.Prefixes =
-					util.MatchAllIPNetsStringFamily(isIPV6, allPrefixes)
+				routers[defaultIdx].Neighbors[i].ToAdvertise.Allowed.Prefixes = allPrefixes
+				if !isUnnumbered {
+					routers[defaultIdx].Neighbors[i].ToAdvertise.Allowed.Prefixes =
+						util.MatchAllIPNetsStringFamily(isIPV6, allPrefixes)
+				}
 				for _, ps := range vtepReceiveSelectors {
-					if utilnet.IsIPv6CIDRString(ps.Prefix) == isIPV6 {
+					if isUnnumbered || utilnet.IsIPv6CIDRString(ps.Prefix) == isIPV6 {
 						routers[defaultIdx].Neighbors[i].ToReceive.Allowed.Prefixes = append(
 							routers[defaultIdx].Neighbors[i].ToReceive.Allowed.Prefixes, ps)
 					}
@@ -1245,8 +1266,13 @@ func (c *Controller) generateFRRConfiguration(
 							neighbor.Address,
 						)
 					}
+					// unnumbered neighbors carry both families
+					isUnnumbered := isUnnumberedNeighbor(neighbor)
 					isIPV6 := utilnet.IsIPv6String(neighbor.Address)
-					filteredVTEPIPs := util.MatchAllIPNetsStringFamily(isIPV6, vtepIPs)
+					filteredVTEPIPs := vtepIPs
+					if !isUnnumbered {
+						filteredVTEPIPs = util.MatchAllIPNetsStringFamily(isIPV6, vtepIPs)
+					}
 					if len(filteredVTEPIPs) == 0 {
 						continue
 					}
@@ -1258,7 +1284,7 @@ func (c *Controller) generateFRRConfiguration(
 						},
 					}
 					for _, ps := range vtepReceiveSelectors {
-						if utilnet.IsIPv6CIDRString(ps.Prefix) == isIPV6 {
+						if isUnnumbered || utilnet.IsIPv6CIDRString(ps.Prefix) == isIPV6 {
 							n.ToReceive.Allowed.Prefixes = append(n.ToReceive.Allowed.Prefixes, ps)
 						}
 					}
@@ -1907,6 +1933,13 @@ func neighborKey(neighbor frrtypes.Neighbor) string {
 		return neighbor.Address
 	}
 	return neighbor.Interface
+}
+
+// isUnnumberedNeighbor returns whether the neighbor is unnumbered, that is
+// defined by interface rather than by address. Coherent with neighborKey, a
+// neighbor that specifies both is considered defined by address.
+func isUnnumberedNeighbor(neighbor frrtypes.Neighbor) bool {
+	return neighbor.Address == "" && neighbor.Interface != ""
 }
 
 func (c *Controller) reconcileEgressIPs(string) error {

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller.go
@@ -987,6 +987,18 @@ func (c *Controller) generateFRRConfiguration(
 
 		targetRouter.Neighbors = make([]frrtypes.Neighbor, 0, len(source.Spec.BGP.Routers[i].Neighbors))
 		for _, neighbor := range source.Spec.BGP.Routers[i].Neighbors {
+			// Validate the neighbor identifier upfront, before any filtering
+			// might skip the neighbor, so that an invalid neighbor is
+			// consistently reported as a configuration error
+			key := neighborKey(neighbor)
+			if key == "" {
+				return nil, fmt.Errorf("%w: neighbor with neither address nor interface on FRRConfiguration %s/%s",
+					errConfig,
+					source.Namespace,
+					source.Name,
+				)
+			}
+
 			// Skip neighbors that are the node itself
 			if (nodeV4 != "" && neighbor.Address == nodeV4) || (nodeV6 != "" && neighbor.Address == nodeV6) {
 				continue
@@ -1050,7 +1062,7 @@ func (c *Controller) generateFRRConfiguration(
 				}
 			}
 
-			vrfNeighbors[matchedVRF] = append(vrfNeighbors[matchedVRF], neighbor.Address)
+			vrfNeighbors[matchedVRF] = append(vrfNeighbors[matchedVRF], key)
 			targetRouter.Neighbors = append(targetRouter.Neighbors, neighbor)
 		}
 		if len(targetRouter.Neighbors) == 0 {
@@ -1111,7 +1123,15 @@ func (c *Controller) generateFRRConfiguration(
 				vrfASNs[""] = router.ASN
 				vrfNeighbors[""] = make([]string, 0, len(router.Neighbors))
 				for _, neighbor := range router.Neighbors {
-					vrfNeighbors[""] = append(vrfNeighbors[""], neighbor.Address)
+					key := neighborKey(neighbor)
+					if key == "" {
+						return nil, fmt.Errorf("%w: neighbor with neither address nor interface on FRRConfiguration %s/%s",
+							errConfig,
+							source.Namespace,
+							source.Name,
+						)
+					}
+					vrfNeighbors[""] = append(vrfNeighbors[""], key)
 				}
 				break
 			}
@@ -1878,6 +1898,15 @@ func (c *Controller) reconcileNAD(key string) error {
 	}
 
 	return nil
+}
+
+// neighborKey returns the identifier of a neighbor as used in raw FRR config:
+// the session address or, for unnumbered neighbors, the interface name.
+func neighborKey(neighbor frrtypes.Neighbor) string {
+	if neighbor.Address != "" {
+		return neighbor.Address
+	}
+	return neighbor.Interface
 }
 
 func (c *Controller) reconcileEgressIPs(string) error {

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -627,6 +627,68 @@ func TestController_reconcile(t *testing.T) {
 			expectNADAnnotations: map[string]map[string]string{"default": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
 		},
 		{
+			name: "reconciles dual-stack pod RouteAdvertisement with an unnumbered interface neighbor",
+			ra:   &testRA{Name: "ra", AdvertisePods: true, SelectsDefault: true},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Neighbors: []*testNeighbor{
+							{ASN: 1, Interface: "enp4s0f0np0"},
+						}},
+					},
+				},
+			},
+			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"default\":[\"1.1.0.0/24\",\"fd01::/64\"]}"}},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.1.0.0/24", "fd01::/64"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Interface: "enp4s0f0np0", Advertise: []string{"1.1.0.0/24", "fd01::/64"}},
+						}},
+					},
+				},
+			},
+			expectNADAnnotations: map[string]map[string]string{"default": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name: "reconciles IPv6-only pod RouteAdvertisement with an unnumbered interface neighbor",
+			ra:   &testRA{Name: "ra", AdvertisePods: true, SelectsDefault: true},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Neighbors: []*testNeighbor{
+							{ASN: 1, Interface: "enp4s0f0np0"},
+						}},
+					},
+				},
+			},
+			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"default\":\"fd01::/64\"}"}},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"fd01::/64"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Interface: "enp4s0f0np0", Advertise: []string{"fd01::/64"}},
+						}},
+					},
+				},
+			},
+			expectNADAnnotations: map[string]map[string]string{"default": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
 			name: "fails to reconcile a neighbor with neither address nor interface",
 			ra:   &testRA{Name: "ra", AdvertisePods: true, SelectsDefault: true},
 			frrConfigs: []*testFRRConfig{
@@ -1101,6 +1163,45 @@ func TestController_reconcile(t *testing.T) {
 							{ASN: 1, Address: "1.0.0.100", Advertise: []string{"1.1.0.0/24"}, NextHopV4: "172.18.255.254"},
 						}},
 					}},
+			},
+			expectNADAnnotations: map[string]map[string]string{"default": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name:        "reconciles dual-stack pod RouteAdvertisement for DPU host with an unnumbered interface neighbor and next-hops",
+			ra:          &testRA{Name: "ra", AdvertisePods: true, SelectsDefault: true},
+			gatewayMode: config.GatewayModeShared,
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Neighbors: []*testNeighbor{
+							{ASN: 1, Interface: "enp4s0f0np0"},
+						}},
+					},
+				},
+			},
+			nodes: []*testNode{
+				{
+					Name:                      "node",
+					Labels:                    map[string]string{types.OvnDPUHostNodeLabel: ""},
+					SubnetsAnnotation:         "{\"default\":[\"1.1.0.0/24\",\"fd01::/64\"]}",
+					L3GatewayConfigAnnotation: `{"default":{"mode":"shared","mac-address":"52:54:00:4c:e6:00","ip-addresses":["172.18.255.254/16","fc00:f853:ccd:e793::4/64"],"next-hops":["172.18.0.1","fc00:f853:ccd:e793::1"]}}`,
+				},
+			},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.1.0.0/24", "fd01::/64"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Interface: "enp4s0f0np0", Advertise: []string{"1.1.0.0/24", "fd01::/64"}, NextHopV4: "172.18.255.254", NextHopV6: "fc00:f853:ccd:e793::4"},
+						}},
+					},
+				},
 			},
 			expectNADAnnotations: map[string]map[string]string{"default": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
 		},
@@ -1795,6 +1896,77 @@ exit
 						{ASN: 65000, VRF: "blue", Prefixes: []string{"10.2.1.0/24"}},
 						{ASN: 65000, Prefixes: []string{"100.64.0.1/32"}, Neighbors: []*testNeighbor{
 							{ASN: 65000, Address: "192.168.1.1", Advertise: []string{"100.64.0.1/32"}, Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}}},
+						}},
+					},
+				},
+			},
+			expectNADAnnotations: map[string]map[string]string{"blue": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name: "advertises dual-stack VTEP IPs to an unnumbered interface neighbor for EVPN IP-VRF",
+			ra:   &testRA{Name: "ra", TargetVRF: "auto", AdvertisePods: true, NetworkSelector: map[string]string{"selected": "true"}},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 65000, Neighbors: []*testNeighbor{
+							{ASN: 65000, Interface: "enp4s0f0np0"},
+						}},
+					},
+				},
+			},
+			nads: []*testNAD{
+				{Name: "blue", Namespace: "blue", Network: util.GenerateCUDNNetworkName("blue"),
+					Topology: "layer3", Subnet: "10.2.0.0/16", Labels: map[string]string{"selected": "true"},
+					EVPNVTEPName: "my-vtep", EVPNIPVRFVNI: 2000, EVPNIPVRFRouteTarget: "65000:2000"},
+			},
+			vteps: []*vtepv1.VTEP{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-vtep"},
+					Spec:       vtepv1.VTEPSpec{CIDRs: []vtepv1.CIDR{"100.64.0.0/16", "fd64::/48"}},
+				},
+			},
+			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"cluster_udn_blue\":\"10.2.1.0/24\"}", VTEPIPs: map[string][]string{"my-vtep": {"100.64.0.1", "fd64::1"}}}},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					RawConfig: `router bgp 65000
+ address-family ipv4 unicast
+  neighbor enp4s0f0np0 allowas-in origin
+ exit-address-family
+ address-family ipv6 unicast
+  neighbor enp4s0f0np0 allowas-in origin
+ exit-address-family
+ address-family l2vpn evpn
+  neighbor enp4s0f0np0 activate
+  neighbor enp4s0f0np0 allowas-in origin
+  advertise-all-vni
+ exit-address-family
+exit
+!
+vrf blue
+ vni 2000
+exit-vrf
+!
+router bgp 65000 vrf blue
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+  route-target import 65000:2000
+  route-target export 65000:2000
+ exit-address-family
+exit
+!
+`,
+					Routers: []*testRouter{
+						{ASN: 65000, VRF: "blue", Prefixes: []string{"10.2.1.0/24"}},
+						{ASN: 65000, Prefixes: []string{"100.64.0.1/32", "fd64::1/128"}, Neighbors: []*testNeighbor{
+							{ASN: 65000, Interface: "enp4s0f0np0", Advertise: []string{"100.64.0.1/32", "fd64::1/128"},
+								Receive: []testPrefixSelector{{Prefix: "100.64.0.0/16", LE: 32, GE: 32}, {Prefix: "fd64::/48", LE: 128, GE: 128}}},
 						}},
 					},
 				},

--- a/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/controller_test.go
@@ -216,6 +216,7 @@ type testPrefixSelector struct {
 type testNeighbor struct {
 	ASN                    uint32
 	Address                string
+	Interface              string
 	DualStackAddressFamily *bool
 	Advertise              []string
 	NextHopV4              string
@@ -225,8 +226,9 @@ type testNeighbor struct {
 
 func (tn testNeighbor) Neighbor() frrapi.Neighbor {
 	n := frrapi.Neighbor{
-		ASN:     tn.ASN,
-		Address: tn.Address,
+		ASN:       tn.ASN,
+		Address:   tn.Address,
+		Interface: tn.Interface,
 		ToAdvertise: frrapi.Advertise{
 			Allowed: frrapi.AllowedOutPrefixes{
 				Mode:     frrapi.AllowRestricted,
@@ -348,9 +350,14 @@ func (tf testFRRConfig) generateUnicastRawConfig() string {
 			fmt.Fprintf(&buf, "router bgp %d vrf %s\n", r.ASN, r.VRF)
 		}
 		for _, n := range r.Neighbors {
-			if utilnet.IsIPv6String(n.Address) {
+			switch {
+			case n.Address == "" && n.Interface != "":
+				// unnumbered neighbors are included in both address families
+				fmt.Fprintf(&buf, " address-family ipv4 unicast\n  neighbor %s allowas-in origin\n exit-address-family\n", n.Interface)
+				fmt.Fprintf(&buf, " address-family ipv6 unicast\n  neighbor %s allowas-in origin\n exit-address-family\n", n.Interface)
+			case utilnet.IsIPv6String(n.Address):
 				fmt.Fprintf(&buf, " address-family ipv6 unicast\n  neighbor %s allowas-in origin\n exit-address-family\n", n.Address)
-			} else {
+			default:
 				fmt.Fprintf(&buf, " address-family ipv4 unicast\n  neighbor %s allowas-in origin\n exit-address-family\n", n.Address)
 			}
 		}
@@ -587,6 +594,73 @@ func TestController_reconcile(t *testing.T) {
 					}},
 			},
 			expectNADAnnotations: map[string]map[string]string{"default": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name: "reconciles pod RouteAdvertisement with an unnumbered interface neighbor",
+			ra:   &testRA{Name: "ra", AdvertisePods: true, SelectsDefault: true},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Neighbors: []*testNeighbor{
+							{ASN: 1, Interface: "enp4s0f0np0"},
+						}},
+					},
+				},
+			},
+			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\"}"}},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionTrue,
+			expectFRRConfigs: []*testFRRConfig{
+				{
+					Labels:       map[string]string{types.OvnRouteAdvertisementsKey: "ra"},
+					Annotations:  map[string]string{types.OvnRouteAdvertisementsKey: "ra/frrConfig/node"},
+					NodeSelector: map[string]string{"kubernetes.io/hostname": "node"},
+					Routers: []*testRouter{
+						{ASN: 1, Prefixes: []string{"1.1.0.0/24"}, Neighbors: []*testNeighbor{
+							{ASN: 1, Interface: "enp4s0f0np0", Advertise: []string{"1.1.0.0/24"}},
+						}},
+					},
+				},
+			},
+			expectNADAnnotations: map[string]map[string]string{"default": {types.OvnRouteAdvertisementsKey: "[\"ra\"]"}},
+		},
+		{
+			name: "fails to reconcile a neighbor with neither address nor interface",
+			ra:   &testRA{Name: "ra", AdvertisePods: true, SelectsDefault: true},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Neighbors: []*testNeighbor{
+							{ASN: 1},
+						}},
+					},
+				},
+			},
+			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"default\":\"1.1.0.0/24\"}"}},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionFalse,
+		},
+		{
+			name: "fails to reconcile a neighbor with neither address nor interface in an IPv6-only cluster",
+			ra:   &testRA{Name: "ra", AdvertisePods: true, SelectsDefault: true},
+			frrConfigs: []*testFRRConfig{
+				{
+					Name:      "frrConfig",
+					Namespace: frrNamespace,
+					Routers: []*testRouter{
+						{ASN: 1, Neighbors: []*testNeighbor{
+							{ASN: 1},
+						}},
+					},
+				},
+			},
+			nodes:                []*testNode{{Name: "node", SubnetsAnnotation: "{\"default\":\"fd01::/64\"}"}},
+			reconcile:            "ra",
+			expectAcceptedStatus: metav1.ConditionFalse,
 		},
 		{
 			name: "reconciles dual-stack pod+eip RouteAdvertisement for a single FRR config, node and default network and target VRF",

--- a/go-controller/pkg/clustermanager/routeadvertisements/rawconfig.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/rawconfig.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util"
+	utilnet "k8s.io/utils/net"
 )
 
 // generateRawConfig generates raw FRR configuration. Main purpose is to
@@ -113,7 +113,7 @@ func genDefaultVRFSection(asn uint32, neighbors []string, selected *selectedNetw
 
 	fmt.Fprintf(&buf, "router bgp %d\n", asn)
 
-	neighbors4, neighbors6 := util.SplitIPStringByIPFamily(neighbors)
+	neighbors4, neighbors6 := splitNeighborsByIPFamily(neighbors)
 	buf.WriteString(genUnicastSection(neighbors4, neighbors6))
 	buf.WriteString(genDefaultVRFEVPNSection(neighbors, selected))
 
@@ -140,13 +140,34 @@ func genNonDefaultVRFSection(vrf string, asn uint32, neighbors []string, cfg *ip
 
 	fmt.Fprintf(&buf, "router bgp %d vrf %s\n", asn, vrf)
 
-	neighbors4, neighbors6 := util.SplitIPStringByIPFamily(neighbors)
+	neighbors4, neighbors6 := splitNeighborsByIPFamily(neighbors)
 	buf.WriteString(genUnicastSection(neighbors4, neighbors6))
 	buf.WriteString(genNonDefaultVRFEVPNSection(cfg))
 
 	buf.WriteString("exit\n!\n")
 
 	return buf.String()
+}
+
+// splitNeighborsByIPFamily splits neighbor identifiers by IP family. Unnumbered
+// neighbors are identified by interface name rather than by address: FRR
+// establishes their session over an IPv4 address derived from a /30 or /31 on
+// the interface or, failing that, over the peer's IPv6 link-local address, and
+// in either case the session can carry prefixes of both families (RFC 8950),
+// so they are included in both results.
+func splitNeighborsByIPFamily(neighbors []string) (neighbors4, neighbors6 []string) {
+	for _, neighbor := range neighbors {
+		switch {
+		case utilnet.IsIPv6String(neighbor):
+			neighbors6 = append(neighbors6, neighbor)
+		case utilnet.IsIPv4String(neighbor):
+			neighbors4 = append(neighbors4, neighbor)
+		default:
+			neighbors4 = append(neighbors4, neighbor)
+			neighbors6 = append(neighbors6, neighbor)
+		}
+	}
+	return
 }
 
 // genUnicastSection generates unicast address-family sections for IPv4 and/or IPv6 neighbors.

--- a/go-controller/pkg/clustermanager/routeadvertisements/rawconfig_test.go
+++ b/go-controller/pkg/clustermanager/routeadvertisements/rawconfig_test.go
@@ -48,6 +48,23 @@ exit
 `,
 		},
 		{
+			name:         "unnumbered neighbor identified by interface name",
+			selected:     &selectedNetworks{},
+			vrfNeighbors: map[string][]string{"": {"enp4s0f0np0", "192.168.1.1"}},
+			vrfASNs:      map[string]uint32{"": 4200000001},
+			want: `router bgp 4200000001
+ address-family ipv4 unicast
+  neighbor 192.168.1.1 allowas-in origin
+  neighbor enp4s0f0np0 allowas-in origin
+ exit-address-family
+ address-family ipv6 unicast
+  neighbor enp4s0f0np0 allowas-in origin
+ exit-address-family
+exit
+!
+`,
+		},
+		{
 			name: "MAC-VRF without route target",
 			selected: &selectedNetworks{
 				macVRFConfigs: []*vrfConfig{


### PR DESCRIPTION
## 📑 Description

Since e08225fc31eb the RouteAdvertisements controller adds `allowas-in origin` for all neighbors to the raw config of every generated FRRConfiguration, but it only ever reads `neighbor.Address`. Neighbors defined by interface (BGP unnumbered peering) have no address, so we rendered a neighbor line with an empty name:

```
 address-family ipv4 unicast
  neighbor  allowas-in origin
```

vtysh rejects that line and, since an FRR reload is all-or-nothing, the whole config reload fails on any node whose base FRRConfiguration uses interface neighbors:

```
ERROR: vtysh failed to process new configuration: vtysh (mark file) exited with status 2: line 101: % Unknown command: neighbor  allowas-in origin
```

FRR establishes an unnumbered session over an IPv4 address derived from a /30 or /31 on the interface or, failing that, over the peer's IPv6 link-local address; in either case the session can carry prefixes of both families (RFC 8950). This PR handles unnumbered neighbors accordingly:

- **First commit** fixes the raw config by using the interface name as the neighbor name, in both unicast address families. A neighbor with no address nor interface now fails the reconcile with a configuration error instead of breaking every FRR reload on the node.
- **Second commit** fixes the generated (non-raw) config, which classified interface neighbors as IPv4: advertise prefixes, next-hops and accepted routes of both families to them. Address-based neighbors keep the exact previous behavior.
- **Third commit** documents address- vs interface-defined neighbors.

## Additional Information for reviewers

All code changes are confined to `go-controller/pkg/clustermanager/routeadvertisements/`.

## ✅ Checks
- [x] My code requires changes to the documentation
- [x] if so, I have updated the documentation as required
- [ ] My code does not require changes to the documentation
- [x] My code requires tests
- [x] if so, I have added and/or updated the tests as required
- [ ] My code does not require tests
- [ ] All the tests have passed in the CI

## How to verify it

Unit tests cover the raw config generation (`TestGenerateRawConfig`, unnumbered neighbor case) and the full reconcile path (`TestController_reconcile`): single-stack, dual-stack and IPv6-only clusters with an unnumbered neighbor, DPU host next-hops of both families, dual-stack VTEP IPs, and the configuration error for a neighbor with no address nor interface.

To verify manually: on a BGP-enabled cluster, define the base FRRConfiguration neighbor with `interface: <ifname>` instead of `address:`, apply a RouteAdvertisements CR selecting it, and check that the generated FRRConfiguration raw config contains `neighbor <ifname> allowas-in origin` in both unicast address families, that prefixes of both families are advertised to it, and that frr-k8s reports a successful reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
