### PR TITLE
uplink: resolve DPU bridges for VF and SF backed host interfaces

### DIFF
--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -654,6 +654,10 @@ func gatewayReady(patchPort string) bool {
 	return true
 }
 
+// getIntfName returns the physical uplink interface of the gateway OVS bridge
+// gatewayIntf, as derived by util.GetNicName (external-ids:bridge-uplink,
+// single system-type port, or the "br<nic>" name convention), and verifies
+// that the result is plugged into OVS (has an ofport).
 func getIntfName(ovsClient libovsdbclient.Client, gatewayIntf string) (string, error) {
 	// The given (or autodetected) interface is an OVS bridge and this could be
 	// created by us using util.NicToBridge() or it was pre-created by the user.

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig.go
@@ -306,7 +306,8 @@ func (b *BridgeConfiguration) setDPUHostGatewayConfiguration(nodeName string) er
 // and moving gateway IPs/MACs onto the selected host interface.
 func NewUnmanagedBridgeConfiguration(ovsClient libovsdbclient.Client, bridgeName, hostInterfaceName, nodeName,
 	physicalNetworkName string, gwIPs []*net.IPNet, macAddress net.HardwareAddr) (*BridgeConfiguration, error) {
-	if _, err := ovsops.GetBridge(ovsClient, bridgeName); err != nil {
+	bridge, err := ovsops.GetBridge(ovsClient, bridgeName)
+	if err != nil {
 		return nil, fmt.Errorf("failed to find OVS bridge %s: %w", bridgeName, err)
 	}
 	if len(gwIPs) == 0 {
@@ -329,7 +330,10 @@ func NewUnmanagedBridgeConfiguration(ovsClient libovsdbclient.Client, bridgeName
 	if gwIface == "" || config.IsModeDPU() {
 		gwIface = bridgeName
 		if config.IsModeDPU() {
-			gwIfaceRep, err = util.GetDPUOps().GetDPUHostRepInterface(ovsClient, bridgeName)
+			// Uplink host interfaces may be backed by a VF or SF, not just a
+			// PF, so select the representor by its host peer MAC rather than
+			// assuming the bridge holds a single PF representor.
+			gwIfaceRep, err = util.GetDPUOps().FindHostRepresentorByPeerMAC(ovsClient, bridge, macAddress, nodeName)
 			if err != nil {
 				return nil, err
 			}

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
@@ -185,11 +185,12 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostVFRepresentor(t *testing.
 	ovsClient, ovsCleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
 		OVSData: []libovsdbtest.TestData{
 			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+			// No bridge-uplink external-id: the physical uplink must be derived
+			// by skipping the VF representors.
 			&vswitchd.Bridge{
-				UUID:        bridgeUUID,
-				Name:        "br-hostvf0",
-				Ports:       []string{uplinkPortUUID, vf0PortUUID, vf7PortUUID},
-				ExternalIDs: map[string]string{"bridge-uplink": "eth1"},
+				UUID:  bridgeUUID,
+				Name:  "br-hostvf0",
+				Ports: []string{uplinkPortUUID, vf0PortUUID, vf7PortUUID},
 			},
 			&vswitchd.Port{UUID: uplinkPortUUID, Name: "eth1", Interfaces: []string{uplinkInterfaceUUID}},
 			&vswitchd.Interface{UUID: uplinkInterfaceUUID, Name: "eth1", Type: "system"},

--- a/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
+++ b/go-controller/pkg/node/bridgeconfig/bridgeconfig_test.go
@@ -137,13 +137,16 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T)
 	t.Cleanup(func() {
 		util.SetSriovnetOpsInst(origSriovOps)
 	})
-	// GetDPUHostRepInterface iterates bridge ports in map order and returns on
-	// the first PF representor, so eth1 may or may not be probed before pfhpf0.
+	// FindHostRepresentorByPeerMAC walks the bridge ports in map order and
+	// returns on the first match, so expectations for the other ports may
+	// legitimately go unused.
 	sriovOps.On("GetRepresentorPortFlavour", "eth1").
-		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_UNKNOWN), fmt.Errorf("not a PF representor")).
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_UNKNOWN), fmt.Errorf("not a representor")).
 		Maybe()
 	sriovOps.On("GetRepresentorPortFlavour", "pfhpf0").
 		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_PF), nil)
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pfhpf0").
+		Return(ovntest.MustParseMAC("00:11:22:33:44:55"), nil)
 
 	bridge, err := NewUnmanagedBridgeConfiguration(
 		ovsClient,
@@ -154,8 +157,93 @@ func TestNewUnmanagedBridgeConfigurationResolvesDPUHostRepresentor(t *testing.T)
 		ovntest.MustParseIPNets("172.28.0.2/24"),
 		ovntest.MustParseMAC("00:11:22:33:44:55"),
 	)
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "the PF-backed unmanaged bridge configuration must succeed")
+	g.Expect(bridge.GetGatewayIfaceRep()).To(gomega.Equal("pfhpf0"),
+		"the PF representor must be selected as the gateway representor")
+	g.Expect(bridge.GetStaticFDBPort()).To(gomega.Equal("pfhpf0"),
+		"the static FDB entry must be pinned to the PF representor")
+	g.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc())
+}
+
+func TestNewUnmanagedBridgeConfigurationResolvesDPUHostVFRepresentor(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+		util.ResetRunner()
+	})
+	config.IPv4Mode = false
+	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
+
+	bridgeUUID := "br-hostvf0-uuid"
+	uplinkPortUUID := "eth1-port-uuid"
+	uplinkInterfaceUUID := "eth1-interface-uuid"
+	vf0PortUUID := "pf0vf0-port-uuid"
+	vf0InterfaceUUID := "pf0vf0-interface-uuid"
+	vf7PortUUID := "pf0vf7-port-uuid"
+	vf7InterfaceUUID := "pf0vf7-interface-uuid"
+	ovsClient, ovsCleanup, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+			&vswitchd.Bridge{
+				UUID:        bridgeUUID,
+				Name:        "br-hostvf0",
+				Ports:       []string{uplinkPortUUID, vf0PortUUID, vf7PortUUID},
+				ExternalIDs: map[string]string{"bridge-uplink": "eth1"},
+			},
+			&vswitchd.Port{UUID: uplinkPortUUID, Name: "eth1", Interfaces: []string{uplinkInterfaceUUID}},
+			&vswitchd.Interface{UUID: uplinkInterfaceUUID, Name: "eth1", Type: "system"},
+			&vswitchd.Port{UUID: vf0PortUUID, Name: "pf0vf0", Interfaces: []string{vf0InterfaceUUID}},
+			&vswitchd.Interface{UUID: vf0InterfaceUUID, Name: "pf0vf0", Type: "system"},
+			&vswitchd.Port{UUID: vf7PortUUID, Name: "pf0vf7", Interfaces: []string{vf7InterfaceUUID}},
+			&vswitchd.Interface{UUID: vf7InterfaceUUID, Name: "pf0vf7", Type: "system"},
+		},
+	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(bridge.GetGatewayIfaceRep()).To(gomega.Equal("pfhpf0"))
-	g.Expect(bridge.GetStaticFDBPort()).To(gomega.Equal("pfhpf0"))
+	t.Cleanup(ovsCleanup.Cleanup)
+
+	fexec := ovntest.NewLooseCompareFakeExec()
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 get interface eth1 ofport",
+		Output: "7",
+	})
+	g.Expect(util.SetExec(fexec)).To(gomega.Succeed())
+
+	sriovOps := utilmocks.NewSriovnetOps(t)
+	origSriovOps := util.GetSriovnetOps()
+	util.SetSriovnetOpsInst(sriovOps)
+	t.Cleanup(func() {
+		util.SetSriovnetOpsInst(origSriovOps)
+	})
+	// The walk returns on the first match (pf0vf7), so the probes of the
+	// other ports may legitimately go unused depending on map order.
+	sriovOps.On("GetRepresentorPortFlavour", "eth1").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_UNKNOWN), fmt.Errorf("not a representor")).
+		Maybe()
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil).
+		Maybe()
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+		Return(ovntest.MustParseMAC("00:11:22:33:44:66"), nil).
+		Maybe()
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf7").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf7").
+		Return(ovntest.MustParseMAC("00:11:22:33:44:55"), nil)
+
+	bridge, err := NewUnmanagedBridgeConfiguration(
+		ovsClient,
+		"br-hostvf0",
+		"enp4s0f0v0",
+		"node-a",
+		"physnet-blue",
+		ovntest.MustParseIPNets("172.28.0.2/24"),
+		ovntest.MustParseMAC("00:11:22:33:44:55"),
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "the VF-backed unmanaged bridge configuration must succeed")
+	g.Expect(bridge.GetGatewayIfaceRep()).To(gomega.Equal("pf0vf7"),
+		"the VF representor whose peer MAC matches must be selected as the gateway representor")
+	g.Expect(bridge.GetStaticFDBPort()).To(gomega.Equal("pf0vf7"),
+		"the static FDB entry must be pinned to the matching VF representor")
 	g.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc())
 }

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -4,7 +4,6 @@
 package uplink
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -19,6 +18,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -1075,23 +1075,31 @@ func (r defaultOVSBridgeResolver) ResolveByHostMAC(hostMAC net.HardwareAddr, nod
 	sort.Slice(bridges, func(i, j int) bool {
 		return bridges[i].Name < bridges[j].Name
 	})
+	var lookupErrors []error
 	for _, bridge := range bridges {
 		if bridge.Name == ovsIntegrationBridge {
 			continue
 		}
-		bridgeMAC, err := util.GetDPUOps().GetHostGatewayMACAddress(r.ovsClient, bridge.Name, nodeName)
+		rep, err := util.GetDPUOps().FindHostRepresentorByPeerMAC(r.ovsClient, bridge, hostMAC, nodeName)
 		if err != nil {
-			klog.V(5).Infof("Failed to read DPU host MAC for bridge %s: %v", bridge.Name, err)
+			if !errors.Is(err, util.ErrHostRepresentorNotFound) {
+				// Keep searching the remaining bridges, but remember why this
+				// one could not be inspected so a total miss can report it.
+				lookupErrors = append(lookupErrors, err)
+			}
+			klog.V(5).Infof("Bridge %s does not back host MAC %s: %v", bridge.Name, hostMAC, err)
 			continue
 		}
-		if bytes.Equal(bridgeMAC, hostMAC) {
-			return bridge.Name, nil
-		}
+		klog.Infof("Resolved Uplink host MAC %s to OVS bridge %s via DPU representor %s",
+			hostMAC, bridge.Name, rep)
+		return bridge.Name, nil
 	}
-	return "", newDiscoveryError(
-		uplinkv1alpha1.UplinkStateReasonBridgeNotFound,
-		fmt.Errorf("failed to find DPU bridge for host MAC %s", hostMAC),
-	)
+
+	err = fmt.Errorf("failed to find DPU bridge for host MAC %s", hostMAC)
+	if len(lookupErrors) > 0 {
+		err = fmt.Errorf("%w: %v", err, kerrors.NewAggregate(lookupErrors))
+	}
+	return "", newDiscoveryError(uplinkv1alpha1.UplinkStateReasonBridgeNotFound, err)
 }
 
 func (r defaultOVSBridgeResolver) bridgeForPortOrInterface(name string) (string, error) {

--- a/go-controller/pkg/node/uplink/controller.go
+++ b/go-controller/pkg/node/uplink/controller.go
@@ -1020,20 +1020,50 @@ func (r defaultOVSBridgeResolver) BridgeUplink(bridgeName string) (string, error
 	for _, port := range ports {
 		for _, interfaceID := range port.Interfaces {
 			iface, ok := interfacesByID[interfaceID]
-			if ok && iface.Type == "system" {
-				systemPorts = append(systemPorts, port.Name)
+			if !ok || iface.Type != "system" {
+				continue
 			}
+			// On a DPU, host function representors are system-type ports too,
+			// but they can never be the bridge's physical uplink; don't let
+			// them make the uplink ambiguous.
+			if config.IsModeDPU() && util.GetDPUOps().IsHostFacingRepresentor(iface.Name) {
+				klog.V(5).Infof("Bridge %s: ignoring host representor %s while deriving the physical uplink",
+					bridgeName, iface.Name)
+				continue
+			}
+			systemPorts = append(systemPorts, port.Name)
+			// A port qualifies at most once, even when it carries several
+			// system interfaces (e.g. a bond).
+			break
 		}
 	}
 
 	var uplinkName string
 	if len(systemPorts) == 1 {
+		// Assume port name == interface name; only bonds break this (checked below).
 		uplinkName = systemPorts[0]
-	} else {
+		if _, err := libovsdbops.GetOVSInterface(r.ovsClient, uplinkName); err != nil {
+			if !errors.Is(err, libovsdbclient.ErrNotFound) {
+				return "", newDiscoveryError(
+					uplinkv1alpha1.UplinkStateReasonBridgeUplinkNotFound,
+					fmt.Errorf("failed to get interface for bridge %s candidate uplink %s: %w", bridgeName, uplinkName, err),
+				)
+			}
+			// An OVS-level bond is a Port (e.g. bond0) whose Interfaces have
+			// different names (e.g. eth0, eth1), so the lookup above finds no
+			// Interface for it; it cannot be the uplink itself, so let the
+			// fallbacks decide.
+			uplinkName = ""
+		}
+	}
+	if uplinkName == "" {
 		if len(systemPorts) > 1 {
 			klog.Infof("Found more than one system Type ports on the OVS bridge %s, so skipping "+
 				"this method of determining the uplink port", bridgeName)
 		}
+		// NicToBridge sets bridge-uplink on bridges OVN-Kubernetes creates
+		// itself; pre-provisioned Uplink bridges carry it only if the
+		// platform set it, so this fallback might not work for them.
 		uplinkName = bridge.ExternalIDs["bridge-uplink"]
 		if uplinkName == "" && strings.HasPrefix(bridgeName, "br") {
 			uplinkName = strings.TrimPrefix(bridgeName, "br")
@@ -1046,6 +1076,10 @@ func (r defaultOVSBridgeResolver) BridgeUplink(bridgeName string) (string, error
 		)
 	}
 
+	// TODO: OVS-level bonds are still unsupported past this point: the
+	// resolved name is later used to read the uplink's ofport for flow
+	// programming and to apply per-netdev settings, which assume a single
+	// interface. Kernel bonds attached as a single interface work today.
 	uplinkInterfaces, err := ovsops.FindInterfacesWithPredicate(r.ovsClient, func(iface *vswitchd.Interface) bool {
 		return iface.Name == uplinkName
 	})

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k8snetworkplumbingwg/sriovnet"
 	"github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
 
@@ -198,6 +199,176 @@ func TestDefaultOVSBridgeResolverResolvesSmartNICRepresentor(t *testing.T) {
 	bridgeName, err := (defaultOVSBridgeResolver{ovsClient: ovsClient}).Resolve("pf0vf1")
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(bridgeName).To(gomega.Equal("ovsbr1"))
+}
+
+// newDPUBridgeResolverHarness models a BlueField style DPU: br-host carries the
+// host PF representor that backs the default gateway bridge, br-vm carries host
+// VF representors, and br-int is the OVN integration bridge.
+func newDPUBridgeResolverHarness(t *testing.T) defaultOVSBridgeResolver {
+	t.Helper()
+	g := gomega.NewWithT(t)
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+
+	ovsData := []libovsdbtest.TestData{
+		&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{"br-int-uuid", "br-host-uuid", "br-vm-uuid"}},
+		&vswitchd.Bridge{UUID: "br-int-uuid", Name: "br-int", Ports: []string{"mp0-port-uuid"}},
+		&vswitchd.Port{UUID: "mp0-port-uuid", Name: "ovn-k8s-mp0", Interfaces: []string{"mp0-iface-uuid"}},
+		&vswitchd.Interface{UUID: "mp0-iface-uuid", Name: "ovn-k8s-mp0"},
+
+		&vswitchd.Bridge{UUID: "br-host-uuid", Name: "br-host", Ports: []string{"p0-port-uuid", "pf0hpf-port-uuid"}},
+		&vswitchd.Port{UUID: "p0-port-uuid", Name: "p0", Interfaces: []string{"p0-iface-uuid"}},
+		&vswitchd.Interface{UUID: "p0-iface-uuid", Name: "p0", Type: "system"},
+		&vswitchd.Port{UUID: "pf0hpf-port-uuid", Name: "pf0hpf", Interfaces: []string{"pf0hpf-iface-uuid"}},
+		&vswitchd.Interface{UUID: "pf0hpf-iface-uuid", Name: "pf0hpf", Type: "system"},
+
+		&vswitchd.Bridge{UUID: "br-vm-uuid", Name: "br-vm", Ports: []string{"p1-port-uuid", "pf0vf0-port-uuid", "pf0vf7-port-uuid"}},
+		&vswitchd.Port{UUID: "p1-port-uuid", Name: "p1", Interfaces: []string{"p1-iface-uuid"}},
+		&vswitchd.Interface{UUID: "p1-iface-uuid", Name: "p1", Type: "system"},
+		&vswitchd.Port{UUID: "pf0vf0-port-uuid", Name: "pf0vf0", Interfaces: []string{"pf0vf0-iface-uuid"}},
+		&vswitchd.Interface{UUID: "pf0vf0-iface-uuid", Name: "pf0vf0", Type: "system"},
+		&vswitchd.Port{UUID: "pf0vf7-port-uuid", Name: "pf0vf7", Interfaces: []string{"pf0vf7-iface-uuid"}},
+		&vswitchd.Interface{UUID: "pf0vf7-iface-uuid", Name: "pf0vf7", Type: "system"},
+	}
+	ovsClient, testCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{OVSData: ovsData})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	t.Cleanup(testCtx.Cleanup)
+
+	sriovOps := utilmocks.NewSriovnetOps(t)
+	origSriovOps := util.GetSriovnetOps()
+	util.SetSriovnetOpsInst(sriovOps)
+	t.Cleanup(func() {
+		util.SetSriovnetOpsInst(origSriovOps)
+	})
+
+	// The physical uplinks are not representors at all.
+	for _, uplink := range []string{"p0", "p1", "ovn-k8s-mp0"} {
+		sriovOps.On("GetRepresentorPortFlavour", uplink).
+			Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_UNKNOWN),
+				fmt.Errorf("not a representor")).Maybe()
+	}
+	sriovOps.On("GetRepresentorPortFlavour", "pf0hpf").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_PF), nil).Maybe()
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0hpf").
+		Return(ovntest.MustParseMAC(dpuHostPFMAC), nil).Maybe()
+	for rep, mac := range map[string]string{"pf0vf0": dpuHostVF0MAC, "pf0vf7": dpuHostVF7MAC} {
+		sriovOps.On("GetRepresentorPortFlavour", rep).
+			Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil).Maybe()
+		sriovOps.On("GetDevlinkPortFunctionMacAddress", rep).
+			Return(ovntest.MustParseMAC(mac), nil).Maybe()
+	}
+
+	return defaultOVSBridgeResolver{ovsClient: ovsClient}
+}
+
+const (
+	dpuHostPFMAC  = "00:73:58:6d:a1:b3"
+	dpuHostVF0MAC = "00:07:3d:f2:76:4a"
+	dpuHostVF7MAC = "00:07:3d:f2:76:51"
+)
+
+func TestResolveByHostMACSucceeds(t *testing.T) {
+	tests := []struct {
+		name           string
+		hostMAC        string
+		expectedBridge string
+		description    string
+	}{
+		{
+			// The Uplink selects host VF enp4s0f0v0, whose DPU representor
+			// pf0vf0 sits on br-vm. Matching only PF representors used to
+			// miss this entirely.
+			name:           "VF representor",
+			hostMAC:        dpuHostVF0MAC,
+			expectedBridge: "br-vm",
+			description:    "the VF0 representor pf0vf0 is attached to br-vm",
+		},
+		{
+			name:           "correct VF on a shared bridge",
+			hostMAC:        dpuHostVF7MAC,
+			expectedBridge: "br-vm",
+			description:    "pf0vf7 shares br-vm with pf0vf0 and the physical port p1",
+		},
+		{
+			name:           "PF representor",
+			hostMAC:        dpuHostPFMAC,
+			expectedBridge: "br-host",
+			description:    "the PF representor pf0hpf is attached to br-host",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+			config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
+
+			resolver := newDPUBridgeResolverHarness(t)
+
+			bridgeName, err := resolver.ResolveByHostMAC(ovntest.MustParseMAC(tt.hostMAC), "node-a")
+			g.Expect(err).NotTo(gomega.HaveOccurred(), "resolving the host MAC of the %s must succeed", tt.name)
+			g.Expect(bridgeName).To(gomega.Equal(tt.expectedBridge), tt.description)
+		})
+	}
+}
+
+func TestResolveByHostMACFallsBackToSriovnetForPF(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
+
+	const (
+		bridgeUUID    = "br-host-uuid"
+		portUUID      = "pf0hpf-port-uuid"
+		interfaceUUID = "pf0hpf-iface-uuid"
+	)
+	ovsClient, testCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{bridgeUUID}},
+			&vswitchd.Bridge{UUID: bridgeUUID, Name: "br-host", Ports: []string{portUUID}},
+			&vswitchd.Port{UUID: portUUID, Name: "pf0hpf", Interfaces: []string{interfaceUUID}},
+			&vswitchd.Interface{UUID: interfaceUUID, Name: "pf0hpf", Type: "system"},
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	t.Cleanup(testCtx.Cleanup)
+
+	sriovOps := utilmocks.NewSriovnetOps(t)
+	origSriovOps := util.GetSriovnetOps()
+	util.SetSriovnetOpsInst(sriovOps)
+	t.Cleanup(func() {
+		util.SetSriovnetOpsInst(origSriovOps)
+	})
+	sriovOps.On("GetRepresentorPortFlavour", "pf0hpf").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_PF), nil)
+	// Older kernels do not report devlink port function attributes; the PF path
+	// must still resolve through the sysfs aware sriovnet helper.
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0hpf").
+		Return(nil, fmt.Errorf("devlink port has no function attributes"))
+	sriovOps.On("GetRepresentorPeerMacAddress", "pf0hpf").
+		Return(ovntest.MustParseMAC(dpuHostPFMAC), nil)
+
+	bridgeName, err := (defaultOVSBridgeResolver{ovsClient: ovsClient}).
+		ResolveByHostMAC(ovntest.MustParseMAC(dpuHostPFMAC), "node-a")
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		"PF resolution must fall back to sriovnet when devlink reports no function attributes")
+	g.Expect(bridgeName).To(gomega.Equal("br-host"), "the PF representor resolved via the fallback is attached to br-host")
+}
+
+func TestResolveByHostMACReportsBridgeNotFound(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
+
+	resolver := newDPUBridgeResolverHarness(t)
+
+	_, err := resolver.ResolveByHostMAC(ovntest.MustParseMAC("02:00:00:00:00:99"), "node-a")
+	g.Expect(err).To(gomega.HaveOccurred(), "a host MAC no representor peers with must not resolve to a bridge")
+	g.Expect(discoveryReason(err)).To(gomega.Equal(uplinkv1alpha1.UplinkStateReasonBridgeNotFound),
+		"the total miss must surface as BridgeNotFound")
 }
 
 func TestNodeUplinkControllerPublishesResolvedState(t *testing.T) {

--- a/go-controller/pkg/node/uplink/controller_test.go
+++ b/go-controller/pkg/node/uplink/controller_test.go
@@ -371,6 +371,87 @@ func TestResolveByHostMACReportsBridgeNotFound(t *testing.T) {
 		"the total miss must surface as BridgeNotFound")
 }
 
+func TestBridgeUplinkIgnoresHostRepresentorsOnDPU(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
+
+	resolver := newDPUBridgeResolverHarness(t)
+
+	// br-vm holds the physical port p1 plus two VF representors, all
+	// system-type in OVS. Without filtering out the representors the uplink
+	// would be ambiguous and fall back to the useless "br"-prefix heuristic.
+	uplinkName, err := resolver.BridgeUplink("br-vm")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "deriving br-vm's uplink must succeed once VF representors are ignored")
+	g.Expect(uplinkName).To(gomega.Equal("p1"), "br-vm's only non-representor system port is p1")
+
+	uplinkName, err = resolver.BridgeUplink("br-host")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "deriving br-host's uplink must succeed once the PF representor is ignored")
+	g.Expect(uplinkName).To(gomega.Equal("p0"), "br-host's only non-representor system port is p0")
+}
+
+func TestBridgeUplinkRejectsRepresentorOnlyBridgeOnDPU(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+	t.Cleanup(func() {
+		_ = config.PrepareTestConfig()
+	})
+	config.OvnKubeNode.Mode = ovntypes.NodeModeDPU
+
+	ovsClient, testCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{"br-hostvf0-uuid"}},
+			&vswitchd.Bridge{UUID: "br-hostvf0-uuid", Name: "br-hostvf0", Ports: []string{"pf0vf7-port-uuid"}},
+			&vswitchd.Port{UUID: "pf0vf7-port-uuid", Name: "pf0vf7", Interfaces: []string{"pf0vf7-iface-uuid"}},
+			&vswitchd.Interface{UUID: "pf0vf7-iface-uuid", Name: "pf0vf7", Type: "system"},
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	t.Cleanup(testCtx.Cleanup)
+
+	sriovOps := utilmocks.NewSriovnetOps(t)
+	origSriovOps := util.GetSriovnetOps()
+	util.SetSriovnetOpsInst(sriovOps)
+	t.Cleanup(func() {
+		util.SetSriovnetOpsInst(origSriovOps)
+	})
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf7").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+
+	// A bridge whose only system-type port is a VF representor has no physical
+	// uplink; it must not silently pass validation with the representor itself
+	// selected as the uplink.
+	_, err = (defaultOVSBridgeResolver{ovsClient: ovsClient}).BridgeUplink("br-hostvf0")
+	g.Expect(err).To(gomega.HaveOccurred(), "a representor-only bridge must not resolve an uplink")
+	g.Expect(discoveryReason(err)).To(gomega.Equal(uplinkv1alpha1.UplinkStateReasonBridgeUplinkNotFound),
+		"the failure must surface as BridgeUplinkNotFound")
+}
+
+func TestBridgeUplinkFallsBackToExternalIDForBondPort(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient, testCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{"br-bond-uuid"}},
+			&vswitchd.Bridge{
+				UUID: "br-bond-uuid", Name: "br-bond", Ports: []string{"bond0-port-uuid"},
+				ExternalIDs: map[string]string{"bridge-uplink": "eth0"},
+			},
+			&vswitchd.Port{UUID: "bond0-port-uuid", Name: "bond0", Interfaces: []string{"eth0-iface-uuid", "eth1-iface-uuid"}},
+			&vswitchd.Interface{UUID: "eth0-iface-uuid", Name: "eth0", Type: "system"},
+			&vswitchd.Interface{UUID: "eth1-iface-uuid", Name: "eth1", Type: "system"},
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to build the OVS test harness for the bond bridge")
+	t.Cleanup(testCtx.Cleanup)
+
+	// bond0 is the bridge's only system-type port, but it has no same-named
+	// Interface row, so it cannot be the uplink itself; the resolver must
+	// fall back to the bridge-uplink external-id.
+	uplinkName, err := (defaultOVSBridgeResolver{ovsClient: ovsClient}).BridgeUplink("br-bond")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "a bond bridge with bridge-uplink set must resolve")
+	g.Expect(uplinkName).To(gomega.Equal("eth0"), "the bridge-uplink external-id must be used for a bond port")
+}
+
 func TestNodeUplinkControllerPublishesResolvedState(t *testing.T) {
 	g := gomega.NewWithT(t)
 	g.Expect(config.PrepareTestConfig()).To(gomega.Succeed())

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -64,6 +64,12 @@ type DPUOps interface {
 	FindHostRepresentorByPeerMAC(ovsClient libovsdbclient.Client, bridge *vswitchd.Bridge, hostMAC net.HardwareAddr,
 		nodeName string) (string, error)
 
+	// IsHostFacingRepresentor reports whether netdev is a DPU-side representor
+	// of a host function (PF, VF or SF). Such representors can never be a
+	// bridge's physical uplink even though OVS reports them as system-type
+	// ports.
+	IsHostFacingRepresentor(netdev string) bool
+
 	// ResolveDeviceDetails returns PF and VF indices for a device identified
 	// by either a PCI address (e.g. "0000:03:00.2") or a netdev name
 	// (e.g. "eth0-1"). It is up to the implementation to interpret the deviceID
@@ -236,6 +242,15 @@ func hostPeerMACAddress(rep string, flavour sriovnet.PortFlavour) (net.HardwareA
 	return mac, nil
 }
 
+func (n *SwitchdevDPUOps) IsHostFacingRepresentor(netdev string) bool {
+	flavour, err := GetSriovnetOps().GetRepresentorPortFlavour(normalizeOVSName(netdev))
+	if err != nil {
+		return false
+	}
+	_, ok := hostFacingRepresentorFlavours[flavour]
+	return ok
+}
+
 func (n *SwitchdevDPUOps) ResolveDeviceDetails(deviceID string) (*NetworkDeviceDetails, error) {
 	if IsPCIDeviceName(deviceID) {
 		return GetNetworkDeviceDetails(deviceID)
@@ -403,6 +418,10 @@ func (s *SimulatedDPUOps) FindHostRepresentorByPeerMAC(
 	}
 	return "", fmt.Errorf("%w: no simulated representor on bridge %q peers with host MAC %s",
 		ErrHostRepresentorNotFound, bridgeName, hostMAC)
+}
+
+func (s *SimulatedDPUOps) IsHostFacingRepresentor(netdev string) bool {
+	return simulatedDPURepresentorIndex(normalizeOVSName(netdev)) >= 0
 }
 
 func normalizeOVSName(name string) string {

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -7,7 +7,9 @@
 package util
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -23,6 +25,7 @@ import (
 
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
 )
 
 // DPU operations abstraction.
@@ -49,6 +52,18 @@ type DPUOps interface {
 	// nodeName is the K8s node name of the host this DPU operates behalf of.
 	GetHostGatewayMACAddress(ovsClient libovsdbclient.Client, bridgeName, nodeName string) (net.HardwareAddr, error)
 
+	// FindHostRepresentorByPeerMAC returns the DPU-side representor attached to
+	// bridge whose host-side peer function has hostMAC. Unlike
+	// GetHostGatewayMACAddress, which only considers the single host PF
+	// representor that backs the default gateway bridge, this inspects every
+	// host-facing representor on the bridge, so it also resolves uplinks backed
+	// by a host VF or SF. It wraps ErrHostRepresentorNotFound when the bridge
+	// has no representor peering with hostMAC, which lets callers distinguish a
+	// clean miss from a lookup failure. nodeName is the K8s node name of the
+	// host this DPU operates on behalf of.
+	FindHostRepresentorByPeerMAC(ovsClient libovsdbclient.Client, bridge *vswitchd.Bridge, hostMAC net.HardwareAddr,
+		nodeName string) (string, error)
+
 	// ResolveDeviceDetails returns PF and VF indices for a device identified
 	// by either a PCI address (e.g. "0000:03:00.2") or a netdev name
 	// (e.g. "eth0-1"). It is up to the implementation to interpret the deviceID
@@ -66,6 +81,10 @@ type DPUOps interface {
 	// itself. On switchdev, failure to resolve PCI for the representor is an error.
 	GetDeviceAddress(repName string) (string, error)
 }
+
+// ErrHostRepresentorNotFound is wrapped by FindHostRepresentorByPeerMAC when a
+// bridge holds no representor whose host-side peer matches the requested MAC.
+var ErrHostRepresentorNotFound = errors.New("dpu host representor not found")
 
 // ---------------------------------------------------------------------------
 // DPUOps singleton
@@ -137,6 +156,79 @@ func (n *SwitchdevDPUOps) GetHostGatewayMACAddress(ovsClient libovsdbclient.Clie
 		return nil, err
 	}
 	return GetSriovnetOps().GetRepresentorPeerMacAddress(hostRep)
+}
+
+// hostFacingRepresentorFlavours are the switchdev port flavours whose
+// representors have a host-side peer function that can carry the gateway L3
+// identity an Uplink selects.
+var hostFacingRepresentorFlavours = map[sriovnet.PortFlavour]struct{}{
+	sriovnet.PORT_FLAVOUR_PCI_PF: {},
+	sriovnet.PORT_FLAVOUR_PCI_VF: {},
+	sriovnet.PORT_FLAVOUR_PCI_SF: {},
+}
+
+func (n *SwitchdevDPUOps) FindHostRepresentorByPeerMAC(
+	ovsClient libovsdbclient.Client,
+	bridge *vswitchd.Bridge,
+	hostMAC net.HardwareAddr,
+	_ string,
+) (string, error) {
+	bridgeName := bridge.Name
+	portsToInterfaces, err := getBridgePortsInterfaces(ovsClient, bridge)
+	if err != nil {
+		return "", err
+	}
+
+	for _, ifaces := range portsToInterfaces {
+		for _, iface := range ifaces {
+			rep := normalizeOVSName(iface.Name)
+			flavour, err := GetSriovnetOps().GetRepresentorPortFlavour(rep)
+			if err != nil {
+				klog.V(5).Infof("Bridge %s: skipping interface %s, not a switchdev representor: %v",
+					bridgeName, rep, err)
+				continue
+			}
+			if _, ok := hostFacingRepresentorFlavours[flavour]; !ok {
+				klog.V(5).Infof("Bridge %s: skipping representor %s, port flavour %d has no host peer",
+					bridgeName, rep, flavour)
+				continue
+			}
+			peerMAC, err := hostPeerMACAddress(rep, flavour)
+			if err != nil {
+				klog.V(5).Infof("Bridge %s: skipping representor %s, failed to read host peer MAC: %v",
+					bridgeName, rep, err)
+				continue
+			}
+			if bytes.Equal(peerMAC, hostMAC) {
+				klog.V(4).Infof("Bridge %s: representor %s (flavour %d) peers with host MAC %s",
+					bridgeName, rep, flavour, hostMAC)
+				return rep, nil
+			}
+			klog.V(5).Infof("Bridge %s: representor %s peers with host MAC %s, looking for %s",
+				bridgeName, rep, peerMAC, hostMAC)
+		}
+	}
+	return "", fmt.Errorf("%w: no representor on bridge %q peers with host MAC %s",
+		ErrHostRepresentorNotFound, bridgeName, hostMAC)
+}
+
+// hostPeerMACAddress returns the MAC of the host-side function peered with the
+// representor rep. devlink reports the function address for every flavour, so it
+// is tried first. sriovnet.GetRepresentorPeerMacAddress is only a fallback for
+// PF representors, where it additionally understands the legacy sysfs layout.
+func hostPeerMACAddress(rep string, flavour sriovnet.PortFlavour) (net.HardwareAddr, error) {
+	mac, devlinkErr := GetSriovnetOps().GetDevlinkPortFunctionMacAddress(rep)
+	if devlinkErr == nil {
+		return mac, nil
+	}
+	if flavour != sriovnet.PORT_FLAVOUR_PCI_PF {
+		return nil, devlinkErr
+	}
+	mac, err := GetSriovnetOps().GetRepresentorPeerMacAddress(rep)
+	if err != nil {
+		return nil, fmt.Errorf("%v; devlink lookup also failed: %v", err, devlinkErr)
+	}
+	return mac, nil
 }
 
 func (n *SwitchdevDPUOps) ResolveDeviceDetails(deviceID string) (*NetworkDeviceDetails, error) {
@@ -262,6 +354,50 @@ func (s *SimulatedDPUOps) GetHostGatewayMACAddress(
 
 	klog.Infof("Derived host gateway peer MAC %s for node %s bridge %s", mac, nodeName, bridgeName)
 	return mac, nil
+}
+
+func (s *SimulatedDPUOps) FindHostRepresentorByPeerMAC(
+	ovsClient libovsdbclient.Client,
+	bridge *vswitchd.Bridge,
+	hostMAC net.HardwareAddr,
+	nodeName string,
+) (string, error) {
+	if nodeName == "" {
+		return "", fmt.Errorf("nodeName must be provided for simulated FindHostRepresentorByPeerMAC")
+	}
+	bridgeName := bridge.Name
+	portsToInterfaces, err := getBridgePortsInterfaces(ovsClient, bridge)
+	if err != nil {
+		return "", err
+	}
+
+	for port, ifaces := range portsToInterfaces {
+		candidates := []string{port}
+		for _, iface := range ifaces {
+			candidates = append(candidates, iface.Name)
+		}
+		for _, candidate := range candidates {
+			rep := normalizeOVSName(candidate)
+			index := simulatedDPURepresentorIndex(rep)
+			if index < 0 {
+				continue
+			}
+			macStr := s.generateMACForHostToDpu(nodeName, "host", index)
+			peerMAC, err := net.ParseMAC(macStr)
+			if err != nil {
+				return "", fmt.Errorf("failed to parse generated MAC %s: %v", macStr, err)
+			}
+			if bytes.Equal(peerMAC, hostMAC) {
+				klog.V(4).Infof("Bridge %s: simulated representor %s peers with host MAC %s",
+					bridgeName, rep, hostMAC)
+				return rep, nil
+			}
+			klog.V(5).Infof("Bridge %s: simulated representor %s peers with host MAC %s, looking for %s",
+				bridgeName, rep, peerMAC, hostMAC)
+		}
+	}
+	return "", fmt.Errorf("%w: no simulated representor on bridge %q peers with host MAC %s",
+		ErrHostRepresentorNotFound, bridgeName, hostMAC)
 }
 
 func normalizeOVSName(name string) string {

--- a/go-controller/pkg/util/dpuops_linux.go
+++ b/go-controller/pkg/util/dpuops_linux.go
@@ -228,6 +228,11 @@ func hostPeerMACAddress(rep string, flavour sriovnet.PortFlavour) (net.HardwareA
 	if err != nil {
 		return nil, fmt.Errorf("%v; devlink lookup also failed: %v", err, devlinkErr)
 	}
+	// GetRepresentorPeerMacAddress can succeed with an empty or all-zero MAC
+	// when the peer function MAC is unset; treat that as absent too.
+	if len(mac) == 0 || isZeroMAC(mac) {
+		return nil, fmt.Errorf("representor %s peer MAC is unset; devlink lookup also failed: %v", rep, devlinkErr)
+	}
 	return mac, nil
 }
 

--- a/go-controller/pkg/util/dpuops_linux_test.go
+++ b/go-controller/pkg/util/dpuops_linux_test.go
@@ -100,6 +100,26 @@ func TestSwitchdevFindHostRepresentorByPeerMACMatchesSF(t *testing.T) {
 	g.Expect(rep).To(gomega.Equal("pf0vf0"), "pf0vf0 is the SF representor peering with the host MAC")
 }
 
+func TestSwitchdevFindHostRepresentorByPeerMACRejectsZeroFallbackMAC(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient := newVFBridgeHarness(t)
+
+	sriovOps := replaceSriovnetOps(t)
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_PF), nil)
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+		Return(nil, fmt.Errorf("devlink unavailable"))
+	// The sriovnet fallback can report an unset PF peer MAC as all zeroes with
+	// a nil error; it must not be matched, even against a zero host MAC.
+	sriovOps.On("GetRepresentorPeerMacAddress", "pf0vf0").
+		Return(ovntest.MustParseMAC("00:00:00:00:00:00"), nil)
+
+	_, err := (&SwitchdevDPUOps{}).FindHostRepresentorByPeerMAC(
+		ovsClient, mustGetBridge(t, ovsClient, "br-vm"), ovntest.MustParseMAC("00:00:00:00:00:00"), "node-a")
+	g.Expect(errors.Is(err, ErrHostRepresentorNotFound)).To(gomega.BeTrue(),
+		"an all-zero fallback MAC must be treated as unset, not matched")
+}
+
 func TestSwitchdevFindHostRepresentorByPeerMACMissWrapsSentinel(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ovsClient := newVFBridgeHarness(t)

--- a/go-controller/pkg/util/dpuops_linux_test.go
+++ b/go-controller/pkg/util/dpuops_linux_test.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright The OVN-Kubernetes Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package util
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/k8snetworkplumbingwg/sriovnet"
+	"github.com/onsi/gomega"
+
+	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
+
+	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
+	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	utilmocks "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
+)
+
+const (
+	testHostPFMAC  = "00:73:58:6d:a1:b3"
+	testHostVF0MAC = "00:07:3d:f2:76:4a"
+)
+
+// newVFBridgeHarness builds an OVS bridge holding a single host VF representor,
+// which is the layout of an Uplink bridge on a BlueField style DPU.
+func newVFBridgeHarness(t *testing.T) libovsdbclient.Client {
+	t.Helper()
+	g := gomega.NewWithT(t)
+
+	ovsClient, testCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{"br-vm-uuid"}},
+			&vswitchd.Bridge{UUID: "br-vm-uuid", Name: "br-vm", Ports: []string{"pf0vf0-port-uuid"}},
+			&vswitchd.Port{UUID: "pf0vf0-port-uuid", Name: "pf0vf0", Interfaces: []string{"pf0vf0-iface-uuid"}},
+			&vswitchd.Interface{UUID: "pf0vf0-iface-uuid", Name: "pf0vf0", Type: "system"},
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to build the OVS test harness for the VF bridge")
+	t.Cleanup(testCtx.Cleanup)
+	return ovsClient
+}
+
+func replaceSriovnetOps(t *testing.T) *utilmocks.SriovnetOps {
+	t.Helper()
+	sriovOps := utilmocks.NewSriovnetOps(t)
+	orig := GetSriovnetOps()
+	SetSriovnetOpsInst(sriovOps)
+	t.Cleanup(func() {
+		SetSriovnetOpsInst(orig)
+	})
+	return sriovOps
+}
+
+func mustGetBridge(t *testing.T, ovsClient libovsdbclient.Client, name string) *vswitchd.Bridge {
+	t.Helper()
+	g := gomega.NewWithT(t)
+	bridge, err := ovsops.GetBridge(ovsClient, name)
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get bridge %s from the test harness", name)
+	return bridge
+}
+
+func TestSwitchdevFindHostRepresentorByPeerMACMatchesVF(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient := newVFBridgeHarness(t)
+
+	sriovOps := replaceSriovnetOps(t)
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+		Return(ovntest.MustParseMAC(testHostVF0MAC), nil)
+
+	rep, err := (&SwitchdevDPUOps{}).FindHostRepresentorByPeerMAC(
+		ovsClient, mustGetBridge(t, ovsClient, "br-vm"), ovntest.MustParseMAC(testHostVF0MAC), "node-a")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "looking up the VF representor by its host peer MAC must succeed")
+	g.Expect(rep).To(gomega.Equal("pf0vf0"), "pf0vf0 is the VF representor peering with the host MAC")
+}
+
+func TestSwitchdevFindHostRepresentorByPeerMACMatchesSF(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient := newVFBridgeHarness(t)
+
+	sriovOps := replaceSriovnetOps(t)
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_SF), nil)
+	// SF representors resolve directly through devlink; there is no sriovnet
+	// fallback to configure.
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+		Return(ovntest.MustParseMAC(testHostVF0MAC), nil)
+
+	rep, err := (&SwitchdevDPUOps{}).FindHostRepresentorByPeerMAC(
+		ovsClient, mustGetBridge(t, ovsClient, "br-vm"), ovntest.MustParseMAC(testHostVF0MAC), "node-a")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "looking up the SF representor by its host peer MAC must succeed")
+	g.Expect(rep).To(gomega.Equal("pf0vf0"), "pf0vf0 is the SF representor peering with the host MAC")
+}
+
+func TestSwitchdevFindHostRepresentorByPeerMACMissWrapsSentinel(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient := newVFBridgeHarness(t)
+
+	sriovOps := replaceSriovnetOps(t)
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+		Return(ovntest.MustParseMAC(testHostVF0MAC), nil)
+
+	_, err := (&SwitchdevDPUOps{}).FindHostRepresentorByPeerMAC(
+		ovsClient, mustGetBridge(t, ovsClient, "br-vm"), ovntest.MustParseMAC(testHostPFMAC), "node-a")
+	g.Expect(errors.Is(err, ErrHostRepresentorNotFound)).To(gomega.BeTrue(),
+		"a clean miss must wrap ErrHostRepresentorNotFound so callers can keep searching")
+}
+
+func TestSwitchdevFindHostRepresentorByPeerMACSkipsUnreadableRepresentor(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient, testCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{"br-vm-uuid"}},
+			&vswitchd.Bridge{UUID: "br-vm-uuid", Name: "br-vm", Ports: []string{"pf0vf0-port-uuid", "pf0vf7-port-uuid"}},
+			&vswitchd.Port{UUID: "pf0vf0-port-uuid", Name: "pf0vf0", Interfaces: []string{"pf0vf0-iface-uuid"}},
+			&vswitchd.Interface{UUID: "pf0vf0-iface-uuid", Name: "pf0vf0", Type: "system"},
+			&vswitchd.Port{UUID: "pf0vf7-port-uuid", Name: "pf0vf7", Interfaces: []string{"pf0vf7-iface-uuid"}},
+			&vswitchd.Interface{UUID: "pf0vf7-iface-uuid", Name: "pf0vf7", Type: "system"},
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to build the OVS test harness for the two-representor bridge")
+	t.Cleanup(testCtx.Cleanup)
+
+	sriovOps := replaceSriovnetOps(t)
+	// pf0vf0 is unreadable: a VF representor has no sriovnet fallback, so
+	// its devlink failure must not abort the scan. The walk is in map order,
+	// so when pf0vf7 happens to be visited first pf0vf0 is never probed;
+	// hence the Maybe.
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil).
+		Maybe()
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf0").
+		Return(nil, fmt.Errorf("devlink unavailable")).
+		Maybe()
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf7").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+	sriovOps.On("GetDevlinkPortFunctionMacAddress", "pf0vf7").
+		Return(ovntest.MustParseMAC(testHostVF0MAC), nil)
+
+	rep, err := (&SwitchdevDPUOps{}).FindHostRepresentorByPeerMAC(
+		ovsClient, mustGetBridge(t, ovsClient, "br-vm"), ovntest.MustParseMAC(testHostVF0MAC), "node-a")
+	g.Expect(err).NotTo(gomega.HaveOccurred(),
+		"the unreadable representor must be skipped, not abort the scan")
+	g.Expect(rep).To(gomega.Equal("pf0vf7"), "the matching representor after the unreadable one must be found")
+}
+
+// TestSwitchdevGetHostGatewayMACAddressStaysPFOnly guards the default gateway
+// bridge path, which must keep resolving through the host PF representor only.
+func TestSwitchdevGetHostGatewayMACAddressStaysPFOnly(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient := newVFBridgeHarness(t)
+
+	sriovOps := replaceSriovnetOps(t)
+	sriovOps.On("GetRepresentorPortFlavour", "pf0vf0").
+		Return(sriovnet.PortFlavour(sriovnet.PORT_FLAVOUR_PCI_VF), nil)
+
+	_, err := (&SwitchdevDPUOps{}).GetHostGatewayMACAddress(ovsClient, "br-vm", "node-a")
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("dpu host interface was not found")))
+}
+
+func TestSimulatedFindHostRepresentorByPeerMAC(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ovsClient, testCtx, err := libovsdbtest.NewOVSTestHarness(libovsdbtest.TestSetup{
+		OVSData: []libovsdbtest.TestData{
+			&vswitchd.OpenvSwitch{UUID: "root-ovs", Bridges: []string{"br-vm-uuid"}},
+			&vswitchd.Bridge{UUID: "br-vm-uuid", Name: "br-vm", Ports: []string{"rep-port-uuid"}},
+			&vswitchd.Port{UUID: "rep-port-uuid", Name: "rep0-1", Interfaces: []string{"rep-iface-uuid"}},
+			&vswitchd.Interface{UUID: "rep-iface-uuid", Name: "rep0-1"},
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to build the OVS test harness for the simulated bridge")
+	t.Cleanup(testCtx.Cleanup)
+
+	ops := &SimulatedDPUOps{}
+	// The MAC the simulator derives for this bridge must be the same one the
+	// reverse lookup accepts.
+	hostMAC, err := ops.GetHostGatewayMACAddress(ovsClient, "br-vm", "node-a")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "deriving the simulated host gateway MAC must succeed")
+
+	rep, err := ops.FindHostRepresentorByPeerMAC(ovsClient, mustGetBridge(t, ovsClient, "br-vm"), hostMAC, "node-a")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "the reverse lookup must accept the MAC the forward lookup derived")
+	g.Expect(rep).To(gomega.Equal("rep0-1"), "rep0-1 is the only simulated representor on br-vm")
+
+	// A different node derives a different MAC, so the lookup must miss.
+	otherMAC, err := ops.GetHostGatewayMACAddress(ovsClient, "br-vm", "node-b")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "deriving the simulated MAC for another node must succeed")
+	_, err = ops.FindHostRepresentorByPeerMAC(ovsClient, mustGetBridge(t, ovsClient, "br-vm"), otherMAC, "node-a")
+	g.Expect(errors.Is(err, ErrHostRepresentorNotFound)).To(gomega.BeTrue(),
+		"a MAC derived for another node must be a clean miss")
+}

--- a/go-controller/pkg/util/mocks/SriovnetOps.go
+++ b/go-controller/pkg/util/mocks/SriovnetOps.go
@@ -18,6 +18,36 @@ type SriovnetOps struct {
 	mock.Mock
 }
 
+// GetDevlinkPortFunctionMacAddress provides a mock function with given fields: netdev
+func (_m *SriovnetOps) GetDevlinkPortFunctionMacAddress(netdev string) (net.HardwareAddr, error) {
+	ret := _m.Called(netdev)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDevlinkPortFunctionMacAddress")
+	}
+
+	var r0 net.HardwareAddr
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (net.HardwareAddr, error)); ok {
+		return rf(netdev)
+	}
+	if rf, ok := ret.Get(0).(func(string) net.HardwareAddr); ok {
+		r0 = rf(netdev)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(net.HardwareAddr)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(netdev)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNetDevicesFromAux provides a mock function with given fields: auxDev
 func (_m *SriovnetOps) GetNetDevicesFromAux(auxDev string) ([]string, error) {
 	ret := _m.Called(auxDev)

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -23,6 +23,7 @@ import (
 	libovsdbclient "github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 
+	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/config"
 	ovsops "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/libovsdb/ops"
 	ovntypes "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/vswitchd"
@@ -115,9 +116,21 @@ func GetNicName(ovsClient libovsdbclient.Client, brName string) (string, error) 
 	systemPorts := make([]string, 0)
 	for port, ifaces := range portsToInterfaces {
 		for _, iface := range ifaces {
-			if iface.Type == "system" {
-				systemPorts = append(systemPorts, port)
+			if iface.Type != "system" {
+				continue
 			}
+			// On a DPU, host function representors are system-type ports too,
+			// but they can never be the bridge's physical uplink; don't let
+			// them make the uplink ambiguous.
+			if config.IsModeDPU() && GetDPUOps().IsHostFacingRepresentor(iface.Name) {
+				klog.V(5).Infof("Bridge %s: ignoring host representor %s while deriving the physical uplink",
+					brName, iface.Name)
+				continue
+			}
+			systemPorts = append(systemPorts, port)
+			// A port qualifies at most once, even when it carries several
+			// system interfaces (e.g. a bond).
+			break
 		}
 	}
 	if len(systemPorts) == 1 {

--- a/go-controller/pkg/util/sriovnet_linux.go
+++ b/go-controller/pkg/util/sriovnet_linux.go
@@ -134,10 +134,20 @@ func (defaultSriovnetOps) GetDevlinkPortFunctionMacAddress(netdev string) (net.H
 	if port.Fn == nil {
 		return nil, fmt.Errorf("devlink port for netdev %s does not report function attributes", netdev)
 	}
-	if len(port.Fn.HwAddr) == 0 {
+	// Drivers may report an unset function MAC as 00:00:00:00:00:00.
+	if len(port.Fn.HwAddr) == 0 || isZeroMAC(port.Fn.HwAddr) {
 		return nil, fmt.Errorf("devlink port function for netdev %s does not report a hardware address", netdev)
 	}
 	return port.Fn.HwAddr, nil
+}
+
+func isZeroMAC(mac net.HardwareAddr) bool {
+	for _, b := range mac {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func (defaultSriovnetOps) GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error) {

--- a/go-controller/pkg/util/sriovnet_linux.go
+++ b/go-controller/pkg/util/sriovnet_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/k8snetworkplumbingwg/sriovnet"
+	"github.com/k8snetworkplumbingwg/sriovnet/pkg/utils/netlinkops"
 
 	"k8s.io/klog/v2"
 )
@@ -40,6 +41,7 @@ type SriovnetOps interface {
 	GetVfRepresentorDPU(pfID, vfIndex string) (string, error)
 	IsVfPciVfioBound(pciAddr string) bool
 	GetRepresentorPeerMacAddress(netdev string) (net.HardwareAddr, error)
+	GetDevlinkPortFunctionMacAddress(netdev string) (net.HardwareAddr, error)
 	GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error)
 	GetPCIFromDeviceName(netdevName string) (string, error)
 	GetPortIndexFromRepresentor(name string) (int, error)
@@ -115,6 +117,27 @@ func (defaultSriovnetOps) GetVfRepresentorDPU(pfID, vfIndex string) (string, err
 
 func (defaultSriovnetOps) GetRepresentorPeerMacAddress(netdev string) (net.HardwareAddr, error) {
 	return sriovnet.GetRepresentorPeerMacAddress(netdev)
+}
+
+// GetDevlinkPortFunctionMacAddress returns the hardware address reported by the
+// devlink port function backing netdev. On a DPU this is the MAC of the host
+// side function that peers with the given representor. Unlike
+// sriovnet.GetRepresentorPeerMacAddress, which only accepts PF representors,
+// this works for PF, VF and SF representors, so it is the only way to resolve
+// the host MAC of a VF or SF backed uplink. It requires devlink port function
+// attributes, available since kernel 5.9.
+func (defaultSriovnetOps) GetDevlinkPortFunctionMacAddress(netdev string) (net.HardwareAddr, error) {
+	port, err := netlinkops.GetNetlinkOps().DevLinkGetPortByNetdevName(netdev)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get devlink port for netdev %s: %w", netdev, err)
+	}
+	if port.Fn == nil {
+		return nil, fmt.Errorf("devlink port for netdev %s does not report function attributes", netdev)
+	}
+	if len(port.Fn.HwAddr) == 0 {
+		return nil, fmt.Errorf("devlink port function for netdev %s does not report a hardware address", netdev)
+	}
+	return port.Fn.HwAddr, nil
 }
 
 func (defaultSriovnetOps) GetRepresentorPortFlavour(netdev string) (sriovnet.PortFlavour, error) {

--- a/go-controller/pkg/util/sriovnet_linux_test.go
+++ b/go-controller/pkg/util/sriovnet_linux_test.go
@@ -8,7 +8,11 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/k8snetworkplumbingwg/sriovnet/pkg/utils/netlinkops"
+	"github.com/vishvananda/netlink"
 
 	ovntest "github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/util/mocks"
@@ -225,6 +229,72 @@ func TestGetFunctionRepresentorName(t *testing.T) {
 			}
 
 			mockSriovnetOps.AssertExpectations(t)
+		})
+	}
+}
+
+type fakeDevlinkNetlinkOps struct {
+	netlinkops.NetlinkOps
+	port *netlink.DevlinkPort
+	err  error
+}
+
+func (f *fakeDevlinkNetlinkOps) DevLinkGetPortByNetdevName(_ string) (*netlink.DevlinkPort, error) {
+	return f.port, f.err
+}
+
+func TestGetDevlinkPortFunctionMacAddress(t *testing.T) {
+	tests := []struct {
+		desc   string
+		port   *netlink.DevlinkPort
+		err    error
+		expMAC string
+		expErr string
+	}{
+		{
+			desc:   "returns the reported function hardware address",
+			port:   &netlink.DevlinkPort{Fn: &netlink.DevlinkPortFn{HwAddr: ovntest.MustParseMAC("00:07:3d:f2:76:4a")}},
+			expMAC: "00:07:3d:f2:76:4a",
+		},
+		{
+			desc:   "fails when devlink lookup fails",
+			err:    fmt.Errorf("no devlink port"),
+			expErr: "failed to get devlink port",
+		},
+		{
+			desc:   "fails when function attributes are missing",
+			port:   &netlink.DevlinkPort{},
+			expErr: "does not report function attributes",
+		},
+		{
+			desc:   "fails when the hardware address is absent",
+			port:   &netlink.DevlinkPort{Fn: &netlink.DevlinkPortFn{}},
+			expErr: "does not report a hardware address",
+		},
+		{
+			desc: "fails when the hardware address is all zeros",
+			// Drivers may report an unset function MAC as 00:00:00:00:00:00.
+			port:   &netlink.DevlinkPort{Fn: &netlink.DevlinkPortFn{HwAddr: ovntest.MustParseMAC("00:00:00:00:00:00")}},
+			expErr: "does not report a hardware address",
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			netlinkops.SetNetlinkOps(&fakeDevlinkNetlinkOps{port: tc.port, err: tc.err})
+			t.Cleanup(netlinkops.ResetNetlinkOps)
+
+			mac, err := defaultSriovnetOps{}.GetDevlinkPortFunctionMacAddress("pf0vf7")
+			if tc.expErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expErr) {
+					t.Errorf("Expected error containing %q, got: %v", tc.expErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			} else if mac.String() != tc.expMAC {
+				t.Errorf("Expected MAC %q, got %q", tc.expMAC, mac)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does and why we need it

Uplink discovery on the DPU only matched host PF representors: `ResolveByHostMAC` compared the host MAC against `GetHostGatewayMACAddress`, which goes through `GetDPUHostRepInterface` (PF-only) and `sriovnet.GetRepresentorPeerMacAddress` (also PF-only). An Uplink backed by a host VF or SF (e.g. `enp4s0f0v0` with representor `pf0vf7` on its own bridge) could never resolve: the `UplinkState` stayed stuck with `Resolved=False`, flapping between `WaitingForDPU` and `BridgeNotFound` as the DPU and DPU-Host sides kept rewriting the condition.

Four commits, each reviewable on its own:

1. **node/uplink: resolve DPU bridges for VF and SF host interfaces**: add `FindHostRepresentorByPeerMAC`, which walks PF/VF/SF representors on each bridge and matches the host peer MAC via the new devlink-based `GetDevlinkPortFunctionMacAddress` helper (sriovnet sysfs path kept as a PF fallback for older kernels). `ResolveByHostMAC` is wired to it.

2. **bridgeconfig: select DPU gateway representor by host peer MAC**: one step downstream, `NewUnmanagedBridgeConfiguration` still discovered the gateway representor through the PF-only lookup, so a VF-only bridge failed right after resolution succeeded, and a bridge mixing PF and VF representors silently pinned the static FDB entry to the wrong representor. It now reuses `FindHostRepresentorByPeerMAC` with the same `UplinkState` MAC the resolver matched on, so bridge resolution and gateway configuration cannot disagree.

3. **util: treat all-zero devlink function hw_addr as unset**: drivers may report an unset function MAC as a present `00:00:00:00:00:00` rather than a missing attribute; without this guard, unprovisioned VF/SF representors could shadow the correct match or false-match a zero host MAC.

4. **node/uplink: ignore host representors when deriving the bridge uplink**: `BridgeUplink` picks the physical uplink as the single system-type port on the bridge, but on a DPU host-function representors are system-type too, so a bridge with the physical port plus VF representors looked ambiguous and flipped the state to `BridgeUplinkNotFound` right after resolution succeeded, while a representor-only bridge silently passed validation with the representor as "uplink". Representors are now skipped when counting candidates, per the okep-6019 requirement that the resolved bridge has a discoverable physical uplink port.

## Which issue(s) this PR fixes

VF/SF-backed Uplink host interfaces on DPU nodes never reach `Resolved=True`.